### PR TITLE
updating gitignore for python packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ AssetProcessorTemp/**
 [Cc]ache/
 Editor/EditorEventLog.xml
 Editor/EditorLayout.xml
-Tools/**/*egg-info/**
-Tools/**/*egg-link
+**/*egg-info/**
+**/*egg-link
 UserSettings.xml
 [Uu]ser/
 FrameCapture/**


### PR DESCRIPTION
Changes the gitignore file to ignore .egg files everywhere as opposed to just the Tools directory. Tested by attempting to git add a directory that includes egg files.