### PR TITLE
Enables verbose ctest logging to avoid Jenkins activity timeouts

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/README.txt
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/README.txt
@@ -33,9 +33,6 @@ Assuming CMake is already setup on your operating system, below are some sample 
     mkdir windows_vs2019
     cd windows_vs2019
     cmake .. -G "Visual Studio 16 2019" -A x64 -T host=x64 -DLY_3RDPARTY_PATH="%3RDPARTYPATH%" -DLY_PROJECTS=AutomatedTesting
-NOTE:
-Using the above command also adds EditorPythonTestTools to the PYTHONPATH OS environment variable.
-Additionally, some CTest scripts will add the Python interpreter path to the PYTHON OS environment variable.
 
 To manually install the project in development mode using your own installed Python interpreter:
     cd /path/to/od3e/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools

--- a/Tools/LyTestTools/README.txt
+++ b/Tools/LyTestTools/README.txt
@@ -19,6 +19,10 @@ the following tools:
      A library to manipulate Lumberyard installations
  * Launchers:
      A library to test the game in a variety of platforms
+ * O3DE:
+     Contains various modules to test o3de specific executables
+ * Environment:
+     Contains various modules to assist with environmental dependencies
 
 
 REQUIREMENTS
@@ -38,10 +42,6 @@ Assuming CMake is already setup on your operating system, below are some sample 
     mkdir windows_vs2019
     cd windows_vs2019
     cmake -E time cmake --build . --target ALL_BUILD --config profile
-NOTE:
-Using the above command also adds LyTestTools to the PYTHONPATH OS environment variable.
-Additionally, some CTest scripts will add the Python interpreter path to the PYTHON OS environment variable.
-There is some LyTestTools functionality that will search for these, so feel free to populate them manually.
 
 To manually install the project in development mode using your own installed Python interpreter:
     cd /path/to/lumberyard/dev/Tools/LyTestTools/


### PR DESCRIPTION
Avoids the 30-minute console inactivity timeout that can terminate running tests which have not frozen, though are reporting only to CTest's stdout capture.

This is primarily creating problems for large test modules running in serial in the Periodic and Sandbox suites, as CTest otherwise only outputs after its test-target returns. The flag was added to all test jobs for output consistency.

While this verbosity does make Jenkins logs less simple to read, CTest will still output failure summaries.