### PR TITLE
Fixed LYN-2998

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -491,6 +491,14 @@ namespace AzToolsFramework
 
         EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnStartPlayInEditorBegin);
 
+        //cache the current selected entities.
+        ToolsApplicationRequests::Bus::BroadcastResult(m_selectedBeforeStartingGame, &ToolsApplicationRequests::GetSelectedEntities);
+        //deselect entities if selected when entering game mode before deactivating the entities in StartPlayInEditor(...)
+        if (!m_selectedBeforeStartingGame.empty())
+        {
+            ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::MarkEntitiesDeselected, m_selectedBeforeStartingGame);
+        }
+
         if (m_isLegacySliceService)
         {
             SliceEditorEntityOwnershipService* editorEntityOwnershipService =
@@ -506,8 +514,6 @@ namespace AzToolsFramework
         }
 
         m_isRunningGame = true;
-
-        ToolsApplicationRequests::Bus::BroadcastResult(m_selectedBeforeStartingGame, &ToolsApplicationRequests::GetSelectedEntities);
 
         EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnStartPlayInEditor);
     }

--- a/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
@@ -686,8 +686,14 @@ namespace PhysX
     {
         if (auto* physXSystem = GetPhysXSystem())
         {
-            physXSystem->RegisterSystemConfigurationChangedEvent(m_physXConfigChangedHandler);
-            physXSystem->RegisterOnDefaultMaterialLibraryChangedEventHandler(m_onDefaultMaterialLibraryChangedEventHandler);
+            if (!m_physXConfigChangedHandler.IsConnected())
+            {
+                physXSystem->RegisterSystemConfigurationChangedEvent(m_physXConfigChangedHandler);
+            }
+            if (!m_onDefaultMaterialLibraryChangedEventHandler.IsConnected())
+            {
+                physXSystem->RegisterOnDefaultMaterialLibraryChangedEventHandler(m_onDefaultMaterialLibraryChangedEventHandler);
+            }
         }
     }
 

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/EditorCharacterControllerComponent.cpp
@@ -149,7 +149,10 @@ namespace PhysX
     {
         if (auto* physXSystem = GetPhysXSystem())
         {
-            physXSystem->RegisterSystemConfigurationChangedEvent(m_physXConfigChangedHandler);
+            if (!m_physXConfigChangedHandler.IsConnected())
+            {
+                physXSystem->RegisterSystemConfigurationChangedEvent(m_physXConfigChangedHandler);
+            }
         }
     }
 


### PR DESCRIPTION
added protections around physx AZ::Events handlers that are connected/disconnected on selection events.
fixed entities not being deselected when entering game mode in editor.