### PR TITLE
Editor launcher missed to set 'sv_isDedicated' to false like the launchers do.

### DIFF
--- a/Code/Sandbox/Editor/GameEngine.cpp
+++ b/Code/Sandbox/Editor/GameEngine.cpp
@@ -18,6 +18,7 @@
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/IO/IStreamer.h>
 #include <AzCore/std/parallel/binary_semaphore.h>
+#include <AzCore/Console/IConsole.h>
 
 // AzFramework
 #include <AzFramework/Asset/AssetSystemBus.h>
@@ -401,6 +402,7 @@ AZ::Outcome<void, AZStd::string> CGameEngine::Init(
 
     sip.bEditor = true;
     sip.bDedicatedServer = false;
+    AZ::Interface<AZ::IConsole>::Get()->PerformCommand("sv_isDedicated false");
     sip.bPreview = bPreviewMode;
     sip.bTestMode = bTestMode;
     sip.hInstance = nullptr;


### PR DESCRIPTION
This fixes cloth simulation running on game mode (with the editor) since cloth simulation is disabled on servers.

Signed-off-by: moraaar <moraaar@amazon.com>