### PR TITLE
{SPEC-7398} Helios - Asset Bundler auto test fixes

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_bundler_batch_tests.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_bundler_batch_tests.py
@@ -538,19 +538,19 @@ class TestsAssetBundlerBatch_WindowsAndMac(object):
             assert os.path.isfile(bundle_file)
 
         # This asset is created both on mac and windows platform
-        file_to_check = b"engineassets/shading/defaultprobe_cm_ibldiffuse.tif.streamingimage"  # [use byte str because file is in binary]
+        file_to_check = b"engineassets/slices/defaultlevelsetup.slice"  # [use byte str because file is in binary]
 
         # Extract the delta catalog file from pc archive. {file_to_check} SHOULD NOT be present for PC
         file_contents = helper.extract_file_content(bundle_files["pc"], "DeltaCatalog.xml")
         # fmt:off
-        assert file_to_check in file_contents, \
+        assert file_contents.find(file_to_check), \
             f"{file_to_check} was found in DeltaCatalog.xml in pc bundle file {bundle_files['pc']}"
         # fmt:on
 
         # Extract the delta catalog file from mac archive. {file_to_check} SHOULD be present for MAC
         file_contents = helper.extract_file_content(bundle_files["mac"], "DeltaCatalog.xml")
         # fmt:off
-        assert file_to_check in file_contents, \
+        assert file_contents.find(file_to_check), \
             f"{file_to_check} was not found in DeltaCatalog.xml in darwin bundle file {bundle_files['mac']}"
         # fmt:on
 
@@ -631,7 +631,7 @@ class TestsAssetBundlerBatch_WindowsAndMac(object):
         if os.path.exists(helper["asset_info_file_request"]):
             fs.delete([helper["asset_info_file_request"]], True, True)
 
-        test_asset = r"levels\testdependencieslevel\level.pak"
+        test_asset = r"fonts/open_sans/license.txt"
         re_pattern = re.compile(r"""field="platformFlags" value="(\d+)" """)
         all_lines = ""
 


### PR DESCRIPTION
* using O3DE engine assets instead of level.pak
* updated the binary find() logic for DeltaCatalog.xml

Tests: AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_bundler_batch_tests.py