### PR TITLE
Remove mention of sample project from welcome screen

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -92,8 +92,7 @@ namespace O3DE::ProjectManager
 
             QLabel* introLabel = new QLabel(this);
             introLabel->setObjectName("introLabel");
-            introLabel->setText(tr("Welcome to O3DE! Start something new by creating a project. Not sure what to create? \nExplore what's "
-                                   "available by downloading our sample project."));
+            introLabel->setText(tr("Welcome to O3DE! Start something new by creating a project."));
             layout->addWidget(introLabel);
 
             QHBoxLayout* buttonLayout = new QHBoxLayout();


### PR DESCRIPTION
Updated welcome page looks like this:

![UpdatedWelcomeScreen](https://user-images.githubusercontent.com/26804013/124044907-57cf8500-d9c3-11eb-80ed-f6c20ca1e519.JPG)

