### PR TITLE
[LYN-3419] First pass of removing unused logic for old viewport interaction model.

### DIFF
--- a/Code/Sandbox/Editor/Controls/ReflectedPropertyControl/PropertyGenericCtrl.cpp
+++ b/Code/Sandbox/Editor/Controls/ReflectedPropertyControl/PropertyGenericCtrl.cpp
@@ -90,9 +90,6 @@ void ShaderPropertyEditor::onEditClicked()
 }
 void MaterialPropertyEditor::onEditClicked()
 {
-    QString name = GetValue();
-    IDataBaseItem *pItem = GetIEditor()->GetMaterialManager()->FindItemByName(name);
-    GetIEditor()->OpenMaterialLibrary(pItem);
 }
 
 void MaterialPropertyEditor::onButton2Clicked()

--- a/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
@@ -605,19 +605,12 @@ void LevelEditorMenuHandler::PopulateEditMenu(ActionManager::MenuWrapper& editMe
     editMenu.AddSeparator();
 
     // Lock Selection
-    editMenu.AddAction(ID_EDIT_FREEZE);
-
     // NEWMENUS: NEEDS IMPLEMENTATION
     //// Unlock Selection
     //auto unlockSelectionMenu = editMenu.Get()->addAction(tr("Unlock Selection"));
 
     //// Unlock Last Locked
     //auto unlockLastLockedMenu = editMenu.Get()->addAction(tr("Unlock Last Locked"));
-
-    // Unlock All
-    editMenu.AddAction(ID_EDIT_UNFREEZEALL);
-
-    editMenu.AddSeparator();
 
     // Editor Settings
     auto editorSettingsMenu = editMenu.AddMenu(tr("Editor Settings"));

--- a/Code/Sandbox/Editor/CryEdit.cpp
+++ b/Code/Sandbox/Editor/CryEdit.cpp
@@ -389,14 +389,9 @@ void CCryEditApp::RegisterActionHandlers()
     ON_COMMAND(ID_EDIT_DELETE, OnEditDelete)
     ON_COMMAND(ID_MOVE_OBJECT, OnMoveObject)
     ON_COMMAND(ID_RENAME_OBJ, OnRenameObj)
-    ON_COMMAND(ID_SET_HEIGHT, OnSetHeight)
     ON_COMMAND(ID_EDITMODE_MOVE, OnEditmodeMove)
     ON_COMMAND(ID_EDITMODE_ROTATE, OnEditmodeRotate)
     ON_COMMAND(ID_EDITMODE_SCALE, OnEditmodeScale)
-    ON_COMMAND(ID_OBJECTMODIFY_SETAREA, OnObjectSetArea)
-    ON_COMMAND(ID_OBJECTMODIFY_SETHEIGHT, OnObjectSetHeight)
-    ON_COMMAND(ID_OBJECTMODIFY_FREEZE, OnObjectmodifyFreeze)
-    ON_COMMAND(ID_OBJECTMODIFY_UNFREEZE, OnObjectmodifyUnfreeze)
     ON_COMMAND(ID_UNDO, OnUndo)
     ON_COMMAND(ID_TOOLBAR_WIDGET_REDO, OnUndo)     // Can't use the same ID, because for the menu we can't have a QWidgetAction, while for the toolbar we want one
     ON_COMMAND(ID_IMPORT_ASSET, OnOpenAssetImporter)
@@ -424,8 +419,6 @@ void CCryEditApp::RegisterActionHandlers()
     ON_COMMAND(ID_EDIT_HIDE, OnEditHide)
     ON_COMMAND(ID_EDIT_SHOW_LAST_HIDDEN, OnEditShowLastHidden)
     ON_COMMAND(ID_EDIT_UNHIDEALL, OnEditUnhideall)
-    ON_COMMAND(ID_EDIT_FREEZE, OnEditFreeze)
-    ON_COMMAND(ID_EDIT_UNFREEZEALL, OnEditUnfreezeall)
 
     ON_COMMAND(ID_SNAP_TO_GRID, OnSnap)
 
@@ -477,7 +470,6 @@ void CCryEditApp::RegisterActionHandlers()
     ON_COMMAND(ID_ROTATESELECTION_YAXIS, OnRotateselectionYaxis)
     ON_COMMAND(ID_ROTATESELECTION_ZAXIS, OnRotateselectionZaxis)
     ON_COMMAND(ID_ROTATESELECTION_ROTATEANGLE, OnRotateselectionRotateangle)
-    ON_COMMAND(ID_MODIFY_OBJECT_HEIGHT, OnObjectSetHeight)
     ON_COMMAND(ID_EDIT_RENAMEOBJECT, OnEditRenameobject)
     ON_COMMAND(ID_CHANGEMOVESPEED_INCREASE, OnChangemovespeedIncrease)
     ON_COMMAND(ID_CHANGEMOVESPEED_DECREASE, OnChangemovespeedDecrease)
@@ -500,7 +492,6 @@ void CCryEditApp::RegisterActionHandlers()
     ON_COMMAND(ID_OPEN_ASSET_BROWSER, OnOpenAssetBrowserView)
     ON_COMMAND(ID_OPEN_AUDIO_CONTROLS_BROWSER, OnOpenAudioControlsEditor)
 
-    ON_COMMAND(ID_OPEN_MATERIAL_EDITOR, OnOpenMaterialEditor)
     ON_COMMAND(ID_GOTO_VIEWPORTSEARCH, OnGotoViewportSearch)
     ON_COMMAND(ID_DISPLAY_SHOWHELPERS, OnShowHelpers)
     ON_COMMAND(ID_OPEN_TRACKVIEW, OnOpenTrackView)
@@ -2734,10 +2725,6 @@ void CCryEditApp::OnRenameObj()
 {
 }
 
-void CCryEditApp::OnSetHeight()
-{
-}
-
 //////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnEditmodeMove()
 {
@@ -2805,167 +2792,6 @@ void CCryEditApp::OnUpdateEditmodeScale(QAction* action)
         &AzToolsFramework::EditorTransformComponentSelectionRequests::GetTransformMode);
 
     action->setChecked(mode == AzToolsFramework::EditorTransformComponentSelectionRequests::Mode::Scale);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnObjectSetArea()
-{
-    CSelectionGroup* pSelection = GetIEditor()->GetSelection();
-    if (!pSelection->IsEmpty())
-    {
-        bool ok = false;
-        int fractionalDigitCount = 2;
-        float area = aznumeric_caster(QInputDialog::getDouble(AzToolsFramework::GetActiveWindow(), QObject::tr("Insert Value"), QStringLiteral(""), 0, std::numeric_limits<float>::lowest(), std::numeric_limits<float>::max(), fractionalDigitCount, &ok));
-        if (!ok)
-        {
-            return;
-        }
-
-        GetIEditor()->BeginUndo();
-        for (int i = 0; i < pSelection->GetCount(); i++)
-        {
-            CBaseObject* obj = pSelection->GetObject(i);
-            obj->SetArea(area);
-        }
-        GetIEditor()->AcceptUndo("Set Area");
-        GetIEditor()->SetModifiedFlag();
-        GetIEditor()->SetModifiedModule(eModifiedBrushes);
-    }
-    else
-    {
-        QMessageBox::critical(AzToolsFramework::GetActiveWindow(), QString(), QObject::tr("No objects selected"));
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnObjectSetHeight()
-{
-    AzFramework::EntityContextId editorContextId;
-    AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
-        editorContextId, &AzToolsFramework::EditorEntityContextRequests::GetEditorEntityContextId);
-
-    CSelectionGroup* sel = GetIEditor()->GetObjectManager()->GetSelection();
-
-    if (!sel->IsEmpty())
-    {
-        // Retrieve the Z origin from where height is messured from
-        auto getZOrigin = [&](const Vec3& pos, [[maybe_unused]] AZ::EntityId entityId)
-        {
-            float z = GetIEditor()->GetTerrainElevation(pos.x, pos.y);
-            if (z != pos.z)
-            {
-                float zdown = FLT_MAX;
-                float zup = FLT_MAX;
-                AzFramework::RenderGeometry::RayRequest ray;
-                ray.m_startWorldPosition = LYVec3ToAZVec3(pos);
-                ray.m_onlyVisible = true;
-                if (entityId.IsValid()) // Don't check height against self
-                {
-                    ray.m_entityFilter.m_ignoreEntities.insert(entityId);
-                }
-                // Down
-                ray.m_endWorldPosition = LYVec3ToAZVec3(pos - Vec3(0, 0, 4000));
-                {
-                    AzFramework::RenderGeometry::RayResult result;
-                    AzFramework::RenderGeometry::IntersectorBus::EventResult(result, editorContextId,
-                        &AzFramework::RenderGeometry::IntersectorInterface::RayIntersect, ray);
-                    if (result)
-                    {
-                        zdown = result.m_worldPosition.GetZ();
-                    }
-                }
-                // Up
-                ray.m_endWorldPosition = LYVec3ToAZVec3(pos + Vec3(0, 0, 4000));
-                {
-                    AzFramework::RenderGeometry::RayResult result;
-                    AzFramework::RenderGeometry::IntersectorBus::EventResult(result, editorContextId,
-                        &AzFramework::RenderGeometry::IntersectorInterface::RayIntersect, ray);
-                    if (result)
-                    {
-                        zup = result.m_worldPosition.GetZ();
-                    }
-                }
-                if (zdown != FLT_MAX && zup != FLT_MAX)
-                {
-                    if (fabs(zup - z) < fabs(zdown - z))
-                    {
-                        z = zup;
-                    }
-                    else
-                    {
-                        z = zdown;
-                    }
-                }
-                else if (zup != FLT_MAX)
-                {
-                    z = zup;
-                }
-                else if (zdown != FLT_MAX)
-                {
-                    z = zdown;
-                }
-            }
-            return z;
-        };
-
-
-        float height = 0;
-        if (sel->GetCount() == 1)
-        {
-            CBaseObject* obj = sel->GetObject(0);
-            Vec3 pos = obj->GetWorldPos();
-            AZ::EntityId entityId;
-            if (obj->GetType() == OBJTYPE_AZENTITY)
-            {
-                entityId = static_cast<CComponentEntityObject*>(obj)->GetAssociatedEntityId();
-            }
-            height = pos.z - getZOrigin(pos, entityId);
-        }
-
-        bool ok = false;
-        int fractionalDigitCount = 2;
-        height = aznumeric_caster(QInputDialog::getDouble(AzToolsFramework::GetActiveWindow(), QObject::tr("Enter Height"), QStringLiteral(""), height, -10000, 10000, fractionalDigitCount, &ok));
-        if (!ok)
-        {
-            return;
-        }
-
-        CUndo undo("Set Height");
-        for (int i = 0; i < sel->GetCount(); i++)
-        {
-            CBaseObject* obj = sel->GetObject(i);
-            Matrix34 wtm = obj->GetWorldTM();
-            Vec3 pos = wtm.GetTranslation();
-            AZ::EntityId entityId;
-            if (obj->GetType() == OBJTYPE_AZENTITY)
-            {
-                entityId = static_cast<CComponentEntityObject*>(obj)->GetAssociatedEntityId();
-            }
-            float z = getZOrigin(pos, entityId);
-            pos.z = z + height;
-            wtm.SetTranslation(pos);
-            obj->SetWorldTM(wtm, eObjectUpdateFlags_UserInput);
-        }
-
-        GetIEditor()->SetModifiedFlag();
-        GetIEditor()->SetModifiedModule(eModifiedBrushes);
-    }
-    else
-    {
-        QMessageBox::critical(AzToolsFramework::GetActiveWindow(), QString(), QObject::tr("No objects selected"));
-    }
-}
-
-void CCryEditApp::OnObjectmodifyFreeze()
-{
-    // Freeze selection.
-    OnEditFreeze();
-}
-
-void CCryEditApp::OnObjectmodifyUnfreeze()
-{
-    // Unfreeze all.
-    OnEditUnfreezeall();
 }
 
 void CCryEditApp::OnViewSwitchToGame()
@@ -3884,54 +3710,6 @@ void CCryEditApp::OnEditUnhideall()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnEditFreeze()
-{
-    if (!GetIEditor()->IsNewViewportInteractionModelEnabled())
-    {
-        // Freeze selection.
-        CSelectionGroup* sel = GetIEditor()->GetSelection();
-        if (!sel->IsEmpty())
-        {
-            AzToolsFramework::ScopedUndoBatch undo("Lock Selected Entities");
-
-            // We need to iterate over the list of selected objects in reverse order
-            // because when the objects are locked, they are removed from the
-            // selection so you would end up with the last selected object not
-            // being locked
-            int numSelected = sel->GetCount();
-            for (int i = numSelected - 1; i >= 0; --i)
-            {
-                // Duplicated object names can exist in the case of prefab objects so passing a name as a script parameter and processing it couldn't be exact.
-                sel->GetObject(i)->SetFrozen(true);
-            }
-        }
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnUpdateEditFreeze(QAction* action)
-{
-    OnUpdateEditHide(action);
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnEditUnfreezeall()
-{
-    if (!GetIEditor()->IsNewViewportInteractionModelEnabled())
-    {
-        if (QMessageBox::question(
-            AzToolsFramework::GetActiveWindow(), QObject::tr("Unlock All"),
-            QObject::tr("Are you sure you want to unlock all the objects?"),
-            QMessageBox::Yes | QMessageBox::Cancel) == QMessageBox::Yes)
-        {
-            // Unfreeze all.
-            AzToolsFramework::ScopedUndoBatch undo("Unlock all Entities");
-            GetIEditor()->GetObjectManager()->UnfreezeAll();
-        }
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////
 void CCryEditApp::OnSnap()
 {
     // Switch current snap to grid state.
@@ -4616,12 +4394,6 @@ void CCryEditApp::OnMaterialResettodefault()
 void CCryEditApp::OnMaterialGetmaterial()
 {
     GetIEditor()->GetMaterialManager()->Command_SelectFromObject();
-}
-
-//////////////////////////////////////////////////////////////////////////
-void CCryEditApp::OnOpenMaterialEditor()
-{
-    QtViewPaneManager::instance()->OpenPane(LyViewPane::MaterialEditor);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Sandbox/Editor/CryEdit.h
+++ b/Code/Sandbox/Editor/CryEdit.h
@@ -220,17 +220,12 @@ public:
     void DeleteSelectedEntities(bool includeDescendants);
     void OnMoveObject();
     void OnRenameObj();
-    void OnSetHeight();
     void OnEditmodeMove();
     void OnEditmodeRotate();
     void OnEditmodeScale();
-    void OnObjectSetArea();
-    void OnObjectSetHeight();
     void OnUpdateEditmodeMove(QAction* action);
     void OnUpdateEditmodeRotate(QAction* action);
     void OnUpdateEditmodeScale(QAction* action);
-    void OnObjectmodifyFreeze();
-    void OnObjectmodifyUnfreeze();
     void OnUndo();
     void OnOpenAssetImporter();
     void OnUpdateSelected(QAction* action);
@@ -388,9 +383,6 @@ private:
     void OnUpdateEditHide(QAction* action);
     void OnEditShowLastHidden();
     void OnEditUnhideall();
-    void OnEditFreeze();
-    void OnUpdateEditFreeze(QAction* action);
-    void OnEditUnfreezeall();
     void OnSnap();
     void OnWireframe();
     void OnUpdateWireframe(QAction* action);
@@ -459,7 +451,6 @@ private:
     void OnUpdateSwitchToSelectedCamera(QAction* action);
     void OnSwitchcameraNext();
     void OnOpenProceduralMaterialEditor();
-    void OnOpenMaterialEditor();
     void OnOpenAssetBrowserView();
     void OnOpenTrackView();
     void OnOpenAudioControlsEditor();

--- a/Code/Sandbox/Editor/ErrorReportDialog.cpp
+++ b/Code/Sandbox/Editor/ErrorReportDialog.cpp
@@ -519,11 +519,6 @@ void CErrorReportDialog::OnReportItemDblClick(const QModelIndex& index)
         }
         bDone = true;
     }
-    if (pError && pError->pItem != NULL)
-    {
-        GetIEditor()->OpenMaterialLibrary(pError->pItem);
-        bDone = true;
-    }
 
     if (!bDone && pError && GetIEditor()->GetActiveView())
     {
@@ -579,11 +574,6 @@ void CErrorReportDialog::OnReportHyperlink(const QModelIndex& index)
         GetIEditor()->ClearSelection();
         // Select this object.
         GetIEditor()->SelectObject(pError->pObject);
-        bDone = true;
-    }
-    if (pError && pError->pItem != NULL)
-    {
-        GetIEditor()->OpenMaterialLibrary(pError->pItem);
         bDone = true;
     }
 

--- a/Code/Sandbox/Editor/IEditor.h
+++ b/Code/Sandbox/Editor/IEditor.h
@@ -632,9 +632,6 @@ struct IEditor
     virtual RefCoordSys GetReferenceCoordSys() = 0;
     virtual XmlNodeRef FindTemplate(const QString& templateName) = 0;
     virtual void AddTemplate(const QString& templateName, XmlNodeRef& tmpl) = 0;
-    //! Open material library and select specified item.
-    //! If parameter is NULL current selection in material library does not change.
-    virtual void OpenMaterialLibrary(IDataBaseItem* pItem = NULL) = 0;
 
     virtual const QtViewPane* OpenView(QString sViewClassName, bool reuseOpen = true) = 0;
     virtual QWidget* FindView(QString viewClassName) = 0;

--- a/Code/Sandbox/Editor/IEditorImpl.cpp
+++ b/Code/Sandbox/Editor/IEditorImpl.cpp
@@ -1013,29 +1013,6 @@ IDataBaseManager* CEditorImpl::GetDBItemManager(EDataBaseItemType itemType)
     return 0;
 }
 
-void CEditorImpl::OpenMaterialLibrary(IDataBaseItem* item)
-{
-    EDataBaseItemType type = item ? item->GetType() : EDB_TYPE_MATERIAL;
-    AZ_Assert(type == EDB_TYPE_MATERIAL, "Call to OpenMaterialLibrary with non-material data base item");
-
-    if (type == EDB_TYPE_MATERIAL)
-    {
-        QtViewPaneManager::instance()->OpenPane(LyViewPane::MaterialEditor);
-
-        // This is a workaround for a timing issue where the material editor
-        // gets in a bad state while it is being polished for the first time
-        // while loading a material at the same time, so delay the setting
-        // of the material until the next event queue check
-        QTimer::singleShot(0, [this, item] {
-                IDataBaseManager* pManager = GetDBItemManager(EDB_TYPE_MATERIAL);
-                if (pManager)
-                {
-                    pManager->SetSelectedItem(item);
-                }
-            });
-    }
-}
-
 bool CEditorImpl::SelectColor(QColor& color, QWidget* parent)
 {
     const AZ::Color c = AzQtComponents::fromQColor(color);

--- a/Code/Sandbox/Editor/IEditorImpl.h
+++ b/Code/Sandbox/Editor/IEditorImpl.h
@@ -237,7 +237,6 @@ public:
     RefCoordSys GetReferenceCoordSys();
     XmlNodeRef FindTemplate(const QString& templateName);
     void AddTemplate(const QString& templateName, XmlNodeRef& tmpl);
-    void OpenMaterialLibrary(IDataBaseItem* pItem = NULL);
    
     const QtViewPane* OpenView(QString sViewClassName, bool reuseOpened = true) override;
 

--- a/Code/Sandbox/Editor/Lib/Tests/IEditorMock.h
+++ b/Code/Sandbox/Editor/Lib/Tests/IEditorMock.h
@@ -135,7 +135,6 @@ public:
     MOCK_METHOD0(GetReferenceCoordSys, RefCoordSys());
     MOCK_METHOD1(FindTemplate, XmlNodeRef(const QString& ));
     MOCK_METHOD2(AddTemplate, void(const QString& , XmlNodeRef& ));
-    MOCK_METHOD1(OpenMaterialLibrary, void (IDataBaseItem*));
     MOCK_METHOD2(OpenView, const QtViewPane* (QString , bool ));
     MOCK_METHOD1(FindView, QWidget* (QString ));
     MOCK_METHOD1(CloseView, bool(const char* ));

--- a/Code/Sandbox/Editor/LyViewPaneNames.h
+++ b/Code/Sandbox/Editor/LyViewPaneNames.h
@@ -43,7 +43,6 @@ namespace LyViewPane
     static const char* const TerrainEditor = "Terrain Editor";
     static const char* const TerrainTool = "Terrain Tool";
     static const char* const TerrainTextureLayers = "Terrain Texture Layers";
-    static const char* const MaterialEditor = "Material Editor";
     static const char* const ParticleEditor = "Particle Editor";
     static const char* const LensFlareEditor = "Lens Flare Editor";
     static const char* const TimeOfDayEditor = "Time Of Day";

--- a/Code/Sandbox/Editor/MainWindow.h
+++ b/Code/Sandbox/Editor/MainWindow.h
@@ -24,13 +24,11 @@
 #include <QPointer>
 #include <QToolButton>
 #include <QTimer>
-#include <QAbstractNativeEventFilter>
 
 #include "Include/SandboxAPI.h"
 #include <AzQtComponents/Components/ToolButtonComboBox.h>
 #include <AzQtComponents/Components/Widgets/ToolBar.h>
 #include <AzToolsFramework/SourceControl/SourceControlAPI.h>
-#include <QAbstractNativeEventFilter>
 
 #include "IEditor.h"
 #endif
@@ -93,9 +91,6 @@ class SANDBOX_API MainWindow
     : public QMainWindow
     , public IEditorNotifyListener
     , private AzToolsFramework::SourceControlNotificationBus::Handler
-#ifdef Q_OS_WIN
-    , public QAbstractNativeEventFilter
-#endif
 {
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
@@ -160,13 +155,9 @@ public:
     void UpdateToolsMenu();
 
     int ViewPaneVersion() const;
-    void MatEditSend(int param);
 
     LevelEditorMenuHandler* GetLevelEditorMenuHandler() { return m_levelEditorMenuHandler; }
 
-#ifdef Q_OS_WIN
-    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override;
-#endif
     bool event(QEvent* event) override;
 
     void OnGotoSliceRoot();

--- a/Code/Sandbox/Editor/Material/MaterialManager.cpp
+++ b/Code/Sandbox/Editor/Material/MaterialManager.cpp
@@ -1668,25 +1668,13 @@ void CMaterialManager::InitMatSender()
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CMaterialManager::GotoMaterial(CMaterial* pMaterial)
+void CMaterialManager::GotoMaterial([[maybe_unused]] CMaterial* pMaterial)
 {
-    if (pMaterial)
-    {
-        GetIEditor()->OpenMaterialLibrary(pMaterial);
-    }
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CMaterialManager::GotoMaterial(_smart_ptr<IMaterial> pMtl)
+void CMaterialManager::GotoMaterial([[maybe_unused]] _smart_ptr<IMaterial> pMtl)
 {
-    if (pMtl)
-    {
-        CMaterial* pEdMaterial = FromIMaterial(pMtl);
-        if (pEdMaterial)
-        {
-            GetIEditor()->OpenMaterialLibrary(pEdMaterial);
-        }
-    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Sandbox/Editor/Resource.h
+++ b/Code/Sandbox/Editor/Resource.h
@@ -75,13 +75,10 @@
 #define IDC_PLATFORM_SALEM                         2759
 #define IDC_GROUPBOX_GLOBALTAGS                    2916
 #define IDC_GROUPBOX_FRAGMENTTAGS                  2917
-#define ID_PARTICLE_EDITOR                         2922
 #define ID_RESOURCES_GENERATECGFTHUMBNAILS         32894
 #define ID_RESOURCES_REDUCEWORKINGSET              32896
 #define ID_EDIT_HIDE                               32898
 #define ID_EDIT_UNHIDEALL                          32899
-#define ID_EDIT_FREEZE                             32900
-#define ID_EDIT_UNFREEZEALL                        32901
 #define ID_RELOAD_TERRAIN                          32902
 #define ID_VIEW_GRIDSETTINGS                       32904
 #define ID_VIEW_CONFIGURELAYOUT                    32906
@@ -125,7 +122,6 @@
 #define ID_EDIT_SELECTNONE                         33377
 #define ID_WIREFRAME                               33410
 #define ID_FILE_GENERATETERRAINTEXTURE             33445
-#define ID_GENERATORS_LIGHTING                     33446
 #define ID_GENERATORS_STATICOBJECTS                33447
 #define ID_GENERATORS_TEXTURE                      33448
 #define ID_FILE_IMPORT                             33457
@@ -136,17 +132,12 @@
 #define ID_EDIT_DELETE                             33480
 #define ID_MOVE_OBJECT                             33481
 #define ID_RENAME_OBJ                              33483
-#define ID_SET_HEIGHT                              33484
 #define ID_FETCH                                   33496
 #define ID_EDITMODE_ROTATE                         33506
 #define ID_EDITMODE_SCALE                          33507
 #define ID_EDITMODE_MOVE                           33508
 #define ID_SELECTION_DELETE                        33512
 #define ID_EDIT_ESCAPE                             33513
-#define ID_OBJECTMODIFY_SETAREA                    33514
-#define ID_OBJECTMODIFY_SETHEIGHT                  33515
-#define ID_OBJECTMODIFY_FREEZE                     33517
-#define ID_OBJECTMODIFY_UNFREEZE                   33518
 #define ID_UNDO                                    33524
 #define ID_EDIT_CLONE                              33525
 #define ID_GOTO_SELECTED                           33535
@@ -230,7 +221,6 @@
 #define ID_VIEW_OPENVIEWPANE                       33709
 #define ID_VIEW_OPENPANE_FIRST          33712
 #define ID_VIEW_OPENPANE_LAST           33811
-#define ID_OPEN_MATERIAL_EDITOR                    33822
 #define ID_OPEN_EMOTIONFX_EDITOR                   39742
 #define ID_BRUSH_CSGSUBSTRUCT                      33837
 #define ID_MATERIAL_PICKTOOL                       33842
@@ -320,7 +310,6 @@
 #define ID_SNAP_TO_ANGLE_RANGE_END      34330
 #define ID_MODIFY_LINK                  34355
 #define ID_MODIFY_UNLINK                34356
-#define ID_MODIFY_OBJECT_HEIGHT         34357
 #define ID_MODIFY_GOTO_SELECTION        34358
 #define ID_VIEW_LAYOUT_FIRST            34363
 #define ID_VIEW_LAYOUT_LAST             34377

--- a/Code/Sandbox/Editor/ToolbarManager.cpp
+++ b/Code/Sandbox/Editor/ToolbarManager.cpp
@@ -609,14 +609,6 @@ AmazonToolbar ToolbarManager::GetObjectToolbar() const
     AmazonToolbar t = AmazonToolbar("Object", QObject::tr("Object Toolbar"));
     t.SetMainToolbar(true);
     t.AddAction(ID_GOTO_SELECTED, ORIGINAL_TOOLBAR_VERSION);
-    t.AddAction(ID_OBJECTMODIFY_SETHEIGHT, ORIGINAL_TOOLBAR_VERSION);
-
-    if (!GetIEditor()->IsNewViewportInteractionModelEnabled())
-    {
-        t.AddAction(ID_TOOLBAR_SEPARATOR, ORIGINAL_TOOLBAR_VERSION);
-        t.AddAction(ID_EDIT_FREEZE, ORIGINAL_TOOLBAR_VERSION);
-        t.AddAction(ID_EDIT_UNFREEZEALL, ORIGINAL_TOOLBAR_VERSION);
-    }
 
     return t;
 }
@@ -636,18 +628,8 @@ AmazonToolbar ToolbarManager::GetPlayConsoleToolbar() const
 AmazonToolbar ToolbarManager::GetEditorsToolbar() const
 {
     AmazonToolbar t = AmazonToolbar("Editors", QObject::tr("Editors Toolbar"));
-    if( !AZ::Interface<AzFramework::AtomActiveInterface>::Get() && !GetIEditor()->IsNewViewportInteractionModelEnabled())
-    {
-        t.AddAction(ID_OPEN_MATERIAL_EDITOR, ORIGINAL_TOOLBAR_VERSION);
-    }
 
     t.AddAction(ID_OPEN_AUDIO_CONTROLS_BROWSER, ORIGINAL_TOOLBAR_VERSION);
-
-    if (!AZ::Interface<AzFramework::AtomActiveInterface>::Get())
-    {
-        t.AddAction(ID_PARTICLE_EDITOR, ORIGINAL_TOOLBAR_VERSION);
-        t.AddAction(ID_GENERATORS_LIGHTING, ORIGINAL_TOOLBAR_VERSION);
-    }
 
     return t;
 }


### PR DESCRIPTION
There is still a decent amount of logic that is fully deprecated/hidden behind IsNewViewportInteractionModelEnabled() checks. There are a lot of these deprecated code paths that are using CSelectionGroup logic that I'm in the process of fixing up, so instead of fixing up these deprecated paths, it would be better to completely remove these first so there is less to clean up for the CSelectionGroup work. I'm breaking up this work into a few passes so the PRs don't get too big.