### PR TITLE
[LYN-3137] Fixed EMFX floating dock widgets not responding to docking events.

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
@@ -2298,6 +2298,12 @@ namespace AzQtComponents
             OptimizedSetParent(dock, mainWindow);
             mainWindow->addDockWidget(Qt::LeftDockWidgetArea, dock);
             dock->show();
+
+            // Make sure we listen for events on the dock widget being put into a floating dock window
+            // because this might be called programmatically, so the dock widget might have never been
+            // parented to our m_mainWindow initially, so it won't already have an event filter,
+            // which will prevent the docking functionality from working.
+            dock->installEventFilter(this);
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/DockWidgetPlugin.cpp
@@ -119,9 +119,7 @@ namespace EMStudio
 
         mDock->setFeatures(features);
 
-        //  mDock->setFloating( true );
         mainWindow->addDockWidget(Qt::RightDockWidgetArea, mDock);
-        mainWindow->setTabPosition(Qt::AllDockWidgetAreas, QTabWidget::North); // put tabs on top?
 
         return mDock;
     }


### PR DESCRIPTION
EMFX exposed a logic error in FancyDocking where if a floating dock widget was created programmatically and had never been parented to the main window yet, then it wouldn't respond to docking events (e.g. dragging) because the event filter never got installed on it. Also removed some code in DockWidgetPlugin that wasn't needed.

Tested docking various panes in EMFX that previously were undockable after being opened as floating. Also ran through docking of normal tools in the Editor.