### PR TITLE
Add lambda function to delete branch EBS volumes on Github branch deletion action

### DIFF
--- a/scripts/build/lambda/delete_branch_ebs.py
+++ b/scripts/build/lambda/delete_branch_ebs.py
@@ -19,6 +19,12 @@ log.setLevel(logging.INFO)
 
 
 def delete_ebs_volumes(repository_name, branch_name):
+    """
+    Delete all EBS volumes that are tagged with repository_name and branch_name
+    :param repository_name: Full repository name.
+    :param branch_name: Branch name that is deleted.
+    :return: Number of EBS volumes that are deleted successfully, number of EBS volumes that are not deleted.
+    """
     success = 0
     failure = 0
     ec2_client = boto3.resource('ec2')


### PR DESCRIPTION
Add lambda function to delete branch EBS volumes on Github branch deletion action.

When a branch is deleted on Github, Github webhook will send a POST request to AWS API Gateway, and API Gateway will trigger the lambda function to validate the POST request and delete EBS volumes of the deleted branch.

Because of a known issue that request body cannot be passed to API Gateway lambda authorizer, we have to validate github webhook request in the lambda function itself.