### PR TITLE
Change create-spawnable benchmarks to not destroy created spawnables immediately

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/SpawnableCreateBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/SpawnableCreateBenchmarks.cpp
@@ -29,18 +29,19 @@ namespace Benchmark
             {},
             m_pathString));
 
-        // Create a vector to store spawnables so that they don't get destroyed immediately after construction.
-        AZStd::vector<AZStd::unique_ptr<AzFramework::Spawnable>> spawnables;
-        spawnables.reserve(numSpawnables);
 
         auto& prefabDom = m_prefabSystemComponent->FindTemplateDom(instance->GetTemplateId());
         for (auto _ : state)
         {
+            // Create a vector to store spawnables so that they don't get destroyed immediately after construction.
+            AZStd::vector<AZStd::unique_ptr<AzFramework::Spawnable>> spawnables;
+            spawnables.reserve(numSpawnables);
+            
             for (int spwanableCounter = 0; spwanableCounter < numSpawnables; ++spwanableCounter)
             {
                 AZStd::unique_ptr<AzFramework::Spawnable> spawnable = AZStd::make_unique<AzFramework::Spawnable>();
                 AzToolsFramework::Prefab::SpawnableUtils::CreateSpawnable(*spawnable, prefabDom);
-                spawnables[spwanableCounter] = AZStd::move(spawnable);
+                spawnables.push_back(AZStd::move(spawnable));
             }
         }
 


### PR DESCRIPTION
Fixed the following bugs:

1. Removed 'state.PauseTiming' on the only action that the benchmarks are supposed to time. If we don't remove this, we would not be calculating the time on anything.
2. Created a vector to store spawnables after creation. This would be closer to the real world scenarios where users would want to create multiple spawnables at once instead of destroying a spawnable immediately before creating the next one. Also, in the previous implementation, the range of 100-10k is not used. It will be used with the current implementation where we will try to create as many spawnables as the range provided.

Why these changes are needed:
The AzToolsFramework benchmarks were timing out on linux jenkins jobs. While debugging why that's happening, I noticed that spawnable benchmarks are written differently than the other benchmarks, which is making them take more number of iterations. I'm still 100% not sure whether the issue is with ctest or google benchmarks or spawnables on linux. But after fixing the above bugs, the tests don't timeout anymore on linux. So, will push these changes first and debug more later.

Testing:
Verified that the AzToolsFramework benchmarks now don't timeout with this changes both locally and in the jenkins jobs of 'BenchMarksReset' branch.