### PR TITLE
Prevent skipping builds from PRs

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -457,7 +457,7 @@ try {
         }
     }
 
-    if(env.BUILD_NUMBER == '1') {
+    if(env.BUILD_NUMBER == '1' && !branchName.startsWith('PR-')) {
         // Exit pipeline early on the intial build. This allows Jenkins to load the pipeline for the branch and enables users
         // to select build parameters on their first actual build. See https://issues.jenkins.io/browse/JENKINS-41929
         currentBuild.result = 'SUCCESS'


### PR DESCRIPTION
This change prevents the pipeline from skipping the build and reporting success on the first build. This was required in CodeCommit because we needed to populate custom parameter to run a PR build. This is no longer required in GitHub. 

This still allows branch builds to only load the parameters on the initial run for testing. 

Testing:
- Branch build in the fork repo still only loaded parameters on the first run
- PR build for this pull request ran the full build on the first run