### PR TITLE
[LYN-4390] Implemented EditorCameraRequestBus::GetActiveCameraState on the EditorViewportWidget so that the "Create camera entity from view" action works again.

### DIFF
--- a/Code/Sandbox/Editor/EditorViewportWidget.cpp
+++ b/Code/Sandbox/Editor/EditorViewportWidget.cpp
@@ -2664,6 +2664,18 @@ bool EditorViewportWidget::GetActiveCameraPosition(AZ::Vector3& cameraPos)
     return false;
 }
 
+bool EditorViewportWidget::GetActiveCameraState(AzFramework::CameraState& cameraState)
+{
+    if (m_pPrimaryViewport == this)
+    {
+        cameraState = GetCameraState();
+
+        return true;
+    }
+
+    return false;
+}
+
 void EditorViewportWidget::OnStartPlayInEditor()
 {
     if (m_viewEntityId.IsValid())

--- a/Code/Sandbox/Editor/EditorViewportWidget.h
+++ b/Code/Sandbox/Editor/EditorViewportWidget.h
@@ -184,6 +184,7 @@ public:
     void SetViewAndMovementLockFromEntityPerspective(const AZ::EntityId& entityId, bool lockCameraMovement) override;
     AZ::EntityId GetCurrentViewEntityId() override { return m_viewEntityId; }
     bool GetActiveCameraPosition(AZ::Vector3& cameraPos) override;
+    bool GetActiveCameraState(AzFramework::CameraState& cameraState) override;
 
     // AzToolsFramework::EditorEntityContextNotificationBus (handler moved to cpp to resolve link issues in unity builds)
     virtual void OnStartPlayInEditor();


### PR DESCRIPTION
Found the "Create camera entity from view" menu action was querying a bus method that wasn't implemented for the EditorViewportWidget. Implementing this bus resolved the issue. Tested creating a camera entity from various locations/camera angles in the viewport.


![createCameraEntityFromView](https://user-images.githubusercontent.com/7519264/121561425-165c4300-c9de-11eb-855a-dc6929d195ec.gif)
