### PR TITLE
[LYN-3008] Only register the Slice Relationship View when prefabs are disabled.

### DIFF
--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/ComponentEntityEditorPlugin.cpp
@@ -179,11 +179,11 @@ ComponentEntityEditorPlugin::ComponentEntityEditorPlugin([[maybe_unused]] IEdito
             LyViewPane::EntityOutliner,
             LyViewPane::CategoryTools,
             outlinerOptions);
-    }
 
-    AzToolsFramework::ViewPaneOptions options;
-    options.preferedDockingArea = Qt::NoDockWidgetArea;
-    RegisterViewPane<SliceRelationshipWidget>(LyViewPane::SliceRelationships, LyViewPane::CategoryTools, options);
+        AzToolsFramework::ViewPaneOptions options;
+        options.preferedDockingArea = Qt::NoDockWidgetArea;
+        RegisterViewPane<SliceRelationshipWidget>(LyViewPane::SliceRelationships, LyViewPane::CategoryTools, options);
+    }
 
     RegisterModuleResourceSelectors(GetIEditor()->GetResourceSelectorHost());
 


### PR DESCRIPTION
Verified the Slice Relationship View does not show up when prefabs are enabled, and still shows up when prefabs are disabled.