### PR TITLE
[LYN-4346] Adding the Diffuse Global Illumination component crashes the Editor (Prefab Mode)

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessorInterface.h
@@ -23,7 +23,9 @@ namespace AZ
         {
             Low,
             Medium,
-            High
+            High,
+
+            Count
         };
 
         //! This class provides general features and configuration for the diffuse global illumination environment,

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
@@ -43,6 +43,12 @@ namespace AZ
 
         void DiffuseGlobalIlluminationFeatureProcessor::SetQualityLevel(DiffuseGlobalIlluminationQualityLevel qualityLevel)
         {
+            if (qualityLevel >= DiffuseGlobalIlluminationQualityLevel::Count)
+            {
+                AZ_Assert(false, "SetQualityLevel called with invalid quality level [%d]", qualityLevel);
+                return;
+            }
+
             m_qualityLevel = qualityLevel;
 
             UpdatePasses();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationComponentConfig.h
@@ -29,7 +29,7 @@ namespace AZ
 
             static void Reflect(ReflectContext* context);
 
-            DiffuseGlobalIlluminationQualityLevel m_qualityLevel;
+            DiffuseGlobalIlluminationQualityLevel m_qualityLevel = DiffuseGlobalIlluminationQualityLevel::Low;
         };
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/EditorDiffuseGlobalIlluminationComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/EditorDiffuseGlobalIlluminationComponent.cpp
@@ -36,7 +36,7 @@ namespace AZ
                         ->Attribute(Edit::Attributes::Category, "Atom")
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Component_Placeholder.svg")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Component_Placeholder.png")
-                        ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZStd::vector<AZ::Crc32>({ AZ_CRC("Level", 0x9aeacc13), AZ_CRC("Game", 0x232b318c) }))
+                        ->Attribute(Edit::Attributes::AppearsInAddComponentMenu, AZStd::vector<AZ::Crc32>({ AZ_CRC("Level", 0x9aeacc13) }))
                         ->Attribute(Edit::Attributes::AutoExpand, true)
                         ->Attribute(Edit::Attributes::HelpPageURL, "https://")
                         ;


### PR DESCRIPTION
Removed the DiffuseGlobalIllumination component from the Entity Component list, it was intended to be a Level Component only.
Checked for a valid quality level in DiffuseGlobalIlluminationFeatureProcessor::SetQualityLevel.
Initialized the quality level to Low in DiffuseGlobalIlluminationComponentConfig.