### PR TITLE
update CMakeLists.txt timeout for Atom renderer tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
@@ -20,7 +20,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
         TEST_SUITE main
         PATH ${CMAKE_CURRENT_LIST_DIR}/test_Atom_MainSuite.py
         TEST_SERIAL
-        TIMEOUT 300
+        TIMEOUT 500
         RUNTIME_DEPENDENCIES
             AssetProcessor
             AutomatedTesting.Assets
@@ -31,7 +31,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
         TEST_SUITE sandbox
         PATH ${CMAKE_CURRENT_LIST_DIR}/test_Atom_SandboxSuite.py
         TEST_SERIAL
-        TIMEOUT 300
+        TIMEOUT 500
         RUNTIME_DEPENDENCIES
             AssetProcessor
             AutomatedTesting.Assets


### PR DESCRIPTION
- A failure occurred on main after this test was updated.
- It was discovered that the test timeout being the same as the CMakeLists.txt timeout caused the debug output to be blank.
- This PR updates the CMakeLists.txt timeout value to be different than the test script's timeout value.