### PR TITLE
[ATOM-15249] Change Specular IBL to use Fresnel

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ibl.azsli
@@ -33,7 +33,7 @@ void ApplyIblDiffuse(
 void ApplyIblSpecular(
     float3 position, 
     float3 normal, 
-    float3 specularF0, 
+    float3 specularResponse,
     float roughnessLinear, 
     float3 dirToCamera, 
     float2 brdf, 
@@ -44,7 +44,7 @@ void ApplyIblSpecular(
 
     // global
     outSpecular = SceneSrg::m_specularEnvMap.SampleLevel(SceneSrg::m_samplerEnv, GetCubemapCoords(reflectDir), GetRoughnessMip(roughnessLinear)).rgb;
-    outSpecular *= (specularF0 * brdf.x + brdf.y);
+    outSpecular *= (specularResponse * brdf.x + brdf.y);
     
     // reflection probe
     if (ObjectSrg::m_reflectionProbeData.m_useReflectionProbe)
@@ -60,7 +60,7 @@ void ApplyIblSpecular(
         }
     
         float3 probeSpecular = ObjectSrg::m_reflectionProbeCubeMap.SampleLevel(SceneSrg::m_samplerEnv, GetCubemapCoords(reflectDir), GetRoughnessMip(roughnessLinear)).rgb;
-        probeSpecular *= (specularF0 * brdf.x + brdf.y);
+        probeSpecular *= (specularResponse * brdf.x + brdf.y);
     
         // compute blend amount based on world position in the reflection probe volume
         float blendAmount = ComputeLerpBetweenInnerOuterAABBs(
@@ -92,7 +92,7 @@ void ApplyIBL(Surface surface, inout LightingData lightingData)
             ApplyIblSpecular(
                 surface.position, 
                 surface.normal, 
-                surface.specularF0, 
+                lightingData.specularResponse, 
                 surface.roughnessLinear, 
                 lightingData.dirToCamera, 
                 lightingData.brdf, 
@@ -112,7 +112,7 @@ void ApplyIBL(Surface surface, inout LightingData lightingData)
             ApplyIblSpecular(
                 surface.position, 
                 surface.normal, 
-                surface.specularF0, 
+                lightingData.specularResponse,
                 surface.roughnessLinear, 
                 lightingData.dirToCamera, 
                 lightingData.brdf, 
@@ -150,7 +150,6 @@ void ApplyIBL(Surface surface, inout LightingData lightingData)
                 }
             }
 
-            
             float iblExposureFactor = pow(2.0f, SceneSrg::m_iblExposure);
             lightingData.specularLighting += (iblSpecular * iblExposureFactor);
         }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.azsl
@@ -106,7 +106,8 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
     NdotV = max(NdotV, 0.01f);    // [GFX TODO][ATOM-4466] This is a current band-aid for specular noise at grazing angles.
     float2 brdf = PassSrg::m_brdfMap.Sample(PassSrg::LinearSampler, GetBRDFTexCoords(roughness, NdotV)).rg;
     float3 multiScatterCompensation = GetMultiScatterCompensation(specularF0, brdf, multiScatterCompensationEnabled);
-    float3 specular = blendWeight * globalSpecular * multiScatterCompensation * (specularF0 * brdf.x + brdf.y);
+    float3 specularResponse = FresnelSchlickWithRoughness(NdotV, specularF0, roughness);
+    float3 specular = blendWeight * globalSpecular * multiScatterCompensation * (specularResponse * brdf.x + brdf.y);
 
     // apply exposure setting
     specular *= pow(2.0, SceneSrg::m_iblExposure);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderCommon.azsli
@@ -59,7 +59,8 @@ bool ComputeProbeSpecular(float2 screenCoords, float3 positionWS, float3 aabbMin
 
     // compute final specular amount
     float3 multiScatterCompensation = GetMultiScatterCompensation(specularF0, brdf, multiScatterCompensationEnabled);
-    specular = probeSpecular * multiScatterCompensation * (specularF0.xyz * brdf.x + brdf.y);
+    float3 specularResponse = FresnelSchlickWithRoughness(NdotV, specularF0, roughness);
+    specular = probeSpecular * multiScatterCompensation * (specularResponse * brdf.x + brdf.y);
 
     return true;
 }


### PR DESCRIPTION
Changed forward pass and specular IBL pass split-sum approximation to use specular response with fresnel.