### PR TITLE
Fixes for SDK include directory structure

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -44,15 +44,15 @@ function(ly_setup_target OUTPUT_CONFIGURED_TARGET ALIAS_TARGET_NAME)
                 unset(current_public_headers)
 
                 cmake_path(NORMAL_PATH include_directory)
-                cmake_path(IS_PREFIX absolute_target_source_dir BASE_DIRECTORY ${LY_ROOT_FOLDER} NORMALIZE include_directory_child_of_o3de_root)
+                string(REGEX REPLACE "/$" "" include_directory "${include_directory}")
+                cmake_path(IS_PREFIX LY_ROOT_FOLDER ${absolute_target_source_dir} NORMALIZE include_directory_child_of_o3de_root)
                 if(NOT include_directory_child_of_o3de_root)
-                     message(FATAL_ERROR "Include directory of \"${include_directory}\" is outside of the O3DE root folder of \"${LY_ROOT_FOLDER}\". For the INSTALL step, the O3DE root folder must be a prefix of all include directories")
-                 endif()
+                    message(FATAL_ERROR "Include directory of \"${include_directory}\" is outside of the O3DE root folder of \"${LY_ROOT_FOLDER}\". For the INSTALL step, the O3DE root folder must be a prefix of all include directories")
+                endif()
 
-                 cmake_path(RELATIVE_PATH include_directory BASE_DIRECTORY ${LY_ROOT_FOLDER} OUTPUT_VARIABLE rel_include_dir)
-                 cmake_path(APPEND include_location "${rel_include_dir}" ".." OUTPUT_VARIABLE destination_dir)
-                 cmake_path(NORMAL_PATH destination_dir)
-                 cmake_path(GET destination_dir PARENT_PATH destination_dir)
+                cmake_path(RELATIVE_PATH include_directory BASE_DIRECTORY ${LY_ROOT_FOLDER} OUTPUT_VARIABLE rel_include_dir)
+                cmake_path(APPEND include_location "${rel_include_dir}" ".." OUTPUT_VARIABLE destination_dir)
+                cmake_path(NORMAL_PATH destination_dir)
 
                 install(DIRECTORY ${include_directory}
                     DESTINATION ${destination_dir}


### PR DESCRIPTION
- Enforces consistency on include paths seen to ensure paths are handled as intended.
- Handle cases where relative paths had been exported to public interface, sometimes going up one or more directories.  Normalize paths as needed.
- Handle cases where the files being exported were sourced in the build directories (AutoGen) and mirror a similar structure in the include structure.