### PR TITLE
Allow smaller increments for editor camera speed

### DIFF
--- a/Code/Sandbox/Editor/ViewportTitleDlg.cpp
+++ b/Code/Sandbox/Editor/ViewportTitleDlg.cpp
@@ -181,7 +181,8 @@ void CViewportTitleDlg::SetupCameraDropdownMenu()
     auto comboBoxTextChanged = static_cast<void (QComboBox::*)(const QString&)>(&QComboBox::currentTextChanged);
 
     SetSpeedComboBox(cameraMoveSpeed);
-    m_cameraSpeed->setInsertPolicy(QComboBox::NoInsert);
+    m_cameraSpeed->setInsertPolicy(QComboBox::InsertAtBottom);
+    m_cameraSpeed->setDuplicatesEnabled(false);
     connect(m_cameraSpeed, comboBoxTextChanged, this, &CViewportTitleDlg::OnUpdateMoveSpeedText);
     connect(m_cameraSpeed->lineEdit(), &QLineEdit::returnPressed, this, &CViewportTitleDlg::OnSpeedComboBoxEnter);
 

--- a/Code/Sandbox/Editor/ViewportTitleDlg.h
+++ b/Code/Sandbox/Editor/ViewportTitleDlg.h
@@ -117,11 +117,11 @@ protected:
     // Speed combobox/lineEdit settings
     double m_minSpeed = 0.01;
     double m_maxSpeed = 100.0;
-    double m_speedStep = 0.01;
+    double m_speedStep = 0.001;
     int m_numDecimals = 3;
 
     // Speed presets
-    float m_speedPresetValues[3] = { 0.1f, 1.0f, 10.0f };
+    float m_speedPresetValues[4] = { 0.01f, 0.1f, 1.0f, 10.0f };
 
     double m_fieldWidthMultiplier = 1.8;
 


### PR DESCRIPTION
This addresses several issues our team has encountered with camera speed:
- a step size of 0.01 is too large for very high detail work (this lowers it to 0.001)
- the user often wants to enter their own custom speeds for their specific scene or scenes, and then be able to easily switch between those without having to enter them again into the text box (this changes the insert policy of the speed combo box to allow this workflow)