### PR TITLE
[LYN-3135] Animation Editor: Some of the default animation assets are broken

### DIFF
--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Actor/Cowboy_01.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Actor/Cowboy_01.fbx.assetinfo
@@ -1,937 +1,442 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="ActorGroup" field="element" version="4" type="{D1AC3803-8282-46C5-8610-93CD39B0F843}">
-					<Class name="IActorGroup" field="BaseClass1" version="2" type="{C86945A8-AEE8-4CFC-8FBF-A20E9BC71348}">
-						<Class name="ISceneNodeGroup" field="BaseClass1" version="1" type="{1D20FA11-B184-429E-8C86-745852234845}">
-							<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-								<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-							</Class>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="cowboy_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="SceneNodeSelectionList" field="nodeSelectionList" version="1" type="{D0CE66CE-1BAD-42F5-86ED-3923573B3A02}">
-						<Class name="ISceneNodeSelectionList" field="BaseClass1" version="1" type="{DC3F9996-E550-4780-A03B-80B0DDA1DA45}"/>
-						<Class name="AZStd::vector" field="selectedNodes" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}">
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01.SkinWeight_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01.map1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01.mat_cowboy_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						</Class>
-						<Class name="AZStd::vector" field="unselectedNodes" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}">
-							<Class name="AZStd::string" field="element" value="RootNode" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Belt1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.HolsterPin1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1.Holster2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Belt1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.aimend" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.LeftLegHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.RightLegHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.HolsterPin1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1.Holster2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmPV" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.aimend.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop.aimwrist" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.LeftLegHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.LeftLegHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.LeftToeBase" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.RightLegHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.RightLegHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.RightToeBase" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.LeftArmHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.RightArmHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmPV.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_eye_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_eye_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop.aimwrist.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.LeftLegHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.LeftToeBase.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.RightLegHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.RightToeBase.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.LeftArmHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.LeftArmHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.RightArmHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.RightArmHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_eye_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_eye_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botTeeth_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browExt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_brow_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browExt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseOut_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseOut_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topTeeth_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Lf_cheek_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Rt_cheek_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.LeftArmHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.RightArmHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.Rt_Hair0_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.Rt_Hair1_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botTeeth_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_cornerLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Ct_botLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_cornerLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.Lf_Hair0_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.Lf_Hair1_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browExt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_brow_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browExt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_in_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_out_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_in_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_out_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseOut_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseOut_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Lf_nostril_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Rt_nostril_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Ct_topLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topTeeth_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Lf_cheek_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Rt_cheek_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.LeftHandThumb3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.RightHandThumb3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.Rt_Hair0_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.Rt_Hair1_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.Ct_BackHair_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_cornerLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Ct_botLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_cornerLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.Lf_Hair0_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.Lf_Hair1_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_in_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_out_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_in_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_out_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Lf_nostril_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Rt_nostril_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Ct_topLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.LeftHandPinky3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.LeftHandRing3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.LeftHandMiddle3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.LeftHandIndex3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.LeftHandThumb3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.RightHandPinky3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.RightHandRing3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.RightHandMiddle3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.RightHandIndex3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.RightHandThumb3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.Ct_BackHair_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.Ct_tongue_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.LeftHandPinky3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.LeftHandRing3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.LeftHandMiddle3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.LeftHandIndex3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.RightHandPinky3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.RightHandRing3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.RightHandMiddle3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.RightHandIndex3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.Ct_tongue_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.Lf_Hat_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.Rt_Hat_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.Ct_FrontHair_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.Lf_Hat_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.Rt_Hat_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.Ct_FrontHair_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						</Class>
-					</Class>
-					<Class name="AZ::Uuid" field="id" value="{0020C9AF-AA5D-50CB-8FE0-4250396B3F9D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="TangentsRule" field="element" version="1" type="{4BD1CE13-D2EB-4CCF-AB21-4877EF69DE7D}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="tangentSpace" value="1" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-									<Class name="int" field="bitangentMethod" value="1" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-									<Class name="bool" field="normalize" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-									<Class name="AZ::u64" field="uvSetIndex" value="0" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="SkinRule" field="element" version="2" type="{B26E7FC9-86A1-4711-8415-8BE4861C08BA}">
-									<Class name="ISkinRule" field="BaseClass1" version="1" type="{5496ECAF-B096-4455-AE72-D55C5B675443}">
-										<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-											<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-										</Class>
-									</Class>
-									<Class name="unsigned int" field="maxWeightsPerVertex" value="4" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="float" field="weightThreshold" value="0.0010000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MeshRule" field="element" version="2" type="{7F115A73-28A2-4E35-8C87-1A1982773034}">
-									<Class name="IMeshRule" field="BaseClass1" version="1" type="{299934A2-22EC-48AF-AB2B-953AFF8E0B19}">
-										<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-											<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-										</Class>
-									</Class>
-									<Class name="bool" field="optimizeTriangleList" value="true" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MaterialRule" field="element" version="2" type="{35620013-A27C-4F6D-87BF-72F11688ACAD}">
-									<Class name="IMaterialRule" field="BaseClass1" version="1" type="{428C9752-6EDF-4FA2-9BDF-DBDFCEB4CC0F}">
-										<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-											<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-										</Class>
-									</Class>
-									<Class name="bool" field="updateMaterials" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-									<Class name="bool" field="removeMaterials" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}"/>
-									<Class name="AZStd::string" field="metaData" value='AdjustActor -actorID $(ACTORID) -name "cowboy_01"
-ActorSetCollisionMeshes -actorID $(ACTORID) -lod 0 -nodeList ""
-AdjustActor -actorID $(ACTORID) -nodesExcludedFromBounds "" -nodeAction "select"
-AdjustActor -actorID $(ACTORID) -nodeAction "replace" -attachmentNodes ""
-AdjustActor -actorID $(ACTORID) -motionExtractionNodeName "Reference"
-AdjustActor -actorID $(ACTORID) -mirrorSetup "LeftUpLeg,RightUpLeg;RightUpLeg,LeftUpLeg;LeftShoulder,RightShoulder;RightShoulder,LeftShoulder;LeftLegHelper4,RightLegHelper4;LeftLeg,RightLeg;RightLegHelper4,LeftLegHelper4;RightLeg,LeftLeg;LeftArm,RightArm;RightArm,LeftArm;LeftLegHelper5,RightLegHelper5;LeftLegHelper8,RightLegHelper8;LeftLegHelper7,RightLegHelper7;LeftLegHelper6,RightLegHelper6;LeftFoot,RightFoot;RightLegHelper5,LeftLegHelper5;RightLegHelper8,LeftLegHelper8;RightLegHelper7,LeftLegHelper7;RightLegHelper6,LeftLegHelper6;RightFoot,LeftFoot;LeftArmHelper4,RightArmHelper4;LeftArmHelper1,RightArmHelper1;LeftArmHelper2,RightArmHelper2;LeftArmHelper3,RightArmHelper3;LeftForeArm,RightForeArm;RightArmHelper4,LeftArmHelper4;RightArmHelper3,LeftArmHelper3;RightArmHelper2,LeftArmHelper2;RightArmHelper1,LeftArmHelper1;RightForeArm,LeftForeArm;LeftLegHelper9,RightLegHelper9;LeftToeBase,RightToeBase;RightLegHelper9,LeftLegHelper9;RightToeBase,LeftToeBase;LeftArmHelper5,RightArmHelper5;LeftArmHelper8,RightArmHelper8;LeftArmHelper6,RightArmHelper6;LeftArmHelper7,RightArmHelper7;LeftHand,RightHand;RightArmHelper5,LeftArmHelper5;RightArmHelper8,LeftArmHelper8;RightArmHelper7,LeftArmHelper7;RightArmHelper6,LeftArmHelper6;RightHand,LeftHand;LeftArmHelper9,RightArmHelper9;LeftInHandPinky,RightInHandPinky;LeftInHandRing,RightInHandRing;LeftInHandIndex,RightInHandIndex;LeftHandThumb1,RightHandThumb1;RightArmHelper9,LeftArmHelper9;RightInHandPinky,LeftInHandPinky;RightInHandRing,LeftInHandRing;RightInHandIndex,LeftInHandIndex;RightHandThumb1,LeftHandThumb1;LeftHandPinky1,RightHandPinky1;LeftHandRing1,RightHandRing1;LeftHandMiddle1,RightHandMiddle1;LeftHandIndex1,RightHandIndex1;LeftHandThumb2,RightHandThumb2;RightHandPinky1,LeftHandPinky1;RightHandRing1,LeftHandRing1;RightHandMiddle1,LeftHandMiddle1;RightHandIndex1,LeftHandIndex1;RightHandThumb2,LeftHandThumb2;LeftHandPinky2,RightHandPinky2;LeftHandRing2,RightHandRing2;LeftHandMiddle2,RightHandMiddle2;LeftHandIndex2,RightHandIndex2;LeftHandThumb3,RightHandThumb3;RightHandPinky2,LeftHandPinky2;RightHandRing2,LeftHandRing2;RightHandMiddle2,LeftHandMiddle2;RightHandIndex2,LeftHandIndex2;RightHandThumb3,LeftHandThumb3;LeftHandPinky3,RightHandPinky3;LeftHandRing3,RightHandRing3;LeftHandMiddle3,RightHandMiddle3;LeftHandIndex3,RightHandIndex3;RightHandPinky3,LeftHandPinky3;RightHandRing3,LeftHandRing3;RightHandMiddle3,LeftHandMiddle3;RightHandIndex3,LeftHandIndex3;"
-' type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MeshGroup" field="element" version="1" type="{5B03C8E6-8CEE-4DA0-A7FA-CD88689DD45B}">
-					<Class name="ISceneNodeGroup" field="BaseClass1" version="1" type="{1D20FA11-B184-429E-8C86-745852234845}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="cowboy_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="bool" field="export as convex" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="float" field="AreaTestEpsilon" value="0.0600000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-					<Class name="float" field="PlaneTolerance" value="0.0007000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-					<Class name="bool" field="Use16bitIndices" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="CheckZeroAreaTriangles" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="QuantizeInput" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="UsePlaneShifting" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="ShiftVertices" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="unsigned int" field="GaussMapLimit" value="32" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-					<Class name="bool" field="WeldVertices" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="DisableCleanMesh" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="Force32BitIndices" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="SuppressTriangleMeshRemapTable" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="bool" field="BuildTriangleAdjacencies" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="float" field="MeshWeldTolerance" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-					<Class name="unsigned int" field="NumTrisPerLeaf" value="4" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-					<Class name="bool" field="BuildGPUData" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-					<Class name="SceneNodeSelectionList" field="NodeSelectionList" version="1" type="{D0CE66CE-1BAD-42F5-86ED-3923573B3A02}">
-						<Class name="ISceneNodeSelectionList" field="BaseClass1" version="1" type="{DC3F9996-E550-4780-A03B-80B0DDA1DA45}"/>
-						<Class name="AZStd::vector" field="selectedNodes" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"/>
-						<Class name="AZStd::vector" field="unselectedNodes" type="{99DAD0BC-740E-5E82-826B-8FC7968CC02C}">
-							<Class name="AZStd::string" field="element" value="RootNode" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01.SkinWeight_0" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01.map1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.cowboy_01.mat_cowboy_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Belt1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.HolsterPin1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1.Holster2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Belt1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.aimend" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.LeftLegHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.RightLegHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.HolsterPin1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.Holster1.Holster2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmPV" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.aimend.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop.aimwrist" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.LeftLegHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.LeftLegHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.LeftToeBase" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.RightLegHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.RightLegHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.RightToeBase" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.LeftArmHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.RightArmHelper5" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper7" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper6" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmPV.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_eye_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_eye_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.aimstart.prop.aimwrist.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.LeftLegHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.LeftToeBase.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.RightLegHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.RightToeBase.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.LeftArmHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.LeftArmHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.RightArmHelper5.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.RightArmHelper9" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper7.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper6.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_eye_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_eye_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botTeeth_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browExt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_brow_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browExt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseOut_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseInt_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseCen_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseOut_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topTeeth_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Lf_cheek_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Rt_cheek_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.LeftArmHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.RightArmHelper9.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.Rt_Hair0_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.Rt_Hair1_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botTeeth_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_cornerLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Ct_botLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_cornerLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.Lf_Hair0_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.Lf_Hair1_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browExt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_brow_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browExt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_in_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_out_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_in_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_out_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseOut_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseInt_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseCen_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseOut_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Lf_nostril_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Rt_nostril_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Ct_topLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topTeeth_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Lf_cheek_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Rt_cheek_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.LeftHandThumb3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.RightHandThumb3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.Rt_Hair0_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.Rt_Hair1_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.Ct_BackHair_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_cornerLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Ct_botLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_cornerLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.Lf_Hair0_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.Lf_Hair1_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_in_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_out_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_in_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_out_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Lf_nostril_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Rt_nostril_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Ct_topLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.LeftHandPinky3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.LeftHandRing3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.LeftHandMiddle3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.LeftHandIndex3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.LeftHandThumb3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.RightHandPinky3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.RightHandRing3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.RightHandMiddle3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.RightHandIndex3" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.RightHandThumb3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.Ct_BackHair_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.Ct_tongue_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_1_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_2_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.LeftHandPinky3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.LeftHandRing3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.LeftHandMiddle3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.LeftHandIndex3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.RightHandPinky3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.RightHandRing3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.RightHandMiddle3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.RightHandIndex3.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.Ct_tongue_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.Lf_Hat_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.Rt_Hat_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.Ct_FrontHair_PUPPET_3_JNT" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_1_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_2_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.Lf_Hat_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.Rt_Hat_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-							<Class name="AZStd::string" field="element" value="RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.Ct_FrontHair_PUPPET_3_JNT.transform" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-						</Class>
-					</Class>
-					<Class name="AZ::Uuid" field="id" value="{0E27B613-8926-5655-AB5F-567CB07D4081}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}"/>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "ActorGroup",
+            "name": "cowboy_01",
+            "id": "{0020C9AF-AA5D-50CB-8FE0-4250396B3F9D}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "metaData": "AdjustActor -actorID $(ACTORID) -name \"cowboy_01\"\r\nActorSetCollisionMeshes -actorID $(ACTORID) -lod 0 -nodeList \"\"\r\nAdjustActor -actorID $(ACTORID) -nodesExcludedFromBounds \"\" -nodeAction \"select\"\r\nAdjustActor -actorID $(ACTORID) -nodeAction \"replace\" -attachmentNodes \"\"\r\nAdjustActor -actorID $(ACTORID) -motionExtractionNodeName \"Reference\"\r\nAdjustActor -actorID $(ACTORID) -mirrorSetup \"LeftUpLeg,RightUpLeg;RightUpLeg,LeftUpLeg;LeftShoulder,RightShoulder;RightShoulder,LeftShoulder;LeftLegHelper4,RightLegHelper4;LeftLeg,RightLeg;RightLegHelper4,LeftLegHelper4;RightLeg,LeftLeg;LeftArm,RightArm;RightArm,LeftArm;LeftLegHelper5,RightLegHelper5;LeftLegHelper8,RightLegHelper8;LeftLegHelper7,RightLegHelper7;LeftLegHelper6,RightLegHelper6;LeftFoot,RightFoot;RightLegHelper5,LeftLegHelper5;RightLegHelper8,LeftLegHelper8;RightLegHelper7,LeftLegHelper7;RightLegHelper6,LeftLegHelper6;RightFoot,LeftFoot;LeftArmHelper4,RightArmHelper4;LeftArmHelper1,RightArmHelper1;LeftArmHelper2,RightArmHelper2;LeftArmHelper3,RightArmHelper3;LeftForeArm,RightForeArm;RightArmHelper4,LeftArmHelper4;RightArmHelper3,LeftArmHelper3;RightArmHelper2,LeftArmHelper2;RightArmHelper1,LeftArmHelper1;RightForeArm,LeftForeArm;LeftLegHelper9,RightLegHelper9;LeftToeBase,RightToeBase;RightLegHelper9,LeftLegHelper9;RightToeBase,LeftToeBase;LeftArmHelper5,RightArmHelper5;LeftArmHelper8,RightArmHelper8;LeftArmHelper6,RightArmHelper6;LeftArmHelper7,RightArmHelper7;LeftHand,RightHand;RightArmHelper5,LeftArmHelper5;RightArmHelper8,LeftArmHelper8;RightArmHelper7,LeftArmHelper7;RightArmHelper6,LeftArmHelper6;RightHand,LeftHand;LeftArmHelper9,RightArmHelper9;LeftInHandPinky,RightInHandPinky;LeftInHandRing,RightInHandRing;LeftInHandIndex,RightInHandIndex;LeftHandThumb1,RightHandThumb1;RightArmHelper9,LeftArmHelper9;RightInHandPinky,LeftInHandPinky;RightInHandRing,LeftInHandRing;RightInHandIndex,LeftInHandIndex;RightHandThumb1,LeftHandThumb1;LeftHandPinky1,RightHandPinky1;LeftHandRing1,RightHandRing1;LeftHandMiddle1,RightHandMiddle1;LeftHandIndex1,RightHandIndex1;LeftHandThumb2,RightHandThumb2;RightHandPinky1,LeftHandPinky1;RightHandRing1,LeftHandRing1;RightHandMiddle1,LeftHandMiddle1;RightHandIndex1,LeftHandIndex1;RightHandThumb2,LeftHandThumb2;LeftHandPinky2,RightHandPinky2;LeftHandRing2,RightHandRing2;LeftHandMiddle2,RightHandMiddle2;LeftHandIndex2,RightHandIndex2;LeftHandThumb3,RightHandThumb3;RightHandPinky2,LeftHandPinky2;RightHandRing2,LeftHandRing2;RightHandMiddle2,LeftHandMiddle2;RightHandIndex2,LeftHandIndex2;RightHandThumb3,LeftHandThumb3;LeftHandPinky3,RightHandPinky3;LeftHandRing3,RightHandRing3;LeftHandMiddle3,RightHandMiddle3;LeftHandIndex3,RightHandIndex3;RightHandPinky3,LeftHandPinky3;RightHandRing3,LeftHandRing3;RightHandMiddle3,LeftHandMiddle3;RightHandIndex3,LeftHandIndex3;\"\r\n"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "{07B356B7-3635-40B5-878A-FAC4EFD5AD86} MeshGroup",
+            "name": "Cowboy_01",
+            "nodeSelectionList": {
+                "selectedNodes": [
+                    "RootNode",
+                    "RootNode.Reference",
+                    "RootNode.cowboy_01",
+                    "RootNode.Reference.transform",
+                    "RootNode.Reference.Hips",
+                    "RootNode.cowboy_01.SkinWeight_0",
+                    "RootNode.cowboy_01.transform",
+                    "RootNode.cowboy_01.map1",
+                    "RootNode.cowboy_01.mat_cowboy_01",
+                    "RootNode.Reference.Hips.transform",
+                    "RootNode.Reference.Hips.Spine",
+                    "RootNode.Reference.Hips.Pelvis",
+                    "RootNode.Reference.Hips.Spine.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1",
+                    "RootNode.Reference.Hips.Pelvis.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg",
+                    "RootNode.Reference.Hips.Pelvis.Holster1",
+                    "RootNode.Reference.Hips.Pelvis.Belt1",
+                    "RootNode.Reference.Hips.Spine.Spine1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.HolsterPin1",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg",
+                    "RootNode.Reference.Hips.Pelvis.Holster1.transform",
+                    "RootNode.Reference.Hips.Pelvis.Holster1.Holster2",
+                    "RootNode.Reference.Hips.Pelvis.Belt1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.aimend",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.propmatch",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.LeftLegHelper5",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper7",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper6",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.RightLegHelper5",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.HolsterPin1.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper7",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper6",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot",
+                    "RootNode.Reference.Hips.Pelvis.Holster1.Holster2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper1",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper2",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper3",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper3",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmPV",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.aimend.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.propmatch.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.propmatch.aimwristmatch",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLegHelper4.LeftLegHelper5.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.LeftLegHelper9",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper7.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper6.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.LeftToeBase",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLegHelper4.RightLegHelper5.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.RightLegHelper9",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper7.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper6.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.RightToeBase",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.LeftArmHelper5",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper6",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper7",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.RightArmHelper5",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper7",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper6",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmPV.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_eye_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_eye_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.aimstart.propmatch.aimwristmatch.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftLegHelper8.LeftLegHelper9.transform",
+                    "RootNode.Reference.Hips.Pelvis.LeftUpLeg.LeftLeg.LeftFoot.LeftToeBase.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightLegHelper8.RightLegHelper9.transform",
+                    "RootNode.Reference.Hips.Pelvis.RightUpLeg.RightLeg.RightFoot.RightToeBase.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftArmHelper4.LeftArmHelper5.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.LeftArmHelper9",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper6.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper7.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightArmHelper4.RightArmHelper5.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.RightArmHelper9",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper7.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper6.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.prop",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_eye_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_eye_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botTeeth_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browExt_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browCen_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browInt_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_brow_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browInt_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browCen_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browExt_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseOut_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseCen_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseInt_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseInt_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseCen_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseOut_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topTeeth_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Lf_cheek_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Rt_cheek_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftArmHelper8.LeftArmHelper9.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightArmHelper8.RightArmHelper9.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.prop.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.Rt_Hair0_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.Rt_Hair1_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botTeeth_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_cornerLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Ct_botLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_cornerLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.Lf_Hair0_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.Lf_Hair1_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browExt_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browCen_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_browInt_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_brow_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browInt_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browCen_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_browExt_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_in_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_out_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_in_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_out_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseOut_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseCen_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_cheekRaiseInt_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseInt_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseCen_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_cheekRaiseOut_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Lf_nostril_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Rt_nostril_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Ct_topLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topTeeth_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Lf_cheek_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Rt_cheek_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.LeftHandThumb3",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.RightHandThumb3",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair0_PUPPET_0_JNT.Rt_Hair0_PUPPET_1_JNT.Rt_Hair0_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Rt_Hair1_PUPPET_0_JNT.Rt_Hair1_PUPPET_1_JNT.Rt_Hair1_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.Ct_BackHair_PUPPET_3_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_cornerLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Rt_botLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Ct_botLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_botLip_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_botMuzzle_0_JNT.Lf_cornerLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair0_PUPPET_0_JNT.Lf_Hair0_PUPPET_1_JNT.Lf_Hair0_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Lf_Hair1_PUPPET_0_JNT.Lf_Hair1_PUPPET_1_JNT.Lf_Hair1_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_in_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_lidCorner_out_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_in_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_lidCorner_out_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Lf_nostril_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_nose_0_JNT.Rt_nostril_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Rt_topLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Ct_topLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headBot_0_JNT.Ct_topMuzzle_0_JNT.Lf_topLip_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.LeftHandPinky3",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.LeftHandRing3",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.LeftHandMiddle3",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.LeftHandIndex3",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftHandThumb1.LeftHandThumb2.LeftHandThumb3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.RightHandPinky3",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.RightHandRing3",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.RightHandMiddle3",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.RightHandIndex3",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightHandThumb1.RightHandThumb2.RightHandThumb3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_BackHair_PUPPET_0_JNT.Ct_BackHair_PUPPET_1_JNT.Ct_BackHair_PUPPET_2_JNT.Ct_BackHair_PUPPET_3_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.Ct_tongue_3_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_1_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_2_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandPinky.LeftHandPinky1.LeftHandPinky2.LeftHandPinky3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandRing.LeftHandRing1.LeftHandRing2.LeftHandRing3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandMIddle.LeftHandMiddle1.LeftHandMiddle2.LeftHandMiddle3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.LeftShoulder.LeftArm.LeftForeArm.LeftHand.LeftInHandIndex.LeftHandIndex1.LeftHandIndex2.LeftHandIndex3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandPinky.RightHandPinky1.RightHandPinky2.RightHandPinky3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandRing.RightHandRing1.RightHandRing2.RightHandRing3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandMiddle.RightHandMiddle1.RightHandMiddle2.RightHandMiddle3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.RightShoulder.RightArm.RightForeArm.RightHand.RightInHandIndex.RightHandIndex1.RightHandIndex2.RightHandIndex3.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_jaw_0_JNT.Ct_tongue_0_JNT.Ct_tongue_1_JNT.Ct_tongue_2_JNT.Ct_tongue_3_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.Lf_Hat_PUPPET_3_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.Rt_Hat_PUPPET_3_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.Ct_FrontHair_PUPPET_3_JNT",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_botLidMain_0_JNT.Rt_botLid_0_JNT.Rt_botLid_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Rt_eyeSocket_0_JNT.Rt_topLidMain_0_JNT.Rt_topLid_0_JNT.Rt_topLid_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_botLidMain_0_JNT.Lf_botLid_0_JNT.Lf_botLid_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_1_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Lf_eyeSocket_0_JNT.Lf_topLidMain_0_JNT.Lf_topLid_0_JNT.Lf_topLid_2_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_0_JNT.Lf_Hat_PUPPET_1_JNT.Lf_Hat_PUPPET_2_JNT.Lf_Hat_PUPPET_3_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_0_JNT.Rt_Hat_PUPPET_1_JNT.Rt_Hat_PUPPET_2_JNT.Rt_Hat_PUPPET_3_JNT.transform",
+                    "RootNode.Reference.Hips.Spine.Spine1.Neck.Neck1.Head.Ct_headTop_0_JNT.Ct_Hat_PUPPET_0_JNT.Ct_FrontHair_PUPPET_0_JNT.Ct_FrontHair_PUPPET_1_JNT.Ct_FrontHair_PUPPET_2_JNT.Ct_FrontHair_PUPPET_3_JNT.transform"
+                ]
+            },
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "SkinRule"
+                    },
+                    {
+                        "$type": "MaterialRule"
+                    }
+                ]
+            },
+            "id": "{6247689D-B117-4653-A672-12198E7EDD69}"
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/aimposes01.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/aimposes01.fbx.assetinfo
@@ -1,109 +1,56 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="aimposes01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{394BA97A-7EF3-56B3-ADE2-D9D734AA5B6B}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MotionRangeRule" field="element" version="1" type="{3107B08E-5D9D-49A0-8B1B-2133B5A1B041}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="unsigned int" field="startFrame" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="unsigned int" field="endFrame" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="bool" field="processRangeRuleConversion" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="aimposes01-1" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{991539D2-8F87-40EF-9664-7994FFEA6B34}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MotionRangeRule" field="element" version="1" type="{3107B08E-5D9D-49A0-8B1B-2133B5A1B041}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="unsigned int" field="startFrame" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="unsigned int" field="endFrame" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="bool" field="processRangeRuleConversion" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="aimposes01-2" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{DBCED014-4E7E-4865-9F94-F84B85F6B007}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MotionRangeRule" field="element" version="1" type="{3107B08E-5D9D-49A0-8B1B-2133B5A1B041}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="unsigned int" field="startFrame" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="unsigned int" field="endFrame" value="2" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-									<Class name="bool" field="processRangeRuleConversion" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "aimposes01",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{394BA97A-7EF3-56B3-ADE2-D9D734AA5B6B}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MotionRangeRule"
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "MotionGroup",
+            "name": "aimposes01-1",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{991539D2-8F87-40EF-9664-7994FFEA6B34}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MotionRangeRule",
+                        "startFrame": 1,
+                        "endFrame": 1
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        },
+        {
+            "$type": "MotionGroup",
+            "name": "aimposes01-2",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{DBCED014-4E7E-4865-9F94-F84B85F6B007}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MotionRangeRule",
+                        "startFrame": 2,
+                        "endFrame": 2
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/idle_cwby_01.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/idle_cwby_01.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="idle_cwby_01" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{492E8A35-2647-581F-A701-F1D2A9FBB979}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="IdleState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "idle_cwby_01",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{492E8A35-2647-581F-A701-F1D2A9FBB979}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/reload.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/reload.fbx.assetinfo
@@ -1,137 +1,61 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="reload" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{28092685-3550-5583-A666-CD60018AB2E9}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="ReloadEvent" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="ReloadEvent" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.5092110" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.5092110" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="AmmoBack" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="ReloadEvent" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="1.2446810" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="1.2446810" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="ReleaseShells" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="ReloadEvent" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="1.4295191" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="1.4295191" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="ReloadEnd" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "reload",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{28092685-3550-5583-A666-CD60018AB2E9}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "ReloadEvent",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "ReloadEvent",
+                                "startTime": 0.509211003780365,
+                                "endTime": 0.509211003780365,
+                                "eventDatas": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "ReloadEvent",
+                                "startTime": 1.2446810007095338,
+                                "endTime": 1.2446810007095338,
+                                "eventDatas": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "ReloadEvent",
+                                "startTime": 1.4295190572738648,
+                                "endTime": 1.4295190572738648,
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/run.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/run.fbx.assetinfo
@@ -1,137 +1,59 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="run" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{7D6889F1-6536-57B6-8B02-93C815D1ADA9}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.3396752" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.3396752" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="LeftFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="RightFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.6319157" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.6319157" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="RightFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="LeftFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="RunState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "run",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{7D6889F1-6536-57B6-8B02-93C815D1ADA9}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "Sync",
+                                "startTime": 0.3396751880645752,
+                                "endTime": 0.3396751880645752,
+                                "eventDatas": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "Sync",
+                                "startTime": 0.6319156885147095,
+                                "endTime": 0.6319156885147095,
+                                "eventDatas": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/shootrecoil.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/shootrecoil.fbx.assetinfo
@@ -1,91 +1,47 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="shootrecoil" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{A1DC3BB2-3324-50F3-8C4B-BBFB61623129}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="RecoilEvent" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="RecoilEvent" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.2325000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.2325000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="RecoilEnd" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "shootrecoil",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{A1DC3BB2-3324-50F3-8C4B-BBFB61623129}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "RecoilEvent",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "RecoilEvent",
+                                "startTime": 0.23250000178813935,
+                                "endTime": 0.23250000178813935,
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeback.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeback.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafeback" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{CA0EF712-DA36-5DA8-B474-207BD250CF2F}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameEvents" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameEvents" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafeback",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{CA0EF712-DA36-5DA8-B474-207BD250CF2F}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameEvents",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameEvents",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafebackl.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafebackl.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafebackl" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{9433F0E6-EA1A-5473-AA21-EE4DC45387C1}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafebackl",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{9433F0E6-EA1A-5473-AA21-EE4DC45387C1}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafebackr.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafebackr.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafebackr" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{5392AC3D-FF18-51F5-984E-248CAAF09F2E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafebackr",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{5392AC3D-FF18-51F5-984E-248CAAF09F2E}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeforward.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeforward.fbx.assetinfo
@@ -1,137 +1,59 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafeforward" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{2FB879C6-B3FB-5BD8-B52B-1012000351C2}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.2708907" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.2708907" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="RightFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="LeftFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.9699266" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.9699266" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="LeftFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="RightFoot" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafeforward",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{2FB879C6-B3FB-5BD8-B52B-1012000351C2}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "Sync",
+                                "startTime": 0.2708907127380371,
+                                "endTime": 0.2708907127380371,
+                                "eventDatas": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "Sync",
+                                "startTime": 0.9699265956878662,
+                                "endTime": 0.9699265956878662,
+                                "eventDatas": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeforwardl.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeforwardl.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafeforwardl" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{2D945D52-C313-57A3-B722-C6402ACC3506}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafeforwardl",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{2D945D52-C313-57A3-B722-C6402ACC3506}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeforwardr.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeforwardr.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafeforwardr" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{3E691B9F-C0D7-5BFD-BBBC-50BAE737886E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafeforwardr",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{3E691B9F-C0D7-5BFD-BBBC-50BAE737886E}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeinplace.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeinplace.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafeinplace" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{A2686CFC-D49B-5468-AE9F-E3F84FA75C6D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafeinplace",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{A2686CFC-D49B-5468-AE9F-E3F84FA75C6D}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeleft.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/strafeleft.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="strafeleft" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{2093C7DF-0C51-5C2B-B763-4DC1CC81D10E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "strafeleft",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{2093C7DF-0C51-5C2B-B763-4DC1CC81D10E}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/straferight.fbx.assetinfo
+++ b/Gems/PhysXSamples/Assets/Characters/Cowboy/Animations/straferight.fbx.assetinfo
@@ -1,91 +1,45 @@
-<ObjectStream version="3">
-	<Class name="SceneManifest" version="1" type="{9274AD17-3212-4651-9F3B-7DCCB080E467}">
-		<Class name="AZStd::vector" field="values" type="{5D6A7C67-11CA-59A4-829B-0B20B781B292}">
-			<Class name="AZStd::shared_ptr" field="element" type="{EB7522F9-0E87-55A9-A191-E924DC5AE867}">
-				<Class name="MotionGroup" field="element" version="3" type="{1B0ABB1E-F6DF-4534-9A35-2DD8244BF58C}">
-					<Class name="IMotionGroup" field="BaseClass1" version="1" type="{1CA400A8-2C3E-423D-B8A3-C457EF88E533}">
-						<Class name="IGroup" field="BaseClass1" version="1" type="{DE008E67-790D-4672-A73A-5CA0F31EDD2D}">
-							<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-						</Class>
-					</Class>
-					<Class name="AZStd::string" field="name" value="straferight" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZStd::string" field="selectedRootBone" value="RootNode.Reference" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-					<Class name="AZ::Uuid" field="id" value="{CE0E45E9-4B8C-5340-9521-B6290BAB24FC}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-					<Class name="RuleContainer" field="rules" version="1" type="{2C20D3DF-57FF-4A31-8680-A4D45302B9CF}">
-						<Class name="AZStd::vector" field="rules" type="{B5BDB053-178F-5D55-8663-70897A71B7C9}">
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="CoordinateSystemRule" field="element" version="1" type="{603207E2-4F55-4C33-9AAB-98CA75C1E351}">
-									<Class name="IRule" field="BaseClass1" version="1" type="{81267F8B-3963-423B-9FF7-D276D82CD110}">
-										<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									</Class>
-									<Class name="int" field="targetCoordinateSystem" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-								</Class>
-							</Class>
-							<Class name="AZStd::shared_ptr" field="element" type="{0BB4AFBA-F087-55C7-95DF-01D71F6CB052}">
-								<Class name="MetaDataRule" field="element" version="2" type="{8D759063-7D2E-4543-8EB3-AB510A5886CF}">
-									<Class name="IManifestObject" field="BaseClass1" type="{3B839407-1884-4FF4-ABEA-CA9D347E83F7}"/>
-									<Class name="AZStd::vector" field="commands" type="{C9984A24-DA9E-518F-9F81-27E51FAEB1F7}">
-										<Class name="CommandSystem::CommandAdjustMotion" field="element" version="1" type="{A8977553-4011-4BEB-97C8-6AE44B07C7A8}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::optional" field="dirtyFlag" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-											<Class name="AZStd::optional" field="motionExtractionFlags" type="{43BA4537-CBCC-54F5-B403-84188A203D60}">
-												<Class name="unsigned char" field="element" value="0" type="{72B9409A-7D1A-4831-9CFE-FCB3FADD3426}"/>
-											</Class>
-											<Class name="AZStd::optional" field="name" type="{B0D91084-263A-54B9-A4F3-7C5F4240E248}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="Sync" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEventTrack" field="element" version="1" type="{961F762D-5B90-4E21-8692-9FADDCA54E6C}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="AZStd::optional" field="eventTrackIndex" type="{5BC30B08-5E9C-5B73-BDE4-4BE8170C21C6}"/>
-											<Class name="AZStd::optional" field="isEnabled" type="{0170062C-2E7E-5CEB-BAB8-F7663BEF7B3E}"/>
-										</Class>
-										<Class name="CommandSystem::CommandCreateMotionEvent" field="element" type="{D19C2AFB-A5AA-4367-BCFC-02EB88C1B61F}">
-											<Class name="MCore::Command" field="BaseClass1" version="1" type="{49C636CE-7C0E-408A-A0F7-F7D12647EFBA}"/>
-											<Class name="CommandSystem::MotionIdCommandMixin" field="BaseClass2" version="1" type="{968E9513-3159-4469-B5FA-97D0920456E3}">
-												<Class name="int" field="motionID" value="0" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-											</Class>
-											<Class name="AZStd::string" field="eventTrackName" value="GameState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-											<Class name="float" field="startTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="float" field="endTime" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-											<Class name="AZStd::optional" field="eventDatas" type="{C69F2148-2DBF-5C3D-8154-447C6E99D041}">
-												<Class name="AZStd::vector" field="element" type="{4918F644-6F31-5DC0-92CC-471D16563C8A}">
-													<Class name="AZStd::shared_ptr" field="element" type="{FA64741F-5600-53BC-9B56-A81DD4938FF5}">
-														<Class name="TwoStringEventData" field="element" version="1" type="{A437CD65-4012-47DE-BC60-4F9EC2A9ACEE}">
-															<Class name="EventDataSyncable" field="BaseClass1" version="1" type="{18A0050C-D05A-424C-B645-8E3B31120CBA}">
-																<Class name="EventData" field="BaseClass1" version="1" type="{F6AFCD3B-D58E-4821-9E7C-D1F437304E5D}"/>
-															</Class>
-															<Class name="AZStd::string" field="subject" value="StrafeState" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="parameters" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-															<Class name="AZStd::string" field="mirrorSubject" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-														</Class>
-													</Class>
-												</Class>
-											</Class>
-										</Class>
-									</Class>
-									<Class name="AZStd::string" field="metaData" value="" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-								</Class>
-							</Class>
-						</Class>
-					</Class>
-				</Class>
-			</Class>
-		</Class>
-	</Class>
-</ObjectStream>
-
+{
+    "values": [
+        {
+            "$type": "MotionGroup",
+            "name": "straferight",
+            "selectedRootBone": "RootNode.Reference",
+            "id": "{CE0E45E9-4B8C-5340-9521-B6290BAB24FC}",
+            "rules": {
+                "rules": [
+                    {
+                        "$type": "MetaDataRule",
+                        "commands": [
+                            {
+                                "$type": "CommandSystem::CommandAdjustMotion",
+                                "dirtyFlag": {},
+                                "motionExtractionFlags": {},
+                                "name": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "Sync",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEventTrack",
+                                "eventTrackName": "GameState",
+                                "eventTrackIndex": {},
+                                "isEnabled": {}
+                            },
+                            {
+                                "$type": "CommandSystem::CommandCreateMotionEvent",
+                                "eventTrackName": "GameState",
+                                "eventDatas": {}
+                            }
+                        ]
+                    },
+                    {
+                        "$type": "MotionSamplingRule"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
**These changes have already been reviewed with PR#348 and are just cherry-picked.**

* Cowboy asset in PhysXSamples for was missing mesh group.
* There was a coordinate system rule mismatch between the animations and the character that led to skinning artefacts.