### PR TITLE
Fixed the loading of uicanvas assets due to the TransformComponent/ScriptComponent missing a version bump

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -881,7 +881,7 @@ namespace AzFramework
             serializeContext->ClassDeprecate("NetBindable", "{80206665-D429-4703-B42E-94434F82F381}");
 
             serializeContext->Class<TransformComponent, AZ::Component>()
-                ->Version(4, &TransformComponentVersionConverter)
+                ->Version(5, &TransformComponentVersionConverter)
                 ->Field("Parent", &TransformComponent::m_parentId)
                 ->Field("Transform", &TransformComponent::m_worldTM)
                 ->Field("LocalTransform", &TransformComponent::m_localTM)

--- a/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Script/ScriptComponent.cpp
@@ -979,7 +979,7 @@ namespace AzFramework
                 };
 
                 serializeContext->Class<ScriptComponent, AZ::Component>()
-                    ->Version(3, converter)
+                    ->Version(4, converter)
                     ->Field("ContextID", &ScriptComponent::m_contextId)
                     ->Field("Properties", &ScriptComponent::m_properties)
                     ->Field("Script", &ScriptComponent::m_script)

--- a/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableComponent.cpp
@@ -546,6 +546,7 @@ void UiInteractableComponent::Reflect(AZ::ReflectContext* context)
             ->Handler<BehaviorUiInteractableNotificationBusHandler>();
     }
 
+    UiInteractableStateAction::Reflect(context);
     UiInteractableStateColor::Reflect(context);
     UiInteractableStateAlpha::Reflect(context);
     UiInteractableStateSprite::Reflect(context);

--- a/Gems/LyShine/Code/Source/UiInteractableState.cpp
+++ b/Gems/LyShine/Code/Source/UiInteractableState.cpp
@@ -42,6 +42,16 @@ void UiInteractableStateAction::SetInteractableEntity(AZ::EntityId interactableE
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+void UiInteractableStateAction::Reflect(AZ::ReflectContext* context)
+{
+    if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+    {
+        serializeContext->Class<UiInteractableStateAction>();
+    }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 void UiInteractableStateAction::Init(AZ::EntityId interactableEntityId)
 {
     m_interactableEntity = interactableEntityId;
@@ -128,8 +138,8 @@ void UiInteractableStateColor::Reflect(AZ::ReflectContext* context)
 
     if (serializeContext)
     {
-        serializeContext->Class<UiInteractableStateColor>()
-            ->Version(2, &VersionConverter)
+        serializeContext->Class<UiInteractableStateColor, UiInteractableStateAction>()
+            ->Version(3, &VersionConverter)
             ->Field("TargetEntity", &UiInteractableStateColor::m_targetEntity)
             ->Field("Color", &UiInteractableStateColor::m_color);
 
@@ -223,8 +233,8 @@ void UiInteractableStateAlpha::Reflect(AZ::ReflectContext* context)
 
     if (serializeContext)
     {
-        serializeContext->Class<UiInteractableStateAlpha>()
-            ->Version(1)
+        serializeContext->Class<UiInteractableStateAlpha, UiInteractableStateAction>()
+            ->Version(2)
             ->Field("TargetEntity", &UiInteractableStateAlpha::m_targetEntity)
             ->Field("Alpha", &UiInteractableStateAlpha::m_alpha);
 
@@ -379,8 +389,8 @@ void UiInteractableStateSprite::Reflect(AZ::ReflectContext* context)
 
     if (serializeContext)
     {
-        serializeContext->Class<UiInteractableStateSprite>()
-            ->Version(3)
+        serializeContext->Class<UiInteractableStateSprite, UiInteractableStateAction>()
+            ->Version(4)
             ->Field("TargetEntity", &UiInteractableStateSprite::m_targetEntity)
             ->Field("Sprite", &UiInteractableStateSprite::m_spritePathname)
             ->Field("Index", &UiInteractableStateSprite::m_spriteSheetCellIndex);
@@ -633,8 +643,8 @@ void UiInteractableStateFont::Reflect(AZ::ReflectContext* context)
 
     if (serializeContext)
     {
-        serializeContext->Class<UiInteractableStateFont>()
-            ->Version(1)
+        serializeContext->Class<UiInteractableStateFont, UiInteractableStateAction>()
+            ->Version(2)
             ->Field("TargetEntity", &UiInteractableStateFont::m_targetEntity)
             ->Field("FontFileName", &UiInteractableStateFont::m_fontFilename)
             ->Field("EffectIndex", &UiInteractableStateFont::m_fontEffectIndex);

--- a/Gems/LyShine/Code/Source/UiInteractableState.h
+++ b/Gems/LyShine/Code/Source/UiInteractableState.h
@@ -42,6 +42,8 @@ public: // member functions
 
     virtual ~UiInteractableStateAction() {}
 
+    static void Reflect(AZ::ReflectContext* context);
+
     //! Called from the Init of the UiInteractableComponent
     virtual void Init(AZ::EntityId);
 

--- a/Gems/LyShineExamples/Assets/UI/Canvases/LyShineExamples/Comp/Text/ImageMarkup.uicanvas
+++ b/Gems/LyShineExamples/Assets/UI/Canvases/LyShineExamples/Comp/Text/ImageMarkup.uicanvas
@@ -56,7 +56,7 @@
 			</Class>
 			<Class name="AZStd::string" field="Name" value="17276776339261280904" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 			<Class name="AZStd::vector" field="Components" type="{13D58FF9-1088-5C69-9A1F-C2A144B57B78}">
-				<Class name="SliceComponent" field="element" version="4" type="{AFD304E4-1773-47C8-855A-8B622398934F}">
+				<Class name="SliceComponent" field="element" version="3" type="{AFD304E4-1773-47C8-855A-8B622398934F}">
 					<Class name="AZ::Component" field="BaseClass1" type="{EDFCB2CF-F75D-43BE-B26B-F35821B29247}">
 						<Class name="AZ::u64" field="Id" value="6533525738636311866" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
 					</Class>


### PR DESCRIPTION
Due to the NetBindable class being removed from the reflection of the TransformComponent and the ScriptComponent, a binary ObjectStream is attempts to serialize in the NetBindable data into the memory address of the next serializable field of the TransformComponent and ScriptComponent resulting in sporadic crashes in the AssetBuilder when processing uicanvas assets and therefore causing certain UI Canvas assets such as `Gems/LyShineExamples/Assets/UI/Canvases/LyShineExamples/Comp/ScrollBar/Simple.uicanvas` to fail to process

Also fixed an issue where the `Gems/LyShineExamples/Assets/UI/Canvases/LyShineExamples/Comp/Text/ImageMarkup.uicanvas` was serialized with a SliceComponent version(4) newer than the current version in code(3)