### PR TITLE
Fix window handle retrieval in frame capture system.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -16,6 +16,7 @@
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
+#include <Atom/RPI.Public/ViewportContextManager.h>
 
 #include <Atom/Utils/DdsFile.h>
 #include <Atom/Utils/PpmFile.h>
@@ -250,11 +251,7 @@ namespace AZ
 
         bool FrameCaptureSystemComponent::CaptureScreenshot(const AZStd::string& filePath)
         {
-            AzFramework::NativeWindowHandle windowHandle = nullptr;
-            AzFramework::WindowSystemRequestBus::BroadcastResult(
-                windowHandle,
-                &AzFramework::WindowSystemRequestBus::Events::GetDefaultWindowHandle);
-
+            AzFramework::NativeWindowHandle windowHandle = AZ::RPI::ViewportContextRequests::Get()->GetDefaultViewportContext()->GetWindowHandle();
             if (windowHandle)
             {
                 return CaptureScreenshotForWindow(filePath, windowHandle);


### PR DESCRIPTION
Fix for capturing screenshots via hydra. 

Testing:
Open Python Terminal in Editor, then run the following commands
```
import azlmbr.atom
import azlmbr.bus

azlmbr.atom.FrameCaptureRequestBus(azlmbr.bus.Broadcast, "CaptureScreenshot", '@user@/PythonTests/Automated/Screenshots/test.ppm')
```

Screenshot generated:
![image](https://user-images.githubusercontent.com/43485729/120361757-1746f380-c2bf-11eb-8e7e-dfc127c802b4.png)

