### PR TITLE
fix AzGenericTypeInfo template handling with clang 12+

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h
@@ -150,8 +150,13 @@ namespace AZ
     // also needs to be an overload for every version because they all represent overloads for different non-types.
     namespace AzGenericTypeInfo
     {
-        template<typename...>
-        constexpr bool false_v = false;
+        /// Needs to match declared parameter type.
+        template <template <typename...> class> constexpr bool false_v1 = false;
+        template <template <AZStd::size_t...> class> constexpr bool false_v2 = false;
+        template <template <typename, AZStd::size_t> class> constexpr bool false_v3 = false;
+        template <template <typename, typename, AZStd::size_t> class> constexpr bool false_v4 = false;
+        template <template <typename, typename, typename, AZStd::size_t> class> constexpr bool false_v5 = false;
+        template <template <typename, AZStd::size_t, typename> class> constexpr bool false_v6 = false;
 
         template<typename T>
         inline const AZ::TypeId& Uuid()
@@ -162,7 +167,7 @@ namespace AZ
         template<template<typename...> class T>
         inline const AZ::TypeId& Uuid()
         {
-            static_assert(false_v<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
+            static_assert(false_v1<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
             static const AZ::TypeId s_uuid = AZ::TypeId::CreateNull();
             return s_uuid;
         }
@@ -170,7 +175,7 @@ namespace AZ
         template<template<AZStd::size_t...> class T>
         inline const AZ::TypeId& Uuid()
         {
-            static_assert(false_v<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
+            static_assert(false_v2<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
             static const AZ::TypeId s_uuid = AZ::TypeId::CreateNull();
             return s_uuid;
         }
@@ -178,7 +183,7 @@ namespace AZ
         template<template<typename, AZStd::size_t> class T>
         inline const AZ::TypeId& Uuid()
         {
-            static_assert(false_v<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
+            static_assert(false_v3<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
             static const AZ::TypeId s_uuid = AZ::TypeId::CreateNull();
             return s_uuid;
         }
@@ -186,7 +191,7 @@ namespace AZ
         template<template<typename, typename, AZStd::size_t> class T>
         inline const AZ::TypeId& Uuid()
         {
-            static_assert(false_v<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
+            static_assert(false_v4<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
             static const AZ::TypeId s_uuid = AZ::TypeId::CreateNull();
             return s_uuid;
         }
@@ -194,7 +199,7 @@ namespace AZ
         template<template<typename, typename, typename, AZStd::size_t> class T>
         inline const AZ::TypeId& Uuid()
         {
-            static_assert(false_v<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
+            static_assert(false_v5<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
             static const AZ::TypeId s_uuid = AZ::TypeId::CreateNull();
             return s_uuid;
         }
@@ -202,7 +207,7 @@ namespace AZ
         template<template<typename, AZStd::size_t, typename> class T>
         inline const AZ::TypeId& Uuid()
         {
-            static_assert(false_v<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
+            static_assert(false_v6<T>, "Missing specialization for this template. Make sure it's registered for type info support.");
             static const AZ::TypeId s_uuid = AZ::TypeId::CreateNull();
             return s_uuid;
         }


### PR DESCRIPTION
As reported in #591, o3de does not compile on clang 12.0.0 (stock clang in Fedora 34). I thought initially this was a compiler bug, but after discussion with the clang upstream, they indicated that the o3de code (in Code/Framework/AzCore/AzCore/RTTI/TypeInfo.h) had always been invalid, because you cannot pass a template as a template argument to a type template parameter.

The fix is to make the template parameter of false_v match the declared parameter type for the template where it is used. Unfortunately, this means that one "false_v" cannot be used for all 6 of the templates, but it is easy enough to create false_v[123456], each matching the parameters for the template usage. I have confirmed locally that this resolves the build failure for me on Fedora 34.