### PR TITLE
KEYSTONE USE CASE | Save changes to non-root container entities in the link to the parent instance

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -242,19 +242,6 @@ namespace AzToolsFramework
                 return false;
             }
         }
-        else  
-        {
-            // The template is already loaded, this is the case of either saving as same name or different name(loaded from before).
-            // Update the template with the changes
-            AzToolsFramework::Prefab::PrefabDom dom;
-            bool success = AzToolsFramework::Prefab::PrefabDomUtils::StoreInstanceInPrefabDom(*m_rootInstance, dom);
-            if (!success)
-            {
-                AZ_Error("Prefab", false, "Failed to convert current root instance into a DOM when saving file '%.*s'", AZ_STRING_ARG(filename));
-                return false;
-            }
-            m_prefabSystemComponent->UpdatePrefabTemplate(templateId, dom);
-        }
 
         Prefab::TemplateId prevTemplateId = m_rootInstance->GetTemplateId();
         m_rootInstance->SetTemplateId(templateId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -200,7 +200,7 @@ namespace AzToolsFramework
             }
 
             return context.Report(result,
-                result.GetProcessing() == JSR::Processing::Completed ? "Succesfully loaded instance information for prefab." :
+                result.GetProcessing() == JSR::Processing::Completed ? "Successfully loaded instance information for prefab." :
                 "Failed to load instance information for prefab");
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -230,6 +230,10 @@ namespace AzToolsFramework
                 AZ_Assert(instanceDom.IsObject(), "Link Id '%u' cannot be added because the DOM of the instance is not an object.", m_id);
                 instanceDom.AddMember(rapidjson::StringRef(PrefabDomUtils::LinkIdName), rapidjson::Value().SetUint64(m_id), allocator);
             }
+            else
+            {
+                linkIdReference->get().SetUint64(m_id);
+            }
         }
 
     } // namespace Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -392,12 +392,27 @@ namespace AzToolsFramework
 
                     if (patch.IsArray() && !patch.Empty() && beforeState.IsObject())
                     {
-                        // Update the state of the entity
-                        PrefabUndoEntityUpdate* state = aznew PrefabUndoEntityUpdate(AZStd::to_string(static_cast<AZ::u64>(entityId)));
-                        state->SetParent(parentUndoBatch);
-                        state->Capture(beforeState, afterState, entityId);
+                        if (IsInstanceContainerEntity(entityId) && !IsLevelInstanceContainerEntity(entityId))
+                        {
+                            m_instanceToTemplateInterface->AppendEntityAliasToPatchPaths(patch, entityId);
 
-                        state->Redo();
+                            // Save these changes as patches to the link
+                            PrefabUndoLinkUpdate* linkUpdate =
+                                aznew PrefabUndoLinkUpdate(AZStd::to_string(static_cast<AZ::u64>(entityId)));
+                            linkUpdate->SetParent(parentUndoBatch);
+                            linkUpdate->Capture(patch, owningInstance->get().GetLinkId());
+
+                            linkUpdate->Redo();
+                        }
+                        else
+                        {
+                            // Update the state of the entity
+                            PrefabUndoEntityUpdate* state = aznew PrefabUndoEntityUpdate(AZStd::to_string(static_cast<AZ::u64>(entityId)));
+                            state->SetParent(parentUndoBatch);
+                            state->Capture(beforeState, afterState, entityId);
+
+                            state->Redo();
+                        }
                     }
 
                     // Update the cache


### PR DESCRIPTION
Save all changes directed to non-root container entities in the link to the parent instance. This allows multiple instances of the same prefab to be positioned independently.

Fixes a bug in the level save workflow; saving the level would restore the current root instance, destroying the link information.

Note: Cached World Transform / Parent info for child entities are still modified and saved to the prefab when the container entity's transform is changed. This will be addressed as a separate task since it involved fixing a bug in the serialization system.