### PR TITLE
{LYN-4213}launching AP with no changes results in thousands of jobs being run

### DIFF
--- a/Code/Tools/AssetProcessor/assetprocessor_static_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_static_files.cmake
@@ -19,6 +19,7 @@ set(FILES
     native/AssetManager/AssetRequestHandler.cpp
     native/AssetManager/AssetRequestHandler.h
     native/AssetManager/assetScanFolderInfo.h
+    native/AssetManager/assetScanFolderInfo.cpp
     native/AssetManager/assetScanner.cpp
     native/AssetManager/assetScanner.h
     native/AssetManager/assetScannerWorker.cpp

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetScanFolderInfo.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetScanFolderInfo.cpp
@@ -1,0 +1,42 @@
+/*
+* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+* its licensors.
+*
+* For complete copyright and license terms please see the LICENSE at the root of this
+* distribution (the "License"). All use of this software is governed by the License,
+* or, if provided, by the license below or the license accompanying this file. Do not
+* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*
+*/
+
+#include <native/AssetManager/assetScanFolderInfo.h>
+#include <native/utilities/assetUtils.h>
+
+namespace AssetProcessor
+{
+        ScanFolderInfo::ScanFolderInfo(
+            QString path,
+            QString displayName,
+            QString portableKey,
+            bool isRoot,
+            bool recurseSubFolders,
+            AZStd::vector<AssetBuilderSDK::PlatformInfo> platforms,
+            int order,
+            AZ::s64 scanFolderID,
+            bool canSaveNewAssets)
+            : m_scanPath(path)
+            , m_displayName(displayName)
+            , m_portableKey (portableKey)
+            , m_isRoot(isRoot)
+            , m_recurseSubFolders(recurseSubFolders)
+            , m_order(order)
+            , m_scanFolderID(scanFolderID)
+            , m_platforms(platforms)
+            , m_canSaveNewAssets(canSaveNewAssets)
+        {
+            m_scanPath = AssetUtilities::NormalizeFilePath(m_scanPath);
+            // note that m_scanFolderID is 0 unless its filled in from the DB.
+        }
+
+} // end namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetScanFolderInfo.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetScanFolderInfo.h
@@ -33,19 +33,7 @@ namespace AssetProcessor
             AZStd::vector<AssetBuilderSDK::PlatformInfo> platforms = AZStd::vector<AssetBuilderSDK::PlatformInfo>{},
             int order = 0,
             AZ::s64 scanFolderID = 0,
-            bool canSaveNewAssets = false)
-            : m_scanPath(path)
-            , m_displayName(displayName)
-            , m_portableKey (portableKey)
-            , m_isRoot(isRoot)
-            , m_recurseSubFolders(recurseSubFolders)
-            , m_order(order)
-            , m_scanFolderID(scanFolderID)
-            , m_platforms(platforms)
-            , m_canSaveNewAssets(canSaveNewAssets)
-        {
-            // note that m_scanFolderID is 0 unless its filled in from the DB.
-        }
+            bool canSaveNewAssets = false);
 
         ScanFolderInfo() = default;
         ScanFolderInfo(const ScanFolderInfo& other) = default;


### PR DESCRIPTION
{LYN-4213}launching AP with no changes results in thousands of jobs being run

Please note that this was happening because if wrong casing of drive letter was inputted by the user in the setreg file for the project path then AP was treating the project directory as a new scan folder and therefore processing assets again. I found a helper function "NormalizeFilePath" in assetUtilities that not only normalize the path but also makes the drive letter uppercase on windows and i am using that util method before AP tries to save the scan folder to the database.