### PR TITLE
Add Image as implicit converter for MaterialPropertyValue

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialPropertyValue.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Material/MaterialPropertyValue.h
@@ -65,6 +65,7 @@ namespace AZ
             MaterialPropertyValue(const Vector4& value) : m_value(value) {}
             MaterialPropertyValue(const Color& value) : m_value(value) {}
             MaterialPropertyValue(const Data::Asset<ImageAsset>& value) : m_value(value) {}
+            MaterialPropertyValue(const Data::Instance<Image>& value) : m_value(value) {}
             MaterialPropertyValue(const AZStd::string& value) : m_value(value) {}
 
             //! Copy constructor


### PR DESCRIPTION
This implicit converter makes it easier to use images generated at runtime with MaterialPropertyValue.