### PR TITLE
Fix frame visualizer not closing

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.h
@@ -38,7 +38,7 @@ namespace AZ
             ~ImGuiFrameVisualizer() = default;
             AZStd::vector<FrameAttachmentVisualizeInfo>& GetFrameAttachments();
             void Init(RHI::Device* device);
-            void Draw(bool* draw);
+            void Draw(bool& draw);
             void DrawTreeView();
             void Reset();
         protected:

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiFrameVisualizer.inl
@@ -466,10 +466,10 @@ namespace ImGui
         }
 
         //!Draw the UI and all the nodes.
-        void Paint(bool* draw)
+        void Paint(bool& draw)
         {
             ImGui::SetNextWindowSize(ImVec2((float)m_windowWidth, (float)m_windowHeight), ImGuiCond_FirstUseEver);
-            if (!ImGui::Begin(m_windowName.c_str(), draw))
+            if (!ImGui::Begin(m_windowName.c_str(), &draw)) 
             {
                 ImGui::End();
                 return;
@@ -580,7 +580,7 @@ static ImGui::ImGuiFrameVisualizerWindow* visualizerWindow = nullptr;
 namespace AZ::Render
 {
     //! Draw the frame graph.
-    inline void ImGuiFrameVisualizer::Draw(bool* draw)
+    inline void ImGuiFrameVisualizer::Draw(bool& draw)
     {
         if (!visualizerWindow)
         {


### PR DESCRIPTION
Fixes issue ATOM-15734 with frame visualizer not closing.


Idea is to take a reference instead of a value so that ImGui can update the actual boolean when the window's X is clicked. 