### PR TITLE
avoid some divisions by zero in simd math types

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_simd.inl
@@ -292,8 +292,13 @@ namespace AZ
                 const typename VecType::FloatType cmp2 = VecType::AndNot(cmp0, cmp1);
 
                 // -1/x
+                // this step is calculated for all values of x, but only used if x > Sqrt(2) + 1
+                // in order to avoid a division by zero, detect if xabs is zero here and replace it with an arbitrary value
+                // if xabs does equal zero, the value here doesn't matter because the result will be thrown away
+                typename VecType::FloatType xabsSafe =
+                    VecType::Add(xabs, VecType::And(VecType::CmpEq(xabs, VecType::ZeroFloat()), FastLoadConstant<VecType>(Simd::g_vec1111)));
                 const typename VecType::FloatType y0 = VecType::And(cmp0, FastLoadConstant<VecType>(Simd::g_HalfPi));
-                typename VecType::FloatType x0 = VecType::Div(FastLoadConstant<VecType>(Simd::g_vec1111), xabs);
+                typename VecType::FloatType x0 = VecType::Div(FastLoadConstant<VecType>(Simd::g_vec1111), xabsSafe);
                 x0 = VecType::Xor(x0, VecType::CastToFloat(FastLoadConstant<VecType>(Simd::g_negateMask)));
 
                 const typename VecType::FloatType y1 = VecType::And(cmp2, FastLoadConstant<VecType>(Simd::g_QuarterPi));
@@ -368,8 +373,12 @@ namespace AZ
 
                 typename VecType::FloatType offset = VecType::And(x_lt_0, offset1);
 
+                // the result of this part of the computation is thrown away if x equals 0,
+                // but if x does equal 0, it will cause a division by zero
+                // so replace zero by an arbitrary value here in that case
+                typename VecType::FloatType xSafe = VecType::Add(x, VecType::And(x_eq_0, FastLoadConstant<VecType>(Simd::g_vec1111)));
                 const typename VecType::FloatType atan_mask = VecType::Not(VecType::Or(x_eq_0, y_eq_0));
-                const typename VecType::FloatType atan_arg = VecType::Div(y, x);
+                const typename VecType::FloatType atan_arg = VecType::Div(y, xSafe);
                 typename VecType::FloatType atan_result = VecType::Atan(atan_arg);
                 atan_result = VecType::Add(atan_result, offset);
                 atan_result = VecType::AndNot(pio2_mask, atan_result);

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_sse.inl
@@ -471,6 +471,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec2::FloatType Vec2::Reciprocal(FloatArgType value)
         {
+            value = Sse::ReplaceFourth(Sse::ReplaceThird(value, 1.0f), 1.0f);
             return Sse::Reciprocal(value);
         }
 
@@ -513,6 +514,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec2::FloatType Vec2::SqrtInv(FloatArgType value)
         {
+            value = Sse::ReplaceFourth(Sse::ReplaceThird(value, 1.0f), 1.0f);
             return Sse::SqrtInv(value);
         }
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_sse.inl
@@ -507,6 +507,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::Reciprocal(FloatArgType value)
         {
+            value = Sse::ReplaceFourth(value, 1.0f);
             return Sse::Reciprocal(value);
         }
 
@@ -549,6 +550,7 @@ namespace AZ
 
         AZ_MATH_INLINE Vec3::FloatType Vec3::SqrtInv(FloatArgType value)
         {
+            value = Sse::ReplaceFourth(value, 1.0f);
             return Sse::SqrtInv(value);
         }
 


### PR DESCRIPTION
This addresses some possible sources of simd division by zero exceptions in the math library, but I believe there are other places which may pop up, such as:
- anything else which calls Div (we might consider adding additional safety directly inside Div)
- Normalize, if the length of the object being normalized is zero (which is already kind of an edge case)