### PR TITLE
[ATOM-15063] Toggling visibility on a reflection probe does not disable rendering

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
@@ -164,6 +164,7 @@ namespace AZ
             if (m_featureProcessor)
             {
                 m_featureProcessor->RemoveProbe(m_handle);
+                m_handle = nullptr;
             }
 
             LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();


### PR DESCRIPTION
Released probe handle when deactivating the controller.