### PR TITLE
Add new API to convert absolute source paths to relative paths.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.cpp
@@ -309,30 +309,30 @@ namespace AzFramework
         }
 
         //---------------------------------------------------------------------
-        GetRelativeSourcePathFromFullSourcePathRequest::GetRelativeSourcePathFromFullSourcePathRequest(const AZ::OSString& sourcePath)
+        GenerateRelativeSourcePathRequest::GenerateRelativeSourcePathRequest(const AZ::OSString& sourcePath)
         {
-            AZ_Assert(!sourcePath.empty(), "GetRelativeSourcePathFromFullSourcePathRequest: asset path is empty");
+            AZ_Assert(!sourcePath.empty(), "GenerateRelativeSourcePathRequest: asset path is empty");
             m_sourcePath = sourcePath;
         }
 
-        unsigned int GetRelativeSourcePathFromFullSourcePathRequest::GetMessageType() const
+        unsigned int GenerateRelativeSourcePathRequest::GetMessageType() const
         {
             return MessageType;
         }
 
-        void GetRelativeSourcePathFromFullSourcePathRequest::Reflect(AZ::ReflectContext* context)
+        void GenerateRelativeSourcePathRequest::Reflect(AZ::ReflectContext* context)
         {
             auto serialize = azrtti_cast<AZ::SerializeContext*>(context);
             if (serialize)
             {
-                serialize->Class<GetRelativeSourcePathFromFullSourcePathRequest, BaseAssetProcessorMessage>()
+                serialize->Class<GenerateRelativeSourcePathRequest, BaseAssetProcessorMessage>()
                     ->Version(1)
-                    ->Field("SourcePath", &GetRelativeSourcePathFromFullSourcePathRequest::m_sourcePath);
+                    ->Field("SourcePath", &GenerateRelativeSourcePathRequest::m_sourcePath);
             }
         }
 
         //---------------------------------------------------------------------
-        GetRelativeSourcePathFromFullSourcePathResponse::GetRelativeSourcePathFromFullSourcePathResponse(
+        GenerateRelativeSourcePathResponse::GenerateRelativeSourcePathResponse(
             bool resolved, const AZ::OSString& relativeSourcePath, const AZ::OSString& rootFolder)
         {
             m_relativeSourcePath = relativeSourcePath;
@@ -340,21 +340,21 @@ namespace AzFramework
             m_rootFolder = rootFolder;
         }
 
-        unsigned int GetRelativeSourcePathFromFullSourcePathResponse::GetMessageType() const
+        unsigned int GenerateRelativeSourcePathResponse::GetMessageType() const
         {
-            return GetRelativeSourcePathFromFullSourcePathRequest::MessageType;
+            return GenerateRelativeSourcePathRequest::MessageType;
         }
 
-        void GetRelativeSourcePathFromFullSourcePathResponse::Reflect(AZ::ReflectContext* context)
+        void GenerateRelativeSourcePathResponse::Reflect(AZ::ReflectContext* context)
         {
             auto serialize = azrtti_cast<AZ::SerializeContext*>(context);
             if (serialize)
             {
-                serialize->Class<GetRelativeSourcePathFromFullSourcePathResponse, BaseAssetProcessorMessage>()
+                serialize->Class<GenerateRelativeSourcePathResponse, BaseAssetProcessorMessage>()
                     ->Version(1)
-                    ->Field("RelativeSourcePath", &GetRelativeSourcePathFromFullSourcePathResponse::m_relativeSourcePath)
-                    ->Field("RootFolder", &GetRelativeSourcePathFromFullSourcePathResponse::m_rootFolder)
-                    ->Field("Resolved", &GetRelativeSourcePathFromFullSourcePathResponse::m_resolved);
+                    ->Field("RelativeSourcePath", &GenerateRelativeSourcePathResponse::m_relativeSourcePath)
+                    ->Field("RootFolder", &GenerateRelativeSourcePathResponse::m_rootFolder)
+                    ->Field("Resolved", &GenerateRelativeSourcePathResponse::m_resolved);
             }
         }
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
@@ -289,33 +289,36 @@ namespace AzFramework
         };
 
         //////////////////////////////////////////////////////////////////////////
-        class GetRelativeSourcePathFromFullSourcePathRequest : public BaseAssetProcessorMessage
+        class GenerateRelativeSourcePathRequest : public BaseAssetProcessorMessage
         {
         public:
-            AZ_CLASS_ALLOCATOR(GetRelativeSourcePathFromFullSourcePathRequest, AZ::OSAllocator, 0);
-            AZ_RTTI(GetRelativeSourcePathFromFullSourcePathRequest, "{B3865033-F5A3-4749-8147-7B1AB04D5F6D}",
+            AZ_CLASS_ALLOCATOR(GenerateRelativeSourcePathRequest, AZ::OSAllocator, 0);
+            AZ_RTTI(GenerateRelativeSourcePathRequest, "{B3865033-F5A3-4749-8147-7B1AB04D5F6D}",
                 BaseAssetProcessorMessage);
             static void Reflect(AZ::ReflectContext* context);
-            static constexpr unsigned int MessageType =
-                AZ_CRC_CE("AssetSystem::GetRelativeSourcePathFromFullSourcePathRequest");
 
-            GetRelativeSourcePathFromFullSourcePathRequest() = default;
-            GetRelativeSourcePathFromFullSourcePathRequest(const AZ::OSString& sourcePath);
+            // For people that are debugging the network messages and just see MessageType as a value,
+            // the CRC value below is 739777771 (0x2C181CEB)
+            static constexpr unsigned int MessageType =
+                AZ_CRC_CE("AssetSystem::GenerateRelativeSourcePathRequest");
+
+            GenerateRelativeSourcePathRequest() = default;
+            GenerateRelativeSourcePathRequest(const AZ::OSString& sourcePath);
             unsigned int GetMessageType() const override;
 
             AZ::OSString m_sourcePath;
         };
 
-        class GetRelativeSourcePathFromFullSourcePathResponse : public BaseAssetProcessorMessage
+        class GenerateRelativeSourcePathResponse : public BaseAssetProcessorMessage
         {
         public:
-            AZ_CLASS_ALLOCATOR(GetRelativeSourcePathFromFullSourcePathResponse, AZ::OSAllocator, 0);
-            AZ_RTTI(GetRelativeSourcePathFromFullSourcePathResponse, "{938D33DB-C8F6-4FA4-BC81-2F139A9BE1D7}",
+            AZ_CLASS_ALLOCATOR(GenerateRelativeSourcePathResponse, AZ::OSAllocator, 0);
+            AZ_RTTI(GenerateRelativeSourcePathResponse, "{938D33DB-C8F6-4FA4-BC81-2F139A9BE1D7}",
                 BaseAssetProcessorMessage);
             static void Reflect(AZ::ReflectContext* context);
 
-            GetRelativeSourcePathFromFullSourcePathResponse() = default;
-            GetRelativeSourcePathFromFullSourcePathResponse(
+            GenerateRelativeSourcePathResponse() = default;
+            GenerateRelativeSourcePathResponse(
                 bool resolved, const AZ::OSString& relativeSourcePath, const AZ::OSString& rootFolder);
             unsigned int GetMessageType() const override;
 

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -202,7 +202,7 @@ namespace AzFramework
             // Requests
             GetUnresolvedDependencyCountsRequest::Reflect(context);
             GetRelativeProductPathFromFullSourceOrProductPathRequest::Reflect(context);
-            GetRelativeSourcePathFromFullSourcePathRequest::Reflect(context);
+            GenerateRelativeSourcePathRequest::Reflect(context);
             GetFullSourcePathFromRelativeProductPathRequest::Reflect(context);
             SourceAssetInfoRequest::Reflect(context);
             AssetInfoRequest::Reflect(context);
@@ -235,7 +235,7 @@ namespace AzFramework
             // Responses
             GetUnresolvedDependencyCountsResponse::Reflect(context);
             GetRelativeProductPathFromFullSourceOrProductPathResponse::Reflect(context);
-            GetRelativeSourcePathFromFullSourcePathResponse::Reflect(context);
+            GenerateRelativeSourcePathResponse::Reflect(context);
             GetFullSourcePathFromRelativeProductPathResponse::Reflect(context);
             SourceAssetInfoResponse::Reflect(context);
             AssetInfoResponse::Reflect(context);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorAssetSystemAPI.h
@@ -64,9 +64,15 @@ namespace AzToolsFramework
             /// asset paths never mention their alias and are relative to the asset cache root
             virtual bool GetRelativeProductPathFromFullSourceOrProductPath(const AZStd::string& fullPath, AZStd::string& relativeProductPath) = 0;
 
-            /// Convert a full source path like "c:\\dev\\gamename\\blah\\test.tga" into a relative source path, like "blah/test.tga".
-            virtual bool GetRelativeSourcePathFromFullSourcePath(
-                const AZStd::string& fullPath, AZStd::string& relativePath, AZStd::string& rootFilePath) = 0;
+            /** Convert a source path like "c:\\dev\\gamename\\blah\\test.tga" into a relative source path, like "blah/test.tga".
+            * If no valid relative path could be created, the input source path will be returned in relativePath.
+            * @param sourcePath partial or full path to a source file.  (The file doesn't need to exist)
+            * @param relativePath the output relative path for the source file, if a valid one could be created
+            * @param rootFilePath the root path that relativePath is relative to
+            * @return true if a valid relative path was created, false if it wasn't
+            */
+            virtual bool GenerateRelativeSourcePath(
+                const AZStd::string& sourcePath, AZStd::string& relativePath, AZStd::string& rootFilePath) = 0;
 
             /// Convert a relative asset path like "blah/test.tga" to a full source path path.
             /// Once the asset processor has finished building, this function is capable of handling even when the extension changes

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSystemComponent.cpp
@@ -265,22 +265,22 @@ namespace AzToolsFramework
             return response.m_resolved;
         }
 
-        bool AssetSystemComponent::GetRelativeSourcePathFromFullSourcePath(
-            const AZStd::string& fullPath, AZStd::string& relativePath, AZStd::string& rootFilePath)
+        bool AssetSystemComponent::GenerateRelativeSourcePath(
+            const AZStd::string& sourcePath, AZStd::string& relativePath, AZStd::string& rootFilePath)
         {
             AzFramework::SocketConnection* engineConnection = AzFramework::SocketConnection::GetInstance();
             if (!engineConnection || !engineConnection->IsConnected())
             {
-                relativePath = fullPath;
+                relativePath = sourcePath;
                 return false;
             }
 
-            AzFramework::AssetSystem::GetRelativeSourcePathFromFullSourcePathRequest request(fullPath);
-            AzFramework::AssetSystem::GetRelativeSourcePathFromFullSourcePathResponse response;
+            AzFramework::AssetSystem::GenerateRelativeSourcePathRequest request(sourcePath);
+            AzFramework::AssetSystem::GenerateRelativeSourcePathResponse response;
             if (!SendRequest(request, response))
             {
-                AZ_Error("Editor", false, "Failed to send GetRelativeSourcePathFromFullSourcePath request for %s", fullPath.c_str());
-                relativePath = fullPath;
+                AZ_Error("Editor", false, "Failed to send GenerateRelativeSourcePath request for %s", sourcePath.c_str());
+                relativePath = sourcePath;
                 return false;
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSystemComponent.h
@@ -63,8 +63,8 @@ namespace AzToolsFramework
             const char* GetAbsoluteDevGameFolderPath() override;
             const char* GetAbsoluteDevRootFolderPath() override;
             bool GetRelativeProductPathFromFullSourceOrProductPath(const AZStd::string& fullPath, AZStd::string& outputPath) override;
-            bool GetRelativeSourcePathFromFullSourcePath(
-                const AZStd::string& fullPath, AZStd::string& outputPath, AZStd::string& watchFolder) override;
+            bool GenerateRelativeSourcePath(
+                const AZStd::string& sourcePath, AZStd::string& outputPath, AZStd::string& watchFolder) override;
             bool GetFullSourcePathFromRelativeProductPath(const AZStd::string& relPath, AZStd::string& fullPath) override;
             bool GetAssetInfoById(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType, const AZStd::string& platformName, AZ::Data::AssetInfo& assetInfo, AZStd::string& rootFilePath) override;
             bool GetSourceInfoBySourcePath(const char* sourcePath, AZ::Data::AssetInfo& assetInfo, AZStd::string& watchFolder) override;

--- a/Code/Framework/AzToolsFramework/Tests/AssetSystemMocks.h
+++ b/Code/Framework/AzToolsFramework/Tests/AssetSystemMocks.h
@@ -25,8 +25,8 @@ namespace UnitTests
         MOCK_METHOD0(GetAbsoluteDevGameFolderPath, const char* ());
         MOCK_METHOD0(GetAbsoluteDevRootFolderPath, const char* ());
         MOCK_METHOD2(GetRelativeProductPathFromFullSourceOrProductPath, bool(const AZStd::string& fullPath, AZStd::string& relativeProductPath));
-        MOCK_METHOD3(GetRelativeSourcePathFromFullSourcePath,
-            bool(const AZStd::string& fullPath, AZStd::string& relativeProductPath, AZStd::string& watchFolder));
+        MOCK_METHOD3(GenerateRelativeSourcePath,
+            bool(const AZStd::string& sourcePath, AZStd::string& relativePath, AZStd::string& watchFolder));
         MOCK_METHOD2(GetFullSourcePathFromRelativeProductPath, bool(const AZStd::string& relPath, AZStd::string& fullSourcePath));
         MOCK_METHOD5(GetAssetInfoById, bool(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType, const AZStd::string& platformName, AZ::Data::AssetInfo& assetInfo, AZStd::string& rootFilePath));
         MOCK_METHOD3(GetSourceInfoBySourcePath, bool(const char* sourcePath, AZ::Data::AssetInfo& assetInfo, AZStd::string& watchFolder));

--- a/Code/Framework/AzToolsFramework/Tests/SliceStabilityTests/SliceStabilityTestFramework.h
+++ b/Code/Framework/AzToolsFramework/Tests/SliceStabilityTests/SliceStabilityTestFramework.h
@@ -149,8 +149,8 @@ namespace UnitTest
         const char* GetAbsoluteDevGameFolderPath() override { return ""; }
         const char* GetAbsoluteDevRootFolderPath() override { return ""; }
         bool GetRelativeProductPathFromFullSourceOrProductPath([[maybe_unused]] const AZStd::string& fullPath, [[maybe_unused]] AZStd::string& relativeProductPath) override { return false; }
-        bool GetRelativeSourcePathFromFullSourcePath(
-            [[maybe_unused]] const AZStd::string& fullPath, [[maybe_unused]] AZStd::string& relativeProductPath,
+        bool GenerateRelativeSourcePath(
+            [[maybe_unused]] const AZStd::string& sourcePath, [[maybe_unused]] AZStd::string& relativePath,
             [[maybe_unused]] AZStd::string& watchFolder) override { return false; }
         bool GetFullSourcePathFromRelativeProductPath([[maybe_unused]] const AZStd::string& relPath, [[maybe_unused]] AZStd::string& fullSourcePath) override { return false; }
         bool GetAssetInfoById([[maybe_unused]] const AZ::Data::AssetId& assetId, [[maybe_unused]] const AZ::Data::AssetType& assetType, [[maybe_unused]] const AZStd::string& platformName, [[maybe_unused]] AZ::Data::AssetInfo& assetInfo, [[maybe_unused]] AZStd::string& rootFilePath) override { return false; }

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -655,20 +655,76 @@ namespace AssetProcessor
         return true;
     }
 
-    bool AssetCatalog::GetRelativeSourcePathFromFullSourcePath(
-        const AZStd::string& fullSourcePath, AZStd::string& relativePath, AZStd::string& rootFolder)
+    bool AssetCatalog::GenerateRelativeSourcePath(
+        const AZStd::string& sourcePath, AZStd::string& relativePath, AZStd::string& rootFolder)
     {
-        ProcessGetRelativeSourcePathFromFullSourcePathRequest(fullSourcePath, relativePath, rootFolder);
+        QString normalizedSourcePath = AssetUtilities::NormalizeFilePath(sourcePath.c_str());
+        QDir inputPath(normalizedSourcePath);
+        QString scanFolder;
+        QString relativeName;
 
-        if (relativePath.empty())
+        bool validResult = false;
+
+        AZ_TracePrintf(AssetProcessor::DebugChannel, "ProcessGenerateRelativeSourcePathRequest: %s...\n", sourcePath.c_str());
+
+        if (sourcePath.empty())
+        {
+            // For an empty input path, do nothing, we'll return an empty, invalid result.
+            // (We check fullPath instead of inputPath, because an empty fullPath actually produces "." for inputPath)
+        }
+        else if (inputPath.isAbsolute())
+        {
+            // For an absolute path, try to convert it to a relative path, based on the existing scan folders.
+            // To get the inputPath, we use absolutePath() instead of path() so that any . or .. entries get collapsed.
+            validResult = m_platformConfig->ConvertToRelativePath(inputPath.absolutePath(), relativeName, scanFolder);
+        }
+        else if (inputPath.isRelative())
+        {
+            // For a relative path, concatenate it with each scan folder, and see if a valid relative path emerges.
+            int scanFolders = m_platformConfig->GetScanFolderCount();
+            for (int scanIdx = 0; scanIdx < scanFolders; scanIdx++)
+            {
+                auto& scanInfo = m_platformConfig->GetScanFolderAt(scanIdx);
+                QDir possibleRoot(scanInfo.ScanPath());
+                QDir possibleAbsolutePath = possibleRoot.filePath(normalizedSourcePath);
+                // To get the inputPath, we use absolutePath() instead of path() so that any . or .. entries get collapsed.
+                if (m_platformConfig->ConvertToRelativePath(possibleAbsolutePath.absolutePath(), relativeName, scanFolder))
+                {
+                    validResult = true;
+                    break;
+                }
+            }
+        }
+
+        // The input has produced a valid relative path.  However, the path might match multiple nested scan folders,
+        // so look to see if a higher-priority folder has a better match.
+        if (validResult)
+        {
+            QString overridingFile = m_platformConfig->GetOverridingFile(relativeName, scanFolder);
+
+            if (!overridingFile.isEmpty())
+            {
+                overridingFile = AssetUtilities::NormalizeFilePath(overridingFile);
+                validResult = m_platformConfig->ConvertToRelativePath(overridingFile, relativeName, scanFolder);
+            }
+        }
+
+        if (!validResult)
         {
             // if we are here it means we have failed to determine the relativePath, so we will send back the original path
-            AZ_TracePrintf(
-                AssetProcessor::DebugChannel, "GetRelativeSourcePathFromFullSourcePath no result, returning original path: %s...\n",
-                fullSourcePath.c_str());
-            relativePath = fullSourcePath;
+            AZ_TracePrintf(AssetProcessor::DebugChannel,
+                "GenerateRelativeSourcePath found no valid result, returning original path: %s...\n", sourcePath.c_str());
+
+            rootFolder.clear();
+            relativePath.clear();
+            relativePath = sourcePath;
             return false;
         }
+
+        relativePath = relativeName.toUtf8().data();
+        rootFolder = scanFolder.toUtf8().data();
+
+        AZ_Assert(!relativePath.empty(), "ConvertToRelativePath returned true, but relativePath is empty");
 
         return true;
     }
@@ -1235,73 +1291,6 @@ namespace AssetProcessor
         }
 
         relativeProductPath = productFileName.toUtf8().data();
-    }
-
-    void AssetCatalog::ProcessGetRelativeSourcePathFromFullSourcePathRequest(
-        const AZStd::string& fullPath, AZStd::string& relativePath, AZStd::string& watchFolder)
-    {
-        QString normalizedSourcePath = AssetUtilities::NormalizeFilePath(fullPath.c_str());
-        QDir inputPath(normalizedSourcePath);
-        QString scanFolder;
-        QString relativeName;
-
-        bool validResult = false;
-
-        AZ_TracePrintf(AssetProcessor::DebugChannel, "ProcessGetRelativeSourcePathFromFullSourcePathRequest: %s...\n", fullPath.c_str());
-
-        if (fullPath.empty())
-        {
-            // For an empty input path, do nothing, we'll return an empty, invalid result.
-            // (We check fullPath instead of inputPath, because an empty fullPath actually produces "." for inputPath)
-        }
-        else if (inputPath.isAbsolute())
-        {
-            // For an absolute path, try to convert it to a relative path, based on the existing scan folders.
-            // To get the inputPath, we use absolutePath() instead of path() so that any . or .. entries get collapsed.
-            validResult = m_platformConfig->ConvertToRelativePath(inputPath.absolutePath(), relativeName, scanFolder);
-        }
-        else if (inputPath.isRelative())
-        {
-            // For a relative path, concatenate it with each scan folder, and see if a valid relative path emerges.
-            int scanFolders = m_platformConfig->GetScanFolderCount();
-            for (int scanIdx = 0; scanIdx < scanFolders; scanIdx++)
-            {
-                auto& scanInfo = m_platformConfig->GetScanFolderAt(scanIdx);
-                QDir possibleRoot(scanInfo.ScanPath());
-                QDir possibleAbsolutePath = possibleRoot.filePath(normalizedSourcePath);
-                // To get the inputPath, we use absolutePath() instead of path() so that any . or .. entries get collapsed.
-                if (m_platformConfig->ConvertToRelativePath(possibleAbsolutePath.absolutePath(), relativeName, scanFolder))
-                {
-                    validResult = true;
-                    break;
-                }
-            }
-        }
-
-        // The input has produced a valid relative path.  However, the path might match multiple nested scan folders,
-        // so look to see if a higher-priority folder has a better match.
-        if (validResult)
-        {
-            QString overridingFile = m_platformConfig->GetOverridingFile(relativeName, scanFolder);
-
-            if (!overridingFile.isEmpty())
-            {
-                overridingFile = AssetUtilities::NormalizeFilePath(overridingFile);
-                validResult = m_platformConfig->ConvertToRelativePath(overridingFile, relativeName, scanFolder);
-            }
-        }
-
-        if (validResult)
-        {
-            relativePath = relativeName.toUtf8().data();
-            watchFolder = scanFolder.toUtf8().data();
-        }
-        else
-        {
-            watchFolder.clear();
-            relativePath.clear();
-        }
-
     }
 
     void AssetCatalog::ProcessGetFullSourcePathFromRelativeProductPathRequest(const AZStd::string& relPath, AZStd::string& fullSourcePath)

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.h
@@ -95,8 +95,12 @@ namespace AssetProcessor
         const char* GetAbsoluteDevGameFolderPath() override;
         const char* GetAbsoluteDevRootFolderPath() override;
         bool GetRelativeProductPathFromFullSourceOrProductPath(const AZStd::string& fullPath, AZStd::string& relativeProductPath) override;
-        bool GetRelativeSourcePathFromFullSourcePath(
-            const AZStd::string& fullPath, AZStd::string& relativePath, AZStd::string& watchFolder) override;
+
+        //! Given a partial or full source file path, respond with its relative path and the watch folder it is relative to.
+        //! The input source path does not need to exist, so this can be used for new files that haven't been saved yet.
+        bool GenerateRelativeSourcePath(
+            const AZStd::string& sourcePath, AZStd::string& relativePath, AZStd::string& watchFolder) override;
+
         bool GetFullSourcePathFromRelativeProductPath(const AZStd::string& relPath, AZStd::string& fullSourcePath) override;
         bool GetAssetInfoById(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType, const AZStd::string& platformName, AZ::Data::AssetInfo& assetInfo, AZStd::string& rootFilePath) override;
         bool GetSourceInfoBySourcePath(const char* sourcePath, AZ::Data::AssetInfo& assetInfo, AZStd::string& watchFolder) override;
@@ -130,11 +134,6 @@ namespace AssetProcessor
         //! string like 'textures/blah.tif' (we don't care about extensions), but eventually, this will
         //! be an actual asset UUID.
         void ProcessGetRelativeProductPathFromFullSourceOrProductPathRequest(const AZStd::string& fullPath, AZStd::string& relativeProductPath);
-
-        //! given a source file's absolute path, respond with its relative path.  For now, this will be a string like
-        //! 'textures/blah.tif' (we don't care about extensions), but eventually, this will be an actual asset UUID.
-        void ProcessGetRelativeSourcePathFromFullSourcePathRequest(
-            const AZStd::string& fullPath, AZStd::string& relativePath, AZStd::string& watchFolder);
 
         //! This function helps in determining the full product path of an relative product path.
         //! In the future we will be sending an asset UUID to this function to request for full path.

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -104,15 +104,15 @@ namespace
         return GetRelativeProductPathFromFullSourceOrProductPathResponse(relPathFound, relProductPath);
     }
 
-    GetRelativeSourcePathFromFullSourcePathResponse HandleGetRelativeSourcePathFromFullSourcePathRequest(
-        MessageData<GetRelativeSourcePathFromFullSourcePathRequest> messageData)
+    GenerateRelativeSourcePathResponse HandleGenerateRelativeSourcePathRequest(
+        MessageData<GenerateRelativeSourcePathRequest> messageData)
     {
         bool relPathFound = false;
         AZStd::string relPath;
         AZStd::string watchFolder;
 
         AzToolsFramework::AssetSystemRequestBus::BroadcastResult(
-            relPathFound, &AzToolsFramework::AssetSystemRequestBus::Events::GetRelativeSourcePathFromFullSourcePath,
+            relPathFound, &AzToolsFramework::AssetSystemRequestBus::Events::GenerateRelativeSourcePath,
             messageData.m_message->m_sourcePath, relPath, watchFolder);
 
         if (!relPathFound)
@@ -122,7 +122,7 @@ namespace
                 messageData.m_message->m_sourcePath.c_str());
         }
 
-        return GetRelativeSourcePathFromFullSourcePathResponse(relPathFound, relPath, watchFolder);
+        return GenerateRelativeSourcePathResponse(relPathFound, relPath, watchFolder);
     }
 
     SourceAssetInfoResponse HandleSourceAssetInfoRequest(MessageData<SourceAssetInfoRequest> messageData)
@@ -428,7 +428,7 @@ AssetRequestHandler::AssetRequestHandler()
 
     m_requestRouter.RegisterMessageHandler(&HandleGetFullSourcePathFromRelativeProductPathRequest);
     m_requestRouter.RegisterMessageHandler(&HandleGetRelativeProductPathFromFullSourceOrProductPathRequest);
-    m_requestRouter.RegisterMessageHandler(&HandleGetRelativeSourcePathFromFullSourcePathRequest);
+    m_requestRouter.RegisterMessageHandler(&HandleGenerateRelativeSourcePathRequest);
     m_requestRouter.RegisterMessageHandler(&HandleSourceAssetInfoRequest);
     m_requestRouter.RegisterMessageHandler(&HandleSourceAssetProductsInfoRequest);
     m_requestRouter.RegisterMessageHandler(&HandleGetScanFoldersRequest);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -57,8 +57,8 @@ namespace AzFramework
         class GetRelativeProductPathFromFullSourceOrProductPathRequest;
         class GetRelativeProductPathFromFullSourceOrProductPathResponse;
 
-        class GetRelativeSourcePathFromFullSourcePathRequest;
-        class GetRelativeSourcePathFromFullSourcePathResponse;
+        class GenerateRelativeSourcePathRequest;
+        class GenerateRelativeSourcePathResponse;
 
         class GetFullSourcePathFromRelativeProductPathRequest;
         class GetFullSourcePathFromRelativeProductPathResponse;
@@ -107,8 +107,8 @@ namespace AssetProcessor
         using GetAbsoluteAssetDatabaseLocationResponse = AzToolsFramework::AssetSystem::GetAbsoluteAssetDatabaseLocationResponse;
         using GetRelativeProductPathFromFullSourceOrProductPathRequest = AzFramework::AssetSystem::GetRelativeProductPathFromFullSourceOrProductPathRequest;
         using GetRelativeProductPathFromFullSourceOrProductPathResponse = AzFramework::AssetSystem::GetRelativeProductPathFromFullSourceOrProductPathResponse;
-        using GetRelativeSourcePathFromFullSourcePathRequest = AzFramework::AssetSystem::GetRelativeSourcePathFromFullSourcePathRequest;
-        using GetRelativeSourcePathFromFullSourcePathResponse = AzFramework::AssetSystem::GetRelativeSourcePathFromFullSourcePathResponse;
+        using GenerateRelativeSourcePathRequest = AzFramework::AssetSystem::GenerateRelativeSourcePathRequest;
+        using GenerateRelativeSourcePathResponse = AzFramework::AssetSystem::GenerateRelativeSourcePathResponse;
         using GetFullSourcePathFromRelativeProductPathRequest = AzFramework::AssetSystem::GetFullSourcePathFromRelativeProductPathRequest;
         using GetFullSourcePathFromRelativeProductPathResponse = AzFramework::AssetSystem::GetFullSourcePathFromRelativeProductPathResponse;
 

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -266,8 +266,8 @@ namespace AssetProcessorMessagesTests
         addPairFunc(new GetFullSourcePathFromRelativeProductPathRequest(), new GetFullSourcePathFromRelativeProductPathResponse());
         addPairFunc(new GetRelativeProductPathFromFullSourceOrProductPathRequest(), new GetRelativeProductPathFromFullSourceOrProductPathResponse());
         addPairFunc(
-            new GetRelativeSourcePathFromFullSourcePathRequest(),
-            new GetRelativeSourcePathFromFullSourcePathResponse());
+            new GenerateRelativeSourcePathRequest(),
+            new GenerateRelativeSourcePathResponse());
         addPairFunc(new SourceAssetInfoRequest(), new SourceAssetInfoResponse());
         addPairFunc(new SourceAssetProductsInfoRequest(), new SourceAssetProductsInfoResponse());
         addPairFunc(new GetScanFoldersRequest(), new GetScanFoldersResponse());

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.cpp
@@ -51,8 +51,8 @@ namespace AssetProcessor
     public:
         using GetRelativeProductPathFromFullSourceOrProductPathRequest = AzFramework::AssetSystem::GetRelativeProductPathFromFullSourceOrProductPathRequest;
         using GetRelativeProductPathFromFullSourceOrProductPathResponse = AzFramework::AssetSystem::GetRelativeProductPathFromFullSourceOrProductPathResponse;
-        using GetRelativeSourcePathFromFullSourcePathRequest = AzFramework::AssetSystem::GetRelativeSourcePathFromFullSourcePathRequest;
-        using GetRelativeSourcePathFromFullSourcePathResponse = AzFramework::AssetSystem::GetRelativeSourcePathFromFullSourcePathResponse;
+        using GenerateRelativeSourcePathRequest = AzFramework::AssetSystem::GenerateRelativeSourcePathRequest;
+        using GenerateRelativeSourcePathResponse = AzFramework::AssetSystem::GenerateRelativeSourcePathResponse;
         using GetFullSourcePathFromRelativeProductPathRequest = AzFramework::AssetSystem::GetFullSourcePathFromRelativeProductPathRequest;
         using GetFullSourcePathFromRelativeProductPathResponse = AzFramework::AssetSystem::GetFullSourcePathFromRelativeProductPathResponse;
     };

--- a/Gems/Atom/RPI/Code/Tests/Common/AssetSystemStub.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/AssetSystemStub.cpp
@@ -72,8 +72,8 @@ namespace UnitTest
         return false;
     }
 
-    bool AssetSystemStub::GetRelativeSourcePathFromFullSourcePath(
-        [[maybe_unused]] const AZStd::string& fullPath, [[maybe_unused]] AZStd::string& relativePath,
+    bool AssetSystemStub::GenerateRelativeSourcePath(
+        [[maybe_unused]] const AZStd::string& sourcePath, [[maybe_unused]] AZStd::string& relativePath,
         [[maybe_unused]] AZStd::string& watchFolder)
     {
         return false;

--- a/Gems/Atom/RPI/Code/Tests/Common/AssetSystemStub.h
+++ b/Gems/Atom/RPI/Code/Tests/Common/AssetSystemStub.h
@@ -63,8 +63,8 @@ namespace UnitTest
         const char* GetAbsoluteDevGameFolderPath() override;
         const char* GetAbsoluteDevRootFolderPath() override;
         bool GetRelativeProductPathFromFullSourceOrProductPath(const AZStd::string& fullPath, AZStd::string& relativeProductPath) override;
-        bool GetRelativeSourcePathFromFullSourcePath(
-            const AZStd::string& fullPath, AZStd::string& relativePath, AZStd::string& watchFolder) override;
+        bool GenerateRelativeSourcePath(
+            const AZStd::string& sourcePath, AZStd::string& relativePath, AZStd::string& watchFolder) override;
         bool GetFullSourcePathFromRelativeProductPath(const AZStd::string& relPath, AZStd::string& fullSourcePath) override;
         bool GetAssetInfoById(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType& assetType, const AZStd::string& platformName, AZ::Data::AssetInfo& assetInfo, AZStd::string& rootFilePath) override;
         bool GetSourceInfoBySourceUUID(const AZ::Uuid& sourceUuid, AZ::Data::AssetInfo& assetInfo, AZStd::string& watchFolder) override;

--- a/Gems/LmbrCentral/Code/Tests/Builders/CopyDependencyBuilderTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/Builders/CopyDependencyBuilderTest.cpp
@@ -217,8 +217,8 @@ protected:
     const char* GetAbsoluteDevGameFolderPath() override { return ""; }
     const char* GetAbsoluteDevRootFolderPath() override { return ""; }
     bool GetRelativeProductPathFromFullSourceOrProductPath([[maybe_unused]] const AZStd::string& fullPath, [[maybe_unused]] AZStd::string& relativeProductPath) { return true; }
-    bool GetRelativeSourcePathFromFullSourcePath(
-        [[maybe_unused]] const AZStd::string& fullPath, [[maybe_unused]] AZStd::string& relativePath,
+    bool GenerateRelativeSourcePath(
+        [[maybe_unused]] const AZStd::string& sourcePath, [[maybe_unused]] AZStd::string& relativePath,
         [[maybe_unused]] AZStd::string& watchFolder) { return true; }
     bool GetFullSourcePathFromRelativeProductPath([[maybe_unused]] const AZStd::string& relPath, [[maybe_unused]] AZStd::string& fullSourcePath) { return true; }
     bool GetAssetInfoById([[maybe_unused]] const AZ::Data::AssetId& assetId, [[maybe_unused]] const AZ::Data::AssetType& assetType, [[maybe_unused]] const AZStd::string& platformName, [[maybe_unused]] AZ::Data::AssetInfo& assetInfo, [[maybe_unused]] AZStd::string& rootFilePath) { return true; }


### PR DESCRIPTION
There are already APIs for getting a relative product path from an absolute source path, or getting a relative source path for an *existing* source file, but there were no APIs for getting a relative source path for a *new* source file.  Prefabs will need this ability to be able to correctly generate a relative source path inside the prefab file before the file has been saved.

The logic for relative source paths is a little bit tricky because the paths are relative to the watch folders, and the watch folders can be nested, with different priorities to explain which should take precedence.  The input paths can also include specifiers like "." and "..", which need to be reconciled before creating the final correct relative path.  The included unit tests test all of the tricky edge cases that I was able to identify.