### PR TITLE
Fix AssetContainer behavior with immediate load errors

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetContainer.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetContainer.h
@@ -137,6 +137,7 @@ namespace AZ
             AZStd::atomic_int m_invalidDependencies{ 0 };
             AZStd::unordered_set<AZ::Data::AssetId> m_unloadedDependencies;
             AZStd::atomic_bool m_initComplete{ false };
+            AZStd::atomic_bool m_finalNotificationSent{false};
 
             mutable AZStd::recursive_mutex m_preloadMutex;
             // AssetId -> List of assets it is still waiting on 


### PR DESCRIPTION
The AssetContainer was getting "stuck" in the case that it tried to load a missing asset that was already registered with the AssetManager as missing.  This fixes the bug, as well as adding a unit test for the specific condition.