### PR TITLE
[ATOM-15269] disabling source control thumbnails in material editor

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialBrowserWidget.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialBrowserWidget.cpp
@@ -73,7 +73,7 @@ namespace MaterialEditor
         m_filterModel->SetFilter(CreateFilter());
 
         m_ui->m_assetBrowserTreeViewWidget->setModel(m_filterModel);
-        m_ui->m_assetBrowserTreeViewWidget->SetShowSourceControlIcons(true);
+        m_ui->m_assetBrowserTreeViewWidget->SetShowSourceControlIcons(false);
         m_ui->m_assetBrowserTreeViewWidget->setSelectionMode(QAbstractItemView::SelectionMode::ExtendedSelection);
 
         // Maintains the tree expansion state between runs


### PR DESCRIPTION
https://jira.agscollab.com/browse/ATOM-15269
Source control thumbnails in Material Editor are causing "Missing Icon" thumbnail to draw on top of other thumbnails. We should probably remove source control thumbnails from the rest of the editor, since the only reason they were added was to support legacy Material Editor.