### PR TITLE
LYN-3465 : The test timeout for AutomatedTesting::PhysicsTests_Sandbox

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/CMakeLists.txt
@@ -51,7 +51,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         TEST_SUITE sandbox
         TEST_SERIAL
         PATH ${CMAKE_CURRENT_LIST_DIR}/physics/TestSuite_Sandbox.py
-        TIMEOUT 3600
+        TIMEOUT 1500
         RUNTIME_DEPENDENCIES
             Legacy::Editor
             AZ::AssetProcessor


### PR DESCRIPTION
Test timeout needs to be adjusted to match the new requirements.

Reducing the timeout to 1500s from 3600s