### PR TITLE
Added IsReadyToSpawn to SpawnerComponent

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Scripting/SpawnerComponent.h
+++ b/Gems/LmbrCentral/Code/Source/Scripting/SpawnerComponent.h
@@ -70,7 +70,8 @@ namespace LmbrCentral
         AZStd::vector<AzFramework::SliceInstantiationTicket> GetCurrentlySpawnedSlices() override;
         bool HasAnyCurrentlySpawnedSlices() override;
         AZStd::vector<AZ::EntityId> GetCurrentEntitiesFromSpawnedSlice(const AzFramework::SliceInstantiationTicket& ticket) override;
-        AZStd::vector<AZ::EntityId> GetAllCurrentlySpawnedEntities();
+        AZStd::vector<AZ::EntityId> GetAllCurrentlySpawnedEntities() override;
+        bool IsReadyToSpawn() override;
         //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Scripting/SpawnerComponentBus.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Scripting/SpawnerComponentBus.h
@@ -91,6 +91,9 @@ namespace LmbrCentral
         //! Note that spawning is not instant, if a slice hasn't finished spawning then none of its entities are returned.
         //! If an entity has been destroyed since it was spawned, its ID is not returned.
         virtual AZStd::vector<AZ::EntityId> GetAllCurrentlySpawnedEntities() = 0;
+
+        //! Returns whether or not the spawner is in a state that's ready to spawn.
+        virtual bool IsReadyToSpawn() = 0;
     };
 
     using SpawnerComponentRequestBus = AZ::EBus<SpawnerComponentRequests>;


### PR DESCRIPTION
Added IsReadyToSpawn so that scripts can tell when a SpawnerComponent is ready to start spawning dynamic slices.  

Also added a small optimization to SetDynamicSliceByAssetId so that it only does work when the asset id changes.