### PR TITLE
SPEC-7435 Vegetation Tests Reference Missing File: Mocks/MockSpawnableEntitiesInterface.h

### DIFF
--- a/scripts/build/Platform/Mac/build_mac.sh
+++ b/scripts/build/Platform/Mac/build_mac.sh
@@ -31,6 +31,11 @@ else
         RUN_CONFIGURE=1
     fi
 fi
+
+# temporarily enabling cmake regeneration for this platform
+# We have observed cases where continous integration has not regenerated but a regeneration was required, leaving the build in a bad state
+RUN_CONFIGURE=1
+
 if [[ ! -z "$RUN_CONFIGURE" ]]; then
     # have to use eval since $CMAKE_OPTIONS (${EXTRA_CMAKE_OPTIONS}) contains quotes that need to be processed
     echo [ci_build] ${CONFIGURE_CMD}


### PR DESCRIPTION
I dont know this issue is a bug in xcode+zero_check or if it is due to us sharing workspaces between branches. I think the problem is the former, but I was not able to reproduce it.
We will re-generate on each build for Mac/iOS for the time being.