### PR TITLE
[stabilization/2106] updated start menu shortcuts generated by the installer

### DIFF
--- a/cmake/Platform/Windows/Packaging/Shortcuts.wxs
+++ b/cmake/Platform/Windows/Packaging/Shortcuts.wxs
@@ -7,7 +7,7 @@
 
         <DirectoryRef Id="TARGETDIR">
             <Directory Id="ProgramMenuFolder">
-                <Directory Id="ApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_NAME)">
+                <Directory Id="ApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_NAME) [Developer Preview]">
                     <Directory Id="VersionedApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_VERSION)"/>
                 </Directory>
             </Directory>
@@ -46,10 +46,20 @@
         <DirectoryRef Id="VersionedApplicationProgramsFolder">
             <Component Id="StartMenuShortcuts" Guid="{E6447F0F-A46E-4A72-83D8-600707B590E8}">
 
-                <Shortcut Id="StartMenuShortcut_Launcher"
+                <Shortcut Id="StartMenuShortcut_Editor"
+                    Target="[root.bin.Windows.profile]Editor.exe"
+                    WorkingDirectory="root.bin.Windows.profile"
+                    Name="$(var.CPACK_PACKAGE_NAME) Editor" />
+
+                <Shortcut Id="StartMenuShortcut_MaterialEditor"
+                    Target="[root.bin.Windows.profile]MaterialEditor.exe"
+                    WorkingDirectory="root.bin.Windows.profile"
+                    Name="$(var.CPACK_PACKAGE_NAME) Material Editor" />
+
+                <Shortcut Id="StartMenuShortcut_ProjectManager"
                     Target="[root.bin.Windows.profile]o3de.exe"
                     WorkingDirectory="root.bin.Windows.profile"
-                    Name="$(var.CPACK_PACKAGE_NAME)" />
+                    Name="$(var.CPACK_PACKAGE_NAME) Project Manager" />
 
                 <RemoveFolder Id="RemoveVersionedApplicationProgramsFolder" Directory='VersionedApplicationProgramsFolder' On="uninstall"/>
                 <RemoveFolder Id="RemoveApplicationProgramsFolder" Directory="ApplicationProgramsFolder" On="uninstall"/>


### PR DESCRIPTION
- Added shortcuts for the Editor and Material Editor
- Renamed original "O3DE" shortcut to "O3DE Project Manager"
- Updated start menu folder name to include the "[Developer Preview]" tag

![updated_start_menu_shortcuts](https://user-images.githubusercontent.com/24445312/122479292-ad497200-cf7f-11eb-98e7-239ff5d21927.jpg)