### PR TITLE
[LYN-2772] Adding White Box Component to an Entity silently crashes the Editor

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
@@ -100,12 +100,12 @@ namespace AZ
                 bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
                 break;
             case CommonBufferPoolType::StaticInputAssembly:
-                bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
+                bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::ShaderRead;
                 bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
                 bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
                 break;
             case CommonBufferPoolType::DynamicInputAssembly:
-                bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::DynamicInputAssembly;
+                bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::DynamicInputAssembly | RHI::BufferBindFlags::ShaderRead;
                 bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
                 bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
                 break;

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxBuffer.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxBuffer.h
@@ -98,7 +98,7 @@ namespace WhiteBox
 
         // specify the data format for vertex stream data
         AZ::RHI::BufferDescriptor bufferDescriptor;
-        bufferDescriptor.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
+        bufferDescriptor.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly | AZ::RHI::BufferBindFlags::ShaderRead;
         bufferDescriptor.m_byteCount = bufferSize;
         bufferDescriptor.m_alignment = elementSize;
 


### PR DESCRIPTION
Added the ShaderRead buffer bind flag to the static and dynamic input assembly pools, and one creation of a static input assembly buffer.