### PR TITLE
Exposing the Settings Registry parse error to a Native UI dialog

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -1065,13 +1065,13 @@ namespace AZ
             auto nativeUI = AZ::Interface<NativeUI::NativeUIRequests>::Get();
             if (jsonPatch.GetParseError() == rapidjson::kParseErrorDocumentEmpty)
             {
-                AZ_Warning("Settings Registry", false, R"(Unable to parse registry file "%s" due to json error "%s" at offset %llu.)",
+                AZ_Warning("Settings Registry", false, R"(Unable to parse registry file "%s" due to json error "%s" at offset %zu.)",
                     path, GetParseError_En(jsonPatch.GetParseError()), jsonPatch.GetErrorOffset());
             }
             else
             {
                 using ErrorString = AZStd::fixed_string<4096>;
-                auto jsonError = ErrorString::format(R"(Unable to parse registry file "%s" due to json error "%s" at offset %llu.)", path,
+                auto jsonError = ErrorString::format(R"(Unable to parse registry file "%s" due to json error "%s" at offset %zu.)", path,
                     GetParseError_En(jsonPatch.GetParseError()), jsonPatch.GetErrorOffset());
                 AZ_Error("Settings Registry", false, "%s", jsonError.c_str());
 


### PR DESCRIPTION
This change now "loudly" notifies the user of an error in a .setreg or .setregpatch file being merged into the Settings Registry within a UI application

![image](https://user-images.githubusercontent.com/56135373/119103525-e7efd700-b9e0-11eb-889e-138e8e0f6d1b.png)
