### PR TITLE
Bug fix: after full screen preview triggers, reset the one time use flag

### DIFF
--- a/Code/Sandbox/Editor/EditorViewportWidget.cpp
+++ b/Code/Sandbox/Editor/EditorViewportWidget.cpp
@@ -3119,7 +3119,7 @@ bool EditorViewportWidget::ShouldPreviewFullscreen() const
     // Check 'ed_previewGameInFullscreen_once'
     if (ed_previewGameInFullscreen_once)
     {
-        ed_previewGameInFullscreen_once = true;
+        ed_previewGameInFullscreen_once = false;
         return true;
     }
     else


### PR DESCRIPTION
This fixes a bug in which, after triggering the full screen preview, subsequent triggers of the regular preview would also be full screen.