### PR TITLE
Fix editor axis gizmo text rendering above gizmo

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
@@ -124,4 +124,15 @@ namespace AzToolsFramework
         
         return cameraState;
     }
+
+    float GetScreenDisplayScaling(const int viewportId)
+    {
+        float scaling = 1.0f;
+        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+            scaling, viewportId,
+            &ViewportInteraction::ViewportInteractionRequestBus::Events::DeviceScalingFactor);
+
+        return scaling;
+    }
+
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
@@ -60,6 +60,9 @@ namespace AzToolsFramework
     /// Wrapper for EBus call to return the CameraState for a given viewport.
     AzFramework::CameraState GetCameraState(int viewportId);
 
+    /// Wrapper for EBus call to return the DPI scaling for a given viewport.
+    float GetScreenDisplayScaling(const int viewportId);
+
     /// A utility to return the center of several points.
     /// Take several positions and store the min and max of each in
     /// turn - when all points have been added return the center/midpoint.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -3573,9 +3573,10 @@ namespace AzToolsFramework
         debugDisplay.SetLineWidth(1.0f);
 
         const float labelOffset = cl_viewportGizmoAxisLabelOffset;
-        const auto labelXScreenPosition = (gizmoStart + (gizmoAxisX * labelOffset)) * editorCameraState.m_viewportSize;
-        const auto labelYScreenPosition = (gizmoStart + (gizmoAxisY * labelOffset)) * editorCameraState.m_viewportSize;
-        const auto labelZScreenPosition = (gizmoStart + (gizmoAxisZ * labelOffset)) * editorCameraState.m_viewportSize;
+        const float screenScale = GetScreenDisplayScaling(viewportId);
+        const auto labelXScreenPosition = (gizmoStart + (gizmoAxisX * labelOffset)) * editorCameraState.m_viewportSize * screenScale;
+        const auto labelYScreenPosition = (gizmoStart + (gizmoAxisY * labelOffset)) * editorCameraState.m_viewportSize * screenScale;
+        const auto labelZScreenPosition = (gizmoStart + (gizmoAxisZ * labelOffset)) * editorCameraState.m_viewportSize * screenScale;
 
         // draw the label of of each axis for the gizmo
         const float labelSize = cl_viewportGizmoAxisLabelSize;


### PR DESCRIPTION
Add AzToolsFramework utility function to query the display scale for a viewport.
Use new function to fix the text location on the axis gizmo.