### PR TITLE
[SPEC-7039] Fix for mac build

### DIFF
--- a/Code/Tools/SerializeContextTools/SliceConverter.h
+++ b/Code/Tools/SerializeContextTools/SliceConverter.h
@@ -52,7 +52,7 @@ namespace AZ
             static bool ConvertNestedSlices(
                 SliceComponent* sliceComponent, AzToolsFramework::Prefab::Instance* sourceInstance,
                 AZ::SerializeContext* serializeContext, bool isDryRun);
-            static bool SliceConverter::ConvertSliceInstance(
+            static bool ConvertSliceInstance(
                 AZ::SliceComponent::SliceInstance& instance, AZ::Data::Asset<AZ::SliceAsset>& sliceAsset,
                 AzToolsFramework::Prefab::TemplateReference nestedTemplate, AzToolsFramework::Prefab::Instance* topLevelInstance);
             static void PrintPrefab(AzToolsFramework::Prefab::TemplateId templateId);


### PR DESCRIPTION
Fix for the following error:
/workspace/o3de/Code/Tools/SerializeContextTools/SliceConverter.h:55:41: error: extra qualification on member 'ConvertSliceInstance'
static bool SliceConverter::ConvertSliceInstance(
~~~~~~~~~~~~~~~~^
1 error generated.