### PR TITLE
Make all targets use CryRenderNULL in all cases

### DIFF
--- a/Code/CryEngine/CrySystem/Platform/Mac/platform_mac.cmake
+++ b/Code/CryEngine/CrySystem/Platform/Mac/platform_mac.cmake
@@ -18,10 +18,10 @@
 if (LY_MONOLITHIC_GAME) # Only Atom is supported in monolithic builds
     set(LY_BUILD_DEPENDENCIES
         PUBLIC
-            Legacy::CryRenderOther
+            Legacy::CryRenderNULL
     )
 else()
     set(LY_RUNTIME_DEPENDENCIES
-        Legacy::CryRenderMetal
+        Legacy::CryRenderNULL
     )
 endif()

--- a/Code/CryEngine/CrySystem/SystemRender.cpp
+++ b/Code/CryEngine/CrySystem/SystemRender.cpp
@@ -61,70 +61,70 @@ extern CMTSafeHeap* g_pPakHeap;
 #elif defined(AZ_PLATFORM_IOS)
 
 #if defined(AZ_MONOLITHIC_BUILD)
-extern bool UIKitGetPrimaryPhysicalDisplayDimensions(int& o_widthPixels, int& o_heightPixels);
+//extern bool UIKitGetPrimaryPhysicalDisplayDimensions(int& o_widthPixels, int& o_heightPixels);
 #else
 
 using NativeScreenType = UIScreen;
 using NativeWindowType = UIWindow;
 
 ////////////////////////////////////////////////////////////////////////////////
-bool UIKitGetPrimaryPhysicalDisplayDimensions(int& o_widthPixels, int& o_heightPixels)
-{
+// bool UIKitGetPrimaryPhysicalDisplayDimensions(int& o_widthPixels, int& o_heightPixels)
+// {
 
-    NativeScreenType* nativeScreen = [NativeScreenType mainScreen];
-    CGRect screenBounds = [nativeScreen bounds];
-    CGFloat screenScale = [nativeScreen scale];
-    o_widthPixels = static_cast<int>(screenBounds.size.width * screenScale);
-    o_heightPixels = static_cast<int>(screenBounds.size.height * screenScale);
+//     NativeScreenType* nativeScreen = [NativeScreenType mainScreen];
+//     CGRect screenBounds = [nativeScreen bounds];
+//     CGFloat screenScale = [nativeScreen scale];
+//     o_widthPixels = static_cast<int>(screenBounds.size.width * screenScale);
+//     o_heightPixels = static_cast<int>(screenBounds.size.height * screenScale);
 
-    const bool isScreenLandscape = o_widthPixels > o_heightPixels;
+//     const bool isScreenLandscape = o_widthPixels > o_heightPixels;
 
-    UIInterfaceOrientation uiOrientation = UIInterfaceOrientationUnknown;
-#if defined(__IPHONE_13_0) || defined(__TVOS_13_0)
-    if(@available(iOS 13.0, tvOS 13.0, *))
-    {
-        UIWindow* foundWindow = nil;
+//     UIInterfaceOrientation uiOrientation = UIInterfaceOrientationUnknown;
+// #if defined(__IPHONE_13_0) || defined(__TVOS_13_0)
+//     if(@available(iOS 13.0, tvOS 13.0, *))
+//     {
+//         UIWindow* foundWindow = nil;
         
-        //Find the key window
-        NSArray* windows = [[UIApplication sharedApplication] windows];
-        for (UIWindow* window in windows)
-        {
-            if (window.isKeyWindow)
-            {
-                foundWindow = window;
-                break;
-            }
-        }
+//         //Find the key window
+//         NSArray* windows = [[UIApplication sharedApplication] windows];
+//         for (UIWindow* window in windows)
+//         {
+//             if (window.isKeyWindow)
+//             {
+//                 foundWindow = window;
+//                 break;
+//             }
+//         }
         
-        //Check if the key window is found
-        if(foundWindow)
-        {
-            uiOrientation = foundWindow.windowScene.interfaceOrientation;
-        }
-        else
-        {
-            //If no key window is found create a temporary window in order to extract the orientation
-            //This can happen as this function gets called before the renderer is initialized
-            CGRect screenBounds = [[NativeScreenType mainScreen] bounds];
-            UIWindow* tempWindow = [[NativeWindowType alloc] initWithFrame: screenBounds];
-            uiOrientation = tempWindow.windowScene.interfaceOrientation;
-            [tempWindow release];
-        }
-    }
-#else
-    uiOrientation = UIApplication.sharedApplication.statusBarOrientation;
-#endif
+//         //Check if the key window is found
+//         if(foundWindow)
+//         {
+//             uiOrientation = foundWindow.windowScene.interfaceOrientation;
+//         }
+//         else
+//         {
+//             //If no key window is found create a temporary window in order to extract the orientation
+//             //This can happen as this function gets called before the renderer is initialized
+//             CGRect screenBounds = [[NativeScreenType mainScreen] bounds];
+//             UIWindow* tempWindow = [[NativeWindowType alloc] initWithFrame: screenBounds];
+//             uiOrientation = tempWindow.windowScene.interfaceOrientation;
+//             [tempWindow release];
+//         }
+//     }
+// #else
+//     uiOrientation = UIApplication.sharedApplication.statusBarOrientation;
+// #endif
     
-    const bool isInterfaceLandscape = UIInterfaceOrientationIsLandscape(uiOrientation);
-    if (isScreenLandscape != isInterfaceLandscape)
-    {
-        const int width = o_widthPixels;
-        o_widthPixels = o_heightPixels;
-        o_heightPixels = width;
-    }
+//     const bool isInterfaceLandscape = UIInterfaceOrientationIsLandscape(uiOrientation);
+//     if (isScreenLandscape != isInterfaceLandscape)
+//     {
+//         const int width = o_widthPixels;
+//         o_widthPixels = o_heightPixels;
+//         o_heightPixels = width;
+//     }
 
-    return true;
-}
+//     return true;
+// }
 #endif
 
 #endif
@@ -151,8 +151,8 @@ bool CSystem::GetPrimaryPhysicalDisplayDimensions([[maybe_unused]] int& o_widthP
     return true;
 #elif defined(AZ_PLATFORM_ANDROID)
     return AZ::Android::Utils::GetWindowSize(o_widthPixels, o_heightPixels);
-#elif defined(AZ_PLATFORM_IOS)
-    return UIKitGetPrimaryPhysicalDisplayDimensions(o_widthPixels, o_heightPixels);
+// #elif defined(AZ_PLATFORM_IOS)
+//     return UIKitGetPrimaryPhysicalDisplayDimensions(o_widthPixels, o_heightPixels); // RedCode, no longer needed with Atom
 #else
     return false;
 #endif

--- a/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/CMakeLists.txt
+++ b/Code/CryEngine/RenderDll/XRenderD3D9/DXGL/CMakeLists.txt
@@ -13,7 +13,7 @@ ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${P
 
 include(${pal_dir}/DXGL_traits_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
-if(DXGL_TRAIT_BUILD_OPENGL_SUPPORTED AND (NOT LY_MONOLITHIC_GAME OR LY_TRAIT_USE_LEGACY_IN_MONOLITHIC)) # Only Atom is supported in monolithic builds
+if(DXGL_TRAIT_BUILD_OPENGL_SUPPORTED AND LY_TRAIT_USE_LEGACY_IN_MONOLITHIC)
     ly_add_target(
         NAME CryRenderGL.Static STATIC
         NAMESPACE Legacy

--- a/Code/CryEngine/RenderDll/XRenderD3D9/DXMETAL/CMakeLists.txt
+++ b/Code/CryEngine/RenderDll/XRenderD3D9/DXMETAL/CMakeLists.txt
@@ -13,7 +13,7 @@ ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${P
 
 include(${pal_dir}/DXMETAL_traits_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
-if(DXGL_TRAIT_BUILD_DXMETAL_SUPPORTED AND NOT LY_MONOLITHIC_GAME) # Only Atom is supported in monolithic builds
+if(DXGL_TRAIT_BUILD_DXMETAL_SUPPORTED)
     ly_add_target(
         NAME CryRenderMetal.Static STATIC
         NAMESPACE Legacy

--- a/Code/CryEngine/RenderDll/XRenderNULL/CMakeLists.txt
+++ b/Code/CryEngine/RenderDll/XRenderNULL/CMakeLists.txt
@@ -40,40 +40,38 @@ if(CRYRENDER_TRAIT_BUILD_NULL_RENDERER_SUPPORTED)
                 Legacy::CryCommon.EngineSettings.Static
     )
 
-    if (NOT LY_MONOLITHIC_GAME) # Only Atom is supported in monolithic builds
+    ly_add_target(
+        NAME CryRenderNULL ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+        NAMESPACE Legacy
+        FILES_CMAKE
+            core_null_renderer_shared_files.cmake
+        INCLUDE_DIRECTORIES
+            PRIVATE
+                .
+        BUILD_DEPENDENCIES
+            PRIVATE
+                Legacy::CryRenderNULL.Static
+    )
+
+    if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+
         ly_add_target(
-            NAME CryRenderNULL ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+            NAME CryRenderNULL.Tests MODULE
             NAMESPACE Legacy
             FILES_CMAKE
-                core_null_renderer_shared_files.cmake
+                core_null_renderer_test_files.cmake
             INCLUDE_DIRECTORIES
                 PRIVATE
                     .
             BUILD_DEPENDENCIES
                 PRIVATE
+                    AZ::AzTest
                     Legacy::CryRenderNULL.Static
         )
-
-        if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-
-            ly_add_target(
-                NAME CryRenderNULL.Tests MODULE
-                NAMESPACE Legacy
-                FILES_CMAKE
-                    core_null_renderer_test_files.cmake
-                INCLUDE_DIRECTORIES
-                    PRIVATE
-                        .
-                BUILD_DEPENDENCIES
-                    PRIVATE
-                        AZ::AzTest
-                        Legacy::CryRenderNULL.Static
-            )
-            # SPEC-1548: disabling since it fails in mac with memory issues
-            #ly_add_googletest(
-            #    NAME Legacy::CryRenderNULL.Tests
-            #)
-        endif()
+        # SPEC-1548: disabling since it fails in mac with memory issues
+        #ly_add_googletest(
+        #    NAME Legacy::CryRenderNULL.Tests
+        #)
     endif()
 
 endif()

--- a/Code/LauncherUnified/Platform/Android/launcher_project_android.cmake
+++ b/Code/LauncherUnified/Platform/Android/launcher_project_android.cmake
@@ -10,9 +10,9 @@
 #
 
 if(LY_MONOLITHIC_GAME)  # only Atom is supported in monolithic
-    list(APPEND LY_BUILD_DEPENDENCIES Legacy::CryRenderOther)
+    list(APPEND LY_BUILD_DEPENDENCIES Legacy::CryRenderNULL)
 else()
     set(LY_RUNTIME_DEPENDENCIES
-        Legacy::CryRenderGL
+        Legacy::CryRenderNULL
     )
 endif()

--- a/Code/LauncherUnified/Platform/Linux/launcher_project_linux.cmake
+++ b/Code/LauncherUnified/Platform/Linux/launcher_project_linux.cmake
@@ -12,11 +12,11 @@
 if (LY_MONOLITHIC_GAME) # only Atom is supported in monolithic
     set(LY_BUILD_DEPENDENCIES
         PUBLIC
-            Legacy::CryRenderOther
+            Legacy::CryRenderNULL
     )
 else()
     set(LY_BUILD_DEPENDENCIES
         PRIVATE
-            Legacy::CryRenderGL
+            Legacy::CryRenderNULL
     )
 endif()

--- a/Code/LauncherUnified/Platform/Mac/launcher_project_mac.cmake
+++ b/Code/LauncherUnified/Platform/Mac/launcher_project_mac.cmake
@@ -14,9 +14,9 @@ set(LY_TARGET_PROPERTIES
 )
 
 if(LY_MONOLITHIC_GAME) # only Atom is supported in monolithic builds
-    list(APPEND LY_BUILD_DEPENDENCIES Legacy::CryRenderOther)
+    list(APPEND LY_BUILD_DEPENDENCIES Legacy::CryRenderNULL)
 else()
-    set(LY_RUNTIME_DEPENDENCIES Legacy::CryRenderMetal)
+    set(LY_RUNTIME_DEPENDENCIES Legacy::CryRenderNULL)
 endif()
 
 # Add resources and app icons to launchers

--- a/Code/LauncherUnified/Platform/Windows/launcher_project_windows.cmake
+++ b/Code/LauncherUnified/Platform/Windows/launcher_project_windows.cmake
@@ -11,7 +11,7 @@
 
 set(LY_BUILD_DEPENDENCIES
     PRIVATE
-        Legacy::CryRenderD3D11
+        Legacy::CryRenderNULL
 )
 
 set(ICON_FILE ${project_real_path}/Gem/Resources/GameSDK.ico)

--- a/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
+++ b/Code/LauncherUnified/Platform/iOS/launcher_project_ios.cmake
@@ -15,10 +15,10 @@ set(LY_LINK_OPTIONS
 )
 
 if(LY_MONOLITHIC_GAME) # only Atom is supported in monolithic
-    list(APPEND LY_BUILD_DEPENDENCIES Legacy::CryRenderOther)
+    list(APPEND LY_BUILD_DEPENDENCIES Legacy::CryRenderNULL)
 else()
     list(APPEND LY_BUILD_DEPENDENCIES CrySystem.Static)
-    set(LY_RUNTIME_DEPENDENCIES Legacy::CryRenderMetal)
+    set(LY_RUNTIME_DEPENDENCIES Legacy::CryRenderNULL)
 endif()
 
 # Add resources and app icons to launchers

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -108,7 +108,7 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             Legacy::CryFont
             Legacy::Cry3DEngine
         )
-        if(PAL_TRAIT_BUILD_SERVER_SUPPORTED AND NOT LY_MONOLITHIC_GAME)  # Only Atom is supported in monolithic builds
+        if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
             set(server_runtime_dependencies
                 Legacy::CryRenderNULL
             )

--- a/Code/Tools/ShaderCacheGen/ShaderCacheGen/Platform/Windows/platform_windows.cmake
+++ b/Code/Tools/ShaderCacheGen/ShaderCacheGen/Platform/Windows/platform_windows.cmake
@@ -10,5 +10,5 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
-    Legacy::CryRenderD3D11
+    Legacy::CryRenderNULL
 )


### PR DESCRIPTION
Force all target platforms to use CryRenderNULL in all cases.
Remove iOS function to get the render resolution of the device for the legacy renderer as it was causing a link error.