### PR TITLE
Make IMGUI & viewport info scale with DPI

### DIFF
--- a/Code/Editor/RenderViewport.h
+++ b/Code/Editor/RenderViewport.h
@@ -219,6 +219,7 @@ public:
     void SetFullScreenState(bool fullScreenState) override;
     bool CanToggleFullScreenState() const override;
     void ToggleFullScreenState() override;
+    float GetDpiScaleFactor() const override { return 1.0f; };
 
     void ConnectViewportInteractionRequestBus();
     void DisconnectViewportInteractionRequestBus();

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -731,12 +731,10 @@ namespace AzFramework
     bool Application::IsPrefabSystemEnabled() const
     {
         bool value = true;
-        /*
         if (auto* registry = AZ::SettingsRegistry::Get())
         {
             registry->Get(value, ApplicationInternal::s_prefabSystemKey);
         }
-        */
         return value;
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -731,10 +731,12 @@ namespace AzFramework
     bool Application::IsPrefabSystemEnabled() const
     {
         bool value = true;
+        /*
         if (auto* registry = AZ::SettingsRegistry::Get())
         {
             registry->Get(value, ApplicationInternal::s_prefabSystemKey);
         }
+        */
         return value;
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.cpp
@@ -116,6 +116,11 @@ namespace AzFramework
         SetFullScreenState(!GetFullScreenState());
     }
 
+    float NativeWindow::GetDpiScaleFactor() const
+    {
+        return m_pimpl->GetDpiScaleFactor();
+    }
+
     /*static*/ bool NativeWindow::GetFullScreenStateOfDefaultWindow()
     {
         NativeWindowHandle defaultWindowHandle = nullptr;
@@ -226,6 +231,12 @@ namespace AzFramework
     {
         // For most implementations full screen is the only option
         return false;
+    }
+
+    float NativeWindow::Implementation::GetDpiScaleFactor() const
+    {
+        // For platforms that aren't DPI-aware, we simply return a 1.0 ratio for no scaling
+        return 1.0f;
     }
 
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/NativeWindow.h
@@ -128,6 +128,7 @@ namespace AzFramework
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override;
         void ToggleFullScreenState() override;
+        float GetDpiScaleFactor() const override;
 
         //! Get the full screen state of the default window.
         //! \return True if the default window is currently in full screen, false otherwise.
@@ -169,6 +170,7 @@ namespace AzFramework
             virtual bool GetFullScreenState() const;
             virtual void SetFullScreenState(bool fullScreenState);
             virtual bool CanToggleFullScreenState() const;
+            virtual float GetDpiScaleFactor() const;
 
         protected:
             uint32_t m_width = 0;

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -68,6 +68,11 @@ namespace AzFramework
 
         //! Toggle the full screen state of the window.
         virtual void ToggleFullScreenState() = 0;
+
+        //! Returns a scalar multiplier representing how dots-per-inch this window has, compared
+        //! to a "standard" value of 96, the default for Windows in a DPI unaware setting. This can
+        //! be used to scale user interface elements to ensure legibility on high density displays.
+        virtual float GetDpiScaleFactor() const = 0;
     };
     using WindowRequestBus = AZ::EBus<WindowRequests>;
 
@@ -86,6 +91,9 @@ namespace AzFramework
 
         //! This is called once when the window is Activated and also called if the user resizes the window.
         virtual void OnWindowResized(uint32_t width, uint32_t height) { AZ_UNUSED(width); AZ_UNUSED(height); };
+
+        //! This is called if the window's underyling DPI scaling factor changes.
+        virtual void OnDpiScaleFactorChanged(float dpiScaleFactor) { AZ_UNUSED(dpiScaleFactor); }
 
         //! This is called when the window is deactivated from code or if the user closes the window.
         virtual void OnWindowClosed() {};

--- a/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Windowing/WindowBus.h
@@ -69,7 +69,7 @@ namespace AzFramework
         //! Toggle the full screen state of the window.
         virtual void ToggleFullScreenState() = 0;
 
-        //! Returns a scalar multiplier representing how dots-per-inch this window has, compared
+        //! Returns a scalar multiplier representing how many dots-per-inch this window has, compared
         //! to a "standard" value of 96, the default for Windows in a DPI unaware setting. This can
         //! be used to scale user interface elements to ensure legibility on high density displays.
         virtual float GetDpiScaleFactor() const = 0;

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -17,7 +17,7 @@ namespace AzFramework
     {
     public:
         AZ_CLASS_ALLOCATOR(NativeWindowImpl_Win32, AZ::SystemAllocator, 0);
-        NativeWindowImpl_Win32() = default;
+        NativeWindowImpl_Win32();
         ~NativeWindowImpl_Win32() override;
 
         // NativeWindow::Implementation overrides...
@@ -33,6 +33,7 @@ namespace AzFramework
         bool GetFullScreenState() const override;
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override { return true; }
+        float GetDpiScaleFactor() const override;
 
     private:
         static DWORD ConvertToWin32WindowStyleMask(const WindowStyleMasks& styleMasks);
@@ -49,6 +50,9 @@ namespace AzFramework
         RECT m_windowRectToRestoreOnFullScreenExit; //!< The position and size of the window to restore when exiting full screen.
         UINT m_windowStyleToRestoreOnFullScreenExit; //!< The style(s) of the window to restore when exiting full screen.
         bool m_isInBorderlessWindowFullScreenState = false; //!< Was a borderless window used to enter full screen state?
+
+        using GetDpiForWindowType = UINT(HWND hwnd);
+        GetDpiForWindowType* m_getDpiFunction = nullptr;
     };
 
     const char* NativeWindowImpl_Win32::s_defaultClassName = "O3DEWin32Class";
@@ -56,6 +60,16 @@ namespace AzFramework
     NativeWindow::Implementation* NativeWindow::Implementation::Create()
     {
         return aznew NativeWindowImpl_Win32();
+    }
+
+    NativeWindowImpl_Win32::NativeWindowImpl_Win32()
+    {
+        // Attempt to load GetDpiForWindow from user32 at runtime, available on Windows 10+ versions >= 1607
+        auto user32module = LoadLibraryA("user32.dll");
+        if (user32module)
+        {
+            m_getDpiFunction = reinterpret_cast<GetDpiForWindowType*>(GetProcAddress(user32module, "GetDpiForWindow"));
+        }
     }
 
     NativeWindowImpl_Win32::~NativeWindowImpl_Win32()
@@ -237,6 +251,11 @@ namespace AzFramework
             // Send all other WM_SYSKEYDOWN messages to the default WndProc.
             break;
         }
+        case WM_DPICHANGED:
+        {
+            const float newScaleFactor = nativeWindowImpl->GetDpiScaleFactor();
+            WindowNotificationBus::Event(nativeWindowImpl->GetWindowHandle(), &WindowNotificationBus::Events::OnDpiScaleFactorChanged, newScaleFactor);
+        }
         default:
             return DefWindowProc(hWnd, message, wParam, lParam);
             break;
@@ -328,6 +347,17 @@ namespace AzFramework
         {
             ExitBorderlessWindowFullScreen();
         }
+    }
+
+    float NativeWindowImpl_Win32::GetDpiScaleFactor() const
+    {
+        constexpr UINT defaultDotsPerInch = 96;
+        UINT dotsPerInch = defaultDotsPerInch;
+        if (m_getDpiFunction)
+        {
+            dotsPerInch = m_getDpiFunction(m_win32Handle);
+        }
+        return aznumeric_cast<float>(dotsPerInch) / aznumeric_cast<float>(defaultDotsPerInch);
     }
 
     void NativeWindowImpl_Win32::EnterBorderlessWindowFullScreen()

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -65,8 +65,7 @@ namespace AzFramework
     NativeWindowImpl_Win32::NativeWindowImpl_Win32()
     {
         // Attempt to load GetDpiForWindow from user32 at runtime, available on Windows 10+ versions >= 1607
-        auto user32module = LoadLibraryA("user32.dll");
-        if (user32module)
+        if (auto user32module = LoadLibraryA("user32.dll"))
         {
             m_getDpiFunction = reinterpret_cast<GetDpiForWindowType*>(GetProcAddress(user32module, "GetDpiForWindow"));
         }
@@ -255,6 +254,7 @@ namespace AzFramework
         {
             const float newScaleFactor = nativeWindowImpl->GetDpiScaleFactor();
             WindowNotificationBus::Event(nativeWindowImpl->GetWindowHandle(), &WindowNotificationBus::Events::OnDpiScaleFactorChanged, newScaleFactor);
+            break;
         }
         default:
             return DefWindowProc(hWnd, message, wParam, lParam);

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Windowing/NativeWindow_Windows.cpp
@@ -8,6 +8,7 @@
 #include <AzFramework/Input/Buses/Notifications/RawInputNotificationBus_Windows.h>
 #include <AzFramework/Windowing/NativeWindow.h>
 
+#include <AzCore/Module/DynamicModuleHandle.h>
 #include <AzCore/PlatformIncl.h>
 
 namespace AzFramework
@@ -65,9 +66,9 @@ namespace AzFramework
     NativeWindowImpl_Win32::NativeWindowImpl_Win32()
     {
         // Attempt to load GetDpiForWindow from user32 at runtime, available on Windows 10+ versions >= 1607
-        if (auto user32module = LoadLibraryA("user32.dll"))
+        if (auto user32module = AZ::DynamicModuleHandle::Create("user32"); user32module->Load(false))
         {
-            m_getDpiFunction = reinterpret_cast<GetDpiForWindowType*>(GetProcAddress(user32module, "GetDpiForWindow"));
+            m_getDpiFunction = user32module->GetFunction<GetDpiForWindowType*>("GetDpiForWindow");
         }
     }
 

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -122,6 +122,8 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             FOLDER ${project_name}
     )
 
+    # After ensuring that we correctly support DPI scaling, this should be switched to "PerMonitor"
+    set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DPI_AWARE "OFF")
     if(LY_DEFAULT_PROJECT_PATH)
         set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\"")
     endif()

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -65,15 +65,15 @@ namespace AZ
             ConstViewPtr GetDefaultView() const;
 
             //! Gets the current size of the viewport.
-            //! This value is cached and updated on-demand, so may be performantly queried.
+            //! This value is cached and updated on-demand, so may be efficiently queried.
             AzFramework::WindowSize GetViewportSize() const;
 
             //! Gets the screen DPI scaling factor.
-            //! This value is cached and updated on-demand, so may be performantly queried.
+            //! This value is cached and updated on-demand, so may be efficiently queried.
             //! \see AzFramework::WindowRequests::GetDpiScaleFactor
             float GetDpiScalingFactor() const;
 
-            // SceneNotificationBus interface
+            // SceneNotificationBus interface overrides...
             //! Ensures our default view remains set when our scene's render pipelines are modified.
             void OnRenderPipelineAdded(RenderPipelinePtr pipeline) override;
             //! Ensures our default view remains set when our scene's render pipelines are modified.
@@ -81,7 +81,7 @@ namespace AZ
             //! OnBeginPrepareRender is forwarded to our RenderTick notification to allow subscribers to do rendering.
             void OnBeginPrepareRender() override;
 
-            //WindowNotificationBus interface
+            // WindowNotificationBus interface overrides...
             //! Used to fire a notification when our window resizes.
             void OnWindowResized(uint32_t width, uint32_t height) override;
             //! Used to fire a notification when our window DPI changes.
@@ -119,7 +119,7 @@ namespace AZ
             //! Notifies consumers when this ViewportContext is about to be destroyed.
             void ConnectAboutToBeDestroyedHandler(ViewportIdEvent::Handler& handler);
 
-            // ViewportRequestBus interface
+            // ViewportRequestBus interface overrides...
             //! Gets the current camera's view matrix.
             const AZ::Matrix4x4& GetCameraViewMatrix() const override;
             //! Sets the current camera's view matrix.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -92,6 +92,11 @@ namespace AZ
             //! Alternatively, connect to ViewportContextNotificationsBus and listen to ViewportContextNotifications::OnViewportSizeChanged.
             void ConnectSizeChangedHandler(SizeChangedEvent::Handler& handler);
 
+            using ScalarChangedEvent = AZ::Event<float>;
+            //! Notifies consumers when the viewport DPI scaling ratio has changed.
+            //! Alternatively, connect to ViewportContextNotificationsBus and listen to ViewportContextNotifications::OnViewportDpiScalingChanged.
+            void ConnectDpiScalingFactorChangedHandler(ScalarChangedEvent::Handler& handler);
+
             using MatrixChangedEvent = AZ::Event<const AZ::Matrix4x4&>;
             //! Notifies consumers when the view matrix has changed.
             void ConnectViewMatrixChangedHandler(MatrixChangedEvent::Handler& handler);
@@ -141,6 +146,7 @@ namespace AZ
             float m_viewportDpiScaleFactor = 1.0f;
 
             SizeChangedEvent m_sizeChangedEvent;
+            ScalarChangedEvent m_dpiScalingFactorChangedEvent;
             MatrixChangedEvent m_viewMatrixChangedEvent;
             MatrixChangedEvent::Handler m_onViewMatrixChangedHandler;
             MatrixChangedEvent m_projectionMatrixChangedEvent;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContext.h
@@ -65,7 +65,13 @@ namespace AZ
             ConstViewPtr GetDefaultView() const;
 
             //! Gets the current size of the viewport.
+            //! This value is cached and updated on-demand, so may be performantly queried.
             AzFramework::WindowSize GetViewportSize() const;
+
+            //! Gets the screen DPI scaling factor.
+            //! This value is cached and updated on-demand, so may be performantly queried.
+            //! \see AzFramework::WindowRequests::GetDpiScaleFactor
+            float GetDpiScalingFactor() const;
 
             // SceneNotificationBus interface
             //! Ensures our default view remains set when our scene's render pipelines are modified.
@@ -76,8 +82,10 @@ namespace AZ
             void OnBeginPrepareRender() override;
 
             //WindowNotificationBus interface
-            //! Used to fire a notification when our window resizes
+            //! Used to fire a notification when our window resizes.
             void OnWindowResized(uint32_t width, uint32_t height) override;
+            //! Used to fire a notification when our window DPI changes.
+            void OnDpiScaleFactorChanged(float dpiScaleFactor) override;
 
             using SizeChangedEvent = AZ::Event<AzFramework::WindowSize>;
             //! Notifies consumers when the viewport size has changed.
@@ -130,6 +138,7 @@ namespace AZ
             WindowContextSharedPtr m_windowContext;
             ViewPtr m_defaultView;
             AzFramework::WindowSize m_viewportSize;
+            float m_viewportDpiScaleFactor = 1.0f;
 
             SizeChangedEvent m_sizeChangedEvent;
             MatrixChangedEvent m_viewMatrixChangedEvent;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContextBus.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContextBus.h
@@ -105,8 +105,10 @@ namespace AZ
         class ViewportContextNotifications
         {
         public:
-            //! Called when the underlying native window size changes for a given viewport context name.
+            //! Called when the underlying native window size changes for a given viewport context.
             virtual void OnViewportSizeChanged(AzFramework::WindowSize size){AZ_UNUSED(size);}
+            //! Called when the window DPI scaling changes for a given viewport context.
+            virtual void OnViewportDpiScalingChanged(float dpiScale){AZ_UNUSED(dpiScale);}
             //! Called when the active view for a given viewport context name changes.
             virtual void OnViewportDefaultViewChanged(AZ::RPI::ViewPtr view){AZ_UNUSED(view);}
             //! Called when the viewport is to be rendered.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContextManager.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/ViewportContextManager.h
@@ -51,6 +51,7 @@ namespace AZ
             {
                 AZStd::weak_ptr<ViewportContext> context;
                 ViewportContext::SizeChangedEvent::Handler sizeChangedHandler;
+                ViewportContext::ScalarChangedEvent::Handler dpiScalingChangedHandler;
             };
 
             // ViewportContextManager is a singleton owned solely by RPISystem, which is tagged as a friend

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -10,7 +10,6 @@
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
 #include <Atom/RPI.Public/View.h>
-#include "..\..\Include\Atom\RPI.Public\ViewportContext.h"
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -163,6 +163,11 @@ namespace AZ
             handler.Connect(m_sizeChangedEvent);
         }
 
+        void ViewportContext::ConnectDpiScalingFactorChangedHandler(ScalarChangedEvent::Handler& handler)
+        {
+            handler.Connect(m_dpiScalingFactorChangedEvent);
+        }
+
         void ViewportContext::ConnectViewMatrixChangedHandler(MatrixChangedEvent::Handler& handler)
         {
             handler.Connect(m_viewMatrixChangedEvent);
@@ -303,6 +308,7 @@ namespace AZ
         void ViewportContext::OnDpiScaleFactorChanged(float dpiScaleFactor)
         {
             m_viewportDpiScaleFactor = dpiScaleFactor;
+            m_dpiScalingFactorChangedEvent.Signal(dpiScaleFactor);
         }
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContext.cpp
@@ -10,6 +10,7 @@
 #include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
 #include <Atom/RPI.Public/View.h>
+#include "..\..\Include\Atom\RPI.Public\ViewportContext.h"
 
 namespace AZ
 {
@@ -28,6 +29,10 @@ namespace AZ
                 m_viewportSize,
                 nativeWindow,
                 &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
+            AzFramework::WindowRequestBus::EventResult(
+                m_viewportDpiScaleFactor,
+                nativeWindow,
+                &AzFramework::WindowRequestBus::Events::GetDpiScaleFactor);
             AzFramework::WindowNotificationBus::Handler::BusConnect(nativeWindow);
             AzFramework::ViewportRequestBus::Handler::BusConnect(id);
 
@@ -146,6 +151,11 @@ namespace AZ
         AzFramework::WindowSize ViewportContext::GetViewportSize() const
         {
             return m_viewportSize;
+        }
+
+        float ViewportContext::GetDpiScalingFactor() const
+        {
+            return m_viewportDpiScaleFactor;
         }
 
         void ViewportContext::ConnectSizeChangedHandler(SizeChangedEvent::Handler& handler)
@@ -288,6 +298,11 @@ namespace AZ
                 m_viewportSize.m_height = height;
                 m_sizeChangedEvent.Signal(m_viewportSize);
             }
+        }
+
+        void ViewportContext::OnDpiScaleFactorChanged(float dpiScaleFactor)
+        {
+            m_viewportDpiScaleFactor = dpiScaleFactor;
         }
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
@@ -55,7 +55,7 @@ namespace AZ
                 auto onSizeChanged = [this, viewportId](AzFramework::WindowSize size)
                 {
                     // Ensure we emit OnViewportSizeChanged with the correct name.
-                    auto viewportContext = this->GetViewportContextById(viewportId);
+                    auto viewportContext = GetViewportContextById(viewportId);
                     if (viewportContext)
                     {
                         ViewportContextNotificationBus::Event(viewportContext->GetName(), &ViewportContextNotificationBus::Events::OnViewportSizeChanged, size);
@@ -65,7 +65,7 @@ namespace AZ
                 auto onDpiScalingChanged = [this, viewportId](float dpiScalingFactor)
                 {
                     // Ensure we emit OnViewportDpiScalingChanged with the correct name.
-                    auto viewportContext = this->GetViewportContextById(viewportId);
+                    auto viewportContext = GetViewportContextById(viewportId);
                     if (viewportContext)
                     {
                         ViewportContextNotificationBus::Event(viewportContext->GetName(), &ViewportContextNotificationBus::Events::OnViewportDpiScalingChanged, dpiScalingFactor);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
@@ -62,9 +62,20 @@ namespace AZ
                     }
                     ViewportContextIdNotificationBus::Event(viewportId, &ViewportContextIdNotificationBus::Events::OnViewportSizeChanged, size);
                 };
+                auto onDpiScalingChanged = [this, viewportId](float dpiScalingFactor)
+                {
+                    // Ensure we emit OnViewportDpiScalingChanged with the correct name.
+                    auto viewportContext = this->GetViewportContextById(viewportId);
+                    if (viewportContext)
+                    {
+                        ViewportContextNotificationBus::Event(viewportContext->GetName(), &ViewportContextNotificationBus::Events::OnViewportDpiScalingChanged, dpiScalingFactor);
+                    }
+                    ViewportContextIdNotificationBus::Event(viewportId, &ViewportContextIdNotificationBus::Events::OnViewportDpiScalingChanged, dpiScalingFactor);
+                };
                 viewportContext->m_name = contextName;
                 viewportData.sizeChangedHandler = ViewportContext::SizeChangedEvent::Handler(onSizeChanged);
                 viewportContext->ConnectSizeChangedHandler(viewportData.sizeChangedHandler);
+                viewportContext->ConnectDpiScalingFactorChangedHandler(viewportData.dpiScalingChangedHandler);
                 ViewPtrStack& associatedViews = GetOrCreateViewStackForContext(contextName);
                 viewportContext->SetDefaultView(associatedViews.back());
                 onSizeChanged(viewportContext->GetViewportSize());
@@ -176,6 +187,7 @@ namespace AZ
             UpdateViewForContext(newContextName);
             // Ensure anyone listening on per-name viewport size updates gets notified.
             ViewportContextNotificationBus::Event(newContextName, &ViewportContextNotificationBus::Events::OnViewportSizeChanged, viewportContext->GetViewportSize());
+            ViewportContextNotificationBus::Event(newContextName, &ViewportContextNotificationBus::Events::OnViewportDpiScalingChanged, viewportContext->GetDpiScalingFactor());
         }
 
         void ViewportContextManager::EnumerateViewportContexts(AZStd::function<void(ViewportContextPtr)> visitorFunction)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/ViewportContextManager.cpp
@@ -74,6 +74,7 @@ namespace AZ
                 };
                 viewportContext->m_name = contextName;
                 viewportData.sizeChangedHandler = ViewportContext::SizeChangedEvent::Handler(onSizeChanged);
+                viewportData.dpiScalingChangedHandler = ViewportContext::ScalarChangedEvent::Handler(onDpiScalingChanged);
                 viewportContext->ConnectSizeChangedHandler(viewportData.sizeChangedHandler);
                 viewportContext->ConnectDpiScalingFactorChangedHandler(viewportData.dpiScalingChangedHandler);
                 ViewPtrStack& associatedViews = GetOrCreateViewStackForContext(contextName);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -113,6 +113,7 @@ namespace AtomToolsFramework
         void SetFullScreenState(bool fullScreenState) override;
         bool CanToggleFullScreenState() const override;
         void ToggleFullScreenState() override;
+        float GetDpiScaleFactor() const override;
 
     protected:
         // AzFramework::InputChannelEventListener ...

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -540,4 +540,9 @@ namespace AtomToolsFramework
     {
         // The RenderViewportWidget does not currently support full screen.
     }
+
+    float RenderViewportWidget::GetDpiScaleFactor() const
+    {
+        return aznumeric_cast<float>(devicePixelRatioF());
+    }
 } //namespace AtomToolsFramework

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -155,7 +155,7 @@ namespace AZ::Render
 
         m_drawParams.m_drawViewportId = viewportContext->GetId();
         auto viewportSize = viewportContext->GetViewportSize();
-        m_drawParams.m_position = AZ::Vector3(viewportSize.m_width, 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding);
+        m_drawParams.m_position = AZ::Vector3(viewportSize.m_width, 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding) * viewportContext->GetDpiScalingFactor();
         m_drawParams.m_color = AZ::Colors::White;
         m_drawParams.m_scale = AZ::Vector2(BaseFontSize * viewportContext->GetDpiScalingFactor());
         m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -157,7 +157,7 @@ namespace AZ::Render
         auto viewportSize = viewportContext->GetViewportSize();
         m_drawParams.m_position = AZ::Vector3(viewportSize.m_width, 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding);
         m_drawParams.m_color = AZ::Colors::White;
-        m_drawParams.m_scale = AZ::Vector2(0.7f);
+        m_drawParams.m_scale = AZ::Vector2(0.7f * viewportContext->GetDpiScalingFactor());
         m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;
         m_drawParams.m_monospace = false;
         m_drawParams.m_depthTest = false;

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -157,7 +157,7 @@ namespace AZ::Render
         auto viewportSize = viewportContext->GetViewportSize();
         m_drawParams.m_position = AZ::Vector3(viewportSize.m_width, 0.0f, 1.0f) + AZ::Vector3(r_topRightBorderPadding);
         m_drawParams.m_color = AZ::Colors::White;
-        m_drawParams.m_scale = AZ::Vector2(0.7f * viewportContext->GetDpiScalingFactor());
+        m_drawParams.m_scale = AZ::Vector2(BaseFontSize * viewportContext->GetDpiScalingFactor());
         m_drawParams.m_hAlign = AzFramework::TextHorizontalAlignment::Right;
         m_drawParams.m_monospace = false;
         m_drawParams.m_depthTest = false;

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.h
@@ -60,6 +60,8 @@ namespace AZ
             void DrawPassInfo();
             void DrawFramerate();
 
+            static constexpr float BaseFontSize = 0.7f;
+
             AZStd::string m_rendererDescription;
             AzFramework::TextDrawParameters m_drawParams;
             AzFramework::FontDrawInterface* m_fontDrawInterface = nullptr;

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
@@ -105,10 +105,20 @@ namespace AZ
                 // Let our ImguiAtomSystemComponent know once we successfully connect and update the viewport size.
                 if (!m_initialized)
                 {
+                    auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
+                    auto defaultViewportContext = atomViewportRequests->GetDefaultViewportContext();
+                    OnViewportDpiScalingChanged(defaultViewportContext->GetDpiScalingFactor());
                     m_initialized = true;
                 }
             });
-#endif
+#endif //define(IMGUI_ENABLED)
+        }
+
+        void ImguiAtomSystemComponent::OnViewportDpiScalingChanged(float dpiScale)
+        {
+#if defined(IMGUI_ENABLED)
+            ImGui::ImGuiManagerBus::Broadcast(&ImGui::ImGuiManagerBus::Events::SetDpiScalingFactor, dpiScale);
+#endif //define(IMGUI_ENABLED)
         }
     }
 }

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.cpp
@@ -50,7 +50,8 @@ namespace AZ
         {
             ImGui::OtherActiveImGuiRequestBus::Handler::BusConnect();
 
-            auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
+            auto atomViewportRequests = AZ::RPI::ViewportContextRequests::Get();
+            AZ_Assert(atomViewportRequests, "AtomViewportContextRequests interface not found!");
             const AZ::Name contextName = atomViewportRequests->GetDefaultViewportContextName();
             AZ::RPI::ViewportContextNotificationBus::Handler::BusConnect(contextName);
 
@@ -105,7 +106,7 @@ namespace AZ
                 // Let our ImguiAtomSystemComponent know once we successfully connect and update the viewport size.
                 if (!m_initialized)
                 {
-                    auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
+                    auto atomViewportRequests = AZ::RPI::ViewportContextRequests::Get();
                     auto defaultViewportContext = atomViewportRequests->GetDefaultViewportContext();
                     OnViewportDpiScalingChanged(defaultViewportContext->GetDpiScalingFactor());
                     m_initialized = true;

--- a/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.h
+++ b/Gems/AtomLyIntegration/ImguiAtom/Code/Source/ImguiAtomSystemComponent.h
@@ -51,6 +51,7 @@ namespace AZ
             // ViewportContextNotificationBus overrides...
             void OnRenderTick() override;
             void OnViewportSizeChanged(AzFramework::WindowSize size) override;
+            void OnViewportDpiScalingChanged(float dpiScale) override;
 
             DebugConsole m_debugConsole;
             bool m_initialized = false;

--- a/Gems/ImGui/Code/Include/ImGuiBus.h
+++ b/Gems/ImGui/Code/Include/ImGuiBus.h
@@ -86,6 +86,8 @@ namespace ImGui
         virtual void SetImGuiRenderResolution(const ImVec2& res) = 0;
         virtual void OverrideRenderWindowSize(uint32_t width, uint32_t height) = 0;
         virtual void RestoreRenderWindowSizeToDefault() = 0;
+        virtual void SetDpiScalingFactor(float dpiScalingFactor) = 0;
+        virtual float GetDpiScalingFactor() const = 0;
         virtual void Render() = 0;
     };
 

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -277,6 +277,20 @@ void ImGui::ImGuiManager::RestoreRenderWindowSizeToDefault()
     InitWindowSize();
 }
 
+void ImGui::ImGuiManager::SetDpiScalingFactor(float dpiScalingFactor)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    // Set the global font scale to size our UI to the scaling factor
+    // Note: Currently we use the default, 13px fixed-size IMGUI font, so this can get somewhat blurry
+    io.FontGlobalScale = dpiScalingFactor;
+}
+
+float ImGui::ImGuiManager::GetDpiScalingFactor() const
+{
+    ImGuiIO& io = ImGui::GetIO();
+    return io.FontGlobalScale;
+}
+
 void ImGuiManager::Render()
 {
     if (m_clientMenuBarState == DisplayState::Hidden && m_editorWindowState == DisplayState::Hidden)

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -82,7 +82,7 @@ namespace ImGui
         DisplayState m_editorWindowState = DisplayState::Hidden;
 
         // ImGui Resolution Settings
-        ImGuiResolutionMode m_resolutionMode = ImGuiResolutionMode::MatchToMaxRenderResolution;
+        ImGuiResolutionMode m_resolutionMode = ImGuiResolutionMode::MatchRenderResolution;
         ImVec2 m_renderResolution = ImVec2(1920.0f, 1080.0f);
         ImVec2 m_lastRenderResolution;
         AzFramework::WindowSize m_windowSize = AzFramework::WindowSize(1920, 1080);

--- a/Gems/ImGui/Code/Source/ImGuiManager.h
+++ b/Gems/ImGui/Code/Source/ImGuiManager.h
@@ -57,6 +57,8 @@ namespace ImGui
         void SetImGuiRenderResolution(const ImVec2& res) override { m_renderResolution = res; }
         void OverrideRenderWindowSize(uint32_t width, uint32_t height) override;
         void RestoreRenderWindowSizeToDefault() override;
+        void SetDpiScalingFactor(float dpiScalingFactor) override;
+        float GetDpiScalingFactor() const override;
         void Render() override;
         // -- ImGuiManagerBus Interface -------------------------------------------------------------------
 

--- a/Tools/LyTestTools/ly_test_tools/log/log_monitor.py
+++ b/Tools/LyTestTools/ly_test_tools/log/log_monitor.py
@@ -133,12 +133,12 @@ class LogMonitor(object):
         except AssertionError:  # Raised by waiter when timeout is reached.
             logger.warning(f"Timeout of '{timeout}' seconds was reached, log lines may not have been found")
             # exception will be raised below by _validate_results with failure analysis
-
-        logger.info("Python log output:\n" + self.py_log)
-        logger.info(
-            "Finished log monitoring for '{}' seconds, validating results.\n"
-            "expected_lines_not_found: {}\n unexpected_lines_found: {}".format(
-                timeout, self.expected_lines_not_found, self.unexpected_lines_found))
+        finally:
+            logger.info("Python log output:\n" + self.py_log)
+            logger.info(
+                "Finished log monitoring for '{}' seconds, validating results.\n"
+                "expected_lines_not_found: {}\n unexpected_lines_found: {}".format(
+                    timeout, self.expected_lines_not_found, self.unexpected_lines_found))
 
         return self._validate_results(self.expected_lines_not_found, self.unexpected_lines_found, expected_lines, unexpected_lines)
 

--- a/Tools/LyTestTools/ly_test_tools/log/log_monitor.py
+++ b/Tools/LyTestTools/ly_test_tools/log/log_monitor.py
@@ -276,7 +276,7 @@ class LogMonitor(object):
             try:
                 process_line(line)
             except LogMonitorException as e:
-                if exception_info is not None:
+                if exception_info is None:
                     exception_info = e.args
 
         if exception_info is not None:


### PR DESCRIPTION
- Fix IMGUI overlay not working in viewports with a resolution >= 1080p
- Scale IMGUI with the current DPI (Editor/Windows only for now)
- Make viewport debug info overlay text scale with the current DPI (Editor/Windows only for now)

This adds a basic DPI scaling factor API to the AZ framework window bus. Implementations are provided for `RenderViewportWidget` (for Editor windows) and the Windows platform, other platforms will simply return a 1.0 ratio for now.

Note: We currently don't actually flag the game launcher as DPI aware in its manifest, so the window created will always have a fixed 96 DPI (1.0 scale factor). This means that on high DPI devices Windows will actually render the launcher at a smaller resolution and upscale it, which is likely not desired behavior. This should likely be switched to per-monitor DPI awareness in the future, but in the interest of not making a large behavioral change in stabilization I've merely made the no DPI scaling option explicit in the CMake so that it can be tweaked later.

Local testing in the launcher did show the DPI awareness being recorded and switching between displays correctly.

Before:
<img width="1248" alt="dpi-scaling-before" src="https://user-images.githubusercontent.com/760096/122867598-9dfb5900-d2de-11eb-8913-96f94c8f317b.png">

After (IMGUI clipping the overlay is a separate issue):
<img width="1246" alt="dpi-scaling-after" src="https://user-images.githubusercontent.com/760096/122867623-a489d080-d2de-11eb-9ee9-30bec0c0953c.png">
