### PR TITLE
EMotionFX: Getting active states from anim graph via script crashes the editor

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.cpp
@@ -378,18 +378,36 @@ namespace EMotionFX
             }
         }
 
+        NodeIndexContainer AnimGraphComponent::s_emptyNodeIndexContainer = {};
         const NodeIndexContainer& AnimGraphComponent::GetActiveStates() const
         {
-            const AZStd::shared_ptr<AnimGraphSnapshot> snapshot = m_animGraphInstance->GetSnapshot();
-            AZ_Error("EMotionFX", snapshot, "Call GetActiveStates function but no snapshot is created for this instance.");
-            return snapshot->GetActiveNodes();
+            if (m_animGraphInstance)
+            {
+                const AZStd::shared_ptr<AnimGraphSnapshot> snapshot = m_animGraphInstance->GetSnapshot();
+                if (snapshot)
+                {
+                    AZ_Warning("EMotionFX", false, "Call GetActiveStates function but no snapshot is created for this instance.");
+                    return snapshot->GetActiveNodes();
+                }
+            }
+
+            return s_emptyNodeIndexContainer;
         }
 
+        MotionNodePlaytimeContainer AnimGraphComponent::s_emptyMotionNodePlaytimeContainer = {};
         const MotionNodePlaytimeContainer& AnimGraphComponent::GetMotionPlaytimes() const
         {
-            const AZStd::shared_ptr<AnimGraphSnapshot> snapshot = m_animGraphInstance->GetSnapshot();
-            AZ_Error("EMotionFX", snapshot, "Call GetActiveStates function but no snapshot is created for this instance.");
-            return snapshot->GetMotionNodePlaytimes();
+            if (m_animGraphInstance)
+            {
+                const AZStd::shared_ptr<AnimGraphSnapshot> snapshot = m_animGraphInstance->GetSnapshot();
+                if (snapshot)
+                {
+                    AZ_Warning("EMotionFX", false, "Call GetActiveStates function but no snapshot is created for this instance.");
+                    return snapshot->GetMotionNodePlaytimes();
+                }
+            }
+
+            return s_emptyMotionNodePlaytimeContainer;
         }
 
         void AnimGraphComponent::UpdateActorExternal(float deltatime)

--- a/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/AnimGraphComponent.h
@@ -155,7 +155,9 @@ namespace EMotionFX
             bool HasSnapshot() const override;
             void CreateSnapshot(bool isAuthoritative) override;
             void SetActiveStates(const NodeIndexContainer& activeStates) override;
+            static NodeIndexContainer s_emptyNodeIndexContainer;
             const NodeIndexContainer& GetActiveStates() const override;
+            static MotionNodePlaytimeContainer s_emptyMotionNodePlaytimeContainer;
             void SetMotionPlaytimes(const MotionNodePlaytimeContainer& motionNodePlaytimes) override;
             const MotionNodePlaytimeContainer& GetMotionPlaytimes() const override;
             void UpdateActorExternal(float deltatime) override;

--- a/Gems/EMotionFX/Code/Tests/AnimGraphNetworkingBusTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphNetworkingBusTests.cpp
@@ -1,0 +1,65 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+
+#include <AzFramework/Components/TransformComponent.h>
+#include <Include/Integration/AnimGraphNetworkingBus.h>
+#include <Integration/Components/ActorComponent.h>
+#include <Integration/Components/AnimGraphComponent.h>
+#include <Tests/Integration/EntityComponentFixture.h>
+
+namespace EMotionFX
+{
+    class AnimGraphNetworkingBusTests
+        : public EntityComponentFixture
+    {
+    public:
+        void SetUp() override
+        {
+            EntityComponentFixture::SetUp();
+
+            m_entity = AZStd::make_unique<AZ::Entity>();
+            m_entityId = AZ::EntityId(740216387);
+            m_entity->SetId(m_entityId);
+
+            m_entity->CreateComponent<AzFramework::TransformComponent>();
+            m_entity->CreateComponent<Integration::ActorComponent>();
+            auto animGraphComponent = m_entity->CreateComponent<Integration::AnimGraphComponent>();
+
+            m_entity->Init();
+
+            m_entity->Activate();
+            AnimGraphInstance* animGraphInstance = animGraphComponent->GetAnimGraphInstance();
+            EXPECT_EQ(animGraphInstance, nullptr) << "Expecting an invalid anim graph instance as no asset has been set.";
+        }
+
+        void TearDown() override
+        {
+            m_entity->Deactivate();
+            EntityComponentFixture::TearDown();
+        }
+
+        AZ::EntityId m_entityId;
+        AZStd::unique_ptr<AZ::Entity> m_entity;
+    };
+
+    TEST_F(AnimGraphNetworkingBusTests, AnimGraphNetworkingBus_GetActiveStates_Test)
+    {
+        NodeIndexContainer result;
+        EMotionFX::AnimGraphComponentNetworkRequestBus::EventResult(result, m_entityId, &EMotionFX::AnimGraphComponentNetworkRequestBus::Events::GetActiveStates);
+    }
+
+    TEST_F(AnimGraphNetworkingBusTests, AnimGraphNetworkingBus_GetMotionPlaytimes_Test)
+    {
+        MotionNodePlaytimeContainer result;
+        EMotionFX::AnimGraphComponentNetworkRequestBus::EventResult(result, m_entityId, &EMotionFX::AnimGraphComponentNetworkRequestBus::Events::GetMotionPlaytimes);
+    }
+} // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/emotionfx_tests_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_tests_files.cmake
@@ -22,6 +22,7 @@ set(FILES
     Tests/AnimGraphActionCommandTests.cpp
     Tests/AnimGraphActionTests.cpp
     Tests/AnimGraphComponentBusTests.cpp
+    Tests/AnimGraphNetworkingBusTests.cpp
     Tests/AnimGraphCopyPasteTests.cpp
     Tests/AnimGraphDeferredInitTests.cpp
     Tests/AnimGraphEventHandlerCounter.h


### PR DESCRIPTION
Cherry picking into upstream/main. Has already been reviewed with https://github.com/aws-lumberyard/o3de/pull/46