### PR TITLE
[stabilization/2106] enable higher compression of installer artifacts

### DIFF
--- a/cmake/Platform/Windows/Packaging/Template.wxs.in
+++ b/cmake/Platform/Windows/Packaging/Template.wxs.in
@@ -14,8 +14,10 @@
 
         <Package InstallerVersion="301" Compressed="yes" InstallPrivileges="elevated" InstallScope="perMachine"/>
 
-        <!-- auto distribute the installable files across N cab files -->
-        <MediaTemplate EmbedCab="$(var.CPACK_EMBED_ARTIFACTS)"/>
+        <!-- auto distribute the install-able files across N cab files that are at most 350 MB in size -->
+        <MediaTemplate EmbedCab="$(var.CPACK_EMBED_ARTIFACTS)"
+            MaximumUncompressedMediaSize="350"
+            CompressionLevel="high"/>
 
         <MajorUpgrade Schedule="afterInstallInitialize"
             AllowSameVersionUpgrades="yes"


### PR DESCRIPTION
Increasing the cab file compression lowers the total windows installer size by another 0.4 GB in its current form at the traded cost of on a few extra minutes (~5 vs ~10 min on an i7-4790k) to generate them.

Additionally, upping the max pre-compression cab file size to 350 MB (from 200 MB) lowers the total number of files by nearly half while still maintaining a reasonable per-cab files size post-compression.