### PR TITLE
[ATOM-15810] Removing maximum values from light intensity

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -11,6 +11,7 @@
 */
 
 #include <AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h>
+#include <AzCore/std/limits.h>
 
 namespace AZ
 {
@@ -135,23 +136,15 @@ namespace AZ
             case PhotometricUnit::Nit:
                 return 0.0f;
             case PhotometricUnit::Ev100Luminance:
-                return -10.0f;
+                return AZStd::numeric_limits<float>::lowest();
             }
             return 0.0f;
         }
 
         float AreaLightComponentConfig::GetIntensityMax() const
         {
-            switch (m_intensityMode)
-            {
-            case PhotometricUnit::Candela:
-            case PhotometricUnit::Lumen:
-            case PhotometricUnit::Nit:
-                return 1'000'000.0f;
-            case PhotometricUnit::Ev100Luminance:
-                return 20.0f;
-            }
-            return 0.0f;
+            // While there is no hard-max, a max must be included when there is a hard min.
+            return AZStd::numeric_limits<float>::max();
         }
 
         float AreaLightComponentConfig::GetIntensitySoftMin() const


### PR DESCRIPTION
Setting hard max values to float max. Also allowing EV100 values hard minimum to be lowest float. Soft min and max will remain the same for a consistent ux, but we will no longer keep people from manually entering really high or low values that are technically fine.