### PR TITLE
[HOTFIX] Fix broken nightly build because of invalid module name

### DIFF
--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthModule.cpp
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthModule.cpp
@@ -39,4 +39,4 @@ namespace AWSClientAuth
 // DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
 // The first parameter should be GemName_GemIdLower
 // The second should be the fully qualified name of the class above
-AZ_DECLARE_MODULE_CLASS(AWSClientAuth_c74f2756f5874c0d8d29646dfc9cb0ad, AWSClientAuth::AWSClientAuthModule)
+AZ_DECLARE_MODULE_CLASS(Gem_AWSClientAuth, AWSClientAuth::AWSClientAuthModule)

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsModule.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsModule.cpp
@@ -32,4 +32,4 @@ namespace AWSMetrics
 // DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
 // The first parameter should be GemName_GemIdLower
 // The second should be the fully qualified name of the class above
-AZ_DECLARE_MODULE_CLASS(AWSMetrics_cc6fc7a18fc047039a369a26100fcbbe, AWSMetrics::AWSMetricsModule)
+AZ_DECLARE_MODULE_CLASS(Gem_AWSMetrics, AWSMetrics::AWSMetricsModule)


### PR DESCRIPTION
## Details
https://jira.agscollab.com/browse/SPEC-6962

## Testing
Tested locally, it can pass failed target AutomatedTesting.GameLauncher.
Other platforms test https://jenkins-pipeline.agscollab.com/job/O3DE-LY-FORK/job/hotfix05202021/