### PR TITLE
Project Manager: Made Intial Startup Screen Text More Exciting!

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -86,7 +86,7 @@ namespace O3DE::ProjectManager
             layout->setAlignment(Qt::AlignTop);
             frame->setLayout(layout);
 
-            QLabel* titleLabel = new QLabel(tr("Ready. Set. Create."), this);
+            QLabel* titleLabel = new QLabel(tr("Ready? Set. Create!"), this);
             titleLabel->setObjectName("titleLabel");
             layout->addWidget(titleLabel);
 


### PR DESCRIPTION
Change came from the UX design but never ended up getting ported over.
![124044907-57cf8500-d9c3-11eb-80ed-f6c20ca1e519](https://user-images.githubusercontent.com/52797929/124202658-ad716380-da8f-11eb-88e9-acca6a11f6b5.JPG)
