### PR TITLE
[LYN-3613] Fixed preferred category for Landscape Canvas when adding components since legacy components have been removed and now Mesh is in the Atom category.

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -206,7 +206,7 @@ namespace LandscapeCanvasEditor
 
         static const QStringList preferredCategories = {
             "Vegetation",
-            "Rendering"
+            "Atom"
         };
 
         // There are a couple of cases where we prefer certain categories of Components


### PR DESCRIPTION
When we create a new node in Landscape Canvas we have to create the corresponding Entity/Component. We automatically add any required component dependencies, and there is some logic where we prefer which component to add based on their category if multiple components provide the required service. We used to use the "Rendering" category so that the legacy "Mesh" would get picked up before the "Actor" component, but there is no longer a "Rendering" category since all the legacy rendering components have been removed. So I replaced that category with "Atom" so that the Atom "Mesh" will be preferred.