### PR TITLE
sig/network: Correcting the issue with processing of prefabs in Multiplayer projects

### DIFF
--- a/Gems/Multiplayer/Code/CMakeLists.txt
+++ b/Gems/Multiplayer/Code/CMakeLists.txt
@@ -123,6 +123,8 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PRIVATE
                 Gem::Multiplayer.Builders.Static
+        RUNTIME_DEPENDENCIES
+            Gem::Multiplayer.Editor
     )
 
     ly_add_target(


### PR DESCRIPTION
Multiplayer.Builders needs to have Multiplayer.Editor reflection data. I'm surprised this worked before or how.