### PR TITLE
Editor performance: avoid un-needed main thread work

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -126,9 +126,9 @@ namespace AzToolsFramework
             {
                 return 0;
             }
-            bool thumbnailLoading;
-            ThumbnailerRequestsBus::BroadcastResult(thumbnailLoading, &ThumbnailerRequests::IsLoading, thumbnailKey, m_thumbnailContext.c_str());
-            if (thumbnailLoading)
+
+            const Thumbnail::State thumbnailState = thumbnail->GetState();
+            if (thumbnailState == Thumbnail::State::Loading)
             {
                 AzQtComponents::StyledBusyLabel* busyLabel;
                 AssetBrowserComponentRequestBus::BroadcastResult(busyLabel , &AssetBrowserComponentRequests::GetStyledBusyLabel);
@@ -137,13 +137,17 @@ namespace AzToolsFramework
                     busyLabel->DrawTo(painter, QRectF(point.x(), point.y(), size.width(), size.height()));
                 }
             }
-            else
+            else if (thumbnailState == Thumbnail::State::Ready)
             {
                 // Scaling and centering pixmap within bounds to preserve aspect ratio
                 const QPixmap pixmap = thumbnail->GetPixmap().scaled(size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
                 const QSize sizeDelta = size - pixmap.size();
                 const QPoint pointDelta = QPoint(sizeDelta.width() / 2, sizeDelta.height() / 2);
                 painter->drawPixmap(point + pointDelta, pixmap);
+            }
+            else
+            {
+                AZ_Assert(false, "Thumbnail state %d unexpected here", int(thumbnailState));
             }
             return m_iconSize;
         }


### PR DESCRIPTION
The call to ThumbnailerRequestsBus::IsLoading is somewhat costly because it must contact the AP via socket (30-300ms observed). This is done from the main thread, so stalls whenever the user clicks different texture rows in the Asset Browser.

This change simply removes this "expensive" call, because the shared thumbnail object already contains the necessary information.