### PR TITLE
Fix function signature of binary +/- operator to not return a reference

### DIFF
--- a/Code/CryEngine/CryCommon/ISystem.h
+++ b/Code/CryEngine/CryCommon/ISystem.h
@@ -1154,13 +1154,13 @@ struct DiskOperationInfo
         return *this;
     }
 
-    DiskOperationInfo& operator - (const DiskOperationInfo& rv)
+    DiskOperationInfo operator - (const DiskOperationInfo& rv)
     {
         DiskOperationInfo res(*this);
         return res -= rv;
     }
 
-    DiskOperationInfo& operator + (const DiskOperationInfo& rv)
+    DiskOperationInfo operator + (const DiskOperationInfo& rv)
     {
         DiskOperationInfo res(*this);
         return res += rv;


### PR DESCRIPTION
This function creates a new object on the stack, and was returning it as
a reference. This would trigger Clang 12's `-Wreturn-stack-address`
warning, and cause the build to fail.

This fixes builds with clang 12, so it will close #591 