### PR TITLE
[LYN-4393] As a dev I want to Enable Gems in O3DE.exe with Keyboard

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -131,6 +131,17 @@ namespace O3DE::ProjectManager
             return false;
         }
 
+        if (event->type() == QEvent::KeyPress)
+        {
+            auto keyEvent = static_cast<const QKeyEvent*>(event);
+            if (keyEvent->key() == Qt::Key_Space)
+            {
+                const bool isAdded = GemModel::IsAdded(modelIndex);
+                GemModel::SetIsAdded(*model, modelIndex, !isAdded);
+                return true;
+            }
+        }
+
         if (event->type() == QEvent::MouseButtonPress)
         {
             QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);


### PR DESCRIPTION
Enabling and disabling the selected gem is now possible by pressing the space bar.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>