### PR TITLE
Switch EditorContextMenu back to using popup instead of exec

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -65,7 +65,7 @@ namespace AzToolsFramework
 
                 if (!contextMenu.m_menu->isEmpty())
                 {
-                    // Use popup instead, this avoids blocking input event processing while the menu dialog is active
+                    // Use popup instead of exec; this avoids blocking input event processing while the menu dialog is active
                     contextMenu.m_menu->popup(QCursor::pos());
                 }
             }


### PR DESCRIPTION
The switch to exec was a deliberate change, but upon further testing with the latest version of our camera input controllers (both the Legacy and Modern variants) it is no longer necessary to call exec, and doing so can cause a bug in which the cursor is still hidden when the context menu appears.