### PR TITLE
Prevent AzToolsFramework benchmarks timeout for now

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
@@ -78,7 +78,7 @@ namespace Benchmark
     }
     BENCHMARK_REGISTER_F(BM_PrefabUpdateInstances, UpdateInstances_SingeEntityInstances)
         ->RangeMultiplier(10)
-        ->Range(100, 10000)
+        ->Range(100, 1000)
         ->Unit(benchmark::kMillisecond)
         ->Complexity();
 


### PR DESCRIPTION
Jira: https://jira.agscollab.com/browse/SPEC-6434

Time spent on Prefab related benchmarks has increased significantly, and benchmark BM_PrefabUpdateInstances/UpdateInstances_SingeEntityInstances/10000 will take more than 1 hour to finish. 
As the result, AzToolsFramework benchmarks are timing out on nightly run, causing the run failed.

We will temporarily remove this benchmark to unblock the run and will create multiple tickets to resolve the performance issues from Prefab System.

Result after the change:
\------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                              Time             CPU   Iterations
\------------------------------------------------------------------------------------------------------------------------
BM_PrefabUpdateInstances/UpdateInstances_SingeEntityInstances/100                    256 ms          245 ms            3
BM_PrefabUpdateInstances/UpdateInstances_SingeEntityInstances/1000                 19232 ms        19234 ms            1
BM_PrefabUpdateInstances/UpdateInstances_SingeEntityInstances_BigO              19232.19 N^2    19234.90 N^2  
BM_PrefabUpdateInstances/UpdateInstances_SingeEntityInstances_RMS                      0 %             0 %    
BM_PrefabUpdateInstances/UpdateInstances_BinaryTreeNestedInstanceHierarchy/8         223 ms          219 ms            3
BM_PrefabUpdateInstances/UpdateInstances_BinaryTreeNestedInstanceHierarchy/10       2785 ms         2781 ms            1
BM_PrefabUpdateInstances/UpdateInstances_BinaryTreeNestedInstanceHierarchy/12      41395 ms        41359 ms            1
BM_PrefabUpdateInstances/UpdateInstances_BinaryTreeNestedInstanceHierarchy_BigO    2469.33 N^2     2467.17 N^2  
BM_PrefabUpdateInstances/UpdateInstances_BinaryTreeNestedInstanceHierarchy_RMS          1 %             1 %    
BM_SpawnableCreate/CreateSpawnable_SingleEntityInstance/100                        0.003 ms        0.003 ms       497778
BM_SpawnableCreate/CreateSpawnable_SingleEntityInstance/1000                       0.003 ms        0.002 ms       263529
BM_SpawnableCreate/CreateSpawnable_SingleEntityInstance/10000                      0.003 ms        0.003 ms       264084
BM_SpawnableCreate/CreateSpawnable_SingleEntityInstance_BigO                     2575.69 (1)     2595.28 (1)  
BM_SpawnableCreate/CreateSpawnable_SingleEntityInstance_RMS                            2 %             4 %    
BM_PrefabCreate/CreatePrefabs_SingleEntityEach/100                                  48.2 ms         50.0 ms           10
BM_PrefabCreate/CreatePrefabs_SingleEntityEach/1000                                  506 ms          500 ms            1
BM_PrefabCreate/CreatePrefabs_SingleEntityEach/10000                                5020 ms         5016 ms            1
BM_PrefabCreate/CreatePrefabs_SingleEntityEach_BigO                            502009.66 N     501546.88 N    
BM_PrefabCreate/CreatePrefabs_SingleEntityEach_RMS                                     0 %             0 %    
BM_PrefabCreate/CreatePrefab_FromEntities/100                                       18.9 ms         19.4 ms           37
BM_PrefabCreate/CreatePrefab_FromEntities/1000                                       192 ms          188 ms            4
BM_PrefabCreate/CreatePrefab_FromEntities/10000                                     2083 ms         2094 ms            1
BM_PrefabCreate/CreatePrefab_FromEntities_BigO                                 208126.38 N     209156.94 N    
BM_PrefabCreate/CreatePrefab_FromEntities_RMS                                          1 %             2 %    
BM_PrefabCreate/CreatePrefab_FromSingleDepthInstances/100                           75.4 ms         74.7 ms            9
BM_PrefabCreate/CreatePrefab_FromSingleDepthInstances/1000                           790 ms          797 ms            1
BM_PrefabCreate/CreatePrefab_FromSingleDepthInstances/10000                         9470 ms         9422 ms            1
BM_PrefabCreate/CreatePrefab_FromSingleDepthInstances_BigO                      71318.06 NlgN   70958.35 NlgN 
BM_PrefabCreate/CreatePrefab_FromSingleDepthInstances_RMS                              1 %             2 %    
BM_PrefabInstantiate/InstantiatePrefab_SingleEntityInstance/100                     91.6 ms         92.0 ms            9
BM_PrefabInstantiate/InstantiatePrefab_SingleEntityInstance/1000                    4291 ms         4266 ms            1
BM_PrefabInstantiate/InstantiatePrefab_SingleEntityInstance/10000                 585108 ms       584219 ms            1
BM_PrefabInstantiate/InstantiatePrefab_SingleEntityInstance_BigO                 5850.93 N^2     5842.03 N^2  
BM_PrefabInstantiate/InstantiatePrefab_SingleEntityInstance_RMS                        0 %             0 %    
BM_PrefabLoad/LoadPrefab_Basic/100                                                  8.43 ms         8.30 ms           64
BM_PrefabLoad/LoadPrefab_Basic/1000                                                  386 ms          383 ms            2
BM_PrefabLoad/LoadPrefab_Basic_BigO                                               386.07 N^2      382.86 N^2  
BM_PrefabLoad/LoadPrefab_Basic_RMS                                                     2 %             2 %    
