### PR TITLE
Corrects ReplicationSet to be an ordered map

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/ReplicationWindows/IReplicationWindow.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/ReplicationWindows/IReplicationWindow.h
@@ -14,7 +14,7 @@
 
 #include <Multiplayer/MultiplayerTypes.h>
 #include <Multiplayer/NetworkEntity/NetworkEntityHandle.h>
-#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/map.h>
 
 namespace Multiplayer
 {
@@ -24,7 +24,7 @@ namespace Multiplayer
         NetEntityRole m_netEntityRole = NetEntityRole::InvalidRole;
         float m_priority = 0.0f;
     };
-    using ReplicationSet = AZStd::unordered_map<ConstNetworkEntityHandle, EntityReplicationData>;
+    using ReplicationSet = AZStd::map<ConstNetworkEntityHandle, EntityReplicationData>;
 
     class IReplicationWindow
     {


### PR DESCRIPTION
So that EntityReplicationManager :: UpdateWindow is correct, which assumes ReplicationSet to be an ordered map

Tested by running a server under a debugger and observed proper behavior in EntityReplicationManager :: UpdateWindow and lack of asserts that were occurring prior to this fix.

The asserts were:
AZ_Assert(!m_event, "Handler is already registered to an event, binding a handler to multiple events is unsupported");