### PR TITLE
Fixing boundary search

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/PointLight.azsli
@@ -15,9 +15,6 @@
 #include <Atom/Features/PBR/Lights/LightTypesCommon.azsli>
 #include <Atom/Features/Shadow/ProjectedShadow.azsli>
 
-// The order should match m_pointShadowTransforms in PointLightFeatureProcessor.h/.cpp
-static const float3 PointLightShadowCubemapDirections[6] = {float3(-1,0,0), float3(1,0,0), float3(0,-1,0), float3(0,1,0), float3(0,0,-1), float3(0,0,1)};                  
-
 int GetPointLightShadowCubemapFace(const float3 targetPos, const float3 lightPos)
 {
     const float3 toPoint = targetPos - lightPos;    
@@ -83,12 +80,13 @@ void ApplyPointLight(ViewSrg::PointLight light, Surface surface, inout LightingD
         {
             const int shadowCubemapFace = GetPointLightShadowCubemapFace(surface.position, light.m_position);
             const int shadowIndex = UnpackPointLightShadowIndex(light, shadowCubemapFace);
-
+            const float3 lightDir = normalize(light.m_position - surface.position);
+             
             litRatio *= ProjectedShadow::GetVisibility(
                     shadowIndex,
                     light.m_position,
                     surface.position,
-                    PointLightShadowCubemapDirections[shadowCubemapFace],
+                    lightDir,
                     surface.normal);
                         
             // Use backShadowRatio to carry thickness from shadow map for thick mode


### PR DESCRIPTION
Fix for artifacts with point light shadows + boundary softening width enabled

ASV shadow and material tests pass
Tested the Editor

ATOM-15764

![image](https://user-images.githubusercontent.com/61609885/122092301-9d366480-cdbe-11eb-96f1-7e65e52c4829.png)
