### PR TITLE
LYN-3734 Bringing back RHI modules to tools deps

### DIFF
--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/Platform/Linux/additional_linux_tool_deps.cmake
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/Platform/Linux/additional_linux_tool_deps.cmake
@@ -10,6 +10,9 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
+    Gem::Atom_RHI_Vulkan.Private
+    Gem::Atom_RHI_DX12.Private
+    Gem::Atom_RHI_Metal.Private
     Gem::Atom_RHI_Vulkan.Builders
     Gem::Atom_RHI_DX12.Builders
     Gem::Atom_RHI_Metal.Builders

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/Platform/Mac/additional_mac_tool_deps.cmake
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/Platform/Mac/additional_mac_tool_deps.cmake
@@ -10,6 +10,9 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
+    Gem::Atom_RHI_Metal.Private
+    Gem::Atom_RHI_Vulkan.Private
+    Gem::Atom_RHI_DX12.Private
     Gem::Atom_RHI_Metal.Builders
     Gem::Atom_RHI_Vulkan.Builders
     Gem::Atom_RHI_DX12.Builders

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/Platform/Windows/additional_windows_tool_deps.cmake
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/Platform/Windows/additional_windows_tool_deps.cmake
@@ -10,6 +10,9 @@
 #
 
 set(LY_RUNTIME_DEPENDENCIES
+    Gem::Atom_RHI_Vulkan.Private
+    Gem::Atom_RHI_DX12.Private
+    Gem::Atom_RHI_Metal.Private
     Gem::Atom_RHI_Vulkan.Builders
     Gem::Atom_RHI_DX12.Builders
     Gem::Atom_RHI_Metal.Builders


### PR DESCRIPTION
Locally, the AP looks good. Editor is functional. There are serialization errors from TransformComponent, though, but nothing Atom related.