### PR TITLE
Fixed Mac compile issue.

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -249,7 +249,7 @@ namespace AZ
             bool m_showTimeline = false;
 
             // Controls how often the timestamp data is refreshed
-            RefreshType m_refreshType = RefreshType::OncePerSecond;
+            RefreshType m_refreshType = RefreshType::Realtime;
             AZStd::sys_time_t m_lastUpdateTimeMicroSecond;
 
         };

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -16,6 +16,8 @@
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 
+#include <inttypes.h>
+
 namespace AZ
 {
     namespace Render
@@ -725,7 +727,7 @@ namespace AZ
                                     ImGui::BeginTooltip();
                                     ImGui::Text("Name: %s", passEntry->m_name.GetCStr());
                                     ImGui::Text("Path: %s", passEntry->m_path.GetCStr());
-                                    ImGui::Text("Duration in ticks: %lu", passEntry->m_timestampResult.GetDurationInTicks());
+                                    ImGui::Text("Duration in ticks: %" PRIu64, passEntry->m_timestampResult.GetDurationInTicks());
                                     ImGui::Text("Duration in microsecond: %.3f us", passEntry->m_timestampResult.GetDurationInNanoseconds()/1000.f);
                                     ImGui::EndTooltip();
                                 }


### PR DESCRIPTION
Set default refresh type to realtime (due to a known issue with OncePerSecond with ASV)