### PR TITLE
Set default CDN for 3p system to production Cloudfront

### DIFF
--- a/cmake/3rdPartyPackages.cmake
+++ b/cmake/3rdPartyPackages.cmake
@@ -32,7 +32,8 @@ include(cmake/LySet.cmake)
 # also allowed:
 # "s3://bucketname" (it will use LYPackage_S3Downloader.cmake to download it from a s3 bucket)
 
-set(LY_PACKAGE_SERVER_URLS "" CACHE STRING "Server URLS to fetch packages from")
+# https://d2c171ws20a1rv.cloudfront.net will be the current "production" CDN until formally moved to the public O3DE repo
+set(LY_PACKAGE_SERVER_URLS "https://d2c171ws20a1rv.cloudfront.net" CACHE STRING "Server URLS to fetch packages from")
 # Note: if you define the "LY_PACKAGE_SERVER_URLS" environment variable
 # it will be added to this value in the front, so that users can set
 # an env var and use that as an "additional" set of servers beyond the default set.


### PR DESCRIPTION
Sets the default CDN during any 3p pull when the CMake build command is executed. Will be updating docs to remove the envvar and zip file once this passes.

Testing done:
- Removed all envvars for LY_PACKAGE_SERVER_URLS - Pass (Exited with no url to pull from)
- Added the CDN as default - Pass (Pulled from the CDN url)
- Added the "prod" S3 bucket - Pass (Pulled from the S3 bucket over the CDN)