### PR TITLE
[LYN-1731] Removed temporary bus for checking if the new viewport interaction model is enabled.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -277,20 +277,6 @@ namespace AzToolsFramework
 
     } // namespace ViewportInteraction
 
-    /// Temporary bus to query if the new Viewport Interaction Model mode is enabled or not.
-    class NewViewportInteractionModelEnabledRequests
-        : public AZ::EBusTraits
-    {
-    public:
-        virtual bool IsNewViewportInteractionModelEnabled() = 0;
-
-    protected:
-        ~NewViewportInteractionModelEnabledRequests() = default;
-    };
-
-    /// Type to inherit to implement NewViewportInteractionModelEnabledRequests
-    using NewViewportInteractionModelEnabledRequestBus = AZ::EBus<NewViewportInteractionModelEnabledRequests>;
-
     /// Utility function to return EntityContextId.
     inline AzFramework::EntityContextId GetEntityContextId()
     {
@@ -299,17 +285,5 @@ namespace AzToolsFramework
             entityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
 
         return entityContextId;
-    }
-
-    /// Utility function to return if the new Viewport Interaction Model
-    /// is enabled (wraps NewViewportInteractionModelEnabledRequests).
-    inline bool IsNewViewportInteractionModelEnabled()
-    {
-        bool newViewportInteractionModelEnabled = false;
-        NewViewportInteractionModelEnabledRequestBus::BroadcastResult(
-            newViewportInteractionModelEnabled,
-            &NewViewportInteractionModelEnabledRequests::IsNewViewportInteractionModelEnabled);
-
-        return newViewportInteractionModelEnabled;
     }
 } // namespace AzToolsFramework

--- a/Code/Sandbox/Editor/IEditor.h
+++ b/Code/Sandbox/Editor/IEditor.h
@@ -759,8 +759,6 @@ struct IEditor
 
     // reloads the plugins
     virtual void LoadPlugins() = 0;
-
-    virtual bool IsNewViewportInteractionModelEnabled() const = 0;
 };
 
 //! Callback used by editor when initializing for info in UI dialogs

--- a/Code/Sandbox/Editor/IEditorImpl.cpp
+++ b/Code/Sandbox/Editor/IEditorImpl.cpp
@@ -1799,11 +1799,6 @@ void CEditorImpl::DestroyQMimeData(QMimeData* data) const
     delete data;
 }
 
-bool CEditorImpl::IsNewViewportInteractionModelEnabled() const
-{
-    return m_isNewViewportInteractionModelEnabled;
-}
-
 IEditorPanelUtils* CEditorImpl::GetEditorPanelUtils()
 {
     return m_panelEditorUtils;

--- a/Code/Sandbox/Editor/IEditorImpl.h
+++ b/Code/Sandbox/Editor/IEditorImpl.h
@@ -339,8 +339,6 @@ public:
     QMimeData* CreateQMimeData() const override;
     void DestroyQMimeData(QMimeData* data) const override;
 
-    bool IsNewViewportInteractionModelEnabled() const override;
-
 protected:
 
     AZStd::string LoadProjectIdFromProjectData();
@@ -442,7 +440,5 @@ protected:
 
     CryMutex m_pluginMutex; // protect any pointers that come from plugins, such as the source control cached pointer.
     static const char* m_crashLogFileName;
-
-    bool m_isNewViewportInteractionModelEnabled = true;
 };
 

--- a/Code/Sandbox/Editor/Lib/Tests/IEditorMock.h
+++ b/Code/Sandbox/Editor/Lib/Tests/IEditorMock.h
@@ -200,7 +200,6 @@ public:
     MOCK_METHOD0(GetLogFile, ILogFile* ());  
     MOCK_METHOD0(UnloadPlugins, void());
     MOCK_METHOD0(LoadPlugins, void());
-    MOCK_CONST_METHOD0(IsNewViewportInteractionModelEnabled, bool());
     MOCK_METHOD1(GetSearchPath, QString(EEditorPathName));
     MOCK_METHOD0(GetEditorPanelUtils, IEditorPanelUtils* ());
 

--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -172,7 +172,6 @@ void SandboxIntegrationManager::Setup()
 
     AzFramework::DisplayContextRequestBus::Handler::BusConnect();
     SetupFileExtensionMap();
-    AzToolsFramework::NewViewportInteractionModelEnabledRequestBus::Handler::BusConnect();
 
     MainWindow::instance()->GetActionManager()->RegisterActionHandler(ID_FILE_SAVE_SLICE_TO_ROOT, [this]() {
         SaveSlice(false);
@@ -376,7 +375,6 @@ void SandboxIntegrationManager::GetEntitiesInSlices(
 void SandboxIntegrationManager::Teardown()
 {
     AzToolsFramework::Layers::EditorLayerComponentNotificationBus::Handler::BusDisconnect();
-    AzToolsFramework::NewViewportInteractionModelEnabledRequestBus::Handler::BusDisconnect();
     AzFramework::DisplayContextRequestBus::Handler::BusDisconnect();
     if( m_debugDisplayBusImplementationActive)
     {
@@ -2770,11 +2768,6 @@ void SandboxIntegrationManager::PopMatrix()
     {
         m_dc->PopMatrix();
     }
-}
-
-bool SandboxIntegrationManager::IsNewViewportInteractionModelEnabled()
-{
-    return GetIEditor()->IsNewViewportInteractionModelEnabled();
 }
 
 bool SandboxIntegrationManager::DisplayHelpersVisible()

--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -104,7 +104,6 @@ class SandboxIntegrationManager
     , private AzToolsFramework::EditorEntityContextNotificationBus::Handler
     , private AzToolsFramework::SliceEditorEntityOwnershipServiceNotificationBus::Handler
     , private IUndoManagerListener
-    , private AzToolsFramework::NewViewportInteractionModelEnabledRequestBus::Handler
     , private AzToolsFramework::Layers::EditorLayerComponentNotificationBus::Handler
 {
 public:
@@ -274,9 +273,6 @@ private:
     // AzFramework::DisplayContextRequestBus
     void SetDC(DisplayContext* dc) override;
     DisplayContext* GetDC() override;
-
-    // NewViewportInteractionModelEnabledRequestBus
-    bool IsNewViewportInteractionModelEnabled() override;
 
     // Context menu handlers.
     void ContextMenu_NewEntity();


### PR DESCRIPTION
Removed the temporary bus for checking if the new viewport interaction model was enabled. This bus was actually unused at this point (had already converted everything to assume the new viewport interaction model was the only viewport interaction model). This was just the final step.