### PR TITLE
Merge pull request #632 from aws-lumberyard-dev/Atom/mriegger/heatmap

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/ExposureControl/ExposureControlSettings.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/ExposureControl/ExposureControlSettings.cpp
@@ -69,9 +69,8 @@ namespace AZ
 
             if (m_shouldUpdatePassParameters)
             {
-                auto* passSystem = AZ::RPI::PassSystemInterface::Get();
-                UpdateEyeAdaptationPass(passSystem);
-                UpdateLuminanceHeatmap(passSystem);
+                UpdateEyeAdaptationPass();
+                UpdateLuminanceHeatmap();
 
                 m_shouldUpdatePassParameters = false;
             }
@@ -140,7 +139,8 @@ namespace AZ
             if (m_heatmapEnabled != value)
             {
                 m_heatmapEnabled = value;
-                m_shouldUpdatePassParameters = true;
+                // Update immediately so that the ExposureControlSettings can just be turned off and killed without having to wait for another Simulate() call
+                UpdateLuminanceHeatmap();
             }
         }
 
@@ -198,8 +198,10 @@ namespace AZ
             }
         }
 
-        void ExposureControlSettings::UpdateEyeAdaptationPass(RPI::PassSystemInterface* passSystem)
+        void ExposureControlSettings::UpdateEyeAdaptationPass()
         {
+            auto* passSystem = AZ::RPI::PassSystemInterface::Get();
+
             // [GFX-TODO][ATOM-13224] Remove UpdateLuminanceHeatmap and UpdateEyeAdaptationPass
             auto passTemplateName = m_eyeAdaptationPassTemplateNameId;
 
@@ -220,8 +222,10 @@ namespace AZ
             }
         }
 
-        void ExposureControlSettings::UpdateLuminanceHeatmap(RPI::PassSystemInterface* passSystem)
+        void ExposureControlSettings::UpdateLuminanceHeatmap()
         {
+            auto* passSystem = AZ::RPI::PassSystemInterface::Get();
+
             // [GFX-TODO][ATOM-13194] Support multiple views for the luminance heatmap
             // [GFX-TODO][ATOM-13224] Remove UpdateLuminanceHeatmap and UpdateEyeAdaptationPass
             const RPI::Ptr<RPI::Pass> luminanceHeatmap = passSystem->GetRootPass()->FindPassByNameRecursive(m_luminanceHeatmapNameId);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/ExposureControl/ExposureControlSettings.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/ExposureControl/ExposureControlSettings.h
@@ -84,8 +84,8 @@ namespace AZ
 
             void UpdateExposureControlRelatedPassParameters();
             
-            void UpdateLuminanceHeatmap(RPI::PassSystemInterface* passSystem);
-            void UpdateEyeAdaptationPass(RPI::PassSystemInterface* passSystem);
+            void UpdateLuminanceHeatmap();
+            void UpdateEyeAdaptationPass();
             
             PostProcessSettings* m_parentSettings = nullptr;
             bool m_shouldUpdatePassParameters = true;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ExposureControl/ExposureControlComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ExposureControl/ExposureControlComponentController.cpp
@@ -88,6 +88,9 @@ namespace AZ
         {
             ExposureControlRequestBus::Handler::BusDisconnect(m_entityId);
 
+            m_configuration.SetHeatmapEnabled(false);
+            OnConfigChanged();
+            
             if (m_postProcessInterface)
             {
                 m_postProcessInterface->RemoveExposureControlSettingsInterface();


### PR DESCRIPTION
Fix for heatmap not turning off even if the Exposure component was deleted.

Previously, the heatmap on/off state was updated during the Simulate() call, e.g. it was deferred. I changed it so that call SetHeatmapEnable works right away

https://jira.agscollab.com/browse/ATOM-15322