### PR TITLE
SPEC-6957: AR test for general.idle_wait() hydra calls causing AR to fail.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_idle_wait_bug.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_idle_wait_bug.py
@@ -1,0 +1,74 @@
+"""
+All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+its licensors.
+
+For complete copyright and license terms please see the LICENSE at the root of this
+distribution (the "License"). All use of this software is governed by the License,
+or, if provided, by the license below or the license accompanying this file. Do not
+remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+Test script investigation into why general.idle_wait() is causing issues.
+"""
+
+import os
+import sys
+
+import azlmbr.paths
+import azlmbr.legacy.general as general
+
+from editor_python_test_tools.utils import TestHelper
+
+sys.path.append(os.path.join(azlmbr.paths.devroot, "AutomatedTesting", "Gem", "PythonTests"))
+
+
+def run():
+    """Testing AR bug with hydra idle_wait() calls."""
+    general.idle_wait(0.5)
+
+    def verify_idle_wait_works(test):
+        general.idle_wait(0.5)
+        general.log(f'Calling verify_idle_wait_works(): {test}')
+        general.idle_wait_frames(1)
+
+        def is_idle_wait_working():
+            general.idle_wait(0.5)
+            general.log(f'Called is_idle_wait_working() once: {test}')
+            general.idle_wait_frames(1)
+            general.idle_wait(1.0)
+            return True
+
+        general.idle_wait(0.5)
+        general.idle_wait(1.0)
+        general.log(f'Testing idle_wait() bug in AR: {is_idle_wait_working()}')
+        general.idle_wait(2.0)
+        general.idle_wait(0.5)
+        general.idle_wait_frames(1)
+
+    class HydraIdleWaitTest:
+        def __init__(self, test):
+            self.run_test(test)
+            self.test = test
+            general.idle_wait(0.5)
+            general.idle_wait_frames(1)
+
+        def run_test(self, test):
+            verify_idle_wait_works(test)
+            general.idle_wait(1.0)
+            general.idle_wait_frames(1)
+
+    # Wait for Editor idle loop before executing Python hydra scripts.
+    TestHelper.init_idle()
+    general.idle_wait_frames(1)
+
+    HydraIdleWaitTest('foo')
+    general.idle_wait(0.5)
+    general.idle_wait_frames(1)
+
+    HydraIdleWaitTest('bar')
+    general.idle_wait(2.0)
+    general.idle_wait_frames(1)
+
+
+if __name__ == "__main__":
+    run()

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -27,142 +27,171 @@ TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "atom_hydra_scripts")
 @pytest.mark.parametrize("level", ["auto_test"])
 class TestAtomEditorComponentsMain(object):
 
-    @pytest.mark.xfail(reason="Timing out sporadically, LYN-3956")
-    @pytest.mark.test_case_id(
-        "C32078130",  # Display Mapper
-        "C32078129",  # Light
-        "C32078131",  # Radius Weight Modifier
-        "C32078127",  # PostFX Layer
-        "C32078125",  # Physical Sky
-        "C32078115",  # Global Skylight (IBL)
-        "C32078121",  # Exposure Control
-        "C32078120",  # Directional Light
-        "C32078119",  # DepthOfField
-        "C32078118")  # Decal (Atom)
-    def test_AtomEditorComponents_AddedToEntity(self, request, editor, level, workspace, project, launcher_platform):
+    # @pytest.mark.xfail(reason="Timing out sporadically, LYN-3956")
+    # @pytest.mark.test_case_id(
+    #     "C32078130",  # Display Mapper
+    #     "C32078129",  # Light
+    #     "C32078131",  # Radius Weight Modifier
+    #     "C32078127",  # PostFX Layer
+    #     "C32078125",  # Physical Sky
+    #     "C32078115",  # Global Skylight (IBL)
+    #     "C32078121",  # Exposure Control
+    #     "C32078120",  # Directional Light
+    #     "C32078119",  # DepthOfField
+    #     "C32078118")  # Decal (Atom)
+    # def test_AtomEditorComponents_AddedToEntity(self, request, editor, level, workspace, project, launcher_platform):
+    #     cfg_args = [level]
+    #
+    #     expected_lines = [
+    #         # Decal (Atom) Component
+    #         "Decal (Atom) Entity successfully created",
+    #         "Decal (Atom)_test: Component added to the entity: True",
+    #         "Decal (Atom)_test: Component removed after UNDO: True",
+    #         "Decal (Atom)_test: Component added after REDO: True",
+    #         "Decal (Atom)_test: Entered game mode: True",
+    #         "Decal (Atom)_test: Exit game mode: True",
+    #         "Decal (Atom) Controller|Configuration|Material: SUCCESS",
+    #         "Decal (Atom)_test: Entity is hidden: True",
+    #         "Decal (Atom)_test: Entity is shown: True",
+    #         "Decal (Atom)_test: Entity deleted: True",
+    #         "Decal (Atom)_test: UNDO entity deletion works: True",
+    #         "Decal (Atom)_test: REDO entity deletion works: True",
+    #         # DepthOfField Component
+    #         "DepthOfField Entity successfully created",
+    #         "DepthOfField_test: Component added to the entity: True",
+    #         "DepthOfField_test: Component removed after UNDO: True",
+    #         "DepthOfField_test: Component added after REDO: True",
+    #         "DepthOfField_test: Entered game mode: True",
+    #         "DepthOfField_test: Exit game mode: True",
+    #         "DepthOfField_test: Entity disabled initially: True",
+    #         "DepthOfField_test: Entity enabled after adding required components: True",
+    #         "DepthOfField Controller|Configuration|Camera Entity: SUCCESS",
+    #         "DepthOfField_test: Entity is hidden: True",
+    #         "DepthOfField_test: Entity is shown: True",
+    #         "DepthOfField_test: Entity deleted: True",
+    #         "DepthOfField_test: UNDO entity deletion works: True",
+    #         "DepthOfField_test: REDO entity deletion works: True",
+    #         # Exposure Control Component
+    #         "Exposure Control Entity successfully created",
+    #         "Exposure Control_test: Component added to the entity: True",
+    #         "Exposure Control_test: Component removed after UNDO: True",
+    #         "Exposure Control_test: Component added after REDO: True",
+    #         "Exposure Control_test: Entered game mode: True",
+    #         "Exposure Control_test: Exit game mode: True",
+    #         "Exposure Control_test: Entity disabled initially: True",
+    #         "Exposure Control_test: Entity enabled after adding required components: True",
+    #         "Exposure Control_test: Entity is hidden: True",
+    #         "Exposure Control_test: Entity is shown: True",
+    #         "Exposure Control_test: Entity deleted: True",
+    #         "Exposure Control_test: UNDO entity deletion works: True",
+    #         "Exposure Control_test: REDO entity deletion works: True",
+    #         # Global Skylight (IBL) Component
+    #         "Global Skylight (IBL) Entity successfully created",
+    #         "Global Skylight (IBL)_test: Component added to the entity: True",
+    #         "Global Skylight (IBL)_test: Component removed after UNDO: True",
+    #         "Global Skylight (IBL)_test: Component added after REDO: True",
+    #         "Global Skylight (IBL)_test: Entered game mode: True",
+    #         "Global Skylight (IBL)_test: Exit game mode: True",
+    #         "Global Skylight (IBL) Controller|Configuration|Diffuse Image: SUCCESS",
+    #         "Global Skylight (IBL) Controller|Configuration|Specular Image: SUCCESS",
+    #         "Global Skylight (IBL)_test: Entity is hidden: True",
+    #         "Global Skylight (IBL)_test: Entity is shown: True",
+    #         "Global Skylight (IBL)_test: Entity deleted: True",
+    #         "Global Skylight (IBL)_test: UNDO entity deletion works: True",
+    #         "Global Skylight (IBL)_test: REDO entity deletion works: True",
+    #         # Physical Sky Component
+    #         "Physical Sky Entity successfully created",
+    #         "Physical Sky component was added to entity",
+    #         "Entity has a Physical Sky component",
+    #         "Physical Sky_test: Component added to the entity: True",
+    #         "Physical Sky_test: Component removed after UNDO: True",
+    #         "Physical Sky_test: Component added after REDO: True",
+    #         "Physical Sky_test: Entered game mode: True",
+    #         "Physical Sky_test: Exit game mode: True",
+    #         "Physical Sky_test: Entity is hidden: True",
+    #         "Physical Sky_test: Entity is shown: True",
+    #         "Physical Sky_test: Entity deleted: True",
+    #         "Physical Sky_test: UNDO entity deletion works: True",
+    #         "Physical Sky_test: REDO entity deletion works: True",
+    #         # PostFX Layer Component
+    #         "PostFX Layer Entity successfully created",
+    #         "PostFX Layer_test: Component added to the entity: True",
+    #         "PostFX Layer_test: Component removed after UNDO: True",
+    #         "PostFX Layer_test: Component added after REDO: True",
+    #         "PostFX Layer_test: Entered game mode: True",
+    #         "PostFX Layer_test: Exit game mode: True",
+    #         "PostFX Layer_test: Entity is hidden: True",
+    #         "PostFX Layer_test: Entity is shown: True",
+    #         "PostFX Layer_test: Entity deleted: True",
+    #         "PostFX Layer_test: UNDO entity deletion works: True",
+    #         "PostFX Layer_test: REDO entity deletion works: True",
+    #         # Radius Weight Modifier Component
+    #         "Radius Weight Modifier Entity successfully created",
+    #         "Radius Weight Modifier_test: Component added to the entity: True",
+    #         "Radius Weight Modifier_test: Component removed after UNDO: True",
+    #         "Radius Weight Modifier_test: Component added after REDO: True",
+    #         "Radius Weight Modifier_test: Entered game mode: True",
+    #         "Radius Weight Modifier_test: Exit game mode: True",
+    #         "Radius Weight Modifier_test: Entity is hidden: True",
+    #         "Radius Weight Modifier_test: Entity is shown: True",
+    #         "Radius Weight Modifier_test: Entity deleted: True",
+    #         "Radius Weight Modifier_test: UNDO entity deletion works: True",
+    #         "Radius Weight Modifier_test: REDO entity deletion works: True",
+    #         # Light Component
+    #         "Light Entity successfully created",
+    #         "Light_test: Component added to the entity: True",
+    #         "Light_test: Component removed after UNDO: True",
+    #         "Light_test: Component added after REDO: True",
+    #         "Light_test: Entered game mode: True",
+    #         "Light_test: Exit game mode: True",
+    #         "Light_test: Entity is hidden: True",
+    #         "Light_test: Entity is shown: True",
+    #         "Light_test: Entity deleted: True",
+    #         "Light_test: UNDO entity deletion works: True",
+    #         "Light_test: REDO entity deletion works: True",
+    #         # Display Mapper Component
+    #         "Display Mapper Entity successfully created",
+    #         "Display Mapper_test: Component added to the entity: True",
+    #         "Display Mapper_test: Component removed after UNDO: True",
+    #         "Display Mapper_test: Component added after REDO: True",
+    #         "Display Mapper_test: Entered game mode: True",
+    #         "Display Mapper_test: Exit game mode: True",
+    #         "Display Mapper_test: Entity is hidden: True",
+    #         "Display Mapper_test: Entity is shown: True",
+    #         "Display Mapper_test: Entity deleted: True",
+    #         "Display Mapper_test: UNDO entity deletion works: True",
+    #         "Display Mapper_test: REDO entity deletion works: True",
+    #     ]
+    #
+    #     unexpected_lines = [
+    #         "Trace::Assert",
+    #         "Trace::Error",
+    #         "Traceback (most recent call last):",
+    #     ]
+    #
+    #     hydra.launch_and_validate_results(
+    #         request,
+    #         TEST_DIRECTORY,
+    #         editor,
+    #         "hydra_AtomEditorComponents_AddedToEntity.py",
+    #         timeout=EDITOR_TIMEOUT,
+    #         expected_lines=expected_lines,
+    #         unexpected_lines=unexpected_lines,
+    #         halt_on_unexpected=True,
+    #         null_renderer=True,
+    #         cfg_args=cfg_args,
+    #     )
+
+    def test_HydraIdleWait_FailsInAR(self, request, editor, level, workspace, project, launcher_platform):
         cfg_args = [level]
 
         expected_lines = [
-            # Decal (Atom) Component
-            "Decal (Atom) Entity successfully created",
-            "Decal (Atom)_test: Component added to the entity: True",
-            "Decal (Atom)_test: Component removed after UNDO: True",
-            "Decal (Atom)_test: Component added after REDO: True",
-            "Decal (Atom)_test: Entered game mode: True",
-            "Decal (Atom)_test: Exit game mode: True",
-            "Decal (Atom) Controller|Configuration|Material: SUCCESS",
-            "Decal (Atom)_test: Entity is hidden: True",
-            "Decal (Atom)_test: Entity is shown: True",
-            "Decal (Atom)_test: Entity deleted: True",
-            "Decal (Atom)_test: UNDO entity deletion works: True",
-            "Decal (Atom)_test: REDO entity deletion works: True",
-            # DepthOfField Component
-            "DepthOfField Entity successfully created",
-            "DepthOfField_test: Component added to the entity: True",
-            "DepthOfField_test: Component removed after UNDO: True",
-            "DepthOfField_test: Component added after REDO: True",
-            "DepthOfField_test: Entered game mode: True",
-            "DepthOfField_test: Exit game mode: True",
-            "DepthOfField_test: Entity disabled initially: True",
-            "DepthOfField_test: Entity enabled after adding required components: True",
-            "DepthOfField Controller|Configuration|Camera Entity: SUCCESS",
-            "DepthOfField_test: Entity is hidden: True",
-            "DepthOfField_test: Entity is shown: True",
-            "DepthOfField_test: Entity deleted: True",
-            "DepthOfField_test: UNDO entity deletion works: True",
-            "DepthOfField_test: REDO entity deletion works: True",
-            # Exposure Control Component
-            "Exposure Control Entity successfully created",
-            "Exposure Control_test: Component added to the entity: True",
-            "Exposure Control_test: Component removed after UNDO: True",
-            "Exposure Control_test: Component added after REDO: True",
-            "Exposure Control_test: Entered game mode: True",
-            "Exposure Control_test: Exit game mode: True",
-            "Exposure Control_test: Entity disabled initially: True",
-            "Exposure Control_test: Entity enabled after adding required components: True",
-            "Exposure Control_test: Entity is hidden: True",
-            "Exposure Control_test: Entity is shown: True",
-            "Exposure Control_test: Entity deleted: True",
-            "Exposure Control_test: UNDO entity deletion works: True",
-            "Exposure Control_test: REDO entity deletion works: True",
-            # Global Skylight (IBL) Component
-            "Global Skylight (IBL) Entity successfully created",
-            "Global Skylight (IBL)_test: Component added to the entity: True",
-            "Global Skylight (IBL)_test: Component removed after UNDO: True",
-            "Global Skylight (IBL)_test: Component added after REDO: True",
-            "Global Skylight (IBL)_test: Entered game mode: True",
-            "Global Skylight (IBL)_test: Exit game mode: True",
-            "Global Skylight (IBL) Controller|Configuration|Diffuse Image: SUCCESS",
-            "Global Skylight (IBL) Controller|Configuration|Specular Image: SUCCESS",
-            "Global Skylight (IBL)_test: Entity is hidden: True",
-            "Global Skylight (IBL)_test: Entity is shown: True",
-            "Global Skylight (IBL)_test: Entity deleted: True",
-            "Global Skylight (IBL)_test: UNDO entity deletion works: True",
-            "Global Skylight (IBL)_test: REDO entity deletion works: True",
-            # Physical Sky Component
-            "Physical Sky Entity successfully created",
-            "Physical Sky component was added to entity",
-            "Entity has a Physical Sky component",
-            "Physical Sky_test: Component added to the entity: True",
-            "Physical Sky_test: Component removed after UNDO: True",
-            "Physical Sky_test: Component added after REDO: True",
-            "Physical Sky_test: Entered game mode: True",
-            "Physical Sky_test: Exit game mode: True",
-            "Physical Sky_test: Entity is hidden: True",
-            "Physical Sky_test: Entity is shown: True",
-            "Physical Sky_test: Entity deleted: True",
-            "Physical Sky_test: UNDO entity deletion works: True",
-            "Physical Sky_test: REDO entity deletion works: True",
-            # PostFX Layer Component
-            "PostFX Layer Entity successfully created",
-            "PostFX Layer_test: Component added to the entity: True",
-            "PostFX Layer_test: Component removed after UNDO: True",
-            "PostFX Layer_test: Component added after REDO: True",
-            "PostFX Layer_test: Entered game mode: True",
-            "PostFX Layer_test: Exit game mode: True",
-            "PostFX Layer_test: Entity is hidden: True",
-            "PostFX Layer_test: Entity is shown: True",
-            "PostFX Layer_test: Entity deleted: True",
-            "PostFX Layer_test: UNDO entity deletion works: True",
-            "PostFX Layer_test: REDO entity deletion works: True",
-            # Radius Weight Modifier Component
-            "Radius Weight Modifier Entity successfully created",
-            "Radius Weight Modifier_test: Component added to the entity: True",
-            "Radius Weight Modifier_test: Component removed after UNDO: True",
-            "Radius Weight Modifier_test: Component added after REDO: True",
-            "Radius Weight Modifier_test: Entered game mode: True",
-            "Radius Weight Modifier_test: Exit game mode: True",
-            "Radius Weight Modifier_test: Entity is hidden: True",
-            "Radius Weight Modifier_test: Entity is shown: True",
-            "Radius Weight Modifier_test: Entity deleted: True",
-            "Radius Weight Modifier_test: UNDO entity deletion works: True",
-            "Radius Weight Modifier_test: REDO entity deletion works: True",
-            # Light Component
-            "Light Entity successfully created",
-            "Light_test: Component added to the entity: True",
-            "Light_test: Component removed after UNDO: True",
-            "Light_test: Component added after REDO: True",
-            "Light_test: Entered game mode: True",
-            "Light_test: Exit game mode: True",
-            "Light_test: Entity is hidden: True",
-            "Light_test: Entity is shown: True",
-            "Light_test: Entity deleted: True",
-            "Light_test: UNDO entity deletion works: True",
-            "Light_test: REDO entity deletion works: True",
-            # Display Mapper Component
-            "Display Mapper Entity successfully created",
-            "Display Mapper_test: Component added to the entity: True",
-            "Display Mapper_test: Component removed after UNDO: True",
-            "Display Mapper_test: Component added after REDO: True",
-            "Display Mapper_test: Entered game mode: True",
-            "Display Mapper_test: Exit game mode: True",
-            "Display Mapper_test: Entity is hidden: True",
-            "Display Mapper_test: Entity is shown: True",
-            "Display Mapper_test: Entity deleted: True",
-            "Display Mapper_test: UNDO entity deletion works: True",
-            "Display Mapper_test: REDO entity deletion works: True",
+            "Called is_idle_wait_working() once: foo",
+            "Called is_idle_wait_working() once: bar",
+            "Testing idle_wait() bug in AR: True",
+            "Calling verify_idle_wait_works(): foo",
+            "Calling verify_idle_wait_works(): bar"
         ]
-
         unexpected_lines = [
             "Trace::Assert",
             "Trace::Error",
@@ -173,7 +202,7 @@ class TestAtomEditorComponentsMain(object):
             request,
             TEST_DIRECTORY,
             editor,
-            "hydra_AtomEditorComponents_AddedToEntity.py",
+            "hydra_idle_wait_bug.py",
             timeout=EDITOR_TIMEOUT,
             expected_lines=expected_lines,
             unexpected_lines=unexpected_lines,


### PR DESCRIPTION
- This PR has to be run to rule out the possibility of this call causing tests to fail.
- The Atom renderer tests always passes locally (in over 200 local runs) but fails AR when `general.idle_wait()` calls from `azlmbr.general` are added to the script.
- The suspicion is that the `general.idle_wait()` call is what is causing AR to fail, but not local.