### PR TITLE
CMake URL Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you have the Git credential manager core or other credential helpers installe
         *   Game Development with C++
         *   MSVC v142 - VS 2019 C++ x64/x86
         *   C++ 2019 redistributable update
-*   CMake 3.19.1 minimum: [https://cmake.org/files/LatestRelease/cmake-3.19.1-win64-x64.msi](https://cmake.org/files/LatestRelease/cmake-3.19.1-win64-x64.msi)
+*   CMake 3.19.1 minimum: [https://cmake.org/files/LatestRelease/?C=M;O=D](https://cmake.org/files/LatestRelease/?C=M;O=D)
 
 #### Optional
 


### PR DESCRIPTION
Updated the url to download CMake as the current one is broken. The new link will take users to see all cmake distributables sorted by last changed.