### PR TITLE
[LYN-3374] Removed Cry3DEngine checks in EditorViewportWidget that was preventing selection, correct camera position, and other issues in the viewport.

### DIFF
--- a/Code/Sandbox/Editor/EditorViewportWidget.cpp
+++ b/Code/Sandbox/Editor/EditorViewportWidget.cpp
@@ -230,9 +230,6 @@ EditorViewportWidget::~EditorViewportWidget()
 //////////////////////////////////////////////////////////////////////////
 int EditorViewportWidget::OnCreate()
 {
-    m_renderer = GetIEditor()->GetRenderer();
-    m_engine = GetIEditor()->Get3DEngine();
-
     CreateRenderContext();
 
     return 0;
@@ -426,7 +423,7 @@ void EditorViewportWidget::Update()
         return;
     }
 
-    if (!m_engine || m_rcClient.isEmpty() || GetIEditor()->IsInMatEditMode())
+    if (m_rcClient.isEmpty() || GetIEditor()->IsInMatEditMode())
     {
         return;
     }
@@ -795,10 +792,6 @@ void EditorViewportWidget::OnRender()
         if (GetIEditor()->GetRenderer())
         {
             GetIEditor()->GetRenderer()->SetCamera(gEnv->pSystem->GetViewCamera());
-        }
-        if (m_engine)
-        {
-            m_engine->RenderWorld(0, SRenderingPassInfo::CreateGeneralPassRenderingInfo(m_Camera), __FUNCTION__);
         }
         return;
     }
@@ -1814,11 +1807,6 @@ void EditorViewportWidget::SetViewTM(const Matrix34& viewTM, bool bMoveOnly)
 //////////////////////////////////////////////////////////////////////////
 void EditorViewportWidget::RenderSelectedRegion()
 {
-    if (!m_engine)
-    {
-        return;
-    }
-
     AABB box;
     GetIEditor()->GetSelectedRegion(box);
     if (box.IsEmpty())

--- a/Code/Sandbox/Editor/EditorViewportWidget.h
+++ b/Code/Sandbox/Editor/EditorViewportWidget.h
@@ -395,9 +395,6 @@ protected:
     };
     void ResetToViewSourceType(const ViewSourceType& viewSourType);
 
-    //! Assigned renderer.
-    IRenderer*  m_renderer = nullptr;
-    I3DEngine*  m_engine = nullptr;
     bool m_bRenderContextCreated = false;
     bool m_bInRotateMode = false;
     bool m_bInMoveMode = false;


### PR DESCRIPTION
The EditorViewportWidget had a couple of checks for Cry3DEngine, so when LOAD_LEGACY_RENDERER_FOR_EDITOR was turned off, there were a couple of spots that would bail out early. Specifically, the EditorViewportWidget::Update() would bail out almost immediately, which would prevent it from processing a lot of logic. For this particular bug, it was preventing selection in the viewport from working because the entity visibility cache was never updated, so the visibility system always thought there were 0 visible entities. I also noticed with this fix, the camera position is restored properly after you load your level.
There might be some other issues fixed as well by this.