### PR TITLE
[LYN-3845] On the Actor component, click on the Animation Editor button, EMFX isn't opening

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -435,18 +435,16 @@ namespace EMotionFX
 
         void EditorActorComponent::LaunchAnimationEditor(const AZ::Data::AssetId& assetId, const AZ::Data::AssetType&)
         {
+            // call to open must be done before LoadCharacter
+            const char* panelName = EMStudio::MainWindow::GetEMotionFXPaneName();
+            EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, OpenViewPane, panelName);
+
             if (assetId.IsValid())
             {
                 AZ::Data::AssetId animgraphAssetId;
-                animgraphAssetId.SetInvalid();
                 EditorAnimGraphComponentRequestBus::EventResult(animgraphAssetId, GetEntityId(), &EditorAnimGraphComponentRequestBus::Events::GetAnimGraphAssetId);
                 AZ::Data::AssetId motionSetAssetId;
-                motionSetAssetId.SetInvalid();
                 EditorAnimGraphComponentRequestBus::EventResult(motionSetAssetId, GetEntityId(), &EditorAnimGraphComponentRequestBus::Events::GetMotionSetAssetId);
-
-                // call to open must be done before LoadCharacter
-                const char* panelName = EMStudio::MainWindow::GetEMotionFXPaneName();
-                EBUS_EVENT(AzToolsFramework::EditorRequests::Bus, OpenViewPane, panelName);
 
                 EMStudio::MainWindow* mainWindow = EMStudio::GetMainWindow();
                 if (mainWindow)


### PR DESCRIPTION
We're opening the Animation Editor now also in case no actor has been chosen yet. In this case the Animation Editor will also just be started without loading any assets.