### PR TITLE
Disabled writing UserSettings.xml in Spawnable tests.

### DIFF
--- a/Code/Framework/Tests/Spawnable/SpawnableEntitiesManagerTests.cpp
+++ b/Code/Framework/Tests/Spawnable/SpawnableEntitiesManagerTests.cpp
@@ -11,6 +11,7 @@
 */
 
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzFramework/Application/Application.h>
 #include <AzFramework/Spawnable/SpawnableAssetHandler.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesManager.h>
@@ -40,6 +41,10 @@ namespace UnitTest
             m_application = new TestApplication();
             AZ::ComponentApplication::Descriptor descriptor;
             m_application->Start(descriptor);
+            // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
+            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
+            // in the unit tests.
+            AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
             
             m_spawnable = aznew AzFramework::Spawnable(
                 AZ::Data::AssetId::CreateString("{EB2E8A2B-F253-4A90-BBF4-55F2EED786B8}:0"), AZ::Data::AssetData::AssetStatus::Ready);


### PR DESCRIPTION
This should fix the random failure of the Spawnable tests on writing UserSettings.xml.