### PR TITLE
Fixing alpha affects specular showing up when the alpha mode is opaque or cut-out

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
@@ -82,6 +82,12 @@ function ProcessEditor(context)
     context:SetMaterialPropertyVisibility("opacity.factor", mainVisibility)
     context:SetMaterialPropertyVisibility("opacity.doubleSided", mainVisibility)
 
+    if(opacityMode == OpacityMode_Blended or opacityMode == OpacityMode_TintedTransparent) then
+        context:SetMaterialPropertyVisibility("opacity.alphaAffectsSpecular", MaterialPropertyVisibility_Enabled)
+    else
+        context:SetMaterialPropertyVisibility("opacity.alphaAffectsSpecular", MaterialPropertyVisibility_Hidden)
+    end
+
     if(mainVisibility == MaterialPropertyVisibility_Enabled) then
         local alphaSource = context:GetMaterialPropertyValue_enum("opacity.alphaSource")
 


### PR DESCRIPTION
It should only be available when mode is blended or tinted transparent.

Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>