### PR TITLE
[cherry-pick] Merge pull request #203 Animation Editor: Removing all layouts causes the Animation Editor to be unusable

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.cpp
@@ -1866,6 +1866,12 @@ namespace EMStudio
             // add each layout in the remove menu
             for (uint32 i = 0; i < numLayoutNames; ++i)
             {
+                // User cannot remove the default layout. This layout is referenced in the qrc file, removing it will
+                // cause compiling issue too.
+                if (mLayoutNames[i] == "AnimGraph")
+                {
+                    continue;
+                }
                 QAction* action = removeMenu->addAction(mLayoutNames[i].c_str());
                 connect(action, &QAction::triggered, this, &MainWindow::OnRemoveLayout);
             }


### PR DESCRIPTION
Animation Editor: Removing all layouts causes the Animation Editor to be unusable
https://jira.agscollab.com/browse/LYN-3139

ALREADY REVIEWED at https://github.com/aws-lumberyard/o3de/pull/203