### PR TITLE
Graph Canvas Node Palette Search Ignore Whitespace

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/Model/NodePaletteSortFilterProxyModel.cpp
@@ -147,17 +147,17 @@ namespace GraphCanvas
             return true;
         }
 
-        // Ignore whitespace when filtering node names
-        QString test = model->data(index).toString().simplified().replace(" ", "");
+
+        QString test = model->data(index).toString();
         
         bool showRow = false;
-        int regexIndex = test.lastIndexOf(m_filterRegex);
+        int regexIndex = m_filterRegex.indexIn(test);
 
         if (regexIndex >= 0)
         {
             showRow = true;
-
-            AZStd::pair<int, int> highlight(regexIndex, m_filter.size());
+            
+            AZStd::pair<int, int> highlight(regexIndex, m_filterRegex.matchedLength());
             currentItem->SetHighlight(highlight);
         }
         else
@@ -285,10 +285,19 @@ namespace GraphCanvas
     void NodePaletteSortFilterProxyModel::SetFilter(const QString& filter)
     {
         // Remove whitespace and escape() so every regexp special character is escaped with a backslash
-        // Removing the whitespace will allow us to find nodes even if the node is written with or without spaces.
+        // Then ignore all whitespace by adding \s* (regex optional whitespace match) in between every other character.
+        // We use \s* instead of simply removing all whitespace from the filter and node-names in order to preserve the node-name and accurately highlight the matching portion.
         // Example: "OnGraphStart" or "On Graph Start"
         m_filter = QRegExp::escape(filter.simplified().replace(" ", ""));
-        m_filterRegex = QRegExp(m_filter, Qt::CaseInsensitive);
+        
+        QString regExIgnoreWhitespace(m_filter[0]);
+        for (int i = 1; i < m_filter.size(); ++i)
+        {
+            regExIgnoreWhitespace.append("\\s*");
+            regExIgnoreWhitespace.append(m_filter[i]);
+        }
+        
+        m_filterRegex = QRegExp(regExIgnoreWhitespace, Qt::CaseInsensitive);
     }
 
     void NodePaletteSortFilterProxyModel::ClearFilter()


### PR DESCRIPTION
Allow users to search graph canvas node palette without worrying about white space.  
For example, searching "OnGraphStart" will now return the node result for "On Graph Start".