### PR TITLE
[LYN-4157] EMotionFX: Adding/removing colliders to/from ragdoll and saving the actor crashes the Editor

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
@@ -218,6 +218,10 @@ namespace EMStudio
         }
 
         const bool saveResult = manifest.SaveToFile(manifestFilename.c_str());
+        if (saveResult)
+        {
+            actor->SetDirtyFlag(false);
+        }
 
         // Source Control: Add file in case it did not exist before (when saving it the first time).
         if (saveResult && !fileExisted)


### PR DESCRIPTION
The actor dirty flag was set to true even after saving the asset info which resulted in the save dirty files dialog to appear providing the user to save the actor another time, just after saving it which is confusing. This might have led to rendering an already deleted actor and the crash. Though, I was not able to stably reproduce the issue and can't reproduce it anymore after this fix.