### PR TITLE
Reduce AP race conditions and fix minor bugs

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/base.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/base.py
@@ -108,15 +108,7 @@ class Launcher(object):
 
         # Wait for the AssetProcessor to be open.
         if launch_ap:
-            timeout = 10
-            self.workspace.asset_processor.start()
-            ly_test_tools.environment.waiter.wait_for(
-                lambda: ly_test_tools.environment.process_utils.process_exists(
-                    name="AssetProcessor", ignore_extensions=True),
-                exc=ly_test_tools.launchers.exceptions.SetupError(
-                    f'AssetProcessor never opened after {timeout} seconds'),
-                timeout=timeout
-            )
+            self.workspace.asset_processor.start(connect_to_ap=True, connection_timeout=10)  # verify connection
             self.workspace.asset_processor.wait_for_idle()
             log.debug('AssetProcessor started from calling Launcher.setup()')
 


### PR DESCRIPTION
Reduces the possibility of tests attempting to interact with the AP while it is not ready, and makes errors more explicit.  Additional errors and docs fixed in asset_processor.py, including broken (dead) code and catching of non-exception interrupts.

LyTT unit and integration tests pass locally in 50/50 runs, as well as all existing tests in the Main and Smoke suites in 10/10 local runs. This is insufficient to prove existing race conditions are now handled, but we will need to instrument as we find where others occur.