### PR TITLE
Avoid serializing `size_t` in EMotionFX code

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.cpp
@@ -10,6 +10,7 @@
 *
 */
 
+#include <cinttypes>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <MCore/Source/ReflectionSerializer.h>
 #include <EMotionFX/CommandSystem/Source/CommandManager.h>
@@ -717,7 +718,7 @@ namespace EMotionFX
         const size_t shapeCount = nodeConfig->m_shapes.size();
         if (m_colliderIndex >= shapeCount)
         {
-            outResult = AZStd::string::format("Cannot remove collider. The joint '%s' is only holding %zu colliders and the index %zu is out of range.", m_jointName.c_str(), shapeCount, m_colliderIndex);
+            outResult = AZStd::string::format("Cannot remove collider. The joint '%s' is only holding %zu colliders and the index %llu is out of range.", m_jointName.c_str(), shapeCount, m_colliderIndex);
             return false;
         }
 

--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.h
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.h
@@ -222,7 +222,7 @@ namespace EMotionFX
 
     private:
         PhysicsSetup::ColliderConfigType m_configType;
-        size_t m_colliderIndex;
+        AZ::u64 m_colliderIndex;
 
         bool m_oldIsDirty;
         AZStd::string m_oldContents;

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MorphTargetRule.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MorphTargetRule.h
@@ -73,7 +73,7 @@ namespace EMotionFX
                 static size_t DetectMorphTargetAnimations(const AZ::SceneAPI::Containers::Scene& scene);
 
             protected:
-                size_t m_morphAnimationCount;
+                AZ::u64 m_morphAnimationCount;
                 AZStd::string m_descriptionText;
             };
 

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MotionAdditiveRule.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MotionAdditiveRule.h
@@ -42,7 +42,7 @@ namespace EMotionFX
                 static void Reflect(AZ::ReflectContext* context);
 
             protected:
-                size_t m_sampleFrameIndex;
+                AZ::u64 m_sampleFrameIndex;
             };
         } // Rule
     } // Pipeline


### PR DESCRIPTION
`size_t` is a typedef that is sized differently on different platforms.
Instead, use `AZ::u64`, which is large enough to hold all platforms'
`size_t` types but is a fixed size, to avoid size mismatches per
platform.