### PR TITLE
{LYN-4456} FIX: assign branch token for LegacyTestAdapter

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzCore/IO/FileIOEventBus.h>
+#include <AzCore/Utils/Utils.h>
 
 #include "BaseAssetProcessorTest.h"
 #include <native/utilities/BatchApplicationManager.h>
@@ -67,11 +68,19 @@ namespace AssetProcessor
             static char** paramStringArray = &namePtr;
 
             auto registry = AZ::SettingsRegistry::Get();
-            auto projectPathKey =
-                AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey) + "/project_path";
+            auto bootstrapKey = AZ::SettingsRegistryInterface::FixedValueString(AZ::SettingsRegistryMergeUtils::BootstrapSettingsRootKey);
+            auto projectPathKey = bootstrapKey + "/project_path";
             registry->Set(projectPathKey, "AutomatedTesting");
             AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_AddRuntimeFilePaths(*registry);
-            
+
+            // Forcing the branch token into settings registry before starting the application manager.
+            // This avoids writing the asset_processor.setreg file which can cause fileIO errors.
+            AZ::IO::FixedMaxPathString enginePath = AZ::Utils::GetEnginePath();
+            auto branchTokenKey = bootstrapKey + "/assetProcessor_branch_token";
+            AZStd::string token;
+            AzFramework::StringFunc::AssetPath::CalculateBranchToken(enginePath.c_str(), token);
+            registry->Set(branchTokenKey, token.c_str());
+
             m_application.reset(new UnitTestAppManager(&numParams, &paramStringArray));
             ASSERT_EQ(m_application->BeforeRun(), ApplicationManager::Status_Success);
             ASSERT_TRUE(m_application->PrepareForTests());


### PR DESCRIPTION
* fixes AssetProcessorManagerUnitTests unexpectedly fails due to writing out the branch token
* instead, the branch token is calculated ahead of time and added to the settings registry

Tests: --gtest_filter=Test/LegacyTestAdapter.*