### PR TITLE
[ATOM-15483] Shader Build Pipeline: Fix "include" file discovery in

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/CommonFiles/Preprocessor.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/CommonFiles/Preprocessor.cpp
@@ -25,6 +25,7 @@
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/Utils/Utils.h>
 
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzFramework/API/ApplicationAPI.h>
@@ -299,6 +300,9 @@ namespace AZ
 
             // we transfer to a set, to order the folders, uniquify them, and ensure deterministic build behavior
             AZStd::set<AZStd::string> scanFoldersSet;
+            // Add the project path to list of include paths
+            AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
+            scanFoldersSet.emplace(projectPath.c_str(), projectPath.size());
             // but while we transfer to the set, we're going to keep only folders where +/ShaderLib exists
             for (AZStd::string folder : scanFoldersVector)
             {
@@ -310,14 +314,12 @@ namespace AZ
             } // the folders constructed this fashion constitute the base of automatic include search paths
 
             // get the engine root:
-            AZStd::string engineRoot;
-            AzFramework::ApplicationRequests::Bus::BroadcastResult(engineRoot, &AzFramework::ApplicationRequests::GetEngineRoot);
-            AzFramework::StringFunc::Path::Normalize(engineRoot);
+            AZ::IO::FixedMaxPath engineRoot = AZ::Utils::GetEnginePath();
 
             // add optional additional options
             for (AZStd::string& path : options.m_projectIncludePaths)
             {
-                AzFramework::StringFunc::Path::Join(engineRoot.c_str(), path.c_str(), path);
+                path = (engineRoot / path).String();
                 DeleteFromSet(path, scanFoldersSet);  // no need to add a path two times.
             }
             // back-insert the default paths (after the config-read paths we just read)


### PR DESCRIPTION
    <Game>/Config/shader_global_build_options.json

Imported fix by @lumberyard-employee-dm from PR #254

Engine wise, the solution is to always add the <Game Project Root>
as the first include directory.

Signed-off-by: garrieta <garrieta@amazon.com>