### PR TITLE
ViewportContext - fix ebus connections

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -168,7 +168,7 @@ namespace AZ
                 return;
             }
 
-            if (!m_rayTracingSceneSrg || m_rayTracingSceneSrg->IsQueuedForCompile())
+            if (m_rayTracingSceneSrg->IsQueuedForCompile())
             {
                 //[GFX TODO][ATOM-14792] AtomSampleViewer: Reset scene and feature processors before switching to sample
                 return;


### PR DESCRIPTION
ViewportContext was missing some BusConnect / BusDisconnect calls, this adds them.