### PR TITLE
[ATOM-14526] DiffuseProbeGrid and ReflectionProbe components alter box shape size

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridComponentConstants.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridComponentConstants.h
@@ -13,8 +13,8 @@ namespace AZ
     {
         static constexpr const char* const DiffuseProbeGridComponentTypeId = "{9B900A04-192F-4F5E-AE31-762605D8159A}";
         static constexpr const char* const EditorDiffuseProbeGridComponentTypeId = "{F80086E1-ECE7-4E8C-B727-A750D10F7D83}";
-        static constexpr float DefaultDiffuseProbeGridSpacing = 4.0f;
-        static constexpr float DefaultDiffuseProbeGridExtents = 20.0f;
+        static constexpr float DefaultDiffuseProbeGridSpacing = 2.0f;
+        static constexpr float DefaultDiffuseProbeGridExtents = 8.0f;
         static constexpr float DefaultDiffuseProbeGridAmbientMultiplier = 1.0f;
         static constexpr float DefaultDiffuseProbeGridViewBias = 0.2f;
         static constexpr float DefaultDiffuseProbeGridNormalBias = 0.1f;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridComponentController.cpp
@@ -169,9 +169,20 @@ namespace AZ
 
             m_featureProcessor->SetMode(m_handle, m_configuration.m_runtimeMode);
 
-            // set box shape component dimensions from the configuration
-            // this will invoke the OnShapeChanged() handler and set the outer extents on the feature processor
-            m_boxShapeInterface->SetBoxDimensions(m_configuration.m_extents);
+            // if this is a new DiffuseProbeGrid entity and the box shape has not been changed (i.e., it's still unit sized)
+            // then use the default extents, otherwise use the current box shape extents
+            AZ::Vector3 extents(0.0f);
+            AZ::Vector3 boxDimensions = m_boxShapeInterface->GetBoxDimensions();
+            if (m_configuration.m_entityId == EntityId::InvalidEntityId && boxDimensions == AZ::Vector3(1.0f))
+            {
+                extents = m_configuration.m_extents;
+            }
+            else
+            {
+                extents = boxDimensions;
+            }
+
+            m_boxShapeInterface->SetBoxDimensions(extents);
         }
 
         void DiffuseProbeGridComponentController::OnAssetReady(Data::Asset<Data::AssetData> asset)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridComponentController.h
@@ -47,6 +47,8 @@ namespace AZ
             Data::Asset<RPI::StreamingImageAsset> m_bakedDistanceTextureAsset;
             Data::Asset<RPI::StreamingImageAsset> m_bakedRelocationTextureAsset;
             Data::Asset<RPI::StreamingImageAsset> m_bakedClassificationTextureAsset;
+
+            AZ::u64 m_entityId{ EntityId::InvalidEntityId };
         };
 
         class DiffuseProbeGridComponentController final

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/EditorDiffuseProbeGridComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/EditorDiffuseProbeGridComponent.cpp
@@ -147,6 +147,9 @@ namespace AZ
             AzToolsFramework::EditorComponentSelectionRequestsBus::Handler::BusConnect(GetEntityId());
             AZ::TickBus::Handler::BusConnect();
             AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusConnect();
+
+            AZ::u64 entityId = (AZ::u64)GetEntityId();
+            m_controller.m_configuration.m_entityId = entityId;
         }
 
         void EditorDiffuseProbeGridComponent::Deactivate()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentConstants.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentConstants.h
@@ -13,5 +13,6 @@ namespace AZ
     {
         static constexpr const char* const ReflectionProbeComponentTypeId = "{E5D29F09-F974-45FE-A1D0-2126079D1021}";
         static constexpr const char* const EditorReflectionProbeComponentTypeId = "{6EBF2E41-2918-48B8-ACC3-FB115ED09E64}";
+        static constexpr float DefaultReflectionProbeExtents = 8.0f;
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.cpp
@@ -127,9 +127,21 @@ namespace AZ
             // set the visualization sphere option
             m_featureProcessor->ShowProbeVisualization(m_handle, m_configuration.m_showVisualization);
 
-            // update the outer extents from the box shape
-            // if the user already resized the box shape on this entity it will inherit those extents
-            UpdateOuterExtents();
+            // if this is a new ReflectionProbe entity and the box shape has not been changed (i.e., it's still unit sized)
+            // then set the shape to the default extents
+            AZ::Vector3 boxDimensions = m_boxShapeInterface->GetBoxDimensions();
+            if (m_configuration.m_entityId == EntityId::InvalidEntityId && boxDimensions == AZ::Vector3(1.0f))
+            {
+                AZ::Vector3 extents(m_configuration.m_outerWidth, m_configuration.m_outerLength, m_configuration.m_outerHeight);
+
+                // resize the box shape, this will invoke OnShapeChanged
+                m_boxShapeInterface->SetBoxDimensions(extents);
+            }
+            else
+            {
+                // update the outer extents from the box shape
+                UpdateOuterExtents();
+            }
 
             // set the inner extents
             m_featureProcessor->SetProbeInnerExtents(m_handle, AZ::Vector3(m_configuration.m_innerWidth, m_configuration.m_innerLength, m_configuration.m_innerHeight));

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/ReflectionProbe/ReflectionProbeComponentController.h
@@ -14,6 +14,7 @@
 #include <Atom/Feature/ReflectionProbe/ReflectionProbeFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Model/Model.h>
 #include <LmbrCentral/Shape/BoxShapeComponentBus.h>
+#include <ReflectionProbe/ReflectionProbeComponentConstants.h>
 
 namespace AZ
 {
@@ -50,12 +51,12 @@ namespace AZ
             AZ_CLASS_ALLOCATOR(ReflectionProbeComponentConfig, SystemAllocator, 0);
             static void Reflect(AZ::ReflectContext* context);
 
-            float m_outerHeight = 20.0f;
-            float m_outerLength = 20.0f;
-            float m_outerWidth = 20.0f;
-            float m_innerHeight = 20.0f;
-            float m_innerLength = 20.0f;
-            float m_innerWidth = 20.0f;
+            float m_outerHeight = DefaultReflectionProbeExtents;
+            float m_outerLength = DefaultReflectionProbeExtents;
+            float m_outerWidth = DefaultReflectionProbeExtents;
+            float m_innerHeight = DefaultReflectionProbeExtents;
+            float m_innerLength = DefaultReflectionProbeExtents;
+            float m_innerWidth = DefaultReflectionProbeExtents;
 
             bool m_useParallaxCorrection = true;
             bool m_showVisualization = true;


### PR DESCRIPTION
Changed the DiffuseProbeGrid and ReflectionProbe components to only override the Box size if it's at the default (unit) size.
Changed the default Box size to 8m.
Changed the default DiffuseProbeGrid spacing to 2m.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>