### PR TITLE
Move the basic Prefab workflows out from behind the WIP flag

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -177,7 +177,6 @@ namespace AzToolsFramework
             }
 
             menu->addSeparator();
-            
 
             bool itemWasShown = false;
 


### PR DESCRIPTION
Remove the checks for EnablePrefabSystemWipFeatures flag to expose basic Prefab workflows.
Create/Instantiate Prefab still work after this change.