### PR TITLE
Add a sanitation pass to prefabs during load

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -52,7 +52,7 @@ namespace AzToolsFramework
                 return valueIterator->value;
             }
 
-            bool StoreInstanceInPrefabDom(const Instance& instance, PrefabDom& prefabDom)
+            bool StoreInstanceInPrefabDom(const Instance& instance, PrefabDom& prefabDom, StoreInstanceFlags flags)
             {
                 InstanceEntityIdMapper entityIdMapper;
                 entityIdMapper.SetStoringInstance(instance);
@@ -62,6 +62,11 @@ namespace AzToolsFramework
                 AZ::JsonSerializerSettings settings;
                 settings.m_metadata.Add(static_cast<AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&entityIdMapper));
                 settings.m_metadata.Add(&entityIdMapper);
+
+                if ((flags & StoreInstanceFlags::DoNotStoreDefaultValues) != StoreInstanceFlags::DoNotStoreDefaultValues)
+                {
+                    settings.m_keepDefaults = true;
+                }
 
                 AZ::JsonSerializationResult::ResultCode result =
                     AZ::JsonSerialization::Store(prefabDom, prefabDom.GetAllocator(), instance, settings);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -41,13 +41,25 @@ namespace AzToolsFramework
             PrefabDomValueReference FindPrefabDomValue(PrefabDomValue& parentValue, const char* valueName);
             PrefabDomValueConstReference FindPrefabDomValue(const PrefabDomValue& parentValue, const char* valueName);
 
+            enum class StoreInstanceFlags : uint8_t
+            {
+                //! No flags used during the call to LoadInstanceFromPrefabDom.
+                None = 0,
+
+                //! By default an instance will be stored with default values. In cases where we want to store less json without defaults
+                //! such as saving to disk, this flag will control that behavior.
+                DoNotStoreDefaultValues = 1 << 0
+            };
+            AZ_DEFINE_ENUM_BITWISE_OPERATORS(StoreInstanceFlags);
+
             /**
             * Stores a valid Prefab Instance within a Prefab Dom. Useful for generating Templates
             * @param instance The instance to store
             * @param prefabDom The prefabDom that will be used to store the Instance data
+            * @param flags Controls behavior such as whether to store default values
             * @return bool on whether the operation succeeded
             */
-            bool StoreInstanceInPrefabDom(const Instance& instance, PrefabDom& prefabDom);
+            bool StoreInstanceInPrefabDom(const Instance& instance, PrefabDom& prefabDom, StoreInstanceFlags flags = StoreInstanceFlags::None);
 
             enum class LoadInstanceFlags : uint8_t
             {
@@ -57,13 +69,13 @@ namespace AzToolsFramework
                 //! unique, e.g. when they are duplicates of live entities, this flag will assign them a random new id.
                 AssignRandomEntityId = 1 << 0
             };
-            AZ_DEFINE_ENUM_BITWISE_OPERATORS(LoadInstanceFlags)
+            AZ_DEFINE_ENUM_BITWISE_OPERATORS(LoadInstanceFlags);
 
             /**
             * Loads a valid Prefab Instance from a Prefab Dom. Useful for generating Instances.
             * @param instance The Instance to load.
             * @param prefabDom The prefabDom that will be used to load the Instance data.
-            * @param shouldClearContainers Whether to clear containers in Instance while loading.
+            * @param flags Controls behavior such as random entity id assignment.
             * @return bool on whether the operation succeeded.
             */
             bool LoadInstanceFromPrefabDom(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.h
@@ -137,7 +137,8 @@ namespace AzToolsFramework
                 TemplateId targetTemplateId,
                 AZStd::unordered_set<AZ::IO::Path>& progressedFilePathsSet);
 
-            bool SanitizeLoadedTemplate(Template& loadedTemplate);
+            bool SanitizeLoadedTemplate(PrefabDomReference loadedTemplateDom);
+            bool SanitizeSavingTemplate(PrefabDomReference savingTemplateDom);
 
             //! Retrieves Dom content and its path from a template id
             AZStd::optional<AZStd::pair<PrefabDom, AZ::IO::Path>> StoreTemplateIntoFileFormat(TemplateId templateId);


### PR DESCRIPTION
Issues where fields are removed from a component or its serialization arise if we load in a prefab with those fields and then attempt to edit instances of them in the Editor. This is due to generating a patch of the entity edit only for that patch to fail or conflict with the legacy format loaded from disk.

This change does a quick load/store combo of the loaded prefab. Doing so will serialize it using the latest data/formats and drop any removed fields.

Note: Any patch data generated with legacy fields will still have issues applying and to fix that I recommend changing our patch application to be best effort.

Note: This change is mostly beneficial for removed fields or altered default values. It doesn't easily cover altered fields. Versioning or a script that upgrades the json in prefabs to the next format would assist in this more advanced use case.