### PR TITLE
Ensure AtomFont loads with the Editor

### DIFF
--- a/AutomatedTesting/Gem/Code/runtime_dependencies.cmake
+++ b/AutomatedTesting/Gem/Code/runtime_dependencies.cmake
@@ -43,7 +43,6 @@ set(GEM_DEPENDENCIES
     Gem::GradientSignal
     Gem::Vegetation
     Gem::Atom_AtomBridge
-    Gem::AtomFont
     Gem::NvCloth
     Gem::Blast
     Gem::AWSCore

--- a/AutomatedTesting/Gem/Code/tool_dependencies.cmake
+++ b/AutomatedTesting/Gem/Code/tool_dependencies.cmake
@@ -55,7 +55,6 @@ set(GEM_DEPENDENCIES
     Gem::Atom_RHI.Private
     Gem::Atom_Feature_Common.Editor
     Gem::Atom_AtomBridge.Editor
-    Gem::AtomFont
     Gem::NvCloth.Editor
     Gem::Blast.Editor
     Gem::AWSCore.Editor

--- a/Gems/AtomLyIntegration/AtomFont/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/AtomFont/Code/CMakeLists.txt
@@ -12,7 +12,7 @@
 ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME})
 
 ly_add_target(
-    NAME AtomFont ${PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE}
+    NAME AtomFont ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         atomfont_files.cmake


### PR DESCRIPTION
- Use PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE which will correctly be set to GEM_MODULE to get loaded at runtime with non-monolithic builds instead of PAL_TRAIT_MONOLITHIC_DRIVEN_LIBRARY_TYPE
- Removed the unneeded entries from AutomatedTesting's runtime config now that this is fixed (AtomBridge will bring it in again)