### PR TITLE
Add Vulkan and DX12 builders for Mac/Automatedtesting

### DIFF
--- a/AutomatedTesting/Gem/Code/Platform/Mac/tool_dependencies.cmake
+++ b/AutomatedTesting/Gem/Code/Platform/Mac/tool_dependencies.cmake
@@ -14,4 +14,6 @@ set(GEM_DEPENDENCIES
     Gem::Atom_RHI_Null.Builders
     Gem::Atom_RHI_Metal.Private
     Gem::Atom_RHI_Metal.Builders
+    Gem::Atom_RHI_Vulkan.Builders
+    Gem::Atom_RHI_DX12.Builders
 )


### PR DESCRIPTION
This will allow Mac to have DX12/Vulkan reflection