### PR TITLE
ATOM-15272 Running game with Actor spams asserts in the log resulting in low framerate

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -74,7 +74,8 @@ namespace AZ
 
         const RHI::BufferView* Buffer::GetBufferView() const
         {
-            if(RHI::CheckBitsAny(m_rhiBuffer->GetDescriptor().m_bindFlags, RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::DynamicInputAssembly))
+            if (m_rhiBuffer->GetDescriptor().m_bindFlags == RHI::BufferBindFlags::InputAssembly ||
+                m_rhiBuffer->GetDescriptor().m_bindFlags == RHI::BufferBindFlags::DynamicInputAssembly)
             {
                 
                 AZ_Assert(false, "Input assembly buffer doesn't need a regular buffer view, it requires a stream or index buffer view.");


### PR DESCRIPTION
The condition was setup wrongly when introducing DynamicInputAssembly.