### PR TITLE
Adjust Pdo shadow map bias

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR_Shadowmap_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR_Shadowmap_WithPS.azsl
@@ -15,6 +15,7 @@
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/Features/ParallaxMapping.azsli>
 #include <Atom/Features/MatrixUtility.azsli>
+#include <Atom/Features/Shadow/Shadow.azsli>
 
 #include "MaterialInputs/AlphaInput.azsli"
 #include "MaterialInputs/ParallaxInput.azsli"
@@ -78,8 +79,6 @@ PSDepthOutput MainPS(VertexOutput IN, bool isFrontFace : SV_IsFrontFace)
     
     if(ShouldHandleParallaxInDepthShaders())
     {
-        static const float ShadowMapDepthBias = 0.000001;
-
         float3 tangents[UvSetCount] = { IN.m_tangent.xyz, IN.m_tangent.xyz };
         float3 bitangents[UvSetCount] = { IN.m_bitangent.xyz, IN.m_bitangent.xyz };
 
@@ -92,7 +91,7 @@ PSDepthOutput MainPS(VertexOutput IN, bool isFrontFace : SV_IsFrontFace)
                          ObjectSrg::GetWorldMatrix(), uvMatrix, uvMatrixInverse,
                          IN.m_uv[MaterialSrg::m_parallaxUvIndex], IN.m_worldPosition, OUT.m_depth);
 
-        OUT.m_depth += ShadowMapDepthBias;
+        OUT.m_depth += PdoShadowMapBias;
     }
     
     // Clip Alpha

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
@@ -126,7 +126,7 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
                          ObjectSrg::GetWorldMatrix(), uvMatrix, uvMatrixInverse,
                          IN.m_uv[MaterialSrg::m_parallaxUvIndex], IN.m_worldPosition, depthNDC, IN.m_position.w, displacementIsClipped);
 
-        // Adjust directional light shadow coorinates for parallax correction
+        // Adjust directional light shadow coordinates for parallax correction
         if(o_parallax_enablePixelDepthOffset)
         {
             const uint shadowIndex = ViewSrg::m_shadowIndexDirectionalLight;

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_Shadowmap_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_Shadowmap_WithPS.azsl
@@ -15,6 +15,7 @@
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/Features/ParallaxMapping.azsli>
 #include <Atom/Features/MatrixUtility.azsli>
+#include <Atom/Features/Shadow/Shadow.azsli>
 
 #include "MaterialInputs/AlphaInput.azsli"
 #include "MaterialInputs/ParallaxInput.azsli"
@@ -78,9 +79,7 @@ PSDepthOutput MainPS(VertexOutput IN, bool isFrontFace : SV_IsFrontFace)
     OUT.m_depth = IN.m_position.z;
 
     if(ShouldHandleParallaxInDepthShaders())
-    {
-        static const float ShadowMapDepthBias = 0.000001;
-    
+    {  
         float3 tangents[UvSetCount] = { IN.m_tangent.xyz, IN.m_tangent.xyz };
         float3 bitangents[UvSetCount] = { IN.m_bitangent.xyz, IN.m_bitangent.xyz };
         PrepareGeneratedTangent(IN.m_normal, IN.m_worldPosition, isFrontFace, IN.m_uv, UvSetCount, tangents, bitangents);
@@ -92,7 +91,7 @@ PSDepthOutput MainPS(VertexOutput IN, bool isFrontFace : SV_IsFrontFace)
                          ObjectSrg::GetWorldMatrix(), uvMatrix, uvMatrixInverse,
                          IN.m_uv[MaterialSrg::m_parallaxUvIndex], IN.m_worldPosition, OUT.m_depth);
 
-        OUT.m_depth += ShadowMapDepthBias;
+        OUT.m_depth += PdoShadowMapBias;
     }
     
     // Alpha

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/Shadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/Shadow.azsli
@@ -14,6 +14,11 @@
 
 static const float EsmExponentialShift = 87.; // slightly smaller value of log(FLT_MAX)
 
+// Slope-scale depth bias doesn't work with depth writes. Apply a small bias with this value so that bicubic filtering 
+// won't have shadow acne
+// Longer-term, we should probably try and implement Normal Offset biasing [GFX TODO][ATOM-15846]
+static const float PdoShadowMapBias = 0.001; 
+
 // Must match the equivalent enumeration in ShadowConstants.h
 enum PcfFilterMethod { PcfFilterMethod_BoundarySearch = 0, PcfFilterMethod_Bicubic = 1 };
 


### PR DESCRIPTION
Increase the offset value that is applied when rendering into the shadowmap with Pdo enabled.

ASV tests pass

LYN-3985


Before fix
![image](https://user-images.githubusercontent.com/61609885/123312100-bdf86b80-d4dc-11eb-9db7-cf0145677abb.png)


After fix
![image](https://user-images.githubusercontent.com/61609885/123312453-3828f000-d4dd-11eb-9167-48fef64935bf.png)
