### PR TITLE
[LYN-3117] Adding a skeletal mesh to a project doesn't include an Actor by default

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
@@ -21,6 +21,7 @@
 #include <SceneAPI/SceneCore/Containers/Utilities/Filters.h>
 #include <SceneAPI/SceneCore/Containers/Utilities/SceneGraphUtilities.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h>
+#include <SceneAPI/SceneCore/DataTypes/GraphData/IBlendShapeData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IBoneData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/ISkinWeightData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IAnimationData.h>
@@ -172,10 +173,13 @@ namespace EMotionFX
 
             AZ::SceneAPI::Events::ProcessingResult ActorGroupBehavior::BuildDefault(AZ::SceneAPI::Containers::Scene& scene) const
             {
-                const bool hasBoneOrSkinData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBoneData>(scene, true) ||
-                                                AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::ISkinWeightData>(scene, true);
-                const bool hasAnimationData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IAnimationData>(scene, true);
-                if (SceneHasActorGroup(scene) || !hasBoneOrSkinData || hasAnimationData)
+                const bool hasBoneData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBoneData>(scene, true);
+                const bool hasSkinData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::ISkinWeightData>(scene, true);
+                const bool hasBlendShapeData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBlendShapeData>(scene, true);
+                // Skip building the default actor in case a valid actor group with overwritten settings exists, or
+                // in the most common case for animation files, that do contain an animated skeleton while not containing a skin or blend shapes.
+                if (SceneHasActorGroup(scene) ||
+                    (hasBoneData && (!hasSkinData && !hasBlendShapeData)))
                 {
                     return AZ::SceneAPI::Events::ProcessingResult::Ignored;
                 }


### PR DESCRIPTION
* Before we were skipping actors in case there was animation data present in the source asset to avoid having many duplicated actors.
* There was an issue though for simple test fbx files containing a full character with a test motion.
* The new rule is that we will be exporting actors on default whenever there is a skeleton including either skinning data or morph targets, as these usually are not included for animation assets to not increase disk space heavily.
* Tested with several of our assets and always showed the expected behavior with the new way.