### PR TITLE
Don't give a broken copy constructor to BehaviorContextObject.

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/BehaviorContextObject.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/BehaviorContextObject.h
@@ -120,7 +120,7 @@ namespace ScriptCanvas
         AZ_FORCE_INLINE BehaviorContextObject() = default;
 
         BehaviorContextObject& operator=(const BehaviorContextObject&) = delete;
-        BehaviorContextObject(const BehaviorContextObject&) = default;
+        BehaviorContextObject(const BehaviorContextObject&) = delete;
 
         // copy ctor
         AZ_FORCE_INLINE BehaviorContextObject(const void* source, const AnyTypeInfo& typeInfo, AZ::u32 flags);


### PR DESCRIPTION
This used to be required by the serialization system, now it handles non-copyable and non-moveable types.