### PR TITLE
Fix for shadow aliasing appearing when enabling/disabling lights

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -104,6 +104,7 @@ namespace AZ::Render
             m_shadowData.Release(id.GetIndex());
         }
 
+        m_filterParameterNeedsUpdate = true;
         m_shadowmapPassNeedsUpdate = true;
     }
 


### PR DESCRIPTION
With a scene with a large number of shadow casting lights, enabling/disabling lights in random order will sometimes shadow aliasing will appear incorrect.

https://jira.agscollab.com/browse/ATOM-15898
