### PR TITLE
LYN-4284 VS 16.10 fails to build /external:W0 and /external:W4 both are defined

### DIFF
--- a/cmake/Platform/Common/Directory.Build.props
+++ b/cmake/Platform/Common/Directory.Build.props
@@ -15,4 +15,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
         <UseMultiToolTask>true</UseMultiToolTask>
         <EnforceProcessCountAcrossBuilds>true</EnforceProcessCountAcrossBuilds>
     </PropertyGroup>
+    <ItemDefinitionGroup>
+        <ClCompile>
+          <ExternalWarningLevel>TurnOffAllWarnings</ExternalWarningLevel>
+        </ClCompile>
+    </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Adding ExternalWarningLevel to the Directory.Build.props to get the default warning level for external headers to match the one we define through compile options