### PR TITLE
LYN-2723: Fixes issues with bad project or engine paths (#369)

### DIFF
--- a/Code/Framework/AzCore/AzCore/AzCoreModule.cpp
+++ b/Code/Framework/AzCore/AzCore/AzCoreModule.cpp
@@ -19,7 +19,6 @@
 #include <AzCore/Jobs/JobManagerComponent.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzCore/Memory/MemoryComponent.h>
-#include <AzCore/NativeUI/NativeUISystemComponent.h>
 #include <AzCore/Script/ScriptSystemComponent.h>
 #include <AzCore/Slice/SliceComponent.h>
 #include <AzCore/Slice/SliceSystemComponent.h>
@@ -43,7 +42,6 @@ namespace AZ
             AssetManagerComponent::CreateDescriptor(),
             UserSettingsComponent::CreateDescriptor(),
             Debug::FrameProfilerComponent::CreateDescriptor(),
-            NativeUI::NativeUISystemComponent::CreateDescriptor(),
             SliceComponent::CreateDescriptor(),
             SliceSystemComponent::CreateDescriptor(),
             SliceMetadataInfoComponent::CreateDescriptor(),

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -28,6 +28,8 @@
 #include <AzCore/Memory/AllocatorManager.h>
 #include <AzCore/Memory/MallocSchema.h>
 
+#include <AzCore/NativeUI/NativeUIRequests.h>
+
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/Utils.h>
@@ -424,7 +426,7 @@ namespace AZ
 
         // Now that the Allocators are initialized, the Command Line parameters can be parsed
         m_commandLine.Parse(m_argC, m_argV);
-        ParseCommandLine(m_commandLine);
+        SettingsRegistryMergeUtils::ParseCommandLine(m_commandLine);
 
         // Create the settings registry and register it with the AZ interface system
         // This is done after the AppRoot has been calculated so that the Bootstrap.cfg
@@ -527,9 +529,41 @@ namespace AZ
         DestroyAllocator();
     }
 
+
+    void ReportBadEngineRoot()
+    {
+        AZStd::string errorMessage = {"Unable to determine a valid path to the engine.\n"
+                                      "Check parameters such as --project-path and --engine-path and make sure they are valid.\n"};
+        if (auto registry = AZ::SettingsRegistry::Get(); registry != nullptr)
+        {
+            AZ::SettingsRegistryInterface::FixedValueString filePathErrorStr;
+            if (registry->Get(filePathErrorStr, AZ::SettingsRegistryMergeUtils::FilePathKey_ErrorText); !filePathErrorStr.empty())
+            {
+                errorMessage += "Additional Info:\n";
+                errorMessage += filePathErrorStr.c_str();
+            }
+        }
+
+        if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get(); nativeUI != nullptr)
+        {
+            nativeUI->DisplayOkDialog("O3DE Fatal Error", errorMessage.c_str(), false);
+        }
+        else
+        {
+            AZ_Error("ComponentApplication", false, "O3DE Fatal Error: %s\n", errorMessage.c_str());
+        }
+    }
+
+
     Entity* ComponentApplication::Create(const Descriptor& descriptor, const StartupParameters& startupParameters)
     {
         AZ_Assert(!m_isStarted, "Component application already started!");
+
+        if (m_engineRoot.empty())
+        {
+            ReportBadEngineRoot();
+            return nullptr;
+        }
 
         m_startupParameters = startupParameters;
 
@@ -868,46 +902,6 @@ namespace AZ
             // Trace messages driller will consume resources only when started.
             m_drillerManager->Register(aznew Debug::TraceMessagesDriller);
             m_drillerManager->Register(aznew Debug::EventTraceDriller);
-        }
-    }
-
-    void ComponentApplication::ParseCommandLine(const AZ::CommandLine& commandLine)
-    {
-        struct OptionKeyToRegsetKey
-        {
-            AZStd::string_view m_optionKey;
-            AZStd::string m_regsetKey;
-        };
-
-        // Provide overrides for the engine root, the project root and the project cache root
-        AZStd::array commandOptions = {
-            OptionKeyToRegsetKey{ "engine-path", AZStd::string::format("%s/engine_path", AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) },
-            OptionKeyToRegsetKey{ "project-path", AZStd::string::format("%s/project_path", AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) },
-            OptionKeyToRegsetKey{ "project-cache-path", AZStd::string::format("%s/project_cache_path", AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) }
-        };
-
-        AZStd::fixed_vector<AZStd::string, commandOptions.size()> overrideArgs;
-
-        for (auto&& [optionKey, regsetKey] : commandOptions)
-        {
-            if (size_t optionCount = commandLine.GetNumSwitchValues(optionKey); optionCount > 0)
-            {
-                // Use the last supplied command option value to override previous values
-                auto overrideArg = AZStd::string::format(R"(--regset="%s=%s")", regsetKey.c_str(),
-                    commandLine.GetSwitchValue(optionKey, optionCount - 1).c_str());
-                overrideArgs.emplace_back(AZStd::move(overrideArg));
-            }
-        }
-
-        if (!overrideArgs.empty())
-        {
-            // Dump the input command line, add the additional option overrides
-            // and Parse the new command line into the Component Application command line
-            AZ::CommandLine::ParamContainer commandLineArgs;
-            commandLine.Dump(commandLineArgs);
-            commandLineArgs.insert(commandLineArgs.end(), AZStd::make_move_iterator(overrideArgs.begin()),
-                AZStd::make_move_iterator(overrideArgs.end()));
-            m_commandLine.Parse(commandLineArgs);
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.h
@@ -328,9 +328,6 @@ namespace AZ
         /// Create the drillers
         void        CreateDrillers();
 
-        /// Parse ComponentApplication specific command line arguments
-        void ParseCommandLine(const AZ::CommandLine& commandLine);
-
         virtual void MergeSettingsToRegistry(SettingsRegistryInterface& registry);
 
         //! Sets the specializations that will be used when loading the Settings Registry. Extend this in derived

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
@@ -15,45 +15,49 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/string/string.h>
 
-namespace AZ
+namespace AZ::NativeUI
 {
-    namespace NativeUI
+    enum AssertAction
     {
-        enum AssertAction
-        {
-            IGNORE_ASSERT = 0,
-            IGNORE_ALL_ASSERTS,
-            BREAK,
-            NONE,
-        };
+        IGNORE_ASSERT = 0,
+        IGNORE_ALL_ASSERTS,
+        BREAK,
+        NONE,
+    };
 
-        class NativeUIRequests
-            : public AZ::EBusTraits
-        {
-        public:
-            //////////////////////////////////////////////////////////////////////////
-            // EBusTraits overrides
-            static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-            static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-            using MutexType = AZStd::recursive_mutex;
+    class NativeUIRequests
+    {
+    public:
+        AZ_RTTI(NativeUIRequests, "{48361EE6-C1E7-4965-A13A-7425B2691817}");
+        virtual ~NativeUIRequests() = default;
 
-            // Waits for user to select an option before execution continues
-            // Returns the option string selected by the user
-            virtual AZStd::string DisplayBlockingDialog(const AZStd::string& /*title*/, const AZStd::string& /*message*/, const AZStd::vector<AZStd::string>& /*options*/) const { return ""; };
+        // Waits for user to select an option before execution continues
+        // Returns the option string selected by the user
+        virtual AZStd::string DisplayBlockingDialog(const AZStd::string& /*title*/, const AZStd::string& /*message*/, const AZStd::vector<AZStd::string>& /*options*/) const { return ""; };
 
-            // Waits for user to select an option ('Ok' or optionally 'Cancel') before execution continues
-            // Returns the option string selected by the user
-            virtual AZStd::string DisplayOkDialog(const AZStd::string& /*title*/, const AZStd::string& /*message*/, bool /*showCancel*/) const { return ""; };
+        // Waits for user to select an option ('Ok' or optionally 'Cancel') before execution continues
+        // Returns the option string selected by the user
+        virtual AZStd::string DisplayOkDialog(const AZStd::string& /*title*/, const AZStd::string& /*message*/, bool /*showCancel*/) const { return ""; };
 
-            // Waits for user to select an option ('Yes', 'No' or optionally 'Cancel') before execution continues
-            // Returns the option string selected by the user
-            virtual AZStd::string DisplayYesNoDialog(const AZStd::string& /*title*/, const AZStd::string& /*message*/, bool /*showCancel*/) const { return ""; };
+        // Waits for user to select an option ('Yes', 'No' or optionally 'Cancel') before execution continues
+        // Returns the option string selected by the user
+        virtual AZStd::string DisplayYesNoDialog(const AZStd::string& /*title*/, const AZStd::string& /*message*/, bool /*showCancel*/) const { return ""; };
 
-            // Displays an assert dialog box
-            // Returns the action selected by the user
-            virtual AssertAction DisplayAssertDialog(const AZStd::string& /*message*/) const { return AssertAction::NONE; };
-        };
+        // Displays an assert dialog box
+        // Returns the action selected by the user
+        virtual AssertAction DisplayAssertDialog(const AZStd::string& /*message*/) const { return AssertAction::NONE; };
+    };
 
-        using NativeUIRequestBus = AZ::EBus<NativeUIRequests>;
-    }
-}
+    class NativeUIEBusTraits
+        : public AZ::EBusTraits
+    {
+    public:
+        //////////////////////////////////////////////////////////////////////////
+        // EBusTraits overrides
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+        using MutexType = AZStd::recursive_mutex;
+    };
+
+    using NativeUIRequestBus = AZ::EBus<NativeUIRequests, NativeUIEBusTraits>;
+} // namespace AZ::NativeUI

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.cpp
@@ -15,50 +15,19 @@
 
 #include <AzCore/NativeUI/NativeUISystemComponent.h>
 
-namespace AZ
+namespace AZ::NativeUI
 {
-    using namespace AZ::NativeUI;
-
-    void NativeUISystemComponent::Reflect(AZ::ReflectContext* context)
+    NativeUISystem::NativeUISystem()
     {
-        if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
-        {
-            serialize->Class<NativeUISystemComponent, AZ::Component>()
-                ->Version(0)
-                ;
-
-            if (AZ::EditContext* ec = serialize->GetEditContext())
-            {
-                ec->Class<NativeUISystemComponent>("NativeUI", "Adds basic support for native (platform specific) UI dialog boxes")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ;
-            }
-        }
+        NativeUIRequestBus::Handler::BusConnect();
     }
 
-    void NativeUISystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+    NativeUISystem::~NativeUISystem()
     {
-        provided.push_back(AZ_CRC("NativeUIService", 0x8ec25f87));
+        NativeUIRequestBus::Handler::BusDisconnect();
     }
 
-    void NativeUISystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
-    {
-        incompatible.push_back(AZ_CRC("NativeUIService", 0x8ec25f87));
-    }
-
-    void NativeUISystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
-    {
-        (void)required;
-    }
-
-    void NativeUISystemComponent::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
-    {
-        (void)dependent;
-    }
-
-    AssertAction NativeUISystemComponent::DisplayAssertDialog(const AZStd::string& message) const
+    AssertAction NativeUISystem::DisplayAssertDialog(const AZStd::string& message) const
     {
         static const char* buttonNames[3] = { "Ignore", "Ignore All", "Break" };
         AZStd::vector<AZStd::string> options;
@@ -80,7 +49,7 @@ namespace AZ
         return AssertAction::NONE;
     }
 
-    AZStd::string NativeUISystemComponent::DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const
+    AZStd::string NativeUISystem::DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const
     {
         AZStd::vector<AZStd::string> options;
 
@@ -93,7 +62,7 @@ namespace AZ
         return DisplayBlockingDialog(title, message, options);
     }
 
-    AZStd::string NativeUISystemComponent::DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const
+    AZStd::string NativeUISystem::DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const
     {
         AZStd::vector<AZStd::string> options;
 
@@ -106,18 +75,4 @@ namespace AZ
 
         return DisplayBlockingDialog(title, message, options);
     }
-
-    void NativeUISystemComponent::Init()
-    {
-    }
-
-    void NativeUISystemComponent::Activate()
-    {
-        NativeUIRequestBus::Handler::BusConnect();
-    }
-
-    void NativeUISystemComponent::Deactivate()
-    {
-        NativeUIRequestBus::Handler::BusDisconnect();
-    }
-}
+} // namespace AZ::NativeUI

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.h
@@ -15,40 +15,24 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/NativeUI/NativeUIRequests.h>
 
-namespace AZ
+namespace AZ::NativeUI
 {
-    namespace NativeUI
+    class NativeUISystem
+        : public NativeUIRequestBus::Handler
     {
-        class NativeUISystemComponent
-            : public AZ::Component
-            , public NativeUIRequestBus::Handler
-        {
-        public:
-            AZ_COMPONENT(NativeUISystemComponent, "{E996C058-4AFE-4C8C-816F-98D864D8576D}");
+    public:
+        AZ_RTTI(NativeUISystem, "{FF534B2C-11BE-4DEA-A5B7-A4FA96FE1EDE}", NativeUIRequests);
+        AZ_CLASS_ALLOCATOR(NativeUISystem, AZ::OSAllocator, 0);
 
-            static void Reflect(AZ::ReflectContext* context);
+        NativeUISystem();
+        ~NativeUISystem() override;
 
-            static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
-            static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
-            static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
-            static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
-
-            ////////////////////////////////////////////////////////////////////////
-            // NativeUIRequestBus interface implementation
-            AZStd::string DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const override;
-            AZStd::string DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
-            AZStd::string DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
-            AssertAction DisplayAssertDialog(const AZStd::string& message) const override;
-            ////////////////////////////////////////////////////////////////////////
-
-        protected:
-
-            ////////////////////////////////////////////////////////////////////////
-            // AZ::Component interface implementation
-            void Init() override;
-            void Activate() override;
-            void Deactivate() override;
-            ////////////////////////////////////////////////////////////////////////
-        };
-    }
-}
+        ////////////////////////////////////////////////////////////////////////
+        // NativeUIRequestBus interface implementation
+        AZStd::string DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const override;
+        AZStd::string DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
+        AZStd::string DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const override;
+        AssertAction DisplayAssertDialog(const AZStd::string& message) const override;
+        ////////////////////////////////////////////////////////////////////////
+    };
+} // namespace AZ::NativeUI

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -256,7 +256,7 @@ namespace AZ
 
         //! Remove the value at the provided path 
         //! @param path The path to a value that should be removed
-        //! @return Whether or not the value was stored at the provided path. An invalid path will return false;
+        //! @return Whether or not the path was found and removed. An invalid path will return false;
         virtual bool Remove(AZStd::string_view path) = 0;
 
         //! Structure which contains configuration settings for how to parse a single command line argument

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.h
@@ -55,6 +55,9 @@ namespace AZ::SettingsRegistryMergeUtils
     //! Development write storage path may be considered temporary or cache storage on some platforms
     inline static constexpr char FilePathKey_DevWriteStorage[] = "/Amazon/AzCore/Runtime/FilePaths/DevWriteStorage";
 
+    //! Stores error text regarding engine boot sequence when engine and project roots cannot be determined
+    inline static constexpr char FilePathKey_ErrorText[] = "/Amazon/AzCore/Runtime/FilePaths/ErrorText";
+
     //! Root key for where command line are stored at within the settings registry
     inline static constexpr char CommandLineRootKey[] = "/Amazon/AzCore/Runtime/CommandLine";
     //! Key set to trigger a notification that the CommandLine has been stored within the settings registry
@@ -218,6 +221,9 @@ namespace AZ::SettingsRegistryMergeUtils
     //! Query the command line settings from the Setting Registry and stores them
     //! into the AZ::CommandLine instance
     bool GetCommandLineFromRegistry(SettingsRegistryInterface& registry, AZ::CommandLine& commandLine);
+
+    //! Parse a CommandLine and transform certain options into formal "regset" options
+    void ParseCommandLine(AZ::CommandLine& commandLine);
 
     //! Structure for configuring how values should be dumped from the Settings Registry
     struct DumperSettings

--- a/Code/Framework/AzCore/Platform/Android/AzCore/NativeUI/NativeUISystemComponent_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/NativeUI/NativeUISystemComponent_Android.cpp
@@ -22,7 +22,7 @@ namespace AZ
 {
     namespace NativeUI
     {
-        AZStd::string NativeUISystemComponent::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
+        AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
             AZ::Android::JNI::Object object("com/amazon/lumberyard/NativeUI/LumberyardNativeUI");
             object.RegisterStaticMethod("DisplayDialog", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)V");

--- a/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/NativeUI/NativeUISystemComponent_Unimplemented.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Unimplemented/AzCore/NativeUI/NativeUISystemComponent_Unimplemented.cpp
@@ -12,16 +12,11 @@
 
 #include <AzCore/NativeUI/NativeUISystemComponent.h>
 
-namespace AZ
+namespace AZ::NativeUI
 {
-    namespace NativeUI
+    AZStd::string NativeUISystem::DisplayBlockingDialog([[maybe_unused]] const AZStd::string& title, [[maybe_unused]] const AZStd::string& message,
+        [[maybe_unused]] const AZStd::vector<AZStd::string>& options) const
     {
-        AZStd::string NativeUISystemComponent::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
-        {
-            AZ_UNUSED(title);
-            AZ_UNUSED(message);
-            AZ_UNUSED(options);
-            return "";
-        }
+        return {};
     }
 }

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/NativeUI/NativeUISystemComponent_Mac.mm
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/NativeUI/NativeUISystemComponent_Mac.mm
@@ -26,7 +26,7 @@ namespace AZ
 {
     namespace NativeUI
     {
-        AZStd::string NativeUISystemComponent::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
+        AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
             __block NSModalResponse response = -1;
             

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/NativeUI/NativeUISystemComponent_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/NativeUI/NativeUISystemComponent_Windows.cpp
@@ -245,7 +245,7 @@ namespace AZ
 {
     namespace NativeUI
     {
-        AZStd::string NativeUISystemComponent::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
+        AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
             if (options.size() >= MAX_ITEMS)
             {

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
@@ -18,7 +18,7 @@ namespace AZ
 {
     namespace NativeUI
     {
-        AZStd::string NativeUISystemComponent::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
+        AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
             __block AZStd::string userSelection = "";
             

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.h
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.h
@@ -16,6 +16,7 @@
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/UserSettings/UserSettings.h>
 #include <AzCore/Math/Uuid.h>
+#include <AzCore/NativeUI/NativeUIRequests.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/string/fixed_string.h>
@@ -187,6 +188,7 @@ namespace AzFramework
         AZStd::unique_ptr<AZ::IO::FileIOBase> m_archiveFileIO; ///> The Default file IO instance is a ArchiveFileIO.
         AZStd::unique_ptr<AZ::IO::Archive> m_archive; ///> The AZ::IO::Instance
         AZStd::unique_ptr<Implementation> m_pimpl;
+        AZStd::unique_ptr<AZ::NativeUI::NativeUIRequests> m_nativeUI;
         bool m_ownsConsole = false;
 
         bool m_exitMainLoopRequested = false;

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponentHelper.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponentHelper.cpp
@@ -220,7 +220,7 @@ namespace AzFramework
             {
                 // Read the wait for connection boolean from the Settings Registry
                 AZ::s64 waitForConnect64{};
-                if (!AZ::SettingsRegistryMergeUtils::PlatformGet(*settingsRegistry, waitForConnect64, AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey, AzFramework::AssetSystem::WaitForConnect))
+                if (AZ::SettingsRegistryMergeUtils::PlatformGet(*settingsRegistry, waitForConnect64, AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey, AzFramework::AssetSystem::WaitForConnect))
                 {
                     outputConnectionSettings.m_waitForConnect = waitForConnect64 != 0;
                 }

--- a/Code/Framework/AzFramework/AzFramework/ProjectManager/ProjectManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/ProjectManager/ProjectManager.cpp
@@ -41,9 +41,10 @@ namespace AzFramework::ProjectManager
             // at the end of the function
             AZ::CommandLine commandLine;
             commandLine.Parse(argc, argv);
-            AZ::SettingsRegistryImpl settingsRegistry;
-            // Store the Command line to the Setting Registry
+            AZ::SettingsRegistryMergeUtils::ParseCommandLine(commandLine);
 
+            // Store the Command line to the Setting Registry
+            AZ::SettingsRegistryImpl settingsRegistry;
             AZ::SettingsRegistryMergeUtils::StoreCommandLineToRegistry(settingsRegistry, commandLine);
             AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_Bootstrap(settingsRegistry);
             AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_O3deUserRegistry(settingsRegistry, AZ_TRAIT_OS_PLATFORM_CODENAME, {});
@@ -68,7 +69,14 @@ namespace AzFramework::ProjectManager
         // If we were able to locate a path to a project, we're done
         if (!projectRootPath.empty())
         {
-            return ProjectPathCheckResult::ProjectPathFound;
+            AZ::IO::FixedMaxPath projectJsonPath = engineRootPath / projectRootPath / "project.json";
+            if (AZ::IO::SystemFile::Exists(projectJsonPath.c_str()))
+            {
+                return ProjectPathCheckResult::ProjectPathFound;
+            }
+            AZ_TracePrintf(
+                "ProjectManager", "Did not find a project file at location '%s', launching the Project Manager...",
+                projectJsonPath.c_str());
         }
 
         if (LaunchProjectManager(engineRootPath))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -284,6 +284,10 @@ namespace AzToolsFramework
     void ToolsApplication::Start(const Descriptor& descriptor, const StartupParameters& startupParameters/* = StartupParameters()*/)
     {
         Application::Start(descriptor, startupParameters);
+        if (!m_isStarted)
+        {
+            return;
+        }
 
         m_editorEntityManager.Start();
 

--- a/Code/Sandbox/Editor/CryEdit.cpp
+++ b/Code/Sandbox/Editor/CryEdit.cpp
@@ -5045,12 +5045,28 @@ extern "C"
 #pragma comment(lib, "Shell32.lib")
 #endif
 
+struct CryAllocatorsRAII
+{
+    CryAllocatorsRAII()
+    {
+        AZ_Assert(!AZ::AllocatorInstance<AZ::LegacyAllocator>::IsReady(), "Expected allocator to not be initialized, hunt down the static that is initializing it");
+        AZ_Assert(!AZ::AllocatorInstance<CryStringAllocator>::IsReady(), "Expected allocator to not be initialized, hunt down the static that is initializing it");
+
+        AZ::AllocatorInstance<AZ::LegacyAllocator>::Create();
+        AZ::AllocatorInstance<CryStringAllocator>::Create();
+    }
+
+    ~CryAllocatorsRAII()
+    {
+        AZ::AllocatorInstance<CryStringAllocator>::Destroy();
+        AZ::AllocatorInstance<AZ::LegacyAllocator>::Destroy();
+    }
+};
+
+
 extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
 {
-    AZ_Assert(!AZ::AllocatorInstance<AZ::LegacyAllocator>::IsReady(), "Expected allocator to not be initialized, hunt down the static that is initializing it");
-    AZ::AllocatorInstance<AZ::LegacyAllocator>::Create();
-    AZ_Assert(!AZ::AllocatorInstance<CryStringAllocator>::IsReady(), "Expected allocator to not be initialized, hunt down the static that is initializing it");
-    AZ::AllocatorInstance<CryStringAllocator>::Create();
+    CryAllocatorsRAII cryAllocatorsRAII;
 
     // ensure the EditorEventsBus context gets created inside EditorLib
     [[maybe_unused]] const auto& editorEventsContext = AzToolsFramework::EditorEvents::Bus::GetOrCreateContext();
@@ -5058,7 +5074,7 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
     // connect relevant buses to global settings
     gSettings.Connect();
 
-    CCryEditApp* theApp = new CCryEditApp();
+    auto theApp = AZStd::make_unique<CCryEditApp>();
     // this does some magic to set the current directory...
     {
         QCoreApplication app(argc, argv);
@@ -5144,8 +5160,6 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
         CCryEditApp::instance()->ExitInstance(exitCode);
 
     }
-
-    delete theApp;
 
     gSettings.Disconnect();
 

--- a/Code/Sandbox/Editor/main.cpp
+++ b/Code/Sandbox/Editor/main.cpp
@@ -30,17 +30,14 @@ int main(int argc, char* argv[])
     [[maybe_unused]] const bool loaded = handle->Load(true);
     AZ_Assert(loaded, "EditorLib could not be loaded");
 
+    int ret = 1;
     if (auto fn = handle->GetFunction<CryEditMain>(CryEditMainName); fn != nullptr)
     {
-        const int ret = AZStd::invoke(fn, argc, argv);
-
-        AZ::AllocatorInstance<AZ::OSAllocator>::Destroy();
-        AZ::Environment::Detach();
-
-        return ret;
+        ret = AZStd::invoke(fn, argc, argv);
     }
 
+    handle = {};
     AZ::AllocatorInstance<AZ::OSAllocator>::Destroy();
     AZ::Environment::Detach();
-    return 1;
+    return ret;
 }

--- a/Code/Tools/RC/ResourceCompiler/main.cpp
+++ b/Code/Tools/RC/ResourceCompiler/main.cpp
@@ -579,6 +579,8 @@ int rcmain(int argc, char** argv, [[maybe_unused]] char** envp)
             // on the command line
             AZ::CommandLine commandLine;
             commandLine.Parse(argc, argv);
+            AZ::SettingsRegistryMergeUtils::ParseCommandLine(commandLine);
+
             AZ::SettingsRegistryImpl settingsRegistry;
             AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_Bootstrap(settingsRegistry);
             AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_O3deUserRegistry(settingsRegistry, AZ_TRAIT_OS_PLATFORM_CODENAME, {});


### PR DESCRIPTION
Cherry-Pick: 6ce7a6d30c57c941459b43c157861df5d9143ae1

* Setup NativeUIRequests as an AZ::Interface.  Adds a NativeUISystemComponent to AzFramework Application.

* Renames NativeUISystemComponent (class) to NativeUISystem, since it's no longer a Component.

* Minor update to SettingsRegistryInterface::Remove doc-comments for accuracy.

* Fixes to make an early fatal shutdown of Editor occur without crash.

* LYN-2723: Updates startup to handle errors: engine root is empty, no valid project.json found (mismatched engine name), or bad project path (launch project picker dialog).

* LYN-2723: Minor formatting/spelling edits.

* LYN-2723: Moves ParseCommandLine from ComponentApplication to SettingsRegistryMergeUtils so it can be used in more places.

* Misc fixes. 'wait_for_connect' setting wasn't being properly applied to AP connection settings. Fix infinite loop in CCmdLine::Next.

* LYN-2723: Addresses review feedback.

* LYN-2723: Reverts some changes that caused a unit test to fail.

* LYN-2723: Reverts one more change that was unnecessary.