### PR TITLE
Fix LyShine instance not being initialized

### DIFF
--- a/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
+++ b/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
@@ -157,6 +157,7 @@ namespace LyShine
         UiSystemBus::Handler::BusConnect();
         UiSystemToolsBus::Handler::BusConnect();
         UiFrameworkBus::Handler::BusConnect();
+        CrySystemEventBus::Handler::BusConnect();
 
         // register all the component types internal to the LyShine module
         // These are registered in the order we want them to appear in the Add Component menu
@@ -201,6 +202,7 @@ namespace LyShine
         UiSystemToolsBus::Handler::BusDisconnect();
         UiFrameworkBus::Handler::BusDisconnect();
         LyShineRequestBus::Handler::BusDisconnect();
+        CrySystemEventBus::Handler::BusDisconnect();
 
         LyShineAllocatorScope::DeactivateAllocators();
     }


### PR DESCRIPTION
A recent change in LyShineSystemComponent moved LyShine initialization to a Cry bus handler, but the associated bus wasn't being connected/disconnected, so the callback wasn't being called.