### PR TITLE
[ATOM-15781] Add Python script for calculating avg/max frame render time of a sample.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Scripts/performance_metrics/timestamp_aggregator.py
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/performance_metrics/timestamp_aggregator.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+"""
+All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+its licensors.
+
+For complete copyright and license terms please see the LICENSE at the root of this
+distribution (the "License"). All use of this software is governed by the License,
+or, if provided, by the license below or the license accompanying this file. Do not
+remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+"""
+
+from genericpath import isdir
+from argparse import ArgumentParser
+import json
+from pathlib import Path
+import os
+
+# this allows us to add additional data if necessary, e.g. frame_test_timestamps.json
+is_timestamp_file = lambda file: file.name.startswith('frame') and file.name.endswith('_timestamps.json')
+ns_to_ms = lambda time: time / 1e6
+
+def main(logs_dir):
+    count = 0
+    total = 0
+    maximum = 0
+
+    print(f'Analyzing frame timestamp logs in {logs_dir}')
+
+    # go through files in alphabetical order (remove sorted() if not necessary)
+    for file in sorted(logs_dir.iterdir(), key=lambda file: len(file.name)):
+        if file.is_dir() or not is_timestamp_file(file):
+            continue
+
+        data = json.loads(file.read_text())
+        entries = data['ClassData']['timestampEntries']
+        timestamps = [entry['timestampResultInNanoseconds'] for entry in entries]
+
+        frame_time = sum(timestamps)
+        frame_name = file.name.split('_')[0]
+        print(f'- Total time for frame {frame_name}: {ns_to_ms(frame_time)}ms')
+
+        maximum = max(maximum, frame_time)
+        total += frame_time
+        count += 1
+
+    if count < 1:
+        print(f'No logs were found in {base_dir}')
+        exit(1)
+
+    print(f'Avg. time across {count} frames: {ns_to_ms(total / count)}ms')
+    print(f'Max frame time: {ns_to_ms(maximum)}ms')
+
+if __name__ == '__main__':
+    parser = ArgumentParser(description='Gathers statistics from a group of pass timestamp logs')
+    parser.add_argument('path', help='Path to the directory containing the pass timestamp logs')
+    args = parser.parse_args()
+
+    base_dir = Path(args.path)
+    if not base_dir.exists():
+        raise FileNotFoundError('Invalid path provided')
+    main(base_dir)


### PR DESCRIPTION
Adds a Python script that takes a given path to a timestamp logs folder to aggregate the total time taken to render each frame logged in the folder, then finds the average and maximum total time.

<details>
<summary>Example usage and output</summary>

```sh
cyntlin@SEA-9901268538:~/Documents/o3de$ ./Gems/Atom/Feature/Common/Assets/Scripts/performance_metrics/timestamp_aggregator.py ~/Documents/o3de/atomsampleviewer/user/scripts/performancestats/cullingandlod
Analyzing frame timestamp logs in C:\Users\cyntlin\Documents\o3de\atomsampleviewer\user\scripts\performancestats\cullingandlod
- Total time for frame frame1: 0.856ms
- Total time for frame frame2: 0.866ms
- Total time for frame frame3: 0.864ms
- Total time for frame frame4: 0.863ms
- Total time for frame frame5: 0.869ms
- Total time for frame frame6: 0.88ms
- Total time for frame frame7: 0.865ms
- Total time for frame frame8: 0.886ms
- Total time for frame frame9: 0.864ms
- Total time for frame frame10: 1.142ms
- Total time for frame frame11: 0.867ms
- Total time for frame frame12: 0.876ms
- Total time for frame frame13: 0.889ms
- Total time for frame frame14: 0.869ms
- Total time for frame frame15: 0.863ms
- Total time for frame frame16: 0.895ms
- Total time for frame frame17: 0.856ms
- Total time for frame frame18: 0.862ms
- Total time for frame frame19: 0.877ms
- Total time for frame frame20: 0.868ms
- Total time for frame frame21: 0.865ms
- Total time for frame frame22: 0.877ms
- Total time for frame frame23: 0.876ms
- Total time for frame frame24: 0.878ms
- Total time for frame frame25: 1.18ms
- Total time for frame frame26: 1.169ms
- Total time for frame frame27: 1.617ms
- Total time for frame frame28: 1.158ms
- Total time for frame frame29: 1.182ms
- Total time for frame frame30: 1.2ms
- Total time for frame frame31: 1.182ms
- Total time for frame frame32: 1.215ms
- Total time for frame frame33: 1.195ms
- Total time for frame frame34: 1.216ms
- Total time for frame frame35: 1.214ms
- Total time for frame frame36: 1.204ms
- Total time for frame frame37: 1.234ms
- Total time for frame frame38: 1.226ms
- Total time for frame frame39: 1.243ms
- Total time for frame frame40: 1.23ms
- Total time for frame frame41: 1.239ms
- Total time for frame frame42: 1.22ms
- Total time for frame frame43: 1.254ms
- Total time for frame frame44: 1.241ms
- Total time for frame frame45: 1.264ms
- Total time for frame frame46: 1.242ms
- Total time for frame frame47: 1.271ms
- Total time for frame frame48: 1.272ms
- Total time for frame frame49: 1.292ms
- Total time for frame frame50: 1.272ms
- Total time for frame frame51: 1.276ms
- Total time for frame frame52: 1.287ms
- Total time for frame frame53: 1.294ms
- Total time for frame frame54: 1.284ms
- Total time for frame frame55: 1.326ms
- Total time for frame frame56: 1.305ms
- Total time for frame frame57: 1.31ms
- Total time for frame frame58: 1.744ms
- Total time for frame frame59: 2.295ms
- Total time for frame frame60: 1.337ms
- Total time for frame frame61: 1.332ms
- Total time for frame frame62: 1.782ms
- Total time for frame frame63: 1.319ms
- Total time for frame frame64: 1.795ms
- Total time for frame frame65: 1.319ms
- Total time for frame frame66: 1.39ms
- Total time for frame frame67: 1.333ms
- Total time for frame frame68: 1.35ms
- Total time for frame frame69: 1.291ms
- Total time for frame frame70: 1.329ms
- Total time for frame frame71: 1.327ms
- Total time for frame frame72: 2.316ms
- Total time for frame frame73: 1.356ms
- Total time for frame frame74: 1.845ms
- Total time for frame frame75: 1.79ms
- Total time for frame frame76: 1.363ms
- Total time for frame frame77: 1.333ms
- Total time for frame frame78: 1.386ms
- Total time for frame frame79: 1.349ms
- Total time for frame frame80: 1.352ms
- Total time for frame frame81: 1.373ms
- Total time for frame frame82: 1.359ms
- Total time for frame frame83: 2.355ms
- Total time for frame frame84: 1.345ms
- Total time for frame frame85: 1.385ms
- Total time for frame frame86: 1.371ms
- Total time for frame frame87: 1.36ms
- Total time for frame frame88: 1.353ms
- Total time for frame frame89: 1.364ms
- Total time for frame frame90: 1.394ms
- Total time for frame frame91: 1.383ms
- Total time for frame frame92: 2.405ms
- Total time for frame frame93: 1.921ms
- Total time for frame frame94: 1.8ms
- Total time for frame frame95: 1.394ms
- Total time for frame frame96: 1.402ms
- Total time for frame frame97: 2.382ms
- Total time for frame frame98: 1.396ms
- Total time for frame frame99: 1.436ms
- Total time for frame frame100: 1.39ms
Avg. time across 100 frames: 1.29088ms
Max frame time: 2.405ms
```
</details