### PR TITLE
ATOM-15287 Materials Disappear When Hot Reloading Parent Materials

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -572,9 +572,11 @@ namespace MaterialEditor
     {
         if (m_compilePending)
         {
-            m_materialInstance->Compile();
-            m_compilePending = false;
-            AZ::TickBus::Handler::BusDisconnect();
+            if (m_materialInstance->Compile())
+            {
+                m_compilePending = false;
+                AZ::TickBus::Handler::BusDisconnect();
+            }
         }
     }
 


### PR DESCRIPTION
The issue was because the material wasn't compiled when creating the draw packet