### PR TITLE
Update 3p CDN to https

### DIFF
--- a/cmake/3rdPartyPackages.cmake
+++ b/cmake/3rdPartyPackages.cmake
@@ -28,7 +28,7 @@ include(cmake/LySet.cmake)
 # also allowed:
 # "s3://bucketname" (it will use LYPackage_S3Downloader.cmake to download it from a s3 bucket)
 
-set(LY_PACKAGE_SERVER_URLS "http://d3t6xeg4fgfoum.cloudfront.net" CACHE STRING "Server URLS to fetch packages from")
+set(LY_PACKAGE_SERVER_URLS "https://d3t6xeg4fgfoum.cloudfront.net" CACHE STRING "Server URLS to fetch packages from")
 # Note: if you define the "LY_PACKAGE_SERVER_URLS" environment variable
 # it will be added to this value in the front, so that users can set
 # an env var and use that as an "additional" set of servers beyond the default set.


### PR DESCRIPTION
Mostly cosmetic, Cloudfront forwards http to https