### PR TITLE
Move ThumbnailerNullComponent into AzToolsFramework so that it can be used by other tools

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AzToolsFrameworkModule.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AzToolsFrameworkModule.cpp
@@ -52,6 +52,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.h>
 #include <AzToolsFramework/UI/EditorEntityUi/EditorEntityUiSystemComponent.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerComponent.h>
+#include <AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserComponent.h>
 #include <AzToolsFramework/ViewportSelection/EditorInteractionSystemComponent.h>
 
@@ -91,6 +92,7 @@ namespace AzToolsFramework
             AzToolsFramework::AssetBundleComponent::CreateDescriptor(),
             AzToolsFramework::SliceDependencyBrowserComponent::CreateDescriptor(),
             AzToolsFramework::Thumbnailer::ThumbnailerComponent::CreateDescriptor(),
+            AzToolsFramework::Thumbnailer::ThumbnailerNullComponent::CreateDescriptor(),
             AzToolsFramework::AssetBrowser::AssetBrowserComponent::CreateDescriptor(),
             AzToolsFramework::EditorInteractionSystemComponent::CreateDescriptor(),
             AzToolsFramework::Components::EditorComponentAPIComponent::CreateDescriptor(),

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.cpp
@@ -12,16 +12,16 @@
 
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include "ThumbnailerNullComponent.h"
+#include <AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailContext.h>
 #include <AzToolsFramework/Thumbnails/MissingThumbnail.h>
 
-namespace LUAEditor
+namespace AzToolsFramework
 {
     namespace Thumbnailer
     {
         ThumbnailerNullComponent::ThumbnailerNullComponent() :
-            m_nullThumbnail(new AzToolsFramework::Thumbnailer::MissingThumbnail())
+            m_nullThumbnail()
         {
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h
@@ -15,7 +15,11 @@
 #include <AzCore/Component/Component.h>
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 
-namespace LUAEditor
+// ThumbnailerNullComponent is an alternative to ThumbnailerComponent that can be used by tools that don't use Qt.
+// It doesn't do anything (hence "null"), but it allows the system and editor components that rely on the ThumbnailService
+// to start up and function.
+
+namespace AzToolsFramework
 {
     namespace Thumbnailer
     {
@@ -53,4 +57,4 @@ namespace LUAEditor
             AzToolsFramework::Thumbnailer::SharedThumbnail m_nullThumbnail;
         };
     } // Thumbnailer
-} // namespace LUAEditor
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -72,6 +72,8 @@ set(FILES
     AssetCatalog/PlatformAddressedAssetCatalogManager.cpp
     Thumbnails/ThumbnailerComponent.cpp
     Thumbnails/ThumbnailerComponent.h
+    Thumbnails/ThumbnailerNullComponent.cpp
+    Thumbnails/ThumbnailerNullComponent.h
     Thumbnails/LoadingThumbnail.cpp
     Thumbnails/LoadingThumbnail.h
     Thumbnails/MissingThumbnail.cpp

--- a/Code/Tools/Standalone/Source/LuaIDEApplication.cpp
+++ b/Code/Tools/Standalone/Source/LuaIDEApplication.cpp
@@ -22,9 +22,9 @@
 #include <AzFramework/Asset/AssetSystemComponent.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorSelectionAccentSystemComponent.h>
+#include <AzToolsFramework/Thumbnails/ThumbnailerNullComponent.h>
 
 #include <Source/AssetDatabaseLocationListener.h>
-#include <Source/ThumbnailerNullComponent.h>
 #include <Source/LUA/LUAEditorContext.h>
 #include <Source/LUA/LUADebuggerComponent.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.h>
@@ -55,7 +55,7 @@ namespace LUAEditor
         RegisterComponentDescriptor(AzToolsFramework::Components::PropertyManagerComponent::CreateDescriptor());
         RegisterComponentDescriptor(AzFramework::AssetSystem::AssetSystemComponent::CreateDescriptor());
         RegisterComponentDescriptor(AzToolsFramework::AssetSystem::AssetSystemComponent::CreateDescriptor());
-        RegisterComponentDescriptor(LUAEditor::Thumbnailer::ThumbnailerNullComponent::CreateDescriptor());
+        RegisterComponentDescriptor(AzToolsFramework::Thumbnailer::ThumbnailerNullComponent::CreateDescriptor());
         RegisterComponentDescriptor(AzToolsFramework::AssetBrowser::AssetBrowserComponent::CreateDescriptor());
         RegisterComponentDescriptor(AzToolsFramework::Components::EditorSelectionAccentSystemComponent::CreateDescriptor());
 
@@ -75,7 +75,7 @@ namespace LUAEditor
         EnsureComponentCreated(AzToolsFramework::Components::PropertyManagerComponent::RTTI_Type());
         EnsureComponentCreated(AzFramework::AssetSystem::AssetSystemComponent::RTTI_Type());
         EnsureComponentCreated(AzToolsFramework::AssetSystem::AssetSystemComponent::RTTI_Type());
-        EnsureComponentCreated(LUAEditor::Thumbnailer::ThumbnailerNullComponent::RTTI_Type());
+        EnsureComponentCreated(AzToolsFramework::Thumbnailer::ThumbnailerNullComponent::RTTI_Type());
         EnsureComponentCreated(AzToolsFramework::AssetBrowser::AssetBrowserComponent::RTTI_Type());
         EnsureComponentCreated(AzToolsFramework::Components::EditorSelectionAccentSystemComponent::RTTI_Type());
     }

--- a/Code/Tools/Standalone/lua_ide_files.cmake
+++ b/Code/Tools/Standalone/lua_ide_files.cmake
@@ -14,8 +14,6 @@ set(FILES
     Source/LuaIDEApplication.cpp
     Source/AssetDatabaseLocationListener.h
     Source/AssetDatabaseLocationListener.cpp
-    Source/ThumbnailerNullComponent.h
-    Source/ThumbnailerNullComponent.cpp
     Source/Editor/LuaEditor.h
     Source/Editor/LuaEditor.cpp
     Source/LUA/BasicScriptChecker.h


### PR DESCRIPTION
SerializeContextTools will soon rely on this.