### PR TITLE
Adding ProjectManager as a runtime dependency

### DIFF
--- a/Code/Sandbox/Editor/CMakeLists.txt
+++ b/Code/Sandbox/Editor/CMakeLists.txt
@@ -173,6 +173,7 @@ ly_add_target(
     RUNTIME_DEPENDENCIES
         Legacy::CrySystem
         Legacy::EditorLib
+        ProjectManager
 )
 ly_add_translations(
     TARGETS Editor


### PR DESCRIPTION
The project manager is needed by the editor if it does not know what project to use

**Testing**

Deleted o3de.exe and compiled editor without any bootstrap project_path.  Verified o3de.exe was built, launched by the editor and I was able to launch the editor from the ProjectManager.