### PR TITLE
[SPEC-6220] Mac clean asset fails "No ShaderPlatformInterfaces found"

### DIFF
--- a/AutomatedTesting/Gem/Code/Platform/Mac/runtime_dependencies.cmake
+++ b/AutomatedTesting/Gem/Code/Platform/Mac/runtime_dependencies.cmake
@@ -8,3 +8,8 @@
 # remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
+
+set(GEM_DEPENDENCIES
+    Gem::Atom_RHI_Metal.Private
+    Gem::Atom_RHI_Null.Private
+)

--- a/AutomatedTesting/Gem/Code/Platform/Mac/tool_dependencies.cmake
+++ b/AutomatedTesting/Gem/Code/Platform/Mac/tool_dependencies.cmake
@@ -8,3 +8,10 @@
 # remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
+
+set(GEM_DEPENDENCIES
+    Gem::Atom_RHI_Null.Private
+    Gem::Atom_RHI_Null.Builders
+    Gem::Atom_RHI_Metal.Private
+    Gem::Atom_RHI_Metal.Builders
+)


### PR DESCRIPTION
Added missing runtime and tools target dependencies.

Signed-off-by: garrieta <garrieta@amazon.com>