### PR TITLE
Bumping threadgroup sizes

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Math/GaussianFilterFloatHorizontal.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Math/GaussianFilterFloatHorizontal.azsl
@@ -11,7 +11,7 @@
 #include <Atom/Features/Math/FilterPassSrg.azsli>
 #include <Atom/Features/Shadow/ShadowmapAtlasLib.azsli>
 
-[numthreads(8,8,1)]
+[numthreads(16,16,1)]
 void MainCS(uint3 dispatchId: SV_DispatchThreadID)
 {
     const float3 inputSize = GetImageSize(FilterPassSrg::m_inputImage);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Math/GaussianFilterFloatVertical.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Math/GaussianFilterFloatVertical.azsl
@@ -11,7 +11,7 @@
 #include <Atom/Features/Math/FilterPassSrg.azsli>
 #include <Atom/Features/Shadow/ShadowmapAtlasLib.azsli>
 
-[numthreads(8,8,1)]
+[numthreads(16,16,1)]
 void MainCS(uint3 dispatchId: SV_DispatchThreadID)
 {
     const float3 inputSize = GetImageSize(FilterPassSrg::m_inputImage);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
@@ -28,7 +28,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     StructuredBuffer<FilterParameter> m_filterParameters;
 }
 
-[numthreads(8,8,1)]
+[numthreads(16,16,1)]
 void MainCS(uint3 dispatchId: SV_DispatchThreadID)
 {
     const float3 inputSize = GetImageSize(PassSrg::m_inputShadowmap);


### PR DESCRIPTION
Increasing number of threads from 64 to 256 for several ESM related compute shaders

Measured a very good perf increase on RDNA and RDNA2 gpus. 18 ms-> 14 ms on 5700XT for the Deadhaus_sonata level in editor. Similar perf improvement on 6800XT

Nvidia 2080 had a much smaller (0.1 ms) improvement

Tested ASV
Tested the Editor

ATOM-15855
