### PR TITLE
{SPEC-7412}AssetPipelineTests.Gui_2_Main.main fails in nightly build

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests_2.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_gui_tests_2.py
@@ -173,6 +173,7 @@ class TestsAssetProcessorGUI_AllPlatforms(object):
     """
 
     @pytest.mark.test_case_id("C1591337")
+    @pytest.mark.SUITE_sandbox
     @pytest.mark.BAT
     @pytest.mark.assetpipeline
     # fmt:off
@@ -217,6 +218,7 @@ class TestsAssetProcessorGUI_AllPlatforms(object):
         asset_processor.stop()
 
     @pytest.mark.test_case_id("C4874115")
+    @pytest.mark.SUITE_sandbox
     @pytest.mark.BAT
     @pytest.mark.assetpipeline
     def test_AllSupportedPlatforms_AddScanFolder_AssetsProcessed(


### PR DESCRIPTION
{SPEC-7412}AssetPipelineTests.Gui_2_Main.main fails in nightly build
moving flaky tests to sandbox