### PR TITLE
Fixing string interpolation security risk in test metrics

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -361,7 +361,7 @@ def TestMetrics(Map options, String workspace, String branchName, String repoNam
             ]
             withCredentials([usernamePassword(credentialsId: "${env.SERVICE_USER}", passwordVariable: 'apitoken', usernameVariable: 'username')]) {
                 def command = "${options.PYTHON_DIR}/python.cmd -u mars/scripts/python/ctest_test_metric_scraper.py " +
-                              '-e jenkins.creds.user $username -e jenkins.creds.pass $apitoken ' +
+                              '-e jenkins.creds.user %username% -e jenkins.creds.pass %apitoken% ' +
                               "-e jenkins.base_url ${env.JENKINS_URL} " +
                               "${cmakeBuildDir} ${branchName} %BUILD_NUMBER% AR ${configuration} ${repoName} "
                 bat label: "Publishing ${buildJobName} Test Metrics",


### PR DESCRIPTION
Found a security risk with the Jenkins credentials during the test metrics phase. Changed to single quote string interpolation which is recommended by the following source:

https://www.jenkins.io/doc/book/pipeline/jenkinsfile/ - Interpolation of sensitive environment variables

"Should Groovy perform the interpolation, the sensitive value will be injected directly into the arguments of the step, which among other issues, means that the literal value will be visible as an argument to the process on the agent in OS process listings. Using single-quotes instead of double-quotes when referencing these sensitive environment variables prevents this type of leaking."