### PR TITLE
Update Android AMI v3 label

### DIFF
--- a/scripts/build/Platform/Android/pipeline.json
+++ b/scripts/build/Platform/Android/pipeline.json
@@ -1,7 +1,7 @@
 {
     "ENV": {
         "GRADLE_HOME": "C:/Gradle/gradle-5.6.4",
-		"GRADLE_BUILD_HOME": "C:/Gradle/gradle-7.0",
+        "GRADLE_BUILD_HOME": "C:/Gradle/gradle-7.0",
         "NODE_LABEL": "windows-b3c8994f1",
         "LY_3RDPARTY_PATH": "C:/ly/3rdParty",
         "TIMEOUT": 30,


### PR DESCRIPTION
- Updates the default label and AMI for android builds
- AMI updates Gradle to 7.0 and CMake to 3.20.2

Note: This will be deployed just prior to the nightly build to allow a clean EBS workspace capture to occur