### PR TITLE
{LYN-4854} AssetProcessor was not able to load libSceneProcessing.Editor.dylib Gem

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Module/DynamicModuleHandle_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Module/DynamicModuleHandle_UnixLike.cpp
@@ -85,7 +85,7 @@ namespace AZ
             else
             {
                 // The module does exist (in 'cwd'), but still needs to be an absolute path for the module to be loaded.
-                AZStd::optional<AZ::IO::FixedMaxPathString> absPathOptional = AZ::Utils::ConvertToAbsolutePath(m_fileName);
+                AZStd::optional<AZ::IO::FixedMaxPathString> absPathOptional = AZ::Utils::ConvertToAbsolutePath(fullFilePath.c_str());
                 if (absPathOptional.has_value())
                 {
                     m_fileName.assign(absPathOptional->c_str(), absPathOptional->size());


### PR DESCRIPTION
{LYN-4854} AssetProcessor was not able to load libSceneProcessing.Editor.dylib Gem on Mac.

Verified locally by launching asset processor batch

AssetProcessor: Loading (Gem) Module 'libSceneProcessing.Editor.dylib'...
Module: Attempting to load module:/Users/s/o3de/release/o3de/mac_xcode/bin/profile/libSceneProcessing.Editor.dylib
Module: Success!
Module: Attempting to load module:/Users/so3de/release/o3de/mac_xcode/bin/profile/libSceneCore.dylib
Module: Success! System already had it opened.
Module: Attempting to load module:/Users/s/o3de/release/o3de/mac_xcode/bin/profile/libSceneData.dylib
Module: Success! System already had it opened.
Module: Attempting to load module:/Users/s/o3de/release/o3de/mac_xcode/bin/profile/libFbxSceneBuilder.dylib
Module: Success!