### PR TITLE
Fix for directional light not having shadows in editor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -1238,6 +1238,8 @@ namespace AZ
 
         void DirectionalLightFeatureProcessor::SetFilterParameterToPass(LightHandle handle, const RPI::View* cameraView)
         {
+            AZ_ATOM_PROFILE_FUNCTION("DirectionalLightFeatureProcessor", "DirectionalLightFeatureProcessor::SetFilterParameterToPass");
+
             if (handle != m_shadowingLightHandle)
             {
                 return;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
@@ -19,6 +19,9 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/containers/vector.h>
+#include <Atom/RPI.Public/ViewportContext.h>
+#include <Atom/RPI.Public/ViewportContextBus.h>
+#include <Atom/RPI.Public/ViewProviderBus.h>
 
 namespace AZ
 {
@@ -586,9 +589,11 @@ namespace AZ
             }
             else
             {
-                Camera::ActiveCameraRequestBus::BroadcastResult(
-                    cameraTransform,
-                    &Camera::ActiveCameraRequestBus::Events::GetActiveCameraTransform);
+                if (const auto& viewportContext = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get()->GetDefaultViewportContext())
+                {
+                    cameraTransform = viewportContext->GetCameraTransform();
+                }
+
             }
             if (cameraTransform == m_lastCameraTransform)
             {


### PR DESCRIPTION
Fix for broken directional shadow maps in the Editor. The old function is deprecated and was returning an identity transform. @NicholasVanSickle provided an alternative that gives the right transform.

Also adding a profile node to a function that is apparently being called every frame.

https://jira.agscollab.com/browse/ATOM-15259
