### PR TITLE
LYN-2772 Atom: Adding White Box Component to an Entity silently crashes the Editor

### DIFF
--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxBuffer.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxBuffer.h
@@ -105,7 +105,7 @@ namespace WhiteBox
         // create the buffer with the specified data
         AZ::RPI::BufferAssetCreator bufferAssetCreator;
         bufferAssetCreator.Begin(AZ::Uuid::CreateRandom());
-        bufferAssetCreator.SetUseCommonPool(AZ::RPI::CommonBufferPoolType::DynamicInputAssembly);
+        bufferAssetCreator.SetUseCommonPool(AZ::RPI::CommonBufferPoolType::StaticInputAssembly);
         bufferAssetCreator.SetBuffer(data.data(), bufferDescriptor.m_byteCount, bufferDescriptor);
         bufferAssetCreator.SetBufferViewDescriptor(m_bufferViewDescriptor);
 


### PR DESCRIPTION
Fixed a buffer creation issue with white box mesh.