### PR TITLE
Disabling Asset Processor test causing intermittent failures

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/ConnectionUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/ConnectionUnitTests.cpp
@@ -44,7 +44,4 @@ ConnectionUnitTest::~ConnectionUnitTest()
 
 }
 
-
-
-REGISTER_UNIT_TEST(ConnectionUnitTest)
-
+// REGISTER_UNIT_TEST(ConnectionUnitTest) // disabling due to intermittent test failure - LYN-3368


### PR DESCRIPTION
Disabling Asset Processor test causing intermittent failures (LYN-3368)