### PR TITLE
Changed the level loading code to always set the default mission name.

### DIFF
--- a/Code/CryEngine/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/CryEngine/CrySystem/LevelSystem/LevelSystem.cpp
@@ -108,10 +108,11 @@ bool CLevelInfo::ReadInfo()
     AzFramework::ApplicationRequests::Bus::BroadcastResult(
         usePrefabSystemForLevels, &AzFramework::ApplicationRequests::IsPrefabSystemForLevelsEnabled);
 
+    // Set up a default game type for legacy code.
+    m_defaultGameTypeName = "Mission0";
+
     if (usePrefabSystemForLevels)
     {
-        // Set up a default game type for legacy code.
-        m_defaultGameTypeName = "Mission0";
         return true;
     }
 


### PR DESCRIPTION
The mission system recently got redcoded, so nothing else was setting this name.