### PR TITLE
Spawnable/game mode load error fix

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -532,6 +532,14 @@ namespace AzToolsFramework
                             AZ::Data::AssetCatalogRequestBus::Broadcast(
                                 &AZ::Data::AssetCatalogRequestBus::Events::RegisterAsset, info.m_assetId, info);
                             m_playInEditorData.m_assets.emplace_back(product.ReleaseAsset().release(), AZ::Data::AssetLoadBehavior::Default);
+
+                            // Ensure the product asset is registered with the AssetManager
+                            // Hold on to the returned asset to keep ref count alive until we assign it the latest data
+                            AZ::Data::Asset<AZ::Data::AssetData> asset =
+                                AZ::Data::AssetManager::Instance().FindOrCreateAsset(info.m_assetId, info.m_assetType, AZ::Data::AssetLoadBehavior::Default);
+
+                            // Update the asset registered in the AssetManager with the data of our product from the Prefab Processor
+                            AZ::Data::AssetManager::Instance().AssignAssetData(m_playInEditorData.m_assets.back());
                         }
 
                         for (auto& product : context.GetProcessedObjects())


### PR DESCRIPTION
Fix for issue where we were not registering assets generated by Prefab Processors to the Asset Manager when entering game mode.

This issue surfaced when Networking attempted to reference a generated Root.network.spawnable in the Root.spawnable representing the Editor scene. The network spawnable failed to load since it was not registered.

Also moved the LoadReferencedAssets call outside of the first Processor Product loop as it could contain references to assets being registered in the first loop. Meaning those loads could fail if they were referenced and loaded by an asset before registration completed.