### PR TITLE
Fixes for the DebugDraw gem

### DIFF
--- a/Gems/AtomLyIntegration/CryRenderAtomShim/AtomShim_RenderAuxGeom.cpp
+++ b/Gems/AtomLyIntegration/CryRenderAtomShim/AtomShim_RenderAuxGeom.cpp
@@ -686,3 +686,16 @@ void CAtomShimRenderAuxGeom::DrawBone(const Vec3& p, const Vec3& c,  ColorB col)
     DrawLine(VBuffer[5], CBuffer[5], VBuffer[3], CBuffer[3]);
     DrawLine(VBuffer[5], CBuffer[5], VBuffer[4], CBuffer[4]);
 }
+
+void CAtomShimRenderAuxGeom::RenderText([[maybe_unused]] Vec3 pos, [[maybe_unused]] SDrawTextInfo& ti, [[maybe_unused]] const char* format, [[maybe_unused]] va_list args)
+{
+    if (format && !gEnv->IsDedicated())
+    {
+        char str[512];
+
+        vsnprintf_s(str, sizeof(str), sizeof(str) - 1, format, args);
+        str[sizeof(str) - 1] = '\0';
+        gEnv->pRenderer->DrawTextQueued(pos, ti, str);
+    }
+}
+

--- a/Gems/AtomLyIntegration/CryRenderAtomShim/AtomShim_RenderAuxGeom.h
+++ b/Gems/AtomLyIntegration/CryRenderAtomShim/AtomShim_RenderAuxGeom.h
@@ -67,8 +67,7 @@ public:
 
     virtual void DrawBone(const Vec3& rParent, const Vec3& rBone, ColorB col);
 
-    virtual void RenderText([[maybe_unused]] Vec3 pos, [[maybe_unused]] SDrawTextInfo& ti, [[maybe_unused]] const char* forma, [[maybe_unused]] va_list args) {}
-    virtual void RenderText_NoArgs([[maybe_unused]] Vec3 pos, [[maybe_unused]] SDrawTextInfo& ti, [[maybe_unused]] const char* text) {}
+    virtual void RenderText([[maybe_unused]] Vec3 pos, [[maybe_unused]] SDrawTextInfo& ti, [[maybe_unused]] const char* format, [[maybe_unused]] va_list args);
 
 public:
     static CAtomShimRenderAuxGeom* Create(CAtomShimRenderer& renderer)

--- a/Gems/DebugDraw/Code/CMakeLists.txt
+++ b/Gems/DebugDraw/Code/CMakeLists.txt
@@ -51,6 +51,9 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Source
             PUBLIC
                 Include
+    COMPILE_DEFINITIONS
+        PRIVATE
+            DEBUGDRAW_GEM_EDITOR=1
         BUILD_DEPENDENCIES
             PRIVATE
                 Gem::DebugDraw.Static

--- a/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
+++ b/Gems/DebugDraw/Code/Source/DebugDrawSystemComponent.cpp
@@ -547,9 +547,9 @@ namespace DebugDraw
             CreateLineEntryForComponent(lineComponent->GetEntityId(), lineComponent->m_element);
         }
         #ifdef DEBUGDRAW_GEM_EDITOR
-        else if (EditorDebugDrawLineComponent* lineComponent = azrtti_cast<EditorDebugDrawLineComponent*>(component))
+        else if (EditorDebugDrawLineComponent* editorLineComponent = azrtti_cast<EditorDebugDrawLineComponent*>(component))
         {
-            CreateLineEntryForComponent(lineComponent->GetEntityId(), lineComponent->m_element);
+            CreateLineEntryForComponent(editorLineComponent->GetEntityId(), editorLineComponent->m_element);
         }
         #endif // DEBUGDRAW_GEM_EDITOR
         else if (DebugDrawRayComponent* rayComponent = azrtti_cast<DebugDrawRayComponent*>(component))
@@ -557,9 +557,9 @@ namespace DebugDraw
             CreateRayEntryForComponent(rayComponent->GetEntityId(), rayComponent->m_element);
         }
         #ifdef DEBUGDRAW_GEM_EDITOR
-        else if (EditorDebugDrawRayComponent* rayComponent = azrtti_cast<EditorDebugDrawRayComponent*>(component))
+        else if (EditorDebugDrawRayComponent* editorRayComponent = azrtti_cast<EditorDebugDrawRayComponent*>(component))
         {
-            CreateRayEntryForComponent(rayComponent->GetEntityId(), rayComponent->m_element);
+            CreateRayEntryForComponent(editorRayComponent->GetEntityId(), editorRayComponent->m_element);
         }
         #endif // DEBUGDRAW_GEM_EDITOR
         else if (DebugDrawSphereComponent* sphereComponent = azrtti_cast<DebugDrawSphereComponent*>(component))
@@ -567,9 +567,9 @@ namespace DebugDraw
             CreateSphereEntryForComponent(sphereComponent->GetEntityId(), sphereComponent->m_element);
         }
         #ifdef DEBUGDRAW_GEM_EDITOR
-        else if (EditorDebugDrawSphereComponent* sphereComponent = azrtti_cast<EditorDebugDrawSphereComponent*>(component))
+        else if (EditorDebugDrawSphereComponent* editorSphereComponent = azrtti_cast<EditorDebugDrawSphereComponent*>(component))
         {
-            CreateSphereEntryForComponent(sphereComponent->GetEntityId(), sphereComponent->m_element);
+            CreateSphereEntryForComponent(editorSphereComponent->GetEntityId(), editorSphereComponent->m_element);
         }
         #endif // DEBUGDRAW_GEM_EDITOR
         else if (DebugDrawObbComponent* obbComponent = azrtti_cast<DebugDrawObbComponent*>(component))
@@ -578,9 +578,9 @@ namespace DebugDraw
         }
 
         #ifdef DEBUGDRAW_GEM_EDITOR
-        else if (EditorDebugDrawObbComponent* obbComponent = azrtti_cast<EditorDebugDrawObbComponent*>(component))
+        else if (EditorDebugDrawObbComponent* editorObbComponent = azrtti_cast<EditorDebugDrawObbComponent*>(component))
         {
-            CreateObbEntryForComponent(obbComponent->GetEntityId(), obbComponent->m_element);
+            CreateObbEntryForComponent(editorObbComponent->GetEntityId(), editorObbComponent->m_element);
         }
         #endif // DEBUGDRAW_GEM_EDITOR
 
@@ -590,9 +590,9 @@ namespace DebugDraw
         }
 
         #ifdef DEBUGDRAW_GEM_EDITOR
-        else if (EditorDebugDrawTextComponent* textComponent = azrtti_cast<EditorDebugDrawTextComponent*>(component))
+        else if (EditorDebugDrawTextComponent* editorTextComponent = azrtti_cast<EditorDebugDrawTextComponent*>(component))
         {
-            CreateTextEntryForComponent(textComponent->GetEntityId(), textComponent->m_element);
+            CreateTextEntryForComponent(editorTextComponent->GetEntityId(), editorTextComponent->m_element);
         }
         #endif // DEBUGDRAW_GEM_EDITOR
     }


### PR DESCRIPTION
Re-added define of DEBUG_DRAW_GEM_EDITOR to the gem CMakeLists.txt
Fixed some new warnings as errors due to name hiding.
Added an implementation of RenderText to AtomShimAuxGeom.