### PR TITLE
Disable metal shaders that dont cross compile correctly

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetCS.shader
@@ -10,6 +10,7 @@
           "type": "Compute"
         }
       ]
-    }
+    },
+    "DisabledRHIBackends": ["metal"]
 
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHistogramGenerator.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHistogramGenerator.shader
@@ -12,6 +12,7 @@
           "type": "Compute"
         }
       ]
-    }
+    },
+    "DisabledRHIBackends": ["metal"]
 
 }


### PR DESCRIPTION
Disabling the following shaders for Metal backend as there are problems with cross compiling them. Jiras have been opened to address the issues and re-enable the shaders.