### PR TITLE
Test metrics uses both Jenkins endpoints fix

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -360,9 +360,9 @@ def TestMetrics(Map options, String workspace, String branchName, String repoNam
                 userRemoteConfigs: [[url: "${env.MARS_REPO}", name: 'mars', credentialsId: "${env.GITHUB_USER}"]]
             ]
             withCredentials([usernamePassword(credentialsId: "${env.SERVICE_USER}", passwordVariable: 'apitoken', usernameVariable: 'username')]) {
-                def command = "${options.PYTHON_DIR}/python.cmd -u mars/scripts/python/ctest_test_metric_scraper.py" +
+                def command = "${options.PYTHON_DIR}/python.cmd -u mars/scripts/python/ctest_test_metric_scraper.py " +
                               "-e jenkins.creds.user ${username} -e jenkins.creds.pass ${apitoken} " +
-                              "-e jenkins.base_url ${env.JENKINS_URL}" +
+                              "-e jenkins.base_url ${env.JENKINS_URL} " +
                               "${cmakeBuildDir} ${branchName} %BUILD_NUMBER% AR ${configuration} ${repoName} "
                 bat label: "Publishing ${buildJobName} Test Metrics",
                     script: command


### PR DESCRIPTION
AR will now override the Jenkins url endpoint since test metrics will need to be collected from both the source repo and its fork. Testing will be proven with AR.