### PR TITLE
AZ::IO::Streamer config changes

### DIFF
--- a/Registry/Platform/Windows/streamer.game.setreg
+++ b/Registry/Platform/Windows/streamer.game.setreg
@@ -73,7 +73,7 @@
                                 "MaxFileHandles": 1024,
                                 "MaxMetaDataCache": 1024,
                                 "Overcommit": 8,
-                                "EnableFileSharing": false,
+                                "EnableFileSharing": true,
                                 "EnableUnbufferedReads": false
                             },
                             {

--- a/Registry/Platform/Windows/streamer.test.setreg
+++ b/Registry/Platform/Windows/streamer.test.setreg
@@ -21,7 +21,7 @@
                                 "MaxFileHandles": 1024,
                                 "MaxMetaDataCache": 1024,
                                 "Overcommit": 8,
-                                "EnableFileSharing": false,
+                                "EnableFileSharing": true,
                                 "EnableUnbufferedReads": true,
                                 "MinimalReporting": true
                             },


### PR DESCRIPTION
Enabled file sharing when AZ::IO::Streamer in tests and when the game is run in DevMode.