### PR TITLE
[LYN-3439] Make sure the toolbar spacer is created with a parent to prevent an empty floating window.

### DIFF
--- a/Code/Sandbox/Editor/MainWindow.cpp
+++ b/Code/Sandbox/Editor/MainWindow.cpp
@@ -1327,7 +1327,7 @@ QToolButton* MainWindow::CreateDebugModeButton()
 
 QWidget* MainWindow::CreateSpacerRightWidget()
 {
-    QWidget* spacer = new QWidget();
+    QWidget* spacer = new QWidget(this);
     spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     spacer->setVisible(true);
     return spacer;


### PR DESCRIPTION
Since the QWidget for the spacer was created with no parent, a floating window ends up getting created for it that is empty because the spacer is invisible. The spacer is then added to the toolbar, but the floating window remains until the user closes it.