### PR TITLE
Fixes icons not displaying in AudioControlsEditor

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.cpp
@@ -23,6 +23,11 @@
 #include <CryPath.h>
 #include <Util/PathUtil.h>
 
+void InitWwiseResources()
+{
+    Q_INIT_RESOURCE(EditorWwise);
+}
+
 namespace AudioControls
 {
     //-------------------------------------------------------------------------------------------//
@@ -78,6 +83,12 @@ namespace AudioControls
             return Audio::WwiseXmlTags::WwiseStateTag;
         }
         return "";
+    }
+
+    //-------------------------------------------------------------------------------------------//
+    CAudioSystemEditor_wwise::CAudioSystemEditor_wwise()
+    {
+        InitWwiseResources();
     }
 
     //-------------------------------------------------------------------------------------------//

--- a/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.h
+++ b/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.h
@@ -63,7 +63,7 @@ namespace AudioControls
         friend class CAudioWwiseLoader;
 
     public:
-        CAudioSystemEditor_wwise() = default;
+        CAudioSystemEditor_wwise();
         ~CAudioSystemEditor_wwise() override = default;
 
         //////////////////////////////////////////////////////////

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
@@ -30,6 +30,11 @@
 #include <QPainter>
 #include <QMessageBox>
 
+void InitACEResources()
+{
+    Q_INIT_RESOURCE(AudioControlsEditorUI);
+}
+
 namespace AudioControls
 {
     //-------------------------------------------------------------------------------------------//
@@ -40,6 +45,8 @@ namespace AudioControls
     CAudioControlsEditorWindow::CAudioControlsEditorWindow(QWidget* parent)
         : QMainWindow(parent)
     {
+        InitACEResources();
+
         setupUi(this);
 
         m_pATLModel = CAudioControlsEditorPlugin::GetATLModel();


### PR DESCRIPTION
The qrc files appeared to be set up correctly, but needed to add a
Q_INIT_RESOURCE call to the code.