### PR TITLE
LYN-3612 Removing reference to redcoded decal component causing drag/drop crash

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.cpp
+++ b/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.cpp
@@ -54,11 +54,6 @@ namespace LmbrCentral
         return "Icons/Components/Decal.svg";
     }
 
-    AZ::Uuid MaterialAssetTypeInfo::GetComponentTypeId() const
-    {
-        return AZ::Uuid("{BA3890BD-D2E7-4DB6-95CD-7E7D5525567A}");
-    }
-
     // DccMaterialAssetTypeInfo
 
     DccMaterialAssetTypeInfo::~DccMaterialAssetTypeInfo()

--- a/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.h
+++ b/Gems/LmbrCentral/Code/Source/Unhandled/Material/MaterialAssetTypeInfo.h
@@ -30,7 +30,6 @@ namespace LmbrCentral
         const char* GetAssetTypeDisplayName() const override;
         const char* GetGroup() const override;
         const char* GetBrowserIcon() const override;
-        AZ::Uuid GetComponentTypeId() const override;
         //////////////////////////////////////////////////////////////////////////////////////////////
 
         void Register();


### PR DESCRIPTION
LYN-3612 Removing reference to redcoded decal component causing drag/drop crash

https://jira.agscollab.com/browse/LYN-3612