### PR TITLE
Editor responsiveness: don't block main thread to generate thumbnails

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Utils/Utils.h>
+#include <AzCore/Jobs/JobFunction.h>
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
@@ -115,8 +116,7 @@ namespace ImageProcessingAtom
         void ImageThumbnailSystemComponent::RenderThumbnail(
             AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize)
         {
-            auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(thumbnailKey.data());
-            if (sourceKey)
+            if (auto sourceKey = azrtti_cast<const AzToolsFramework::AssetBrowser::SourceThumbnailKey*>(thumbnailKey.data()))
             {
                 bool foundIt = false;
                 AZ::Data::AssetInfo assetInfo;
@@ -129,52 +129,72 @@ namespace ImageProcessingAtom
                 {
                     AZStd::string fullPath;
                     AZ::StringFunc::Path::Join(watchFolder.c_str(), assetInfo.m_relativePath.c_str(), fullPath);
-                    if (RenderThumbnailFromImage(thumbnailKey, thumbnailSize, IImageObjectPtr(LoadImageFromFile(fullPath))))
-                    {
-                        return;
-                    }
+                    RenderThumbnailFromImage(thumbnailKey, thumbnailSize,
+                        [fullPath]() { return IImageObjectPtr(LoadImageFromFile(fullPath)); }
+                    );
                 }
             }
-
-            auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(thumbnailKey.data());
-            if (productKey)
+            else if (auto productKey = azrtti_cast<const AzToolsFramework::AssetBrowser::ProductThumbnailKey*>(thumbnailKey.data()))
             {
-                if (RenderThumbnailFromImage(thumbnailKey, thumbnailSize, Utils::LoadImageFromImageAsset(productKey->GetAssetId())))
-                {
-                    return;
-                }
+                RenderThumbnailFromImage(thumbnailKey, thumbnailSize,
+                    [assetId = productKey->GetAssetId()]() { return Utils::LoadImageFromImageAsset(assetId); }
+                );
             }
-
-            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+            else
+            {
+                AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                    thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+            }
         }
 
-        bool ImageThumbnailSystemComponent::RenderThumbnailFromImage(
-            AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, IImageObjectPtr previewImage) const
+        template<class MkImageFn>
+        void ImageThumbnailSystemComponent::RenderThumbnailFromImage(
+            AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, MkImageFn mkPreviewImage) const
         {
-            if (!previewImage)
+            const auto JobRunner = [mkPreviewImage, thumbnailKey, thumbnailSize]() mutable
             {
-                return false;
-            }
+                IImageObjectPtr previewImage = mkPreviewImage();
+                if (!previewImage)
+                {
+                    AZ::SystemTickBus::QueueFunction(
+                    [
+                        thumbnailKey
+                    ]()
+                    {
+                        AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                            thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailFailedToRender);
+                    });
 
-            ImageToProcess imageToProcess(previewImage);
-            imageToProcess.ConvertFormat(ePixelFormat_R8G8B8A8);
-            previewImage = imageToProcess.Get();
+                    return;
+                }
 
-            AZ::u8* imageBuf = nullptr;
-            AZ::u32 mip = 0;
-            AZ::u32 pitch = 0;
-            previewImage->GetImagePointer(mip, imageBuf, pitch);
-            const AZ::u32 width = previewImage->GetWidth(mip);
-            const AZ::u32 height = previewImage->GetHeight(mip);
+                ImageToProcess imageToProcess(previewImage);
+                imageToProcess.ConvertFormat(ePixelFormat_R8G8B8A8);
+                previewImage = imageToProcess.Get();
 
-            QImage image(imageBuf, width, height, pitch, QImage::Format_RGBA8888);
+                AZ::u8* imageBuf = nullptr;
+                AZ::u32 mip = 0;
+                AZ::u32 pitch = 0;
+                previewImage->GetImagePointer(mip, imageBuf, pitch);
+                const AZ::u32 width = previewImage->GetWidth(mip);
+                const AZ::u32 height = previewImage->GetHeight(mip);
 
-            AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
-                thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
-                QPixmap::fromImage(image.scaled(QSize(thumbnailSize, thumbnailSize), Qt::KeepAspectRatio, Qt::SmoothTransformation)));
+                // Note that this image holds a non-owning pointer to the `previewImage' raw data buffer
+                const QImage image(imageBuf, width, height, pitch, QImage::Format_RGBA8888);
 
-            return true;
+                // Dispatch event on main thread
+                AZ::SystemTickBus::QueueFunction(
+                [
+                    thumbnailKey, thumbnailSize,
+                    pixmap = QPixmap::fromImage(image.scaled(QSize(thumbnailSize, thumbnailSize), Qt::KeepAspectRatio, Qt::SmoothTransformation))
+                ]() mutable
+                {
+                    AzToolsFramework::Thumbnailer::ThumbnailerRendererNotificationBus::Event(
+                        thumbnailKey, &AzToolsFramework::Thumbnailer::ThumbnailerRendererNotifications::ThumbnailRendered,
+                        pixmap);
+                });
+            };
+            AZ::CreateJobFunction(JobRunner, true)->Start();
         }
     } // namespace Thumbnails
 } // namespace ImageProcessingAtom

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Thumbnail/ImageThumbnailSystemComponent.h
@@ -52,8 +52,9 @@ namespace ImageProcessingAtom
             bool Installed() const override;
             void RenderThumbnail(AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize) override;
 
-            bool RenderThumbnailFromImage(
-                AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, IImageObjectPtr previewImage) const;
+            template<class MkImageFn>
+            void RenderThumbnailFromImage(
+                AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey, int thumbnailSize, MkImageFn mkPreviewImage) const;
         };
     } // namespace Thumbnails
 } // namespace ImageProcessingAtom


### PR DESCRIPTION
Currently, while browsing your texture assets in the Asset Browser, when a texture asset comes into view, an event is queued on the SystemTickBus which generates a thumbnail for each texture. Generating thumbnails is a fairly expensive operations, a rough estimation, if you happen to make ~30 thumbnail requests in a single tick, each for a 4k texture, this takes about 3s (which blocks the main thread for that time).

This change moves all of this work from the main thread to a job thread.

The thumbnailing system already has a response event, i.e. callers of RenderThumbnail do not expect an immediate response and instead connect to ThumbnailerRendererNotificationBus to find out when their thumbnail is ready. So moving this work to a job thread has no impact on the thumbnail interface.