### PR TITLE
Removing unneeded function

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -139,7 +139,6 @@ namespace AZ
 
             GetLightDataFromFeatureProcessor();
             SetLightBuffersToSRG();
-            SetLightListToSRG();
             SetLightsCountToSRG();
             SetConstantdataToSRG();
 
@@ -185,13 +184,6 @@ namespace AZ
                 m_shaderResourceGroup->SetBuffer(elem.m_lightBufferIndex, elem.m_lightBuffer.get());
                 elem.m_lightBufferIndex.AssertValid();
             }
-        }
-
-        void LightCullingPass::SetLightListToSRG()
-        {
-            auto inputIndex = m_shaderResourceGroup->FindShaderInputBufferIndex(AZ::Name("m_lightList"));
-            [[maybe_unused]] bool succeeded = m_shaderResourceGroup->SetBuffer(inputIndex, m_lightList);
-            AZ_Assert(succeeded, "SetImage failed for light list");
         }
 
         void LightCullingPass::SetLightsCountToSRG()

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.h
@@ -59,7 +59,6 @@ namespace AZ
             void SetLightBuffersToSRG();
             void SetLightsCountToSRG();
             void SetConstantdataToSRG();
-            void SetLightListToSRG();
 
             AZ::RHI::Size GetDepthBufferResolution();
             float CreateTraceValues(const AZ::Vector2& unprojection);


### PR DESCRIPTION
Vicky noted that I didn't need this function because the light list is set in the pass files. 

Light culling and other tests pass fine.

NOJIRA