### PR TITLE
Rename tests that reference issue numbers to have descriptive names

### DIFF
--- a/Gems/EMotionFX/Code/Tests/AnimGraphParameterConditionTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/AnimGraphParameterConditionTests.cpp
@@ -10,6 +10,7 @@
 *
 */
 
+#include "EMotionFX/CommandSystem/Source/AnimGraphParameterCommands.h"
 #include <AzCore/RTTI/TypeInfo.h>
 #include <EMotionFX/CommandSystem/Source/CommandManager.h>
 #include <EMotionFX/Source/AnimGraphBindPoseNode.h>
@@ -87,26 +88,16 @@ namespace EMotionFX
         const AnimGraphParameterCondition* condition = GetAnimGraph()->GetParameterCondition();
         EXPECT_EQ(condition->GetParameterType(), azrtti_typeid<EMotionFX::FloatSliderParameter>());
 
-        {
-            AZStd::string result;
-            EXPECT_TRUE(manager.ExecuteCommand("AnimGraphRemoveParameter -animGraphID 0 -name P0", result)) << result.c_str();
-        }
-
+        EXPECT_TRUE(CommandSystem::BuildRemoveParametersCommandGroup(GetAnimGraph(), {"P0"}));
         EXPECT_EQ(condition->GetParameterType(), azrtti_typeid<EMotionFX::FloatSliderParameter>());
 
-        {
-            AZStd::string result;
-            EXPECT_TRUE(manager.ExecuteCommand("AnimGraphRemoveParameter -animGraphID 0 -name P1", result)) << result.c_str();
-        }
-
+        EXPECT_TRUE(CommandSystem::BuildRemoveParametersCommandGroup(GetAnimGraph(), {"P1"}));
         EXPECT_EQ(condition->GetParameterType(), AZ::TypeId::CreateNull());
 
-        // Will be fixed by LY-109269
-        //{
-        //    AZStd::string result;
-        //    EXPECT_TRUE(manager.Undo(result)) << result.c_str();
-        //}
-
-        //EXPECT_EQ(condition->GetParameterType(), azrtti_typeid<EMotionFX::FloatSliderParameter>());
+        {
+            AZStd::string result;
+            EXPECT_TRUE(manager.Undo(result)) << result.c_str();
+        }
+        EXPECT_EQ(condition->GetParameterType(), azrtti_typeid<EMotionFX::FloatSliderParameter>());
     }
 } // namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/BlendTreeBlendNNodeTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/BlendTreeBlendNNodeTests.cpp
@@ -264,8 +264,8 @@ namespace EMotionFX
         BlendTreeBlendNNode* m_blendNNode = nullptr;
     };
 
-    // Make sure we don't crash when we have no inputs, such as reported by bug LY-114828
-    // Also make sure removing connections on BlendN doesn't crash, as reported by LY-114846
+    // Make sure we don't crash when we have no inputs
+    // Also make sure removing connections on BlendN doesn't crash
     TEST_F(BlendTreeBlendNNodeTests, NoInputsNoCrashTest)
     {
         // Remove all input connections of the blendN node.

--- a/Gems/EMotionFX/Code/Tests/Bugs/CanUndoParameterDeletionAndRestoreBlendTreeConnections.cpp
+++ b/Gems/EMotionFX/Code/Tests/Bugs/CanUndoParameterDeletionAndRestoreBlendTreeConnections.cpp
@@ -106,7 +106,7 @@ namespace EMotionFX
         R"str(AnimGraphCreateConnection -animGraphID 0 -sourceNode Parameters0 -targetNode Smoothing2 -sourcePort 2 -targetPort 0 -startOffsetX 119 -startOffsetY 70 -endOffsetX -2 -endOffsetY 40)str"
     };
 
-    class LY92860Fixture
+    class UndoParameterDeletionTests
         : public CommandRunnerFixture
     {
     public:
@@ -183,10 +183,10 @@ namespace EMotionFX
         }
     };
 
-    TEST_P(LY92860Fixture, ExecuteCommands)
+    TEST_P(UndoParameterDeletionTests, CanUndoParameterDeletionAndRestoreBlendTreeConnections)
     {
         Run();
     };
 
-    INSTANTIATE_TEST_CASE_P(LY92860, LY92860Fixture, ::testing::Values(prepareLY92860Commands));
+    INSTANTIATE_TEST_CASE_P(UndoParameterDeletionTests, UndoParameterDeletionTests, ::testing::Values(prepareLY92860Commands));
 } // EMotionFX

--- a/Gems/EMotionFX/Code/Tests/UI/CanAdjustGroupParameter.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAdjustGroupParameter.cpp
@@ -14,7 +14,7 @@
 
 namespace EMotionFX
 {
-    INSTANTIATE_TEST_CASE_P(LY93621, CommandRunnerFixture,
+    INSTANTIATE_TEST_CASE_P(CanAdjustGroupParameter, CommandRunnerFixture,
         ::testing::Values(std::vector<std::string> {
             R"str(CreateAnimGraph)str",
             R"str(AnimGraphAddGroupParameter -animGraphID 0 -name Group0)str",

--- a/Gems/EMotionFX/Code/Tests/UI/CanDeleteAnimGraphNode_AnimGraphModelUpdates.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanDeleteAnimGraphNode_AnimGraphModelUpdates.cpp
@@ -21,12 +21,12 @@
 
 namespace EMotionFX
 {
-    class LY92748Fixture
+    class CanDeleteAnimGraphNode
         : public CommandRunnerFixture
     {
     };
 
-    TEST_P(LY92748Fixture, ExecuteCommands)
+    TEST_P(CanDeleteAnimGraphNode, CanDeleteAnimGraphNode_AnimGraphModelUpdates)
     {
         ExecuteCommands(GetParam());
 
@@ -68,7 +68,7 @@ namespace EMotionFX
 
     }
 
-    INSTANTIATE_TEST_CASE_P(DISABLED_LY92748, LY92748Fixture,
+    INSTANTIATE_TEST_CASE_P(CanDeleteAnimGraphNode_AnimGraphModelUpdates, CanDeleteAnimGraphNode,
         ::testing::Values(std::vector<std::string> {
             R"str(CreateAnimGraph)str",
             R"str(Select -animGraphID 0)str",

--- a/Gems/EMotionFX/Code/Tests/UI/CanRenameParameter_ParameterNodeUpdates.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanRenameParameter_ParameterNodeUpdates.cpp
@@ -14,7 +14,7 @@
 
 namespace EMotionFX
 {
-    INSTANTIATE_TEST_CASE_P(LY92269, CommandRunnerFixture,
+    INSTANTIATE_TEST_CASE_P(CanRenameParameter_ParameterNodeUpdates, CommandRunnerFixture,
         ::testing::Values(std::vector<std::string> {
             R"str(CreateAnimGraph)str",
             R"str(AnimGraphCreateNode -animGraphID 0 -type {A8B5BB1E-5BA9-4B0A-88E9-21BB7A199ED2} -parentName Root -xPos 240 -yPos 230 -name GENERATE -namePrefix BlendTree)str",

--- a/Gems/EMotionFX/Code/emotionfx_editor_tests_files.cmake
+++ b/Gems/EMotionFX/Code/emotionfx_editor_tests_files.cmake
@@ -54,15 +54,15 @@ set(FILES
     Tests/UI/AnimGraphUIFixture.h
     Tests/UI/MenuUIFixture.cpp
     Tests/UI/MenuUIFixture.h
-    Tests/UI/LY-92269.cpp
-    Tests/UI/LY-92748.cpp
-    Tests/UI/LY-93621.cpp
+    Tests/UI/CanRenameParameter_ParameterNodeUpdates.cpp
+    Tests/UI/CanDeleteAnimGraphNode_AnimGraphModelUpdates.cpp
+    Tests/UI/CanAdjustGroupParameter.cpp
     Tests/UI/CanAddJointAndChildren.cpp
     Tests/Integration/CanAddActor.cpp
     Tests/Integration/CanAddSimpleMotionComponent.cpp
     Tests/Integration/CanDeleteJackEntity.cpp
     Tests/Bugs/CanDeleteMotionWhenMotionIsBeingBlended.cpp
-    Tests/Bugs/LY-92860.cpp
+    Tests/Bugs/CanUndoParameterDeletionAndRestoreBlendTreeConnections.cpp
     Tests/D6JointLimitConfiguration.cpp
     Tests/D6JointLimitConfiguration.h
     Tests/Editor/FileManagerTests.cpp


### PR DESCRIPTION
This also enables one such test that was named after an issue tracker
id, that was disabled because of an already resolved issue.