### PR TITLE
Add a wildcard source dependecy to the scene builder for wrinklemasks

### DIFF
--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -98,7 +98,7 @@ namespace SceneBuilder
             descriptor.m_jobKey = "Scene compilation";
             descriptor.SetPlatformIdentifier(enabledPlatform.m_identifier.c_str());
             descriptor.m_failOnError = true;
-            descriptor.m_priority = 11; // more important than static mesh files, since these may control logic (actors and motions specifically)
+            descriptor.m_priority = 11; // these may control logic (actors and motions specifically)
             descriptor.m_additionalFingerprintInfo = GetFingerprint();
 
             AZ::SceneAPI::SceneBuilderDependencyBus::Broadcast(&AZ::SceneAPI::SceneBuilderDependencyRequests::ReportJobDependencies,
@@ -107,11 +107,17 @@ namespace SceneBuilder
             response.m_createJobOutputs.push_back(descriptor);
         }
 
-        // Adding corresponding material file as a source file dependency
+        // Adding corresponding _wrinklemask folder as a source file dependency
+        // This enables morph target assets to get references to the wrinkle masks
+        // in the MorphTargetExporter, so they can be automatically applied at runtime
         AssetBuilderSDK::SourceFileDependency sourceFileDependencyInfo;
         AZStd::string relPath = request.m_sourceFile.c_str();
-        AzFramework::StringFunc::Path::ReplaceExtension(relPath, "mtl");
+        AzFramework::StringFunc::Path::StripExtension(relPath);
+        relPath += "_wrinklemasks";
+        AzFramework::StringFunc::Path::AppendSeparator(relPath);
+        relPath += "*_wrinklemask.*";
         sourceFileDependencyInfo.m_sourceFileDependencyPath = relPath;
+        sourceFileDependencyInfo.m_sourceDependencyType = AssetBuilderSDK::SourceFileDependency::SourceFileDependencyType::Wildcards;
         response.m_sourceFileDependencyList.push_back(sourceFileDependencyInfo);
 
         response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;


### PR DESCRIPTION
-Added a wildcard dependency that looks for a subfolder named <fbxname>_wrinklemask, and any files in that folder with the _wrinklemask suffix. This is so that references to _wrinklemask textures that match this naming convention can be found by the MorphTargetExporter, and so that the morph target assets produced by the ModelAssetBuilderComponent will be updated if masks are added or removed.
-Removed a source dependency on .mtl files, which are from the legacy renderer
-Updated a comment about static meshes, which I believe was referring to .cgf files since static meshes now also go through scene builder.