### PR TITLE
[LYN-3306] EMotionFX: Client sample asset does not animate with simple motion component 

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
@@ -43,6 +43,7 @@ namespace EMotionFX
                     ->Field("BlendIn", &Configuration::m_blendInTime)
                     ->Field("BlendOut", &Configuration::m_blendOutTime)
                     ->Field("PlayOnActivation", &Configuration::m_playOnActivation)
+                    ->Field("InPlace", &Configuration::m_inPlace)
                     ;
 
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
@@ -61,7 +62,9 @@ namespace EMotionFX
                             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_blendOutTime, "Blend Out Time", "Determines the blend out time in seconds")
                             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_playOnActivation, "Play on active", "Playing animation immediately after activition.")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_playOnActivation, "Play on active", "Playing animation immediately after activation.")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_inPlace, "In-place",
+                            "Plays the animation in-place and removes any positional and rotational changes from root joints.")
                         ;
                 }
             }
@@ -128,6 +131,7 @@ namespace EMotionFX
             , m_blendInTime(0.0f)
             , m_blendOutTime(0.0f)
             , m_playOnActivation(true)
+            , m_inPlace(false)
         {
         }
 
@@ -235,7 +239,7 @@ namespace EMotionFX
 
         void SimpleMotionComponent::PlayMotion()
         {
-            m_motionInstance = PlayMotionInternal(m_actorInstance.get(), m_configuration, /*deleteOnZeroWeight*/true, /*inPlace*/false);
+            m_motionInstance = PlayMotionInternal(m_actorInstance.get(), m_configuration, /*deleteOnZeroWeight*/true);
         }
 
         void SimpleMotionComponent::RemoveMotionInstanceFromActor(EMotionFX::MotionInstance* motionInstance)
@@ -425,7 +429,7 @@ namespace EMotionFX
             return m_configuration.m_blendOutTime;
         }
 
-        EMotionFX::MotionInstance* SimpleMotionComponent::PlayMotionInternal(const EMotionFX::ActorInstance* actorInstance, const SimpleMotionComponent::Configuration& cfg, bool deleteOnZeroWeight, bool inPlace)
+        EMotionFX::MotionInstance* SimpleMotionComponent::PlayMotionInternal(const EMotionFX::ActorInstance* actorInstance, const SimpleMotionComponent::Configuration& cfg, bool deleteOnZeroWeight)
         {
             if (!actorInstance || !cfg.m_motionAsset.IsReady())
             {
@@ -439,6 +443,7 @@ namespace EMotionFX
 
             auto* motionAsset = cfg.m_motionAsset.GetAs<MotionAsset>();
             if (!motionAsset)
+
             {
                 AZ_Error("EMotionFX", motionAsset, "Motion asset is not valid.");
                 return nullptr;
@@ -456,7 +461,7 @@ namespace EMotionFX
             info.mCanOverwrite = false;
             info.mBlendInTime = cfg.m_blendInTime;
             info.mBlendOutTime = cfg.m_blendOutTime;
-            info.mInPlace = inPlace;
+            info.mInPlace = cfg.m_inPlace;
             return actorInstance->GetMotionSystem()->PlayMotion(motionAsset->m_emfxMotion.get(), &info);
         }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
@@ -46,7 +46,7 @@ namespace EMotionFX
             struct Configuration
             {
                 AZ_TYPE_INFO(Configuration, "{DA661C5F-E79E-41C3-B055-5F5A4E353F84}")
-                    Configuration();
+                Configuration();
 
                 AZ::Data::Asset<MotionAsset>         m_motionAsset;             ///< Assigned motion asset
                 bool                                 m_loop;                    ///< Toggles looping of the motion
@@ -56,7 +56,8 @@ namespace EMotionFX
                 float                                m_playspeed;               ///< Determines the rate at which the motion is played
                 float                                m_blendInTime;             ///< Determines the blend in time in seconds.
                 float                                m_blendOutTime;            ///< Determines the blend out time in seconds.
-                bool                                 m_playOnActivation;                 ///< Determines if the motion should be played immediately
+                bool                                 m_playOnActivation;        ///< Determines if the motion should be played immediately
+                bool                                 m_inPlace;                 ///< Determines if the motion should be played in-place.
 
                 static void Reflect(AZ::ReflectContext* context);
             };
@@ -121,7 +122,7 @@ namespace EMotionFX
 
             void RemoveMotionInstanceFromActor(EMotionFX::MotionInstance* motionInstance);
 
-            static EMotionFX::MotionInstance* PlayMotionInternal(const EMotionFX::ActorInstance* actorInstance, const SimpleMotionComponent::Configuration& cfg, bool deleteOnZeroWeight, bool inPlace);
+            static EMotionFX::MotionInstance* PlayMotionInternal(const EMotionFX::ActorInstance* actorInstance, const SimpleMotionComponent::Configuration& cfg, bool deleteOnZeroWeight);
 
             Configuration                               m_configuration;        ///< Component configuration.
             EMotionFXPtr<EMotionFX::ActorInstance>      m_actorInstance;        ///< Associated actor instance (retrieved from Actor Component).

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorSimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorSimpleMotionComponent.cpp
@@ -170,7 +170,7 @@ namespace EMotionFX
                 // The Editor allows scrubbing back and forth on animation blending transitions, so don't delete 
                 // motion instances if it's blend weight is zero.
                 // The Editor preview should preview the motion in place to prevent off center movement.
-                m_motionInstance = SimpleMotionComponent::PlayMotionInternal(m_actorInstance, m_configuration, /*deleteOnZeroWeight*/false, /*inPlace*/true);
+                m_motionInstance = SimpleMotionComponent::PlayMotionInternal(m_actorInstance, m_configuration, /*deleteOnZeroWeight*/false);
             }
         }
 


### PR DESCRIPTION
**These changes have already been reviewed with PR#308 and are just cherry-picked from 1.0.**

* Removed discrepancy between editor and game simple motion components which led to an animation being played in the game one while the editor component looked broken for animations with root joints animated only.
* Sharing a new in-place attribute between the game and editor components that lets users control whether positional and rotational changes shall be applied onto root joints or not.