### PR TITLE
ATOM-15808 [RHI][Vulkan] Take out the early memory check exit to let …

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -62,8 +62,6 @@ namespace AZ
             {
                 RHI::Ptr<PhysicalDevice> physicalDevice = aznew PhysicalDevice;
                 physicalDevice->Init(device);
-                size_t gpuMemSize =  physicalDevice->GetDescriptor().m_heapSizePerLevel[static_cast<size_t>(RHI::HeapMemoryLevel::Device)];
-                AZ_Warning("Vulkan", gpuMemSize >= MinGPUMemSize, "Rejecting GPU %s as it's gpu mem size of %zu bytes is less than min required size of %zu bytes for Vulkan API", physicalDevice->GetDescriptor().m_description.c_str(), gpuMemSize, MinGPUMemSize);
                 physicalDeviceList.emplace_back(physicalDevice);
             }
 


### PR DESCRIPTION
…the developers decide what to do if device memory is less than the requirement.

JIRA: https://jira.agscollab.com/browse/ATOM-15808