### PR TITLE
Fixes issue with ACE displaying only banks

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.cpp
@@ -17,6 +17,7 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/Utils/Utils.h>
 
 #include <ACETypes.h>
 #include <AudioSystemControl_wwise.h>
@@ -540,11 +541,10 @@ namespace AudioControls
     }
 
     //-------------------------------------------------------------------------------------------//
-    AZStd::string CAudioSystemEditor_wwise::GetDataPath() const
+    AZ::IO::FixedMaxPath CAudioSystemEditor_wwise::GetDataPath() const
     {
-        AZStd::string path(Path::GetEditingGameDataFolder());
-        AZ::StringFunc::Path::Join(path.c_str(), "sounds/wwise_project/", path);
-        return path;
+        auto projectPath = AZ::IO::FixedMaxPath{ AZ::Utils::GetProjectPath() };
+        return (projectPath / "sounds" / "wwise_project");
     }
 
 } // namespace AudioControls

--- a/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.h
+++ b/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.h
@@ -86,7 +86,7 @@ namespace AudioControls
         const AZStd::string_view GetTypeIcon(TImplControlType type) const override;
         const AZStd::string_view GetTypeIconSelected(TImplControlType type) const override;
         AZStd::string GetName() const override;
-        AZStd::string GetDataPath() const;
+        AZ::IO::FixedMaxPath GetDataPath() const override;
         void DataSaved() override {}
         void ConnectionRemoved(IAudioSystemControl* control) override;
         //////////////////////////////////////////////////////////

--- a/Gems/AudioEngineWwise/Code/Source/Editor/AudioWwiseLoader.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Editor/AudioWwiseLoader.cpp
@@ -54,12 +54,12 @@ namespace AudioControls
     void CAudioWwiseLoader::Load(CAudioSystemEditor_wwise* audioSystemImpl)
     {
         m_audioSystemImpl = audioSystemImpl;
-        const AZStd::string wwiseProjectFullPath(m_audioSystemImpl->GetDataPath());
-        LoadControlsInFolder(wwiseProjectFullPath + WwiseStrings::GameParametersFolder);
-        LoadControlsInFolder(wwiseProjectFullPath + WwiseStrings::GameStatesFolder);
-        LoadControlsInFolder(wwiseProjectFullPath + WwiseStrings::SwitchesFolder);
-        LoadControlsInFolder(wwiseProjectFullPath + WwiseStrings::EventsFolder);
-        LoadControlsInFolder(wwiseProjectFullPath + WwiseStrings::EnvironmentsFolder);
+        const AZ::IO::FixedMaxPath wwiseProjectFullPath{ m_audioSystemImpl->GetDataPath() };
+        LoadControlsInFolder(AZ::IO::FixedMaxPath{ wwiseProjectFullPath / WwiseStrings::GameParametersFolder }.Native());
+        LoadControlsInFolder(AZ::IO::FixedMaxPath{ wwiseProjectFullPath / WwiseStrings::GameStatesFolder }.Native());
+        LoadControlsInFolder(AZ::IO::FixedMaxPath{ wwiseProjectFullPath / WwiseStrings::SwitchesFolder }.Native());
+        LoadControlsInFolder(AZ::IO::FixedMaxPath{ wwiseProjectFullPath / WwiseStrings::EventsFolder }.Native());
+        LoadControlsInFolder(AZ::IO::FixedMaxPath{ wwiseProjectFullPath / WwiseStrings::EnvironmentsFolder }.Native());
         LoadSoundBanks(Audio::Wwise::GetBanksRootPath(), "", false);
     }
 

--- a/Gems/AudioSystem/Code/Include/Editor/IAudioSystemEditor.h
+++ b/Gems/AudioSystem/Code/Include/Editor/IAudioSystemEditor.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/std/string/string_view.h>
 
 #include <ACETypes.h>
@@ -151,7 +152,7 @@ namespace AudioControls
         //! Gets the folder where the implementation specific controls data are stored.
         //! This is used by the ACE to update if controls are changed while the editor is open.
         //! @return String with the path to the folder where the implementation specific controls are stored.
-        virtual AZStd::string GetDataPath() const = 0;
+        virtual AZ::IO::FixedMaxPath GetDataPath() const = 0;
 
         //! Informs the plugin that the ACE has saved the data in case it needs to do any clean up.
         virtual void DataSaved() = 0;

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
@@ -218,7 +218,7 @@ namespace AudioControls
         IAudioSystemEditor* pAudioSystemImpl = CAudioControlsEditorPlugin::GetAudioSystemEditorImpl();
         if (pAudioSystemImpl)
         {
-            StartWatchingFolder(pAudioSystemImpl->GetDataPath());
+            StartWatchingFolder(pAudioSystemImpl->GetDataPath().LexicallyNormal().Native());
             m_pMiddlewareDockWidget->setWindowTitle(QString(pAudioSystemImpl->GetName().c_str()) + " Controls");
         }
     }


### PR DESCRIPTION
Updates to some AzCore functions a while ago made some path functions
strip off a trailing slash, which caused bad paths to be used when
loading middleware data.  Updated the code to use better path APIs.