### PR TITLE
Editor responsiveness: don't block main thread to load textures from disk

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.cpp
@@ -51,6 +51,12 @@ namespace ImageProcessingAtom
 
     ImagePreviewer::~ImagePreviewer()
     {
+        AZ::SystemTickBus::Handler::BusDisconnect();
+
+        if (m_createDisplayTextureResult.isRunning())
+        {
+            m_createDisplayTextureResult.waitForFinished();
+        }
     }
 
     void ImagePreviewer::Clear() const
@@ -214,21 +220,30 @@ namespace ImageProcessingAtom
         m_ui->m_fileInfoCtrl->show();
         m_fileinfo = QString::fromUtf8(product->GetName().c_str());
         m_fileinfo += GetFileSize(product->GetRelativePath().c_str());
-               
-        AZ::Data::Asset<AZ::RPI::StreamingImageAsset> imageAsset = Utils::LoadImageAsset(product->GetAssetId());
-        IImageObjectPtr image = Utils::LoadImageFromImageAsset(imageAsset);
 
-        if (image)
+        CreateAndDisplayTextureItemAsync(
+        [assetId = product->GetAssetId()]
+        () -> CreateDisplayTextureResult
         {
-            // Add product image info
-            AZStd::string productInfo;
-            GetImageInfoString(imageAsset, productInfo);
+            AZ::Data::Asset<AZ::RPI::StreamingImageAsset> imageAsset = Utils::LoadImageAsset(assetId);
+            IImageObjectPtr image = Utils::LoadImageFromImageAsset(imageAsset);
 
-            m_fileinfo += QStringLiteral("\r\n");
-            m_fileinfo += productInfo.c_str();
+            if (image)
+            {
+                // Add product image info
+                AZStd::string productInfo;
+                GetImageInfoString(imageAsset, productInfo);
 
-            m_previewImageObject = ConvertImageForPreview(image);
-        }
+                QString fileInfo = QStringLiteral("\r\n");
+                fileInfo += productInfo.c_str();
+
+                return { ConvertImageForPreview(image), fileInfo };
+            }
+            else
+            {
+                return { nullptr, "" };
+            }
+        });
 
         DisplayTextureItem();
     }
@@ -239,19 +254,28 @@ namespace ImageProcessingAtom
         m_fileinfo = QString::fromUtf8(source->GetName().c_str());
         m_fileinfo += GetFileSize(source->GetFullPath().c_str());
 
-        IImageObjectPtr image = IImageObjectPtr(LoadImageFromFile(source->GetFullPath()));
-
-        if (image)
+        CreateAndDisplayTextureItemAsync(
+        [fullPath = source->GetFullPath()]
+        () -> CreateDisplayTextureResult
         {
-            // Add source image info
-            AZStd::string sourceInfo;
-            GetImageInfoString(image, sourceInfo);
+            IImageObjectPtr image = IImageObjectPtr(LoadImageFromFile(fullPath));
 
-            m_fileinfo += QStringLiteral("\r\n");
-            m_fileinfo += sourceInfo.c_str();
+            if (image)
+            {
+                // Add source image info
+                AZStd::string sourceInfo;
+                GetImageInfoString(image, sourceInfo);
 
-            m_previewImageObject = ConvertImageForPreview(image);
-        }
+                QString fileInfo = QStringLiteral("\r\n");
+                fileInfo += sourceInfo.c_str();
+
+                return { ConvertImageForPreview(image), fileInfo };
+            }
+            else
+            {
+                return { nullptr, "" };
+            }
+        });
 
         DisplayTextureItem();
     }
@@ -287,6 +311,27 @@ namespace ImageProcessingAtom
         m_ui->m_fileInfoCtrl->setText(WordWrap(m_fileinfo, m_ui->m_fileInfoCtrl->width() / IMAGE_PREVIEWER_CHAR_WIDTH));
 
         updateGeometry();
+    }
+
+    template<class CreateFn>
+    void ImagePreviewer::CreateAndDisplayTextureItemAsync(CreateFn create)
+    {
+        AZ::SystemTickBus::Handler::BusConnect();
+        m_createDisplayTextureResult = QtConcurrent::run(AZStd::move(create));
+    }
+
+    void ImagePreviewer::OnSystemTick()
+    {
+        if (m_createDisplayTextureResult.isFinished())
+        {
+            CreateDisplayTextureResult result = m_createDisplayTextureResult.result();
+            m_previewImageObject = AZStd::move(result.first);
+            m_fileinfo += result.second;
+
+            AZ::SystemTickBus::Handler::BusDisconnect();
+
+            DisplayTextureItem();
+        }
     }
 
     void ImagePreviewer::PreviewSubImage(uint32_t mip)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Previewer/ImagePreviewer.h
@@ -13,12 +13,15 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzToolsFramework/AssetBrowser/Previewer/Previewer.h>
 
 #include <Atom/ImageProcessing/ImageObject.h>
 
 #include <QWidget>
 #include <QScopedPointer>
+#include <QFuture>
+#include <QtConcurrent/QtConcurrent>
 #endif
 
 namespace Ui
@@ -42,6 +45,7 @@ namespace ImageProcessingAtom
 {
     class ImagePreviewer
         : public AzToolsFramework::AssetBrowser::Previewer
+        , private AZ::SystemTickBus::Handler
     {
         Q_OBJECT
     public:
@@ -65,10 +69,16 @@ namespace ImageProcessingAtom
         QString GetFileSize(const char* path);
 
         void DisplayTextureItem();
+        template<class CreateFn>
+        void CreateAndDisplayTextureItemAsync(CreateFn create);
+
         void PreviewSubImage(uint32_t mip);
 
         // QLabel word wrap does not break long words such as filenames, so manual word wrap needed
         static QString WordWrap(const QString& string, int maxLength);
+
+        // SystemTickBus
+        void OnSystemTick() override;
 
         QScopedPointer<Ui::ImagePreviewerClass> m_ui;
         QString m_fileinfo;
@@ -76,5 +86,10 @@ namespace ImageProcessingAtom
 
         // Decompressed image in preview. Cache it so we can preview its sub images
         IImageObjectPtr m_previewImageObject;
+
+        // Properties for tracking the status of an asynchronous request to display an asset browser entry
+        using CreateDisplayTextureResult = AZStd::pair<IImageObjectPtr, QString>;
+
+        QFuture<CreateDisplayTextureResult> m_createDisplayTextureResult;
     };
 }//namespace ImageProcessingAtom


### PR DESCRIPTION
I have observed that, roughly, loading the texture preview for typical 4k textures takes on the order of 1s. Before this change, the ImagePreviewer widget would do this work in the main thread whenever the user clicks on a texture in the Asset Browser widget. This stalls the main thread for an acceptable duration.

This change moves this work from the main thread to a job thread by way of QFuture. While the texture preview is not yet ready, the image preview widget will just show a blank space (this could potentially be improved)