### PR TITLE
ATOM-5921 Material Editor: Select newly created materials in the asset browser 

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialBrowserWidget.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialBrowserWidget.cpp
@@ -10,36 +10,32 @@
 *
 */
 
-#include <AzQtComponents/Utilities/DesktopUtilities.h>
-
-#include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
-#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
-#include <AzToolsFramework/AssetBrowser/Search/Filter.h>
-#include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
-#include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
-
-#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
-#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
-
-#include <Atom/Document/MaterialDocumentSystemRequestBus.h>
 #include <Atom/Document/MaterialDocumentRequestBus.h>
+#include <Atom/Document/MaterialDocumentSystemRequestBus.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <Atom/RPI.Reflect/Material/MaterialAsset.h>
+#include <AzQtComponents/Utilities/DesktopUtilities.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserFilterModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserModel.h>
+#include <AzToolsFramework/AssetBrowser/AssetSelectionModel.h>
+#include <AzToolsFramework/AssetBrowser/Search/Filter.h>
+#include <AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h>
 
 #include <Source/Window/MaterialBrowserWidget.h>
-
 #include <Source/Window/ui_MaterialBrowserWidget.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
-#include <QDesktopServices>
-#include <QUrl>
-#include <QMessageBox>
-#include <QMenu>
 #include <QAction>
-#include <QCursor>
-#include <QPushButton>
-#include <QList>
 #include <QByteArray>
+#include <QCursor>
+#include <QDesktopServices>
+#include <QList>
+#include <QMenu>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QUrl>
 AZ_POP_DISABLE_WARNING
 
 namespace MaterialEditor
@@ -99,7 +95,6 @@ namespace MaterialEditor
             }
         });
 
-        AssetBrowserModelNotificationBus::Handler::BusConnect();
         MaterialDocumentNotificationBus::Handler::BusConnect();
     }
 
@@ -108,7 +103,7 @@ namespace MaterialEditor
         // Maintains the tree expansion state between runs
         m_ui->m_assetBrowserTreeViewWidget->SaveState();
         MaterialDocumentNotificationBus::Handler::BusDisconnect();
-        AssetBrowserModelNotificationBus::Handler::BusDisconnect();
+        AZ::TickBus::Handler::BusDisconnect();
     }
 
     AzToolsFramework::AssetBrowser::FilterConstType MaterialBrowserWidget::CreateFilter() const
@@ -151,59 +146,20 @@ namespace MaterialEditor
 
         for (const AssetBrowserEntry* entry : entries)
         {
-            const SourceAssetBrowserEntry* sourceEntry = azrtti_cast<const SourceAssetBrowserEntry*>(entry);
-            if (!sourceEntry)
+            if (entry)
             {
-                const ProductAssetBrowserEntry* productEntry = azrtti_cast<const ProductAssetBrowserEntry*>(entry);
-                if (productEntry)
+                if (AzFramework::StringFunc::Path::IsExtension(entry->GetFullPath().c_str(), MaterialExtension))
                 {
-                    sourceEntry = azrtti_cast<const SourceAssetBrowserEntry*>(productEntry->GetParent());
+                    MaterialDocumentSystemRequestBus::Broadcast(&MaterialDocumentSystemRequestBus::Events::OpenDocument, entry->GetFullPath());
                 }
-            }
-
-            if (sourceEntry)
-            {
-                if (AzFramework::StringFunc::Path::IsExtension(sourceEntry->GetFullPath().c_str(), MaterialExtension))
-                {
-                    MaterialDocumentSystemRequestBus::Broadcast(&MaterialDocumentSystemRequestBus::Events::OpenDocument, sourceEntry->GetFullPath());
-                }
-                else if (AzFramework::StringFunc::Path::IsExtension(sourceEntry->GetFullPath().c_str(), MaterialTypeExtension))
+                else if (AzFramework::StringFunc::Path::IsExtension(entry->GetFullPath().c_str(), MaterialTypeExtension))
                 {
                     //ignore MaterialTypeExtension
                 }
                 else
                 {
-                    QDesktopServices::openUrl(QUrl::fromLocalFile(sourceEntry->GetFullPath().c_str()));
+                    QDesktopServices::openUrl(QUrl::fromLocalFile(entry->GetFullPath().c_str()));
                 }
-            }
-        }
-    }
-
-    void MaterialBrowserWidget::EntryAdded(const AssetBrowserEntry* entry)
-    {
-        if (m_pathToSelect.empty())
-        {
-            return;
-        }
-
-        const SourceAssetBrowserEntry* sourceEntry = azrtti_cast<const SourceAssetBrowserEntry*>(entry);
-        if (!sourceEntry)
-        {
-            const ProductAssetBrowserEntry* productEntry = azrtti_cast<const ProductAssetBrowserEntry*>(entry);
-            if (productEntry)
-            {
-                sourceEntry = azrtti_cast<const SourceAssetBrowserEntry*>(productEntry->GetParent());
-            }
-        }
-
-        if (sourceEntry)
-        {
-            AZStd::string sourcePath = sourceEntry->GetFullPath();
-            AzFramework::StringFunc::Path::Normalize(sourcePath);
-            if (m_pathToSelect == sourcePath)
-            {
-                m_ui->m_assetBrowserTreeViewWidget->SelectFileAtPath(m_pathToSelect);
-                m_pathToSelect.clear();
             }
         }
     }
@@ -214,9 +170,41 @@ namespace MaterialEditor
         MaterialDocumentRequestBus::EventResult(absolutePath, documentId, &MaterialDocumentRequestBus::Events::GetAbsolutePath);
         if (!absolutePath.empty())
         {
+            // Selecting a new asset in the browser is not guaranteed to happen immediately.
+            // The asset browser model notifications are sent before the model is updated.
+            // Instead of relying on the notifications, queue the selection and process it on tick until this change occurs.
             m_pathToSelect = absolutePath;
             AzFramework::StringFunc::Path::Normalize(m_pathToSelect);
-            m_ui->m_assetBrowserTreeViewWidget->SelectFileAtPath(m_pathToSelect);
+            AZ::TickBus::Handler::BusConnect();
+        }
+    }
+
+    void MaterialBrowserWidget::OnTick(float deltaTime, AZ::ScriptTimePoint time)
+    {
+        AZ_UNUSED(time);
+        AZ_UNUSED(deltaTime);
+
+        if (!m_pathToSelect.empty())
+        {
+            // Attempt to select the new path
+            AzToolsFramework::AssetBrowser::AssetBrowserViewRequestBus::Broadcast(
+                &AzToolsFramework::AssetBrowser::AssetBrowserViewRequestBus::Events::SelectFileAtPath, m_pathToSelect);
+
+            // Iterate over the selected entries to verify if the selection was made 
+            for (const AssetBrowserEntry* entry : m_ui->m_assetBrowserTreeViewWidget->GetSelectedAssets())
+            {
+                if (entry)
+                {
+                    AZStd::string sourcePath = entry->GetFullPath();
+                    AzFramework::StringFunc::Path::Normalize(sourcePath);
+                    if (m_pathToSelect == sourcePath)
+                    {
+                        // Once the selection is confirmed, cancel the operation and disconnect
+                        AZ::TickBus::Handler::BusDisconnect();
+                        m_pathToSelect.clear();
+                    }
+                }
+            }
         }
     }
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialBrowserWidget.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialBrowserWidget.h
@@ -13,11 +13,11 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <Atom/Document/MaterialDocumentNotificationBus.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
-#include <AzToolsFramework/AssetBrowser/Search/Filter.h>
 #include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntry.h>
 #include <AzToolsFramework/AssetBrowser/Search/Filter.h>
-#include <Atom/Document/MaterialDocumentNotificationBus.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QWidget>
@@ -25,8 +25,6 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 AZ_POP_DISABLE_WARNING
 
 #endif
-
-
 
 namespace AzToolsFramework
 {
@@ -50,8 +48,8 @@ namespace MaterialEditor
     //! Provides a tree view of all available materials and other assets exposed by the MaterialEditor.
     class MaterialBrowserWidget
         : public QWidget
-        , public AzToolsFramework::AssetBrowser::AssetBrowserModelNotificationBus::Handler
-        , public MaterialDocumentNotificationBus::Handler
+        , protected AZ::TickBus::Handler
+        , protected MaterialDocumentNotificationBus::Handler
     {
         Q_OBJECT
     public:
@@ -62,19 +60,19 @@ namespace MaterialEditor
         AzToolsFramework::AssetBrowser::FilterConstType CreateFilter() const;
         void OpenSelectedEntries();
 
+        // MaterialDocumentNotificationBus::Handler implementation
+        void OnDocumentOpened(const AZ::Uuid& documentId) override;
+
+        // AZ::TickBus::Handler
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+        void OpenOptionsMenu();
+
         QScopedPointer<Ui::MaterialBrowserWidget> m_ui;
         AzToolsFramework::AssetBrowser::AssetBrowserFilterModel* m_filterModel = nullptr;
 
         //! if new asset is being created with this path it will automatically be selected
         AZStd::string m_pathToSelect;
-
-        // AssetBrowserModelNotificationBus::Handler implementation
-        void EntryAdded(const AzToolsFramework::AssetBrowser::AssetBrowserEntry* entry) override;
-
-        // MaterialDocumentNotificationBus::Handler implementation
-        void OnDocumentOpened(const AZ::Uuid& documentId) override;
-
-        void OpenOptionsMenu();
 
         QByteArray m_materialBrowserState;
     };


### PR DESCRIPTION
ATOM-5921 Material Editor: Select newly created materials in the asset browser 

The code was previously using asset browser notifications to listen for new files being added in order to select newly created materials.
Attempting to change the selection within the notification failed because the new entry still had not been added.
Now the material browser queues and processes the selection on tick.

https://jira.agscollab.com/browse/ATOM-5921