### PR TITLE
Pefabs - Saving changes after enabling/disabling the Prefab System can result in failed saves and broken levels.

### DIFF
--- a/Code/Sandbox/Editor/EditorPreferencesPageGeneral.cpp
+++ b/Code/Sandbox/Editor/EditorPreferencesPageGeneral.cpp
@@ -28,8 +28,6 @@
 #define EDITORPREFS_EVENTVALTOGGLE "operation"
 #define UNDOSLICESAVE_VALON "UndoSliceSaveValueOn"
 #define UNDOSLICESAVE_VALOFF "UndoSliceSaveValueOff"
-#define EDITORUI10_ENABLED "EditorUI10On"
-#define EDITORUI10_DISABLED "EditorUI10Off"
 
 void CEditorPreferencesPage_General::Reflect(AZ::SerializeContext& serialize)
 {
@@ -45,8 +43,7 @@ void CEditorPreferencesPage_General::Reflect(AZ::SerializeContext& serialize)
         ->Field("StylusMode", &GeneralSettings::m_stylusMode)
         ->Field("ShowNews", &GeneralSettings::m_bShowNews)
         ->Field("EnableSceneInspector", &GeneralSettings::m_enableSceneInspector)
-        ->Field("RestoreViewportCamera", &GeneralSettings::m_restoreViewportCamera)
-        ->Field("PrefabSystem", &GeneralSettings::m_enablePrefabSystem);
+        ->Field("RestoreViewportCamera", &GeneralSettings::m_restoreViewportCamera);
 
     serialize.Class<Messaging>()
         ->Version(2)
@@ -94,8 +91,7 @@ void CEditorPreferencesPage_General::Reflect(AZ::SerializeContext& serialize)
                 ->EnumAttribute(AzQtComponents::ToolBar::ToolBarIconSize::IconLarge, "Large")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &GeneralSettings::m_stylusMode, "Stylus Mode", "Stylus Mode for tablets and other pointing devices")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &GeneralSettings::m_restoreViewportCamera, EditorPreferencesGeneralRestoreViewportCameraSettingName, "Keep the original editor viewport transform when exiting game mode.")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &GeneralSettings::m_enableSceneInspector, "Enable Scene Inspector (EXPERIMENTAL)", "Enable the option to inspect the internal data loaded from scene files like .fbx. This is an experimental feature. Restart the Scene Settings if the option is not visible under the Help menu.")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &GeneralSettings::m_enablePrefabSystem, "Enable Prefab System (EXPERIMENTAL)", "Enable this option to preview Open 3D Engine's new prefab system. Enabling this setting removes slice support for level entities; you will need to restart the Editor for the change to take effect.");
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &GeneralSettings::m_enableSceneInspector, "Enable Scene Inspector (EXPERIMENTAL)", "Enable the option to inspect the internal data loaded from scene files like .fbx. This is an experimental feature. Restart the Scene Settings if the option is not visible under the Help menu.");
 
         editContext->Class<Messaging>("Messaging", "")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Messaging::m_showDashboard, "Show Welcome to Open 3D Engine at startup", "Show Welcome to Open 3D Engine at startup")
@@ -159,8 +155,6 @@ void CEditorPreferencesPage_General::OnApply()
     gSettings.restoreViewportCamera = m_generalSettings.m_restoreViewportCamera;
     gSettings.enableSceneInspector = m_generalSettings.m_enableSceneInspector;
 
-    gSettings.prefabSystem = m_generalSettings.m_enablePrefabSystem;
-
     if (static_cast<int>(m_generalSettings.m_toolbarIconSize) != gSettings.gui.nToolbarIconSize)
     {
         gSettings.gui.nToolbarIconSize = static_cast<int>(m_generalSettings.m_toolbarIconSize);
@@ -178,16 +172,6 @@ void CEditorPreferencesPage_General::OnApply()
 
     //slices
     gSettings.sliceSettings.dynamicByDefault = m_sliceSettings.m_slicesDynamicByDefault;
-
-    // if the user enabled/disabled the prefab context - notify them that a restart
-    // is required in order to see the effect of the change
-    if (gSettings.prefabSystem != m_generalSettings.m_enablePrefabSystemInitialValue)
-    {
-        QMessageBox::warning(
-            AzToolsFramework::GetActiveWindow(), QObject::tr("Restart required"),
-            QObject::tr("Restart the Editor in order for the Prefab/Slice system changes to take effect.")
-        );
-    }
 }
 
 void CEditorPreferencesPage_General::InitializeSettings()
@@ -202,8 +186,6 @@ void CEditorPreferencesPage_General::InitializeSettings()
     m_generalSettings.m_stylusMode = gSettings.stylusMode;
     m_generalSettings.m_restoreViewportCamera = gSettings.restoreViewportCamera;
     m_generalSettings.m_enableSceneInspector = gSettings.enableSceneInspector;
-    m_generalSettings.m_enablePrefabSystem = gSettings.prefabSystem;
-    m_generalSettings.m_enablePrefabSystemInitialValue = gSettings.prefabSystem;
 
     m_generalSettings.m_toolbarIconSize = static_cast<AzQtComponents::ToolBar::ToolBarIconSize>(gSettings.gui.nToolbarIconSize);
 

--- a/Code/Sandbox/Editor/EditorPreferencesPageGeneral.h
+++ b/Code/Sandbox/Editor/EditorPreferencesPageGeneral.h
@@ -58,10 +58,6 @@ private:
         bool m_restoreViewportCamera;
         bool m_bShowNews;
         bool m_enableSceneInspector;
-        bool m_enablePrefabSystem;
-
-        // Only used to tell if the user has changed this value since it requires a restart
-        bool m_enablePrefabSystemInitialValue;
     };
 
     struct Messaging


### PR DESCRIPTION
Removed the Prefab System toggle from the Editor Preferences dialog.
Tried reproducing by changing the value in the setreg file manually instead of using the settings dialog, but I don't get the crash that way.