### PR TITLE
Fix for LYN-4594: [Atom][EMFX] Loading a saved level with entity and an actor component causes the editor to freeze. 

### DIFF
--- a/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/AtomFont.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/AtomFont.h
@@ -16,7 +16,7 @@
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/smart_ptr/weak_ptr.h>
 #include <AzCore/std/parallel/shared_mutex.h>
-#include <Azcore/Asset/AssetCommon.h>
+#include <AzCore/Asset/AssetCommon.h>
 #include <map>
 
 #include <AzFramework/Font/FontInterface.h>

--- a/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/AtomFont.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/AtomFont.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/smart_ptr/weak_ptr.h>
 #include <AzCore/std/parallel/shared_mutex.h>
+#include <Azcore/Asset/AssetCommon.h>
 #include <map>
 
 #include <AzFramework/Font/FontInterface.h>
@@ -38,6 +39,7 @@ namespace AZ
     class AtomFont
         : public ICryFont
         , public AzFramework::FontQueryInterface
+        , private Data::AssetBus::Handler
     {
         friend class FFont;
 
@@ -121,6 +123,9 @@ namespace AZ
         //! \param outputDirectory Path to loaded font family (no filename), may need resolving with PathUtil::MakeGamePath.
         //! \param outputFullPath Full path to loaded font family, may need resolving with PathUtil::MakeGamePath.
         XmlNodeRef LoadFontFamilyXml(const char* fontFamilyName, string& outputDirectory, string& outputFullPath);
+
+        // Data::AssetBus::Handler overrides...
+        void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
 
     private:
         AzFramework::ISceneSystem::SceneEvent::Handler m_sceneEventHandler;

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
@@ -29,6 +29,7 @@
 
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 
 // Static member definitions
 const AZ::AtomFont::GlyphSize AZ::AtomFont::defaultGlyphSize = AZ::AtomFont::GlyphSize(ICryFont::defaultGlyphSizeX, ICryFont::defaultGlyphSizeY);
@@ -351,10 +352,9 @@ AZ::AtomFont::AtomFont(ISystem* system)
 
     // Queue a load for the font per viewport dynamic draw context shader, and wait for it to load
     static const char* shaderFilepath = "Shaders/SimpleTextured.azshader";
-    Data::AssetId shaderAssetId = RPI::GetShaderAssetId(shaderFilepath);
-    Data::Asset<RPI::ShaderAsset> shaderAsset = Data::AssetManager::Instance().GetAsset<RPI::ShaderAsset>(shaderAssetId, AZ::Data::AssetLoadBehavior::PreLoad);
+    Data::Asset<RPI::ShaderAsset> shaderAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ShaderAsset>(shaderFilepath, RPI::AssetUtils::TraceLevel::Assert);
     shaderAsset.QueueLoad();
-    Data::AssetBus::Handler::BusConnect(shaderAssetId);   
+    Data::AssetBus::Handler::BusConnect(shaderAsset.GetId());
 
 }
 

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/AtomFont.cpp
@@ -349,30 +349,19 @@ AZ::AtomFont::AtomFont(ISystem* system)
 #endif
     AZ::Interface<AzFramework::FontQueryInterface>::Register(this);
 
-    // register font per viewport dynamic draw context.
+    // Queue a load for the font per viewport dynamic draw context shader, and wait for it to load
     static const char* shaderFilepath = "Shaders/SimpleTextured.azshader";
-    AZ::AtomBridge::PerViewportDynamicDraw::Get()->RegisterDynamicDrawContext(
-        AZ::Name(AZ::AtomFontDynamicDrawContextName),
-        [](RPI::Ptr<RPI::DynamicDrawContext> drawContext)
-        {
-            Data::Instance<RPI::Shader> shader = AZ::RPI::LoadShader(shaderFilepath);
-            AZ::RPI::ShaderOptionList shaderOptions;
-            shaderOptions.push_back(AZ::RPI::ShaderOption(AZ::Name("o_useColorChannels"), AZ::Name("false")));
-            shaderOptions.push_back(AZ::RPI::ShaderOption(AZ::Name("o_clamp"), AZ::Name("true")));
-            drawContext->InitShaderWithVariant(shader, &shaderOptions);
-            drawContext->InitVertexFormat(
-                {
-                    {"POSITION", RHI::Format::R32G32B32_FLOAT},
-                    {"COLOR", RHI::Format::B8G8R8A8_UNORM},
-                    {"TEXCOORD0", RHI::Format::R32G32_FLOAT}
-                });
-            drawContext->EndInit();
-        });
+    Data::AssetId shaderAssetId = RPI::GetShaderAssetId(shaderFilepath);
+    Data::Asset<RPI::ShaderAsset> shaderAsset = Data::AssetManager::Instance().GetAsset<RPI::ShaderAsset>(shaderAssetId, AZ::Data::AssetLoadBehavior::PreLoad);
+    shaderAsset.QueueLoad();
+    Data::AssetBus::Handler::BusConnect(shaderAssetId);   
 
 }
 
 AZ::AtomFont::~AtomFont()
 {
+    Data::AssetBus::Handler::BusDisconnect();
+
     AZ::Interface<AzFramework::FontQueryInterface>::Unregister(this);
     m_defaultFontDrawInterface = nullptr;
 
@@ -864,5 +853,36 @@ XmlNodeRef AZ::AtomFont::LoadFontFamilyXml(const char* fontFamilyName, string& o
 
     return root;
 }
+
+void AZ::AtomFont::OnAssetReady(Data::Asset<Data::AssetData> asset)
+{
+    Data::Asset<RPI::ShaderAsset> shaderAsset = asset;
+
+    AZ::AtomBridge::PerViewportDynamicDraw::Get()->RegisterDynamicDrawContext(
+        AZ::Name(AZ::AtomFontDynamicDrawContextName),
+        [shaderAsset](RPI::Ptr<RPI::DynamicDrawContext> drawContext)
+        {
+            AZ_Assert(shaderAsset->IsReady(), "Attempting to register the AtomFont"
+                " dynamic draw context before the shader asset is loaded. The shader should be loaded first"
+                " to avoid a blocking asset load and potentail deadlock, since the DynamicDrawContext lambda"
+                " will be executed during scene processing and there may be multiple scenes executing in parallel.");
+
+            Data::Instance<RPI::Shader> shader = RPI::Shader::FindOrCreate(shaderAsset);
+            AZ::RPI::ShaderOptionList shaderOptions;
+            shaderOptions.push_back(AZ::RPI::ShaderOption(AZ::Name("o_useColorChannels"), AZ::Name("false")));
+            shaderOptions.push_back(AZ::RPI::ShaderOption(AZ::Name("o_clamp"), AZ::Name("true")));
+            drawContext->InitShaderWithVariant(shader, &shaderOptions);
+            drawContext->InitVertexFormat(
+                {
+                    {"POSITION", RHI::Format::R32G32B32_FLOAT},
+                    {"COLOR", RHI::Format::B8G8R8A8_UNORM},
+                    {"TEXCOORD0", RHI::Format::R32G32_FLOAT}
+                });
+            drawContext->EndInit();
+        });
+
+    Data::AssetBus::Handler::BusDisconnect();
+}
+
 #endif
 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
@@ -87,6 +87,7 @@ namespace AZ::Render
 
     void AtomViewportDisplayIconsSystemComponent::Deactivate()
     {
+        Data::AssetBus::Handler::BusDisconnect();
         Bootstrap::NotificationBus::Handler::BusDisconnect();
 
         auto perViewportDynamicDrawInterface = AtomBridge::PerViewportDynamicDraw::Get();
@@ -338,15 +339,33 @@ namespace AZ::Render
 
     void AtomViewportDisplayIconsSystemComponent::OnBootstrapSceneReady([[maybe_unused]]AZ::RPI::Scene* bootstrapScene)
     {
-        AtomBridge::PerViewportDynamicDraw::Get()->RegisterDynamicDrawContext(m_drawContextName, [](RPI::Ptr<RPI::DynamicDrawContext> drawContext)
-        {
-            auto shader = RPI::LoadShader(DrawContextShaderPath);
-            drawContext->InitShader(shader);
-            drawContext->InitVertexFormat(
-                {{"POSITION", RHI::Format::R32G32B32_FLOAT},
-                 {"COLOR", RHI::Format::R8G8B8A8_UNORM},
-                 {"TEXCOORD", RHI::Format::R32G32_FLOAT}});
-            drawContext->EndInit();
-        });
+        // Queue a load for the draw context shader, and wait for it to load
+        Data::AssetId shaderAssetId = RPI::GetShaderAssetId(DrawContextShaderPath);
+        Data::Asset<RPI::ShaderAsset> shaderAsset = Data::AssetManager::Instance().GetAsset<RPI::ShaderAsset>(shaderAssetId, AZ::Data::AssetLoadBehavior::PreLoad);
+        shaderAsset.QueueLoad();
+        Data::AssetBus::Handler::BusConnect(shaderAssetId);
+    }
+
+    void AtomViewportDisplayIconsSystemComponent::OnAssetReady(Data::Asset<Data::AssetData> asset)
+    {
+        // Once the shader is loaded, register it with the dynamic draw context
+        Data::Asset<RPI::ShaderAsset> shaderAsset = asset;
+        AtomBridge::PerViewportDynamicDraw::Get()->RegisterDynamicDrawContext(m_drawContextName, [shaderAsset](RPI::Ptr<RPI::DynamicDrawContext> drawContext)
+            {
+                AZ_Assert(shaderAsset->IsReady(), "Attempting to register the AtomViewportDisplayIconsSystemComponent"
+                    " dynamic draw context before the shader asset is loaded. The shader should be loaded first"
+                    " to avoid a blocking asset load and potentail deadlock, since the DynamicDrawContext lambda"
+                    " will be executed during scene processing and there may be multiple scenes executing in parallel.");
+
+                Data::Instance<RPI::Shader> shader = RPI::Shader::FindOrCreate(shaderAsset);
+                drawContext->InitShader(shader);
+                drawContext->InitVertexFormat(
+                    { {"POSITION", RHI::Format::R32G32B32_FLOAT},
+                     {"COLOR", RHI::Format::R8G8B8A8_UNORM},
+                     {"TEXCOORD", RHI::Format::R32G32_FLOAT} });
+                drawContext->EndInit();
+            });
+
+        Data::AssetBus::Handler::BusDisconnect();
     }
 } // namespace AZ::Render

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.cpp
@@ -27,6 +27,7 @@
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 #include <Atom/RPI.Reflect/Image/StreamingImageAssetCreator.h>
 #include <Atom/RPI.Reflect/Image/ImageMipChainAssetCreator.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/RPI.Public/Image/StreamingImagePool.h>
 
 #include <AtomBridge/PerViewportDynamicDrawInterface.h>
@@ -340,10 +341,9 @@ namespace AZ::Render
     void AtomViewportDisplayIconsSystemComponent::OnBootstrapSceneReady([[maybe_unused]]AZ::RPI::Scene* bootstrapScene)
     {
         // Queue a load for the draw context shader, and wait for it to load
-        Data::AssetId shaderAssetId = RPI::GetShaderAssetId(DrawContextShaderPath);
-        Data::Asset<RPI::ShaderAsset> shaderAsset = Data::AssetManager::Instance().GetAsset<RPI::ShaderAsset>(shaderAssetId, AZ::Data::AssetLoadBehavior::PreLoad);
+        Data::Asset<RPI::ShaderAsset> shaderAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ShaderAsset>(DrawContextShaderPath, RPI::AssetUtils::TraceLevel::Assert);
         shaderAsset.QueueLoad();
-        Data::AssetBus::Handler::BusConnect(shaderAssetId);
+        Data::AssetBus::Handler::BusConnect(shaderAsset.GetId());
     }
 
     void AtomViewportDisplayIconsSystemComponent::OnAssetReady(Data::Asset<Data::AssetData> asset)

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.h
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Code/Source/AtomViewportDisplayIconsSystemComponent.h
@@ -27,6 +27,7 @@ namespace AZ
             : public AZ::Component
             , public AzToolsFramework::EditorViewportIconDisplayInterface
             , public AZ::Render::Bootstrap::NotificationBus::Handler
+            , private Data::AssetBus::Handler
         {
         public:
             AZ_COMPONENT(AtomViewportDisplayIconsSystemComponent, "{AEC1D3E1-1D9A-437A-B4C6-CFAEE620C160}");
@@ -50,6 +51,9 @@ namespace AZ
 
             // AZ::Render::Bootstrap::NotificationBus::Handler overrides...
             void OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene) override;
+
+            // Data::AssetBus::Handler overrides...
+            void OnAssetReady(Data::Asset<Data::AssetData> asset) override;
 
         private:
             static constexpr const char* DrawContextShaderPath = "Shaders/TexturedIcon.azshader";

--- a/Gems/Blast/Code/Include/Blast/BlastDebug.h
+++ b/Gems/Blast/Code/Include/Blast/BlastDebug.h
@@ -8,7 +8,7 @@
 
 #include <AzCore/Math/Vector3.h>
 #include <IRenderAuxGeom.h>
-#include <Azcore/Math/Color.h>
+#include <AzCore/Math/Color.h>
 
 namespace Blast
 {

--- a/Gems/Blast/Code/Source/Family/ActorRenderManager.h
+++ b/Gems/Blast/Code/Source/Family/ActorRenderManager.h
@@ -8,7 +8,7 @@
 
 #include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
 #include <AzCore/std/containers/vector.h>
-#include <Azcore/Math/Vector3.h>
+#include <AzCore/Math/Vector3.h>
 
 namespace Blast
 {


### PR DESCRIPTION
Fix to not do a blocking asset load in the lambdas for RegisterDynamicDrawContext and avoid a deadlock

Here's what was happening.
Main Thread:
This lambda does not get executed until OnBeginPrepareRender because PerViewportDynamicDrawManager::GetDynamicDrawContextForViewport creates the DynamicDrawContext the first time something goes to use it. So SceneA finishes its 'Simulate' functions, and RenderTick, fires off the OnBeginPrepareRender event, and triggers this blocking asset load, which in turn locks the asset bus triggers the OnAssetReady event for any assets that have finished loading but have not yet reached the tick function that normally sends OnAssetReady events. This results in an OnAssetReady event firing for the rin actor, which then tries to acquire a mesh, which builds a draw packet, which tries to acquire a lock in Shader::GetVariant

Worker Thread:

Meanwhile, SceneB is still running its simulate function in a job, which includes updating draw packets in MeshFeatureProcessor::Simulate. Updating the draw packet gets the lock in Shader::GetVariant before the main thread can. But Shader::GetVariant doesn't find and exiting variant, and inits a new one instead. ShaderVariant::Init tries to connect to the asset bus, but can't because the main thread already has a lock, leading to deadlock.

Fixed by getting rid of the blocking asset load in the RegisterDynamicDrawContext lambda for both AtomViewportDisplayIconsSystemComponent and AtomFont. Instead, those systems queue a load for the shader, and register their dynamic draw contexts once their shaders are ready.