### PR TITLE
[LYN-4929] Correct gems not showing as enabled for a template

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
@@ -10,6 +10,7 @@
 #include <PythonBindingsInterface.h>
 #include <NewProjectSettingsScreen.h>
 #include <ScreenHeaderWidget.h>
+#include <GemCatalog/GemModel.h>
 #include <GemCatalog/GemCatalogScreen.h>
 
 #include <QDialogButtonBox>
@@ -46,6 +47,40 @@ namespace O3DE::ProjectManager
         m_stack->addWidget(m_gemCatalogScreen);
         vLayout->addWidget(m_stack);
 
+        // When there are multiple project templates present, we re-gather the gems when changing the selected the project template.
+        connect(m_newProjectSettingsScreen, &NewProjectSettingsScreen::OnTemplateSelectionChanged, this, [=](int oldIndex, [[maybe_unused]] int newIndex)
+            {
+                const GemModel* gemModel = m_gemCatalogScreen->GetGemModel();
+                const QVector<QModelIndex> toBeAdded = gemModel->GatherGemsToBeAdded();
+                const QVector<QModelIndex> toBeRemoved = gemModel->GatherGemsToBeRemoved();
+                if (!toBeAdded.isEmpty() || !toBeRemoved.isEmpty())
+                {
+                    // In case the user enabled or disabled any gem and the current selection does not match the default from the
+                    // // project template anymore, we need to ask the user if they want to proceed as their modifications will be lost.
+                    const QString title = tr("Modifications will be lost");
+                    const QString text = tr("You selected a new project template after modifying the enabled gems.\n\n"
+                        "All modifications will be lost and the default from the new project template will be used.\n\n"
+                        "Do you want to proceed?");
+                    if (QMessageBox::warning(this, title, text, QMessageBox::Yes, QMessageBox::No) == QMessageBox::Yes)
+                    {
+                        // The users wants to proceed. Reinitialize based on the newly selected project template.
+                        ReinitGemCatalogForSelectedTemplate();
+                    }
+                    else
+                    {
+                        // Roll-back to the previously selected project template and
+                        // block signals so that we don't end up in this same callback again.
+                        m_newProjectSettingsScreen->SelectProjectTemplate(oldIndex, /*blockSignals=*/true);
+                    }
+                }
+                else
+                {
+                    // In case the user did not enable or disable any gem and the currently enabled gems matches the previously selected
+                    // ones from the project template, we can just reinitialize based on the newly selected project template.
+                    ReinitGemCatalogForSelectedTemplate();
+                }
+            });
+
         QDialogButtonBox* buttons = new QDialogButtonBox();
         buttons->setObjectName("footer");
         vLayout->addWidget(buttons);
@@ -81,10 +116,8 @@ namespace O3DE::ProjectManager
             currentScreen->NotifyCurrentScreen();
         }
 
-        // Gather the gems from the project template. When we will have multiple project templates, we need to re-gather them
-        // on changing the template and let the user know that any further changes on top of the template will be lost.
-        QString projectTemplatePath = m_newProjectSettingsScreen->GetProjectTemplatePath();
-        m_gemCatalogScreen->ReinitForProject(projectTemplatePath + "/Template", /*isNewProject=*/true);
+        // Gather the enabled gems from the default project template when starting the create new project workflow.
+        ReinitGemCatalogForSelectedTemplate();
     }
 
     void CreateProjectCtrl::HandleBackButton()
@@ -223,4 +256,9 @@ namespace O3DE::ProjectManager
         }
     }
 
+    void CreateProjectCtrl::ReinitGemCatalogForSelectedTemplate()
+    {
+        const QString projectTemplatePath = m_newProjectSettingsScreen->GetProjectTemplatePath();
+        m_gemCatalogScreen->ReinitForProject(projectTemplatePath + "/Template", /*isNewProject=*/true);
+    }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/CreateProjectCtrl.h
+++ b/Code/Tools/ProjectManager/Source/CreateProjectCtrl.h
@@ -40,6 +40,7 @@ namespace O3DE::ProjectManager
 #ifdef TEMPLATE_GEM_CONFIGURATION_ENABLED
         void OnChangeScreenRequest(ProjectManagerScreen screen);
         void HandleSecondaryButton();
+        void ReinitGemCatalogForSelectedTemplate();
 #endif // TEMPLATE_GEM_CONFIGURATION_ENABLED
 
     private:

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -30,6 +30,8 @@ namespace O3DE::ProjectManager
         void ReinitForProject(const QString& projectPath, bool isNewProject);
         bool EnableDisableGemsForProject(const QString& projectPath);
 
+        GemModel* GetGemModel() const { return m_gemModel; }
+
     private:
         void FillModel(const QString& projectPath, bool isNewProject);
 

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.h
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.h
@@ -22,6 +22,8 @@ namespace O3DE::ProjectManager
     class NewProjectSettingsScreen
         : public ProjectSettingsScreen
     {
+        Q_OBJECT
+
     public:
         explicit NewProjectSettingsScreen(QWidget* parent = nullptr);
         ~NewProjectSettingsScreen() = default;
@@ -30,6 +32,11 @@ namespace O3DE::ProjectManager
         QString GetProjectTemplatePath();
 
         void NotifyCurrentScreen() override;
+
+        void SelectProjectTemplate(int index, bool blockSignals = false);
+
+    signals:
+        void OnTemplateSelectionChanged(int oldIndex, int newIndex);
 
     private:
         QString GetDefaultProjectPath();
@@ -41,6 +48,7 @@ namespace O3DE::ProjectManager
         QLabel* m_templateSummary;
         TagContainerWidget* m_templateIncludedGems;
         QVector<ProjectTemplateInfo> m_templates;
+        int m_selectedTemplateIndex = -1;
 
         inline constexpr static int s_spacerSize = 20;
         inline constexpr static int s_templateDetailsContentMargin = 20;


### PR DESCRIPTION
* When there are multiple project templates present, we re-gather the gems when changing the selected the project template.
* In case the user enabled or disabled any gem and they select a new project template, we show a warning dialog where users can either cancel the operation or proceed to the new project template. The warning dialog will only appear in case the enabled gems actually differ from the currently used template's default.
* New helper function to select the used project template.
* Storing the currently used project template index and only update the template details and emitting the changed event in case the user has actually chosen another template. This avoids emitting signals in case the user clicks on the already selected template.

![EnabledGemsTemplate_org](https://user-images.githubusercontent.com/43751992/124146560-2c659c80-da8e-11eb-8409-7022e088e955.gif)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>