### PR TITLE
Adding the PrimitiveAssets gem to the Default Project template

### DIFF
--- a/Templates/DefaultProject/Template/Code/enabled_gems.cmake
+++ b/Templates/DefaultProject/Template/Code/enabled_gems.cmake
@@ -24,6 +24,7 @@ set(ENABLED_GEMS
     LyShine
     Multiplayer
     PhysX
+    PrimitiveAssets
     SaveData
     ScriptCanvasPhysics
     ScriptEvents


### PR DESCRIPTION
Created a new project from the template and invoked the cmake configuration command to generate the `cmake_dependencies.<project-name>.assetprocessor.setreg` files

![image](https://user-images.githubusercontent.com/56135373/123027035-c6e52200-d3a2-11eb-876d-cb626ed8c5e6.png)
