### PR TITLE
[SPEC-7010] Windows release_vs2019 build fails with an unreferenced f…

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
@@ -886,7 +886,7 @@ namespace AZ
             }
 
             RHI::Ptr<RHI::PipelineLayoutDescriptor> BuildPipelineLayoutDescriptorForApi(
-                const char* builderName, const RPI::ShaderResourceGroupLayoutList& srgLayoutList, const MapOfStringToStageType& shaderEntryPoints,
+                [[maybe_unused]] const char* builderName, const RPI::ShaderResourceGroupLayoutList& srgLayoutList, const MapOfStringToStageType& shaderEntryPoints,
                 const RHI::ShaderCompilerArguments& shaderCompilerArguments, const RootConstantData& rootConstantData,
                 RHI::ShaderPlatformInterface* shaderPlatformInterface, BindingDependencies& bindingDependencies /*inout*/)
             {


### PR DESCRIPTION
[SPEC-7010] Windows release_vs2019 build fails with an unreferenced formal parameter

in ShaderBuilderUtility.cpp

Added [[maybe_unused]] to a parameter that was not used under all
conditions.