### PR TITLE
Cherry pick nightly clean pipeline change to 1.0

### DIFF
--- a/Tools/build/JenkinsScripts/build/Platform/Android/build_config.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Android/build_config.json
@@ -27,7 +27,8 @@
   },
   "debug": {
     "TAGS":[
-        "nightly",
+        "nightly-incremental",
+        "nightly-clean",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",
@@ -57,7 +58,8 @@
   },
   "profile_nounity": {
     "TAGS":[
-        "nightly",
+        "nightly-incremental",
+        "nightly-clean",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",
@@ -73,7 +75,9 @@
   "asset_profile": {
     "TAGS":[
         "default",
-        "weekly-build-metrics"
+        "weekly-build-metrics",
+        "nightly-incremental",
+        "nightly-clean"
     ],
     "COMMAND":"../Windows/build_asset_windows.cmd",
     "PARAMETERS": {
@@ -88,21 +92,10 @@
         "ASSET_PROCESSOR_PLATFORMS":"es3"
     }
   },
-  "asset_clean_profile": {
-    "TAGS":[
-        "nightly"
-    ],
-    "PIPELINE_ENV": {
-        "CLEAN_ASSETS": "1"
-    },
-    "steps": [
-        "clean",
-        "asset_profile"
-    ]
-  },
   "release": {
     "TAGS":[
-        "nightly",
+        "nightly-incremental",
+        "nightly-clean",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",
@@ -117,7 +110,8 @@
   },
   "monolithic_release": {
     "TAGS":[
-        "nightly",
+        "nightly-incremental",
+        "nightly-clean",
         "weekly-build-metrics"
     ],
     "COMMAND":"../Windows/build_ninja_windows.cmd",

--- a/Tools/build/JenkinsScripts/build/Platform/Android/pipeline.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Android/pipeline.json
@@ -13,6 +13,9 @@
         },
         "packaging": {
             "CLEAN_WORKSPACE": true
+        },
+        "nightly-clean": {
+            "CLEAN_WORKSPACE": true
         }
     }
 }

--- a/Tools/build/JenkinsScripts/build/Platform/Linux/build_config.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Linux/build_config.json
@@ -29,7 +29,8 @@
   },
   "debug": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",
@@ -43,8 +44,10 @@
   },
   "profile": {
     "TAGS": [
-        "daily-pipeline-metrics",
-        "weekly-build-metrics"
+      "nightly-incremental",
+      "nightly-clean",
+      "daily-pipeline-metrics",
+      "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",
     "PARAMETERS": {
@@ -86,7 +89,9 @@
   },
   "asset_profile": {
     "TAGS": [
-      "weekly-build-metrics"
+      "weekly-build-metrics",
+      "nightly-incremental",
+      "nightly-clean"
     ],
     "COMMAND": "build_asset_linux.sh",
     "PARAMETERS": {
@@ -100,21 +105,10 @@
       "ASSET_PROCESSOR_PLATFORMS": "pc,server"
     }
   },
-  "asset_clean_profile": {
-    "TAGS": [
-      "nightly"
-    ],
-    "PIPELINE_ENV": {
-      "CLEAN_ASSETS": "1"
-    },
-    "steps": [
-      "clean",
-      "asset_profile"
-    ]
-  },
   "periodic_test_profile": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_linux.sh",
@@ -129,7 +123,8 @@
   },
   "benchmark_test_profile": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_linux.sh",
@@ -144,7 +139,8 @@
   },
   "release": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",
@@ -158,7 +154,8 @@
   },
   "monolithic_release": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_linux.sh",

--- a/Tools/build/JenkinsScripts/build/Platform/Linux/pipeline.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Linux/pipeline.json
@@ -12,6 +12,9 @@
         },
         "packaging": {
             "CLEAN_WORKSPACE": true
+        },
+        "nightly-clean": {
+            "CLEAN_WORKSPACE": true
         }
     }
 }

--- a/Tools/build/JenkinsScripts/build/Platform/Mac/build_config.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Mac/build_config.json
@@ -9,7 +9,8 @@
   },
   "profile_pipe": {
     "TAGS": [
-      "nightly"
+      "nightly-incremental",
+      "nightly-clean"
     ],
     "steps": [
       "profile",
@@ -28,7 +29,8 @@
   },
   "debug": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -56,7 +58,8 @@
   },
   "profile_nounity": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -70,7 +73,9 @@
   },
   "asset_profile": {
     "TAGS": [
-        "weekly-build-metrics"
+      "weekly-build-metrics",
+      "nightly-incremental",
+      "nightly-clean"
     ],
     "COMMAND": "build_asset_mac.sh",
     "PARAMETERS": {
@@ -84,21 +89,10 @@
       "ASSET_PROCESSOR_PLATFORMS": "osx_gl"
     }
   },
-  "asset_clean_profile": {
-    "TAGS": [
-      "nightly"
-    ],
-    "PIPELINE_ENV": {
-      "CLEAN_ASSETS": "1"
-    },
-    "steps": [
-      "clean",
-      "asset_profile"
-    ]
-  },
   "periodic_test_profile": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_mac.sh",
@@ -113,7 +107,8 @@
   },
   "benchmark_test_profile": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_mac.sh",
@@ -128,7 +123,8 @@
   },
   "release": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",
@@ -142,7 +138,8 @@
   },
   "monolithic_release": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_mac.sh",

--- a/Tools/build/JenkinsScripts/build/Platform/Mac/pipeline.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Mac/pipeline.json
@@ -12,6 +12,9 @@
         },
         "packaging": {
             "CLEAN_WORKSPACE": true
+        },
+        "nightly-clean": {
+            "CLEAN_WORKSPACE": true
         }
     }
 }

--- a/Tools/build/JenkinsScripts/build/Platform/Windows/build_config.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Windows/build_config.json
@@ -17,7 +17,8 @@
   },
   "debug_vs2019_pipe": {
     "TAGS": [
-      "nightly"
+      "nightly-incremental",
+      "nightly-clean"
     ],
     "steps": [
       "debug_vs2019",
@@ -125,7 +126,8 @@
   },
   "profile_vs2019_nounity": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_windows.cmd",
@@ -156,10 +158,11 @@
   },
   "test_gpu_profile_vs2019": {
     "TAGS":[
-        "nightly"
+      "nightly-incremental",
+      "nightly-clean"
     ],
     "PIPELINE_ENV":{
-        "NODE_LABEL":"windows-gpu"
+      "NODE_LABEL":"windows-gpu"
     },
     "COMMAND": "build_test_windows.cmd",
     "PARAMETERS": {
@@ -174,7 +177,9 @@
   },
   "asset_profile_vs2019": {
     "TAGS": [
-        "weekly-build-metrics"
+      "weekly-build-metrics",
+      "nightly-incremental",
+      "nightly-clean"
     ],
     "COMMAND": "build_asset_windows.cmd",
     "PARAMETERS": {
@@ -189,21 +194,10 @@
       "ASSET_PROCESSOR_PLATFORMS": "pc,server"
     }
   },
-  "asset_clean_profile_vs2019": {
-    "TAGS": [
-      "nightly"
-    ],
-    "PIPELINE_ENV": {
-      "CLEAN_ASSETS": "1"
-    },
-    "steps": [
-      "clean",
-      "asset_profile_vs2019"
-    ]
-  },
   "periodic_test_profile_vs2019": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_windows.cmd",
@@ -219,7 +213,8 @@
   },
   "sandbox_test_profile_vs2019": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "PIPELINE_ENV": {
@@ -238,7 +233,8 @@
   },
   "benchmark_test_profile_vs2019": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_windows.cmd",
@@ -254,7 +250,8 @@
   },
   "release_vs2019": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_windows.cmd",
@@ -269,7 +266,8 @@
   },
   "monolithic_release_vs2019": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "build_windows.cmd",

--- a/Tools/build/JenkinsScripts/build/Platform/Windows/pipeline.json
+++ b/Tools/build/JenkinsScripts/build/Platform/Windows/pipeline.json
@@ -12,6 +12,9 @@
         },
         "packaging": {
             "CLEAN_WORKSPACE": true
+        },
+        "nightly-clean": {
+            "CLEAN_WORKSPACE": true
         }
     }
 }

--- a/Tools/build/JenkinsScripts/build/Platform/iOS/build_config.json
+++ b/Tools/build/JenkinsScripts/build/Platform/iOS/build_config.json
@@ -19,7 +19,8 @@
   },
   "debug": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_mac.sh",
@@ -34,7 +35,8 @@
   },
   "profile": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "daily-pipeline-metrics",
       "weekly-build-metrics"
     ],
@@ -50,7 +52,8 @@
   },
   "profile_nounity": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_mac.sh",
@@ -65,7 +68,8 @@
   },
   "asset_profile": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_asset_mac.sh",
@@ -80,21 +84,10 @@
       "ASSET_PROCESSOR_PLATFORMS": "ios"
     }
   },
-  "asset_clean_profile": {
-    "TAGS": [
-      "nightly"
-    ],
-    "PIPELINE_ENV": {
-      "CLEAN_ASSETS": "true"
-    },
-    "steps": [
-        "clean",
-        "asset_profile"
-    ]
-  },
   "release": {
     "TAGS": [
-      "nightly",
+      "nightly-incremental",
+      "nightly-clean",
       "weekly-build-metrics"
     ],
     "COMMAND": "../Mac/build_mac.sh",

--- a/Tools/build/JenkinsScripts/build/Platform/iOS/pipeline.json
+++ b/Tools/build/JenkinsScripts/build/Platform/iOS/pipeline.json
@@ -12,6 +12,9 @@
         },
         "packaging": {
             "CLEAN_WORKSPACE": true
+        },
+        "nightly-clean": {
+            "CLEAN_WORKSPACE": true
         }
     }
 }


### PR DESCRIPTION
Rename nightly pipeline to nightly_incremental to always run incremental build.
Create a new nightly pipeline nightly_clean to always run clean build.
Remove asset_clean jobs because they are now covered by nightly_clean pipeline.