### PR TITLE
SPEC-6677 Remove TestRail URLs from Physx Tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/physics/C100000_RigidBody_EnablingGravityWorksPoC.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C100000_RigidBody_EnablingGravityWorksPoC.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C100000
 # Test Case Title : Check that Gravity works
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/100000
+
 
 
 # fmt:off

--- a/AutomatedTesting/Gem/PythonTests/physics/C111111_RigidBody_EnablingGravityWorksUsingNotificationsPoC.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C111111_RigidBody_EnablingGravityWorksUsingNotificationsPoC.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C111111
 # Test Case Title : Check that Gravity works
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/111111
+
 
 # fmt:off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C12712452_ScriptCanvas_CollisionEvents.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12712452_ScriptCanvas_CollisionEvents.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C12712452
 # Test Case Title : Verify ScriptCanvas Collision Events
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/12712452
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C12712453_ScriptCanvas_MultipleRaycastNode.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12712453_ScriptCanvas_MultipleRaycastNode.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C12712453
 # Test Case Title : Verify Raycast Multiple Node
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12712453
+
 
 # fmt:off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C12712454_ScriptCanvas_OverlapNodeVerification.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12712454_ScriptCanvas_OverlapNodeVerification.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : 12712454
 # Test Case Title : Verify overlap nodes in script canvas
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12712454
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C12712455_ScriptCanvas_ShapeCastVerification.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12712455_ScriptCanvas_ShapeCastVerification.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C12712455
 # Test Case Title : Verify shape cast nodes in SC
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12712455
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C12868578_ForceRegion_DirectionHasNoAffectOnMagnitude.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12868578_ForceRegion_DirectionHasNoAffectOnMagnitude.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C12868578
 # Test Case Title : Check that World space and local space force direction doesn't affect magnitude of force exerted
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12868578
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C12868580_ForceRegion_SplineModifiedTransform.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12868580_ForceRegion_SplineModifiedTransform.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C12868580
 # Test Case Title : Check that spline follow force works if transform components of entity are altered
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12868580
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C12905527_ForceRegion_MagnitudeDeviation.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12905527_ForceRegion_MagnitudeDeviation.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C12905527
 # Test Case Title : Check that deviation occurring in Force Magnitude due to Values in Force direction is not large
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12905527
+
 
 # fmt: off
 class Tests():

--- a/AutomatedTesting/Gem/PythonTests/physics/C12905528_ForceRegion_WithNonTriggerCollider.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C12905528_ForceRegion_WithNonTriggerCollider.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C12905528
 Test Case Title : Check that user is warned if non-trigger collider component is used with force region
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/12905528
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C13351703_COM_NotIncludeTriggerShapes.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C13351703_COM_NotIncludeTriggerShapes.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C13351703
 # Test Case Title : Check that Center of Mass calculations should not include trigger shapes
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/13351703
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C13352089_RigidBodies_MaxAngularVelocity.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C13352089_RigidBodies_MaxAngularVelocity.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C13352089
 # Test Case Title : Verify that maximum angular velocity interacts correctly with initial angular velocity
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/13352089
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C13508019_Terrain_TerrainTexturePainterWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C13508019_Terrain_TerrainTexturePainterWorks.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C13508019
 # Test Case Title : Verify terrain materials are updated after using terrain texture layer painter.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/13508019
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C13895144_Ragdoll_ChangeLevel.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C13895144_Ragdoll_ChangeLevel.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C13895144
 # Test Case Title : Run a level with multiple ragdolls and then switch levels
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/13895144
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C14195074_ScriptCanvas_PostUpdateEvent.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14195074_ScriptCanvas_PostUpdateEvent.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C14195074
 # Test Case Title : Verify Postsimulate Events
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14195074
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C14654881_CharacterController_SwitchLevels.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14654881_CharacterController_SwitchLevels.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C14654881
 # Test Case Title : Switching levels from a level containing a character controller component
 # should not lead to a crash
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14654881
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C14654882_Ragdoll_ragdollAPTest.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14654882_Ragdoll_ragdollAPTest.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 Test case ID : C14654882
 Test Case Title : Loading level with old PhysX Ragdoll component serialization should not produce asset processor errors
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14654882
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C14861498_ConfirmError_NoPxMesh.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14861498_ConfirmError_NoPxMesh.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C14861498
 # Test Case Title : Confirm that when a PhysXCollider has no physics asset, the physics asset collider \
 #   shape throw an error
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14861498
+
 
 
 # fmt:off

--- a/AutomatedTesting/Gem/PythonTests/physics/C14861500_DefaultSetting_ColliderShape.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14861500_DefaultSetting_ColliderShape.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C14861500
 Test Case Title : Verify Default shape is Physics Asset
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14861500
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C14861501_PhysXCollider_RenderMeshAutoAssigned.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14861501_PhysXCollider_RenderMeshAutoAssigned.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C14861501
 Test Case Title : Verify PxMesh is auto-assigned when Collider component is added after Rendering Mesh component
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14861501
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C14861502_PhysXCollider_AssetAutoAssigned.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14861502_PhysXCollider_AssetAutoAssigned.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C14861502
 Test Case Title : Verify PxMesh is auto-assigned in collider when Mesh is assigned in Rendering Mesh component
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14861502
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C14861504_RenderMeshAsset_WithNoPxAsset.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14861504_RenderMeshAsset_WithNoPxAsset.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C14861504
 Test Case Title : Verify if Rendering Mesh does not have a PhysX Collision Mesh fbx, then PxMesh is not auto-assigned
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14861504
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C14902097_ScriptCanvas_PreUpdateEvent.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14902097_ScriptCanvas_PreUpdateEvent.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C14902097
 # Test Case Title : Verify Presimulate Events
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14902097
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C14902098_ScriptCanvas_PostPhysicsUpdate.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14902098_ScriptCanvas_PostPhysicsUpdate.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C14902098
 # Test Case Title : Check that force region simulation with Postsimulate works independently from rendering tick
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14902098
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C14976307_Gravity_SetGravityWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14976307_Gravity_SetGravityWorks.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C14976307
 # Test Case Title : Check that Set Gravity Enabled works on an entity with gravity that starts as disabled
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/14976307
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C14976308_ScriptCanvas_SetKinematicTargetTransform.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C14976308_ScriptCanvas_SetKinematicTargetTransform.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test Case
 # ID    : C14976308
 # Title : Verify that SetKinematicTarget on PhysX rigid body updates transform for kinematic entities and vice versa
-# URL   : https://testrail.agscollab.com/index.php?/cases/view/14976308
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15096732_Material_DefaultLibraryUpdatedAcrossLevels_after.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15096732_Material_DefaultLibraryUpdatedAcrossLevels_after.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15096732
 # Test Case Title : Verify Default material library works across different levels
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15096732
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C15096732_Material_DefaultLibraryUpdatedAcrossLevels_before.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15096732_Material_DefaultLibraryUpdatedAcrossLevels_before.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15096732
 # Test Case Title : Verify Default material library works across different levels
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15096732
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C15096735_Materials_DefaultLibraryConsistency.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15096735_Materials_DefaultLibraryConsistency.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15096735
 # Test Case Title : Verify that default material library works consistently across all systems that use it
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15096735
+
 
 
 # fmt:off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15096737_Materials_DefaultMaterialLibraryChanges.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15096737_Materials_DefaultMaterialLibraryChanges.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test Case Title : Verify that a change in the default material library material information
 # affects all the materials that reference it, even non-defaulted
 # exactly like if the library was selected
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15096737
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C15096740_Material_LibraryUpdatedCorrectly.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15096740_Material_LibraryUpdatedCorrectly.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 Test case ID : C15096740
 Test Case Title : Verify that clearing a material library on all systems that use it,
                   assigns the default material library
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15096740
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C15308217_NoCrash_LevelSwitch.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15308217_NoCrash_LevelSwitch.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C15308217
 # Test Case Title : Verify that the Terrain texture layer doesn't crash when changing
 # from on a level with a terrain component to another level without a terrain component
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15308217
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15308221_Material_ComponentsInSyncWithLibrary.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15308221_Material_ComponentsInSyncWithLibrary.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C15308221
 # Test Case Title : Verify that material library and slots are always in sync and work consistently through the different places of usage
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/15308221
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15425929_Undo_Redo.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15425929_Undo_Redo.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15425929
 # Test Case Title : Verify that undo - redo operations do not create any error
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15425929
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15425935_Material_LibraryUpdatedAcrossLevels.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15425935_Material_LibraryUpdatedAcrossLevels.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15425935
 # Test Case Title : Verify that the change in Material Library gets updated across levels
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15425935
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C15556261_PhysXMaterials_CharacterControllerMaterialAssignment.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15556261_PhysXMaterials_CharacterControllerMaterialAssignment.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15556261
 # Test Case Title : Check that the material assignment works with Character Controller
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15556261
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15563573_Material_AddModifyDeleteOnCharacterController.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15563573_Material_AddModifyDeleteOnCharacterController.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C15563573
 # Test Case Title : Check that any change (Add/Delete/Modify) made to the material surface in the material library reflects immediately in the PhysX Character Controller
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/15563573
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C15845879_ForceRegion_HighLinearDampingForce.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C15845879_ForceRegion_HighLinearDampingForce.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C15845879
 # Test Case Title : Check that linear damping with high values do not make the object to quiver
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/15845879
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C17411467_AddPhysxRagdollComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C17411467_AddPhysxRagdollComponent.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C17411467
 Test Case Title : Check that Physx Ragdoll component can be added without errors/warnings
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/17411467
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243580_Joints_Fixed2BodiesConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243580_Joints_Fixed2BodiesConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243580
 # Test Case Title : Check that fixed joint constrains 2 bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243580
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243581_Joints_FixedBreakable.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243581_Joints_FixedBreakable.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243581
 # Test Case Title : Check that fixed joint is breakable
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243581
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243582_Joints_FixedLeadFollowerCollide.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243582_Joints_FixedLeadFollowerCollide.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243582
 # Test Case Title : Check that fixed joint allows lead-follower collision
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243582
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243583_Joints_Hinge2BodiesConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243583_Joints_Hinge2BodiesConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243583
 # Test Case Title : Check that hinge joint constrains 2 bodies about X-axis
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243583
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243584_Joints_HingeSoftLimitsConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243584_Joints_HingeSoftLimitsConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243584
 # Test Case Title : Check that hinge joint allows soft limit constraints on 2 bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243584
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243585_Joints_HingeNoLimitsConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243585_Joints_HingeNoLimitsConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243585
 # Test Case Title : Check that hinge joint allows no limit constraints on 2 bodies
-# URL of the test case :https://testrail.agscollab.com/index.php?/cases/view/18243585
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243586_Joints_HingeLeadFollowerCollide.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243586_Joints_HingeLeadFollowerCollide.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243586
 # Test Case Title : Check that hinge joint allows lead-follower collision
-# URL of the test case :https://testrail.agscollab.com/index.php?/cases/view/18243586
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243587_Joints_HingeBreakable.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243587_Joints_HingeBreakable.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243587
 # Test Case Title : Check that hinge joint is breakable
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243587
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243588_Joints_Ball2BodiesConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243588_Joints_Ball2BodiesConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243588
 # Test Case Title : Check that ball joint constrains 2 bodies within cone limits
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243588
+
 # fmt: off
 class Tests:
     enter_game_mode                 = ("Entered game mode",                         "Failed to enter game mode")

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243589_Joints_BallSoftLimitsConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243589_Joints_BallSoftLimitsConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : 18243589
 # Test Case Title : Check that ball joint allows soft limit constraints
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243589
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243590_Joints_BallNoLimitsConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243590_Joints_BallNoLimitsConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243590
 # Test Case Title : Check that ball joint allows no limit constraints
-# URL of the test case :https://testrail.agscollab.com/index.php?/cases/view/18243590
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243591_Joints_BallLeadFollowerCollide.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243591_Joints_BallLeadFollowerCollide.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243591
 # Test Case Title : Check that ball joint allows lead-follower collision
-# URL of the test case :https://testrail.agscollab.com/index.php?/cases/view/18243591
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243592_Joints_BallBreakable.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243592_Joints_BallBreakable.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243592
 # Test Case Title : Check that ball joint is breakable
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243592
+
 # fmt: off
 class Tests:
     enter_game_mode                 = ("Entered game mode",                            "Failed to enter game mode")

--- a/AutomatedTesting/Gem/PythonTests/physics/C18243593_Joints_GlobalFrameConstrained.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18243593_Joints_GlobalFrameConstrained.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18243593
 # Test Case Title : Check that fixed/hinge/ball joints allow constraints to global frame
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18243593
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C18977601_Material_FrictionCombinePriority.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18977601_Material_FrictionCombinePriority.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18977601
 # Test Case Title : Verify that when two objects with different materials collide, the friction combine priority works
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18977601
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C18981526_Material_RestitutionCombinePriority.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C18981526_Material_RestitutionCombinePriority.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C18981526
 # Test Case Title : Verify when two objects with different materials collide, the restitution combine priority works
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/18981526
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C19536274_GetCollisionName_PrintsName.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C19536274_GetCollisionName_PrintsName.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C19536274
 Test Case Title : Verify that the Get Collision Layer Name node prints the name of the collision layer
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/19536274
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C19536277_GetCollisionName_PrintsNothing.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C19536277_GetCollisionName_PrintsNothing.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C19536277
 Test Case Title : Verify that when a group is modified using ToggleCollisionLayer node such that the new group is not in the pre-existing groups, GetCollisionGroupName node prints no value
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/19536277
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C19578018_ShapeColliderWithNoShapeComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C19578018_ShapeColliderWithNoShapeComponent.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C19578018
 Test Case Title : Verify that a shape collider component with no shape component indicates a missing service
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/19578018
+
 """
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C19578021_ShapeCollider_CanBeAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C19578021_ShapeCollider_CanBeAdded.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C19578021
 Test Case Title : Verify that a shape collider component may be added to an entity along with one or more PhysX collider components
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/19578021
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C19723164_ShapeColliders_WontCrashEditor.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C19723164_ShapeColliders_WontCrashEditor.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C19723164
 Test Case Title : Verify that if we had 512 shape colliders in the level, the level does not crash
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/19723164
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C24308873_CylinderShapeCollider_CollidesWithPhysXTerrain.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C24308873_CylinderShapeCollider_CollidesWithPhysXTerrain.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C24308873
 # Test Case Title : Check that cylinder shape collider collides with terrain
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/24308873
+
 # A cylinder is suspended slightly over PhysX Terrain to check that it collides when dropped
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C28978033_Ragdoll_WorldBodyBusTests.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C28978033_Ragdoll_WorldBodyBusTests.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C28978033
 # Test Case Title : Check that WorldRequestBus works with PhysX ragdoll
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/28978033
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C29032500_EditorComponents_WorldBodyBusWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C29032500_EditorComponents_WorldBodyBusWorks.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C29032500
 # Test Case Title : Check that WorldRequestBus works with editor components
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/29032500
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C3510642_Terrain_NotCollideWithTerrain.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C3510642_Terrain_NotCollideWithTerrain.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C3510642
 # Test Case Title : Check that when no physX terrain component is added, collision of a PhysX object
 # with terrain does not work. Consequently, PhysX material assignment to terrain cannot be tested.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/3510642
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044455_Material_libraryChangesInstantly.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044455_Material_libraryChangesInstantly.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : 4044455
 # Test Case Title : Verify that any change in any of the values including the name of the material, 
 #   once saved, is immediately reflected in the component and functionality
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044455
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044456_Material_FrictionCombine.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044456_Material_FrictionCombine.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4044456
 # Test Case Title : Verify that when two objects with different materials collide, the friction combine works
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044456
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044457_Material_RestitutionCombine.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044457_Material_RestitutionCombine.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4044457
 # Test Case Title : Verify that when two objects with different materials collide, the restitution combine works
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044457
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044459_Material_DynamicFriction.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044459_Material_DynamicFriction.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4044459
 # Test Case Title : Verify the functionality of dynamic friction
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044459
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044460_Material_StaticFriction.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044460_Material_StaticFriction.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4044460
 # Test Case Title : Verify the functionality of static friction
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044460
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044461_Material_Restitution.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044461_Material_Restitution.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4044461
 # Test Case Title : Verify the functionality of restitution
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044461
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044694_Material_EmptyLibraryUsesDefault.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044694_Material_EmptyLibraryUsesDefault.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C4044694
 # Test Case Title : Verify that if we add an empty Material library in Collider Component, the object continues to use Default material values
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/4044694
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044695_PhysXCollider_AddMultipleSurfaceFbx.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044695_PhysXCollider_AddMultipleSurfaceFbx.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 Test case ID : C4044695
 Test Case Title : Verify that when you add a multiple surface fbx in PxMesh in PhysxCollider,
                   multiple number of Material Slots populate in the Materials Section
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044695
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C4044697_Material_PerfaceMaterialValidation.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4044697_Material_PerfaceMaterialValidation.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4044697
 # Test Case Title : Verify that each surface picks up the material assigned to it and behaves accordingly.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4044697
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4888315_Material_AddModifyDeleteOnCollider.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4888315_Material_AddModifyDeleteOnCollider.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C4888315
 # Test Case Title : Check that any change (Add/Delete/Modify) made to the material surface in the material library reflects immediately in the PhysX Collider component
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/4888315
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4925577_Materials_MaterialAssignedToTerrain.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4925577_Materials_MaterialAssignedToTerrain.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4925577
 # Test Case Title : Verify that material can be assigned to PhysX terrain in Terrain Texture Layers
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4925577
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4925579_Material_AddModifyDeleteOnTerrain.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4925579_Material_AddModifyDeleteOnTerrain.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C4925579
 # Test Case Title : Check that any change (Add/Delete/Modify) made to the material surface in the material library reflects immediately in the PhysX Terrain layers
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/4925579
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4925580_Material_RagdollBonesMaterial.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4925580_Material_RagdollBonesMaterial.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C4925580
 # Test Case Title : Verify that Material can be assigned to Ragdoll Bones and they behave as per their material
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/4925580
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4925582_Material_AddModifyDeleteOnRagdollBones.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4925582_Material_AddModifyDeleteOnRagdollBones.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test Case ID    : C4925582
 # Test Case Title : Check that any change (Add/Delete/Modify) made to the material surface in the material library reflects immediately in the ragdoll bones
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/4925582
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976194_RigidBody_PhysXComponentIsValid.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976194_RigidBody_PhysXComponentIsValid.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976194
 # Test Case Title : Verify that you can add PhysX Rigid Bodies Physics component to an Entity without any warning or Error.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976194
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976195_RigidBodies_InitialLinearVelocity.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976195_RigidBodies_InitialLinearVelocity.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976195
 # Test Case Title : Verify that when you assign an Initial Linear Velocity to an object,
 # ... it moves with that linear velocity when we switch to game mode.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976195
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976197_RigidBodies_InitialAngularVelocity.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976197_RigidBodies_InitialAngularVelocity.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976197
 # Test Case Title : Verify that when you assign an Initial Angular Velocity to an object,
 #   it moves with that Angular velocity when we switch to game mode
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976197
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976199_RigidBodies_LinearDampingObjectMotion.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976199_RigidBodies_LinearDampingObjectMotion.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976199
 # Test Case Title : Verify that with higher linear damping, the object in motion comes to rest faster
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976199
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976200_RigidBody_AngularDampingObjectRotation.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976200_RigidBody_AngularDampingObjectRotation.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976200
 # Test Case Title : Verify that with higher angular damping, the object in rotation comes to rest faster
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976200
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976201_RigidBody_MassIsAssigned.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976201_RigidBody_MassIsAssigned.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976201
 # Test Case Title : Verify that the value assigned to the Mass of the object, gets actually assigned to the object
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976201
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976202_RigidBody_StopsWhenBelowKineticThreshold.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976202_RigidBody_StopsWhenBelowKineticThreshold.py
@@ -14,7 +14,7 @@ Test case ID : C4976202
 Test Case Title : Verify that if the object is moving with Kinetic energy less than 
   the sleep threshold value, then physX will put it to stop after 0.4 secs (once the 
   wake counter goes to zero) if the KE is still below the threshold
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976202
+
 """
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976204_Verify_Start_Asleep_Condition.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976204_Verify_Start_Asleep_Condition.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976204
 # Test Case Title : Verify that when Start Asleep is checked, the object in air does not fall down due to
 # gravity or does not start moving with initial linear velocity assigned to it when switched to game mode
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976204
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976206_RigidBodies_GravityEnabledActive.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976206_RigidBodies_GravityEnabledActive.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976206
 # Test Case Title : VErify that when Gravity enables is checked, the object falls down due to gravity [sic]
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976206
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976207_PhysXRigidBodies_KinematicBehavior.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976207_PhysXRigidBodies_KinematicBehavior.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976207
 # Test Case Title : Verify that when Kinematic is checked, the object behaves as a Kinematic object
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976207
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976209_RigidBody_ComputesCOM.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976209_RigidBody_ComputesCOM.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976209
 # Test Case Title : Verify that when Compute COM is enabled, the PhysX system computes the COM of the object on its own
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976209
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976210_COM_ManualSetting.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976210_COM_ManualSetting.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976210
 # Test Case Title : Verify that when Compute COM is disabled, the user gets an option to add the co-ordinates of
 #                       the COM and the COM gets implemented at those co-ordinates.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976210
+
 
 
 import os

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976218_RigidBodies_InertiaObjectsNotComputed.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976218_RigidBodies_InertiaObjectsNotComputed.py
@@ -9,7 +9,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 # Test case ID : C4976218
 # Test Case Title: Verify that when compute inertia is checked, the physX engine does compute the inertia of the objects
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976218
+
 # fmt: off
 
 class Tests():

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976227_Collider_NewGroup.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976227_Collider_NewGroup.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976227
 # Test Case Title : Validate that a Collision Group can be added
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976227
+
 # Level has entity with custom collision group added.
 # If level enters game mode, collision group addition is validated.
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976236_AddPhysxColliderComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976236_AddPhysxColliderComponent.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 Test case ID : C4976236
 Test Case Title : Verify that you can add the physX collider component to an entity
                   without it throwing an error or warning
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976236
+
 """
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976242_Collision_SameCollisionlayerSameCollisiongroup.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976242_Collision_SameCollisionlayerSameCollisiongroup.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976242
 # Test Case Title : Assign same collision layer and same collision group to two entities and
 # verify that they collide or not
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976242
+
 
 # fmt: off
 class Tests():

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976243_Collision_SameCollisionGroupDiffCollisionLayers.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976243_Collision_SameCollisionGroupDiffCollisionLayers.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976243
 # Test Case Title : Assign different collision layers and same collision group
 # (such that this group has both these collision layers enabled) to two entities and verify that they collide
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976243
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976244_Collider_SameGroupSameLayerCollision.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976244_Collider_SameGroupSameLayerCollision.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4976244
 # Test Case Title : Checks that two entities of similar custom layer collide
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976244
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4976245_PhysXCollider_CollisionLayerTest.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4976245_PhysXCollider_CollisionLayerTest.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4976245
 # Test Case Title : Check that two entities of collision group "None" do not collide,
 #       even though they have the same collision layer
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4976245
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982593_PhysXCollider_CollisionLayerTest.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982593_PhysXCollider_CollisionLayerTest.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C4982593
 # Test Case Title : Check that two entities with different collision groups and layers do not collide.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982593
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982595_Collider_TriggerDisablesCollision.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982595_Collider_TriggerDisablesCollision.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test Case ID    : C4982595
 # Test Case Title : Verify that when the Trigger Checkbox is ticked, the object no longer collides with another object
 #                   but simply passes through it
-# Test Case URL   : https://testrail.agscollab.com/index.php?/cases/view/4982595
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982797_Collider_ColliderOffset.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982797_Collider_ColliderOffset.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4982797
 # Test Case Title : Check that collision offsets trigger collision events,
 #                   not entity transform locations
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982797
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982798_Collider_ColliderRotationOffset.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982798_Collider_ColliderRotationOffset.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C4982798
 # Test Case Title : Verify that when the x,y,z values are defined in the offset, the collider frame
 #                   rotates from its original orientation in the direction defined by the x,y,z units
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982798
+
 
 
 import os

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982800_PhysXColliderShape_CanBeSelected.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982800_PhysXColliderShape_CanBeSelected.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C4982800
 Test Case Title : Verify that the shape Sphere can be selected from the drop downlist and the value for its radius can be set
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982800
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982801_PhysXColliderShape_CanBeSelected.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982801_PhysXColliderShape_CanBeSelected.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C4982801
 Test Case Title : Verify that the shape Box can be selected from drop downlist and the value for its dimensions in x,y,z can be set after that
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982801
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982802_PhysXColliderShape_CanBeSelected.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982802_PhysXColliderShape_CanBeSelected.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 Test case ID : C4982802
 Test Case Title : Verify that the shape capsule can be selected from drop downlist and the value for its height and radius can be set after that
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982802
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C4982803_Enable_PxMesh_Option.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C4982803_Enable_PxMesh_Option.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 Test case ID : C4982803
 Test Case Title : Verify that when the shape Physics Asset is selected,
     PxMesh option gets enabled and a Px Mesh can be selected and assigned to the object
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/4982803
+
 """
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5296614_PhysXMaterial_ColliderShape.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5296614_PhysXMaterial_ColliderShape.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C5296614
 # Test Case Title : Check that unless you assign a shape to a physX collider component,
 # the material assigned to it does not take affect
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5296614
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5340400_RigidBody_ManualMomentOfInertia.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5340400_RigidBody_ManualMomentOfInertia.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C5340400
 # Test Case Title : Verify that when Compute inertia is disabled, the user gets to set the moment of inertia
 #                   and physX engine work accordingly
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5340400
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5689518_PhysXTerrain_CollidesWithPhysXTerrain.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5689518_PhysXTerrain_CollidesWithPhysXTerrain.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5689518
 # Test Case Title : PhysX entities collide with PhysX Terrain
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5689518
+
 # A ball is suspended slightly over PhysX Terrain to check that it collides when dropped
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C5689522_Physxterrain_AddPhysxterrainNoEditorCrash.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5689522_Physxterrain_AddPhysxterrainNoEditorCrash.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C5689522
 # Test Case Title : Create an entity with PhysX terrain. Add another PhysX terrain and verify that
 # you are able to add it without any crash or error.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5689522
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5689524_MultipleTerrains_CheckWarningInConsole.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5689524_MultipleTerrains_CheckWarningInConsole.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C5689524
 # Test Case Title : Create multiple entities each with one or more terrain components and verify that you are
 # able to successfully add the PhysX Terrain components to them.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5689524
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5689528_Terrain_MultipleTerrainComponents.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5689528_Terrain_MultipleTerrainComponents.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C5689528
 # Test Case Title : Create multiple entities each with one PhysX terrain component and verify that a warning
 # is thrown to the user
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5689528
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5689529_Verify_Terrain_RigidBody_Collider_Mesh.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5689529_Verify_Terrain_RigidBody_Collider_Mesh.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test Case Title : Create an entity with PhysX Terrain component and add
 #                   PhysX Rigid Body PhysX, PhysX Collider and Rendering Mesh to it and
 #                   verify that it works in game mode
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5689529
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5689531_Warning_TerrainSliceTerrainComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5689531_Warning_TerrainSliceTerrainComponent.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C5689531
 # Test Case Title : Check that when you add a spawner component to a level to spawn a
 # terrain and also add a terrain component explicitly, no crash happens
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5689531
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5932040_ForceRegion_CubeExertsWorldForce.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5932040_ForceRegion_CubeExertsWorldForce.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5932040
 # Test Case Title : Check that force region exerts world space force on rigid bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5932040
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5932041_PhysXForceRegion_LocalSpaceForceOnRigidBodies.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5932041_PhysXForceRegion_LocalSpaceForceOnRigidBodies.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5932041
 # Test Case Title : Check that force region exerts local space force on rigid bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5932041
+
 # Sphere drops and is acted upon in an upward and positive x-ward direction by a force
 # with a magnitude close to the assigned force region magnitude when it reaches the force region.
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C5932042_PhysXForceRegion_LinearDamping.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5932042_PhysXForceRegion_LinearDamping.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5932042
 # Test Case Title : Check that force region exerts linear damping force on rigid bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5932042
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5932043_ForceRegion_SimpleDragOnRigidBodies.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5932043_ForceRegion_SimpleDragOnRigidBodies.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5932043
 # Test Case Title : Check that force region exerts simple drag force on rigid bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5932043
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C5932044_ForceRegion_PointForceOnRigidBody.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5932044_ForceRegion_PointForceOnRigidBody.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5932044
 # Test Case Title : Check that force region exerts point force on rigid bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5932044
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5932045_ForceRegion_Spline.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5932045_ForceRegion_Spline.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5932045
 # Test Case Title : Check that force region exerts spline follow force on rigid bodies
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5932045
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959759_RigidBody_ForceRegionSpherePointForce.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959759_RigidBody_ForceRegionSpherePointForce.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959759
 # Test Case Title : Check that force region (sphere) exerts point force
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959759
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959760_PhysXForceRegion_PointForceExertion.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959760_PhysXForceRegion_PointForceExertion.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959760
 # Test Case Title : Check that force region (capsule) exerts point force
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959760
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959761_ForceRegion_PhysAssetExertsPointForce.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959761_ForceRegion_PhysAssetExertsPointForce.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959761
 # Test Case Title : Check that force region (physics asset) exerts point force
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959761
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959763_ForceRegion_ForceRegionImpulsesCube.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959763_ForceRegion_ForceRegionImpulsesCube.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959764
 # Test Case Title : Check that rigid body (Cube) gets impulse from force region
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959764
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959764_ForceRegion_ForceRegionImpulsesCapsule.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959764_ForceRegion_ForceRegionImpulsesCapsule.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959764
 # Test Case Title : Check that rigid body (Capsule) gets impulse from force region
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959764
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959765_ForceRegion_AssetGetsImpulsed.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959765_ForceRegion_AssetGetsImpulsed.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959765
 # Test Case Title : Check that rigid body (asset) gets impulse from force region
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959765
+
 
 # fmt: off
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959808_ForceRegion_PositionOffset.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959808_ForceRegion_PositionOffset.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959808
 # Test Case Title : Verify Force Region Position Offset
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959808
+
 
 
 # fmt:off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959809_ForceRegion_RotationalOffset.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959809_ForceRegion_RotationalOffset.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959809
 # Test Case Title : Verify Force Region Rotational Offset
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959809
+
 
 
 # fmt:off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5959810_ForceRegion_ForceRegionCombinesForces.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5959810_ForceRegion_ForceRegionCombinesForces.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5959810
 # Test Case Title : Check that multiple forces in single force region create correct net force
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5959810
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C5968759_ForceRegion_ExertsSeveralForcesOnRigidBody.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5968759_ForceRegion_ExertsSeveralForcesOnRigidBody.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5968759
 # Test Case Title : Check nested force regions exert forces simultaneously on rigid body
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5968759
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C5968760_ForceRegion_CheckNetForceChange.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C5968760_ForceRegion_CheckNetForceChange.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C5968760
 # Test Case Title : Check moving force region changes net force
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/5968760
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6032082_Terrain_MultipleResolutionsValid.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6032082_Terrain_MultipleResolutionsValid.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6032082
 # Test Case Title : Verify multiple terrain resolutions are supported
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6032082
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090546_ForceRegion_SliceFileInstantiates.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090546_ForceRegion_SliceFileInstantiates.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6090546
 # Test Case Title : Check that a force region slice can be saved and instantiated
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090546
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090547_ForceRegion_ParentChildForceRegions.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090547_ForceRegion_ParentChildForceRegions.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6090547
 # Test Case Title : Check that force regions in parent and child entities work together.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090547
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090550_ForceRegion_WorldSpaceForceNegative.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090550_ForceRegion_WorldSpaceForceNegative.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 Test case ID : C6090550
 Test Case Title : Check that force region exerts world space force on rigid bodies (negative test)
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090550
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090551_ForceRegion_LocalSpaceForceNegative.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090551_ForceRegion_LocalSpaceForceNegative.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 Test case ID : C6090551
 Test Case Title : Check that force region exerts local space force on rigid bodies (negative test)
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090551
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090552_ForceRegion_LinearDampingNegative.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090552_ForceRegion_LinearDampingNegative.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 Test case ID : C6090552
 Test Case Title : Check that force region exerts linear damping force on rigid bodies (negative test)
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090552
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090553_ForceRegion_SimpleDragForceOnRigidBodies.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090553_ForceRegion_SimpleDragForceOnRigidBodies.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6090553
 # Test Case Title : Check that force region exerts simple drag force on rigid bodies (negative test)
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090553
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090554_ForceRegion_PointForceNegative.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090554_ForceRegion_PointForceNegative.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 """
 Test case ID : C6090554
 Test Case Title : Check that force region exerts point force on rigid bodies (negative test)
-URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090554
+
 """
 
 

--- a/AutomatedTesting/Gem/PythonTests/physics/C6090555_ForceRegion_SplineFollowOnRigidBodies.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6090555_ForceRegion_SplineFollowOnRigidBodies.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6090555
 # Test Case Title : Check that force region exerts spline follow force on rigid bodies(negative test)
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6090555
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6131473_StaticSlice_OnDynamicSliceSpawn.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6131473_StaticSlice_OnDynamicSliceSpawn.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Test case ID : C6131473
 # Test Case Title : Verify a static slice is not spawned automatically everytime a dynamic slice with
 # PhysX Components is spawned
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6131473
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6224408_ScriptCanvas_EntitySpawn.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6224408_ScriptCanvas_EntitySpawn.py
@@ -11,7 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6224408
 # Test Case Title : Entity using PhysX nodes in Script Canvas can be spawned.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6224408
+
 
 # fmt: off
 class Tests:

--- a/AutomatedTesting/Gem/PythonTests/physics/C6274125_ScriptCanvas_TriggerEvents.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6274125_ScriptCanvas_TriggerEvents.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6274125
 # Test Case Title : Verify ScriptCanvas Trigger Events.
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6274125
+
 
 
 # fmt: off

--- a/AutomatedTesting/Gem/PythonTests/physics/C6321601_Force_HighValuesDirectionAxes.py
+++ b/AutomatedTesting/Gem/PythonTests/physics/C6321601_Force_HighValuesDirectionAxes.py
@@ -12,7 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 
 # Test case ID : C6321601
 # Test Case Title : Check that very high values of direction axes of forces do not throw error
-# URL of the test case : https://testrail.agscollab.com/index.php?/cases/view/6321601
+
 
 
 # fmt: off


### PR DESCRIPTION
Updated 143 test cases, removed TestRail URL from them. 