### PR TITLE
[Prefabs] Move Duplicate menu items and shortcuts out of the Prefab Wip flag

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -2240,42 +2240,31 @@ namespace AzToolsFramework
                 RegenerateManipulators();
             });
 
-        bool isPrefabSystemEnabled = false;
-        AzFramework::ApplicationRequests::Bus::BroadcastResult(
-            isPrefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+        // duplicate selection
+        AddAction(
+            m_actions, { QKeySequence(Qt::CTRL + Qt::Key_D) },
+            /*ID_EDIT_CLONE =*/33525, s_duplicateTitle, s_duplicateDesc,
+            []()
+            {
+                AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::AzToolsFramework);
 
-        bool prefabWipFeaturesEnabled = false;
-        AzFramework::ApplicationRequests::Bus::BroadcastResult(
-            prefabWipFeaturesEnabled, &AzFramework::ApplicationRequests::ArePrefabWipFeaturesEnabled);
-
-        if (!isPrefabSystemEnabled || (isPrefabSystemEnabled && prefabWipFeaturesEnabled))
-        {
-            // duplicate selection
-            AddAction(
-                m_actions, { QKeySequence(Qt::CTRL + Qt::Key_D) },
-                /*ID_EDIT_CLONE =*/33525, s_duplicateTitle, s_duplicateDesc,
-                []()
+                // Clear Widget selection - Prevents issues caused by cloning entities while a property in the Reflected Property Editor
+                // is being edited.
+                if (QApplication::focusWidget())
                 {
-                    AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::AzToolsFramework);
+                    QApplication::focusWidget()->clearFocus();
+                }
 
-                    // Clear Widget selection - Prevents issues caused by cloning entities while a property in the Reflected Property Editor
-                    // is being edited.
-                    if (QApplication::focusWidget())
-                    {
-                        QApplication::focusWidget()->clearFocus();
-                    }
+                ScopedUndoBatch undoBatch(s_duplicateUndoRedoDesc);
+                auto selectionCommand = AZStd::make_unique<SelectionCommand>(EntityIdList(), s_duplicateUndoRedoDesc);
+                selectionCommand->SetParent(undoBatch.GetUndoBatch());
+                selectionCommand.release();
 
-                    ScopedUndoBatch undoBatch(s_duplicateUndoRedoDesc);
-                    auto selectionCommand = AZStd::make_unique<SelectionCommand>(EntityIdList(), s_duplicateUndoRedoDesc);
-                    selectionCommand->SetParent(undoBatch.GetUndoBatch());
-                    selectionCommand.release();
+                bool handled = false;
+                EditorRequestBus::Broadcast(&EditorRequests::CloneSelection, handled);
 
-                    bool handled = false;
-                    EditorRequestBus::Broadcast(&EditorRequests::CloneSelection, handled);
-
-                    // selection update handled in AfterEntitySelectionChanged
-                });
-        }
+                // selection update handled in AfterEntitySelectionChanged
+            });
 
         // delete selection
         AddAction(

--- a/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
@@ -473,18 +473,8 @@ void LevelEditorMenuHandler::PopulateEditMenu(ActionManager::MenuWrapper& editMe
     // editMenu->addAction(ID_EDIT_PASTE);
     // editMenu.AddSeparator();
 
-    bool isPrefabSystemEnabled = false;
-    AzFramework::ApplicationRequests::Bus::BroadcastResult(isPrefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
-
-    bool prefabWipFeaturesEnabled = false;
-    AzFramework::ApplicationRequests::Bus::BroadcastResult(
-        prefabWipFeaturesEnabled, &AzFramework::ApplicationRequests::ArePrefabWipFeaturesEnabled);
-
-    if (!isPrefabSystemEnabled || (isPrefabSystemEnabled && prefabWipFeaturesEnabled))
-    {
-        // Duplicate
-        editMenu.AddAction(ID_EDIT_CLONE);
-    }
+    // Duplicate
+    editMenu.AddAction(ID_EDIT_CLONE);
 
     // Delete
     editMenu.AddAction(ID_EDIT_DELETE);

--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -670,18 +670,11 @@ void SandboxIntegrationManager::PopulateEditorGlobalContextMenu(QMenu* menu, con
         AzToolsFramework::EditorContextMenuBus::Broadcast(&AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu, menu);
     }
 
-    bool prefabWipFeaturesEnabled = false;
-    AzFramework::ApplicationRequests::Bus::BroadcastResult(
-        prefabWipFeaturesEnabled, &AzFramework::ApplicationRequests::ArePrefabWipFeaturesEnabled);
-
-    if (!prefabSystemEnabled || (prefabSystemEnabled && prefabWipFeaturesEnabled))
+    action = menu->addAction(QObject::tr("Duplicate"));
+    QObject::connect(action, &QAction::triggered, action, [this] { ContextMenu_Duplicate(); });
+    if (selected.size() == 0)
     {
-        action = menu->addAction(QObject::tr("Duplicate"));
-        QObject::connect(action, &QAction::triggered, action, [this] { ContextMenu_Duplicate(); });
-        if (selected.size() == 0)
-        {
-            action->setDisabled(true);
-        }
+        action->setDisabled(true);
     }
 
     if (!prefabSystemEnabled)


### PR DESCRIPTION
Make duplicate prefab workflows available by default in Prefab mode.