### PR TITLE
enabling smoke test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -40,6 +40,6 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AutomatedTesting.GameLauncher
             AutomatedTesting.Assets
         COMPONENT
-            Smoke
+            Sandbox
     )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_Editor_NewExistingLevels_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_Editor_NewExistingLevels_Works.py
@@ -15,7 +15,7 @@ from automatedtesting_shared.base import TestAutomationBase
 import ly_test_tools.environment.file_system as file_system
 
 
-@pytest.mark.SUITE_sandbox
+@pytest.mark.SUITE_smoke
 @pytest.mark.parametrize("launcher_platform", ["windows_editor"])
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("level", ["temp_level"])


### PR DESCRIPTION
Re-enabling the smoke test that was previously failing. Ran the test both locally and on Jenkins 100 times with 100% success rate.