### PR TITLE
Fixed dangling pointer in InitializeCatalog

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -617,9 +617,9 @@ namespace AzFramework
             // won't free the mutex until the load is complete.
             // So instead, queue the notification until the next tick, so that it doesn't occur within the AssetCatalogRequestBus mutex, and also
             // so that the entire AssetCatalog initialization is complete.
-            AZ::TickBus::QueueFunction([catalogRegistryFile]()
+            AZ::TickBus::QueueFunction([catalogRegistryString = AZStd::string(catalogRegistryFile)]()
                 {
-                    AssetCatalogEventBus::Broadcast(&AssetCatalogEventBus::Events::OnCatalogLoaded, catalogRegistryFile);
+                    AssetCatalogEventBus::Broadcast(&AssetCatalogEventBus::Events::OnCatalogLoaded, catalogRegistryString.c_str());
                 });
         }
     }


### PR DESCRIPTION
The input string will go out of scope when the lambda is executed, hence capturing a string copy