### PR TITLE
Fix EditorViewportWidget stealing keyboard focus

### DIFF
--- a/Code/Sandbox/Editor/EditorViewportWidget.cpp
+++ b/Code/Sandbox/Editor/EditorViewportWidget.cpp
@@ -1617,11 +1617,6 @@ void EditorViewportWidget::keyPressEvent(QKeyEvent* event)
     // because we want the movement to be butter smooth.
     if (!event->isAutoRepeat())
     {
-        if (m_keyDown.isEmpty())
-        {
-            grabKeyboard();
-        }
-
         m_keyDown.insert(event->key());
     }
 


### PR DESCRIPTION
grabKeyboard was used by CRenderViewport to ensure it received some events, but that logic is no longer needed and the corresponding release was removed. This just removes grabKeyboard entirely - eventually all input event logic will be removed as well.