### PR TITLE
ATOM-15326 support for image thumbnails in asset browser and thumbnail widget

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -139,8 +139,11 @@ namespace AzToolsFramework
             }
             else
             {
-                QPixmap pixmap = thumbnail->GetPixmap(size);
-                painter->drawPixmap(point, pixmap.scaled(size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+                // Scaling and centering pixmap within bounds to preserve aspect ratio
+                const QPixmap pixmap = thumbnail->GetPixmap(size).scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                const QSize sizeDelta = size - pixmap.size();
+                const QPoint pointDelta = QPoint(sizeDelta.width() / 2, sizeDelta.height() / 2);
+                painter->drawPixmap(point + pointDelta, pixmap);
             }
             return m_iconSize;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailWidget.cpp
@@ -71,20 +71,12 @@ namespace AzToolsFramework
                 SharedThumbnail thumbnail;
                 ThumbnailerRequestsBus::BroadcastResult(thumbnail, &ThumbnailerRequests::GetThumbnail, m_key, m_contextName.c_str());
                 QPainter painter(this);
-                QPixmap pixmap = thumbnail->GetPixmap();
-                // preserve thumbnail image's ratio, if the widget is wider than the image, center the image hotizontally
-                float aspectRatio = aznumeric_cast<float>(pixmap.width()) / pixmap.height();
-                int originalWidth = width();
-                int originalHeight = height();
-                int realHeight = qMin(aznumeric_cast<int>(originalWidth /aspectRatio), originalHeight);
-                int realWidth = aznumeric_cast<int>(realHeight * aspectRatio);
-                int x = (originalWidth - realWidth) / 2;
-                // pixmap needs to be manually scaled to produce smoother result and avoid looking pixelated
-                // using painter.setRenderHint(QPainter::SmoothPixmapTransform); does not seem to work
-                // Note: there is a potential issue with pixmap.scaled:
-                // it is multithreaded (using global threadPool) and blocking until finished.
-                // A deadlock will happen if global threadPool has no free threads available.
-                painter.drawPixmap(QPoint(x, 0), pixmap.scaled(realWidth, realHeight, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+
+                // Scaling and centering pixmap within bounds to preserve aspect ratio
+                const QPixmap pixmap = thumbnail->GetPixmap().scaled(size(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                const QSize sizeDelta = size() - pixmap.size();
+                const QPoint pointDelta = QPoint(sizeDelta.width() / 2, sizeDelta.height() / 2);
+                painter.drawPixmap(pointDelta, pixmap);
             }
             QWidget::paintEvent(event);
         }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageProcessingModule.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageProcessingModule.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Module/Module.h>
 #include "ImageProcessingSystemComponent.h"
 #include "ImageBuilderComponent.h"
+#include "Thumbnail/ImageThumbnailSystemComponent.h"
 
 namespace ImageProcessingAtom
 {
@@ -28,8 +29,9 @@ namespace ImageProcessingAtom
         {
             // Push results of the components' ::CreateDescriptor() into m_descriptors here.
             m_descriptors.insert(m_descriptors.end(), {
-                    ImageProcessingSystemComponent::CreateDescriptor(), //system component for editor
-                    BuilderPluginComponent::CreateDescriptor(), //builder component for AP
+                    Thumbnails::ImageThumbnailSystemComponent::CreateDescriptor(),
+                    ImageProcessingSystemComponent::CreateDescriptor(), // system component for editor
+                    BuilderPluginComponent::CreateDescriptor(), // builder component for AP
                 });
         }
 
@@ -40,6 +42,7 @@ namespace ImageProcessingAtom
         {
             return AZ::ComponentTypeList{
                 azrtti_typeid<ImageProcessingSystemComponent>(),
+                azrtti_typeid<Thumbnails::ImageThumbnailSystemComponent>(),
             };
         }
     };

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.cpp
@@ -218,12 +218,10 @@ namespace ImageProcessingAtom
         AZ::Data::Asset<AZ::RPI::StreamingImageAsset> imageAsset = Utils::LoadImageAsset(product->GetAssetId());
         IImageObjectPtr image = Utils::LoadImageFromImageAsset(imageAsset);
 
-        AZStd::string productInfo;
-
-        QImage previewImage;
         if (image)
         {
             // Add product image info
+            AZStd::string productInfo;
             GetImageInfoString(imageAsset, productInfo);
 
             m_fileinfo += QStringLiteral("\r\n");
@@ -242,11 +240,11 @@ namespace ImageProcessingAtom
         m_fileinfo += GetFileSize(source->GetFullPath().c_str());
 
         IImageObjectPtr image = IImageObjectPtr(LoadImageFromFile(source->GetFullPath()));
-        AZStd::string sourceInfo;
-        QImage previewImage;
+
         if (image)
         {
             // Add source image info
+            AZStd::string sourceInfo;
             GetImageInfoString(image, sourceInfo);
 
             m_fileinfo += QStringLiteral("\r\n");

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.cpp
@@ -1,0 +1,140 @@
+/*
+ * All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+ * its licensors.
+ *
+ * For complete copyright and license terms please see the LICENSE at the root of this
+ * distribution (the "License"). All use of this software is governed by the License,
+ * or, if provided, by the license below or the license accompanying this file. Do not
+ * remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+#include <AssetBrowser/Thumbnails/ProductThumbnail.h>
+#include <AssetBrowser/Thumbnails/SourceThumbnail.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <QtConcurrent/QtConcurrent>
+#include <Source/ImageLoader/ImageLoaders.h>
+#include <Source/Thumbnail/ImageThumbnail.h>
+
+namespace ImageProcessingAtom
+{
+    namespace Thumbnails
+    {
+        const int ImageThumbnailSize = 200;
+
+        //////////////////////////////////////////////////////////////////////////
+        // ImageThumbnail
+        //////////////////////////////////////////////////////////////////////////
+        ImageThumbnail::ImageThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key, int thumbnailSize)
+            : Thumbnail(key, thumbnailSize)
+        {
+            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.data());
+            if (sourceKey)
+            {
+                bool foundIt = false;
+                AZStd::vector<AZ::Data::AssetInfo> productAssetInfo;
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    foundIt, &AzToolsFramework::AssetSystemRequestBus::Events::GetAssetsProducedBySourceUUID, sourceKey->GetSourceUuid(),
+                    productAssetInfo);
+
+                for (const auto& assetInfo : productAssetInfo)
+                {
+                    m_assetIds.insert(assetInfo.m_assetId);
+                }
+            }
+
+            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.data());
+            if (productKey && productKey->GetAssetType() == AZ::RPI::StreamingImageAsset::RTTI_Type())
+            {
+                m_assetIds.insert(productKey->GetAssetId());
+            }
+
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Handler::BusConnect(key);
+            AzFramework::AssetCatalogEventBus::Handler::BusConnect();
+        }
+
+        ImageThumbnail::~ImageThumbnail()
+        {
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Handler::BusDisconnect();
+            AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
+        }
+
+        void ImageThumbnail::LoadThread()
+        {
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::QueueEvent(
+                AZ::RPI::StreamingImageAsset::RTTI_Type(), &AzToolsFramework::Thumbnailer::ThumbnailerRendererRequests::RenderThumbnail,
+                m_key,
+                m_thumbnailSize);
+            // wait for response from thumbnail renderer
+            m_renderWait.acquire();
+        }
+
+        void ImageThumbnail::ThumbnailRendered(QPixmap& thumbnailImage)
+        {
+            m_pixmap = thumbnailImage;
+            m_renderWait.release();
+        }
+
+        void ImageThumbnail::ThumbnailFailedToRender()
+        {
+            m_state = State::Failed;
+            m_renderWait.release();
+        }
+
+        void ImageThumbnail::OnCatalogAssetChanged([[maybe_unused]] const AZ::Data::AssetId& assetId)
+        {
+            if (m_state == State::Ready && m_assetIds.find(assetId) != m_assetIds.end())
+            {
+                m_state = State::Unloaded;
+                Load();
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        // ImageThumbnailCache
+        //////////////////////////////////////////////////////////////////////////
+        ImageThumbnailCache::ImageThumbnailCache()
+            : ThumbnailCache<ImageThumbnail>()
+        {
+        }
+
+        ImageThumbnailCache::~ImageThumbnailCache() = default;
+
+        int ImageThumbnailCache::GetPriority() const
+        {
+            // Image thumbnails override default source thumbnails, so carry higher priority
+            return 1;
+        }
+
+        const char* ImageThumbnailCache::GetProviderName() const
+        {
+            return ProviderName;
+        }
+
+        bool ImageThumbnailCache::IsSupportedThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key) const
+        {
+            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(key.data());
+            if (sourceKey)
+            {
+                bool foundIt = false;
+                AZ::Data::AssetInfo assetInfo;
+                AZStd::string watchFolder;
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    foundIt, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourceUUID, sourceKey->GetSourceUuid(),
+                    assetInfo, watchFolder);
+
+                if (foundIt)
+                {
+                    AZStd::string ext;
+                    AZ::StringFunc::Path::GetExtension(assetInfo.m_relativePath.c_str(), ext, false);
+                    return IsExtensionSupported(ext.c_str());
+                }
+            }
+
+            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(key.data());
+            return productKey && productKey->GetAssetType() == AZ::RPI::StreamingImageAsset::RTTI_Type();
+        }
+    } // namespace Thumbnails
+} // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnail.h
@@ -1,0 +1,74 @@
+/*
+ * All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+ * its licensors.
+ *
+ * For complete copyright and license terms please see the LICENSE at the root of this
+ * distribution (the "License"). All use of this software is governed by the License,
+ * or, if provided, by the license below or the license accompanying this file. Do not
+ * remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/parallel/binary_semaphore.h>
+#include <AzFramework/Asset/AssetCatalogBus.h>
+#include <AzToolsFramework/Thumbnails/Thumbnail.h>
+#include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
+#endif
+
+namespace ImageProcessingAtom
+{
+    namespace Thumbnails
+    {
+        /**
+         * Custom image thumbnail that detects when an asset changes and updates the thumbnail
+         */
+        class ImageThumbnail
+            : public AzToolsFramework::Thumbnailer::Thumbnail
+            , public AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Handler
+            , public AzFramework::AssetCatalogEventBus::Handler
+        {
+            Q_OBJECT
+        public:
+            ImageThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key, int thumbnailSize);
+            ~ImageThumbnail() override;
+
+            //! AzToolsFramework::ThumbnailerRendererNotificationBus::Handler overrides...
+            void ThumbnailRendered(QPixmap& thumbnailImage) override;
+            void ThumbnailFailedToRender() override;
+
+        protected:
+            void LoadThread() override;
+
+        private:
+            // AzFramework::AssetCatalogEventBus::Handler interface overrides...
+            void OnCatalogAssetChanged(const AZ::Data::AssetId& assetId) override;
+
+            AZStd::binary_semaphore m_renderWait;
+            AZStd::unordered_set<AZ::Data::AssetId> m_assetIds;
+        };
+
+        /**
+         * Cache configuration for large image thumbnails
+         */
+        class ImageThumbnailCache
+            : public AzToolsFramework::Thumbnailer::ThumbnailCache<ImageThumbnail>
+        {
+        public:
+            ImageThumbnailCache();
+            ~ImageThumbnailCache() override;
+
+            int GetPriority() const override;
+            const char* GetProviderName() const override;
+
+            static constexpr const char* ProviderName = "Image Thumbnails";
+
+        protected:
+            bool IsSupportedThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey key) const override;
+        };
+    } // namespace Thumbnails
+} // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
@@ -1,0 +1,180 @@
+/*
+ * All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+ * its licensors.
+ *
+ * For complete copyright and license terms please see the LICENSE at the root of this
+ * distribution (the "License"). All use of this software is governed by the License,
+ * or, if provided, by the license below or the license accompanying this file. Do not
+ * remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+
+#include "ImageProcessing_precompiled.h"
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Utils/Utils.h>
+#include <AzFramework/Asset/AssetSystemBus.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
+#include <AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.h>
+#include <AzToolsFramework/AssetBrowser/Thumbnails/SourceThumbnail.h>
+#include <AzToolsFramework/Thumbnails/ThumbnailContext.h>
+#include <ImageLoader/ImageLoaders.h>
+#include <Processing/ImageConvert.h>
+#include <Processing/ImageToProcess.h>
+#include <Processing/Utils.h>
+#include <Thumbnail/ImageThumbnail.h>
+#include <Thumbnail/ImageThumbnailSystemComponent.h>
+
+namespace ImageProcessingAtom
+{
+    namespace Thumbnails
+    {
+        void ImageThumbnailSystemComponent::Reflect(AZ::ReflectContext* context)
+        {
+            if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serialize->Class<ImageThumbnailSystemComponent, AZ::Component>()
+                    ->Version(0);
+
+                if (AZ::EditContext* ec = serialize->GetEditContext())
+                {
+                    ec->Class<ImageThumbnailSystemComponent>("ImageThumbnailSystemComponent", "System component for image thumbnails.")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true);
+                }
+            }
+        }
+
+        void ImageThumbnailSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+        {
+            provided.push_back(AZ_CRC_CE("ImageThumbnailSystem"));
+        }
+
+        void ImageThumbnailSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+        {
+            incompatible.push_back(AZ_CRC_CE("ImageThumbnailSystem"));
+        }
+
+        void ImageThumbnailSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+        {
+            required.push_back(AZ_CRC_CE("ThumbnailerService"));
+        }
+
+        void ImageThumbnailSystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
+        {
+            AZ_UNUSED(dependent);
+        }
+
+        void ImageThumbnailSystemComponent::Activate()
+        {
+            AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusConnect();
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::Handler::BusConnect(AZ::RPI::StreamingImageAsset::RTTI_Type());
+            SetupThumbnails();
+        }
+
+        void ImageThumbnailSystemComponent::Deactivate()
+        {
+            TeardownThumbnails();
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::Handler::BusDisconnect();
+            AzFramework::ApplicationLifecycleEvents::Bus::Handler::BusDisconnect();
+        }
+
+        void ImageThumbnailSystemComponent::SetupThumbnails()
+        {
+            using namespace AzToolsFramework::Thumbnailer;
+
+            ThumbnailerRequestsBus::Broadcast(
+                &ThumbnailerRequests::RegisterThumbnailProvider, MAKE_TCACHE(Thumbnails::ImageThumbnailCache),
+                ThumbnailContext::DefaultContext);
+        }
+
+        void ImageThumbnailSystemComponent::TeardownThumbnails()
+        {
+            using namespace AzToolsFramework::Thumbnailer;
+
+            ThumbnailerRequestsBus::Broadcast(
+                &ThumbnailerRequests::UnregisterThumbnailProvider, Thumbnails::ImageThumbnailCache::ProviderName,
+                ThumbnailContext::DefaultContext);
+        }
+
+        void ImageThumbnailSystemComponent::OnApplicationAboutToStop()
+        {
+            TeardownThumbnails();
+        }
+
+        bool ImageThumbnailSystemComponent::Installed() const
+        {
+            return true;
+        }
+
+        void ImageThumbnailSystemComponent::RenderThumbnail(
+            AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize)
+        {
+            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(thumbnailKey.data());
+            if (sourceKey)
+            {
+                bool foundIt = false;
+                AZ::Data::AssetInfo assetInfo;
+                AZStd::string watchFolder;
+                AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
+                    foundIt, &AzToolsFramework::AssetSystemRequestBus::Events::GetSourceInfoBySourceUUID, sourceKey->GetSourceUuid(),
+                    assetInfo, watchFolder);
+
+                if (foundIt)
+                {
+                    AZStd::string fullPath;
+                    AZ::StringFunc::Path::Join(watchFolder.c_str(), assetInfo.m_relativePath.c_str(), fullPath);
+                    if (RenerThumbnailFromImage(thumbnailKey, thumbnailSize, IImageObjectPtr(LoadImageFromFile(fullPath))))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(thumbnailKey.data());
+            if (productKey)
+            {
+                if (RenerThumbnailFromImage(thumbnailKey, thumbnailSize, Utils::LoadImageFromImageAsset(productKey->GetAssetId())))
+                {
+                    return;
+                }
+            }
+
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+        }
+
+        bool ImageThumbnailSystemComponent::RenerThumbnailFromImage(
+            AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, IImageObjectPtr previewImage) const
+        {
+            if (!previewImage)
+            {
+                return false;
+            }
+
+            ImageToProcess imageToProcess(previewImage);
+            imageToProcess.ConvertFormat(ePixelFormat_R8G8B8A8);
+            previewImage = imageToProcess.Get();
+
+            AZ::u8* imageBuf = nullptr;
+            AZ::u32 mip = 0;
+            AZ::u32 pitch = 0;
+            previewImage->GetImagePointer(mip, imageBuf, pitch);
+            const AZ::u32 width = previewImage->GetWidth(mip);
+            const AZ::u32 height = previewImage->GetHeight(mip);
+
+            QImage image(imageBuf, width, height, pitch, QImage::Format_RGBA8888);
+
+            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
+                QPixmap::fromImage(image.scaled(QSize(thumbnailSize, thumbnailSize), Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+
+            return true;
+        }
+    } // namespace Thumbnails
+} // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.h
@@ -1,0 +1,59 @@
+/*
+ * All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+ * its licensors.
+ *
+ * For complete copyright and license terms please see the LICENSE at the root of this
+ * distribution (the "License"). All use of this software is governed by the License,
+ * or, if provided, by the license below or the license accompanying this file. Do not
+ * remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzFramework/Application/Application.h>
+#include <AzToolsFramework/Thumbnails/Thumbnail.h>
+#include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
+
+namespace ImageProcessingAtom
+{
+    namespace Thumbnails
+    {
+        //! System component for image thumbnails.
+        class ImageThumbnailSystemComponent
+            : public AZ::Component
+            , public AzFramework::ApplicationLifecycleEvents::Bus::Handler
+            , public AzToolsFramework::Thumbnailer::ThumbnailerRendererRequestBus::Handler
+        {
+        public:
+            AZ_COMPONENT(ImageThumbnailSystemComponent, "{C45D69BB-4A3B-49CF-916B-580F05CAA755}");
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
+            static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+            static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+            static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
+
+        protected:
+            // AZ::Component interface overrides...
+            void Activate() override;
+            void Deactivate() override;
+
+        private:
+            void SetupThumbnails();
+            void TeardownThumbnails();
+
+            // AzFramework::ApplicationLifecycleEvents overrides...
+            void OnApplicationAboutToStop() override;
+
+            // ThumbnailerRendererRequestsBus::Handler interface overrides...
+            bool Installed() const override;
+            void RenderThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize) override;
+
+            bool RenerThumbnailFromImage(
+                AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, IImageObjectPtr previewImage) const;
+        };
+    } // namespace Thumbnails
+} // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/imageprocessing_files.cmake
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/imageprocessing_files.cmake
@@ -133,4 +133,8 @@ set(FILES
     Source/Compressors/CryTextureSquisher/ColorBlockRGBA4x4s.h
     Source/Compressors/CryTextureSquisher/ColorBlockRGBA4x4c.h
     Source/Compressors/CryTextureSquisher/ColorTypes.h
+    Source/Thumbnail/ImageThumbnail.cpp
+    Source/Thumbnail/ImageThumbnail.h
+    Source/Thumbnail/ImageThumbnailSystemComponent.cpp
+    Source/Thumbnail/ImageThumbnailSystemComponent.h
 )


### PR DESCRIPTION
ATOM-15326 support for image thumbnails in asset browser and thumbnail widget

This change adds support for streaming image thumbnails in the asset browser tree and thumbnail widget.

This is a prerequisite for displaying image previews inside of the material inspector.

https://jira.agscollab.com/browse/ATOM-15326

https://jira.agscollab.com/browse/ATOM-14003