### PR TITLE
[SPEC-6668] Fix email notifications and limit to watched branches

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -549,17 +549,16 @@ finally {
                 message:"${currentBuild.currentResult}:${BUILD_URL}:${env.RECREATE_VOLUME}:${env.CLEAN_OUTPUT_DIRECTORY}:${env.CLEAN_ASSETS}"
             )
         }
-        if (env.WATCHED_BRANCHES.tokenize(',').contains(branchName)) {
-            node('controller') {
-                step([
-                    $class: 'Mailer', 
-                    notifyEveryUnstableBuild: true, 
-                    recipients: emailextrecipients([
-                        [$class: 'CulpritsRecipientProvider'],
-                        [$class: 'RequesterRecipientProvider']
-                    ])
-                ])
+        node('controller') {
+            emailRecipients = [[$class: 'RequesterRecipientProvider']]
+            if (env.WATCHED_BRANCHES.tokenize(',').contains(branchName)) {
+                emailRecipients.add([$class: 'CulpritsRecipientProvider'])
             }
+            step([
+                $class: 'Mailer', 
+                notifyEveryUnstableBuild: true, 
+                recipients: emailextrecipients(emailRecipients)
+            ])
         }
     } catch(Exception e) {
     }


### PR DESCRIPTION
Notifications stopped working awhile back likely due to a plugin update. Email step required reformatting. Also devs would be confused by notifications when the pipeline failed in another branch due to commits merged from main. 

This fixes notifications and also limits emails to reduce noise. The list of watched branches is configured in Jenkins. If the list is not configured it returns false and no emails are sent. 

Tested in branch:
- Build success: no emails
- Build failure on watched branch: email sent to users that committed change since last green build
- Build failure on non-watch branch: no email sent
- watched branch setting not configured: no email sent and no error