### PR TITLE
[ATOM-15876] fixed subsurface scattering on vulkan

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/DetailMapsInput.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/MaterialInputs/DetailMapsInput.azsli
@@ -33,7 +33,12 @@ bool m_detail_normal_flipX;                   \
 bool m_detail_normal_flipY;                   \
                                               \
 float3x3 m_detailUvMatrix;                    \
-float3x3 m_detailUvMatrixInverse;
+float4   m_detailUvMatrixPad;                 \
+float3x3 m_detailUvMatrixInverse;             \
+float4   m_detailUvMatrixInversePad;
+
+// [GFX TODO][ATOM-14595] m_detailUvMatrixPad and m_detailUvMatrixInversePad are a workaround for a data stomping bug.
+// Remove them once the bug is fixed.
 
 
 #define COMMON_OPTIONS_DETAIL_MAPS(prefix)   \


### PR DESCRIPTION
Material SRG was missing padding around two float3x3 matrices, adding the padding fixed subsurface scattering on vulkan.