### PR TITLE
Multiplayer RPC Parameter Names Exposed to Behavior Context

### DIFF
--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -392,7 +392,8 @@ void {{ ClassName }}::Signal{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.jo
                         }
 
                         controller->{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.join(paramNames) }});
-                    })
+                    }, { { { "Source", "The Source containing the {{ ClassName }}Controller" }{% for paramName in paramNames %}, {"{{ paramName }}"}{% endfor %}}})
+                ->Attribute(AZ::Script::Attributes::ToolTip, "{{Property.attrib['Description']}}")
 {%    endif %}
 {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Add parameter names to RPC behavior context so users know what each parameter does. Also added tooltip, although script canvas isnt always showing it (I will create a separate bug)