### PR TITLE
Cherry-pick: Fix context menu popping up in EditorViewportWidget when it shouldn't

### DIFF
--- a/Code/Sandbox/Editor/LegacyViewportCameraController.cpp
+++ b/Code/Sandbox/Editor/LegacyViewportCameraController.cpp
@@ -96,6 +96,11 @@ bool LegacyViewportCameraControllerInstance::HandleMouseMove(
         speedScale *= gSettings.cameraFastMoveSpeed;
     }
 
+    if (m_inMoveMode || m_inOrbitMode || m_inRotateMode || m_inZoomMode)
+    {
+        m_totalMouseMoveDelta += (QPoint(currentMousePos.m_x, currentMousePos.m_y)-QPoint(previousMousePos.m_x, previousMousePos.m_y)).manhattanLength();
+    }
+
     if ((m_inRotateMode && m_inMoveMode) || m_inZoomMode)
     {
         Matrix34 m = AZTransformToLYTransform(viewportContext->GetCameraTransform());
@@ -343,11 +348,15 @@ bool LegacyViewportCameraControllerInstance::HandleInputChannelEvent(const AzFra
             }
 
             shouldCaptureCursor = true;
+            // Record how much the cursor has been moved to see if we should own the mouse up event.
+            m_totalMouseMoveDelta = 0;
         }
         else if (state == InputChannel::State::Ended)
         {
             m_inZoomMode = false;
             m_inRotateMode = false;
+            // If we've moved the cursor more than a couple pixels, we should eat this mouse up event to prevent the context menu controller from seeing it.
+            shouldConsumeEvent = m_totalMouseMoveDelta > 2;
             shouldCaptureCursor = false;
         }
     }

--- a/Code/Sandbox/Editor/LegacyViewportCameraController.h
+++ b/Code/Sandbox/Editor/LegacyViewportCameraController.h
@@ -58,6 +58,7 @@ namespace SandboxEditor
         bool m_inMoveMode = false;
         bool m_inOrbitMode = false;
         bool m_inZoomMode = false;
+        int m_totalMouseMoveDelta = 0;
         float m_orbitDistance = 10.f;
         float m_moveSpeed = 1.f;
         AZ::Vector3 m_orbitTarget = {};


### PR DESCRIPTION
Accidentally left this out of the enable patch earlier, and it's **super annoying**, apologies!