### PR TITLE
LYN-4814 | Display project and level name on the main editor

### DIFF
--- a/Code/Sandbox/Editor/CryEdit.cpp
+++ b/Code/Sandbox/Editor/CryEdit.cpp
@@ -1717,7 +1717,7 @@ BOOL CCryEditApp::InitInstance()
         }
     }
 
-    SetEditorWindowTitle();
+    SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), 0);
     if (!GetIEditor()->IsInMatEditMode())
     {
         m_pEditor->InitFinished();
@@ -1839,7 +1839,7 @@ void CCryEditApp::LoadFile(QString fileName)
 
     if (MainWindow::instance() || m_pConsoleDialog)
     {
-        SetEditorWindowTitle(0, 0, GetIEditor()->GetGameEngine()->GetLevelName());
+        SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
     }
 
     GetIEditor()->SetModifiedFlag(false);
@@ -4029,7 +4029,6 @@ void CCryEditApp::SetEditorWindowTitle(QString sTitleStr, QString sPreTitleStr, 
 {
     if (MainWindow::instance() || m_pConsoleDialog)
     {
-
         if (sTitleStr.isEmpty())
         {
             sTitleStr = QObject::tr("O3DE Editor [Developer Preview]");
@@ -4037,7 +4036,7 @@ void CCryEditApp::SetEditorWindowTitle(QString sTitleStr, QString sPreTitleStr, 
 
         if (!sPreTitleStr.isEmpty())
         {
-            sTitleStr.insert(0, sPreTitleStr);
+            sTitleStr.insert(sTitleStr.length(), QStringLiteral(" - %1").arg(sPreTitleStr));
         }
 
         if (!sPostTitleStr.isEmpty())

--- a/Code/Sandbox/Editor/MainWindow.cpp
+++ b/Code/Sandbox/Editor/MainWindow.cpp
@@ -30,6 +30,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/Utils/Utils.h>
 
 // AzFramework
 #include <AzFramework/API/ApplicationAPI.h>
@@ -1275,7 +1276,7 @@ void MainWindow::OnEditorNotifyEvent(EEditorNotifyEvent ev)
         auto cryEdit = CCryEditApp::instance();
         if (cryEdit)
         {
-            cryEdit->SetEditorWindowTitle(0, 0, GetIEditor()->GetGameEngine()->GetLevelName());
+            cryEdit->SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
         }
     }
     break;
@@ -1284,7 +1285,7 @@ void MainWindow::OnEditorNotifyEvent(EEditorNotifyEvent ev)
         auto cryEdit = CCryEditApp::instance();
         if (cryEdit)
         {
-            cryEdit->SetEditorWindowTitle();
+            cryEdit->SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), 0);
         }
     }
     break;


### PR DESCRIPTION
Send project name as the sPreTitleStr for the Editor Window title.

![image](https://user-images.githubusercontent.com/82231674/123318339-f485b480-d4e3-11eb-82f2-6b63f1080bed.png)
