### PR TITLE
Remove Project namespace from project template

### DIFF
--- a/Templates/DefaultProject/Template/Code/enabled_gems.cmake
+++ b/Templates/DefaultProject/Template/Code/enabled_gems.cmake
@@ -10,7 +10,7 @@
 # {END_LICENSE}
 
 set(ENABLED_GEMS
-    Project::${Name}
+    ${Name}
     Atom_AtomBridge
     Camera
     CameraFramework


### PR DESCRIPTION
In the enabled_gems.cmake file, can remove the Project:: namespace on
the project module because it's treated the same as a Gem module now.