### PR TITLE
LYN2911 Script canvas delay node

### DIFF
--- a/Code/CryEngine/CrySystem/Timer.cpp
+++ b/Code/CryEngine/CrySystem/Timer.cpp
@@ -39,7 +39,8 @@ static const float fDEFAULT_PROFILE_SMOOTHING = 1.0f;
 
 
 
-#define DEFAULT_FRAME_SMOOTHING 1
+
+#define DEFAULT_FRAME_SMOOTHING 0
 
 /////////////////////////////////////////////////////
 CTimer::CTimer()


### PR DESCRIPTION
Turn off cryengine frame smoothing. This was causing time dilation which adds up over longer periods of time. Will make a new jira for removing cry's timer system and replacing it.