### PR TITLE
LYN-4128 EditorPythonBindings.Editor in debug does not load (missing python_d.dll)

### DIFF
--- a/Gems/PythonAssetBuilder/Code/CMakeLists.txt
+++ b/Gems/PythonAssetBuilder/Code/CMakeLists.txt
@@ -13,24 +13,11 @@ if(NOT PAL_TRAIT_BUILD_HOST_TOOLS)
     return()
 endif()
 
-set(static_files pythonassetbuilder_common_files.cmake)
-set(editor_files pythonassetbuilder_editor_files.cmake)
-set(shared_files pythonassetbuilder_shared_files.cmake)
-set(static_dependencies
-        3rdParty::Python
-        Gem::EditorPythonBindings.Static
-        AZ::AssetBuilderSDK
-)
-set(editor_dependencies
-        Gem::EditorPythonBindings.Static
-        AZ::AssetBuilderSDK
-)
-
 ly_add_target(
     NAME PythonAssetBuilder.Static STATIC
     NAMESPACE Gem
     FILES_CMAKE
-        ${static_files}
+        pythonassetbuilder_common_files.cmake
     PLATFORM_INCLUDE_FILES
         Source/Platform/Common/${PAL_TRAIT_COMPILER_ID}/pythonassetbuilder_static_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
@@ -43,7 +30,9 @@ ly_add_target(
         PRIVATE
             AZ::AzCore
         PUBLIC
-            ${static_dependencies}
+            3rdParty::Python
+            Gem::EditorPythonBindings.Static
+            AZ::AssetBuilderSDK
             AZ::AzToolsFramework
 )
 
@@ -52,8 +41,8 @@ ly_add_target(
 
     NAMESPACE Gem
     FILES_CMAKE
-        ${editor_files}
-        ${shared_files}
+        pythonassetbuilder_editor_files.cmake
+        pythonassetbuilder_shared_files.cmake
     PLATFORM_INCLUDE_FILES
         Source/Platform/Common/${PAL_TRAIT_COMPILER_ID}/pythonassetbuilder_static_${PAL_TRAIT_COMPILER_ID_LOWERCASE}.cmake
     INCLUDE_DIRECTORIES
@@ -64,7 +53,8 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PRIVATE
-            ${editor_dependencies}
+            Gem::EditorPythonBindings.Static
+            AZ::AssetBuilderSDK
     RUNTIME_DEPENDENCIES
         Gem::EditorPythonBindings.Editor
 )

--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -105,7 +105,7 @@ function(ly_get_runtime_dependencies ly_RUNTIME_DEPENDENCIES ly_TARGET)
                 set(skip_imported TRUE)
             endif()
         endif()
-        if(target_type MATCHES "(INTERFACE_LIBRARY|STATIC_LIBRARY)")
+        if(target_type MATCHES "(STATIC_LIBRARY)")
             # No need to copy these dependencies since the outputs are not used at runtime
             set(skip_imported TRUE)
         endif()


### PR DESCRIPTION
INTERFACE_LIBRARIES is what is being used in 3rdParty, we added this before we made the targets from the SDK imported