### PR TITLE
[LYN-4527] Make sure the PrefabIntegrationManager is only created when prefabs are enabled, otherwise could result in crashes.

### DIFF
--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -154,11 +154,23 @@ SandboxIntegrationManager::SandboxIntegrationManager()
 {
     // Required to receive events from the Cry Engine undo system
     GetIEditor()->GetUndoManager()->AddListener(this);
+
+    // Only create the PrefabIntegrationManager if prefabs are enabled
+    bool prefabSystemEnabled = false;
+    AzFramework::ApplicationRequests::Bus::BroadcastResult(
+        prefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+    if (prefabSystemEnabled)
+    {
+        m_prefabIntegrationManager = aznew AzToolsFramework::Prefab::PrefabIntegrationManager();
+    }
 }
 
 SandboxIntegrationManager::~SandboxIntegrationManager()
 {
     GetIEditor()->GetUndoManager()->RemoveListener(this);
+
+    delete m_prefabIntegrationManager;
+    m_prefabIntegrationManager = nullptr;
 }
 
 void SandboxIntegrationManager::Setup()
@@ -187,11 +199,16 @@ void SandboxIntegrationManager::Setup()
     AZ_Assert((m_editorEntityUiInterface != nullptr),
         "SandboxIntegrationManager requires a EditorEntityUiInterface instance to be present on Setup().");
 
-    m_prefabIntegrationInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabIntegrationInterface>::Get();
-
-    AZ_Assert(
-        (m_prefabIntegrationInterface != nullptr),
-        "SandboxIntegrationManager requires a PrefabIntegrationInterface instance to be present on Setup().");
+    bool prefabSystemEnabled = false;
+    AzFramework::ApplicationRequests::Bus::BroadcastResult(
+        prefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+    if (prefabSystemEnabled)
+    {
+        m_prefabIntegrationInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabIntegrationInterface>::Get();
+        AZ_Assert(
+            (m_prefabIntegrationInterface != nullptr),
+            "SandboxIntegrationManager requires a PrefabIntegrationInterface instance to be present on Setup().");
+    }
 
     m_editorEntityAPI = AZ::Interface<AzToolsFramework::EditorEntityAPI>::Get();
     AZ_Assert(m_editorEntityAPI, "SandboxIntegrationManager requires an EditorEntityAPI instance to be present on Setup().");

--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -305,7 +305,7 @@ private:
 
     bool m_debugDisplayBusImplementationActive = false;
 
-    AzToolsFramework::Prefab::PrefabIntegrationManager m_prefabIntegrationManager;
+    AzToolsFramework::Prefab::PrefabIntegrationManager* m_prefabIntegrationManager = nullptr;
 
     AzToolsFramework::EditorEntityUiInterface* m_editorEntityUiInterface = nullptr;
     AzToolsFramework::Prefab::PrefabIntegrationInterface* m_prefabIntegrationInterface = nullptr;


### PR DESCRIPTION
It was originally suspected that https://github.com/aws-lumberyard/o3de/pull/1209/ had introduced this crash, but upon further digging it seems to have only exposed the real issue which was that the PrefabIntegrationManager was being created even if prefabs were disabled. I checked and noticed that the SandboxIntegration was the only place using the PrefabIntegrationInterface (provided by PrefabIntegrationManager), so nothing else should be affected by making the PrefabIntegrationManager only be created when prefabs are enabled.

Tested various slice/prefab basic workflows (create entity, create slice/prefab, instantiate slice/prefab, etc...) and verified they work as expected. Also tested specific use-case that caused this issue to be opened and it no longer crashes the Editor.