### PR TITLE
LYN-4346 Adding the Diffuse Global Illumination component to the entity crashes the Editor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
@@ -60,7 +60,7 @@ namespace AZ
 
         void DiffuseGlobalIlluminationFeatureProcessor::UpdatePasses()
         {
-            float sizeMultiplier = 0.0f;
+            float sizeMultiplier = 0.25f;
             switch (m_qualityLevel)
             {
             case DiffuseGlobalIlluminationQualityLevel::Low:

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationComponentConfig.h
@@ -29,7 +29,7 @@ namespace AZ
 
             static void Reflect(ReflectContext* context);
 
-            DiffuseGlobalIlluminationQualityLevel m_qualityLevel;
+            DiffuseGlobalIlluminationQualityLevel m_qualityLevel = DiffuseGlobalIlluminationQualityLevel::Low;
         };
     }
 }


### PR DESCRIPTION
The quality level in component's config doesn't have a default value which lead to size multiplier set to 0 then lead to creating invalid attachment. 
 