### PR TITLE
LYN-2905 Script Canvas: Saving a graph that contains an Item Variable crashes the Editor

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -40,13 +40,22 @@ namespace AZ
                 // Dependent asset references aren't guaranteed to finish loading by the time this asset is serialized, only by
                 // the time this asset load is completed.  But since the data is needed here, we will deliberately block until the
                 // shader asset has finished loading.
-                shaderVariantReference->m_shaderAsset.QueueLoad();
-                shaderVariantReference->m_shaderAsset.BlockUntilLoadComplete();
+                if (shaderVariantReference->m_shaderAsset.QueueLoad())
+                {
+                    shaderVariantReference->m_shaderAsset.BlockUntilLoadComplete();
+                }
 
-                shaderVariantReference->m_shaderOptionGroup = ShaderOptionGroup{
-                    shaderVariantReference->m_shaderAsset->GetShaderOptionGroupLayout(),
-                    shaderVariantReference->m_shaderVariantId
-                };
+                if (shaderVariantReference->m_shaderAsset.IsReady())
+                {
+                    shaderVariantReference->m_shaderOptionGroup = ShaderOptionGroup{
+                        shaderVariantReference->m_shaderAsset->GetShaderOptionGroupLayout(),
+                        shaderVariantReference->m_shaderVariantId
+                    };
+                }
+                else
+                {
+                    shaderVariantReference->m_shaderOptionGroup = {};
+                }
             }
         };
 


### PR DESCRIPTION
Added a check for m_shaderAsset.IsReady() before trying to use the asset data. Also added a check before calling BlockUntilLoadComplete() to prevent reporting an error message unnecessarily.

Here is the PR for cherrypicking into main: https://github.com/aws-lumberyard/o3de/pull/304