### PR TITLE
Setting the build timeout for the ProjectBuilder CMake commands to -1

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilder.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilder.cpp
@@ -24,8 +24,8 @@
 
 namespace O3DE::ProjectManager
 {
-    // 10 Minutes
-    constexpr int MaxBuildTimeMSecs = 600000;
+    // QProcess::waitForFinished uses -1 to indicate that the process should not timeout
+    constexpr int MaxBuildTimeMSecs = -1;
 
     ProjectBuilderWorker::ProjectBuilderWorker(const ProjectInfo& projectInfo)
         : QObject()

--- a/Code/Tools/ProjectManager/Source/ProjectManagerDefs.h
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerDefs.h
@@ -13,7 +13,7 @@ namespace O3DE::ProjectManager
     inline constexpr static int ProjectPreviewImageWidth = 210;
     inline constexpr static int ProjectPreviewImageHeight = 280;
 
-    static const QString ProjectBuildPathPostfix = "Windows_VS2019";
+    static const QString ProjectBuildPathPostfix = "build/windows_vs2019";
     static const QString ProjectBuildErrorLogPathPostfix = "CMakeFiles/CMakeProjectBuildError.log";
     static const QString ProjectPreviewImagePath = "preview.png";
 } // namespace O3DE::ProjectManager


### PR DESCRIPTION
This prevents Project build step from timing out

Moving the project build directory to be under the <project-path>/build/ folder to prevent two issues
1. The AssetProcessor from scanning that folder for assets.
   [Bb]uild is part of the excluded folders
2. To prevent git from seeing modified files in the build directory as
   the default .gitignore file ignores [Bb]uild