### PR TITLE
Fixed issue with the Settings Registry .setreg(patch) sorting when merging folders

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -880,6 +880,13 @@ namespace AZ
         const Specializations& specializations, const rapidjson::Pointer& historyPointer, AZStd::string_view folderPath)
     {
         using namespace rapidjson;
+        
+        if (&lhs == &rhs)
+        {
+            // Early return to avoid setting the collisionFound reference to true
+            // std::sort is allowed to pass in the same memory address for the left and right elements
+            return false;
+        }
 
         AZ_Assert(!lhs.m_tags.empty(), "Comparing a settings file without at least a name tag.");
         AZ_Assert(!rhs.m_tags.empty(), "Comparing a settings file without at least a name tag.");


### PR DESCRIPTION
Fixed issue where the SettingsRegistryImpl::LessThan function would set the collisionFound boolean to true when comparing two elements that happened to be at the same address via std::sort.

In reality there is no such collision and the comparisons needs to early return with false, but not change the collisionFound flag.