### PR TITLE
ATOM-15861 fixed material editor screen capture and test scripts

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportWidget.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportWidget.cpp
@@ -6,13 +6,14 @@
  */
 
 #include <Atom/RHI/Device.h>
-#include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/ViewportContext.h>
+#include <Atom/RPI.Public/ViewportContextBus.h>
 #include <Atom/RPI.Public/WindowContext.h>
 
-#include <Source/Viewport/MaterialViewportWidget.h>
 #include <Source/Viewport/MaterialViewportRenderer.h>
+#include <Source/Viewport/MaterialViewportWidget.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QAbstractEventDispatcher>
@@ -42,6 +43,12 @@ namespace MaterialEditor
         {
             dispatcher->installNativeEventFilter(this);
         }
+
+        // The viewport context created by AtomToolsFramework::RenderViewportWidget has no name.
+        // Systems like frame capturing and post FX expect there to be a context with DefaultViewportContextName
+        auto viewportContextManager = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
+        const AZ::Name defaultContextName = viewportContextManager->GetDefaultViewportContextName();
+        viewportContextManager->RenameViewportContext(GetViewportContext(), defaultContextName);
 
         m_renderer = AZStd::make_unique<MaterialViewportRenderer>(GetViewportContext()->GetWindowContext());
         GetControllerList()->Add(m_renderer->GetController());


### PR DESCRIPTION
Frame capture required a context with the default viewport context name