### PR TITLE
Update integral Json serializers to support deserializing enums

### DIFF
--- a/Code/Framework/AzCore/Tests/Serialization/Json/TestCases.h
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/TestCases.h
@@ -21,7 +21,7 @@ namespace JsonSerializationTests
 {
     using JsonSerializationTestCases = ::testing::Types<
         // Structures
-        SimpleClass, SimpleInheritence, MultipleInheritence, SimpleNested, SimpleEnumWrapper,
+        SimpleClass, SimpleInheritence, MultipleInheritence, SimpleNested, SimpleEnumWrapper, NonReflectedEnumWrapper,
         // Pointers
         SimpleNullPointer, SimpleAssignedPointer, ComplexAssignedPointer, ComplexNullInheritedPointer,
         ComplexAssignedDifferentInheritedPointer, ComplexAssignedSameInheritedPointer,

--- a/Code/Framework/AzCore/Tests/Serialization/Json/TestCases_Classes.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/TestCases_Classes.cpp
@@ -373,6 +373,57 @@ namespace JsonSerializationTests
         return MakeInstanceWithoutDefaults(AZStd::move(instance), json);
     }
 
+    // NonReflectedEnumWrapper
+    bool NonReflectedEnumWrapper::Equals(const NonReflectedEnumWrapper& rhs, bool fullReflection) const
+    {
+        return !fullReflection || (m_enumClass == rhs.m_enumClass && m_rawEnum== rhs.m_rawEnum);
+    }
+
+    void NonReflectedEnumWrapper::Reflect(AZStd::unique_ptr<AZ::SerializeContext>& context, bool fullReflection)
+    {
+        if (fullReflection)
+        {
+            // Note that the enums are not reflected using context->Enum<>
+
+            context->Class<NonReflectedEnumWrapper>()
+                ->Field("enumClass", &NonReflectedEnumWrapper::m_enumClass)
+                ->Field("rawEnum", &NonReflectedEnumWrapper::m_rawEnum);
+        }
+    }
+
+    InstanceWithSomeDefaults<NonReflectedEnumWrapper> NonReflectedEnumWrapper::GetInstanceWithSomeDefaults()
+    {
+        auto instance = AZStd::make_unique<NonReflectedEnumWrapper>();
+        instance->m_enumClass = NonReflectedEnumWrapper::SimpleEnumClass::Option2;
+
+        const char* strippedDefaults = R"(
+            {
+                "enumClass": 2
+            })";
+        const char* keptDefaults = R"(
+            {
+                "enumClass": 2,
+                "rawEnum": 0
+            })";
+
+        return MakeInstanceWithSomeDefaults(AZStd::move(instance),
+            strippedDefaults, keptDefaults);
+    }
+
+    InstanceWithoutDefaults<NonReflectedEnumWrapper> NonReflectedEnumWrapper::GetInstanceWithoutDefaults()
+    {
+        auto instance = AZStd::make_unique<NonReflectedEnumWrapper>();
+        instance->m_enumClass = NonReflectedEnumWrapper::SimpleEnumClass::Option2;
+        instance->m_rawEnum = NonReflectedEnumWrapper::SimpleRawEnum::RawOption1;
+
+        const char* json = R"(
+            {
+                "enumClass": 2,
+                "rawEnum": 1
+            })";
+        return MakeInstanceWithoutDefaults(AZStd::move(instance), json);
+    }
+
     // TemplatedClass<int>
 
     bool TemplatedClass<int>::Equals(const TemplatedClass<int>& rhs, bool fullReflection) const

--- a/Code/Framework/AzCore/Tests/Serialization/Json/TestCases_Classes.h
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/TestCases_Classes.h
@@ -134,6 +134,35 @@ namespace JsonSerializationTests
         SimpleRawEnum m_rawEnum{};
     };
 
+    struct NonReflectedEnumWrapper
+    {
+        enum class SimpleEnumClass
+        {
+            Option1 = 1,
+            Option2,
+        };
+        enum SimpleRawEnum
+        {
+            RawOption1 = 1,
+            RawOption2,
+        };
+        AZ_CLASS_ALLOCATOR(NonReflectedEnumWrapper, AZ::SystemAllocator, 0);
+        AZ_RTTI(NonReflectedEnumWrapper, "{A80D5B6B-2FD1-46E9-A7A9-44C5E2650526}");
+        
+        static constexpr bool SupportsPartialDefaults = true;
+
+        NonReflectedEnumWrapper() = default;
+        virtual ~NonReflectedEnumWrapper() = default;
+
+        bool Equals(const NonReflectedEnumWrapper& rhs, bool fullReflection) const;
+        static void Reflect(AZStd::unique_ptr<AZ::SerializeContext>& context, bool fullReflection);
+        static InstanceWithSomeDefaults<NonReflectedEnumWrapper> GetInstanceWithSomeDefaults();
+        static InstanceWithoutDefaults<NonReflectedEnumWrapper> GetInstanceWithoutDefaults();
+
+        SimpleEnumClass m_enumClass{};
+        SimpleRawEnum m_rawEnum{};
+    };
+
     template<typename T>
     struct TemplatedClass
     {
@@ -158,5 +187,7 @@ namespace AZ
 {
     AZ_TYPE_INFO_SPECIALIZE(JsonSerializationTests::SimpleEnumWrapper::SimpleEnumClass, "{AF6F1964-5B20-4689-BF23-F36B9C9AAE6A}");
     AZ_TYPE_INFO_SPECIALIZE(JsonSerializationTests::SimpleEnumWrapper::SimpleRawEnum, "{EB24207F-B48F-4D8B-940D-3CD06A371739}");
+    AZ_TYPE_INFO_SPECIALIZE(JsonSerializationTests::NonReflectedEnumWrapper::SimpleEnumClass, "{E80E4A41-B29E-4B7C-B630-3B599172C837}");
+    AZ_TYPE_INFO_SPECIALIZE(JsonSerializationTests::NonReflectedEnumWrapper::SimpleRawEnum, "{C42AF28D-4F84-4540-972A-5B6EEFAB13FF}");
     AZ_TYPE_INFO_TEMPLATE(JsonSerializationTests::TemplatedClass, "{CA4ADF74-66E7-4D16-B4AC-F71278C60EC7}", AZ_TYPE_INFO_TYPENAME);
 }


### PR DESCRIPTION
Enums have distinct type ids from the raw data types. So in addition to
checking directly if `azrtti_typeid<int>() == outputValueTypeId`, a check
against the enum's `RttiHelper::IsTypeOf<int>` is necessary. That case is
probably uncommon, so this change leaves the original check in place, since
it is much quicker to do. Also, this only applies to enums, and their
underlying type must be an integral type, so only add these additional
checks to the integral serializers.