### PR TITLE
{LYN-3645} Fix up EPB search paths for Editor Scripts

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -544,7 +544,7 @@ namespace EditorPythonBindings
         {
             if (!oldPathSet.contains(thisStr))
             {
-                pathAppend.append(AZStd::string::format("sys.path.append('%s')\n", thisStr.c_str()));
+                pathAppend.append(AZStd::string::format("sys.path.append(r'%s')\n", thisStr.c_str()));
                 appended = true;
             }
         }


### PR DESCRIPTION
Changes the path to a raw string to properly escape Windows paths that use backslashes
Tests: The PythonVMLoads_SysPathExtendedToGemScripts_EditorPythonBindingsValidaitonFound now works