### PR TITLE
[LYN-4782] Make sure Entity notifications are being listened to if a level was already opened before Landscape Canvas was launched.

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -462,6 +462,13 @@ namespace LandscapeCanvasEditor
         CrySystemEventBus::Handler::BusConnect();
         AZ::EntitySystemBus::Handler::BusConnect();
 
+        // Listen for Entity notifications if a level is already loaded
+        // Otherwise, we will connect/disconnect from this bus when levels are loaded/closed
+        if (GetLegacyEditor()->IsLevelLoaded())
+        {
+            AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
+        }
+
         // Create our temporary Node Inspector using a Pinned Inspector
         m_customNodeInspector = aznew CustomNodeInspectorDockWidget(this);
 


### PR DESCRIPTION
As part of an optimization, I had changed the Landscape Canvas tool to connect/disconnect from the Entity notifications bus when levels were loaded/closed, so that it wouldn't try to react to Entity notifications when the user was switching levels. This was just a tad over zealous because it didn't account for if Landscape Canvas wasn't already open when launching the Editor, resulting in it not listening to these notifications if it wasn't opened until after a level was already loaded.

Tested the use-case in the bug repro steps, the related automated test and ad-hoc testing and verified the Landscape Canvas tool now appropriately responds to entities being deleted.