### PR TITLE
Fix AssetProcessor crash on Mac

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/UnitTesting/UnitTestBusSender.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/UnitTesting/UnitTestBusSender.cpp
@@ -388,9 +388,8 @@ namespace ScriptCanvas
             {
                 AZ::ScriptCanvasAttributes::HiddenIndices uniqueIdIndex = { 0 };
 
-                auto builder = behaviorContext->Class<EventSender>("Unit Testing")
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
-                    ;
+                auto builder = behaviorContext->Class<EventSender>("Unit Testing");
+                builder->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common);
 
                 builder->Method("Add Failure", &EventSender::AddFailure, { { {"", "", behaviorContext->MakeDefaultValue(UniqueId)}, {"Report", "additional notes for the test report"} } })
                         ->Attribute(AZ::ScriptCanvasAttributes::HiddenParameterIndex, uniqueIdIndex)


### PR DESCRIPTION
Cherry-pick fix for AssetProcessor crash on Mac to 1.0