### PR TITLE
Fix for Decal Feature Processor not using async loading correctly

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/AsyncLoadTracker.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/AsyncLoadTracker.h
@@ -23,7 +23,9 @@ namespace AZ
         {
         public:
 
-            void TrackAssetLoad(const FeatureProcessorHandle handle, const AZ::Data::AssetId asset)
+            using MaterialAssetPtr = AZ::Data::Asset<AZ::RPI::MaterialAsset>;
+
+            void TrackAssetLoad(const FeatureProcessorHandle handle, const MaterialAssetPtr asset)
             {
                 if (IsAssetLoading(handle))
                 {
@@ -77,12 +79,12 @@ namespace AZ
             {
                 const auto asset = EraseFromInFlightHandles(handle);
 
-                AZ_Assert(m_inFlightHandlesByAsset.count(asset) > 0, "AsyncLoadTracker in a bad state");
-                auto& handleList = m_inFlightHandlesByAsset[asset];
+                AZ_Assert(m_inFlightHandlesByAsset.count(asset.GetId()) > 0, "AsyncLoadTracker in a bad state");
+                auto& handleList = m_inFlightHandlesByAsset[asset.GetId()];
                 EraseFromVector(handleList, handle);
                 if (handleList.empty())
                 {
-                    m_inFlightHandlesByAsset.erase(asset);
+                    m_inFlightHandlesByAsset.erase(asset.GetId());
                 }
             }
 
@@ -104,14 +106,14 @@ namespace AZ
                 vec.pop_back();
             }
 
-            void Add(const FeatureProcessorHandle handle, const AZ::Data::AssetId asset)
+            void Add(const FeatureProcessorHandle handle, const MaterialAssetPtr asset)
             {
                 AZ_Assert(m_inFlightHandles.count(handle) == 0, "AsyncLoadTracker::Add() - told to add a handle that was already being tracked.");
-                m_inFlightHandlesByAsset[asset].push_back(handle);
+                m_inFlightHandlesByAsset[asset.GetId()].push_back(handle);
                 m_inFlightHandles[handle] = asset;
             }
 
-            AZ::Data::AssetId EraseFromInFlightHandles(const FeatureProcessorHandle handle)
+            MaterialAssetPtr EraseFromInFlightHandles(const FeatureProcessorHandle handle)
             {
                 const auto iter = m_inFlightHandles.find(handle);
                 AZ_Assert(iter != m_inFlightHandles.end(), "Told to remove handle that was not present");
@@ -125,7 +127,7 @@ namespace AZ
 
             // Hash table that tracks the reverse of the m_inFlightHandlesByAsset hash table.
             // i.e. for each object, it stores what asset that it needs.
-            AZStd::unordered_map<FeatureProcessorHandle, AZ::Data::AssetId> m_inFlightHandles;
+            AZStd::unordered_map<FeatureProcessorHandle, MaterialAssetPtr> m_inFlightHandles;
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -85,7 +85,6 @@ namespace AZ
 
             m_decalData.Clear();
             m_decalBufferHandler.Release();
-            m_materialAssets.clear();
         }
 
         DecalTextureArrayFeatureProcessor::DecalHandle DecalTextureArrayFeatureProcessor::AcquireDecal()
@@ -410,7 +409,7 @@ namespace AZ
             int iter = m_textureArrayList.begin();
             while (iter != -1)
             {
-                const auto packedTexture = m_textureArrayList[iter].second.GetPackedTexture();
+                const auto& packedTexture = m_textureArrayList[iter].second.GetPackedTexture();
                 view->GetShaderResourceGroup()->SetImage(m_decalTextureArrayIndices[iter], packedTexture);
                 iter = m_textureArrayList.next(iter);
             }
@@ -482,22 +481,15 @@ namespace AZ
             return material;
         }
 
-        void DecalTextureArrayFeatureProcessor::QueueMaterialLoadForDecal(const AZ::Data::AssetId material, const DecalHandle handle)
+        void DecalTextureArrayFeatureProcessor::QueueMaterialLoadForDecal(const AZ::Data::AssetId materialId, const DecalHandle handle)
         {
-            // Note that another decal might have already queued this material for loading
-            if (m_materialLoadTracker.IsAssetLoading(material))
-            {
-                m_materialLoadTracker.TrackAssetLoad(handle, material);
-                return;
-            }
+            const auto materialAsset = QueueMaterialAssetLoad(materialId);
 
-            const auto materialAsset = QueueMaterialAssetLoad(material);
-            m_materialAssets.emplace(material, materialAsset);
-            m_materialLoadTracker.TrackAssetLoad(handle, material);
+            m_materialLoadTracker.TrackAssetLoad(handle, materialAsset);
 
             if (materialAsset.IsLoading())
             {
-                AZ::Data::AssetBus::MultiHandler::BusConnect(material);
+                AZ::Data::AssetBus::MultiHandler::BusConnect(materialId);
             }
             else if (materialAsset.IsReady())
             {

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.h
@@ -136,10 +136,7 @@ namespace AZ
             GpuBufferHandler m_decalBufferHandler;
 
             AsyncLoadTracker<DecalHandle> m_materialLoadTracker;
-
             AZStd::unordered_map< AZ::Data::AssetId, DecalLocationAndUseCount> m_materialToTextureArrayLookupTable;
-
-            AZStd::unordered_map<AZ::Data::AssetId, AZ::Data::Asset<AZ::RPI::MaterialAsset>> m_materialAssets;
 
             bool m_deviceBufferNeedsUpdate = false;
         };


### PR DESCRIPTION
DecalTextureArrayFeatureProcessor has a hack that was put in place due to changes in the async loading code. Basically the async loader now has a requirement that users must hold references to the MaterialAsset while it is being loaded.

I had previously added a hack to simply hold references to the MaterialAssets in an unordered_map. This has a flaw that prevents them from ever being unloaded since I never updated it, only added to it.

I removed the unordered_map and changed the AsyncLoader to hold MaterialAssetPtrs instead of AssetIds. 

Testing: ASV decal test is fine and also created a decal test level in the Editor. I added a debug printf that printed the loading state of the decals. With this change it now shows the decals being loaded / unloaded as you scrub the Imgui slider back and forth.

Atom/mriegger/ATOM-14271
