### PR TITLE
[LYN-3072] TQO Animation: "Retarget Motion" on Simple Motion sends Asserts

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/MotionData.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/MotionData.cpp
@@ -23,8 +23,6 @@
 #include <MCore/Source/Endian.h>
 #include <MCore/Source/Stream.h>
 
-#pragma optimize("", off)
-
 namespace EMotionFX
 {
     MotionLinkCache::MotionLinkCache()


### PR DESCRIPTION
* Added a check to only apply retargeting to animated joints. Joints that the motion does not animate won't have a valid motion data link and thus retargeting can't be applied.
* The check cannot be applied at a level above as we still need to adjust the translation for root nodes, even for the ones that the motion does not animate.

![Retargeting_fixed](https://user-images.githubusercontent.com/43751992/116231775-980f4e80-a759-11eb-8fea-d0c7fc208a4e.gif)
