### PR TITLE
Fixing test metrics to run on test failures

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -504,9 +504,8 @@ try {
                             envVars['IS_UNIX'] = 1
                         }
                         withEnv(GetEnvStringList(envVars)) {
+                            def build_job_name = build_job.key
                             try {
-                                def build_job_name = build_job.key
-
                                 CreateSetupStage(pipelineConfig, repositoryName, projectName, pipelineName, branchName, platform.key, build_job.key, envVars).call()
 
                                 if(build_job.value.steps) { //this is a pipe with many steps so create all the build stages


### PR DESCRIPTION
Moving the test metrics stage to always run, even if a build failure occurs. Will test in AR.

Questions for reviewers:
1. Are the variables in the try block available in the finally block?
2. Should I be using a try/except for the test metrics stage or a catchError?