### PR TITLE
[LYN-3145] Removed unnecessary spam message from legacy CEntityObject class when entering game mode.

### DIFF
--- a/Code/Sandbox/Editor/Objects/EntityObject.cpp
+++ b/Code/Sandbox/Editor/Objects/EntityObject.cpp
@@ -1277,7 +1277,6 @@ void CEntityObject::OnEvent(ObjectEvent event)
         break;
     }
     default:
-        AZ_TracePrintf("CEntityObject", "Unhandled object event: %d", event);
         break;
     }
 }


### PR DESCRIPTION
This warning spam isn't needed and is coming from a class that will soon be red-coded, so just removing the message.