### PR TITLE
ATOM-15240 Fixing thumbnails attempting to use a feature processor that no longer exists

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Thumbnails/Rendering/ThumbnailRendererSteps/InitializeStep.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Thumbnails/Rendering/ThumbnailRendererSteps/InitializeStep.cpp
@@ -54,8 +54,9 @@ namespace AZ
                 RPI::SceneDescriptor sceneDesc;
                 sceneDesc.m_featureProcessorNames.push_back("AZ::Render::TransformServiceFeatureProcessor");
                 sceneDesc.m_featureProcessorNames.push_back("AZ::Render::MeshFeatureProcessor");
+                sceneDesc.m_featureProcessorNames.push_back("AZ::Render::SimplePointLightFeatureProcessor");
+                sceneDesc.m_featureProcessorNames.push_back("AZ::Render::SimpleSpotLightFeatureProcessor");
                 sceneDesc.m_featureProcessorNames.push_back("AZ::Render::PointLightFeatureProcessor");
-                sceneDesc.m_featureProcessorNames.push_back("AZ::Render::SpotLightFeatureProcessor");
                 // There is currently a bug where having multiple DirectionalLightFeatureProcessors active can result in shadow flickering [ATOM-13568]
                 // as well as continually rebuilding MeshDrawPackets [ATOM-13633]. Lets just disable the directional light FP for now.
                 // Possibly re-enable with [GFX TODO][ATOM-13639] 


### PR DESCRIPTION
Adding simple point and simple spot feature processors to the thumbnail scene descriptor.

(cherry picked from commit 243af5f697155ff8489d0a310ceaae1bd84eb90b)