### PR TITLE
Moved null check before setting the status to "initializing".  

### DIFF
--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -101,6 +101,11 @@ AZ::RPI::WindowContextSharedPtr AZ::FFont::GetDefaultWindowContext() const
 
 bool AZ::FFont::InitFont(AZ::RPI::Scene* renderScene)
 {
+    if (!renderScene)
+    {
+        return false;
+    }
+
     auto initializationState = InitializationState::Uninitialized;
     // Do an atomic transition to Initializing if we're in the Uninitialized state.
     // Otherwise, check the current state.
@@ -109,11 +114,6 @@ bool AZ::FFont::InitFont(AZ::RPI::Scene* renderScene)
     if (!m_fontInitializationState.compare_exchange_strong(initializationState, InitializationState::Initializing))
     {
         return initializationState == InitializationState::Initialized;
-    }
-
-    if (!renderScene)
-    {
-        return false;
     }
 
     // Create and initialize DynamicDrawContext for font draw


### PR DESCRIPTION
If the first call to InitFont() is with a null render scene, the status will get stuck in initializing forever and fonts will never render.  

This does NOT fix the text being drawn in the wrong location, that's a separate bug.