### PR TITLE
Fix DefaultProject Template to use Gem::TextureAtlas.Editor

### DIFF
--- a/Templates/DefaultProject/Template/Code/tool_dependencies.cmake
+++ b/Templates/DefaultProject/Template/Code/tool_dependencies.cmake
@@ -12,7 +12,7 @@
 set(GEM_DEPENDENCIES
     Project::${Name}
     Gem::Maestro.Editor
-    Gem::TextureAtlas
+    Gem::TextureAtlas.Editor
     Gem::LmbrCentral.Editor
     Gem::NvCloth.Editor
     Gem::LyShine.Editor


### PR DESCRIPTION
 in tool_dependencies.cmake

This fixes a crash on editor startup. This was already changed in the AutomaticTesting project, but not in the template.

The crash looks something like this:
```
==================================================================
Trace::Error
 D:\dev\open3d\o3de_main\Gems\TextureAtlas\Code\Source\TextureAtlasSystemComponent.h(28): 'class AZ::ComponentDescriptor *__cdecl TextureAtlasNamespace::TextureAtlasSystemComponent::CreateDescriptor(void)'
The same component UUID ({436E8E5A-76CA-458D-8DAD-835C30D8C41B}) / name (TextureAtlasSystemComponent) was registered twice.  This isn't allowed, it can cause lifetime management issues / crashes.
This situation can happen by declaring a component in a header and registering it from two different Gems.

==================================================================

==================================================================
Trace::Warning
 D:/dev/open3d/o3de_main/Code/Framework/AzCore/AzCore/Module/Module.cpp(34): 'void __cdecl AZ::Module::RegisterComponentDescriptors(void)'
Null module descriptor is being skipped ({D3997F41-8117-4E0F-9BFE-937C4AE7E71F})
==================================================================
Exception thrown: read access violation.
**descriptor** was nullptr.
```