### PR TITLE
Switch directional light to use the same reformulation as projected s…

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/DepthExponentiation.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/DepthExponentiation.pass
@@ -54,7 +54,7 @@
                         "Attachment": "Depth"
                     },
                     "ImageDescriptor": {
-                        "Format": "R32_FLOAT"
+                        "Format": "R16_FLOAT"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/Passes/FilterDepthVertical.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/FilterDepthVertical.pass
@@ -54,7 +54,7 @@
                         "Attachment": "Input"
                     },
                     "ImageDescriptor": {
-                        "Format": "R32_FLOAT"
+                        "Format": "R16_FLOAT"
                     }
                 }
             ],

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -356,8 +356,9 @@ float DirectionalLightShadow::GetVisibilityFromLightEsm()
         {
             const float distanceWithinCameraView = depthDiff / (1. - distanceMin);
             const float3 coord = float3(shadowCoord.xy, indexOfCascade);
-            const float expDepthInShadowmap = expShadowmap.Sample(PassSrg::LinearSampler, coord).r;
-            const float ratio = exp(-EsmExponentialShift * distanceWithinCameraView) * expDepthInShadowmap;
+            const float occluder = expShadowmap.Sample(PassSrg::LinearSampler, coord).r;                        
+            const float exponent = -EsmExponentialShift * (distanceWithinCameraView - occluder);
+            const float ratio = exp(exponent);
 
             m_debugInfo.m_cascadeIndex = indexOfCascade;
             return saturate(ratio);
@@ -385,8 +386,9 @@ float DirectionalLightShadow::GetVisibilityFromLightEsmPcf()
         {
             const float distanceWithinCameraView = depthDiff / (1. - distanceMin);
             const float3 coord = float3(shadowCoord.xy, indexOfCascade);
-            const float expDepthInShadowmap = expShadowmap.Sample(PassSrg::LinearSampler, coord).r;
-            float ratio = exp(-EsmExponentialShift * distanceWithinCameraView) * expDepthInShadowmap;
+            const float occluder = expShadowmap.Sample(PassSrg::LinearSampler, coord).r;
+            const float exponent = -EsmExponentialShift * (distanceWithinCameraView - occluder);
+            float ratio = exp(exponent);
 
             static const float pcfFallbackThreshold = 1.04;
             if (ratio > pcfFallbackThreshold)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.azsl
@@ -63,12 +63,7 @@ void MainCS(uint3 dispatchId: SV_DispatchThreadID)
             // So this converts it to "depth" to emphasize the difference
             // within the frustum.
             const float depth = (depthInClip - distanceMin) / (1. - distanceMin);
-
-            // Todo: Expose Esm exponent slider for directional lights
-            // This would remove the exp calculation below, collapsing it into a subtraction in DirectionalLightShadow.azsli
-            // ATOM-15775
-            const float outValue = exp(EsmExponentialShift * depth);
-            PassSrg::m_outputShadowmap[dispatchId].r = outValue;
+            PassSrg::m_outputShadowmap[dispatchId].r = depth;
             break;
         }
         case ShadowmapLightType::Spot:


### PR DESCRIPTION
Switch to using 16-bit floating point targets for ESM instead of 32-bit. This is doable because by storing viewspace depth instead of exp(depth) so we can get away with less precision

Small perf boost (0.5-1 ms on deadhaus on nvidia and 1-2 ms on amd)

Tested asv
Tested the deadhaus sonata level
Tested ESM in the editor with very large spotlights set far away and also the sun (Directional light)

Inspired by https://advances.realtimerendering.com/s2009/SIGGRAPH%202009%20-%20Lighting%20Research%20at%20Bungie.pdf
(Lighting Research at Bungie)

ATOM-15855
