### PR TITLE
{SPEC-6899} Several tests in AssetPipelineTests.MissingDependency.periodic are failing

### DIFF
--- a/AutomatedTesting/TestAssets/ReportOneMissingDependency.txt
+++ b/AutomatedTesting/TestAssets/ReportOneMissingDependency.txt
@@ -1,0 +1,5 @@
+This is the UUID for libs / particles / milestone2particles . xml. 
+6BDE282B49C957F7B0714B26579BCA9A
+This isn an invalid UUID
+33bdee92F3225688ABEE534F6058593F
+This is another invalid UUID B076CDDC-14DK-50F4-A5E9-7518ABB3E851

--- a/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/asset_processor.py
@@ -597,9 +597,10 @@ class AssetProcessor(object):
         run_result = subprocess.run(command, close_fds=True, timeout=timeout, capture_output=capture_output)
         output_list = None
         if capture_output:
-            output_list = run_result.stdout.splitlines()
             if decode:
-                output_list = [line.decode('utf-8') for line in output_list]
+                output_list = run_result.stdout.decode('utf-8').splitlines()
+            else:
+                output_list = run_result.stdout.splitlines()
 
         if run_result.returncode != 0:
             errorMessage = f"{command} returned error code: {run_result.returncode}"


### PR DESCRIPTION
{SPEC-6899}Several tests in AssetPipelineTests.MissingDependency.periodic are failing

Please note that all tests except test_WindowsAndMac_AssetReportsAllButOneReference_ReportsOneMissingDependency were passing locally for me  but they were failing in jenkins with UnicodeDecodeError as below

output_list = [line.decode('utf-8') for line in output_list]
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x99 in position 91: invalid start byte

test_WindowsAndMac_AssetReportsAllButOneReference_ReportsOneMissingDependency test was failing due to a missing test asset.

testing done 
Ran test ..\python\python.cmd -m pytest ..\AutomatedTesting\Gem\PythonTests\assetpipeline\asset_processor_tests\missing_dependency_tests.py --build-directory bin\profile
============================================ 16 passed, 1 warning in 272.29s (0:04:32) =============================================
