### PR TITLE
Merge pull request #395 from aws-lumberyard-dev/Atom/mriegger/PLS

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -13,6 +13,49 @@
 #pragma once
 
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
+#include <Atom/Features/Shadow/ProjectedShadow.azsli>
+
+// The order should match m_pointShadowTransforms in PointLightFeatureProcessor.h/.cpp
+static const float3 PointLightShadowCubemapDirections[6] = {float3(-1,0,0), float3(1,0,0), float3(0,-1,0), float3(0,1,0), float3(0,0,-1), float3(0,0,1)};                  
+
+int GetPointLightShadowCubemapFace(const float3 targetPos, const float3 lightPos)
+{
+    const float3 toPoint = targetPos - lightPos;    
+    const float maxElement = max(abs(toPoint.z), max(abs(toPoint.x), abs(toPoint.y)));
+    if (toPoint.x == -maxElement)
+    {
+        return 0;
+    }
+    else if (toPoint.x == maxElement)
+    {
+        return 1;
+    }   
+    else if (toPoint.y == -maxElement)
+    {
+        return 2;
+    }
+    else if (toPoint.y == maxElement)
+    {
+        return 3;
+    }
+    else if (toPoint.z == -maxElement)
+    {
+        return 4;
+    }
+    else 
+    {
+        return 5;
+    }   
+}
+
+// PointLight::m_shadowIndices actually consists of uint16_t x 6 on the CPU, but visible as a uint32_t x 3 on the GPU. 
+// This function returns the proper uint16_t value given an input face in the range 0-5
+int UnpackPointLightShadowIndex(const ViewSrg::PointLight light, const int face)
+{
+    const int index = face >> 1;
+    const int shiftAmount = (face & 1) * 16;
+    return (light.m_shadowIndices[index] >> shiftAmount) & 0xFFFF;
+} 
 
 void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingData lightingData)
 {
@@ -31,11 +74,38 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
         d2 = max(0.001 * 0.001, d2); // clamp the light to at least 1mm away to avoid extreme values.
         float3 lightIntensity = (light.m_rgbIntensityCandelas / d2) * radiusAttenuation;
 
+        // shadow
+        float litRatio = 1.0;
+
+        // How much is back face shadowed, it's set to the reverse of litRatio to share the same default value with thickness, which should be 0 if no shadow map available
+        float backShadowRatio = 0.0;
+        if (o_enableShadows)
+        {
+            const int shadowCubemapFace = GetPointLightShadowCubemapFace(surface.position, light.m_position);
+            const int shadowIndex = UnpackPointLightShadowIndex(light, shadowCubemapFace);
+
+            litRatio *= ProjectedShadow::GetVisibility(
+                    shadowIndex,
+                    light.m_position,
+                    surface.position,
+                    PointLightShadowCubemapDirections[shadowCubemapFace],
+                    surface.normal);
+                        
+            // Use backShadowRatio to carry thickness from shadow map for thick mode
+            backShadowRatio = 1.0 - litRatio;
+            if (o_transmission_mode == TransmissionMode::ThickObject)
+            {
+                backShadowRatio = ProjectedShadow::GetThickness(
+                    shadowIndex,
+                    surface.position);
+            }                   
+        }
+
         // Diffuse contribution
-        lightingData.diffuseLighting += GetDiffuseLighting(surface, lightingData, lightIntensity, normalize(posToLight));
+        lightingData.diffuseLighting += GetDiffuseLighting(surface, lightingData, lightIntensity, normalize(posToLight)) * litRatio;
 
         // Tranmission contribution
-        lightingData.translucentBackLighting += GetBackLighting(surface, lightingData, lightIntensity, normalize(posToLight), 0.0);
+        lightingData.translucentBackLighting += GetBackLighting(surface, lightingData, lightIntensity, normalize(posToLight), backShadowRatio);
 
         // Adjust the light direcion for specular based on bulb size
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/RayTracing/RayTracingSceneSrg.azsli
@@ -61,6 +61,8 @@ ShaderResourceGroup RayTracingSceneSrg : SRG_RayTracingScene
         float  m_invAttenuationRadiusSquared;
         float3 m_rgbIntensity;
         float  m_bulbRadius;
+        uint3 m_shadowIndices;
+        uint m_padding;
     };
     
     StructuredBuffer<PointLight> m_pointLights;

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -73,6 +73,8 @@ partial ShaderResourceGroup ViewSrg
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_rgbIntensityCandelas;
         float m_bulbRadius;
+        uint3 m_shadowIndices;
+        uint m_padding;
     };
 
     StructuredBuffer<PointLight> m_pointLights;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.azsl
@@ -59,6 +59,8 @@ ShaderResourceGroup PassSrg : SRG_PerPass
         float m_invAttenuationRadiusSquared; // For a radius at which this light no longer has an effect, 1 / radius^2.
         float3 m_rgbIntensityCandelas;
         float m_bulbRadius;
+        uint3 m_shadowIndices;
+        uint m_padding;
     };
 
     struct DiskLight

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
@@ -380,7 +380,7 @@ namespace AZ
             const float invRadiusSquared = diskLight.m_invAttenuationRadiusSquared;
             if (invRadiusSquared <= 0.f)
             {
-                AZ_Assert(false, "Attenuation radius have to be set before use the light.");
+                AZ_Assert(false, "Attenuation radius must be set before using the light.");
                 return;
             }
             const float attenuationRadius = sqrtf(1.f / invRadiusSquared);

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.h
@@ -59,7 +59,7 @@ namespace AZ
             void SetSofteningBoundaryWidthAngle(LightHandle handle, float boundaryWidthRadians) override;
             void SetPredictionSampleCount(LightHandle handle, uint16_t count) override;
             void SetFilteringSampleCount(LightHandle handle, uint16_t count) override;
-            void SetPcfMethod(LightHandle handle, PcfMethod method);
+            void SetPcfMethod(LightHandle handle, PcfMethod method) override;
 
             void SetDiskData(LightHandle handle, const DiskLightData& data) override;
 
@@ -84,7 +84,7 @@ namespace AZ
             template <typename Functor, typename ParamType>
             void SetShadowSetting(LightHandle handle, Functor&&, ParamType&& param);
 
-            ProjectedShadowFeatureProcessor* m_shadowFeatureProcessor;
+            ProjectedShadowFeatureProcessor* m_shadowFeatureProcessor = nullptr;
 
             IndexedDataVector<DiskLightData> m_diskLightData;
             GpuBufferHandler m_lightBufferHandler;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.h
@@ -16,6 +16,7 @@
 #include <Atom/Feature/CoreLights/PointLightFeatureProcessorInterface.h>
 #include <Atom/Feature/Utils/GpuBufferHandler.h>
 #include <CoreLights/IndexedDataVector.h>
+#include <Shadows/ProjectedShadowFeatureProcessor.h>
 
 namespace AZ
 {
@@ -24,15 +25,6 @@ namespace AZ
 
     namespace Render
     {
-
-        struct PointLightData
-        {
-            AZStd::array<float, 3> m_position = { { 0.0f, 0.0f, 0.0f } };
-            float m_invAttenuationRadiusSquared = 0.0f; // Inverse of the distance at which this light no longer has an effect, squared. Also used for falloff calculations.
-            AZStd::array<float, 3> m_rgbIntensity = { { 0.0f, 0.0f, 0.0f } };
-            float m_bulbRadius = 0.0f; // Radius of spherical light in meters.
-        };
-
         class PointLightFeatureProcessor final
             : public PointLightFeatureProcessorInterface
         {
@@ -58,18 +50,34 @@ namespace AZ
             void SetPosition(LightHandle handle, const AZ::Vector3& lightPosition) override;
             void SetAttenuationRadius(LightHandle handle, float attenuationRadius) override;
             void SetBulbRadius(LightHandle handle, float bulbRadius) override;
+            void SetShadowsEnabled(LightHandle handle, bool enabled) override;
+            void SetShadowmapMaxResolution(LightHandle handle, ShadowmapSize shadowmapSize) override;
+            void SetShadowFilterMethod(LightHandle handle, ShadowFilterMethod method) override;
+            void SetSofteningBoundaryWidthAngle(LightHandle handle, float boundaryWidthRadians) override;
+            void SetPredictionSampleCount(LightHandle handle, uint16_t count) override;
+            void SetFilteringSampleCount(LightHandle handle, uint16_t count) override;
+            void SetPcfMethod(LightHandle handle, PcfMethod method) override;
+            void SetPointData(LightHandle handle, const PointLightData& data) override;
 
             const Data::Instance<RPI::Buffer>  GetLightBuffer() const;
             uint32_t GetLightCount()const;
 
         private:
             PointLightFeatureProcessor(const PointLightFeatureProcessor&) = delete;
+            using ShadowId = ProjectedShadowFeatureProcessor::ShadowId;
 
             static constexpr const char* FeatureProcessorName = "PointLightFeatureProcessor";
+            void UpdateShadow(LightHandle handle);
+            // Convenience function for forwarding requests to the ProjectedShadowFeatureProcessor
+            template<typename Functor, typename ParamType>
+            void SetShadowSetting(LightHandle handle, Functor&&, ParamType&& param);
+            ProjectedShadowFeatureProcessor* m_shadowFeatureProcessor = nullptr;
 
             IndexedDataVector<PointLightData> m_pointLightData;
             GpuBufferHandler m_lightBufferHandler;
             bool m_deviceBufferNeedsUpdate = false;
+
+            AZStd::array<AZ::Transform, PointLightData::NumShadowFaces> m_pointShadowTransforms;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -107,7 +107,7 @@ namespace AZ
 
         bool AreaLightComponentConfig::SupportsShadows() const
         {
-            return m_shapeType == AZ_CRC_CE("DiskShape");
+            return m_lightType == LightType::SpotDisk || m_lightType == LightType::Sphere;
         }
         
         bool AreaLightComponentConfig::ShadowsDisabled() const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.cpp
@@ -63,5 +63,64 @@ namespace AZ
                 debugDisplay.DrawWireSphere(transform.GetTranslation(), CalculateAttenuationRadius(AreaLightComponentConfig::CutoffIntensity));
             }
         }
+
+        void SphereLightDelegate::SetEnableShadow(bool enabled)
+        {
+            Base::SetEnableShadow(enabled);
+
+            if (GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetShadowsEnabled(GetLightHandle(), enabled);
+            }
+        }
+
+        void SphereLightDelegate::SetShadowmapMaxSize(ShadowmapSize size)
+        {
+            if (GetShadowsEnabled() && GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetShadowmapMaxResolution(GetLightHandle(), size);
+            }
+        }
+
+        void SphereLightDelegate::SetShadowFilterMethod(ShadowFilterMethod method)
+        {
+            if (GetShadowsEnabled() && GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetShadowFilterMethod(GetLightHandle(), method);
+            }
+        }
+
+        void SphereLightDelegate::SetSofteningBoundaryWidthAngle(float widthInDegrees)
+        {
+            if (GetShadowsEnabled() && GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetSofteningBoundaryWidthAngle(GetLightHandle(), DegToRad(widthInDegrees));
+            }
+        }
+
+        void SphereLightDelegate::SetPredictionSampleCount(uint32_t count)
+        {
+            if (GetShadowsEnabled() && GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetPredictionSampleCount(GetLightHandle(), count);
+            }
+        }
+
+        void SphereLightDelegate::SetFilteringSampleCount(uint32_t count)
+        {
+            if (GetShadowsEnabled() && GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetFilteringSampleCount(GetLightHandle(), count);
+            }
+        }
+
+        void SphereLightDelegate::SetPcfMethod(PcfMethod method)
+        {
+            if (GetShadowsEnabled() && GetLightHandle().IsValid())
+            {
+                GetFeatureProcessor()->SetPcfMethod(GetLightHandle(), method);
+            }
+        }
+
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.h
@@ -24,6 +24,8 @@ namespace AZ
         class SphereLightDelegate final
             : public LightDelegateBase<PointLightFeatureProcessorInterface>
         {
+            using Base = LightDelegateBase<PointLightFeatureProcessorInterface>;
+
         public:
             SphereLightDelegate(LmbrCentral::SphereShapeComponentRequests* shapeBus, EntityId entityId, bool isVisible);
 
@@ -32,6 +34,13 @@ namespace AZ
             void DrawDebugDisplay(const Transform& transform, const Color& color, AzFramework::DebugDisplayRequests& debugDisplay, bool isSelected) const override;
             float GetSurfaceArea() const override;
             float GetEffectiveSolidAngle() const override { return PhotometricValue::OmnidirectionalSteradians; }
+            void SetEnableShadow(bool enabled) override;
+            void SetShadowmapMaxSize(ShadowmapSize size) override;
+            void SetShadowFilterMethod(ShadowFilterMethod method) override;
+            void SetSofteningBoundaryWidthAngle(float widthInDegrees) override;
+            void SetPredictionSampleCount(uint32_t count) override;
+            void SetFilteringSampleCount(uint32_t count) override;
+            void SetPcfMethod(PcfMethod method) override;
 
         private:
 


### PR DESCRIPTION
Integrating pointlight shadows into 1.0 branch

First pass point light shadows.

Does 6 passes (note that I intend to modify this to use fewer passes in the near future)
Tested ASV and Editor

ATOM-5114