### PR TITLE
Disable exposing destroy game entity calls to behavior context when prefabs are enabled

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -41,18 +41,27 @@ namespace AzFramework
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->EBus<GameEntityContextRequestBus>("GameEntityContextRequestBus")
-                ->Attribute(AZ::Script::Attributes::Module, "entity")
+            auto gameEntityContextEbusBuilder = behaviorContext->EBus<GameEntityContextRequestBus>("GameEntityContextRequestBus");
+            gameEntityContextEbusBuilder->Attribute(AZ::Script::Attributes::Module, "entity")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Event("CreateGameEntity", &GameEntityContextRequestBus::Events::CreateGameEntityForBehaviorContext)
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                ->Event("DestroyGameEntity", &GameEntityContextRequestBus::Events::DestroyGameEntity)
-                ->Event("DestroyGameEntityAndDescendants", &GameEntityContextRequestBus::Events::DestroyGameEntityAndDescendants)
+                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
                 ->Event("ActivateGameEntity", &GameEntityContextRequestBus::Events::ActivateGameEntity)
                 ->Event("DeactivateGameEntity", &GameEntityContextRequestBus::Events::DeactivateGameEntity)
-                    ->Attribute(AZ::ScriptCanvasAttributes::DeactivatesInputEntity, true)
-                ->Event("GetEntityName", &GameEntityContextRequestBus::Events::GetEntityName)
-                ;
+                ->Attribute(AZ::ScriptCanvasAttributes::DeactivatesInputEntity, true)
+                ->Event("GetEntityName", &GameEntityContextRequestBus::Events::GetEntityName);
+
+            bool prefabSystemEnabled = false;
+            AzFramework::ApplicationRequests::Bus::BroadcastResult(
+                prefabSystemEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+
+            if (!prefabSystemEnabled)
+            {
+                // Temporarily disable destroying game entities when prefabs are enabled until the spawnable system can support this.
+                gameEntityContextEbusBuilder->Event("DestroyGameEntity", &GameEntityContextRequestBus::Events::DestroyGameEntity)
+                    ->Event("DestroyGameEntityAndDescendants", &GameEntityContextRequestBus::Events::DestroyGameEntityAndDescendants);
+            }
+            
         }
     }
 


### PR DESCRIPTION
Spawnables doesn't currently support destroying game entities directly through an entity id. Until we add support to that (in the next 1-2 weeks), this is a stop-gap solution to prevent crashes in the editor.

Testing:
Tested that destroying game entities through script canvas doesn't crash the editor. If there are any pre-existing scripts, the destroy game entity node wouldn't function and would need to be removed to save the script canvas file. But since that never worked correctly, it shouldn't be a problem.