### PR TITLE
LYN-2480 | Minor fixes to the Prefab system

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -414,7 +414,6 @@ namespace AzToolsFramework
             }
 
             m_templateFilePathToIdMap.emplace(AZStd::make_pair(filePath, newTemplateId));
-            newTemplate.MarkAsDirty(true);
             
             return newTemplateId;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoCache.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndoCache.cpp
@@ -130,10 +130,7 @@ namespace AzToolsFramework
 
             if (!instanceOptionalReference.has_value())
             {
-                AZ_Warning(
-                    "Undo", false,
-                    "PrefabUndoCache was told to update the cache for entity of id %p (%s), but that entity does not have an owning instance.",
-                    entityId, entity->GetName().c_str());
+                // This is not an error, we just don't handle this entity.
                 return;
             }
 


### PR DESCRIPTION
Remove warning when entities that aren't registered to instances get passed to the Prefab Undo Cache (just ignore them to avoid noise in the console).

Also avoid marking templates dirty when they are added.