### PR TITLE
fixing linux sanity tests

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/__init__.py
+++ b/Tools/LyTestTools/ly_test_tools/__init__.py
@@ -28,6 +28,7 @@ WINDOWS = sys.platform.startswith('win')
 HOST_OS_PLATFORM = 'unknown'
 HOST_OS_EDITOR = 'unknown'
 HOST_OS_DEDICATED_SERVER = 'unknown'
+HOST_OS_GENERIC_EXECUTABLE = 'unknown'
 LAUNCHERS = {}
 for launcher_option in ALL_LAUNCHER_OPTIONS:
     LAUNCHERS[launcher_option] = None

--- a/scripts/ctest/ctest_entrypoint.sh
+++ b/scripts/ctest/ctest_entrypoint.sh
@@ -14,7 +14,7 @@
 #
 
 CURRENT_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE:-0}" )" >/dev/null 2>&1 && pwd )"
-DEV_DIR="$( dirname "$CURRENT_SCRIPT_DIR" )"
+DEV_DIR=$( dirname "$( dirname "$CURRENT_SCRIPT_DIR" )" )
 PYTHON=$DEV_DIR/python/python.sh
 CTEST_SCRIPT=$CURRENT_SCRIPT_DIR/ctest_driver.py
 


### PR DESCRIPTION
Fixes the Linux python sanity tests.

Also fixes the Python path for the ctest_entrypoint bash script.