### PR TITLE
SPEC-6553: Temporarily moving LargeWorlds tests out of main suite

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/CMakeLists.txt
@@ -177,21 +177,22 @@ include(${pal_dir}/PAL_traits_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_LARGE_WORLDS_TEST_SUPPORTED)
 
 ## DynVeg ##
-    ly_add_pytest(
-        NAME AutomatedTesting::DynamicVegetationTests_Main
-        TEST_SERIAL
-        TEST_SUITE main
-        PATH ${CMAKE_CURRENT_LIST_DIR}/largeworlds/dyn_veg
-        PYTEST_MARKS "not SUITE_sandbox and not SUITE_periodic and not SUITE_benchmark"
-        TIMEOUT 36000
-        RUNTIME_DEPENDENCIES
-            AZ::AssetProcessor
-            Legacy::Editor
-            AutomatedTesting.GameLauncher
-            AutomatedTesting.Assets
-        COMPONENT
-            LargeWorlds
-    )
+    # Temporarily moving all tests to periodic suite - SPEC-6553
+    #ly_add_pytest(
+    #    NAME AutomatedTesting::DynamicVegetationTests_Main
+    #    TEST_SERIAL
+    #    TEST_SUITE main
+    #    PATH ${CMAKE_CURRENT_LIST_DIR}/largeworlds/dyn_veg
+    #    PYTEST_MARKS "not SUITE_sandbox and not SUITE_periodic and not SUITE_benchmark"
+    #    TIMEOUT 36000
+    #    RUNTIME_DEPENDENCIES
+    #        AZ::AssetProcessor
+    #        Legacy::Editor
+    #        AutomatedTesting.GameLauncher
+    #        AutomatedTesting.Assets
+    #    COMPONENT
+    #        LargeWorlds
+    #)
 
     ly_add_pytest(
         NAME AutomatedTesting::DynamicVegetationTests_Sandbox
@@ -225,20 +226,21 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_
     )
 
 ## LandscapeCanvas ##
-    ly_add_pytest(
-        NAME AutomatedTesting::LandscapeCanvasTests_Main
-        TEST_SERIAL
-        TEST_SUITE main
-        PATH ${CMAKE_CURRENT_LIST_DIR}/largeworlds/landscape_canvas
-        PYTEST_MARKS "not SUITE_sandbox and not SUITE_periodic and not SUITE_benchmark"
-        TIMEOUT 3600
-        RUNTIME_DEPENDENCIES
-           AZ::AssetProcessor
-           Legacy::Editor
-           AutomatedTesting.Assets
-        COMPONENT
-            LargeWorlds
-    )
+    # Temporarily moving all tests to periodic suite - SPEC-6553
+    #ly_add_pytest(
+    #    NAME AutomatedTesting::LandscapeCanvasTests_Main
+    #    TEST_SERIAL
+    #    TEST_SUITE main
+    #    PATH ${CMAKE_CURRENT_LIST_DIR}/largeworlds/landscape_canvas
+    #    PYTEST_MARKS "not SUITE_sandbox and not SUITE_periodic and not SUITE_benchmark"
+    #    TIMEOUT 3600
+    #    RUNTIME_DEPENDENCIES
+    #       AZ::AssetProcessor
+    #       Legacy::Editor
+    #       AutomatedTesting.Assets
+    #    COMPONENT
+    #        LargeWorlds
+    #)
 
     ly_add_pytest(
         NAME AutomatedTesting::LandscapeCanvasTests_Periodic

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/test_DynamicSliceInstanceSpawner.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/test_DynamicSliceInstanceSpawner.py
@@ -41,7 +41,7 @@ class TestDynamicSliceInstanceSpawner(object):
         return console
 
     @pytest.mark.test_case_id("C28851763")
-    @pytest.mark.SUITE_main
+    @pytest.mark.SUITE_periodic
     @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
     def test_DynamicSliceInstanceSpawner_DynamicSliceSpawnerWorks(self, request, editor, level, workspace, project,
                                                                   launcher_platform):

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/test_EmptyInstanceSpawner.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/test_EmptyInstanceSpawner.py
@@ -36,7 +36,7 @@ class TestEmptyInstanceSpawner(object):
         file_system.delete([os.path.join(workspace.paths.engine_root(), project, "Levels", level)], True, True)
 
     @pytest.mark.test_case_id("C28851762")
-    @pytest.mark.SUITE_main
+    @pytest.mark.SUITE_periodic
     def test_EmptyInstanceSpawner_EmptySpawnerWorks(self, request, editor, level, launcher_platform):
         cfg_args = [level]
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/test_GraphComponentSync.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/test_GraphComponentSync.py
@@ -43,7 +43,7 @@ class TestGraphComponentSync(object):
 
     @pytest.mark.test_case_id('C4705586')
     @pytest.mark.BAT
-    @pytest.mark.SUITE_main
+    @pytest.mark.SUITE_periodic
     def test_LandscapeCanvas_SlotConnections_UpdateComponentReferences(self, request, editor, level, launcher_platform):
         cfg_args = [level]
 
@@ -116,7 +116,7 @@ class TestGraphComponentSync(object):
                                           expected_lines, unexpected_lines=unexpected_lines, cfg_args=cfg_args)
 
     @pytest.mark.test_case_id('C15987206')
-    @pytest.mark.SUITE_main
+    @pytest.mark.SUITE_periodic
     def test_LandscapeCanvas_GradientMixerNodeConstruction(self, request, editor, level, launcher_platform):
         """
         Verifies a Gradient Mixer can be setup in Landscape Canvas and all references are property set.


### PR DESCRIPTION
Test runtimes have exploded after enabling these for the branch. Temporarily moving out to investigate in order to not bloat AR runtimes for team.