### PR TITLE
ATOM-13950 Material Editor: Removing auto select option from lighting and model presets

### DIFF
--- a/AutomatedTesting/LightingPresets/greenwich_park_02.lightingconfig.json
+++ b/AutomatedTesting/LightingPresets/greenwich_park_02.lightingconfig.json
@@ -1,7 +1,6 @@
 {
     "configurations": [
         {
-            "autoSelect": false,
             "displayName": "Greenwich Park 02",
             "skyboxImageAsset": {
                 "assetId": {
@@ -64,7 +63,6 @@
             "shadowCatcherOpacity": 0.20000000298023225
         },
         {
-            "autoSelect": false,
             "displayName": "Greenwich Park 02 (Alt)",
             "skyboxImageAsset": {
                 "assetId": {

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/LightingPreset.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/LightingPreset.h
@@ -78,7 +78,6 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(LightingPreset, AZ::SystemAllocator, 0);
             static void Reflect(AZ::ReflectContext* context);
 
-            bool m_autoSelect = false;
             AZStd::string m_displayName;
             AZ::Data::Asset<AZ::RPI::StreamingImageAsset> m_iblDiffuseImageAsset;
             AZ::Data::Asset<AZ::RPI::StreamingImageAsset> m_iblSpecularImageAsset;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ModelPreset.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ModelPreset.h
@@ -32,7 +32,6 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(ModelPreset, AZ::SystemAllocator, 0);
             static void Reflect(AZ::ReflectContext* context);
 
-            bool m_autoSelect = false;
             AZStd::string m_displayName;
             AZ::Data::Asset<AZ::RPI::ModelAsset> m_modelAsset;
             AZ::Data::Asset<AZ::RPI::StreamingImageAsset> m_previewImageAsset;

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
@@ -112,7 +112,6 @@ namespace AZ
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_displayName, "Display Name", "Identifier used for display and selection")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_autoSelect, "Auto Select", "When true, the configuration is automatically selected when loaded")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_iblDiffuseImageAsset, "IBL Diffuse Image Asset", "IBL diffuse image asset reference")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_iblSpecularImageAsset, "IBL Specular Image Asset", "IBL specular image asset reference")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightingPreset::m_skyboxImageAsset, "Skybox Image Asset", "Skybox image asset reference")

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/EditorModelPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/EditorModelPreset.cpp
@@ -32,7 +32,6 @@ namespace AZ
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &ModelPreset::m_displayName, "Display Name", "Identifier used for display and selection")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &ModelPreset::m_autoSelect, "Auto Select", "When true, the configuration is automatically selected when loaded")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &ModelPreset::m_modelAsset, "Model Asset", "Model asset reference")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &ModelPreset::m_previewImageAsset, "Preview Image Asset", "Preview image asset reference")
                         ;

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/LightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/LightingPreset.cpp
@@ -105,8 +105,7 @@ namespace AZ
                 serializeContext->RegisterGenericType<AZStd::vector<LightConfig>>();
 
                 serializeContext->Class<LightingPreset>()
-                    ->Version(4)
-                    ->Field("autoSelect", &LightingPreset::m_autoSelect)
+                    ->Version(5)
                     ->Field("displayName", &LightingPreset::m_displayName)
                     ->Field("iblDiffuseImageAsset", &LightingPreset::m_iblDiffuseImageAsset)
                     ->Field("iblSpecularImageAsset", &LightingPreset::m_iblSpecularImageAsset)
@@ -128,7 +127,6 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Module, "render")
                     ->Constructor()
                     ->Constructor<const LightingPreset&>()
-                    ->Property("autoSelect", BehaviorValueProperty(&LightingPreset::m_autoSelect))
                     ->Property("displayName", BehaviorValueProperty(&LightingPreset::m_displayName))
                     ->Property("alternateSkyboxImageAsset", BehaviorValueProperty(&LightingPreset::m_alternateSkyboxImageAsset))
                     ->Property("skyboxImageAsset", BehaviorValueProperty(&LightingPreset::m_skyboxImageAsset))

--- a/Gems/Atom/Feature/Common/Code/Source/Utils/ModelPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/ModelPreset.cpp
@@ -25,8 +25,7 @@ namespace AZ
             if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<ModelPreset>()
-                    ->Version(2)
-                    ->Field("autoSelect", &ModelPreset::m_autoSelect)
+                    ->Version(3)
                     ->Field("displayName", &ModelPreset::m_displayName)
                     ->Field("modelAsset", &ModelPreset::m_modelAsset)
                     ->Field("previewImageAsset", &ModelPreset::m_previewImageAsset)
@@ -41,7 +40,6 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Module, "render")
                     ->Constructor()
                     ->Constructor<const ModelPreset&>()
-                    ->Property("autoSelect", BehaviorValueProperty(&ModelPreset::m_autoSelect))
                     ->Property("displayName", BehaviorValueProperty(&ModelPreset::m_displayName))
                     ->Property("modelAsset", BehaviorValueProperty(&ModelPreset::m_modelAsset))
                     ->Property("previewImageAsset", BehaviorValueProperty(&ModelPreset::m_previewImageAsset))

--- a/Gems/Atom/TestData/TestData/LightingPresets/urban_street_02.lightingpreset.azasset
+++ b/Gems/Atom/TestData/TestData/LightingPresets/urban_street_02.lightingpreset.azasset
@@ -3,7 +3,6 @@
     "Version": 1,
     "ClassName": "AZ::Render::LightingPreset",
     "ClassData": {
-        "autoSelect": false,
         "displayName": "Urban Street 02",
         "skyboxImageAsset": {
             "assetId": {

--- a/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/LightingPresets/_TEMPLATE_.lightingconfig.json.template
+++ b/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/LightingPresets/_TEMPLATE_.lightingconfig.json.template
@@ -2,7 +2,6 @@
     "configurations": [
         {
             "displayName": "Substance: <template>",
-            "autoSelect": false,
             "iblSpecularImageFilePath": "materialeditor/lightingpresets/_Substance_/<latlong_image>_iblskyboxcm_iblspecular.exr.streamingimage",
             "iblDiffuseImageFilePath": "materialeditor/lightingpresets/_Substance_/<latlong_image>_iblskyboxcm_ibldiffuse.exr.streamingimage",
             "skyboxFilePath": "materialeditor/lightingpresets/_Substance_/<latlong_image>_iblskyboxcm.exr.streamingimage",
@@ -45,7 +44,6 @@
         },
         {
             "displayName": "Substance: <template> (Alt)",
-            "autoSelect": false,
             "iblSpecularImageFilePath": "materialeditor/lightingpresets/_Substance_/<latlong_image>_iblskyboxcm_iblspecular.exr.streamingimage",
             "iblDiffuseImageFilePath": "materialeditor/lightingpresets/_Substance_/<latlong_image>_iblskyboxcm_ibldiffuse.exr.streamingimage",
             "skyboxFilePath": "materialeditor/lightingpresets/_Substance_/<latlong_image>_iblskyboxcm_ibldiffuse.exr.streamingimage",

--- a/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/LightingPresets/neutral_urban.lightingpreset.azasset
+++ b/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/LightingPresets/neutral_urban.lightingpreset.azasset
@@ -3,7 +3,6 @@
     "Version": 1,
     "ClassName": "AZ::Render::LightingPreset",
     "ClassData": {
-        "autoSelect": true,
         "displayName": "Neutral Urban",
         "iblDiffuseImageAsset": {
             "assetId": {

--- a/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/ViewportModels/Shaderball.modelpreset.azasset
+++ b/Gems/Atom/Tools/MaterialEditor/Assets/MaterialEditor/ViewportModels/Shaderball.modelpreset.azasset
@@ -3,7 +3,6 @@
     "Version": 1,
     "ClassName": "AZ::Render::ModelPreset",
     "ClassData": {
-        "autoSelect": true,
         "displayName": "Shader Ball",
         "modelAsset": {
             "assetId": {

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportComponent.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportComponent.cpp
@@ -278,7 +278,7 @@ namespace MaterialEditor
 
         MaterialViewportNotificationBus::Broadcast(&MaterialViewportNotificationBus::Events::OnLightingPresetAdded, presetPtr);
 
-        if (preset.m_autoSelect || m_lightingPresetVector.size() == 1)
+        if (m_lightingPresetVector.size() == 1)
         {
             SelectLightingPreset(presetPtr);
         }
@@ -373,7 +373,7 @@ namespace MaterialEditor
 
         MaterialViewportNotificationBus::Broadcast(&MaterialViewportNotificationBus::Events::OnModelPresetAdded, presetPtr);
 
-        if (preset.m_autoSelect || m_modelPresetVector.size() == 1)
+        if (m_modelPresetVector.size() == 1)
         {
             SelectModelPreset(presetPtr);
         }
@@ -510,6 +510,13 @@ namespace MaterialEditor
 
     void MaterialViewportComponent::OnCatalogLoaded([[maybe_unused]] const char* catalogFile)
     {
-        AZ::TickBus::QueueFunction([this]() { ReloadContent(); });
+        AZ::TickBus::QueueFunction([this]() {
+            ReloadContent();
+
+            // Automatically select preferred default presets if they exist
+            // We will later data drive this with editor settings
+            SelectLightingPresetByName("Neutral Urban");
+            SelectModelPresetByName("Shader Ball");
+        });
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Assets/EnvHDRi/photo_studio_01.lightingconfig.json
+++ b/Gems/AtomLyIntegration/CommonFeatures/Assets/EnvHDRi/photo_studio_01.lightingconfig.json
@@ -1,7 +1,6 @@
 {
     "configurations": [
         {
-            "autoSelect": false,
             "displayName": "Photo Studio 01",
             "skyboxImageAsset": {
                 "assetId": {
@@ -64,7 +63,6 @@
             "shadowCatcherOpacity": 0.25
         },
         {
-            "autoSelect": false,
             "displayName": "Photo Studio 01 (Alt)",
             "skyboxImageAsset": {
                 "assetId": {


### PR DESCRIPTION
ATOM-13950 Material Editor: Removing auto select option from lighting and model presets

Remove option from presets

Updated code to select current default options

Will data drive default options with editor settings or settings registry in upcoming tasks

https://jira.agscollab.com/browse/ATOM-13950