### PR TITLE
[Cherry-Pick] LYN-3200 EMotionFX: Removing the Motions after corresponding Motionset is removed from the active Animgraph crashes the Editor

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionSetCommands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionSetCommands.cpp
@@ -177,7 +177,7 @@ namespace CommandSystem
         }
 
         // Update unique datas for all anim graph instances using the given motion set.
-        EMotionFX::GetAnimGraphManager().UpdateInstancesUniqueDataUsingMotionSet(motionSet);
+        EMotionFX::GetAnimGraphManager().InvalidateInstanceUniqueDataUsingMotionSet(motionSet);
 
         // Mark the workspace as dirty
         mOldWorkspaceDirtyFlag = GetCommandManager()->GetWorkspaceDirtyFlag();
@@ -260,7 +260,12 @@ namespace CommandSystem
             const AZStd::string commandString = AZStd::string::format("AdjustMotionSet -motionSetID %i -dirtyFlag true", mOldParentSetID);
             GetCommandManager()->ExecuteCommandInsideCommand(commandString, outResult);
         }
-        
+
+        // Update unique datas for all anim graph instances using the given motion set.
+        // After removing a motion set, the used motion set from an anim graph instance will be reset. If we call this function after
+        // RemoveMotionSet, the anim graph instance would hold a nullptr for motion set, and wouldn't be invalidated.
+        EMotionFX::GetAnimGraphManager().InvalidateInstanceUniqueDataUsingMotionSet(motionSet);
+
         // Destroy the motion set.
         EMotionFX::GetMotionManager().RemoveMotionSet(motionSet, true);
 
@@ -277,9 +282,6 @@ namespace CommandSystem
 
             animGraph->RecursiveReinit();
         }
-
-        // Update unique datas for all anim graph instances using the given motion set.
-        EMotionFX::GetAnimGraphManager().UpdateInstancesUniqueDataUsingMotionSet(motionSet);
 
         // Mark the workspace as dirty.
         mOldWorkspaceDirtyFlag = GetCommandManager()->GetWorkspaceDirtyFlag();
@@ -487,7 +489,7 @@ namespace CommandSystem
         }
 
         // Update unique datas for all anim graph instances using the given motion set.
-        EMotionFX::GetAnimGraphManager().UpdateInstancesUniqueDataUsingMotionSet(motionSet);
+        EMotionFX::GetAnimGraphManager().InvalidateInstanceUniqueDataUsingMotionSet(motionSet);
 
         // Return the id of the newly created motion set.
         AZStd::to_string(outResult, motionSet->GetID());
@@ -610,7 +612,7 @@ namespace CommandSystem
         }
 
         // Update unique datas for all anim graph instances using the given motion set.
-        EMotionFX::GetAnimGraphManager().UpdateInstancesUniqueDataUsingMotionSet(motionSet);
+        EMotionFX::GetAnimGraphManager().InvalidateInstanceUniqueDataUsingMotionSet(motionSet);
 
         // Check if we were able to remove all requested motion entries.
         if (!failedToRemoveMotionIdsString.empty())
@@ -806,7 +808,7 @@ namespace CommandSystem
         }
 
         // Update unique datas for all anim graph instances using the given motion set.
-        EMotionFX::GetAnimGraphManager().UpdateInstancesUniqueDataUsingMotionSet(motionSet);
+        EMotionFX::GetAnimGraphManager().InvalidateInstanceUniqueDataUsingMotionSet(motionSet);
 
         // Set the dirty flag.
         const AZStd::string command = AZStd::string::format("AdjustMotionSet -motionSetID %i -dirtyFlag true", motionSetID);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphManager.cpp
@@ -327,7 +327,7 @@ namespace EMotionFX
         }
     }
 
-    void AnimGraphManager::UpdateInstancesUniqueDataUsingMotionSet(EMotionFX::MotionSet* motionSet)
+    void AnimGraphManager::InvalidateInstanceUniqueDataUsingMotionSet(EMotionFX::MotionSet* motionSet)
     {
         // Update unique datas for all anim graph instances that use the given motion set.
         for (EMotionFX::AnimGraphInstance* animGraphInstance : mAnimGraphInstances)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphManager.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphManager.h
@@ -66,7 +66,7 @@ namespace EMotionFX
         bool RemoveAnimGraphInstance(AnimGraphInstance* animGraphInstance, bool delFromMemory = true);
         void RemoveAnimGraphInstances(AnimGraph* animGraph, bool delFromMemory = true);
         void RemoveAllAnimGraphInstances(bool delFromMemory = true);
-        void UpdateInstancesUniqueDataUsingMotionSet(EMotionFX::MotionSet* motionSet);
+        void InvalidateInstanceUniqueDataUsingMotionSet(EMotionFX::MotionSet* motionSet);
 
         size_t GetNumAnimGraphInstances() const                        { MCore::LockGuardRecursive lock(mAnimGraphInstanceLock); return mAnimGraphInstances.size(); }
         AnimGraphInstance* GetAnimGraphInstance(size_t index) const    { MCore::LockGuardRecursive lock(mAnimGraphInstanceLock); return mAnimGraphInstances[index]; }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace1DNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace1DNode.cpp
@@ -75,6 +75,11 @@ namespace EMotionFX
 
     void BlendSpace1DNode::UniqueData::Reset()
     {
+        BlendSpaceNode::ClearMotionInfos(m_motionInfos);
+        m_currentSegment.m_segmentIndex = MCORE_INVALIDINDEX32;
+        m_motionCoordinates.clear();
+        m_sortedMotions.clear();
+
         Invalidate();
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace2DNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace2DNode.cpp
@@ -152,6 +152,13 @@ namespace EMotionFX
 
     void BlendSpace2DNode::UniqueData::Reset()
     {
+        BlendSpaceNode::ClearMotionInfos(m_motionInfos);
+        m_currentTriangle.m_triangleIndex = MCORE_INVALIDINDEX32;
+        m_currentEdge.m_edgeIndex = MCORE_INVALIDINDEX32;
+        m_motionCoordinates.clear();
+        m_normMotionPositions.clear();
+        m_blendInfos.clear();
+
         Invalidate();
     }
 


### PR DESCRIPTION
LYN-3200 EMotionFX: Removing the Motions after corresponding Motionset is removed from the active Animgraph crashes the Editor

