### PR TITLE
Wireframe menu option removal causes error message in debug builds

### DIFF
--- a/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
@@ -715,10 +715,10 @@ QMenu* LevelEditorMenuHandler::CreateViewMenu()
         {
             return view.IsViewportPane();
         });
-#endif
 
-    viewportViewsMenuWrapper.AddAction(ID_WIREFRAME);
     viewportViewsMenuWrapper.AddSeparator();
+
+#endif
 
     if (CViewManager::IsMultiViewportEnabled())
     {


### PR DESCRIPTION
Addressing issue introduced by [previous PR](https://github.com/aws-lumberyard/o3de/pull/1248) in debug builds. Identifier for the wireframe menu item was still being referenced and would trigger an error window on Editor startup.

![image](https://user-images.githubusercontent.com/82231674/121641472-14c56600-ca44-11eb-80ff-caf0285d63b2.png)
