### PR TITLE
ATOM-13723 BaseViewer DynamicMaterialTest Crash With Many Objects on dx12	

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Config/Platform/Windows/DX12/PlatformLimits.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Config/Platform/Windows/DX12/PlatformLimits.azasset
@@ -8,7 +8,7 @@
       "$type": "DX12::PlatformLimitsDescriptor",
       
       "m_descriptorHeapLimits": {
-        "DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV": [16384, 262144],
+        "DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV": [1000000, 1000000],
         "DESCRIPTOR_HEAP_TYPE_SAMPLER": [2048, 2048],
         "DESCRIPTOR_HEAP_TYPE_RTV": [2048, 0],
         "DESCRIPTOR_HEAP_TYPE_DSV": [2048, 0]


### PR DESCRIPTION
The cause is because Constant Buffer View (CBV), Shader Resource View (SRV), or Unordered Access View(UAV) heap pool has reached its limit defined in PlatformLimits.azasset. And SRG creation fails, then result in nullptr in the material.

According to:
https://docs.microsoft.com/en-us/windows/win32/direct3d12/hardware-support
Tier 3 has 1,000,000+ maximum number of descriptors, while tier 2 and tier 1 cap at 1,000,000.
Non-shader-visible heap creation fails at 1,047,079 on my RTX2070.
So to be safe for tier 1, 2 hardware, it might be better to just set them to 1,000,000. And that already prevent the DynamicMaterialTest from crashing. (But really, we should reduce the max number of objects in that sample because it's already running slow at 1000 objects, while the max is 8000).
