### PR TITLE
[ATOM-15600] Fix cpu over-usage when loading shader variant assets.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariantAsyncLoader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariantAsyncLoader.cpp
@@ -150,10 +150,7 @@ namespace AZ
                     }
                 }
 
-                if (!shaderVariantTreePendingRequests.empty() || !shaderVariantPendingRequests.empty())
-                {
-                    AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1000));
-                }
+                AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(1000));
             }
         }
 


### PR DESCRIPTION
This is a temporary fix, in the future ShaderVariantAsyncLoader will use
OnCatalogAssetRemoved()/ OnCatalogAssetAdded().

Signed-off-by: garrieta <garrieta@amazon.com>