### PR TITLE
Removed AddOn(De)SpawnedHandler from Spawnable Entities Interface

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -322,12 +322,6 @@ namespace AzFramework
         //! @param optionalArgs Optional additional arguments, see BarrierOptionalArgs.
         virtual void Barrier(EntitySpawnTicket& ticket, BarrierCallback completionCallback, BarrierOptionalArgs optionalArgs = {}) = 0;
 
-        //! Register a handler for OnSpawned events.
-        virtual void AddOnSpawnedHandler(AZ::Event<AZ::Data::Asset<Spawnable>>::Handler& handler) = 0;
-
-        //! Register a handler for OnDespawned events.
-        virtual void AddOnDespawnedHandler(AZ::Event<AZ::Data::Asset<Spawnable>>::Handler& handler) = 0;
-
     protected:
         [[nodiscard]] virtual AZStd::pair<EntitySpawnTicket::Id, void*> CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable) = 0;
         virtual void DestroyTicket(void* ticket) = 0;

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -150,16 +150,6 @@ namespace AzFramework
         QueueRequest(ticket, optionalArgs.m_priority, AZStd::move(queueEntry));
     }
 
-    void SpawnableEntitiesManager::AddOnSpawnedHandler(AZ::Event<AZ::Data::Asset<Spawnable>>::Handler& handler)
-    {
-        handler.Connect(m_onSpawnedEvent);
-    }
-
-    void SpawnableEntitiesManager::AddOnDespawnedHandler(AZ::Event<AZ::Data::Asset<Spawnable>>::Handler& handler)
-    {
-        handler.Connect(m_onDespawnedEvent);
-    }
-
     auto SpawnableEntitiesManager::ProcessQueue(CommandQueuePriority priority) -> CommandQueueStatus
     {
         CommandQueueStatus result = CommandQueueStatus::NoCommandsLeft;
@@ -320,8 +310,6 @@ namespace AzFramework
                         ticket.m_spawnedEntities.begin() + spawnedEntitiesInitialCount, ticket.m_spawnedEntities.end()));
             }
 
-            m_onSpawnedEvent.Signal(ticket.m_spawnable);
-
             ticket.m_currentRequestId++;
             return true;
         }
@@ -401,8 +389,6 @@ namespace AzFramework
                     ticket.m_spawnedEntities.begin() + spawnedEntitiesInitialCount, ticket.m_spawnedEntities.end()));
             }
 
-            m_onSpawnedEvent.Signal(ticket.m_spawnable);
-
             ticket.m_currentRequestId++;
             return true;
         }
@@ -434,8 +420,6 @@ namespace AzFramework
                 request.m_completionCallback(request.m_ticketId);
             }
 
-            m_onDespawnedEvent.Signal(ticket.m_spawnable);
-
             ticket.m_currentRequestId++;
             return true;
         }
@@ -463,8 +447,6 @@ namespace AzFramework
                 }
             }
 
-            m_onDespawnedEvent.Signal(ticket.m_spawnable);
-            
             // Rebuild the list of entities.
             ticket.m_spawnedEntities.clear();
             const Spawnable::EntityList& entities = request.m_spawnable->GetEntities();
@@ -516,8 +498,6 @@ namespace AzFramework
             }
 
             ticket.m_currentRequestId++;
-
-            m_onSpawnedEvent.Signal(ticket.m_spawnable);
 
             return true;
         }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
@@ -73,9 +73,6 @@ namespace AzFramework
 
         void Barrier(EntitySpawnTicket& spawnInfo, BarrierCallback completionCallback, BarrierOptionalArgs optionalArgs = {}) override;
 
-        void AddOnSpawnedHandler(AZ::Event<AZ::Data::Asset<Spawnable>>::Handler& handler) override;
-        void AddOnDespawnedHandler(AZ::Event<AZ::Data::Asset<Spawnable>>::Handler& handler) override;
-
         //
         // The following function is thread safe but intended to be run from the main thread.
         //
@@ -199,9 +196,6 @@ namespace AzFramework
 
         Queue m_highPriorityQueue;
         Queue m_regularPriorityQueue;
-
-        AZ::Event<AZ::Data::Asset<Spawnable>> m_onSpawnedEvent;
-        AZ::Event<AZ::Data::Asset<Spawnable>> m_onDespawnedEvent;
 
         AZ::SerializeContext* m_defaultSerializeContext { nullptr };
         //! The threshold used to determine if a request goes in the regular (if bigger than the value) or high priority queue (if smaller


### PR DESCRIPTION
The calls AddOnSpawnedHandler and AddOnDespawnedHandler were removed from the SpawnableEntitiesInterface. These functions will eventually be called from multiple threads and AZ::Event currently doesn't have a thread-safe version to support this. There's also a performance concern as these callbacks are called for each individual (de)spawn requests which can lead to multiple handlers being called without information that's relevant to the callback. It would be better to batch up all (de)spawn requests per ProcessQueue call and only have a single event do a single signal. Since both events are currently not being used they have been removed for now, but can be introduced -with the previously mentioned concerns in mind- when needed.