### PR TITLE
Several Dynamic Vegetation automated test updates

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/automatedtesting_shared/editor_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/automatedtesting_shared/editor_test_helper.py
@@ -117,7 +117,8 @@ class EditorTestHelper:
         # Set the viewport back to whatever size it was at the start and restore the pane layout
         general.set_viewport_size(int(self.viewport_size.x), int(self.viewport_size.y))
         general.set_viewport_expansion_policy("AutoExpand")
-        general.set_view_pane_layout(self.viewport_layout)
+        # Temporarily disabling reset of view pane layout: LYN-3120
+        # general.set_view_pane_layout(self.viewport_layout)
         general.update_viewport()
 
         self.log("test finished")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/AltitudeFilter_FilterStageToggle.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/AltitudeFilter_FilterStageToggle.py
@@ -53,6 +53,8 @@ class TestAltitudeFilterFilterStageToggle(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # Create basic vegetation entity
         position = math.Vector3(512.0, 512.0, 32.0)
         asset_path = os.path.join("Slices", "PinkFlower.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/AreaComponentSlices_SliceCreationAndVisibilityToggle.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/AreaComponentSlices_SliceCreationAndVisibilityToggle.py
@@ -59,6 +59,8 @@ class TestAreaComponentsSliceCreationAndVisibilityToggle(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) C2627900 Verifies if a slice containing the Vegetation Layer Spawner component can be created.
         # 2.1) Create basic vegetation entity
         position = math.Vector3(512.0, 512.0, 32.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DistanceBetweenFilterOverrides_InstancesPlantAtSpecifiedRadius.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DistanceBetweenFilterOverrides_InstancesPlantAtSpecifiedRadius.py
@@ -63,6 +63,8 @@ class TestDistanceBetweenFilterComponentOverrides(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) Create a new entity with required vegetation area components
         spawner_center_point = math.Vector3(520.0, 520.0, 32.0)
         asset_path = os.path.join("Slices", "1m_cube.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DistanceBetweenFilter_InstancesPlantAtSpecifiedRadius.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DistanceBetweenFilter_InstancesPlantAtSpecifiedRadius.py
@@ -61,6 +61,8 @@ class TestDistanceBetweenFilterComponent(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) Create a new entity with required vegetation area components
         spawner_center_point = math.Vector3(520.0, 520.0, 32.0)
         asset_path = os.path.join("Slices", "1m_cube.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_DynamicSliceSpawnerWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_DynamicSliceSpawnerWorks.py
@@ -43,6 +43,7 @@ class TestDynamicSliceInstanceSpawner(EditorTestHelper):
             use_terrain=False,
         )
         general.idle_wait(1.0)
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # Grab the UUID that we need for creating an Dynamic Slice Instance Spawner
         dynamic_slice_spawner_uuid = azlmbr.math.Uuid_CreateString('{BBA5CC1E-B4CA-4792-89F7-93711E98FBD1}', 0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_Embedded_E2E.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_Embedded_E2E.py
@@ -65,6 +65,8 @@ class TestDynamicSliceInstanceSpawnerEmbeddedEditor(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) Create a new entity with required vegetation area components and Script Canvas component for launcher test
         center_point = math.Vector3(512.0, 512.0, 32.0)
         asset_path = os.path.join("Slices", "PinkFlower.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_External_E2E.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_External_E2E.py
@@ -65,6 +65,8 @@ class TestDynamicSliceInstanceSpawnerExternalEditor(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) Create a new entity with required vegetation area components and switch the Vegetation Asset List Source
         # Type to External
         entity_position = math.Vector3(512.0, 512.0, 32.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/EmptyInstanceSpawner_EmptySpawnerWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/EmptyInstanceSpawner_EmptySpawnerWorks.py
@@ -43,6 +43,7 @@ class TestEmptyInstanceSpawner(EditorTestHelper):
             use_terrain=False,
         )
         general.idle_wait(1.0)
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # Grab the UUID that we need for creating an Empty Spawner
         empty_spawner_uuid = azlmbr.math.Uuid_CreateString('{23C40FD4-A55F-4BD3-BE5B-DC5423F217C2}', 0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerSpawner_InheritBehaviorFlag.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/LayerSpawner_InheritBehaviorFlag.py
@@ -60,6 +60,8 @@ class TestLayerSpawnerInheritBehavior(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # Create Emitter entity and add the required components
         position = math.Vector3(512.0, 512.0, 32.0)
         emitter_entity = dynveg.create_surface_entity("emitter_entity", position, 16.0, 16.0, 1.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
@@ -61,6 +61,9 @@ class test_MeshBlocker_InstancesBlockedByMesh(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(500.49, 498.69, 46.66)
+        general.set_current_view_rotation(-42.05, 0.00, -36.33)
+
         # Create entity with components "Vegetation Layer Spawner", "Vegetation Asset List", "Box Shape"
         entity_position = math.Vector3(512.0, 512.0, 32.0)
         asset_path = os.path.join("Slices", "PurpleFlower.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/RotationModifierOverrides_InstancesRotateWithinRange.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/RotationModifierOverrides_InstancesRotateWithinRange.py
@@ -90,7 +90,7 @@ class TestRotationModifierOverrides_InstancesRotateWithinRange(EditorTestHelper)
             terrain_texture_resolution=4096,
             use_terrain=False,
         )
-        general.run_console("e_WaterOcean=0")
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # 2) Create vegetation entity and add components
         entity_position = math.Vector3(512.0, 512.0, 32.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/RotationModifier_InstancesRotateWithinRange.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/RotationModifier_InstancesRotateWithinRange.py
@@ -103,7 +103,7 @@ class TestRotationModifier_InstancesRotateWithinRange(EditorTestHelper):
             terrain_texture_resolution=4096,
             use_terrain=False,
         )
-        general.run_console("e_WaterOcean=0")
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # 2) Set up vegetation entities
         asset_path = os.path.join("Slices", "PurpleFlower.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SlopeFilter_FilterStageToggle.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SlopeFilter_FilterStageToggle.py
@@ -17,6 +17,7 @@ import azlmbr.paths
 import azlmbr.editor as editor
 import azlmbr.entity as EntityId
 import azlmbr.components as components
+import azlmbr.legacy.general as general
 
 sys.path.append(os.path.join(azlmbr.paths.devroot, "AutomatedTesting", "Gem", "PythonTests"))
 import automatedtesting_shared.hydra_editor_utils as hydra
@@ -47,6 +48,8 @@ class TestSlopeFilterFilterStageToggle(EditorTestHelper):
             terrain_texture_resolution=4096,
             use_terrain=False,
         )
+
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # Create basic vegetation entity
         position = math.Vector3(512.0, 512.0, 32.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SurfaceMaskFilter_ExclusionList.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SurfaceMaskFilter_ExclusionList.py
@@ -103,6 +103,8 @@ class TestExclusiveSurfaceMasksTag(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) Create entity with components "Vegetation Layer Spawner", "Vegetation Asset List", "Box Shape"
         entity_position = math.Vector3(512.0, 512.0, 32.0)
         asset_path = os.path.join("Slices", "PurpleFlower.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SurfaceMaskFilter_InclusionList.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SurfaceMaskFilter_InclusionList.py
@@ -104,6 +104,8 @@ class TestInclusiveSurfaceMasksTag(EditorTestHelper):
             use_terrain=False,
         )
 
+        general.set_current_view_position(512.0, 480.0, 38.0)
+
         # 2) Create entity with components "Vegetation Layer Spawner", "Vegetation Asset List", "Box Shape"
         entity_position = math.Vector3(512.0, 512.0, 32.0)
         asset_path = os.path.join("Slices", "PurpleFlower.dynamicslice")

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SystemSettings_SectorPointDensity.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SystemSettings_SectorPointDensity.py
@@ -15,6 +15,7 @@ import azlmbr.math as math
 import azlmbr.paths
 import azlmbr.editor as editor
 import azlmbr.bus as bus
+import azlmbr.legacy.general as general
 
 sys.path.append(os.path.join(azlmbr.paths.devroot, "AutomatedTesting", "Gem", "PythonTests"))
 import automatedtesting_shared.hydra_editor_utils as hydra
@@ -51,6 +52,8 @@ class TestSystemSettingsSectorPointDensity(EditorTestHelper):
             terrain_texture_resolution=4096,
             use_terrain=False,
         )
+
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # Create basic vegetation entity
         position = math.Vector3(512.0, 512.0, 32.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SystemSettings_SectorSize.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/SystemSettings_SectorSize.py
@@ -15,6 +15,7 @@ import azlmbr.math as math
 import azlmbr.paths
 import azlmbr.editor as editor
 import azlmbr.bus as bus
+import azlmbr.legacy.general as general
 
 sys.path.append(os.path.join(azlmbr.paths.devroot, "AutomatedTesting", "Gem", "PythonTests"))
 import automatedtesting_shared.hydra_editor_utils as hydra
@@ -47,6 +48,8 @@ class TestSystemSettingsSectorSize(EditorTestHelper):
             terrain_texture_resolution=4096,
             use_terrain=False,
         )
+
+        general.set_current_view_position(512.0, 480.0, 38.0)
 
         # Create basic vegetation entity
         position = math.Vector3(512.0, 512.0, 32.0)


### PR DESCRIPTION
Temporarily disabling reset of view pane layout in editor_test_helper.py teardown (LYN-3120). Updating view of planting area for several DynVeg tests that was changed with the addition of the default level entity.