### PR TITLE
Small fix for debug cascades not working with bicubic pcf filtering

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -427,6 +427,7 @@ float DirectionalLightShadow::SamplePcfBicubic()
             shadowCoord.y >= 0. && shadowCoord.y * size < size - PixelMargin && 
             shadowCoord.z < 1. - DepthMargin)
         {
+            m_debugInfo.m_cascadeIndex = indexOfCascade;
             return SamplePcfBicubic(shadowCoord, indexOfCascade);
         }
     }


### PR DESCRIPTION
ATOM-15805

Prior to this change, the debug cascades were only showing red. Afterwards, they showed the full cascade range, nearly identical to boundary search pcf filtering

![image](https://user-images.githubusercontent.com/61609885/123011264-e8c7b000-d374-11eb-8b5e-3cb674bfdf4b.png)
