### PR TITLE
Fixing xml directory race condition on incremental runs

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -366,10 +366,10 @@ def ExportTestResults(Map options, String platform, String type, String workspac
         dir("${o3deroot}/${params.OUTPUT_DIRECTORY}") {
             junit testResults: "Testing/**/*.xml"
             palRmDir("Testing")
+            // Recreate test runner xml directories that need to be pre generated
+            palMkdir("Testing/Pytest")
+            palMkdir("Testing/Gtest")
         }
-        // Recreate test runner xml directories that need to be pre generated
-        palMkdir("Testing/Pytest")
-        palMkdir("Testing/Gtest")
     }
 }
 


### PR DESCRIPTION
The Pytest and Gtest directories need to be pre generated before the tests run to prevent a race condition on folder creation. They are normally generated on CMake configure, but this step is skipped on incremental builds. This is not able to be tested locally and will be verified in AR.