### PR TITLE
[LYN-3252] EMotion FX: Morph target buffer only found on first Atom mesh

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Actor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Actor.cpp
@@ -3012,17 +3012,22 @@ namespace EMotionFX
                 jointInfo.mStack->InsertDeformer(/*deformerPosition=*/0, morphTargetDeformer);
             }
 
-            // The lod has shared buffers that combine the data from each submesh. These buffers can be accessed through the first submesh in their entirety
-            const AZ::RPI::ModelLodAsset::Mesh& sourceMesh = sourceMeshes[0];
+            // The lod has shared buffers that combine the data from each submesh. In case any of the submeshes has a
+            // morph target buffer view we can access the entire morph target buffer via the buffer asset.
             AZStd::array_view<uint8_t> morphTargetDeltaView;
-            if (const auto* bufferAssetView = sourceMesh.GetSemanticBufferAssetView(AZ::Name("MORPHTARGET_VERTEXDELTAS")))
+            for (const AZ::RPI::ModelLodAsset::Mesh& sourceMesh : sourceMeshes)
             {
-                if (const auto* bufferAsset = bufferAssetView->GetBufferAsset().Get())
+                if (const auto* bufferAssetView = sourceMesh.GetSemanticBufferAssetView(AZ::Name("MORPHTARGET_VERTEXDELTAS")))
                 {
-                    // The buffer of the view is the buffer of the whole LOD, not just the source mesh.
-                    morphTargetDeltaView = bufferAsset->GetBuffer();
+                    if (const auto* bufferAsset = bufferAssetView->GetBufferAsset().Get())
+                    {
+                        // The buffer of the view is the buffer of the whole LOD, not just the source mesh.
+                        morphTargetDeltaView = bufferAsset->GetBuffer();
+                        break;
+                    }
                 }
             }
+
             AZ_Assert(morphTargetDeltaView.data(), "Unable to find MORPHTARGET_VERTEXDELTAS buffer");
             const AZ::RPI::PackedCompressedMorphTargetDelta* vertexDeltas = reinterpret_cast<const AZ::RPI::PackedCompressedMorphTargetDelta*>(morphTargetDeltaView.data());
 


### PR DESCRIPTION
**This PR has already been submitted to upstream/1.0 and been reviewed with PR#279**

We were using the first Atom mesh to check for morph target buffers by getting access to the buffer asset from the buffer asset view. This won't work for models with multiple meshes while the first mesh is not morphed.