### PR TITLE
LYN-4870 | Update the Tray Icon for Editor and Asset Processor to these new ones

### DIFF
--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qrc
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qrc
@@ -17,5 +17,6 @@
         <file>AssetProcessor_arrow_up.svg</file>
         <file>AssetProcessor_refresh.png</file>
         <file>o3de_assetprocessor.png</file>
+        <file>o3de_assetprocessor_taskbar.svg</file>
     </qresource>
 </RCC>

--- a/Code/Tools/AssetProcessor/native/ui/style/o3de_assetprocessor_taskbar.svg
+++ b/Code/Tools/AssetProcessor/native/ui/style/o3de_assetprocessor_taskbar.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.3.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+</style>
+<g>
+	<path class="st0" d="M11.3,2.9c-0.6,0-1.2,0-1.8,0.1C7.9,3.2,6.4,4,5.2,5.2l2,1.9c3.3-3.4,9.3-1,9.3,3.9h-2.7l4.1,4.1L22,11h-2.7
+		C19.3,6.3,15.3,3.1,11.3,2.9L11.3,2.9z M0,11h2.7c0,7.2,9.1,10.9,14.1,5.8l-2-1.9c-3.3,3.4-9.3,1-9.3-3.9h2.7L4.1,6.9
+		C4.1,6.9,0,11,0,11z"/>
+</g>
+</svg>

--- a/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/GUIApplicationManager.cpp
@@ -268,10 +268,9 @@ bool GUIApplicationManager::Run()
         trayIconMenu->addAction(quitAction);
 #endif
 
-        m_trayIcon = new QSystemTrayIcon(m_mainWindow);
+        m_trayIcon = new QSystemTrayIcon(QIcon(":/o3de_assetprocessor_taskbar.svg"), m_mainWindow);
         m_trayIcon->setContextMenu(trayIconMenu);
         m_trayIcon->setToolTip(QObject::tr("O3DE Asset Processor"));
-        m_trayIcon->setIcon(QIcon(":/o3de_assetprocessor.png"));
         m_trayIcon->show();
         QObject::connect(m_trayIcon, &QSystemTrayIcon::activated, m_mainWindow, [&, wrapper](QSystemTrayIcon::ActivationReason reason)
             {


### PR DESCRIPTION
Changes the Asset Processor icon in the system tray to a more readable one.

![image](https://user-images.githubusercontent.com/82231674/123716078-92ec7f80-d82e-11eb-8ae9-4759ffe7b3c0.png)

Note: the taskbar icon is unchanged.