### PR TITLE
Adding Tools and Builders alias to the DccScriptingInterface gem targets

### DIFF
--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Code/CMakeLists.txt
@@ -9,6 +9,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #
 
+if(NOT PAL_TRAIT_BUILD_HOST_TOOLS)
+    return()
+endif()
+
 ly_add_target(
     NAME DccScriptingInterface.Static STATIC
     NAMESPACE Gem
@@ -39,6 +43,8 @@ ly_add_target(
             Gem::DccScriptingInterface.Static
 )
 
-# Any 'tool' and 'builder' type applications should use Gem::DccScriptingInterface.Editor:
-ly_create_alias(NAME DccScriptingInterface.Builders NAMESPACE Gem TARGETS Gem::DccScriptingInterface.Editor)
+# Any 'tool' type applications should use Gem::DccScriptingInterface.Editor:
 ly_create_alias(NAME DccScriptingInterface.Tools    NAMESPACE Gem TARGETS Gem::DccScriptingInterface.Editor)
+# Add an empty 'builders' alias to allow the DccScriptInterface root gem path to be added to the generated
+# cmake_dependencies.<project>.assetprocessor.setreg to allow the asset scan folder for it to be added
+ly_create_alias(NAME DccScriptingInterface.Builders NAMESPACE Gem)

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -29,9 +29,6 @@ function(ly_create_alias)
         message(FATAL_ERROR "Provide the namespace of the alias to create using the NAMESPACE keyword")
     endif()
 
-    if (NOT ly_create_alias_TARGETS)
-        message(FATAL_ERROR "Provide the name of the targets the alias be associated with, using the TARGETS keyword")
-    endif()
 
     if(TARGET ${ly_create_alias_NAMESPACE}::${ly_create_alias_NAME})
         message(FATAL_ERROR "Target already exists, cannot create an alias for it: ${ly_create_alias_NAMESPACE}::${ly_create_alias_NAME}\n"
@@ -78,8 +75,11 @@ function(ly_create_alias)
         list(APPEND final_targets ${de_aliased_target_name})
     endforeach()
     
-    ly_parse_third_party_dependencies("${final_targets}")
-    ly_add_dependencies(${ly_create_alias_NAME} ${final_targets})
+    # add_dependencies must be called with at least one dependent target
+    if(final_targets)
+        ly_parse_third_party_dependencies("${final_targets}")
+        ly_add_dependencies(${ly_create_alias_NAME} ${final_targets})
+    endif()
 
     # now add the final alias:
     add_library(${ly_create_alias_NAMESPACE}::${ly_create_alias_NAME} ALIAS ${ly_create_alias_NAME})

--- a/cmake/SettingsRegistry.cmake
+++ b/cmake/SettingsRegistry.cmake
@@ -25,14 +25,15 @@ set(gems_json_template [[
 @target_gem_dependencies_names@
         }
     }
-}]]
+}
+]]
 )
-set(gem_module_template [[
-            "@stripped_gem_target@":
-            {
-                "Modules":["$<TARGET_FILE_NAME:@gem_target@>"],
-                "SourcePaths":["@gem_module_root_relative_to_engine_root@"]
-            }]]
+ string(APPEND gem_module_template
+[=[            "@stripped_gem_target@":]=] "\n"
+[=[            {]=] "\n"
+[=[$<$<NOT:$<IN_LIST:$<TARGET_PROPERTY:@gem_target@,TYPE>,INTERFACE_LIBRARY>>:                "Modules":["$<TARGET_FILE_NAME:@gem_target@>"]]=] "$<COMMA>\n>"
+[=[                "SourcePaths":["@gem_module_root_relative_to_engine_root@"]]=] "\n"
+[=[            }]=]
 )
 
 #!ly_get_gem_load_dependencies: Retrieves the list of "load" dependencies for a target
@@ -161,10 +162,12 @@ function(ly_delayed_generate_settings_registry)
                 message(FATAL_ERROR "Dependency ${gem_target} from ${target} does not exist")
             endif()
 
+            get_property(has_manually_added_dependencies TARGET ${gem_target} PROPERTY MANUALLY_ADDED_DEPENDENCIES SET)
             get_target_property(target_type ${gem_target} TYPE)
-            if (target_type STREQUAL "INTERFACE_LIBRARY")
-                # don't use interface libraries here, we only want ones which produce actual binaries.
-                # we have still already recursed into their dependencies - they'll show up later.
+            if (target_type STREQUAL "INTERFACE_LIBRARY" AND has_manually_added_dependencies)
+                # don't use interface libraries here, we only want ones which produce actual binaries unless the target
+                # is empty. We have still already recursed into their dependencies - they'll show up later.
+                # When the target has no dependencies however we want to add the gem root path to the generated setreg
                 continue()
             endif()
 


### PR DESCRIPTION
This allows DccScriptingInterface to be used as a gem in the new `ly_enable_gem()` cmake command.