### PR TITLE
Change node label for Mac/iOS for new AMI update

### DIFF
--- a/scripts/build/Platform/Mac/pipeline.json
+++ b/scripts/build/Platform/Mac/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "mac-catalina-44d2685",
+        "NODE_LABEL": "mac-catalina-7ad2e45b",
         "LY_3RDPARTY_PATH": "/Users/lybuilder/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "/Users/lybuilder/workspace",

--- a/scripts/build/Platform/iOS/pipeline.json
+++ b/scripts/build/Platform/iOS/pipeline.json
@@ -1,6 +1,6 @@
 {
     "ENV": {
-        "NODE_LABEL": "mac-catalina-44d2685",
+        "NODE_LABEL": "mac-catalina-7ad2e45b",
         "LY_3RDPARTY_PATH": "/Users/lybuilder/3rdParty",
         "TIMEOUT": 30,
         "WORKSPACE": "/Users/lybuilder/workspace",


### PR DESCRIPTION
Changes the default node label for Mac/iOS to the newest AMI
- This AMI contains updates for XCode and CMake
- CMake is now on 3.20.2

Tested on Mac and iOS profile builds