### PR TITLE
ATOM-14065 fix problems with material editor details group property descriptions

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
@@ -211,10 +211,7 @@ namespace AtomToolsFramework
 
     AZStd::string DynamicProperty::GetDescription() const
     {
-        return AZStd::string::format("%s%s(Script Name = '%s')",
-            m_config.m_description.c_str(),
-            m_config.m_description.empty() ? "" : "\n",
-            m_config.m_id.GetCStr());
+        return m_config.m_description;
     }
 
     AZ::Crc32 DynamicProperty::GetVisibility() const

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/MaterialPropertyUtil.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/MaterialPropertyUtil.cpp
@@ -91,6 +91,13 @@ namespace AtomToolsFramework
         propertyConfig.m_vectorLabels = propertyDefinition.m_vectorLabels;
         propertyConfig.m_visible = propertyDefinition.m_visibility != AZ::RPI::MaterialPropertyVisibility::Hidden;
         propertyConfig.m_readOnly = propertyDefinition.m_visibility == AZ::RPI::MaterialPropertyVisibility::Disabled;
+
+        // Update the description for material properties to include script name assuming id is set beforehand
+        propertyConfig.m_description = AZStd::string::format(
+            "%s%s(Script Name = '%s')",
+            propertyConfig.m_description.c_str(),
+            propertyConfig.m_description.empty() ? "" : "\n",
+            propertyConfig.m_id.GetCStr());
     }
 
     void ConvertToPropertyConfig(AtomToolsFramework::DynamicPropertyConfig& propertyConfig, const AZ::RPI::MaterialPropertyDynamicMetadata& propertyMetaData)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -762,6 +762,8 @@ namespace MaterialEditor
         // in the hierarchy are applied
         m_materialTypeSourceData.EnumerateProperties([this, &parentPropertyValues](const AZStd::string& groupNameId, const AZStd::string& propertyNameId, const auto& propertyDefinition) {
             AtomToolsFramework::DynamicPropertyConfig propertyConfig;
+
+            // Assign id before conversion so it can be used in dynamic description
             propertyConfig.m_id = MaterialPropertyId(groupNameId, propertyNameId).GetCStr();
 
             const auto& propertyIndex = m_materialAsset->GetMaterialPropertiesLayout()->FindPropertyIndex(propertyConfig.m_id);
@@ -792,7 +794,8 @@ namespace MaterialEditor
         propertyConfig.m_nameId = "materialType";
         propertyConfig.m_displayName = "Material Type";
         propertyConfig.m_groupName = "Details";
-        propertyConfig.m_description = propertyConfig.m_displayName;
+        propertyConfig.m_description = "The material type defines the layout, properties, default values, shader connections, and other "
+                                       "data needed to create and edit a derived material.";
         propertyConfig.m_defaultValue = AZStd::any(materialTypeAsset);
         propertyConfig.m_originalValue = propertyConfig.m_defaultValue;
         propertyConfig.m_parentValue = propertyConfig.m_defaultValue;
@@ -806,7 +809,8 @@ namespace MaterialEditor
         propertyConfig.m_nameId = "parentMaterial";
         propertyConfig.m_displayName = "Parent Material";
         propertyConfig.m_groupName = "Details";
-        propertyConfig.m_description = propertyConfig.m_displayName;
+        propertyConfig.m_description =
+            "The parent material provides an initial configuration whose properties are inherited and overriden by a derived material.";
         propertyConfig.m_defaultValue = AZStd::any(parentMaterialAsset);
         propertyConfig.m_originalValue = propertyConfig.m_defaultValue;
         propertyConfig.m_parentValue = propertyConfig.m_defaultValue;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentInspector.cpp
@@ -245,9 +245,12 @@ namespace AZ
                         for (const auto& propertyDefinition : propertyListItr->second)
                         {
                             AtomToolsFramework::DynamicPropertyConfig propertyConfig;
+
+                            // Assign id before conversion so it can be used in dynamic description
+                            propertyConfig.m_id = AZ::RPI::MaterialPropertyId(groupNameId, propertyDefinition.m_nameId).GetFullName();
+
                             AtomToolsFramework::ConvertToPropertyConfig(propertyConfig, propertyDefinition);
 
-                            propertyConfig.m_id = AZ::RPI::MaterialPropertyId(groupNameId, propertyDefinition.m_nameId).GetFullName();
                             propertyConfig.m_groupName = groupDisplayName;
                             const auto& propertyIndex = m_editData.m_materialAsset->GetMaterialPropertiesLayout()->FindPropertyIndex(propertyConfig.m_id);
                             propertyConfig.m_showThumbnail = true;


### PR DESCRIPTION
ATOM-14065 fix problems with material editor details group property descriptions

Moved the code that automatically appended a script variable name to a property description out of the dynamic property class and into the material property conversion utility functions.

Added proper descriptions for the material type and parent material placeholder properties

https://jira.agscollab.com/browse/ATOM-14065