### PR TITLE
Allow overriding of AWSAttribution settings to skip consent dialog for automation tests

### DIFF
--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionManager.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionManager.h
@@ -9,9 +9,14 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/vector.h>
 
-#include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <Editor/Attribution/AWSAttributionServiceApi.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+
+
+namespace AZ
+{
+    class SettingsRegistryInterface;
+}
 
 namespace AWSCore
 {
@@ -49,7 +54,7 @@ namespace AWSCore
         // AzToolsFramework::EditorEvents interface implementation
         void NotifyMainWindowInitialized(QMainWindow* mainWindow) override;
 
-        AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_settingsRegistry;
+        AZ::SettingsRegistryInterface* m_settingsRegistry;
     };
 
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/PlatformId/PlatformId.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/Jobs/JobFunction.h>
@@ -35,7 +36,7 @@ namespace AWSCore
     constexpr char AWSAttributionEnabledKey[] = "/Amazon/AWS/Preferences/AWSAttributionEnabled";
     constexpr char AWSAttributionDelaySecondsKey[] = "/Amazon/AWS/Preferences/AWSAttributionDelaySeconds";
     constexpr char AWSAttributionLastTimeStampKey[] = "/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp";
-    constexpr char AWSAttributionConsentShown[] = "/Amazon/AWS/Preferences/AWSAttributionConsentShown";
+    constexpr char AWSAttributionConsentShownKey[] = "/Amazon/AWS/Preferences/AWSAttributionConsentShown";
     constexpr char AWSAttributionApiId[] = "2zxvvmv8d7";
     constexpr char AWSAttributionChinaApiId[] = "";
     constexpr char AWSAttributionApiStage[] = "prod";
@@ -43,18 +44,25 @@ namespace AWSCore
 
     AWSAttributionManager::AWSAttributionManager()
     {
-        m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+        m_settingsRegistry = AZ::SettingsRegistry::Get();
         AzToolsFramework::EditorEvents::Bus::Handler::BusConnect();
     }
 
     AWSAttributionManager::~AWSAttributionManager()
     {
         AzToolsFramework::EditorEvents::Bus::Handler::BusDisconnect();
-        m_settingsRegistry.reset();
+        m_settingsRegistry = nullptr;
     }
 
     void AWSAttributionManager::Init()
     {
+        bool consentShown;
+        // If override is used skip merging the settings file
+        if (m_settingsRegistry->Get(consentShown, AWSAttributionConsentShownKey))
+        {
+            return;
+        }
+
         AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetInstance();
         AZ_Assert(fileIO, "File IO is not initialized.");
 
@@ -158,7 +166,7 @@ namespace AWSCore
     {
         AWSCoreAttributionConsentDialog* msgBox = aznew AWSCoreAttributionConsentDialog();
         int ret = msgBox->exec();
-        m_settingsRegistry->Set(AWSAttributionConsentShown, true);
+        m_settingsRegistry->Set(AWSAttributionConsentShownKey, true);
         switch (ret)
         {
         case QMessageBox::Save:
@@ -260,7 +268,7 @@ namespace AWSCore
     bool AWSAttributionManager::CheckConsentShown()
     {
         bool consentShown = false;
-        m_settingsRegistry->Get(consentShown, AWSAttributionConsentShown);
+        m_settingsRegistry->Get(consentShown, AWSAttributionConsentShownKey);
         return consentShown;
     }
 

--- a/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionManagerTest.cpp
@@ -253,7 +253,6 @@ namespace AWSAttributionUnitTest
         manager.MetricCheck();
 
         // THEN
-        m_settingsRegistry->MergeSettingsFile(m_resolvedSettingsPath.data(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
         AZ::u64 timeStamp = 0;
         m_settingsRegistry->Get(timeStamp, "/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp");
         ASSERT_TRUE(timeStamp == 0);
@@ -287,7 +286,6 @@ namespace AWSAttributionUnitTest
         manager.MetricCheck();
 
         // THEN
-        m_settingsRegistry->MergeSettingsFile(m_resolvedSettingsPath.data(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
         AZ::u64 timeStamp = 0;
         m_settingsRegistry->Get(timeStamp, "/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp");
         ASSERT_TRUE(timeStamp > 0);
@@ -324,7 +322,6 @@ namespace AWSAttributionUnitTest
         manager.MetricCheck();
 
         // THEN
-        m_settingsRegistry->MergeSettingsFile(m_resolvedSettingsPath.data(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
         AZ::u64 timeStamp = 0;
         m_settingsRegistry->Get(timeStamp, "/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp");
         ASSERT_TRUE(timeStamp > 0);
@@ -355,15 +352,14 @@ namespace AWSAttributionUnitTest
         AZ::u64 delayInSeconds = AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now().time_since_epoch()).count();
         ASSERT_TRUE(m_settingsRegistry->Set("/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp", delayInSeconds));
 
-        EXPECT_CALL(manager, SubmitMetric(testing::_)).Times(1);
-        EXPECT_CALL(m_moduleManagerRequestBusMock, EnumerateModules(testing::_)).Times(1);
+        EXPECT_CALL(manager, SubmitMetric(testing::_)).Times(0);
+        EXPECT_CALL(m_moduleManagerRequestBusMock, EnumerateModules(testing::_)).Times(0);
         EXPECT_CALL(m_credentialRequestBusMock, GetCredentialsProvider()).Times(1);
 
         // WHEN
         manager.MetricCheck();
 
         // THEN
-        m_settingsRegistry->MergeSettingsFile(m_resolvedSettingsPath.data(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
         AZ::u64 timeStamp = 0;
         m_settingsRegistry->Get(timeStamp, "/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp");
         ASSERT_TRUE(timeStamp == delayInSeconds);
@@ -396,7 +392,6 @@ namespace AWSAttributionUnitTest
         manager.MetricCheck();
 
         // THEN
-        m_settingsRegistry->MergeSettingsFile(m_resolvedSettingsPath.data(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
         AZ::u64 timeStamp = 0;
         m_settingsRegistry->Get(timeStamp, "/Amazon/AWS/Preferences/AWSAttributionLastTimeStamp");
         ASSERT_TRUE(timeStamp == 0);

--- a/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionSystemComponentTest.cpp
@@ -8,6 +8,9 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+#include <AzCore/Serialization/Json/JsonSystemComponent.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzTest/AzTest.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
@@ -65,7 +68,8 @@ namespace AWSCoreUnitTest
         MOCK_METHOD0(Deactivate, void());
     };
 
-    class AWSAttributionSystemComponentTest : public AWSCoreFixture
+    class AWSAttributionSystemComponentTest
+        : public AWSCoreFixture
     {
         void SetUp() override
         {
@@ -73,6 +77,7 @@ namespace AWSCoreUnitTest
             m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
             m_serializeContext->CreateEditContext();
             m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            AZ::JsonSystemComponent::Reflect(m_registrationContext.get());
 
             m_awsCoreComponentDescriptor.reset(AWSCoreSystemComponentMock::CreateDescriptor());
             m_awsCoreComponentDescriptor->Reflect(m_serializeContext.get());
@@ -81,6 +86,13 @@ namespace AWSCoreUnitTest
             m_componentDescriptor.reset(AWSAttributionSystemComponent::CreateDescriptor());
             m_componentDescriptor->Reflect(m_serializeContext.get());
             m_componentDescriptor->Reflect(m_behaviorContext.get());
+
+            m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+
+            m_settingsRegistry->SetContext(m_serializeContext.get());
+            m_settingsRegistry->SetContext(m_registrationContext.get());
+
+            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
 
             m_entity = aznew AZ::Entity();
             m_awsCoreSystemComponentMock = aznew testing::NiceMock<AWSCoreSystemComponentMock>();
@@ -101,6 +113,8 @@ namespace AWSCoreUnitTest
             m_awsCoreComponentDescriptor.reset();
             m_componentDescriptor.reset();
             m_behaviorContext.reset();
+            m_settingsRegistry.reset();
+            m_registrationContext.reset();
             m_serializeContext.reset();
             AWSCoreFixture::TearDown();
         }
@@ -113,8 +127,10 @@ namespace AWSCoreUnitTest
     private:
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+        AZStd::unique_ptr<AZ::JsonRegistrationContext> m_registrationContext;
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_componentDescriptor;
         AZStd::unique_ptr<AZ::ComponentDescriptor> m_awsCoreComponentDescriptor;
+        AZStd::shared_ptr<AZ::SettingsRegistryImpl> m_settingsRegistry;
     };
 
     TEST_F(AWSAttributionSystemComponentTest, SystemComponentInitActivate_Success)

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
@@ -209,6 +209,8 @@ class WinEditor(WinLauncher):
     def __init__(self, build, args):
         super(WinEditor, self).__init__(build, args)
         self.args.append('--regset="/Amazon/Settings/EnableSourceControl=false"')
+        self.args.append('--regset="/Amazon/AWS/Preferences/AWSAttributionConsentShown=true"')
+        self.args.append('--regset="/Amazon/AWS/Preferences/AWSAttributionEnabled=false"')
 
     def binary_path(self):
         """


### PR DESCRIPTION
Changes:
1. Use global settings registry instance to get settings override.
2. Add set reg override for AWSAttribution in automation tests.