### PR TITLE
Fix rare re-entrancy issue with CCryEditApp::IdleProcessing

### DIFF
--- a/Code/Sandbox/Editor/CryEdit.cpp
+++ b/Code/Sandbox/Editor/CryEdit.cpp
@@ -2271,6 +2271,14 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
         return 0;
     }
 
+    // Ensure we don't get called re-entrantly
+    // This can occur when a nested Qt event loop fires (e.g. by way of a modal dialog calling exec)
+    if (m_idleProcessingRunning)
+    {
+        return 0;
+    }
+    QScopedValueRollback<bool> guard(m_idleProcessingRunning, true);
+
     ////////////////////////////////////////////////////////////////////////
     // Call the update function of the engine
     ////////////////////////////////////////////////////////////////////////

--- a/Code/Sandbox/Editor/CryEdit.h
+++ b/Code/Sandbox/Editor/CryEdit.h
@@ -332,6 +332,8 @@ private:
     // If this flag is set, the next OnIdle() will update, even if the app is in the background, and then
     // this flag will be reset.
     bool m_bForceProcessIdle = false;
+    // This is set while IdleProcessing is running to prevent re-entrancy
+    bool m_idleProcessingRunning = false;
     // Keep the editor alive, even if no focus is set
     bool m_bKeepEditorActive = false;
     // Currently creating a new level


### PR DESCRIPTION
This issue manifested in a crash in rare circumstances when the Editor lost and gained focus while a modal dialog was active. After investigation, it was discovered that native event processing can lead to IdleProcessing being called again from the main thread while idle processing is still happening. As this is unintentional and generally undesirable, we now guard against this within the IdleProcessing method.