### PR TITLE
Fixing clone function in DecalTextureArrayFeatureProcessor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -138,6 +138,10 @@ namespace AZ
                 {
                     m_materialToTextureArrayLookupTable.at(materialAsset).m_useCount++;
                 }
+                else
+                {
+                    AZ_Warning("DecalTextureArrayFeatureProcessor", false, "CloneDecal called on a decal with no material set.");
+                }
                 m_deviceBufferNeedsUpdate = true;
             }
             return decal;


### PR DESCRIPTION
Clone function has not been tested properly. I've added some code in the decal ASV test to test this and it needed only this small change.

https://jira.agscollab.com/browse/ATOM-15542
