### PR TITLE
lyn2919: Update all references to O3DE

### DIFF
--- a/Gems/AWSClientAuth/cdk/README.md
+++ b/Gems/AWSClientAuth/cdk/README.md
@@ -26,9 +26,9 @@ Once the python and pip are set up, you can install the required dependencies.
 
 Set variables
 ```
-set O3D_AWS_DEPLOY_REGION="us-west-2"
-set O3D_AWS_DEPLOY_ACCOUNT=""
-set O3D_AWS_PROJECT_NAME="AWSIProject"
+set O3DE_AWS_DEPLOY_REGION="us-west-2"
+set O3DE_AWS_DEPLOY_ACCOUNT=""
+set O3DE_AWS_PROJECT_NAME="AWSIProject"
 
 If you want to add 3rd party providers fill values in utils/constant.py
 ```

--- a/Gems/AWSClientAuth/cdk/app.py
+++ b/Gems/AWSClientAuth/cdk/app.py
@@ -16,11 +16,11 @@ from aws_client_auth.client_auth_stack import AWSClientAuthStack
 import os
 
 """Configuration"""
-REGION = os.environ.get('O3D_AWS_DEPLOY_REGION', os.environ['CDK_DEFAULT_REGION'])
-ACCOUNT = os.environ.get('O3D_AWS_DEPLOY_ACCOUNT', os.environ['CDK_DEFAULT_ACCOUNT'])
+REGION = os.environ.get('O3DE_AWS_DEPLOY_REGION', os.environ['CDK_DEFAULT_REGION'])
+ACCOUNT = os.environ.get('O3DE_AWS_DEPLOY_ACCOUNT', os.environ['CDK_DEFAULT_ACCOUNT'])
 
 # Set the common prefix to group stacks in a project together.
-PROJECT_NAME = os.environ.get('O3D_AWS_PROJECT_NAME', f'O3D-AWS-PROJECT').upper()
+PROJECT_NAME = os.environ.get('O3DE_AWS_PROJECT_NAME', f'O3DE-AWS-PROJECT').upper()
 
 env = core.Environment(account=ACCOUNT, region=REGION)
 app = core.App()

--- a/Gems/AWSClientAuth/cdk/cognito/cognito_identity_pool.py
+++ b/Gems/AWSClientAuth/cdk/cognito/cognito_identity_pool.py
@@ -58,7 +58,7 @@ class CognitoIdentityPool:
         self._identity_pool.add_depends_on(cognito_user_pool.get_user_pool())
         self._identity_pool.add_depends_on(cognito_user_pool.get_user_pool_client())
 
-        # Create roles to associate with Cognito Idenity pool
+        # Create roles to associate with Cognito Identity pool
         self._auth_role = CognitoIdentityPoolRole(scope, feature_name, project_name, env,
                                                   self._identity_pool, authenticated=True)
         self._unauth_role = CognitoIdentityPoolRole(scope, feature_name, project_name, env,

--- a/Gems/AWSClientAuth/cdk/utils/name_utils.py
+++ b/Gems/AWSClientAuth/cdk/utils/name_utils.py
@@ -8,7 +8,7 @@
  remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
-
+import re
 from aws_cdk import core
 
 
@@ -21,7 +21,9 @@ def format_aws_resource_id(feature_name: str, project_name: str, env: core.Envir
 
 
 def format_aws_resource_sid(feature_name: str, project_name: str, resource_type: str):
-    return f'{project_name}{feature_name}{resource_type}SId'
+    sid = f'{project_name}{feature_name}{resource_type}SId'
+    # Strip out all chars not valid in a sid
+    return re.sub(r'[^a-zA-Z0-9]', '', sid)
 
 
 def format_aws_resource_authenticated_id(feature_name: str, project_name: str, env: core.Environment,

--- a/Gems/AWSCore/cdk/README.md
+++ b/Gems/AWSCore/cdk/README.md
@@ -44,9 +44,9 @@ $ pip install -r requirements.txt
 
 ## Set environment variables or accept defaults
 
-* O3D_AWS_DEPLOY_REGION*: The region to deploy the stacks into, will default to CDK_DEFAULT_REGION
-* O3D_AWS_DEPLOY_ACCOUNT*: The account to deploy stacks into, will default to CDK_DEFAULT_ACCOUNT
-* O3D_AWS_PROJECT_NAME*: The name of the O3DE project stacks should be deployed for will default to AWS-PROJECT
+* O3DE_AWS_DEPLOY_REGION*: The region to deploy the stacks into, will default to CDK_DEFAULT_REGION
+* O3DE_AWS_DEPLOY_ACCOUNT*: The account to deploy stacks into, will default to CDK_DEFAULT_ACCOUNT
+* O3DE_AWS_PROJECT_NAME*: The name of the O3DE project stacks should be deployed for will default to AWS-PROJECT
 
 See https://docs.aws.amazon.com/cdk/latest/guide/environments.html for more information including how to pass parameters
 to use for environment variables.

--- a/Gems/AWSCore/cdk/app.py
+++ b/Gems/AWSCore/cdk/app.py
@@ -22,11 +22,11 @@ from core.aws_core import AWSCore
 from example.example_resources_stack import ExampleResources
 
 """Configuration"""
-REGION = os.environ.get('O3D_AWS_DEPLOY_REGION', os.environ.get('CDK_DEFAULT_REGION'))
-ACCOUNT = os.environ.get('O3D_AWS_DEPLOY_ACCOUNT', os.environ.get('CDK_DEFAULT_ACCOUNT'))
+REGION = os.environ.get('O3DE_AWS_DEPLOY_REGION', os.environ.get('CDK_DEFAULT_REGION'))
+ACCOUNT = os.environ.get('O3DE_AWS_DEPLOY_ACCOUNT', os.environ.get('CDK_DEFAULT_ACCOUNT'))
 
 # Set the common prefix to group stacks in a project together.
-PROJECT_NAME = os.environ.get('O3D_AWS_PROJECT_NAME', f'AWS-PROJECT').upper()
+PROJECT_NAME = os.environ.get('O3DE_AWS_PROJECT_NAME', f'O3DE-AWS-PROJECT').upper()
 
 # The name of this feature
 FEATURE_NAME = 'Core'

--- a/Gems/AWSCore/cdk/core/core_stack.py
+++ b/Gems/AWSCore/cdk/core/core_stack.py
@@ -27,7 +27,7 @@ class CoreStack(core.Stack):
     """
 
     # Resource groups cannot start with 'AWS' or 'aws' so add this prefix
-    RESOURCE_GROUP_PREFIX = 'O3D'
+    RESOURCE_GROUP_PREFIX = 'O3DE'
 
     def __init__(self, scope: core.Construct, id_: str, project_name: str, feature_name: str, **kwargs) -> None:
         super().__init__(scope, id_, **kwargs)

--- a/Gems/AWSMetrics/cdk/README.md
+++ b/Gems/AWSMetrics/cdk/README.md
@@ -42,9 +42,9 @@ $ pip install -r requirements.txt
 
 ## Set environment variables or accept defaults
 
-* O3D_AWS_DEPLOY_REGION*: The region to deploy the stacks into, will default to CDK_DEFAULT_REGION
-* O3D_AWS_DEPLOY_ACCOUNT*: The account to deploy stacks into, will default to CDK_DEFAULT_ACCOUNT
-* O3D_AWS_PROJECT_NAME*: The name of the O3DE project stacks should be deployed for will default to AWS-PROJECT
+* O3DE_AWS_DEPLOY_REGION*: The region to deploy the stacks into, will default to CDK_DEFAULT_REGION
+* O3DE_AWS_DEPLOY_ACCOUNT*: The account to deploy stacks into, will default to CDK_DEFAULT_ACCOUNT
+* O3DE_AWS_PROJECT_NAME*: The name of the O3DE project stacks should be deployed for will default to AWS-PROJECT
 
 See https://docs.aws.amazon.com/cdk/latest/guide/environments.html for more information including how to pass parameters
 to use for environment variables.

--- a/Gems/AWSMetrics/cdk/app.py
+++ b/Gems/AWSMetrics/cdk/app.py
@@ -17,11 +17,11 @@ from aws_metrics.aws_metrics_construct import AWSMetrics
 import os
 
 """Configuration"""
-REGION = os.environ.get('O3D_AWS_DEPLOY_REGION', os.environ['CDK_DEFAULT_REGION'])
-ACCOUNT = os.environ.get('O3D_AWS_DEPLOY_ACCOUNT', os.environ['CDK_DEFAULT_ACCOUNT'])
+REGION = os.environ.get('O3DE_AWS_DEPLOY_REGION', os.environ['CDK_DEFAULT_REGION'])
+ACCOUNT = os.environ.get('O3DE_AWS_DEPLOY_ACCOUNT', os.environ['CDK_DEFAULT_ACCOUNT'])
 
 # Set the common prefix to group stacks in a project together. Defaults to LY-AWS<UUID>.
-PROJECT_NAME = os.environ.get('O3D_AWS_PROJECT_NAME', f'AWS-PROJECT').upper()
+PROJECT_NAME = os.environ.get('O3DE_AWS_PROJECT_NAME', f'O3DE-AWS-PROJECT').upper()
 
 # The name of this feature
 FEATURE_NAME = 'AWSMetrics'

--- a/Gems/AWSMetrics/cdk/aws_metrics/batch_processing.py
+++ b/Gems/AWSMetrics/cdk/aws_metrics/batch_processing.py
@@ -259,7 +259,7 @@ class BatchProcessing:
         )
         policy_statements.append(input_stream_policy_statement)
 
-        log_policy_statetement = iam.PolicyStatement(
+        log_policy_statement = iam.PolicyStatement(
             actions=[
                 'logs:PutLogEvents',
             ],
@@ -268,7 +268,7 @@ class BatchProcessing:
                 self._firehose_delivery_stream_log_group.log_group_arn
             ]
         )
-        policy_statements.append(log_policy_statetement)
+        policy_statements.append(log_policy_statement)
 
         data_catalog_policy_statement = iam.PolicyStatement(
             actions=[


### PR DESCRIPTION
Move all 'O3D' references to 'O3DE'
- Fix small spelling mistakes
- Also fix issue where invalid SIDs could be generated that prevent ClientAuth from being deployed using just ```cdk synth   cdk deploy```
- Make default project name consistent across Gems