### PR TITLE
SPEC-6543: fix DEV_DIR variable for ctest_entrypoint.cmd

### DIFF
--- a/scripts/ctest/ctest_entrypoint.cmd
+++ b/scripts/ctest/ctest_entrypoint.cmd
@@ -13,7 +13,7 @@ REM Continuous Integration CLI entrypoint script to start CTest, triggering post
 REM
 SETLOCAL
 
-SET DEV_DIR=%~dp0\..
+SET DEV_DIR=%~dp0\..\..
 SET PYTHON=%DEV_DIR%\python\python.cmd
 SET CTEST_SCRIPT=%~dp0\ctest_driver.py
 


### PR DESCRIPTION
- This variable was broken when `ctest_entrypoint.cmd` got moved in https://github.com/aws-lumberyard/o3de/pull/45
- This fixes the `DEV_DIR` variable and resolves the issue.
- For an example of a test succeeding with this change, look at https://github.com/aws-lumberyard/o3de/pull/326