### PR TITLE
[LYN-4743] Add CFN resource attribute key check

### DIFF
--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_aws_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_aws_utils.py
@@ -261,6 +261,25 @@ class TestAWSUtils(TestCase):
         mocked_paginator.paginate.assert_called_once_with(StackName=TestAWSUtils._expected_stack, PaginationConfig=ANY)
         assert not actual_stack_resources
 
+    def test_list_cloudformation_stack_resources_return_empty_list_when_resource_has_invalid_attributes(self) -> None:
+        mocked_cloudformation_client: MagicMock = self._mock_client.return_value
+        mocked_paginator: MagicMock = MagicMock()
+        mocked_cloudformation_client.get_paginator.return_value = mocked_paginator
+        mocked_iterator: MagicMock = MagicMock()
+        mocked_iterator.resume_token = None
+        mocked_paginator.paginate.return_value = mocked_iterator
+        mocked_iterator.__iter__.return_value = [{"StackResourceSummaries": [
+            {"DummyAttribute": "DummyValue"}]}]
+
+        actual_stack_resources: List[BasicResourceAttributes] = \
+            aws_utils.list_cloudformation_stack_resources(TestAWSUtils._expected_stack, TestAWSUtils._expected_region)
+        self._mock_client.assert_called_once_with(aws_utils.AWSConstants.CLOUDFORMATION_SERVICE_NAME,
+                                                  region_name=TestAWSUtils._expected_region)
+        mocked_cloudformation_client.get_paginator.assert_called_once_with(
+            aws_utils.AWSConstants.CLOUDFORMATION_LIST_STACK_RESOURCES_API_NAME)
+        mocked_paginator.paginate.assert_called_once_with(StackName=TestAWSUtils._expected_stack, PaginationConfig=ANY)
+        assert not actual_stack_resources
+
     def test_list_cloudformation_stack_resources_return_expected_stack_resources(self) -> None:
         mocked_cloudformation_client: MagicMock = self._mock_client.return_value
         mocked_paginator: MagicMock = MagicMock()

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/aws_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/aws_utils.py
@@ -179,10 +179,11 @@ def list_cloudformation_stack_resources(stack_name, region=None) -> List[BasicRe
                 # iterate through page iterator to fetch all resources
                 resource: Dict[str, any]
                 for resource in page["StackResourceSummaries"]:
-                    resource_type_and_name.append(BasicResourceAttributesBuilder()
-                                                  .build_type(resource["ResourceType"])
-                                                  .build_name_id(resource["PhysicalResourceId"])
-                                                  .build())
+                    if "ResourceType" in resource.keys() and "PhysicalResourceId" in resource.keys():
+                        resource_type_and_name.append(BasicResourceAttributesBuilder()
+                                                      .build_type(resource["ResourceType"])
+                                                      .build_name_id(resource["PhysicalResourceId"])
+                                                      .build())
             if iterator.resume_token is None:
                 # when resume token is none, it means there is no more resources left
                 break


### PR DESCRIPTION
## Details
When CFN stack gets rollback, there is a case that resource won't have physical id:
```
    "StackResourceSummaries": [
        {
            "LogicalResourceId": "ATVINCENTAWSClientAuthCfnUserPoolIduswest2",
            "ResourceType": "AWS::Cognito::UserPool",
            "LastUpdatedTimestamp": "2021-06-22T18:28:31.780000+00:00",
            "ResourceStatus": "DELETE_COMPLETE",
            "DriftInformation": {
                "StackResourceDriftStatus": "NOT_CHECKED"
            }
        },
        {
            "LogicalResourceId": "ATVINCENTAWSClientAuthRoleIduswest207BD179C",
            "PhysicalResourceId": "ATVINCENT-AWSClientAuth-S-ATVINCENTAWSClientAuthRo-1OBVZJJ9NU5P6",
            "ResourceType": "AWS::IAM::Role",
            "LastUpdatedTimestamp": "2021-06-22T18:28:34.069000+00:00",
            "ResourceStatus": "DELETE_COMPLETE",
            "DriftInformation": {
                "StackResourceDriftStatus": "NOT_CHECKED"
            }
        },
        ....
```

## Testing
Manual tested
Pass 125 unit test cases