### PR TITLE
Add gradle to the windows setup scripts

### DIFF
--- a/scripts/build/build_node/Platform/Windows/install_android.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_android.ps1
@@ -28,8 +28,8 @@ Start-Process -FilePath $sdkmanager -ArgumentList $build_tools -NoNewWindow -Wai
 Write-Host "Installing Gradle and Ninja"
 Import-Module C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1 #Grade needs a custom installer due to being hardcoded to C:\Programdata in Chocolatey
 $packageName = 'gradle'
-$version = '5.6.4'
-$checksum = 'ABC10BCEDB58806E8654210F96031DB541BCD2D6FC3161E81CB0572D6A15E821'
+$version = '7.0'
+$checksum = '81003F83B0056D20EEDF48CDDD4F52A9813163D4BA185BCF8ABD34B8EEEA4CBD'
 $url = "https://services.gradle.org/distributions/gradle-$version-all.zip"
 $installDir = "C:\Gradle"
 
@@ -38,6 +38,6 @@ Install-ChocolateyZipPackage $packageName $url $installDir -Checksum $checksum -
 $gradle_home = Join-Path $installDir "$packageName-$version"
 $gradle_bat = Join-Path $gradle_home 'bin/gradle.bat'
 
-Install-ChocolateyEnvironmentVariable "GRADLE_HOME" $gradle_home 'Machine'
+Install-ChocolateyEnvironmentVariable "GRADLE_BUILD_HOME" $gradle_home 'Machine'
 
 choco install -y ninja --version=1.10.0 --package-parameters="/installDir:C:\Ninja"

--- a/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
+++ b/scripts/build/build_node/Platform/Windows/install_utiltools.ps1
@@ -29,6 +29,3 @@ choco install corretto8jdk -y --ia INSTALLDIR="c:\jdk8" # Custom directory to ha
 
 # Install CMake
 choco install cmake -y --installargs 'ADD_CMAKE_TO_PATH=System'
-
-# Install Gradle (for Android projects)
-choco install -y gradle


### PR DESCRIPTION
The Choco install currently installs gradle 7.0. There is an incoming android fix that will require the newer (6.5 >) gradle in order to work, but right now the current android gradle jobs still relies on the CMAKE_HOME environment, which wont be needed when the fix comes in