### PR TITLE
Bug fix: check for valid extension in case insensitive manner

### DIFF
--- a/Code/Tools/SceneAPI/FbxSceneBuilder/FbxImportRequestHandler.cpp
+++ b/Code/Tools/SceneAPI/FbxSceneBuilder/FbxImportRequestHandler.cpp
@@ -77,6 +77,7 @@ namespace AZ
             {
                 AZStd::string extension;
                 StringFunc::Path::GetExtension(path.c_str(), extension);
+                AZStd::to_lower(extension.begin(), extension.end());
                 
                 if (!m_settings.m_supportedFileTypeExtensions.contains(extension))
                 {


### PR DESCRIPTION
Before this change, "x.FBX" and "x.FbX" and "x.fBx" will all fail to compile with an extremely cryptic error message: "Failed to load requested scene file" and nothing else.