### PR TITLE
Remove Jenkins failure notifications

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -577,6 +577,15 @@ finally {
                 message:"${currentBuild.currentResult}:${BUILD_URL}:${env.RECREATE_VOLUME}:${env.CLEAN_OUTPUT_DIRECTORY}:${env.CLEAN_ASSETS}"
             )
         }
+        node('controller') {
+            step([
+                $class: 'Mailer',
+                notifyEveryUnstableBuild: true,
+                recipients: emailextrecipients([
+                    [$class: 'RequesterRecipientProvider']
+                ])
+            ])
+        }
     } catch(Exception e) {
     }
 }


### PR DESCRIPTION
Now that failure notifications are sent through MARS we can probably
remove sending them through Jenkins also.

One argument for keeping them is that this will work on all branches,
not just main and release branches.

An argument against keeping them is that they duplicate the information
sent in the MARS notifications so people may start ignoring them. The
MARS notifications offer a better workflow (acknowledgements) and will
ensure that emails are not sent to external contributors. Moreover, the
MARS notifications are also sent to a mailing list by default, so that
people who hide their email addresses in Git can still receive them.