### PR TITLE
Fix for SPEC-6960. Use AZ::u64 instead of uint64_t to avoid issue that PRIu64 won't match uint64_t in some case

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -727,7 +727,7 @@ namespace AZ
                                     ImGui::BeginTooltip();
                                     ImGui::Text("Name: %s", passEntry->m_name.GetCStr());
                                     ImGui::Text("Path: %s", passEntry->m_path.GetCStr());
-                                    ImGui::Text("Duration in ticks: %" PRIu64, passEntry->m_timestampResult.GetDurationInTicks());
+                                    ImGui::Text("Duration in ticks: %llu", static_cast<AZ::u64>(passEntry->m_timestampResult.GetDurationInTicks()));
                                     ImGui::Text("Duration in microsecond: %.3f us", passEntry->m_timestampResult.GetDurationInNanoseconds()/1000.f);
                                     ImGui::EndTooltip();
                                 }


### PR DESCRIPTION
SPEC-6960 Android & Windows asset jobs have failing assets preventing the new ASV code submission gate from passing.

Use PRIu64 for uint64_t could lead to compiling issue with android. 