### PR TITLE
[LYN-4160] Fixed intermittent crash by changing instantiate prefab dialog to use the AzToolsFramework::GetActiveWindow() helper which always gives a valid active window.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -28,6 +28,7 @@
 #include <AzToolsFramework/ToolsComponents/EditorLayerComponentBus.h>
 #include <AzToolsFramework/UI/EditorEntityUi/EditorEntityUiInterface.h>
 #include <AzToolsFramework/UI/Prefab/PrefabIntegrationInterface.h>
+#include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
 #include <QApplication>
 #include <QFileDialog>
@@ -588,15 +589,6 @@ namespace AzToolsFramework
 
         bool PrefabIntegrationManager::QueryUserForPrefabFilePath(AZStd::string& outPrefabFilePath)
         {
-            QWidget* mainWindow = nullptr;
-            EditorRequests::Bus::BroadcastResult(mainWindow, &EditorRequests::Bus::Events::GetMainWindow);
-
-            if (mainWindow == nullptr)
-            {
-                AZ_Assert(false, "Prefab - Could not detect Editor main window to generate the asset picker.");
-                return false;
-            }
-
             AssetSelectionModel selection;
 
             // Note, stringfilter will match every source file CONTAINING ".prefab".
@@ -624,7 +616,7 @@ namespace AzToolsFramework
             selection.SetDisplayFilter(compositeFilterPtr);
             selection.SetSelectionFilter(compositeFilterPtr);
 
-            AssetBrowserComponentRequestBus::Broadcast(&AssetBrowserComponentRequests::PickAssets, selection, mainWindow);
+            AssetBrowserComponentRequestBus::Broadcast(&AssetBrowserComponentRequests::PickAssets, selection, AzToolsFramework::GetActiveWindow());
 
             if (!selection.IsValid())
             {
@@ -983,12 +975,7 @@ namespace AzToolsFramework
                         includedEntities.c_str(),
                         referencedEntities.c_str());
 
-                    QWidget* mainWindow = nullptr;
-                    AzToolsFramework::EditorRequests::Bus::BroadcastResult(
-                        mainWindow,
-                        &AzToolsFramework::EditorRequests::Bus::Events::GetMainWindow);
-
-                    QMessageBox msgBox(mainWindow);
+                    QMessageBox msgBox(AzToolsFramework::GetActiveWindow());
                     msgBox.setWindowTitle("External Entity References");
                     msgBox.setText("The prefab contains references to external entities that are not selected.");
                     msgBox.setInformativeText("You can move the referenced entities into this prefab or retain the external references.");


### PR DESCRIPTION
Tested the instantiate prefab popup (and the other popup I found in the same file using the same pattern) after switching them to use the helper method instead.