### PR TITLE
Replace Cry renderer call to get viewport height

### DIFF
--- a/Gems/LyShine/Code/Source/UiTextInputComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiTextInputComponent.cpp
@@ -1450,13 +1450,17 @@ void UiTextInputComponent::CheckStartTextInput()
         EBUS_EVENT_ID_RESULT(textString, m_textEntity, UiTextBus, GetText);
         options.m_initialText = Utf8SubString(textString, m_textCursorPos, m_textSelectionStartPos);
 
+        AZ::EntityId canvasEntityId;
+        EBUS_EVENT_ID_RESULT(canvasEntityId, GetEntityId(), UiElementBus, GetCanvasEntityId);
+
+        // Calculate height available for virtual keyboard. In game mode, canvas size is the same as viewport size
+        AZ::Vector2 canvasSize;
+        EBUS_EVENT_ID_RESULT(canvasSize, canvasEntityId, UiCanvasBus, GetCanvasSize);
         UiTransformInterface::RectPoints rectPoints;
         EBUS_EVENT_ID(GetEntityId(), UiTransformBus, GetViewportSpacePoints, rectPoints);
         const AZ::Vector2 bottomRight = rectPoints.GetAxisAlignedBottomRight();
-        options.m_normalizedMinY = bottomRight.GetY() / static_cast<float>(gEnv->pRenderer->GetHeight());
+        options.m_normalizedMinY = (canvasSize.GetY() > 0.0f) ? bottomRight.GetY() / canvasSize.GetY() : 0.0f;
 
-        AZ::EntityId canvasEntityId;
-        EBUS_EVENT_ID_RESULT(canvasEntityId, GetEntityId(), UiElementBus, GetCanvasEntityId);
         EBUS_EVENT_ID_RESULT(options.m_localUserId, canvasEntityId, UiCanvasBus, GetLocalUserIdInputFilter);
 
         AzFramework::InputTextEntryRequestBus::Broadcast(&AzFramework::InputTextEntryRequests::TextEntryStart, options);


### PR DESCRIPTION
This fixes a crash in game mode when entering text in the UiTextInputComponent.