### PR TITLE
[ATOM-15356] Reflection probe cubemaps do not have shadows

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -306,7 +306,7 @@ namespace AZ
             for (const RPI::ViewPtr& view : packet.m_views)
             {
                 if (m_renderPipelineIdsForPersistentView.find(view.get()) != m_renderPipelineIdsForPersistentView.end() &&
-                    (view->GetUsageFlags() & RPI::View::UsageCamera))
+                    (RHI::CheckBitsAny(view->GetUsageFlags(), RPI::View::UsageCamera | RPI::View::UsageReflectiveCubeMap)))
                 {
                     RPI::ShaderResourceGroup* viewSrg = view->GetShaderResourceGroup().get();
 


### PR DESCRIPTION
Checked for the ReflectiveCubeMap view type when updating the shadow Srg data.