### PR TITLE
[LYN-3344] EMotionFX: Data integrity error, missing keyframe at the end of the animation

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Importer/ChunkProcessors.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Importer/ChunkProcessors.cpp
@@ -775,7 +775,7 @@ namespace EMotionFX
         } // for all submotions
 
         motion->UpdateDuration();
-
+        AZ_Assert(motion->GetMotionData()->VerifyIntegrity(), "Data integrity issue in animation '%s'.", motion->GetName());
         return true;
     }
 
@@ -1572,7 +1572,7 @@ namespace EMotionFX
         } // for all submotions
 
         motion->UpdateDuration();
-
+        AZ_Assert(motion->GetMotionData()->VerifyIntegrity(), "Data integrity issue in animation '%s'.", motion->GetName());
         return true;
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/MotionData.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/MotionData.h
@@ -195,6 +195,7 @@ namespace EMotionFX
         virtual bool IsMorphAnimated(size_t morphDataIndex) const = 0;
         virtual bool IsFloatAnimated(size_t floatDataIndex) const = 0;
         virtual void UpdateDuration() {}
+        virtual bool VerifyIntegrity() const { return true; }
 
         void Resize(size_t numJoints, size_t numMorphs, size_t numFloats);
         void Clear();

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.h
@@ -82,7 +82,15 @@ namespace EMotionFX
         void ClearMorphSamples(size_t morphDataIndex) override;
         void ClearFloatSamples(size_t floatDataIndex) override;
 
-        bool VerifyIntegrity() const;
+        bool VerifyIntegrity() const override;
+
+        //! Animation tracks in the DCC tool formats are often stored individually, each having its own duration.
+        //! For the motion data, it is required to have tracks with the same duration and e.g. a position track
+        //! has to match the duration of a morph track. This will be automatically fixed by adding missing
+        //! keyframes at the end of the tracks to match the animation's global duration. The value of these
+        //! are the same as the last one of the given track so that they freeze at that value.
+        void FixMissingEndKeyframes();
+
         void ScaleData(float scaleFactor) override;
         void UpdateDuration() override;
 
@@ -154,6 +162,9 @@ namespace EMotionFX
         void RemoveJointSampleData(size_t jointDataIndex) override;
         void RemoveMorphSampleData(size_t morphDataIndex) override;
         void RemoveFloatSampleData(size_t floatDataIndex) override;
+
+        template<class KeyTrackType>
+        void FixMissingEndKeyframes(KeyTrackType& keytrack, float endTimeToMatch);
 
     private:
         AZStd::vector<JointData> m_jointData;


### PR DESCRIPTION
**These changes have already been reviewed with PR#393 which went into 1.0 and are just cherry-picked.**

Animation tracks in the DCC tool formats are often stored individually, each having its own duration. For EMotion FX motion data, it is required to have tracks with the same duration and e.g. a position track has to match the duration of a morph track. This will be automatically fixed by adding missing keyframes at the end of the tracks to match the animation's global duration. The value of these are the same as the last one of the given track so that they freeze at that value.

* Added function that adds missing keyframes to match the individual tracks' duration for the non-uniform motion data in emfx.
* Added data integrity checks for various stages of the motion data builder / motion exporter.
* Checking for data integrity issues with an assert in the emfx importer. This is just a safety check and we don't need that for release builds as they should be captured at asset processing time already.