### PR TITLE
[ATOM-15926] Fixing light delegates attenuation radius

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/CapsuleLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/CapsuleLightDelegate.cpp
@@ -69,7 +69,7 @@ namespace AZ
             if (isSelected)
             {
                 // Attenuation radius shape is just a capsule with the same internal height, but a radius of the attenuation radius.
-                float radius = CalculateAttenuationRadius(AreaLightComponentConfig::CutoffIntensity);
+                float radius = GetConfig()->m_attenuationRadius;
 
                 // Add on the caps for the attenuation radius
                 float scale = GetTransform().GetUniformScale();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/PolygonLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/PolygonLightDelegate.cpp
@@ -79,7 +79,7 @@ namespace AZ
                 debugDisplay.SetColor(color);
 
                 // Draw a Polygon for the attenuation radius
-                debugDisplay.DrawWireSphere(transform.GetTranslation(), CalculateAttenuationRadius(AreaLightComponentConfig::CutoffIntensity));
+                debugDisplay.DrawWireSphere(transform.GetTranslation(), GetConfig()->m_attenuationRadius);
                 debugDisplay.DrawArrow(transform.GetTranslation(), transform.GetTranslation() + transform.GetBasisZ());
             }
         }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/QuadLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/QuadLightDelegate.cpp
@@ -65,7 +65,7 @@ namespace AZ
                 debugDisplay.SetColor(color);
 
                 // Draw a quad for the attenuation radius
-                debugDisplay.DrawWireSphere(transform.GetTranslation(), CalculateAttenuationRadius(AreaLightComponentConfig::CutoffIntensity));
+                debugDisplay.DrawWireSphere(transform.GetTranslation(), GetConfig()->m_attenuationRadius);
             }
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimplePointLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SimplePointLightDelegate.cpp
@@ -48,9 +48,9 @@ namespace AZ
             if (isSelected)
             {
                 debugDisplay.SetColor(color);
-
+                
                 // Draw a sphere for the attenuation radius
-                debugDisplay.DrawWireSphere(transform.GetTranslation(), CalculateAttenuationRadius(AreaLightComponentConfig::CutoffIntensity));
+                debugDisplay.DrawWireSphere(transform.GetTranslation(), GetConfig()->m_attenuationRadius);
             }
         }
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.cpp
@@ -53,9 +53,9 @@ namespace AZ
             if (isSelected)
             {
                 debugDisplay.SetColor(color);
-
+                
                 // Draw a sphere for the attenuation radius
-                debugDisplay.DrawWireSphere(transform.GetTranslation(), CalculateAttenuationRadius(AreaLightComponentConfig::CutoffIntensity));
+                debugDisplay.DrawWireSphere(transform.GetTranslation(), GetConfig()->m_attenuationRadius);
             }
         }
 


### PR DESCRIPTION
Light delegates were always calculating the attenuation radius automatically for their debug display instead of respecting the user-set attenuation radius.

Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>