### PR TITLE
{SPEC-7465} AssetsReprocessed fails on Debug Nightly Builds

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py
@@ -218,7 +218,8 @@ class TestsAssetProcessorBatch_Windows(object):
 
         asset_processor.create_temp_asset_root()
         # Start the processor
-        asset_processor.gui_process(quitonidle=False, connect_to_ap=True)
+        # using -ap_disableAssetTreeView=true to skip the UI building of the Asset Tree for this test
+        asset_processor.gui_process(quitonidle=False, connect_to_ap=True, extra_params=[f'-ap_disableAssetTreeView=true'])
         asset_processor.stop()
 
         # fmt:off

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
@@ -16,9 +16,11 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzFramework/StringFunc/StringFunc.h>
+#include <AzCore/Console/IConsole.h>
 
 namespace AssetProcessor
 {
+    AZ_CVAR_EXTERNED(bool, ap_disableAssetTreeView);
 
     ProductAssetTreeModel::ProductAssetTreeModel(AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> sharedDbConnection, QObject *parent) :
         AssetTreeModel(sharedDbConnection, parent)
@@ -31,6 +33,11 @@ namespace AssetProcessor
 
     void ProductAssetTreeModel::ResetModel()
     {
+        if (ap_disableAssetTreeView)
+        {
+            return;
+        }
+
         m_productToTreeItem.clear();
         m_productIdToTreeItem.clear();
         AZStd::string databaseLocation;
@@ -51,6 +58,11 @@ namespace AssetProcessor
 
     void ProductAssetTreeModel::OnProductFileChanged(const AzToolsFramework::AssetDatabase::ProductDatabaseEntry& entry)
     {
+        if (ap_disableAssetTreeView)
+        {
+            return;
+        }
+
         // Model changes need to be run on the main thread.
         AZ::SystemTickBus::QueueFunction([&, entry]()
         {
@@ -112,6 +124,11 @@ namespace AssetProcessor
 
     void ProductAssetTreeModel::OnProductFileRemoved(AZ::s64 productId)
     {
+        if (ap_disableAssetTreeView)
+        {
+            return;
+        }
+
         // UI changes need to be done on the main thread.
         AZ::SystemTickBus::QueueFunction([&, productId]()
         {
@@ -121,6 +138,11 @@ namespace AssetProcessor
 
     void ProductAssetTreeModel::OnProductFilesRemoved(const AzToolsFramework::AssetDatabase::ProductDatabaseEntryContainer& products)
     {
+        if (ap_disableAssetTreeView)
+        {
+            return;
+        }
+
         // UI changes need to be done on the main thread.
         AZ::SystemTickBus::QueueFunction([&, products]()
         {
@@ -133,6 +155,11 @@ namespace AssetProcessor
 
     QModelIndex ProductAssetTreeModel::GetIndexForProduct(const AZStd::string& product)
     {
+        if (ap_disableAssetTreeView)
+        {
+            return QModelIndex();
+        }
+
         auto productItem = m_productToTreeItem.find(product);
         if (productItem == m_productToTreeItem.end())
         {


### PR DESCRIPTION
{SPEC-7465} Fix DeleteCachedAssets_AssetsReprocessed fails on Debug Nightly Builds

* Fix for DeleteCachedAssets_AssetsReprocessed fails on Debug Nightly Builds
* added -ap_disableAssetTreeView=true to disable the Qt tree view for the asset tab to get the parts that want to be tested finish
* only shows up on Debug

Tests:
=== test session starts ===
AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py::TestsAssetProcessorBatch_AllPlatforms::test_AllSupportedPlatforms_FastScanWorks_FasterThanFullScan[windows-AutomatedTesting] PASSED [ 50%]
AutomatedTesting/Gem/PythonTests/assetpipeline/asset_processor_tests/asset_processor_batch_tests_2.py::TestsAssetProcessorBatch_Windows::test_WindowsPlatforms_RunAPBatchAndConnectGui_RunsWithoutEditor[windows-AutomatedTesting] PASSED [100%]
--- generated xml file: F:\amazon\o3de\build\vs2019\Testing\Pytest\AssetPipelineTests.Batch_2_Sandbox.xml ---
=== 2 passed, 4 deselected in 18.32s ===