### PR TITLE
ATOM-15708 ATOM-15709. Disabling the low end shader for blended and tinted transparencies

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
@@ -25,8 +25,6 @@ AlphaSource_Packed = 0
 AlphaSource_Split = 1
 AlphaSource_None = 2
 
-ForwardPassIndex = 1
-
 function ConfigureAlphaBlending(shaderItem) 
     shaderItem:GetRenderStatesOverride():SetDepthEnabled(true)
     shaderItem:GetRenderStatesOverride():SetDepthWriteMask(DepthWriteMask_Zero)
@@ -58,15 +56,17 @@ end
 function Process(context)
     local opacityMode = context:GetMaterialPropertyValue_enum("opacity.mode")
 
+    local forwardPassEDS = context:GetShaderByTag("ForwardPass_EDS")
+
     if(opacityMode == OpacityMode_Blended) then
-        ConfigureAlphaBlending(context:GetShader(ForwardPassIndex))
-        context:GetShader(ForwardPassIndex):SetDrawListTagOverride("transparent")
+        ConfigureAlphaBlending(forwardPassEDS)
+        forwardPassEDS:SetDrawListTagOverride("transparent")
     elseif(opacityMode == OpacityMode_TintedTransparent) then
-        ConfigureDualSourceBlending(context:GetShader(ForwardPassIndex))
-        context:GetShader(ForwardPassIndex):SetDrawListTagOverride("transparent")
+        ConfigureDualSourceBlending(forwardPassEDS)
+        forwardPassEDS:SetDrawListTagOverride("transparent")
     else
-        ResetAlphaBlending(context:GetShader(ForwardPassIndex))
-        context:GetShader(ForwardPassIndex):SetDrawListTagOverride("") -- reset to default draw list
+        ResetAlphaBlending(forwardPassEDS)
+        forwardPassEDS:SetDrawListTagOverride("") -- reset to default draw list
     end
 end
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ShaderEnable.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ShaderEnable.lua
@@ -74,7 +74,9 @@ function Process(context)
         shadowMapWithPS:SetEnabled(opacityMode == OpacityMode_Cutout)
         forwardPass:SetEnabled(opacityMode == OpacityMode_Cutout)
 
-        TrySetShaderEnabled(lowEndForwardEDS, (opacityMode == OpacityMode_Opaque) or (opacityMode == OpacityMode_Blended) or (opacityMode == OpacityMode_TintedTransparent))
+        -- Only enable lowEndForwardEDS in Opaque mode, Transparent mode will be handled by forwardPassEDS. The transparent pass uses the "transparent" draw tag
+        -- for both standard and low end pipelines, so this keeps both shaders from rendering to the transparent draw list.
+        TrySetShaderEnabled(lowEndForwardEDS, opacityMode == OpacityMode_Opaque)
         TrySetShaderEnabled(lowEndForward, opacityMode == OpacityMode_Cutout)
     end
     


### PR DESCRIPTION
The standard shader is already drawing in the transparent pass for those blend modes. This change also improves the way StandardPBR_HandleOpacityMode gets the correct shader by using a tag instead of index. This needs a better fix long term, see ATOM-15802 for more information.