### PR TITLE
[stabilization/2106] generalize progress screen text and split out download/execution progress

### DIFF
--- a/cmake/Platform/Windows/Packaging/BootstrapperTheme.wxl.in
+++ b/cmake/Platform/Windows/Packaging/BootstrapperTheme.wxl.in
@@ -32,9 +32,9 @@ Setup will install [WixBundleName] on your computer. Click install to continue, 
     <String Id="ModifyCloseButton">&amp;Close</String>
 
     <!-- action progress page -->
-    <String Id="ProgressHeader">Installing @CPACK_PACKAGE_FULL_NAME@...</String>
-    <String Id="ProgressLabel">Processing:</String>
-    <String Id="OverallProgressPackageText">Initializing...</String>
+    <String Id="ProgressHeader">Processing @CPACK_PACKAGE_FULL_NAME@...</String>
+    <String Id="CacheProgressLabel">Caching Progress</String>
+    <String Id="ExecuteProgressLabel">Execution Progress</String>
     <String Id="ProgressCancelButton">&amp;Cancel</String>
 
     <!-- final page (success state) -->

--- a/cmake/Platform/Windows/Packaging/BootstrapperTheme.xml.in
+++ b/cmake/Platform/Windows/Packaging/BootstrapperTheme.xml.in
@@ -54,9 +54,13 @@
     <Page Name="Progress">
         <Text X="38" Y="142" Width="-42" Height="34" FontId="0" DisablePrefix="yes">#(loc.ProgressHeader)</Text>
 
-        <Text X="42" Y="202" Width="70" Height="18" FontId="1" DisablePrefix="yes">#(loc.ProgressLabel)</Text>
-        <Text Name="OverallProgressPackageText" X="116" Y="202" Width="-42" Height="18" FontId="2" DisablePrefix="yes">#(loc.OverallProgressPackageText)</Text>
-        <Progressbar Name="OverallCalculatedProgressbar" X="42" Y="230" Width="-90" Height="20" />
+        <Text X="42" Y="202" Width="-45" Height="18" FontId="1" DisablePrefix="yes">#(loc.CacheProgressLabel)</Text>
+        <Progressbar Name="CacheProgressbar" X="42" Y="230" Width="-90" Height="20" />
+        <Text Name="CacheProgressText" X="-45" Y="232" Width="32" Height="18" FontId="2" DisablePrefix="yes"/>
+
+        <Text X="42" Y="262" Width="-45" Height="18" FontId="1" DisablePrefix="yes">#(loc.ExecuteProgressLabel)</Text>
+        <Progressbar Name="ExecuteProgressbar" X="42" Y="290" Width="-90" Height="20" />
+        <Text Name="ExecuteProgressText" X="-45" Y="292" Width="32" Height="18" FontId="2" DisablePrefix="yes"/>
 
         <Text X="0" Y="426" Width="672" Height="46" FontId="3" HideWhenDisabled="yes" />
         <Button Name="ProgressCancelButton" X="-22" Y="-10" Width="80" Height="24" TabStop="yes" FontId="2">#(loc.ProgressCancelButton)</Button>


### PR DESCRIPTION
![installer_progress_screen](https://user-images.githubusercontent.com/24445312/123858617-93d9eb80-d8d8-11eb-8f03-5bacd4e5c360.gif)

The uninstall version will look nearly identical, the caching progress bar will be shown but unused.  This is a bit of a compromise as we are limited in what's technically possible with this screen without writing a custom bootstrapper from source.