### PR TITLE
LYN-4783 | Replace Component Help URLs with O3DE help URLs - Fix debug build

### DIFF
--- a/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/Code/Sandbox/Editor/Core/LevelEditorMenuHandler.cpp
@@ -827,9 +827,6 @@ QMenu* LevelEditorMenuHandler::CreateHelpMenu()
     connect(helpMenu.Get(), &QMenu::aboutToShow, lineEdit, &QLineEdit::clearFocus);
     helpMenu->addAction(lineEditSearchAction);
 
-    // Getting Started
-    helpMenu.AddAction(ID_DOCUMENTATION_GETTINGSTARTEDGUIDE);
-
     // Tutorials
     helpMenu.AddAction(ID_DOCUMENTATION_TUTORIALS);
 


### PR DESCRIPTION
Follow-up PR for action that was left behind in LYN-3483, PR #1520 and would trigger an assert on Editor load in debug builds.