### PR TITLE
Updates to ensure OnEntityTransformChanged is called correctly

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityTransformBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityTransformBus.h
@@ -1,47 +1,36 @@
 /*
-* All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
-* its licensors.
-*
-* For complete copyright and license terms please see the LICENSE at the root of this
-* distribution (the "License"). All use of this software is governed by the License,
-* or, if provided, by the license below or the license accompanying this file. Do not
-* remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-*
-*/
-#include <AzCore/EBus/EBus.h>
+ * All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+ * its licensors.
+ *
+ * For complete copyright and license terms please see the LICENSE at the root of this
+ * distribution (the "License"). All use of this software is governed by the License,
+ * or, if provided, by the license below or the license accompanying this file. Do not
+ * remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ */
 
 #pragma once
+
+#include <AzCore/EBus/EBus.h>
 
 namespace AzToolsFramework
 {
     using EntityIdList = AZStd::vector<AZ::EntityId>;
 
-    /*!
-     * Bus for notifications about entity transform changes from the editor viewport
-     */
-    class EditorTransformChangeNotifications
-        : public AZ::EBusTraits
+    //! Notifications about entity transform changes from the editor.
+    class EditorTransformChangeNotifications : public AZ::EBusTraits
     {
     public:
-        virtual ~EditorTransformChangeNotifications() = default;
+        //! A notification that these entities had their transforms changed due to a user interaction in the editor.
+        //! @param entityIds Entities that had their transform changed.
+        virtual void OnEntityTransformChanged([[maybe_unused]] const AzToolsFramework::EntityIdList& entityIds)
+        {
+        }
 
-        /*!
-         * Notification that the specified entities are about to have their transforms changed due to user interaction in the editor viewport
-         *
-         * \param entityIds Entities about to be changed
-         */
-        virtual void OnEntityTransformChanging(const AzToolsFramework::EntityIdList& /*entityIds*/) {};
-
-        /*!
-         * Notification that the specified entities had their transforms changed due to user interaction in the editor viewport
-         *
-         * \param entityIds Entities changed
-         */
-        virtual void OnEntityTransformChanged(const AzToolsFramework::EntityIdList& /*entityIds*/) {};
+    protected:
+        ~EditorTransformChangeNotifications() = default;
     };
 
     using EditorTransformChangeNotificationBus = AZ::EBus<EditorTransformChangeNotifications>;
-
 } // namespace AzToolsFramework
-

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -182,9 +182,12 @@ namespace AzToolsFramework
             static void Reflect(AZ::ReflectContext* context);
 
             AZ::Outcome<void, AZStd::string> ValidatePotentialParent(void* newValue, const AZ::Uuid& valueType);
-            AZ::u32 ParentChanged();
-            AZ::u32 TransformChanged();
-            AZ::u32 StaticChanged();
+
+            AZ::u32 TransformChangedInspector();
+            AZ::u32 ParentChangedInspector();
+            AZ::u32 StaticChangedInspector();
+
+            bool TransformChanged();
 
             AZ::Transform GetLocalTranslationTM() const;
             AZ::Transform GetLocalRotationTM() const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
@@ -165,11 +165,13 @@ namespace UnitTest
     void EditorEntityComponentChangeDetector::OnEntityTransformChanged(
         const AzToolsFramework::EntityIdList& entityIds)
     {
+        m_entityIds = entityIds;
+
         for (const AZ::EntityId& entityId : entityIds)
         {
             if (const auto* entity = GetEntityById(entityId))
             {
-                if (AZ::Component * transformComponent = entity->FindComponent<Components::TransformComponent>())
+                if (AZ::Component* transformComponent = entity->FindComponent<Components::TransformComponent>())
                 {
                     OnEntityComponentPropertyChanged(transformComponent->GetId());
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -239,6 +239,7 @@ namespace UnitTest
         bool PropertyDisplayInvalidated() const { return m_propertyDisplayInvalidated; }
 
         AZStd::vector<AZ::ComponentId> m_componentIds;
+        AzToolsFramework::EntityIdList m_entityIds;
 
     private:
         // PropertyEditorEntityChangeNotificationBus ...


### PR DESCRIPTION
This change is to address LYN-2644 that was affecting Kythera - it ensures `OnEntityTransformChanged` is called when entities have finished moving after using the manipulators, we also send this even in the Entity Inspector now to be consistent.

I still have some more tests to write but the first one is an indication of how the others will follow.