### PR TITLE
{LYN-3365} GraphObjectProxy is now hidden from Script Canvas

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -25,9 +25,12 @@ namespace AZ
                 AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
                 if (behaviorContext)
                 {
+                    behaviorContext->Class<DataTypes::IGraphObject>();
+
                     behaviorContext->Class<GraphObjectProxy>()
                         ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                         ->Attribute(AZ::Script::Attributes::Module, "scene.graph")
+                        ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                         ->Method("CastWithTypeName", &GraphObjectProxy::CastWithTypeName)
                         ->Method("Invoke", &GraphObjectProxy::Invoke)
                         ;


### PR DESCRIPTION
* GraphObjectProxy is now hidden from Script Canvas
* the IGraphObject has been added to the BC

Jira: https://jira.agscollab.com/browse/LYN-3365
Tests: manual testing the node type is not in the SC editor