### PR TITLE
Removed unnecessary "is not a function" warnings from ScriptContext.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -2048,10 +2048,6 @@ LUA_API const Node* lua_getDummyNode()
 
             return true;
         }
-        else
-        {
-            AZ_Warning("Script", false, "Index %d is not a function!", functionIndex);
-        }
 
         return false;
     }
@@ -2078,7 +2074,6 @@ LUA_API const Node* lua_getDummyNode()
         }
         else
         {
-            AZ_Warning("Script", lua_isnil(m_nativeContext, -1), "Name %s exists but is not a function!", functionName);
             lua_pop(m_nativeContext, 1);
         }
 
@@ -5888,7 +5883,6 @@ LUA_API const Node* lua_getDummyNode()
         else
         {
             lua_pop(m_impl->m_lua, 1);
-            AZ_Warning("Script", false, "%s is not a function!", functionName);
         }
         return false;
     }
@@ -5906,7 +5900,6 @@ LUA_API const Node* lua_getDummyNode()
         else
         {
             lua_pop(m_impl->m_lua, 1);
-            AZ_Warning("Script", false, "CacheIndex %d is not a function!", cachedIndex);
         }
         return false;
     }


### PR DESCRIPTION
All these warnings are followed by returning false, which call sites can use to report warnings where appropriate. In the case of material lua functors, it is not appropriate to report a warning which is why I'm removing these. The material system uses the "Call" API to potentially call a function that may or may not exist, and it is acceptable for that function to be absent.