### PR TITLE
[LYN-3356] Replaced GetSelectedEntities + size() with new API.

### DIFF
--- a/Code/Sandbox/Editor/EditorViewportWidget.cpp
+++ b/Code/Sandbox/Editor/EditorViewportWidget.cpp
@@ -1509,10 +1509,10 @@ bool EditorViewportWidget::AddCameraMenuItems(QMenu* menu)
     }
 
     action = customCameraMenu->addAction(tr("Look through entity"));
-    AzToolsFramework::EntityIdList selectedEntityList;
-    AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(selectedEntityList, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
-    action->setCheckable(selectedEntityList.size() > 0 || m_viewSourceType == ViewSourceType::AZ_Entity);
-    action->setEnabled(selectedEntityList.size() > 0 || m_viewSourceType == ViewSourceType::AZ_Entity);
+    bool areAnyEntitiesSelected = false;
+    AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(areAnyEntitiesSelected, &AzToolsFramework::ToolsApplicationRequests::AreAnyEntitiesSelected);
+    action->setCheckable(areAnyEntitiesSelected || m_viewSourceType == ViewSourceType::AZ_Entity);
+    action->setEnabled(areAnyEntitiesSelected || m_viewSourceType == ViewSourceType::AZ_Entity);
     action->setChecked(m_viewSourceType == ViewSourceType::AZ_Entity);
     connect(action, &QAction::triggered, this, [this](bool isChecked)
         {

--- a/Code/Sandbox/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Sandbox/Editor/TrackView/TrackViewDialog.cpp
@@ -807,18 +807,11 @@ void CTrackViewDialog::UpdateActions()
         m_actions[ID_TRACKVIEW_MUTE_ALL]->setEnabled(true);
         m_actions[ID_ADDSCENETRACK]->setEnabled(true);
 
-        AzToolsFramework::EntityIdList entityIds;
-        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-            entityIds, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        bool areAnyEntitiesSelected = false;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            areAnyEntitiesSelected, &AzToolsFramework::ToolsApplicationRequests::AreAnyEntitiesSelected);
 
-        if (entityIds.empty())
-        {
-            m_actions[ID_ADDNODE]->setEnabled(false);
-        }
-        else
-        {
-            m_actions[ID_ADDNODE]->setEnabled(true);
-        }
+        m_actions[ID_ADDNODE]->setEnabled(areAnyEntitiesSelected);
     }
     else
     {
@@ -1569,12 +1562,12 @@ void CTrackViewDialog::OnAddSelectedNode()
             sequence->MarkAsModified();
         }
 
-        AzToolsFramework::EntityIdList entityIds;
-        AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-            entityIds, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+        int selectedEntitiesCount = 0;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntitiesCount, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntitiesCount);
 
         // check to make sure all nodes were added and notify user if they weren't
-        if (addedNodes.GetCount() != entityIds.size())
+        if (addedNodes.GetCount() != selectedEntitiesCount)
         {
             IMovieSystem* movieSystem = GetIEditor()->GetMovieSystem();
 

--- a/Code/Sandbox/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Sandbox/Editor/TrackView/TrackViewNodes.cpp
@@ -1137,12 +1137,12 @@ void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
                 CTrackViewAnimNodeBundle addedNodes = groupNode->AddSelectedEntities(m_pTrackViewDialog->GetDefaultTracksForEntityNode());
                 undoBatch.MarkEntityDirty(groupNode->GetSequence()->GetSequenceComponentEntityId());
 
-                AzToolsFramework::EntityIdList entityIds;
-                AzToolsFramework::ToolsApplicationRequests::Bus::BroadcastResult(
-                    entityIds, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+                int selectedEntitiesCount = 0;
+                AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+                    selectedEntitiesCount, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntitiesCount);
 
                 // check to make sure all nodes were added and notify user if they weren't
-                if (addedNodes.GetCount() != entityIds.size())
+                if (addedNodes.GetCount() != selectedEntitiesCount)
                 {
                     IMovieSystem* movieSystem = GetIEditor()->GetMovieSystem();
 


### PR DESCRIPTION
Replaced handful of usages of GetSelectedEntities that was ultimately only checking the size() or if it was empty with the new API. Tested and verified the workflows still worked as intended.