### PR TITLE
LYN-3001 : Simple Motion component doesn't animate actors

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -205,7 +205,8 @@ namespace AZ
         void Buffer::InitBufferView()
         {
             // Skip buffer view creation for input assembly buffers
-            if(RHI::CheckBitsAny(m_rhiBuffer->GetDescriptor().m_bindFlags, RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::DynamicInputAssembly))
+            if (m_rhiBuffer->GetDescriptor().m_bindFlags == RHI::BufferBindFlags::InputAssembly ||
+                m_rhiBuffer->GetDescriptor().m_bindFlags == RHI::BufferBindFlags::DynamicInputAssembly)
             {
                 return;
             }


### PR DESCRIPTION
Buffers that have InputAssembly bind flags but also have ShaderRead flags should still create buffer views.