### PR TITLE
Prevent skipping build if it's from a pull request

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -270,7 +270,7 @@ def PreBuildCommonSteps(Map pipelineConfig, String projectName, String pipeline,
         if(env.IS_UNIX) pythonCmd = 'sudo -E python -u '
         else pythonCmd = 'python -u '
 
-        if(env.RECREATE_VOLUME.toBoolean()) {
+        if(env.RECREATE_VOLUME?.toBoolean()) {
             palSh("${pythonCmd} ${INCREMENTAL_BUILD_SCRIPT_PATH} --action delete --project ${projectName} --pipeline ${pipeline} --branch ${branchName} --platform ${platform} --build_type ${buildType}", 'Deleting volume')
         }
         timeout(5) {
@@ -291,7 +291,7 @@ def PreBuildCommonSteps(Map pipelineConfig, String projectName, String pipeline,
 
     // Cleanup previous repo location, we are currently at the root of the workspace, if we have a .git folder
     // we need to cleanup. Once all branches take this relocation, we can remove this
-    if(env.CLEAN_WORKSPACE.toBoolean() || fileExists("${workspace}/.git")) {
+    if(env.CLEAN_WORKSPACE?.toBoolean() || fileExists("${workspace}/.git")) {
         if(fileExists(workspace)) {
             palRmDir(workspace)
         }
@@ -315,7 +315,7 @@ def PreBuildCommonSteps(Map pipelineConfig, String projectName, String pipeline,
                 script: 'python/get_python.bat'
         }
 
-        if(env.CLEAN_OUTPUT_DIRECTORY.toBoolean() || env.CLEAN_ASSETS.toBoolean()) {
+        if(env.CLEAN_OUTPUT_DIRECTORY?.toBoolean() || env.CLEAN_ASSETS?.toBoolean()) {
             def command = "${pipelineConfig.BUILD_ENTRY_POINT} --platform ${platform} --type clean"
             if (env.IS_UNIX) {
                 sh label: "Running ${platform} clean",
@@ -457,7 +457,7 @@ try {
         }
     }
 
-    if(env.BUILD_NUMBER == '1') {
+    if(env.BUILD_NUMBER == '1' && !branchName.startsWith('PR-')) {
         // Exit pipeline early on the intial build. This allows Jenkins to load the pipeline for the branch and enables users
         // to select build parameters on their first actual build. See https://issues.jenkins.io/browse/JENKINS-41929
         currentBuild.result = 'SUCCESS'


### PR DESCRIPTION
Also add safe navigation operator on parameters. This avoids encoutering NullPointerException when accessing build parameters on the first build since these values will be set to null.

This change prevents the pipeline from skipping the build and reporting success on the first build. This is no longer required in GitHub.

This still allows branch builds to only load the parameters on the initial run for testing selective platforms.

Testing:

- Branch build in the fork repo still only loaded parameters on the first run
- PR build for this pull request ran the full build on the first run
