### PR TITLE
LYN-3519 Disabled drag/drop component creation for legacy assets in 1.0

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Rendering/LensFlareAssetHandler.cpp
+++ b/Gems/LmbrCentral/Code/Source/Rendering/LensFlareAssetHandler.cpp
@@ -116,11 +116,6 @@ namespace LmbrCentral
         return "Editor/Icons/Components/LensFlare.svg";
     }
 
-    AZ::Uuid LensFlareAssetHandler::GetComponentTypeId() const
-    {
-        return AZ::Uuid("{4B85E77D-91F9-40C5-8FCB-B494000A9E69}");
-    }
-
     void LensFlareAssetHandler::GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions)
     {
         extensions.push_back(LENS_FLARE_EXT);

--- a/Gems/LmbrCentral/Code/Source/Rendering/LensFlareAssetHandler.h
+++ b/Gems/LmbrCentral/Code/Source/Rendering/LensFlareAssetHandler.h
@@ -43,7 +43,6 @@ namespace LmbrCentral
         AZ::Data::AssetType GetAssetType() const override;
         const char* GetAssetTypeDisplayName() const override;
         const char* GetBrowserIcon() const override;
-        AZ::Uuid GetComponentTypeId() const override;
         void GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions) override;
         //////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/Gems/LmbrCentral/Code/Source/Rendering/MeshAssetHandler.cpp
+++ b/Gems/LmbrCentral/Code/Source/Rendering/MeshAssetHandler.cpp
@@ -252,11 +252,6 @@ namespace LmbrCentral
         return "Editor/Icons/Components/StaticMesh.svg";
     }
 
-    AZ::Uuid MeshAssetHandler::GetComponentTypeId() const
-    {
-        return AZ::Uuid("{FC315B86-3280-4D03-B4F0-5553D7D08432}");
-    }
-
     void MeshAssetHandler::GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions)
     {
         extensions.push_back(CRY_GEOMETRY_FILE_EXT);
@@ -365,11 +360,6 @@ namespace LmbrCentral
     const char* GeomCacheAssetHandler::GetGroup() const
     {
         return "Geometry";
-    }
-
-    AZ::Uuid GeomCacheAssetHandler::GetComponentTypeId() const
-    {
-        return AZ::Uuid("{045C0C58-C13E-49B0-A471-D4AC5D3FC6BD}");
     }
 
     void GeomCacheAssetHandler::GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions)

--- a/Gems/LmbrCentral/Code/Source/Rendering/MeshAssetHandler.h
+++ b/Gems/LmbrCentral/Code/Source/Rendering/MeshAssetHandler.h
@@ -85,7 +85,6 @@ namespace LmbrCentral
         const char* GetAssetTypeDisplayName() const override;
         const char* GetGroup() const override;
         const char* GetBrowserIcon() const override;
-        AZ::Uuid GetComponentTypeId() const override;
         void GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions) override;
         //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -123,7 +122,6 @@ namespace LmbrCentral
         AZ::Data::AssetType GetAssetType() const override;
         const char* GetAssetTypeDisplayName() const override;
         const char* GetGroup() const override;
-        AZ::Uuid GetComponentTypeId() const override;
         void GetAssetTypeExtensions(AZStd::vector<AZStd::string>& extensions) override;
 
         void Register();

--- a/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.cpp
+++ b/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.cpp
@@ -54,11 +54,6 @@ namespace LmbrCentral
         return "Editor/Icons/Components/Decal.svg";
     }
 
-    AZ::Uuid MaterialAssetTypeInfo::GetComponentTypeId() const
-    {
-        return AZ::Uuid("{BA3890BD-D2E7-4DB6-95CD-7E7D5525567A}");
-    }
-
     // DccMaterialAssetTypeInfo
 
     DccMaterialAssetTypeInfo::~DccMaterialAssetTypeInfo()

--- a/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.h
+++ b/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.h
@@ -30,7 +30,6 @@ namespace LmbrCentral
         const char* GetAssetTypeDisplayName() const override;
         const char* GetGroup() const override;
         const char* GetBrowserIcon() const override;
-        AZ::Uuid GetComponentTypeId() const override;
         //////////////////////////////////////////////////////////////////////////////////////////////
 
         void Register();


### PR DESCRIPTION
All of these component and assets types have been removed from main but not integrated to 1.0

https://jira.agscollab.com/browse/LYN-3519