### PR TITLE
SystemComponent is now only built once in the PhysX.Static target

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/SystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/SystemBus.h
@@ -142,13 +142,6 @@ namespace Physics
 
         virtual AZStd::shared_ptr<Shape> CreateShape(const ColliderConfiguration& colliderConfiguration, const ShapeConfiguration& configuration) = 0;
 
-        /// Adds an appropriate collider component to the entity based on the provided shape configuration.
-        /// @param entity Entity where the component should be added to.
-        /// @param colliderConfiguration Configuration of the collider.
-        /// @param shapeConfiguration Configuration of the shape of the collider.
-        /// @param addEditorComponents Tells whether to add the Editor version of the collider component or the Game one.
-        virtual void AddColliderComponentToEntity(AZ::Entity* entity, const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& shapeConfiguration, bool addEditorComponents = false) = 0;
-
         /// Releases the mesh object created by the physics backend.
         /// @param nativeMeshObject Pointer to the mesh object.
         virtual void ReleaseNativeMeshObject(void* nativeMeshObject) = 0;

--- a/Gems/Blast/Code/Tests/Mocks/BlastMocks.h
+++ b/Gems/Blast/Code/Tests/Mocks/BlastMocks.h
@@ -213,9 +213,6 @@ namespace Blast
             CreateShape,
             AZStd::shared_ptr<Physics::Shape>(
                 const Physics::ColliderConfiguration&, const Physics::ShapeConfiguration&));
-        MOCK_METHOD4(
-            AddColliderComponentToEntity,
-            void(AZ::Entity*, const Physics::ColliderConfiguration&, const Physics::ShapeConfiguration&, bool));
         MOCK_METHOD1(ReleaseNativeMeshObject, void(void*));
         MOCK_METHOD1(CreateMaterial, AZStd::shared_ptr<Physics::Material>(const Physics::MaterialConfiguration&));
         MOCK_METHOD0(GetDefaultMaterial, AZStd::shared_ptr<Physics::Material>());

--- a/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
+++ b/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
@@ -33,7 +33,6 @@ namespace Physics
             BusDisconnect();
         }
         MOCK_METHOD2(CreateShape, AZStd::shared_ptr<Physics::Shape>(const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& configuration));
-        MOCK_METHOD4(AddColliderComponentToEntity, void(AZ::Entity* entity, const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& shapeConfiguration, bool addEditorComponents));
         MOCK_METHOD1(ReleaseNativeMeshObject, void(void* nativeMeshObject));
         MOCK_METHOD1(CreateMaterial, AZStd::shared_ptr<Physics::Material>(const Physics::MaterialConfiguration& materialConfiguration));
         MOCK_METHOD0(GetDefaultMaterial, AZStd::shared_ptr<Physics::Material>());

--- a/Gems/PhysX/Code/Editor/EditorWindow.cpp
+++ b/Gems/PhysX/Code/Editor/EditorWindow.cpp
@@ -15,6 +15,7 @@
 #include <AzFramework/Physics/CollisionBus.h>
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/Configuration/CollisionConfiguration.h>
+#include <AzFramework/Physics/Configuration/SceneConfiguration.h>
 #include <AzToolsFramework/API/ViewPaneOptions.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <LyViewPaneNames.h>
@@ -23,6 +24,8 @@
 #include <Editor/EditorWindow.h>
 #include <Editor/ConfigurationWidget.h>
 #include <System/PhysXSystem.h>
+#include <PhysX/Configuration/PhysXConfiguration.h>
+#include <PhysX/Debug/PhysXDebugConfiguration.h>
 
 namespace PhysX
 {

--- a/Gems/PhysX/Code/Editor/EditorWindow.h
+++ b/Gems/PhysX/Code/Editor/EditorWindow.h
@@ -19,6 +19,7 @@
 namespace AzPhysics
 {
     class CollisionConfiguration;
+    struct SceneConfiguration;
 }
 
 namespace Ui
@@ -28,6 +29,12 @@ namespace Ui
 
 namespace PhysX
 {
+    struct PhysXSystemConfiguration;
+    namespace Debug
+    {
+        struct DebugConfiguration;
+    }
+
     namespace Editor
     {
         /// Window pane wrapper for the PhysX Configuration Widget.

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -18,13 +18,15 @@
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/Collision/CollisionEvents.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
-#include <Editor/ConfigStringLineEditCtrl.h>
-#include <Editor/EditorJointConfiguration.h>
 
 #include <I3DEngine.h>
 #include <IEditor.h>
 #include <ISurfaceType.h>
 
+#include <Editor/ConfigStringLineEditCtrl.h>
+#include <Editor/EditorJointConfiguration.h>
+#include <Editor/EditorWindow.h>
+#include <Editor/PropertyTypes.h>
 #include <System/PhysXSystem.h>
 
 namespace PhysX
@@ -116,18 +118,20 @@ namespace PhysX
         {
             AzPhysics::SceneConfiguration editorWorldConfiguration = physicsSystem->GetDefaultSceneConfiguration();
             editorWorldConfiguration.m_sceneName = AzPhysics::EditorPhysicsSceneName;
-            editorWorldConfiguration.m_sceneName = "EditorScene";
             m_editorWorldSceneHandle = physicsSystem->AddScene(editorWorldConfiguration);
         }
 
         PhysX::RegisterConfigStringLineEditHandler(); // Register custom unique string line edit control
+        PhysX::Editor::RegisterPropertyTypes();
 
+        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
     }
 
     void EditorSystemComponent::Deactivate()
     {
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
+        AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
         Physics::EditorWorldBus::Handler::BusDisconnect();
 
         if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
@@ -162,6 +166,16 @@ namespace PhysX
                 scene->SetEnabled(true);
             }
         }
+    }
+
+    void EditorSystemComponent::PopulateEditorGlobalContextMenu([[maybe_unused]] QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
+    {
+
+    }
+
+    void EditorSystemComponent::NotifyRegisterViews()
+    {
+        PhysX::Editor::EditorWindow::RegisterViewClass();
     }
 
     AZ::Data::AssetId EditorSystemComponent::GenerateSurfaceTypesLibrary()

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.h
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.h
@@ -30,6 +30,7 @@ namespace PhysX
         : public AZ::Component
         , public Physics::EditorWorldBus::Handler
         , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
+        , private AzToolsFramework::EditorEvents::Bus::Handler
     {
     public:
         AZ_COMPONENT(EditorSystemComponent, "{560F08DC-94F5-4D29-9AD4-CDFB3B57C654}");
@@ -59,6 +60,10 @@ namespace PhysX
         // AzToolsFramework::EditorEntityContextNotificationBus
         void OnStartPlayInEditorBegin() override;
         void OnStopPlayInEditor() override;
+
+        // AztoolsFramework::EditorEvents::Bus::Handler
+        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
+        void NotifyRegisterViews() override;
 
         AZ::Data::AssetId GenerateSurfaceTypesLibrary();
 

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -15,37 +15,17 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-#include <AzFramework/Physics/Utils.h>
-#include <AzFramework/Physics/Material.h>
-#include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
-#include <AzFramework/Physics/Configuration/RigidBodyConfiguration.h>
-#include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
-#include <AzFramework/Asset/AssetSystemBus.h>
-#include <AzFramework/API/ApplicationAPI.h>
 #include <PhysX/MeshAsset.h>
 #include <PhysX/HeightFieldAsset.h>
-#include <Source/RigidBody.h>
-#include <Source/RigidBodyStatic.h>
 #include <Source/Utils.h>
 #include <Source/Collision.h>
 #include <Source/Shape.h>
 #include <Source/Joint.h>
-#include <Source/SphereColliderComponent.h>
-#include <Source/BoxColliderComponent.h>
-#include <Source/CapsuleColliderComponent.h>
 #include <Source/Pipeline/MeshAssetHandler.h>
 #include <Source/Pipeline/HeightFieldAssetHandler.h>
 #include <Source/PhysXCharacters/API/CharacterUtils.h>
 #include <Source/PhysXCharacters/API/CharacterController.h>
 #include <Source/WindProvider.h>
-
-#ifdef PHYSX_EDITOR
-#include <Source/EditorColliderComponent.h>
-#include <Editor/EditorWindow.h>
-#include <Editor/PropertyTypes.h>
-#include <AzToolsFramework/SourceControl/SourceControlAPI.h>
-#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
-#endif
 
 #include <PhysX/Debug/PhysXDebugInterface.h>
 #include <System/PhysXSystem.h>
@@ -233,21 +213,11 @@ namespace PhysX
         Physics::CollisionRequestBus::Handler::BusConnect();
         Physics::CharacterSystemRequestBus::Handler::BusConnect();
 
-#ifdef PHYSX_EDITOR
-        PhysX::Editor::RegisterPropertyTypes();
-        AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
-        AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
-#endif
-
         ActivatePhysXSystem();
     }
 
     void SystemComponent::Deactivate()
     {
-#ifdef PHYSX_EDITOR
-        AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
-        AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
-#endif
         AZ::TickBus::Handler::BusDisconnect();
         Physics::CharacterSystemRequestBus::Handler::BusDisconnect();
         Physics::CollisionRequestBus::Handler::BusDisconnect();
@@ -271,19 +241,6 @@ namespace PhysX
         }
         m_assetHandlers.clear(); //this need to be after m_physXSystem->Shutdown(); For it will drop the default material library reference.
     }
-
-#ifdef PHYSX_EDITOR
-
-    // AztoolsFramework::EditorEvents::Bus::Handler overrides
-    void SystemComponent::PopulateEditorGlobalContextMenu([[maybe_unused]] QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
-    {
-    }
-
-    void SystemComponent::NotifyRegisterViews()
-    {
-        PhysX::Editor::EditorWindow::RegisterViewClass();
-    }
-#endif
 
     physx::PxConvexMesh* SystemComponent::CreateConvexMesh(const void* vertices, AZ::u32 vertexNum, AZ::u32 vertexStride)
     {
@@ -461,54 +418,6 @@ namespace PhysX
         if (nativeMeshObject)
         {
             static_cast<physx::PxBase*>(nativeMeshObject)->release();
-        }
-    }
-
-    void SystemComponent::AddColliderComponentToEntity(AZ::Entity* entity, const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& shapeConfiguration, [[maybe_unused]] bool addEditorComponents)
-    {
-        [[maybe_unused]] Physics::ShapeType shapeType = shapeConfiguration.GetShapeType();
-
-#ifdef PHYSX_EDITOR
-        if (addEditorComponents)
-        {
-            entity->CreateComponent<EditorColliderComponent>(colliderConfiguration, shapeConfiguration);
-        }
-        else
-#else
-        {
-            if (shapeType == Physics::ShapeType::Sphere)
-            {
-                const Physics::SphereShapeConfiguration& sphereConfiguration = static_cast<const Physics::SphereShapeConfiguration&>(shapeConfiguration);
-                auto sphereColliderComponent = entity->CreateComponent<SphereColliderComponent>();
-                sphereColliderComponent->SetShapeConfigurationList({ AZStd::make_pair(
-                    AZStd::make_shared<Physics::ColliderConfiguration>(colliderConfiguration),
-                    AZStd::make_shared<Physics::SphereShapeConfiguration>(sphereConfiguration)) });
-            }
-            else if (shapeType == Physics::ShapeType::Box)
-            {
-                const Physics::BoxShapeConfiguration& boxConfiguration = static_cast<const Physics::BoxShapeConfiguration&>(shapeConfiguration);
-                auto boxColliderComponent = entity->CreateComponent<BoxColliderComponent>();
-                boxColliderComponent->SetShapeConfigurationList({ AZStd::make_pair(
-                    AZStd::make_shared<Physics::ColliderConfiguration>(colliderConfiguration),
-                    AZStd::make_shared<Physics::BoxShapeConfiguration>(boxConfiguration)) });
-            }
-            else if (shapeType == Physics::ShapeType::Capsule)
-            {
-                const Physics::CapsuleShapeConfiguration& capsuleConfiguration = static_cast<const Physics::CapsuleShapeConfiguration&>(shapeConfiguration);
-                auto capsuleColliderComponent = entity->CreateComponent<CapsuleColliderComponent>();
-                capsuleColliderComponent->SetShapeConfigurationList({ AZStd::make_pair(
-                    AZStd::make_shared<Physics::ColliderConfiguration>(colliderConfiguration),
-                    AZStd::make_shared<Physics::CapsuleShapeConfiguration>(capsuleConfiguration)) });
-            }
-        }
-
-        AZ_Error("PhysX System", !addEditorComponents, "AddColliderComponentToEntity(): Trying to add an Editor collider component in a stand alone build.",
-            static_cast<AZ::u8>(shapeType));
-
-#endif
-        {
-            AZ_Error("PhysX System", shapeType == Physics::ShapeType::Sphere || shapeType == Physics::ShapeType::Box || shapeType == Physics::ShapeType::Capsule,
-                "AddColliderComponentToEntity(): Using Shape of type %d is not implemented.", static_cast<AZ::u8>(shapeType));
         }
     }
 

--- a/Gems/PhysX/Code/Source/SystemComponent.h
+++ b/Gems/PhysX/Code/Source/SystemComponent.h
@@ -36,9 +36,6 @@
 #include <DefaultWorldComponent.h>
 #include <Material.h>
 
-#ifdef PHYSX_EDITOR
-#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
-#endif
 namespace AzPhysics
 {
     struct StaticRigidBodyConfiguration;
@@ -61,10 +58,6 @@ namespace PhysX
         , public Physics::SystemRequestBus::Handler
         , public PhysX::SystemRequestsBus::Handler
         , public Physics::CharacterSystemRequestBus::Handler
-#ifdef PHYSX_EDITOR
-        , public AzToolsFramework::EditorEntityContextNotificationBus::Handler
-        , private AzToolsFramework::EditorEvents::Bus::Handler
-#endif
         , private Physics::CollisionRequestBus::Handler
         , private AZ::TickBus::Handler
     {
@@ -100,8 +93,6 @@ namespace PhysX
         bool CookTriangleMeshToMemory(const AZ::Vector3* vertices, AZ::u32 vertexCount,
             const AZ::u32* indices, AZ::u32 indexCount, AZStd::vector<AZ::u8>& result) override;
 
-        void AddColliderComponentToEntity(AZ::Entity* entity, const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& shapeConfiguration, bool addEditorComponents = false) override;
-
         physx::PxFilterData CreateFilterData(const AzPhysics::CollisionLayer& layer, const AzPhysics::CollisionGroup& group) override;
         physx::PxCooking* GetCooking() override;
 
@@ -124,13 +115,6 @@ namespace PhysX
         void Init() override;
         void Activate() override;
         void Deactivate() override;
-
-#ifdef PHYSX_EDITOR
-
-        // AztoolsFramework::EditorEvents::Bus::Handler overrides
-        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
-        void NotifyRegisterViews() override;
-#endif
 
         // Physics::SystemRequestBus::Handler
         AZStd::shared_ptr<Physics::Shape> CreateShape(const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& configuration) override;

--- a/Gems/PhysX/Code/physx_editor_shared_files.cmake
+++ b/Gems/PhysX/Code/physx_editor_shared_files.cmake
@@ -11,6 +11,4 @@
 
 set(FILES
     Source/Module.cpp
-    Source/SystemComponent.cpp
-    Source/SystemComponent.h
 )

--- a/Gems/PhysX/Code/physx_editor_tests_files.cmake
+++ b/Gems/PhysX/Code/physx_editor_tests_files.cmake
@@ -11,8 +11,6 @@
 
 set(FILES
     Source/Module.cpp
-    Source/SystemComponent.cpp
-    Source/SystemComponent.h
     Tests/PhysXTestCommon.cpp
     Tests/PhysXTestCommon.h
     Tests/ColliderScalingTests.cpp

--- a/Gems/PhysX/Code/physx_files.cmake
+++ b/Gems/PhysX/Code/physx_files.cmake
@@ -12,6 +12,8 @@
 set(FILES
     Source/PhysX_precompiled.cpp
     Source/PhysX_precompiled.h
+    Source/SystemComponent.cpp
+    Source/SystemComponent.h
     Include/PhysX/SystemComponentBus.h
     Include/PhysX/ColliderComponentBus.h
     Include/PhysX/NativeTypeIdentifiers.h

--- a/Gems/PhysX/Code/physx_shared_files.cmake
+++ b/Gems/PhysX/Code/physx_shared_files.cmake
@@ -11,8 +11,6 @@
 
 set(FILES
     Source/Module.cpp
-    Source/SystemComponent.cpp
-    Source/SystemComponent.h
     Source/ComponentDescriptors.cpp
     Source/ComponentDescriptors.h
 )

--- a/Gems/PhysX/Code/physx_tests_files.cmake
+++ b/Gems/PhysX/Code/physx_tests_files.cmake
@@ -10,8 +10,6 @@
 #
 
 set(FILES
-    Source/SystemComponent.cpp
-    Source/SystemComponent.h
     Source/ComponentDescriptors.cpp
     Source/ComponentDescriptors.h
     Tests/PhysXComponentBusTests.cpp


### PR DESCRIPTION
The SystemComponent had PHYSX_EDITOR defines in it which i've refactored to be able to remove, so the component is only built once in the static lib instead of in most of the PhysX projects.