### PR TITLE
{LYN-3787} Fix for infinite loop in the scene builder's import phase

### DIFF
--- a/AutomatedTesting/Assets/BadAssets/three_same_named_nodes.fbx
+++ b/AutomatedTesting/Assets/BadAssets/three_same_named_nodes.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b58009dc2f9340e08cafd5e68f142d15d77e19e7cef142933f2dff3cfb9293
+size 38352

--- a/Code/Tools/SceneAPI/FbxSceneBuilder/FbxImporter.cpp
+++ b/Code/Tools/SceneAPI/FbxSceneBuilder/FbxImporter.cpp
@@ -139,6 +139,8 @@ namespace AZ
                     if (!nodeNameMap.RegisterNode(node.m_node, scene.GetGraph(), node.m_parent))
                     {
                         AZ_TracePrintf(Utilities::ErrorWindow, "Failed to register asset importer node in name table.");
+                        // Skip this node since it could not be registered
+                        nodes.pop();
                         continue;
                     }
                     AZStd::string nodeName = nodeNameMap.GetNodeName(node.m_node);


### PR DESCRIPTION
* This simple fix pops any node that can not be registered using it name and unique ID
* Any scene file (i.e FBX) with the three or more nodes with the same name and parent will sort of work
* After the 2nd child node with the same name and parent will be dropped on export

Tests: added the new AutomatedTesting/Assets/BadAssets/three_same_named_nodes.fbx to regress test this