### PR TITLE
[stabilization/2106] fixed startup crash in project manager from installer build

### DIFF
--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -278,8 +278,11 @@ namespace O3DE::ProjectManager
             pybind11::gil_scoped_acquire acquire;
 
             // sanity import check
-            int result = PyRun_SimpleString("import sys");
-            AZ_Error("ProjectManagerWindow", result != -1, "Import sys failed");
+            if (PyRun_SimpleString("import sys") != 0)
+            {
+                AZ_Assert(false, "Import sys failed");
+                return false;
+            }
 
             // import required modules
             m_cmake = pybind11::module::import("o3de.cmake");
@@ -293,7 +296,7 @@ namespace O3DE::ProjectManager
             // make sure the engine is registered
             RegisterThisEngine();
 
-            return result == 0 && !PyErr_Occurred();
+            return !PyErr_Occurred();
         }
         catch ([[maybe_unused]] const std::exception& e)
         {


### PR DESCRIPTION
The adding of an un-escaped install to the python system path was causing silent failures when using the current default (e.g. C:\Program Files\O3DE\0.0.0.0) for some o3de script module imports.  This path addition is no longer needed now that the o3de python package is pip installed via the get_python script.