### PR TITLE
ATOM-15371 Adding missing RHI dependency to Atom tools

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/Code/tool_dependencies.cmake
+++ b/Gems/Atom/Tools/MaterialEditor/Code/tool_dependencies.cmake
@@ -10,6 +10,7 @@
 #
 
 set(GEM_DEPENDENCIES
+    Gem::Atom_RHI_Null.Private
     Gem::Atom_RHI_DX12.Private
     Gem::Atom_RHI_Vulkan.Private
     Gem::Atom_RHI.Private

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/tool_dependencies.cmake
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/tool_dependencies.cmake
@@ -10,6 +10,7 @@
 #
 
 set(GEM_DEPENDENCIES
+    Gem::Atom_RHI_Null.Private
     Gem::Atom_RHI_DX12.Private
     Gem::Atom_RHI_Vulkan.Private
     Gem::Atom_RHI.Private


### PR DESCRIPTION
This was causing error message spam and possibly other issues when launching the tools.

https://jira.agscollab.com/browse/ATOM-15371