### PR TITLE
Increase Atom AutomatedTesting tests timeout so that it passes in debug builds.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -18,7 +18,7 @@ import pytest
 import editor_python_test_tools.hydra_test_utils as hydra
 
 logger = logging.getLogger(__name__)
-EDITOR_TIMEOUT = 120
+EDITOR_TIMEOUT = 300
 TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "atom_hydra_scripts")
 
 


### PR DESCRIPTION
See SPEC-6574 - debug builds still fail on nightly because the timeout isn't long enough. This small fix should allow it to pass on debug builds.