### PR TITLE
Fix PhysXDebug not showing correctly in Editor

### DIFF
--- a/Gems/PhysXDebug/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysXDebug/Code/Source/SystemComponent.cpp
@@ -213,6 +213,9 @@ namespace PhysXDebug
     void SystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC("PhysXService"));
+#ifdef PHYSXDEBUG_GEM_EDITOR
+        required.push_back(AZ_CRC("PhysXEditorService"));
+#endif // PHYSXDEBUG_GEM_EDITOR
     }
 
     void SystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)


### PR DESCRIPTION
[jira](https://jira.agscollab.com/browse/LYN-2618)

The loading order was incorrect resulting in default editor scene not being created at the time of registering handler on the events to it, resulting in editor flag being always dirty