### PR TITLE
[ATOM-14935] MaterialHotReloadTest Fails On Second Try

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariantAsyncLoader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderVariantAsyncLoader.cpp
@@ -323,9 +323,8 @@ namespace AZ
 
         void ShaderVariantAsyncLoader::Reset()
         {
-            // [GFX TODO ATOM-14544] Idealy we want to be able to reset the ShaderVariantAsyncLoader but this is causing some problems that need to be worked out first.
-            //Shutdown();
-            //Init();
+            Shutdown();
+            Init();
         }
 
         ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
[ATOM-14544] Add Reset() function to IShaderVariantFinder

ShaderVariantAsyncLoader::Reset() now Shutdown and Init(). It clears
the cache of ShaderVariantAssets it keeps in memory.

Signed-off-by: garrieta <garrieta@amazon.com>