### PR TITLE
Make the EventDataSet that is used by the CreateMotionEvent command not use AZStd::optional

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionEventCommands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionEventCommands.cpp
@@ -590,7 +590,7 @@ namespace CommandSystem
         }
 
         // add the motion event and check if everything worked fine
-        mMotionEventNr = eventTrack->AddEvent(m_startTime, m_endTime, AZStd::move(m_eventDatas.value_or(EMotionFX::EventDataSet())));
+        mMotionEventNr = eventTrack->AddEvent(m_startTime, m_endTime, EMotionFX::EventDataSet{m_eventDatas});
 
         if (mMotionEventNr == MCORE_INVALIDINDEX32)
         {

--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionEventCommands.h
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/MotionEventCommands.h
@@ -152,7 +152,7 @@ namespace CommandSystem
     public:
         AZStd::string m_eventTrackName;
         AZStd::optional<AZStd::string> m_serializedEventData;
-        AZStd::optional<EMotionFX::EventDataSet> m_eventDatas;
+        EMotionFX::EventDataSet m_eventDatas;
         float m_startTime = 0.0f;
         float m_endTime = 0.0f;
         size_t mMotionEventNr;


### PR DESCRIPTION
`AZStd::optional` is not supported by the Json serializer. Having this
member wrapped in an `optional` causes the event data attached to an
event to fail to be written to the scene manifest .assetinfo file.