### PR TITLE
Fixes audio crash and issues w/ audio playback

### DIFF
--- a/Code/CryEngine/CryCommon/ISystem.h
+++ b/Code/CryEngine/CryCommon/ISystem.h
@@ -808,11 +808,6 @@ struct ISystem
     virtual bool UpdateLoadtime() = 0;
 
     // Summary:
-    //   Optimisation: do part of the update while waiting for occlusion queries to complete
-    virtual void DoWorkDuringOcclusionChecks() = 0;
-    virtual bool NeedDoWorkDuringOcclusionChecks() = 0;
-
-    // Summary:
     //   Retrieve the name of the user currently logged in to the computer.
     virtual const char* GetUserName() = 0;
 

--- a/Code/CryEngine/CryCommon/Mocks/ISystemMock.h
+++ b/Code/CryEngine/CryCommon/Mocks/ISystemMock.h
@@ -26,10 +26,6 @@ public:
         bool(int, int));
     MOCK_METHOD0(UpdateLoadtime,
         bool());
-    MOCK_METHOD0(DoWorkDuringOcclusionChecks,
-        void());
-    MOCK_METHOD0(NeedDoWorkDuringOcclusionChecks,
-        bool());
     MOCK_METHOD0(RenderStatistics,
         void());
     MOCK_METHOD0(GetUserName,

--- a/Code/CryEngine/CrySystem/System.cpp
+++ b/Code/CryEngine/CrySystem/System.cpp
@@ -352,8 +352,6 @@ CSystem::CSystem(SharedEnvironmentInstance* pSharedEnvironment)
         AZ::Debug::Trace::Instance().Init();
     }
 
-    m_bNeedDoWorkDuringOcclusionChecks = false;
-
     m_eRuntimeState = ESYSTEM_EVENT_LEVEL_UNLOAD;
 
     m_bHasRenderedErrorMessage = false;
@@ -948,15 +946,11 @@ bool CSystem::UpdatePostTickBus(int updateFlags, int /*nPauseMode*/)
     }
 
     //////////////////////////////////////////////////////////////////////
-    //update sound system part 2
-    if (!g_cvars.sys_deferAudioUpdateOptim && !m_bNoUpdate)
+    // Update sound system
+    if (!m_bNoUpdate)
     {
         FRAME_PROFILER("SysUpdate:UpdateAudioSystems", this, PROFILE_SYSTEM);
         UpdateAudioSystems();
-    }
-    else
-    {
-        m_bNeedDoWorkDuringOcclusionChecks = true;
     }
 
     //Now update frame statistics
@@ -1002,15 +996,6 @@ bool CSystem::UpdatePostTickBus(int updateFlags, int /*nPauseMode*/)
 bool CSystem::UpdateLoadtime()
 {
     return !IsQuitting();
-}
-
-void CSystem::DoWorkDuringOcclusionChecks()
-{
-    if (g_cvars.sys_deferAudioUpdateOptim && !m_bNoUpdate)
-    {
-        UpdateAudioSystems();
-        m_bNeedDoWorkDuringOcclusionChecks = false;
-    }
 }
 
 void CSystem::UpdateAudioSystems()

--- a/Code/CryEngine/CrySystem/System.h
+++ b/Code/CryEngine/CrySystem/System.h
@@ -225,8 +225,6 @@ struct SSystemCVars
 
     int sys_FilesystemCaseSensitivity;
 
-    int sys_deferAudioUpdateOptim;
-
     AZ::IO::ArchiveVars archiveVars;
 
 #if defined(WIN32)
@@ -305,8 +303,6 @@ public:
     virtual bool UpdatePreTickBus(int updateFlags = 0, int nPauseMode = 0);
     virtual bool UpdatePostTickBus(int updateFlags = 0, int nPauseMode = 0);
     virtual bool UpdateLoadtime();
-    virtual void DoWorkDuringOcclusionChecks();
-    virtual bool NeedDoWorkDuringOcclusionChecks() { return m_bNeedDoWorkDuringOcclusionChecks; }
 
     ////////////////////////////////////////////////////////////////////////
     // CrySystemRequestBus interface implementation
@@ -737,7 +733,6 @@ protected: // -------------------------------------------------------------
     typedef std::list<SErrorMessage> TErrorMessages;
     TErrorMessages m_ErrorMessages;
     bool m_bHasRenderedErrorMessage;
-    bool m_bNeedDoWorkDuringOcclusionChecks;
 
     ESystemEvent m_eRuntimeState;
     bool m_bIsAsserting;

--- a/Code/CryEngine/CrySystem/SystemInit.cpp
+++ b/Code/CryEngine/CrySystem/SystemInit.cpp
@@ -1823,11 +1823,6 @@ void CSystem::CreateSystemVars()
         "1 - CryPak preserves file name casing\n"
         "Default is 1");
 
-    REGISTER_CVAR2("sys_deferAudioUpdateOptim", &g_cvars.sys_deferAudioUpdateOptim, 1, VF_NULL,
-        "0 - disable optimisation\n"
-        "1 - enable optimisation\n"
-        "Default is 1");
-
     m_sysNoUpdate = REGISTER_INT("sys_noupdate", 0, VF_CHEAT,
             "Toggles updating of system with sys_script_debugger.\n"
             "Usage: sys_noupdate [0/1]\n"

--- a/Code/Sandbox/Editor/CryEdit.cpp
+++ b/Code/Sandbox/Editor/CryEdit.cpp
@@ -2336,12 +2336,6 @@ int CCryEditApp::IdleProcessing(bool bBackgroundUpdate)
 
             GetIEditor()->Notify(eNotify_OnIdleUpdate);
 
-            IEditor* pEditor = GetIEditor();
-            if (!pEditor->GetGameEngine()->IsLevelLoaded() && pEditor->GetSystem()->NeedDoWorkDuringOcclusionChecks())
-            {
-                pEditor->GetSystem()->DoWorkDuringOcclusionChecks();
-            }
-
             // Since the rendering is done based on the eNotify_OnIdleUpdate, we should trigger a TickSystem as well.
             // To ensure that there's a system tick for every render done in Idle
             AZ::ComponentApplication* componentApplication = nullptr;


### PR DESCRIPTION
This was caused by the main thread audio update not being called all the
time, especially Editor Game mode.

The crash was due to main thread containers not being processed and
emptied of their requests.