### PR TITLE
Fix for White Box mesh disappearing

### DIFF
--- a/Code/Framework/AzCore/Tests/AZTestShared/Math/MathTestHelpers.cpp
+++ b/Code/Framework/AzCore/Tests/AZTestShared/Math/MathTestHelpers.cpp
@@ -20,6 +20,7 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/Math/Aabb.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Color.h>
 
@@ -51,6 +52,11 @@ namespace AZ
             << ", Z: " << vec.GetZ()
             << ", W: " << vec.GetW()
             << ")";
+    }
+
+    std::ostream& operator<<(std::ostream& os, const Aabb& aabb)
+    {
+        return os << "(min: " << aabb.GetMin() << ", max: " << aabb.GetMax() << ")";
     }
 
     std::ostream& operator<<(std::ostream& os, const Quaternion& quat)

--- a/Code/Framework/AzCore/Tests/AZTestShared/Math/MathTestHelpers.h
+++ b/Code/Framework/AzCore/Tests/AZTestShared/Math/MathTestHelpers.h
@@ -25,12 +25,14 @@ namespace AZ
     class Vector2;
     class Vector3;
     class Vector4;
+    class Aabb;
     class Transform;
     class Color;
 
     std::ostream& operator<<(std::ostream& os, const Vector2& vec);
     std::ostream& operator<<(std::ostream& os, const Vector3& vec);
     std::ostream& operator<<(std::ostream& os, const Vector4& vec);
+    std::ostream& operator<<(std::ostream& os, const Aabb& aabb);
     std::ostream& operator<<(std::ostream& os, const Quaternion& quat);
     std::ostream& operator<<(std::ostream& os, const Transform& transform);
     std::ostream& operator<<(std::ostream& os, const Color& transform);

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxMeshAtomData.h
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/WhiteBoxMeshAtomData.h
@@ -45,6 +45,6 @@ namespace WhiteBox
         AZStd::vector<AZ::PackedVector3f> m_bitangents;
         AZStd::vector<PackedFloat2> m_uvs;
         AZStd::vector<AZ::Vector4> m_colors;
-        AZ::Aabb m_aabb;
+        AZ::Aabb m_aabb = AZ::Aabb::CreateNull();
     };
 } // namespace WhiteBox

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxUVTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxUVTest.cpp
@@ -14,6 +14,7 @@
 
 #include "Util/WhiteBoxTextureUtil.h"
 #include "WhiteBoxTestFixtures.h"
+#include "Rendering/Atom/WhiteBoxMeshAtomData.h"
 
 #include <AzCore/Casting/lossy_cast.h>
 #include <AzCore/Casting/numeric_cast.h>
@@ -284,5 +285,11 @@ namespace UnitTest
         ::testing::Combine(
             ::testing::ValuesIn(Noise), ::testing::ValuesIn(Source),
             ::testing::Values(Rotation::Identity, Rotation::XZAxis)));
+
+    TEST(WhiteBoxRenderTest, WhiteBoxMeshAtomDataAabbIsInitializedToNull)
+    {
+        WhiteBox::WhiteBoxMeshAtomData atomData(WhiteBox::WhiteBoxFaces{});
+        EXPECT_EQ(atomData.GetAabb(), AZ::Aabb::CreateNull());
+    }
 
 } // namespace UnitTest


### PR DESCRIPTION
Fixes bug with White Box atom data where the AABB was not set to an initial null value.

```
[----------] Global test environment tear-down
[==========] 518 tests from 14 test cases ran. (6582 ms total)
[  PASSED  ] 517 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] WhiteBoxRenderTest.WhiteBoxMeshAtomDataAabbIsInitializedToNull



[----------] Global test environment tear-down
[==========] 518 tests from 14 test cases ran. (6027 ms total)
[  PASSED  ] 518 tests.
```