### PR TITLE
Cherry pick [ATOM-15427] from 1.0 to main.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -731,11 +731,12 @@ namespace AZ
                     }
                 }
             }
-
+            
             // Remove unnecessary camera views in shadow properties
-            for (uint16_t lightIndex = 0; lightIndex < aznumeric_cast<uint16_t>(m_shadowProperties.GetDataCount()); ++lightIndex)
+            auto& shadowPropertiesVector = m_shadowProperties.GetDataVector();
+            for (ShadowProperty& shadowProperty : shadowPropertiesVector)
             {
-                AZStd::unordered_map<const RPI::View*, AZStd::fixed_vector<CascadeSegment, Shadow::MaxNumberOfCascades>>& cascades = m_shadowProperties.GetData(lightIndex).m_segments;
+                auto& cascades = shadowProperty.m_segments;
                 for (auto it = cascades.begin(); it != cascades.end();)
                 {
                     if (AZStd::find(cameraViews.begin(), cameraViews.end(), it->first) != cameraViews.end())


### PR DESCRIPTION
[ATOM-15427] Fixing crash in DirectionalLightFeatureProcessor caused by incorrect use of a container.
original hash : 06044522763512b78ae504f658a3e7cb5f99996c