### PR TITLE
LYN-3628 | Creating a child entity causes an Editor crash in Slice mode

### DIFF
--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
@@ -1481,7 +1481,7 @@ void OutlinerListModel::OnEntityInfoUpdatedRemoveChildEnd(AZ::EntityId parentId,
     (void)childId;
     AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::AzToolsFramework);
 
-    endRemoveRows();
+    endResetModel();
 
     //must refresh partial lock/visibility of parents
     m_isFilterDirty = true;


### PR DESCRIPTION
While porting a fix from the Prefab Outliner to the Slice Outliner, a line was missed. This restores that line.