### PR TITLE
[CherryPick][SPEC-6434] Prevent AzToolsFramework benchmarks timeout for now 

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
@@ -78,7 +78,7 @@ namespace Benchmark
     }
     BENCHMARK_REGISTER_F(BM_PrefabUpdateInstances, UpdateInstances_SingeEntityInstances)
         ->RangeMultiplier(10)
-        ->Range(100, 10000)
+        ->Range(100, 1000)
         ->Unit(benchmark::kMillisecond)
         ->Complexity();
 


### PR DESCRIPTION
Cheery pick the change(#398) from 1.0 to main.
