### PR TITLE
Add parameter so created EBS volumes are encrypted

### DIFF
--- a/scripts/build/bootstrap/incremental_build_util.py
+++ b/scripts/build/bootstrap/incremental_build_util.py
@@ -202,6 +202,7 @@ def create_volume(ec2_client, availability_zone, snapshot_hint, repository_name,
     parameters = dict(
         AvailabilityZone = availability_zone,
         VolumeType=disk_type,
+        Encrypted=True,
         TagSpecifications= [{
             'ResourceType': 'volume',
             'Tags': [


### PR DESCRIPTION
This addresses a pentest finding that our EBS volumes should be encrypted. The script will now create an encrypted EBS volume when mounting it to a build node.  

Tested in the fork repo pipeline.

Signed-off-by: brianherrera <briher@amazon.com>