### PR TITLE
Preserve asset ids for assets that fail to load, when deserializing from json

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetJsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetJsonSerializer.cpp
@@ -133,7 +133,15 @@ namespace AZ
                 if (!id.m_guid.IsNull())
                 {
                     *instance = AssetManager::Instance().FindOrCreateAsset(id, instance->GetType(), instance->GetAutoLoadBehavior());
-
+                    if (!instance->GetId().IsValid())
+                    {
+                        // If the asset failed to be created, FindOrCreateAsset returns an asset instance with a null
+                        // id. To preserve the asset id in the source json, reset the asset to an empty one, but with
+                        // the right id.
+                        const auto loadBehavior = instance->GetAutoLoadBehavior();
+                        *instance = Asset<AssetData>(id, instance->GetType());
+                        instance->SetAutoLoadBehavior(loadBehavior);
+                    }
 
                     result.Combine(context.Report(result, "Successfully created Asset<T> with id."));
                 }


### PR DESCRIPTION
Sometimes deserializing a Json document happens when asset handlers are not
registered. In that case, `FindOrCreateAsset` will fail to create the
asset, since there's no handler registered to create it. When this happens,
`FindOrCreateAsset` returns an Asset instance with a null asset id. This
effectively causes the json deserializer to lose that data, even in
situations where the the actual asset data doesn't need to be loaded, but
the asset id needs to be preserved.