### PR TITLE
[LYN-2942] Editor crashes when creating a new level

### DIFF
--- a/AutomatedTesting/ShaderLib/raytracingscenesrg.srgi
+++ b/AutomatedTesting/ShaderLib/raytracingscenesrg.srgi
@@ -1,0 +1,28 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+
+#pragma once
+
+// Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
+// located in this folder (And how you can optionally customize your own scenesrg.srgi
+// and viewsrg.srgi in your game project).
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+partial ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
+{
+/* Intentionally Empty. Helps define the SrgSemantic for RayTracingSceneSrg once.*/
+};
+
+#define AZ_COLLECTING_PARTIAL_SRGS
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/RayTracingSceneSrgAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -66,6 +66,7 @@ namespace AZ
             // load the RayTracingSceneSrg asset
             Data::Asset<RPI::ShaderResourceGroupAsset> rayTracingSceneSrgAsset =
                 RPI::AssetUtils::LoadAssetByProductPath<RPI::ShaderResourceGroupAsset>("shaderlib/raytracingscenesrg_raytracingscenesrg.azsrg", RPI::AssetUtils::TraceLevel::Error);
+            AZ_Assert(rayTracingSceneSrgAsset.IsReady(), "Failed to load RayTracingSceneSrg asset");
 
             m_rayTracingSceneSrg = RPI::ShaderResourceGroup::Create(rayTracingSceneSrgAsset);
         }

--- a/Templates/DefaultProject/Template/ShaderLib/raytracingscenesrg.srgi
+++ b/Templates/DefaultProject/Template/ShaderLib/raytracingscenesrg.srgi
@@ -1,0 +1,28 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+
+#pragma once
+
+// Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
+// located in this folder (And how you can optionally customize your own scenesrg.srgi
+// and viewsrg.srgi in your game project).
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+partial ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
+{
+/* Intentionally Empty. Helps define the SrgSemantic for RayTracingSceneSrg once.*/
+};
+
+#define AZ_COLLECTING_PARTIAL_SRGS
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/RayTracingSceneSrgAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRGS


### PR DESCRIPTION
Added raytracingscenesrg.srgi to the default project template and  AutomatedTesting project.
Added assert to check for successful load of the raytracingscenesrg asset.