### PR TITLE
LYN-3468 Fixed WhiteBox Editor Physics Tests failures on a clean build

### DIFF
--- a/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
@@ -53,7 +53,7 @@ namespace UnitTest
 
     void EditorWhiteBoxPhysicsTestEnvironment::AddGemsAndComponents()
     {
-        AddDynamicModulePaths({"PhysX.Editor"});
+        AddDynamicModulePaths({"PhysX.Editor.Gem"});
         AddComponentDescriptors(
             {AzToolsFramework::EditorEntityContextComponent::CreateDescriptor(),
              WhiteBox::EditorWhiteBoxComponent::CreateDescriptor(), WhiteBox::WhiteBoxComponent::CreateDescriptor(),


### PR DESCRIPTION
The WhiteBox Editor Physics Tests need to be updated  to match the changes to the PhysX Gem output name made in commit 771a7a25aa4bf8cbafd85459b370eef22ade6105.

Otherwise the WhiteBox Editor Physics Tests attempts to load a stale PhysX.Editor.dll file, which will get removed on a clean build causing the test to fail
