### PR TITLE
LYN-4042 | No UI Indication that Level is Modified

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -252,13 +252,20 @@ namespace AzToolsFramework
         }
 
         AZStd::string out;
-        if (m_loaderInterface->SaveTemplateToString(m_rootInstance->GetTemplateId(), out))
+
+        if (!m_loaderInterface->SaveTemplateToString(m_rootInstance->GetTemplateId(), out))
         {
-            const size_t bytesToWrite = out.size();
-            const size_t bytesWritten = stream.Write(bytesToWrite, out.data());
-            return bytesWritten == bytesToWrite;
+            return false;
         }
-        return false;
+
+        const size_t bytesToWrite = out.size();
+        const size_t bytesWritten = stream.Write(bytesToWrite, out.data());
+        if(bytesWritten != bytesToWrite)
+        {
+            return false;
+        }
+        m_prefabSystemComponent->SetTemplateDirtyFlag(templateId, false);
+        return true;
     }
 
     void PrefabEditorEntityOwnershipService::CreateNewLevelPrefab(AZStd::string_view filename, const AZStd::string& templateFilename)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabLoader.cpp
@@ -363,7 +363,6 @@ namespace AzToolsFramework
                 );
                 return false;
             }
-            m_prefabSystemComponentInterface->SetTemplateDirtyFlag(templateId, false);
             return true;
         }
 


### PR DESCRIPTION
Reintroduces the dirty mark for the Level Container. Fixes the level save code to correctly clear the dirty flag.