### PR TITLE
Fix up incorrect autoDelete use and handling.

### DIFF
--- a/Gems/GradientSignal/Code/Source/UI/GradientPreviewDataWidget.cpp
+++ b/Gems/GradientSignal/Code/Source/UI/GradientPreviewDataWidget.cpp
@@ -25,8 +25,6 @@ namespace GradientSignal
     // GradientPreviewDataWidgetHandler
     //
 
-    GradientPreviewDataWidgetHandler* GradientPreviewDataWidgetHandler::s_instance = nullptr;
-
     AZ::u32 GradientPreviewDataWidgetHandler::GetHandlerName() const
     {
         return AZ_CRC("GradientPreviewer", 0x1dbbba45);
@@ -92,23 +90,18 @@ namespace GradientSignal
     {
         using namespace AzToolsFramework;
 
-        if (!s_instance)
-        {
-            s_instance = aznew GradientPreviewDataWidgetHandler();
-            PropertyTypeRegistrationMessages::Bus::Broadcast(&PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, s_instance);
-        }
+        // Property handlers are set to auto-delete by default, which means that we're handing off ownership of the pointer to the
+        // PropertyManagerComponent, where it will get cleaned up on system shutdown.
+        auto propertyHandler = aznew GradientPreviewDataWidgetHandler();
+        AZ_Assert(propertyHandler->AutoDelete(),
+            "GradientPreviewDataWidgetHandler is no longer set to auto-delete, it will leak memory.");
+        PropertyTypeRegistrationMessages::Bus::Broadcast(
+            &PropertyTypeRegistrationMessages::Bus::Events::RegisterPropertyType, propertyHandler);
     }
 
     void GradientPreviewDataWidgetHandler::Unregister()
     {
-        using namespace AzToolsFramework;
-
-        if (s_instance)
-        {
-            PropertyTypeRegistrationMessages::Bus::Broadcast(&PropertyTypeRegistrationMessages::Bus::Events::UnregisterPropertyType, s_instance);
-            delete s_instance;
-            s_instance = nullptr;
-        }
+        // We don't need to call UnregisterPropertyType here because it's an autoDelete handler.
     }
 
     //

--- a/Gems/GradientSignal/Code/Source/UI/GradientPreviewDataWidget.h
+++ b/Gems/GradientSignal/Code/Source/UI/GradientPreviewDataWidget.h
@@ -76,8 +76,5 @@ namespace GradientSignal
 
         static void Register();
         static void Unregister();
-
-    private:
-        static GradientPreviewDataWidgetHandler* s_instance;
     };
 }

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -134,7 +134,7 @@ namespace ScriptCanvasEditor
 
         PopulateEditorCreatableTypes();
 
-        m_propertyHandlers.emplace_back(AzToolsFramework::RegisterGenericComboBoxHandler<ScriptCanvas::VariableId>());
+        AzToolsFramework::RegisterGenericComboBoxHandler<ScriptCanvas::VariableId>();
 
         SystemRequestBus::Handler::BusConnect();
         ScriptCanvasExecutionBus::Handler::BusConnect();
@@ -176,12 +176,6 @@ namespace ScriptCanvasEditor
         ScriptCanvasExecutionBus::Handler::BusDisconnect();
         SystemRequestBus::Handler::BusDisconnect();
         AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
-
-        for (auto&& propertyHandler : m_propertyHandlers)
-        {
-            AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(&AzToolsFramework::PropertyTypeRegistrationMessages::UnregisterPropertyType, propertyHandler.get());
-        }
-        m_propertyHandlers.clear();
 
         m_jobContext.reset();
         m_jobManager.reset();

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
@@ -147,7 +147,6 @@ namespace ScriptCanvasEditor
         AZStd::unique_ptr<AZ::JobManager> m_jobManager;
         AZStd::unique_ptr<AZ::JobContext> m_jobContext;
 
-        AZStd::vector<AZStd::unique_ptr<AzToolsFramework::PropertyHandlerBase>> m_propertyHandlers;
         AZStd::unordered_set<ScriptCanvas::Data::Type> m_creatableTypes;
 
         AssetTracker m_assetTracker;

--- a/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
+++ b/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.cpp
@@ -236,17 +236,11 @@ namespace ScriptEventsEditor
             moduleConfiguration->RegisterAssetHandler();
         }
 
-        m_propertyHandlers.emplace_back(AzToolsFramework::RegisterGenericComboBoxHandler<ScriptEventData::VersionedProperty>());
+        AzToolsFramework::RegisterGenericComboBoxHandler<ScriptEventData::VersionedProperty>();
     }
 
     void ScriptEventEditorSystemComponent::Deactivate()
     {
-        for (auto&& propertyHandler : m_propertyHandlers)
-        {
-            AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(&AzToolsFramework::PropertyTypeRegistrationMessages::UnregisterPropertyType, propertyHandler.get());
-        }
-        m_propertyHandlers.clear();
-        
         using namespace ScriptEvents;
         ScriptEventsSystemComponentImpl* moduleConfiguration = nullptr;
         ScriptEventModuleConfigurationRequestBus::BroadcastResult(moduleConfiguration, &ScriptEventModuleConfigurationRequests::GetSystemComponentImpl);

--- a/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.h
+++ b/Gems/ScriptEvents/Code/Source/Editor/ScriptEventsSystemEditorComponent.h
@@ -90,8 +90,6 @@ namespace ScriptEventsEditor
         void Deactivate() override;
         ////////////////////////////////////////////////////////////////////////
 
-        AZStd::vector<AZStd::unique_ptr<AzToolsFramework::PropertyHandlerBase>> m_propertyHandlers;
-
         // Script Event Assets
         AZStd::unordered_map<ScriptEvents::ScriptEventKey, AZStd::intrusive_ptr<ScriptEvents::Internal::ScriptEventRegistration>> m_scriptEvents;
 

--- a/Gems/Vegetation/Code/Source/Editor/EditorVegetationSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/Editor/EditorVegetationSystemComponent.cpp
@@ -58,14 +58,11 @@ namespace Vegetation
     void EditorVegetationSystemComponent::Activate()
     {
         // This is necessary for the m_spawnerType in Descriptor.cpp to display properly as a ComboBox
-        m_propertyHandler = aznew AzToolsFramework::GenericComboBoxHandler<AZ::TypeId>();
-        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(&AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType, m_propertyHandler);
+        AzToolsFramework::RegisterGenericComboBoxHandler<AZ::TypeId>();
     }
 
     void EditorVegetationSystemComponent::Deactivate()
     {
-        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(&AzToolsFramework::PropertyTypeRegistrationMessages::UnregisterPropertyType, m_propertyHandler);
-        delete m_propertyHandler;
     }
 
 }

--- a/Gems/Vegetation/Code/Source/Editor/EditorVegetationSystemComponent.h
+++ b/Gems/Vegetation/Code/Source/Editor/EditorVegetationSystemComponent.h
@@ -35,9 +35,6 @@ namespace Vegetation
 
         void Activate() override;
         void Deactivate() override;
-
-    private:
-        AzToolsFramework::PropertyHandlerBase* m_propertyHandler{ nullptr };
     };
 
 } // namespace Vegetation


### PR DESCRIPTION
Several UI property handlers were incorrectly using the autoDelete feature by calling UnregisterPropertyType and deleting the pointer themselves, which caused double-delete crashes on application shutdown.  PropertyManagerComponent now gracefully handles that condition but also explicitly asserts explaining how the code should be changed, and the "known offenders" have been fixed up to use autoDelete correctly.