### PR TITLE
LYN-3133 Adding material editor asset path dependencies to Automated Testing project

### DIFF
--- a/AutomatedTesting/Registry/assets_scan_folders.setreg
+++ b/AutomatedTesting/Registry/assets_scan_folders.setreg
@@ -38,6 +38,13 @@
                     "Gems/PrimitiveAssets"
                 ]
             },
+            "MaterialEditor":
+            {
+                "SourcePaths":
+                [
+                    "Gems/Atom/Tools/MaterialEditor"
+                ]
+            },
             "UiBasics":
             {
                 "SourcePaths":


### PR DESCRIPTION
LYN-3133 Adding material editor asset path dependencies to Automated Testing project

Some of these changes may not be necessary but comparing against the Atom Test project

https://jira.agscollab.com/browse/LYN-3133