### PR TITLE
Fix AssetBuilders when project-path has a trailing slash

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.cpp
@@ -187,9 +187,9 @@ namespace AssetProcessor
         QDir projectCacheRoot;
         AssetUtilities::ComputeProjectCacheRoot(projectCacheRoot);
 
-        auto projectName = AZ::Utils::GetProjectName();
-        auto projectPath = AZ::Utils::GetProjectPath();
-        auto enginePath = AZ::Utils::GetEnginePath();
+        AZ::SettingsRegistryInterface::FixedValueString projectName = AZ::Utils::GetProjectName();
+        AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
+        AZ::IO::FixedMaxPathString enginePath = AZ::Utils::GetEnginePath();
 
         int portNumber = 0;
         ApplicationServerBus::BroadcastResult(portNumber, &ApplicationServerBus::Events::GetServerListeningPort);


### PR DESCRIPTION
Normally a trailing slash on command-line will get stripped off, but AssetBuilders had slightly different code that sets up the parameters.  It would grab the raw command-line from Qt and use that without any normalization.  Path operations have slightly different behaviors with that, and would cause many downstream issues.

This updates the parameters to use more standard functions that are known to be sanitized.