### PR TITLE
Add max value for editor bloom intensity.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/Bloom/EditorBloomComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/Bloom/EditorBloomComponent.cpp
@@ -60,9 +60,10 @@ namespace AZ
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                         ->Attribute(Edit::Attributes::ReadOnly, &BloomComponentConfig::ArePropertiesReadOnly)
 
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &BloomComponentConfig::m_intensity, "Intensity", "Brightness of bloom")
+                        ->DataElement(AZ::Edit::UIHandlers::Slider, &BloomComponentConfig::m_intensity, "Intensity", "Brightness of bloom")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Max, 10000.0f)
+                        ->Attribute(AZ::Edit::Attributes::SoftMax, 25.0f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                         ->Attribute(Edit::Attributes::ReadOnly, &BloomComponentConfig::ArePropertiesReadOnly)
 


### PR DESCRIPTION
Notes:
* There's doesn't seem to be much changes going above 10000 for bloom intensity.
* This clamping is done because bloom seems to black out at very large numbers (e.g. 9999999999999999999999999999999999)

This is what it looks like when a very large number is used for bloom intensity
![image](https://user-images.githubusercontent.com/43485729/123700529-7263fb80-d815-11eb-9f1a-7319726e6c63.png)

Signed-off-by: Robin <rbarrand@amazon.com>