### PR TITLE
Fix a crash when deleting blend tree node

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTree.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTree.cpp
@@ -303,7 +303,8 @@ namespace EMotionFX
 
         if (GetFinalNode() == nodeToRemove)
         {
-            SetFinalNodeId(AnimGraphNodeId::InvalidId);
+            m_finalNodeId = AnimGraphNodeId::InvalidId;
+            m_finalNode = nullptr;
         }
 
         // call it for all children


### PR DESCRIPTION
When the final node is removed, in the blendTree we call the SetFinalNodeId() function - however, those function has a callback check, which basically did not do the job of clearing the cached final node and final id.

The fix directly clear the id and cached node.