### PR TITLE
[LYN-4938] Prism: Paths in Engine settings page do not use consistent slashes

### DIFF
--- a/Code/Tools/ProjectManager/Source/FormBrowseEditWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormBrowseEditWidget.cpp
@@ -21,4 +21,9 @@ namespace O3DE::ProjectManager
         connect(browseButton, &QPushButton::pressed, this, &FormBrowseEditWidget::HandleBrowseButton);
         m_frameLayout->addWidget(browseButton); 
     }
+
+    FormBrowseEditWidget::FormBrowseEditWidget(const QString& labelText, QWidget* parent)
+        : FormBrowseEditWidget(labelText, "", parent)
+    {
+    }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/FormBrowseEditWidget.h
+++ b/Code/Tools/ProjectManager/Source/FormBrowseEditWidget.h
@@ -20,6 +20,7 @@ namespace O3DE::ProjectManager
 
     public:
         explicit FormBrowseEditWidget(const QString& labelText, const QString& valueText = "", QWidget* parent = nullptr);
+        explicit FormBrowseEditWidget(const QString& labelText = "", QWidget* parent = nullptr);
         ~FormBrowseEditWidget() = default;
 
     protected slots:

--- a/Code/Tools/ProjectManager/Source/FormFolderBrowseEditWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormFolderBrowseEditWidget.cpp
@@ -15,8 +15,9 @@
 namespace O3DE::ProjectManager
 {
     FormFolderBrowseEditWidget::FormFolderBrowseEditWidget(const QString& labelText, const QString& valueText, QWidget* parent)
-        : FormBrowseEditWidget(labelText, valueText, parent)
+        : FormBrowseEditWidget(labelText, parent)
     {
+        setText(valueText);
     }
 
     void FormFolderBrowseEditWidget::HandleBrowseButton()
@@ -30,8 +31,14 @@ namespace O3DE::ProjectManager
         QString directory = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(this, tr("Browse"), defaultPath));
         if (!directory.isEmpty())
         {
-            m_lineEdit->setText(directory);
+            setText(directory);
         }
 
+    }
+
+    void FormFolderBrowseEditWidget::setText(const QString& text)
+    {
+        QString path = QDir::toNativeSeparators(text);
+        FormBrowseEditWidget::setText(path);
     }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/FormFolderBrowseEditWidget.h
+++ b/Code/Tools/ProjectManager/Source/FormFolderBrowseEditWidget.h
@@ -22,6 +22,8 @@ namespace O3DE::ProjectManager
         explicit FormFolderBrowseEditWidget(const QString& labelText, const QString& valueText = "", QWidget* parent = nullptr);
         ~FormFolderBrowseEditWidget() = default;
 
+        void setText(const QString& text) override;
+
     protected:
         void HandleBrowseButton() override;
     };

--- a/Code/Tools/ProjectManager/Source/FormLineEditWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/FormLineEditWidget.cpp
@@ -123,4 +123,14 @@ namespace O3DE::ProjectManager
             child->style()->polish(child);
         }
     }
+
+    void FormLineEditWidget::setText(const QString& text)
+    {
+        m_lineEdit->setText(text);
+    }
+
+    void FormLineEditWidget::mousePressEvent([[maybe_unused]] QMouseEvent* event)
+    {
+        m_lineEdit->setFocus();
+    }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/FormLineEditWidget.h
+++ b/Code/Tools/ProjectManager/Source/FormLineEditWidget.h
@@ -15,6 +15,7 @@ QT_FORWARD_DECLARE_CLASS(QLineEdit)
 QT_FORWARD_DECLARE_CLASS(QLabel)
 QT_FORWARD_DECLARE_CLASS(QFrame)
 QT_FORWARD_DECLARE_CLASS(QHBoxLayout)
+QT_FORWARD_DECLARE_CLASS(QMouseEvent)
 
 namespace AzQtComponents
 {
@@ -39,6 +40,8 @@ namespace O3DE::ProjectManager
         //! Returns a pointer to the underlying LineEdit.
         QLineEdit* lineEdit() const;
 
+        virtual void setText(const QString& text);
+
     protected:
         QLabel* m_errorLabel = nullptr;
         QFrame* m_frame = nullptr;
@@ -51,6 +54,8 @@ namespace O3DE::ProjectManager
         void onFocusOut();
 
     private:
+        void mousePressEvent(QMouseEvent* event) override;
+
         void refreshStyle();
     };
 } // namespace O3DE::ProjectManager


### PR DESCRIPTION
* Corrected focus for form line edit widgets.
* Consistent slash usage for folder browse edit widgets.

Focus on line edit widgets on the whole widget rather than just the line edit itself:
![LineEditFocus](https://user-images.githubusercontent.com/43751992/124131565-3b455280-da80-11eb-9ba4-d5658c7f344b.gif)

Before:
![image](https://user-images.githubusercontent.com/43751992/124130944-96c31080-da7f-11eb-9a47-ed055ceffe6a.png)

After:
![image](https://user-images.githubusercontent.com/43751992/124130988-a4789600-da7f-11eb-80ae-d8deb10c3efd.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>