### PR TITLE
[ATOM-15683] StandardPBR shader now makes sure to mark w for no subsurface scattering.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
@@ -295,6 +295,10 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
         lightingOutput.m_diffuseColor.rgb += lightingOutput.m_specularColor.rgb; // add specular
         lightingOutput.m_specularColor.rgb = baseColor * (1.0 - lightingOutput.m_diffuseColor.w); 
     }
+    else
+    {
+        lightingOutput.m_diffuseColor.w = -1; // Disable subsurface scattering
+    }
 
     return lightingOutput;
 }
@@ -341,4 +345,3 @@ ForwardPassOutput StandardPbr_ForwardPassPS_EDS(VSOutput IN, bool isFrontFace : 
 #endif
     return OUT;
 }
-


### PR DESCRIPTION
Currently all StandardPBR materials may have their diffuse channel be subject to a 2x2 box blur because the DiffuseSpecalarMerge pass may think they have samples with subsurface scattering turned on. It seems that this bug was only affecting certain pipelines like msaa, but the main pipeline seemed ok. It's possible in the main pipeline a value was being written to w elsewhere that's preventing the blur. I didn't notice any new issues in ASV when running automated tests.