### PR TITLE
[SPEC-6486] DiffuseProbeGrid Resultcode initialized but not referenced in release builds

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseProbeGrid/DiffuseProbeGrid.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseProbeGrid/DiffuseProbeGrid.cpp
@@ -263,7 +263,7 @@ namespace AZ
                 RHI::ImageInitRequest request;
                 request.m_image = m_classificationImage[m_currentImageIndex].get();
                 request.m_descriptor = RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::ShaderReadWrite, width, height, DiffuseProbeGridRenderData::ClassificationImageFormat);
-                RHI::ResultCode result = m_renderData->m_imagePool->InitImage(request);
+                [[maybe_unused]] RHI::ResultCode result = m_renderData->m_imagePool->InitImage(request);
                 AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize m_probeClassificationImage image");
             }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseProbeGrid/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseProbeGrid/DiffuseProbeGridRayTracingPass.cpp
@@ -294,7 +294,7 @@ namespace AZ
 
                 // probe classification
                 {
-                    RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetClassificationImageAttachmentId(), diffuseProbeGrid->GetClassificationImage());
+                    [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(diffuseProbeGrid->GetClassificationImageAttachmentId(), diffuseProbeGrid->GetClassificationImage());
                     AZ_Assert(result == RHI::ResultCode::Success, "Failed to import probeClassificationImage");
 
                     RHI::ImageScopeAttachmentDescriptor desc;


### PR DESCRIPTION
Added maybe_used to result codes that are only used in Asserts.