### PR TITLE
Fix editor crash when slices are deleted with prefabs enabled

### DIFF
--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -328,7 +328,7 @@ void SandboxIntegrationManager::OnCatalogAssetRemoved(const AZ::Data::AssetId& a
         AZ::SliceComponent* rootSlice = nullptr;
         AzToolsFramework::SliceEditorEntityOwnershipServiceRequestBus::BroadcastResult(rootSlice,
             &AzToolsFramework::SliceEditorEntityOwnershipServiceRequestBus::Events::GetEditorRootSlice);
-        AZ_Assert(rootSlice != nullptr, "Editor root slice missing!");
+        AZ_Assert(rootSlice, "Editor root slice missing!");
 
         AZStd::vector<AZ::EntityId> entitiesToDetach;
         const AZ::SliceComponent::SliceList& subSlices = rootSlice->GetSlices();


### PR DESCRIPTION
It was noticed that if prefabs are enabled and slices are deleted from the disk, it would result in the editor crash. This was because of one of the functions was looking for root slice, which wouldn't be available when prefabs are enabled. Put that logic behind the !isPrefabSystemEnabled logic.

Testing:
Tested that editor doesn't crash when slices are deleted either with prefabs enabled or disabled.
AR is successful.