### PR TITLE
Integrating a PR for a customer. Shrink shared data in Importer to re…

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/Importer.cpp
@@ -597,6 +597,7 @@ namespace EMotionFX
         // get rid of shared data
         ResetSharedData(sharedData);
         sharedData.Clear();
+        sharedData.Shrink();
 
         return motion;
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionInstancePool.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionInstancePool.cpp
@@ -220,7 +220,7 @@ namespace EMotionFX
             //mPool->mFreeList.Reserve( numInstances * 2 );
             if (mPool->mFreeList.GetMaxLength() < mPool->mNumInstances)
             {
-                mPool->mFreeList.Reserve(mPool->mNumInstances);
+                mPool->mFreeList.Reserve(mPool->mNumInstances + mPool->mFreeList.GetMaxLength() / 2);
             }
 
             mPool->mFreeList.ResizeFast(startIndex + numInstances);

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/ActorAsset.cpp
@@ -78,6 +78,7 @@ namespace EMotionFX
 
             // Note: Render actor depends on the mesh asset, so we need to manually create it after mesh asset has been loaded.
 
+            assetData->ReleaseEmotionFXData();
             return static_cast<bool>(assetData->m_emfxActor);
         }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/AnimGraphAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/AnimGraphAsset.cpp
@@ -90,6 +90,7 @@ namespace EMotionFX
                 }
             }
 
+            assetData->ReleaseEmotionFXData();
             AZ_Error("EMotionFX", assetData->m_emfxAnimGraph, "Failed to initialize anim graph asset %s", asset.GetHint().c_str());
             return static_cast<bool>(assetData->m_emfxAnimGraph);
         }

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/AssetCommon.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/AssetCommon.h
@@ -36,6 +36,12 @@ namespace EMotionFX
                 : AZ::Data::AssetData(id)
             {}
 
+            void ReleaseEmotionFXData()
+            {
+                m_emfxNativeData.clear();
+                m_emfxNativeData.shrink_to_fit();
+            }
+
             AZStd::vector<AZ::u8> m_emfxNativeData;
         };
 

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/MotionAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/MotionAsset.cpp
@@ -47,6 +47,7 @@ namespace EMotionFX
                 assetData->m_emfxMotion->SetIsOwnedByRuntime(true);
             }
 
+            assetData->ReleaseEmotionFXData();
             AZ_Error("EMotionFX", assetData->m_emfxMotion, "Failed to initialize motion asset %s", asset.GetHint().c_str());
             return (assetData->m_emfxMotion);
         }

--- a/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Assets/MotionSetAsset.cpp
@@ -232,6 +232,7 @@ namespace EMotionFX
             // Set motion set's motion load callback, so if EMotion FX queries back for a motion,
             // we can pull the one managed through an AZ::Asset.
             assetData->m_emfxMotionSet->SetCallback(aznew CustomMotionSetCallback(asset));
+            assetData->ReleaseEmotionFXData();
 
             return true;
         }


### PR DESCRIPTION
Integrating a PR for a customer:
- Shrink shared data in Importer to reclaim some memory. 
- Change reservation strategy in MotionInstancePool to reduce fragmentation. 
- Released unused raw asset data in EmotionFX asset to reclaim memory after asset initialization.