### PR TITLE
Fix Xcode breakpoints not working and debug symbols not being loaded in profile/debug builds for iOS

### DIFF
--- a/cmake/Platform/iOS/Configurations_ios.cmake
+++ b/cmake/Platform/iOS/Configurations_ios.cmake
@@ -41,6 +41,11 @@ endif()
 # Signing
 ly_set(CMAKE_XCODE_ATTRIBUTE_OTHER_CODE_SIGN_FLAGS --deep)
 
+# Symbol Stripping
+ly_set(CMAKE_XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=debug] "NO")
+ly_set(CMAKE_XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=profile] "NO")
+ly_set(CMAKE_XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=release] "YES")
+
 # Generate scheme files for Xcode
 ly_set(CMAKE_XCODE_GENERATE_SCHEME TRUE)
 

--- a/cmake/Platform/iOS/LYWrappers_ios.cmake
+++ b/cmake/Platform/iOS/LYWrappers_ios.cmake
@@ -14,13 +14,6 @@ include(cmake/Platform/Common/LYWrappers_default.cmake)
 function(ly_apply_platform_properties target)
     get_target_property(target_type ${target} TYPE)
 
-    set_target_properties(${target}
-        PROPERTIES
-        XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=debug] "NO"
-        XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=profile] "NO"
-        XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING[variant=release] "YES"
-    )
-
     if(${target_type} STREQUAL "SHARED_LIBRARY")
         # Some projects use an "_" in their target name which is not allowed in a bundle identifier
         get_target_property(target_name ${target} NAME)


### PR DESCRIPTION
The Deployment post-processing step is the one that strips symbols from the binaries before placing them in the .app. We want this enabled for release builds to reduce the size of the package. In debug and profile, we want this disabled so we can set breakpoints and get callstack information.