### PR TITLE
Fix path not showing up in asset property control

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -936,11 +936,16 @@ namespace AzToolsFramework
             return;
         }
 
-        const AZ::Data::AssetId assetID = GetCurrentAssetID();
-        m_currentAssetHint = "";
-
-        if (!m_unnamedType)
+        const AZStd::string& folderPath = GetFolderSelection();
+        if (!folderPath.empty())
         {
+            m_currentAssetHint = folderPath;
+        }
+        else
+        {
+            const AZ::Data::AssetId assetID = GetCurrentAssetID();
+            m_currentAssetHint = "";
+
             AZ::Outcome<AssetSystem::JobInfoContainer> jobOutcome = AZ::Failure();
             AssetSystemJobRequestBus::BroadcastResult(jobOutcome, &AssetSystemJobRequestBus::Events::GetAssetJobsInfoByAssetID, assetID, false, false);
 
@@ -954,7 +959,7 @@ namespace AzToolsFramework
 
                 if (!jobs.empty())
                 {
-                    // The default behavior is show to the source filename.
+                    // The default behavior is to show the source filename.
                     assetPath = jobs[0].m_sourceFile;
 
                     AZStd::string errorLog;

--- a/Gems/LyShine/Code/Editor/PropertyHandlerDirectory.cpp
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerDirectory.cpp
@@ -158,7 +158,10 @@ bool PropertyHandlerDirectory::ReadValuesIntoGUI(size_t index, PropertyDirectory
 
     ctrl->blockSignals(true);
     {
+        // Set currently selected folder path
+        // Note: this must be done before setting asset type below which updates the GUI display
         ctrl->SetCurrentAssetHint(instance);
+        ctrl->SetFolderSelection(instance);
 
         // We need to set the asset type so the property panel labels get
         // populated properly (via SetCurrentAssetType). To avoid defining
@@ -166,8 +169,6 @@ bool PropertyHandlerDirectory::ReadValuesIntoGUI(size_t index, PropertyDirectory
         // logic to run (otherwise it will early-out due to invalid asset type).
         const char* throwAwayAssetType = "{43EDD212-F589-43C8-BC02-A8F9243271CB}";
         ctrl->SetCurrentAssetType(AZ::Data::AssetType(throwAwayAssetType));
-
-        ctrl->SetFolderSelection(instance);
     }
     ctrl->blockSignals(false);
 


### PR DESCRIPTION
Two issues were fixed:
- Some code still uses the deprecated SimpleAssetReference type asset which is "unnamed" and therefore wasn't hitting the logic to set the selected asset name. Fix was to allow unnamed asset types to go through the asset name logic and update the GUI
- Folder path "asset" selection was not updating the GUI to display the selected folder