### PR TITLE
[LYN-4879] Incorrect colour UI issue on Gem Configure

### DIFF
--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -463,6 +463,21 @@ QProgressBar::chunk {
     font-weight: 600;
 }
 
+#GemCatalogHeaderLabel {
+    font-size: 12px;
+    color: #FFFFFF;
+}
+
+#GemCatalogHeaderShowCountLabel {
+    font-size: 12px;
+    font: italic;
+    color: #FFFFFF;
+}
+
+#GemCatalogListView {
+    background-color: #333333;
+}
+
 /************** Gem Catalog (Inspector) **************/
 
 #GemCatalogInspector {

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemListHeaderWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemListHeaderWidget.cpp
@@ -31,7 +31,7 @@ namespace O3DE::ProjectManager
         topLayout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Expanding));
 
         QLabel* showCountLabel = new QLabel();
-        showCountLabel->setStyleSheet("font-size: 12px; font: italic; color: #FFFFFF;");
+        showCountLabel->setObjectName("GemCatalogHeaderShowCountLabel");
         topLayout->addWidget(showCountLabel);
         connect(proxyModel, &GemSortFilterProxyModel::OnInvalidated, this, [=]
             {
@@ -57,27 +57,27 @@ namespace O3DE::ProjectManager
         QHBoxLayout* columnHeaderLayout = new QHBoxLayout();
         columnHeaderLayout->setAlignment(Qt::AlignLeft);
 
-        const int gemNameStartX = GemItemDelegate::s_itemMargins.left() + GemItemDelegate::s_contentMargins.left() - 3;
+        const int gemNameStartX = GemItemDelegate::s_itemMargins.left() + GemItemDelegate::s_contentMargins.left() - 1;
         columnHeaderLayout->addSpacing(gemNameStartX);
 
         QLabel* gemNameLabel = new QLabel(tr("Gem Name"));
-        gemNameLabel->setStyleSheet("font-size: 12px; color: #FFFFFF;");
+        gemNameLabel->setObjectName("GemCatalogHeaderLabel");
         columnHeaderLayout->addWidget(gemNameLabel);
 
-        columnHeaderLayout->addSpacing(77);
+        columnHeaderLayout->addSpacing(89);
 
         QLabel* gemSummaryLabel = new QLabel(tr("Gem Summary"));
-        gemSummaryLabel->setStyleSheet("font-size: 12px; color: #FFFFFF;");
+        gemSummaryLabel->setObjectName("GemCatalogHeaderLabel");
         columnHeaderLayout->addWidget(gemSummaryLabel);
 
         QSpacerItem* horizontalSpacer = new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Minimum);
         columnHeaderLayout->addSpacerItem(horizontalSpacer);
 
         QLabel* gemSelectedLabel = new QLabel(tr("Selected"));
-        gemSelectedLabel->setStyleSheet("font-size: 12px; color: #FFFFFF;");
+        gemSelectedLabel->setObjectName("GemCatalogHeaderLabel");
         columnHeaderLayout->addWidget(gemSelectedLabel);
 
-        columnHeaderLayout->addSpacing(60);
+        columnHeaderLayout->addSpacing(65);
 
         vLayout->addLayout(columnHeaderLayout);
     }

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemListView.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemListView.cpp
@@ -14,9 +14,8 @@ namespace O3DE::ProjectManager
     GemListView::GemListView(QAbstractItemModel* model, QItemSelectionModel* selectionModel, QWidget* parent)
         : QListView(parent)
     {
+        setObjectName("GemCatalogListView");
         setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-
-        setStyleSheet("background-color: #333333;");
 
         setModel(model);
         setSelectionModel(selectionModel);


### PR DESCRIPTION
* Aligned the column headers to the elements
* Moved the styling of the gem column header labels to the qss
* Fixed the scrollbar for the gem list view

Signed-off-by: Benjamin Jillich <jillich@amazon.com>

![image](https://user-images.githubusercontent.com/43751992/123961034-3b761d00-d9b0-11eb-8501-0ed2a42d8488.png)