### PR TITLE
Use the material id from the base mesh when optimizing blend shapes

### DIFF
--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.h
@@ -66,6 +66,7 @@ namespace AZ::SceneGenerationComponents
             AZStd::unique_ptr<AZ::SceneAPI::DataTypes::ISkinWeightData>
         > OptimizeMesh(
             const MeshDataType* meshData,
+            const SceneAPI::DataTypes::IMeshData* baseMesh,
             const AZStd::vector<AZStd::reference_wrapper<const AZ::SceneAPI::DataTypes::IMeshVertexUVData>>& uvs,
             const AZStd::vector<AZStd::reference_wrapper<const AZ::SceneAPI::DataTypes::IMeshVertexTangentData>>& tangents,
             const AZStd::vector<AZStd::reference_wrapper<const AZ::SceneAPI::DataTypes::IMeshVertexBitangentData>>& bitangents,
@@ -73,9 +74,6 @@ namespace AZ::SceneGenerationComponents
             const AZStd::vector<AZStd::reference_wrapper<const AZ::SceneAPI::DataTypes::ISkinWeightData>>& skinWeights,
             const AZ::SceneAPI::DataTypes::IMeshGroup& meshGroup,
             bool hasBlendShapes);
-
-        static unsigned int GetFaceMaterialId(const AZ::SceneAPI::DataTypes::IBlendShapeData* meshData, unsigned int index);
-        static unsigned int GetFaceMaterialId(const AZ::SceneAPI::DataTypes::IMeshData* meshData, unsigned int index);
 
         static void AddFace(AZ::SceneData::GraphData::BlendShapeData* blendShape, unsigned int index1, unsigned int index2, unsigned int index3, unsigned int faceMaterialId);
         static void AddFace(AZ::SceneData::GraphData::MeshData* mesh, unsigned int index1, unsigned int index2, unsigned int index3, unsigned int faceMaterialId);


### PR DESCRIPTION
When processing meshes with blend shapes, the mesh optimizer disables the
optimize duplicates setting, to prevent potential vertex reodering that
could cause the base mesh vertices to become out of sync with the blend
shape. However, it will still reorder vertices based on their material.
It places all triangles that use the same material in the same submesh,
grouping them together in the resulting mesh. The SceneAPI does not track
material ids for blend shapes. To ensure that the blend shape triangles are
reordered in the same way as the base shape, this change makes the blend
shape optimization use the material id from the base shape.