### PR TITLE
Fix weight blending in look modification postfx.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/LookModification/LookModificationSettings.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/LookModification/LookModificationSettings.cpp
@@ -40,7 +40,6 @@ namespace AZ
 
         void LookModificationSettings::ApplySettingsTo(LookModificationSettings* target, float alpha) const
         {
-            AZ_UNUSED(alpha);
             AZ_Assert(target != nullptr, "LookModificationSettings::ApplySettingsTo called with nullptr as argument.");
 
             auto lutAssetId = GetColorGradingLut();
@@ -48,20 +47,10 @@ namespace AZ
             {
                 Render::LutBlendItem lutBlend;
                 lutBlend.m_intensity = GetColorGradingLutIntensity();
-                lutBlend.m_overrideStrength = GetColorGradingLutOverride();
+                lutBlend.m_overrideStrength = GetColorGradingLutOverride() * alpha;
                 lutBlend.m_assetId = lutAssetId;
                 target->AddLutBlend(lutBlend);
             }
-
-            // Auto-gen code to blend individual params based on their override value onto target settings
-#define OVERRIDE_TARGET target
-#define OVERRIDE_ALPHA alpha
-
-#include <Atom/Feature/ParamMacros/StartOverrideBlend.inl>
-#include <Atom/Feature/PostProcess/LookModification/LookModificationParams.inl>
-#include <Atom/Feature/ParamMacros/EndParams.inl>
-#undef OVERRIDE_TARGET
-#undef OVERRIDE_ALPHA
         }
 
         void LookModificationSettings::Simulate(float deltaTime)


### PR DESCRIPTION
Notes:
* PostFx layer weight slider now works as expected.
* Test scene is using night LUT as the global postfx layer, while sepia LUT is used for the camera postfx layer. 
![image](https://user-images.githubusercontent.com/43485729/123694624-67f23380-d80e-11eb-8e85-382921a96957.png)
![image](https://user-images.githubusercontent.com/43485729/123694666-76d8e600-d80e-11eb-88b0-8c37d8dc4a9c.png)
