### PR TITLE
Fix bug when .shadervariantlist file is located in the project folder.

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -162,7 +162,7 @@ namespace AZ
             AZStd::string expectedHigherPrecedenceFileFullPath;
             AzFramework::StringFunc::Path::Join(gameProjectPath, RPI::ShaderVariantTreeAsset::CommonSubFolder, expectedHigherPrecedenceFileFullPath, false /* handle directory overlap? */, false /* be case insensitive? */);
             AzFramework::StringFunc::Path::Join(expectedHigherPrecedenceFileFullPath.c_str(), shaderProductFileRelativePath.c_str(), expectedHigherPrecedenceFileFullPath, false /* handle directory overlap? */, false /* be case insensitive? */);
-            AzFramework::StringFunc::Path::ReplaceExtension(expectedHigherPrecedenceFileFullPath, AZ::RPI::ShaderVariantAsset::Extension);
+            AzFramework::StringFunc::Path::ReplaceExtension(expectedHigherPrecedenceFileFullPath, AZ::RPI::ShaderVariantListSourceData::Extension);
             AzFramework::StringFunc::Path::Normalize(expectedHigherPrecedenceFileFullPath);
 
             AZStd::string normalizedShaderVariantListFileFullPath = shaderVariantListFileFullPath;


### PR DESCRIPTION
Porting code that was fixed in https://github.com/aws-lumberyard/o3de/pull/61 into the 1.0 branch. 

JIRA: https://jira.agscollab.com/browse/ATOM-15351