### PR TITLE
The lrelease qt library depends on the QtCore framework which is located in the 3rdParty Qt package.

### DIFF
--- a/Gems/LmbrCentral/Code/Platform/Mac/lrelease_mac.cmake
+++ b/Gems/LmbrCentral/Code/Platform/Mac/lrelease_mac.cmake
@@ -5,6 +5,15 @@
 #
 #
 
+add_custom_command(TARGET LmbrCentral.Editor POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -P "${LY_ROOT_FOLDER}/cmake/Platform/Mac/RPathChange.cmake"
+            "$<TARGET_FILE_DIR:LmbrCentral.Editor>/lrelease"
+            "@loader_path/../lib"
+            "${QT_PATH}/lib"
+    COMMENT "Patching lrelease..."
+    VERBATIM
+)
+
 set(lrelease_files
     ${QT_LRELEASE_EXECUTABLE}
 )


### PR DESCRIPTION
This fixes an asset processing failure on Mac when running AssetProcessorBatch. This issue does not occur when running AssetProcessor GUI bundle because fixup_bundle() fixes the rpath for the lrelease executable that is placed into the bundle.