### PR TITLE
ATOM-15892 fixing material component clear overrides button

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.cpp
@@ -172,6 +172,11 @@ namespace AZ
         void EditorMaterialComponentSlot::Clear()
         {
             m_materialAsset = {};
+            ClearOverrides();
+        }
+
+        void EditorMaterialComponentSlot::ClearOverrides()
+        {
             m_propertyOverrides = {};
             m_matModUvOverrides = {};
             OnMaterialChanged();
@@ -284,7 +289,7 @@ namespace AZ
 
             menu.addSeparator();
 
-            action = menu.addAction("Clear Material Instance Overrides", [this]() { m_propertyOverrides = {}; m_matModUvOverrides = {}; });
+            action = menu.addAction("Clear Material Instance Overrides", [this]() { ClearOverrides(); });
             action->setEnabled(!m_propertyOverrides.empty() || !m_matModUvOverrides.empty());
 
             menu.exec(QCursor::pos());

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSlot.h
@@ -35,6 +35,7 @@ namespace AZ
             void OpenMaterialEditor() const;
             void SetDefaultAsset();
             void Clear();
+            void ClearOverrides();
             void OpenMaterialExporter();
             void OpenMaterialInspector();
             void OpenUvNameMapInspector();


### PR DESCRIPTION
The clear material override properties button was not sending the notification to update the entity or undo state.