### PR TITLE
Fix code that triggers `-Wnon-pod-varargs`

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -417,7 +417,7 @@ namespace AZ
             AZ::IO::FileIOStream sourceMtlfileStream(inputMetalFile.c_str(), AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeBinary);
             if (!sourceMtlfileStream.IsOpen())
             {
-                AZ_Error(platformName, false, "Failed because the shader file \"%s\" could not be opened", inputMetalFile);
+                AZ_Error(platformName, false, "Failed because the shader file \"%s\" could not be opened", inputMetalFile.c_str());
                 return false;
             }
             


### PR DESCRIPTION
This fixes mac-specific instances of the `-Wnon-pod-varargs` warning.