### PR TITLE
ATOM-15391 [RHI][Vulkan][Android] SSAO introduces horizontal lines

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SsaoCompute.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SsaoCompute.azsl
@@ -277,6 +277,8 @@ void MainCS(uint3 thread_id : SV_GroupThreadID, uint3 group_id : SV_GroupID, uin
 
         // Gather depth values
         float2 depthGatherUV = mad(float2(ldsPosition), GetPixelSize(), ldsOffsetUV);
+        // Gather on some GPUs will fall onto same pixels in adjacent coordinates due to rounding errors
+        depthGatherUV += GetHalfPixelSize();
         float4 depthGather = PassSrg::m_linearDepth.Gather(PassSrg::PointSampler, depthGatherUV);
 
         WriteDepthGatherToLDS(ldsPosition, depthGather);


### PR DESCRIPTION
Texture Gather() has inconsistent rounding errors across different GPUs. The issue is found in AMD, Android Qualcomm and Mali.
On those GPUs, it has a chance to sample the same pixel in adjacent coordinates.

SSAO uses adjacent depth to calculate the normal, in the above case, view space vectors would introduce some 0s, and magnified by the cross product. The artifacts are more significant on planes.

A straightforward fix would be using Texture Load() for integer coordinates. It works well but perforce is reduced.
By adding half pixel size to it, it eliminates the ambiguity from rounding errors as well. So choose the later.