### PR TITLE
update usages of transform vector scale

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalFeatureProcessor.cpp
@@ -279,7 +279,7 @@ namespace AZ
             if (handle.IsValid())
             {
                 Quaternion orientation = world.GetRotation();
-                Vector3 scale = world.GetScale() * nonUniformScale;
+                Vector3 scale = world.GetUniformScale() * nonUniformScale;
 
                 SetDecalHalfSize(handle, scale);
                 SetDecalPosition(handle, world.GetTranslation());

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -285,7 +285,7 @@ namespace AZ
         {
             if (handle.IsValid())
             {
-                SetDecalHalfSize(handle, nonUniformScale * world.GetScale());
+                SetDecalHalfSize(handle, nonUniformScale * world.GetUniformScale());
                 SetDecalPosition(handle, world.GetTranslation());
                 SetDecalOrientation(handle, world.GetRotation());
 

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -209,7 +209,7 @@ namespace AZ
         void ReflectionProbe::SetTransform(const AZ::Transform& transform)
         {
             // retrieve previous scale and revert the scale on the inner/outer extents
-            AZ::Vector3 previousScale = m_transform.GetScale();
+            float previousScale = m_transform.GetUniformScale();
             m_outerExtents /= previousScale;
             m_innerExtents /= previousScale;
 
@@ -218,12 +218,12 @@ namespace AZ
 
             // avoid scaling the visualization sphere
             AZ::Transform visualizationTransform = m_transform;
-            visualizationTransform.ExtractScale();
+            visualizationTransform.ExtractUniformScale();
             m_meshFeatureProcessor->SetTransform(m_visualizationMeshHandle, visualizationTransform);
 
             // update the inner/outer extents with the new scale
-            m_outerExtents *= m_transform.GetScale();
-            m_innerExtents *= m_transform.GetScale();
+            m_outerExtents *= m_transform.GetUniformScale();
+            m_innerExtents *= m_transform.GetUniformScale();
 
             m_outerAabbWs = Aabb::CreateCenterHalfExtents(m_transform.GetTranslation(), m_outerExtents / 2.0f);
             m_innerAabbWs = Aabb::CreateCenterHalfExtents(m_transform.GetTranslation(), m_innerExtents / 2.0f);
@@ -232,14 +232,14 @@ namespace AZ
 
         void ReflectionProbe::SetOuterExtents(const AZ::Vector3& outerExtents)
         {
-            m_outerExtents = outerExtents * m_transform.GetScale();
+            m_outerExtents = outerExtents * m_transform.GetUniformScale();
             m_outerAabbWs = Aabb::CreateCenterHalfExtents(m_transform.GetTranslation(), m_outerExtents / 2.0f);
             m_updateSrg = true;
         }
 
         void ReflectionProbe::SetInnerExtents(const AZ::Vector3& innerExtents)
         {
-            m_innerExtents = innerExtents * m_transform.GetScale();
+            m_innerExtents = innerExtents * m_transform.GetUniformScale();
             m_innerAabbWs = Aabb::CreateCenterHalfExtents(m_transform.GetTranslation(), m_innerExtents / 2.0f);
             m_updateSrg = true;
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/EditorAttachmentComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/EditorAttachmentComponent.cpp
@@ -21,18 +21,42 @@ namespace AZ
 {
     namespace Render
     {
+        bool EditorAttachmentComponentVersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)
+        {
+            if (classElement.GetVersion() < 2)
+            {
+                float uniformScaleOffset = 1.0f;
+
+                int scaleElementIndex = classElement.FindElement(AZ_CRC_CE("Scale Offset"));
+                if (scaleElementIndex != -1)
+                {
+                    AZ::Vector3 oldScaleValue = AZ::Vector3::CreateOne();
+                    AZ::SerializeContext::DataElementNode& dataElementNode = classElement.GetSubElement(scaleElementIndex);
+                    if (dataElementNode.GetData<AZ::Vector3>(oldScaleValue))
+                    {
+                        uniformScaleOffset = oldScaleValue.GetMaxElement();
+                    }
+                    classElement.RemoveElement(scaleElementIndex);
+                }
+
+                classElement.AddElementWithData(context, "Uniform Scale Offset", uniformScaleOffset);
+            }
+
+            return true;
+        }
+
         void EditorAttachmentComponent::Reflect(AZ::ReflectContext* context)
         {
             AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
             if (serializeContext)
             {
                 serializeContext->Class<EditorAttachmentComponent, EditorComponentBase>()
-                    ->Version(1)
+                    ->Version(2, &EditorAttachmentComponentVersionConverter)
                     ->Field("Target ID", &EditorAttachmentComponent::m_targetId)
                     ->Field("Target Bone Name", &EditorAttachmentComponent::m_targetBoneName)
                     ->Field("Position Offset", &EditorAttachmentComponent::m_positionOffset)
                     ->Field("Rotation Offset", &EditorAttachmentComponent::m_rotationOffset)
-                    ->Field("Scale Offset", &EditorAttachmentComponent::m_scaleOffset)
+                    ->Field("Uniform Scale Offset", &EditorAttachmentComponent::m_uniformScaleOffset)
                     ->Field("Attached Initially", &EditorAttachmentComponent::m_attachedInitially)
                     ->Field("Scale Source", &EditorAttachmentComponent::m_scaleSource);
 
@@ -70,7 +94,7 @@ namespace AZ
                         ->Attribute(AZ::Edit::Attributes::Min, -AZ::RadToDeg(AZ::Constants::TwoPi))
                         ->Attribute(AZ::Edit::Attributes::Max, AZ::RadToDeg(AZ::Constants::TwoPi))
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorAttachmentComponent::OnTargetOffsetChanged)
-                        ->DataElement(0, &EditorAttachmentComponent::m_scaleOffset, "Scale offset", "Local scale offset from target entity")
+                        ->DataElement(0, &EditorAttachmentComponent::m_uniformScaleOffset, "Scale offset", "Local scale offset from target entity")
                         ->Attribute(AZ::Edit::Attributes::Step, 0.1f)
                         ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &EditorAttachmentComponent::OnTargetOffsetChanged)
@@ -128,7 +152,7 @@ namespace AZ
         {
             AZ::Transform offset = AZ::ConvertEulerDegreesToTransform(m_rotationOffset);
             offset.SetTranslation(m_positionOffset);
-            offset.MultiplyByScale(m_scaleOffset);
+            offset.MultiplyByUniformScale(m_uniformScaleOffset);
             return offset;
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/EditorAttachmentComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/EditorAttachmentComponent.h
@@ -88,7 +88,7 @@ namespace AZ
             AZ::Vector3 m_rotationOffset = AZ::Vector3::CreateZero();
 
             //! Offset from target entity's scale.
-            AZ::Vector3 m_scaleOffset = AZ::Vector3::CreateOne();
+            float m_uniformScaleOffset = 1.0f;
 
             //! Observe scale information from the specified source.       
             AttachmentConfiguration::ScaleSource m_scaleSource = AttachmentConfiguration::ScaleSource::WorldScale;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/QuadLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/QuadLightDelegate.cpp
@@ -76,12 +76,12 @@ namespace AZ
 
         float QuadLightDelegate::GetWidth() const
         {
-            return m_shapeBus->GetQuadWidth() * GetTransform().GetScale().GetX();
+            return m_shapeBus->GetQuadWidth() * GetTransform().GetUniformScale();
         }
 
         float QuadLightDelegate::GetHeight() const
         {
-            return m_shapeBus->GetQuadHeight() * GetTransform().GetScale().GetY();
+            return m_shapeBus->GetQuadHeight() * GetTransform().GetUniformScale();
         }
 
     } // namespace Render


### PR DESCRIPTION
Changes attachment component to use uniform scale rather than non-uniform scale. This is not ideal but is required for removing vector scale from AZ::Transform. Currently the only thing using attachments is animation, and while non-uniform scale was supported in EMFX when it was a standalone product, it has never worked in the integration. So this will need to be revisited if we want to more fully support non-uniform scale in EMFX, but I don't see a better approach in the short term for supporting the necessary changes to AZ::Transform.

Also updates some other instances in Atom gems which used vector scale functions on Transform.