### PR TITLE
Fix duplicated camera entities in the Editor sharing a transform

### DIFF
--- a/Gems/Camera/Code/Source/EditorCameraComponent.cpp
+++ b/Gems/Camera/Code/Source/EditorCameraComponent.cpp
@@ -26,8 +26,10 @@ namespace Camera
 
     void EditorCameraComponent::Activate()
     {
-        auto controllerConfig = m_controller.GetConfiguration();
+        // Ensure our Editor Entity ID is up-to-date to sync camera configurations between Edit & Game mode.
+        CameraComponentConfig controllerConfig = m_controller.GetConfiguration();
         controllerConfig.m_editorEntityId = GetEntityId().operator AZ::u64();
+        m_controller.SetConfiguration(controllerConfig);
 
         // Call base class activate, which in turn calls Activate on our controller.
         EditorCameraComponentBase::Activate();


### PR DESCRIPTION
Ensure the Editor Entity ID tied to the camera is up-to-date on component activate to avoid erroneously copying camera state to the wrong camera