### PR TITLE
Entity Outliner - Sort Order options don't show current selection

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
@@ -514,6 +514,20 @@ namespace AzQtComponents
                         }
                     }
                 }
+                // Implement checkmark with icon in menu.
+                QStyleOptionMenuItem myOpt = *qstyleoption_cast<const QStyleOptionMenuItem*>(option);
+                bool checkable = myOpt.checkType != QStyleOptionMenuItem::NotCheckable;
+                bool checked = checkable ? myOpt.checked : false;
+
+                if (!myOpt.icon.isNull() && checked)
+                {
+                    const int iconSize{ 18 };
+                    int topPadding{ AZStd::max( 0 , (myOpt.rect.height() - iconSize) / 2) - 1};
+
+                    QProxyStyle::drawControl(element, &myOpt, painter, widget);
+                    myOpt.rect.adjust(0, topPadding, iconSize - myOpt.rect.width(), iconSize - myOpt.rect.height());
+                    return drawPrimitive(PE_IndicatorMenuCheckMark, &myOpt, painter, widget);
+                }
             }
             break;
         }


### PR DESCRIPTION
Also fixes the menus that have checkmark and icon
![image](https://user-images.githubusercontent.com/82226755/123252781-8ee5f800-d4e4-11eb-8b71-19c5f383a015.png)
![image](https://user-images.githubusercontent.com/82226755/123252799-960d0600-d4e4-11eb-83a4-04c44ce7bb1f.png)
