### PR TITLE
Custom UV Stream Names in assimp

### DIFF
--- a/Code/Tools/SceneAPI/FbxSceneBuilder/Importers/AssImpUvMapImporter.cpp
+++ b/Code/Tools/SceneAPI/FbxSceneBuilder/Importers/AssImpUvMapImporter.cpp
@@ -44,7 +44,7 @@ namespace AZ
                 SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
                 if (serializeContext)
                 {
-                    serializeContext->Class<AssImpUvMapImporter, SceneCore::LoadingComponent>()->Version(2); // LYN-2576
+                    serializeContext->Class<AssImpUvMapImporter, SceneCore::LoadingComponent>()->Version(3); // LYN-2506
                 }
             }
 


### PR DESCRIPTION
{LYN-2506} AssImp Does Not Preserve Custom UV Stream Names
https://jira.agscollab.com/browse/LYN-2506

manual testing by launching ap and processing lucy.fbx