### PR TITLE
[LYN-3269] EMotionFX Editor save changed files prompts users to save files to the cache

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/SaveChangedFilesManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/SaveChangedFilesManager.cpp
@@ -420,15 +420,7 @@ namespace EMStudio
                     productFilename,
                     sourceAssetFilename);
 
-                AZStd::string usedFilename;
-                if (sourceAssetFound)
-                {
-                    usedFilename = sourceAssetFilename;
-                }
-                else
-                {
-                    usedFilename = dirtyFileNames[i];
-                }
+                const AZStd::string usedFilename = sourceAssetFound ? sourceAssetFilename : dirtyFileNames[i];
 
                 // Separate the path from the filename, so that we can display the filename in bold.
                 AZStd::string fullPath;


### PR DESCRIPTION
* The asset source filename is now displayed instead of the product filename.
* Fixed a stylesheet issue with screen scaling on 4K monitors for the saved changed files window.
* Cleaned up surrounding code.

![image](https://user-images.githubusercontent.com/43751992/116546452-e9524600-a8f1-11eb-8d3b-1eb8c0a103e4.png)
