### PR TITLE
Fix for cursor not being displayed when asked to display

### DIFF
--- a/Code/CryEngine/CryCommon/LyShine/Bus/UiSystemBus.h
+++ b/Code/CryEngine/CryCommon/LyShine/Bus/UiSystemBus.h
@@ -18,11 +18,6 @@ public:
 
     // Public functions
 
-    //! Initialize the UI system. This should be called when all other systems that the UI
-    //! system depends upon are initialized. Once the engine is fully modularized this
-    //! function will be unnecessary.
-    virtual void InitializeSystem() {}
-
     //! Register a component type with the UI system.
     //! The order in which component types are registered is the order that they show up in
     //! the add component and in the properties pane.

--- a/Code/CryEngine/CrySystem/System.h
+++ b/Code/CryEngine/CrySystem/System.h
@@ -431,7 +431,6 @@ private:
     bool InitFileSystem();
     bool InitFileSystem_LoadEngineFolders(const SSystemInitParams& initParams);
     bool InitAudioSystem(const SSystemInitParams& initParams);
-    bool InitShine(const SSystemInitParams& initParams);
 
     //@}
 

--- a/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -852,16 +852,6 @@ bool CSystem::InitVTuneProfiler()
     return true;
 }
 
-/////////////////////////////////////////////////////////////////////////////////
-bool CSystem::InitShine([[maybe_unused]] const SSystemInitParams& initParams)
-{
-    LOADING_TIME_PROFILE_SECTION(GetISystem());
-
-    EBUS_EVENT(UiSystemBus, InitializeSystem);
-
-    return true;
-}
-
 //////////////////////////////////////////////////////////////////////////
 void CSystem::InitLocalization()
 {
@@ -1550,20 +1540,6 @@ AZ_POP_DISABLE_WARNING
         }
         m_Time.ResetTimer();
 
-        //////////////////////////////////////////////////////////////////////////
-        // UI. Should be after input and hardware mouse
-        //////////////////////////////////////////////////////////////////////////
-        if (!m_bDedicatedServer)
-        {
-            AZ_Printf(AZ_TRACE_SYSTEM_WINDOW, "UI system initialization");
-            INDENT_LOG_DURING_SCOPE();
-            if (!InitShine(startupParams))
-            {
-                return false;
-            }
-        }
-
-        InlineInitializationProcessing("CSystem::Init InitShine");
         // CONSOLE
         //////////////////////////////////////////////////////////////////////////
         if (!InitConsole())

--- a/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
+++ b/Gems/LyShine/Code/Source/LyShineSystemComponent.cpp
@@ -203,12 +203,6 @@ namespace LyShine
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////
-    void LyShineSystemComponent::InitializeSystem()
-    {
-        BroadcastCursorImagePathname();
-    }
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////
     void LyShineSystemComponent::RegisterComponentTypeForMenuOrdering(const AZ::Uuid& typeUuid)
     {
         m_componentTypes.push_back(typeUuid);
@@ -379,6 +373,8 @@ namespace LyShine
 #endif
         m_pLyShine = new CLyShine(gEnv->pSystem);
         gEnv->pLyShine = m_pLyShine;
+
+        BroadcastCursorImagePathname();
     }
 
     void LyShineSystemComponent::OnCrySystemShutdown([[maybe_unused]] ISystem& system)

--- a/Gems/LyShine/Code/Source/LyShineSystemComponent.h
+++ b/Gems/LyShine/Code/Source/LyShineSystemComponent.h
@@ -60,7 +60,6 @@ namespace LyShine
 
         ////////////////////////////////////////////////////////////////////////
         // UiSystemBus interface implementation
-        void InitializeSystem() override;
         void RegisterComponentTypeForMenuOrdering(const AZ::Uuid& typeUuid) override;
         const AZStd::vector<AZ::Uuid>* GetComponentTypesForMenuOrdering() override;
         const AZStd::list<AZ::ComponentDescriptor*>* GetLyShineComponentDescriptors();


### PR DESCRIPTION
- Move cursor image setting to OnCrySystemInitialized
- Remove CSystem::InitShine and UiSystemInterface's InitializeSystem as it's no longer needed