### PR TITLE
3rd Party static libraries need to be public dependencies to work from installed engine.

### DIFF
--- a/Code/Framework/AzCore/CMakeLists.txt
+++ b/Code/Framework/AzCore/CMakeLists.txt
@@ -40,14 +40,13 @@ ly_add_target(
             ${common_dir}
             ${AZ_CORE_RADTELEMETRY_INCLUDE_DIRECTORIES}
     BUILD_DEPENDENCIES
-        PRIVATE
-            3rdParty::zlib
-            3rdParty::zstd
-            3rdParty::cityhash
         PUBLIC
             3rdParty::Lua
             3rdParty::RapidJSON
             3rdParty::RapidXML
+            3rdParty::zlib
+            3rdParty::zstd
+            3rdParty::cityhash
             ${AZ_CORE_RADTELEMETRY_BUILD_DEPENDENCIES}
 )
 ly_add_source_properties(

--- a/Code/Framework/AzFramework/CMakeLists.txt
+++ b/Code/Framework/AzFramework/CMakeLists.txt
@@ -33,12 +33,12 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
+        PUBLIC
+            AZ::GridMate
             3rdParty::md5
             3rdParty::zlib
             3rdParty::zstd
             3rdParty::lz4
-        PUBLIC
-            AZ::GridMate
 )
 
 if(LY_ENABLE_STATISTICAL_PROFILING)

--- a/Code/Framework/GridMate/CMakeLists.txt
+++ b/Code/Framework/GridMate/CMakeLists.txt
@@ -28,8 +28,9 @@ ly_add_target(
             ${pal_dir}
     BUILD_DEPENDENCIES
         PRIVATE
-            3rdParty::OpenSSL
             AZ::AzCore
+        PUBLIC
+            3rdParty::OpenSSL
 )
 
 ly_add_source_properties(


### PR DESCRIPTION
Static libraries need to be marked as public dependencies since when using an installed engine, if an executable(eg. Game launcher) depends on a static library(eg. AzCore) that depends on another static library(eg. 3rdParty lib), then the 3rdParty lib needs to be pulled in when linking the executable to avoid missing symbols.