### PR TITLE
Fix iOS Crash

### DIFF
--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/DebugConsole.cpp
@@ -126,7 +126,12 @@ namespace AZ
         SetFilter(inputFilter);
 
         // Bind our custom log handler.
-        AZ::Interface<AZ::ILogger>::Get()->BindLogHandler(m_logHandler);
+        AZ::ILogger* loggerInstance = AZ::Interface<AZ::ILogger>::Get();
+        AZ_Assert(loggerInstance, "Failed to get ILogger instance. Log handler not bound.")
+        if (loggerInstance)
+        {
+            loggerInstance->BindLogHandler(m_logHandler);
+        }
 
         // Connect to receive render tick events.
         auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();


### PR DESCRIPTION
ILogger instance is null on iOS for some reason. I'm still investigating why. But this doesn't need to be fatal. 