### PR TITLE
A quick fix for Asset Processor automated tests

### DIFF
--- a/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/RCBuilder.h
@@ -31,7 +31,7 @@ namespace AssetProcessor
         };
 
         virtual ~RCCompiler() = default;
-        virtual bool Initialize(const QString& systemRoot, const QString& rcExecutableFullPath) = 0;
+        virtual bool Initialize() = 0;
         virtual bool Execute(const QString& inputFile, const QString& watchFolder, const QString& platformIdentifier, const QString& params,
             const QString& dest, const AssetBuilderSDK::JobCancelListener* jobCancelListener, Result& result) const = 0;
         virtual void RequestQuit() = 0;
@@ -44,7 +44,7 @@ namespace AssetProcessor
     public:
         NativeLegacyRCCompiler();
 
-        bool Initialize(const QString& systemRoot, const QString& rcExecutableFullPath) override;
+        bool Initialize() override;
         bool Execute(const QString& inputFile, const QString& watchFolder, const QString& platformIdentifier, const QString& params, const QString& dest,
             const AssetBuilderSDK::JobCancelListener* jobCancelListener, Result& result) const override;
         static QString BuildCommand(const QString& inputFile, const QString& watchFolder, const QString& platformIdentifier, const QString& params, const QString& dest);
@@ -53,8 +53,6 @@ namespace AssetProcessor
         static const int            s_maxSleepTime;
         static const unsigned int   s_jobMaximumWaitTime;
         bool                        m_resourceCompilerInitialized;
-        QDir                        m_systemRoot;
-        QString                     m_rcExecutableFullPath;
         volatile bool               m_requestedQuit;
     };
 

--- a/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCBuilderTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCBuilderTest.cpp
@@ -43,19 +43,6 @@ TEST_F(RCBuilderTest, Shutdown_NormalShutdown_Requested)
 }
 
 
-TEST_F(RCBuilderTest, Initialize_StandardInitialization_Fail)
-{
-    MockRCCompiler*                     mockRC = new MockRCCompiler();
-    TestInternalRecognizerBasedBuilder  test(mockRC);
-
-    MockRecognizerConfiguration     configuration;
-
-    mockRC->SetResultInitialize(false);
-    bool initialization_result = test.Initialize(configuration);
-    ASSERT_FALSE(initialization_result);
-}
-
-
 TEST_F(RCBuilderTest, Initialize_StandardInitializationWithDuplicateAndInvalidRecognizers_Valid)
 {
     MockRCCompiler*                     mockRC = new MockRCCompiler();

--- a/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCBuilderTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/resourcecompiler/RCBuilderTest.h
@@ -34,7 +34,7 @@ public:
     {
     }
 
-    bool Initialize([[maybe_unused]] const QString& systemRoot, [[maybe_unused]] const QString& rcExecutableFullPath) override
+    bool Initialize() override
     {
         m_initialize++;
         return m_initializeResult;

--- a/Code/Tools/AssetProcessor/native/unittests/MockApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/MockApplicationManager.cpp
@@ -47,7 +47,7 @@ namespace AssetProcessor
         {
         }
 
-        bool Initialize([[maybe_unused]] const QString& systemRoot, [[maybe_unused]] const QString& rcExecutableFullPath) override
+        bool Initialize() override
         {
             m_initialize++;
             return m_initializeResult;


### PR DESCRIPTION
These tests broke because RC.EXE is no longer a thing.

A more comprehensive fix and cleanup needs to be performed to
properly remove references to it while still keeping the existing
tests and other things.  This just removes as little as is possible
to avoid error.
fixes #643

