### PR TITLE
[ATOM-15868] Collect and serialize initial benchmark metadata.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ProfilingCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ProfilingCaptureBus.h
@@ -17,7 +17,7 @@ namespace AZ
         {
         public:
             virtual ~ProfilingCaptureRequests() = default;
-            
+
             //! Dump the Timestamp from passes to a json file.
             virtual bool CapturePassTimestamp(const AZStd::string& outputFilePath) = 0;
 
@@ -27,6 +27,8 @@ namespace AZ
             //! Dump the Cpu Profiling Statistics to a json file.
             virtual bool CaptureCpuProfilingStatistics(const AZStd::string& outputFilePath) = 0;
 
+            //! Dump the benchmark metadata to a json file.
+            virtual bool CaptureBenchmarkMetadata(const AZStd::string& benchmarkName, const AZStd::string& outputFilePath) = 0;
         };
         using ProfilingCaptureRequestBus = EBus<ProfilingCaptureRequests>;
 
@@ -35,21 +37,26 @@ namespace AZ
         {
         public:
             virtual ~ProfilingCaptureNotifications() = default;
-            
+
             //! Notify when the current Timestamp query capture is finished
             //! @param result Set to true if it's finished successfully
-            //! @param info The output file path or error information which depends on the return. 
+            //! @param info The output file path or error information which depends on the return.
             virtual void OnCaptureQueryTimestampFinished(bool result, const AZStd::string& info) = 0;
 
             //! Notify when the current PipelineStatistics query capture is finished
             //! @param result Set to true if it's finished successfully
-            //! @param info The output file path or error information which depends on the return. 
+            //! @param info The output file path or error information which depends on the return.
             virtual void OnCaptureQueryPipelineStatisticsFinished(bool result, const AZStd::string& info) = 0;
 
             //! Notify when the current CpuProfilingStatistics capture is finished
             //! @param result Set to true if it's finished successfully
-            //! @param info The output file path or error information which depends on the return. 
+            //! @param info The output file path or error information which depends on the return.
             virtual void OnCaptureCpuProfilingStatisticsFinished(bool result, const AZStd::string& info) = 0;
+
+            //! Notify when the current BenchmarkMetadata capture is finished
+            //! @param result Set to true if it's finished successfully
+            //! @param info The output file path or error information which depends on the return.
+            virtual void OnCaptureBenchmarkMetadataFinished(bool result, const AZStd::string& info) = 0;
         };
         using ProfilingCaptureNotificationBus = EBus<ProfilingCaptureNotifications>;
 

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
@@ -8,6 +8,7 @@
 #include "ProfilingCaptureSystemComponent.h"
 
 #include <Atom/RHI/CpuProfiler.h>
+#include <Atom/RHI/RHIUtils.h>
 
 #include <Atom/RPI.Public/GpuQuery/GpuQueryTypes.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
@@ -33,7 +34,8 @@ namespace AZ
             AZ_EBUS_BEHAVIOR_BINDER(ProfilingCaptureNotificationBusHandler, "{E45E4F37-EC1F-4010-994B-4F80998BEF15}", AZ::SystemAllocator,
                 OnCaptureQueryTimestampFinished,
                 OnCaptureQueryPipelineStatisticsFinished,
-                OnCaptureCpuProfilingStatisticsFinished
+                OnCaptureCpuProfilingStatisticsFinished,
+                OnCaptureBenchmarkMetadataFinished
             );
 
             void OnCaptureQueryTimestampFinished(bool result, const AZStd::string& info) override
@@ -49,6 +51,11 @@ namespace AZ
             void OnCaptureCpuProfilingStatisticsFinished(bool result, const AZStd::string& info) override
             {
                 Call(FN_OnCaptureCpuProfilingStatisticsFinished, result, info);
+            }
+
+            void OnCaptureBenchmarkMetadataFinished(bool result, const AZStd::string& info) override
+            {
+                Call(FN_OnCaptureBenchmarkMetadataFinished, result, info);
             }
 
             static void Reflect(AZ::ReflectContext* context)
@@ -121,7 +128,7 @@ namespace AZ
                 static void Reflect(AZ::ReflectContext* context);
 
                 CpuProfilingStatisticsSerializerEntry() = default;
-                CpuProfilingStatisticsSerializerEntry(const RHI::CachedTimeRegion& cahcedTimeRegion);
+                CpuProfilingStatisticsSerializerEntry(const RHI::CachedTimeRegion& cachedTimeRegion);
 
             private:
                 Name m_groupName;
@@ -137,6 +144,34 @@ namespace AZ
             CpuProfilingStatisticsSerializer(RHI::CpuProfiler::TimeRegionMap& timeRegionMap);
 
             AZStd::vector<CpuProfilingStatisticsSerializerEntry> m_cpuProfilingStatisticsSerializerEntries;
+        };
+
+        // Intermediate class to serialize benchmark metadata.
+        class BenchmarkMetadataSerializer
+        {
+        public:
+            class GpuEntry
+            {
+            public:
+                AZ_TYPE_INFO(Render::BenchmarkMetadataSerializer::GpuEntry, "{3D5C2DDE-59FB-4E28-9605-D2A083E34505}");
+                static void Reflect(AZ::ReflectContext* context);
+
+                GpuEntry() = default;
+                GpuEntry(const RHI::PhysicalDeviceDescriptor& descriptor);
+
+            private:
+                AZStd::string m_description;
+                uint32_t m_driverVersion;
+            };
+
+            AZ_TYPE_INFO(Render::BenchmarkMetadataSerializer, "{2BC41B6F-528F-4E59-AEDA-3B9D74E323EC}");
+            static void Reflect(AZ::ReflectContext* context);
+
+            BenchmarkMetadataSerializer() = default;
+            BenchmarkMetadataSerializer(const AZStd::string& benchmarkName, const RHI::PhysicalDeviceDescriptor& gpuDescriptor);
+
+            AZStd::string m_benchmarkName;
+            GpuEntry m_gpuEntry;
         };
 
         // --- DelayedQueryCaptureHelper ---
@@ -309,6 +344,49 @@ namespace AZ
             }
         }
 
+        // --- BenchmarkMetadataSerializer ---
+
+        BenchmarkMetadataSerializer::BenchmarkMetadataSerializer(const AZStd::string& benchmarkName, const RHI::PhysicalDeviceDescriptor& gpuDescriptor)
+        {
+            m_benchmarkName = benchmarkName;
+            m_gpuEntry = GpuEntry(gpuDescriptor);
+        }
+
+        void BenchmarkMetadataSerializer::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<BenchmarkMetadataSerializer>()
+                    ->Version(1)
+                    ->Field("benchmarkName", &BenchmarkMetadataSerializer::m_benchmarkName)
+                    ->Field("gpuInfo", &BenchmarkMetadataSerializer::m_gpuEntry)
+                    ;
+            }
+
+            GpuEntry::Reflect(context);
+        }
+
+        // --- GpuEntry ---
+
+        BenchmarkMetadataSerializer::GpuEntry::GpuEntry(const RHI::PhysicalDeviceDescriptor& descriptor)
+        {
+            m_description = descriptor.m_description;
+            m_driverVersion = descriptor.m_driverVersion;
+        }
+
+
+        void BenchmarkMetadataSerializer::GpuEntry::Reflect(AZ::ReflectContext* context)
+        {
+            if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<GpuEntry>()
+                    ->Version(1)
+                    ->Field("description", &GpuEntry::m_description)
+                    ->Field("driverVersion", &GpuEntry::m_driverVersion)
+                    ;
+            }
+        }
+
         // --- ProfilingCaptureSystemComponent ---
 
         void ProfilingCaptureSystemComponent::Reflect(AZ::ReflectContext* context)
@@ -328,6 +406,7 @@ namespace AZ
                     ->Event("CapturePassTimestamp", &ProfilingCaptureRequestBus::Events::CapturePassTimestamp)
                     ->Event("CapturePassPipelineStatistics", &ProfilingCaptureRequestBus::Events::CapturePassPipelineStatistics)
                     ->Event("CaptureCpuProfilingStatistics", &ProfilingCaptureRequestBus::Events::CaptureCpuProfilingStatistics)
+                    ->Event("CaptureBenchmarkMetadata", &ProfilingCaptureRequestBus::Events::CaptureBenchmarkMetadata)
                     ;
 
                 ProfilingCaptureNotificationBusHandler::Reflect(context);
@@ -336,6 +415,7 @@ namespace AZ
             TimestampSerializer::Reflect(context);
             PipelineStatisticsSerializer::Reflect(context);
             CpuProfilingStatisticsSerializer::Reflect(context);
+            BenchmarkMetadataSerializer::Reflect(context);
         }
 
         void ProfilingCaptureSystemComponent::Activate()
@@ -507,6 +587,43 @@ namespace AZ
             return captureStarted;
         }
 
+        bool ProfilingCaptureSystemComponent::CaptureBenchmarkMetadata(const AZStd::string& benchmarkName, const AZStd::string& outputFilePath)
+        {
+            const bool captureStarted = m_benchmarkMetadataCapture.StartCapture([this, benchmarkName, outputFilePath]()
+            {
+                JsonSerializerSettings serializationSettings;
+                serializationSettings.m_keepDefaults = true;
+
+                const RHI::PhysicalDeviceDescriptor& gpuDescriptor = RHI::GetRHIDevice()->GetPhysicalDevice().GetDescriptor();
+
+                BenchmarkMetadataSerializer serializer(benchmarkName, gpuDescriptor);
+                const auto saveResult = JsonSerializationUtils::SaveObjectToFile(&serializer,
+                    outputFilePath, (BenchmarkMetadataSerializer*)nullptr, &serializationSettings);
+
+                AZStd::string captureInfo = outputFilePath;
+                if (!saveResult.IsSuccess())
+                {
+                    captureInfo = AZStd::string::format("Failed to save benchmark metadata data to file '%s'. Error: %s",
+                        outputFilePath.c_str(),
+                        saveResult.GetError().c_str());
+                    AZ_Warning("ProfilingCaptureSystemComponent", false, captureInfo.c_str());
+                }
+
+                // Notify listeners that the benchmark metadata capture has finished.
+                ProfilingCaptureNotificationBus::Broadcast(&ProfilingCaptureNotificationBus::Events::OnCaptureBenchmarkMetadataFinished,
+                    saveResult.IsSuccess(),
+                    captureInfo);
+            });
+
+            // Start the TickBus.
+            if (captureStarted)
+            {
+                TickBus::Handler::BusConnect();
+            }
+
+            return captureStarted;
+        }
+
         AZStd::vector<const RPI::Pass*> ProfilingCaptureSystemComponent::CollectPassesRecursively(const RPI::Pass* root) const
         {
             AZStd::vector<const RPI::Pass*> passes;
@@ -548,9 +665,10 @@ namespace AZ
             m_timestampCapture.UpdateCapture();
             m_pipelineStatisticsCapture.UpdateCapture();
             m_cpuProfilingStatisticsCapture.UpdateCapture();
+            m_benchmarkMetadataCapture.UpdateCapture();
 
             // Disconnect from the TickBus if all capture states are set to idle.
-            if (m_timestampCapture.IsIdle() && m_pipelineStatisticsCapture.IsIdle() && m_cpuProfilingStatisticsCapture.IsIdle())
+            if (m_timestampCapture.IsIdle() && m_pipelineStatisticsCapture.IsIdle() && m_cpuProfilingStatisticsCapture.IsIdle() && m_benchmarkMetadataCapture.IsIdle())
             {
                 TickBus::Handler::BusDisconnect();
             }

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -69,6 +69,7 @@ namespace AZ
             bool CapturePassTimestamp(const AZStd::string& outputFilePath) override;
             bool CapturePassPipelineStatistics(const AZStd::string& outputFilePath) override;
             bool CaptureCpuProfilingStatistics(const AZStd::string& outputFilePath) override;
+            bool CaptureBenchmarkMetadata(const AZStd::string& benchmarkName, const AZStd::string& outputFilePath) override;
 
         private:
             void OnTick(float deltaTime, ScriptTimePoint time) override;
@@ -81,6 +82,7 @@ namespace AZ
             DelayedQueryCaptureHelper m_timestampCapture;
             DelayedQueryCaptureHelper m_pipelineStatisticsCapture;
             DelayedQueryCaptureHelper m_cpuProfilingStatisticsCapture;
+            DelayedQueryCaptureHelper m_benchmarkMetadataCapture;
         };
     }
 }


### PR DESCRIPTION
Sample JSON file `atomsampleviewer/user/scripts/performancestats/CullingAndLod/benchmark_metadata.json` output:

```json
{
    "Type": "JsonSerialization",
    "Version": 1,
    "ClassName": "BenchmarkMetadataSerializer",
    "ClassData": {
        "benchmarkName": "CullingAndLod",
        "gpuInfo": {
            "description": "NVIDIA GeForce RTX 3070 Laptop GPU",
            "driverVersion": 1935081472
        }
    }
}
```

`driverVersion` will hopefully be decrypted into a human-readable format in the future.

PR aws-lumberyard/o3de-atom-sampleviewer#143 depends on this being merged first.