### PR TITLE
Fixes a crash in Audio Controls Editor when Wwise Gem is not enabled

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
@@ -290,6 +290,12 @@ namespace AudioControls
     //-------------------------------------------------------------------------------------------//
     void CAudioControlsEditorWindow::UpdateAudioSystemData()
     {
+        IAudioSystemEditor* audioSystemImpl = CAudioControlsEditorPlugin::GetAudioSystemEditorImpl();
+        if (!audioSystemImpl)
+        {
+            return;
+        }
+
         Audio::SAudioRequest oConfigDataRequest;
         oConfigDataRequest.nFlags = Audio::eARF_PRIORITY_HIGH;
 
@@ -310,17 +316,17 @@ namespace AudioControls
         oConfigDataRequest.pData = &oParseGlobalRequestData;
         Audio::AudioSystemRequestBus::Broadcast(&Audio::AudioSystemRequestBus::Events::PushRequest, oConfigDataRequest);
 
-        //parse the AudioSystem level-specific config data
-        const char* levelName = GetIEditor()->GetLevelName().toUtf8().data();
+        // parse the AudioSystem level-specific config data
+        AZStd::string levelName{ GetIEditor()->GetLevelName().toUtf8().data() };
         AZ::StringFunc::Path::Join(sControlsPath.c_str(), "levels", sControlsPath);
-        AZ::StringFunc::Path::Join(sControlsPath.c_str(), levelName, sControlsPath);
+        AZ::StringFunc::Path::Join(sControlsPath.c_str(), levelName.c_str(), sControlsPath);
         Audio::SAudioManagerRequestData<Audio::eAMRT_PARSE_CONTROLS_DATA> oParseLevelRequestData(sControlsPath.c_str(), Audio::eADS_LEVEL_SPECIFIC);
         oConfigDataRequest.pData = &oParseLevelRequestData;
         Audio::AudioSystemRequestBus::Broadcast(&Audio::AudioSystemRequestBus::Events::PushRequest, oConfigDataRequest);
 
         // inform the middleware specific plugin that the data has been saved
         // to disk (in case it needs to update something)
-        CAudioControlsEditorPlugin::GetAudioSystemEditorImpl()->DataSaved();
+        audioSystemImpl->DataSaved();
     }
 
     //-------------------------------------------------------------------------------------------//


### PR DESCRIPTION
- Fixed the nullptr dereference.
- Fixed an issue with a char* pointing to a destructed QString when getting the current level name.