### PR TITLE
Scripting/fix lua clear cache

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptSystemComponent.cpp
@@ -349,7 +349,7 @@ ScriptLoadResult ScriptSystemComponent::LoadAndGetNativeContext(const Data::Asse
 
         // Check if already loaded
         auto scriptIt = container->m_loadedScripts.find(asset.GetId().m_guid);
-        if (scriptIt != container->m_loadedScripts.end() && scriptIt->second.m_scriptAsset.Get())
+        if (scriptIt != container->m_loadedScripts.end())
         {
             lua_rawgeti(lua, LUA_REGISTRYINDEX, scriptIt->second.m_tableReference);
 


### PR DESCRIPTION
Restored the code that clears the cache of scripts, it got removed some time along the way, but it needs to be there otherwise old scripts never get ejected from the cache.