### PR TITLE
Fix bug with DetachPrefab incorrectly replacing old entity aliases in patches

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -326,6 +326,16 @@ namespace AzToolsFramework
             return *(m_nestedInstances[newInstanceAlias] = std::move(instance));
         }
 
+        void Instance::DetachNestedInstances(const AZStd::function<void(AZStd::unique_ptr<Instance>)>& callback)
+        {
+            for (auto&& [instanceAlias, instance] : m_nestedInstances)
+            {
+                instance->m_parent = nullptr;
+                callback(AZStd::move(instance));
+            }
+            m_nestedInstances.clear();
+        }
+
         AZStd::unique_ptr<Instance> Instance::DetachNestedInstance(const InstanceAlias& instanceAlias)
         {
             AZStd::unique_ptr<Instance> removedNestedInstance;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
@@ -103,6 +103,7 @@ namespace AzToolsFramework
             Instance& AddInstance(AZStd::unique_ptr<Instance> instance);
             Instance& AddInstance(AZStd::unique_ptr<Instance> instance, InstanceAlias instanceAlias);
             AZStd::unique_ptr<Instance> DetachNestedInstance(const InstanceAlias& instanceAlias);
+            void DetachNestedInstances(const AZStd::function<void(AZStd::unique_ptr<Instance>)>& callback);
 
             /**
             * Gets the aliases for the entities in the Instance DOM.


### PR DESCRIPTION
Problem: In one of our recent changes, we changed the container entity of every prefab instance to have an entity alias of 'ContainerEntity'. This surfaced a bug in our logic with DetachPrefab where we tried to replace old entity aliases with new entity aliases generated during the detaching logic. But since 'ContainerEntity' would be present on the child instance as well, the replace logic was generating incorrect patches.

Solution: Instead of trying to figure out what is an entity reference within a given set of patches and trying to replace them, we will no regenerate the patches on the nested instance after detaching, giving us the correct entity references

Testing:
Tested basic use cases of detach prefab work and LYN-4238 is fixed. Found another pre-existing bug with detaching triple nested prefabs, which I'll be fixing in a separate PR