### PR TITLE
[ATOM-15682] Initial CPU Visualizer widget

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
@@ -229,6 +229,7 @@ namespace AZ
             {
                 m_clearContainers = false;
 
+                m_stackLevel = 0;
                 m_cachedTimeRegionMap.clear();
                 m_timeRegionStack.clear();
                 m_cachedTimeRegions.clear();

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -214,7 +214,7 @@ namespace AZ
             {
                 AZ_PROFILE_SCOPE(AZ::Debug::ProfileCategory::AzRender, "main per-frame work");
                 m_frameScheduler.BeginFrame();
-                
+
                 frameGraphCallback(m_frameScheduler);
 
                 /**

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -214,7 +214,7 @@ namespace AZ
             {
                 AZ_PROFILE_SCOPE(AZ::Debug::ProfileCategory::AzRender, "main per-frame work");
                 m_frameScheduler.BeginFrame();
-
+                
                 frameGraphCallback(m_frameScheduler);
 
                 /**

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -47,7 +47,8 @@ namespace AZ
         //! It uses ImGui as the library for displaying the Attachments and Heaps.
         //! It shows all heaps that are being used by the RHI and how the
         //! resources are allocated in each heap.
-        class ImGuiCpuProfiler : SystemTickBus::Handler
+        class ImGuiCpuProfiler
+            : SystemTickBus::Handler
         {
             // Region Name -> Array of ThreadRegion entries
             using RegionEntryMap = AZStd::map<AZStd::string, AZStd::vector<ThreadRegionEntry>>;
@@ -68,6 +69,9 @@ namespace AZ
             void DrawVisualizer(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& currentCpuTimingStatistics);
 
         private:
+            static constexpr float RowHeight = 50.0;
+            static constexpr int DefaultFramesToCollect = 50;
+
             // Update the GroupRegionMap with the latest cached time regions
             void UpdateGroupRegionMap();
 
@@ -122,13 +126,13 @@ namespace AZ
             ImU32 GetBlockColor(const TimeRegion& block);
 
             // System tick bus overrides
-            virtual void OnSystemTick();
+            virtual void OnSystemTick() override;
 
             // Visualizer state
 
             bool m_showVisualizer = false;
 
-            int m_framesToCollect = 50;
+            int m_framesToCollect = DefaultFramesToCollect;
 
             // Tally of the number of saved profiling events so far
             u64 m_savedRegionCount = 0;
@@ -142,8 +146,6 @@ namespace AZ
 
             // Region color cache
             AZStd::unordered_map<const GroupRegionName*, ImVec4> m_regionColorMap;
-
-            static constexpr float RowHeight = 50.0;
 
             // Tracks the frame boundaries
             AZStd::vector<AZStd::sys_time_t> m_frameEndTicks = { INT64_MIN };

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -37,10 +37,10 @@ namespace AZ
             float CalcAverageTimeMs() const;
             void RecordRegion(const AZ::RHI::CachedTimeRegion& region);
 
-            bool m_draw;
+            bool m_draw = false;
             bool m_record = true;
-            u64 m_invocations;
-            AZStd::sys_time_t m_totalTicks;
+            u64 m_invocations = 0;
+            AZStd::sys_time_t m_totalTicks = 0;
         };
 
         //! Visual profiler for Cpu statistics.
@@ -64,6 +64,7 @@ namespace AZ
             //! Draws the provided Cpu statistics.
             void Draw(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
 
+            //! Draws the CPU profiling visualizer in a new window. 
             void DrawVisualizer(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& currentCpuTimingStatistics);
 
         private:
@@ -94,11 +95,12 @@ namespace AZ
             void CullFrameData(const AZ::RHI::CpuTimingStatistics& currentCpuTimingStatistics);
 
             // Draws a single block onto the timeline
-            void DrawBlock(const TimeRegion& block, u64 targetRow, AZStd::thread_id threadId);
+            void DrawBlock(const TimeRegion& block, u64 targetRow);
 
             // Draw horizontal lines between threads in the timeline
             void DrawThreadSeparator(u64 threadBoundary, u64 maxDepth);
 
+            // Draw the "Thread XXXXX" label onto the viewport
             void DrawThreadLabel(u64 baseRow, AZStd::thread_id threadId);
 
             // Draws all active function statistics windows
@@ -140,11 +142,11 @@ namespace AZ
             // Member variable to avoid repeated construction - could be expensive
             std::random_device m_rd;
 
-            // Fundamental data structure for storing TimeRegions, each individual vector is sorted by start tick
-            AZStd::map<AZStd::thread_id, AZStd::vector<TimeRegion>> m_savedData;
+            // Map to store each thread's TimeRegions, individual vectors are sorted by start tick
+            AZStd::unordered_map<AZStd::thread_id, AZStd::vector<TimeRegion>> m_savedData;
 
             // Region color cache
-            AZStd::map<const GroupRegionName*, ImVec4> m_regionColorMap;
+            AZStd::unordered_map<const GroupRegionName*, ImVec4> m_regionColorMap;
 
             static constexpr float RowHeight = 50.0;
 
@@ -153,8 +155,8 @@ namespace AZ
 
             // Main data structure for storing function statistics to be shown in the popup windows.
             // For now we default allocate for all regions on the first render frame and then use RegionStatistics.m_draw to determine
-            // if we should draw the window or not. FIXME this should be changed once RegionStatistics gets heavier. 
-            AZStd::map<const GroupRegionName*, RegionStatistics> m_regionStatisticsMap;
+            // if we should draw the window or not. FIXME(ATOM-15948) this should be changed once RegionStatistics gets heavier. 
+            AZStd::unordered_map<const GroupRegionName*, RegionStatistics> m_regionStatisticsMap;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -38,7 +38,7 @@ namespace AZ
             void RecordRegion(const AZ::RHI::CachedTimeRegion& region);
 
             bool m_draw;
-            bool m_record;
+            bool m_record = true;
             u64 m_invocations;
             AZStd::sys_time_t m_totalTicks;
         };
@@ -106,6 +106,9 @@ namespace AZ
 
             // Draw the vertical lines separating frames in the timeline
             void DrawFrameBoundaries();
+
+            // Draw the ruler with frame time labels
+            void DrawRuler();
 
             // Converts raw ticks to a pixel value suitable to give to ImDrawList, handles window scrolling
             float ConvertTickToPixelSpace(AZStd::sys_time_t tick) const;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/Math/Random.h>
 
 #include <Atom/RHI.Reflect/CpuTimingStatistics.h>
 #include <Atom/RHI/CpuProfiler.h>
 
-#include <random>
 
 namespace AZ
 {
@@ -47,7 +47,7 @@ namespace AZ
         //! It uses ImGui as the library for displaying the Attachments and Heaps.
         //! It shows all heaps that are being used by the RHI and how the
         //! resources are allocated in each heap.
-        class ImGuiCpuProfiler : TickBus::Handler
+        class ImGuiCpuProfiler : SystemTickBus::Handler
         {
             // Region Name -> Array of ThreadRegion entries
             using RegionEntryMap = AZStd::map<AZStd::string, AZStd::vector<ThreadRegionEntry>>;
@@ -121,9 +121,8 @@ namespace AZ
             // Generates a random ImU32 if the block does not yet have a color
             ImU32 GetBlockColor(const TimeRegion& block);
 
-            // Tick bus overrides
-            virtual void OnTick(float deltaTime, ScriptTimePoint time);
-            virtual int GetTickOrder();
+            // System tick bus overrides
+            virtual void OnSystemTick();
 
             // Visualizer state
 
@@ -137,10 +136,6 @@ namespace AZ
             // Viewport tick bounds, these are used to convert tick space -> screen space and cull so we only draw onscreen objects
             AZStd::sys_time_t m_viewportStartTick;
             AZStd::sys_time_t m_viewportEndTick;
-
-            // Used for random color generation
-            // Member variable to avoid repeated construction - could be expensive
-            std::random_device m_rd;
 
             // Map to store each thread's TimeRegions, individual vectors are sorted by start tick
             AZStd::unordered_map<AZStd::thread_id, AZStd::vector<TimeRegion>> m_savedData;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -761,7 +761,7 @@ namespace AZ
             return TICK_DEFAULT;
         }
 
-        // ----- RegionStatistics implementation ----
+        // ----- RegionStatistics implementation ----- 
         
         inline float RegionStatistics::CalcAverageTimeMs() const
         {

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -402,13 +402,18 @@ namespace AZ
                         }
                         else if (io.MouseWheel != 0 && io.KeyCtrl) // Zooming
                         {
+                            // We want zooming to be relative to the mouse's current position
                             const float mouseVel = io.MouseWheel;
+                            const float mouseX = ImGui::GetMousePos().x;
 
-                            const auto newStartTick =
-                                m_viewportStartTick + aznumeric_cast<AZStd::sys_time_t>(0.05 * io.MouseWheel * GetViewportTickWidth());
+                            // Find the normalized position of the cursor relative to the window
+                            const float percentWindow = (mouseX - ImGui::GetWindowPos().x) / ImGui::GetWindowWidth();
 
-                            const auto newEndTick =
-                                m_viewportEndTick - aznumeric_cast<AZStd::sys_time_t>(0.05 * io.MouseWheel * GetViewportTickWidth());
+                            const auto overallTickDelta = aznumeric_cast<AZStd::sys_time_t>(0.05 * io.MouseWheel * GetViewportTickWidth());
+
+                            // Split the overall delta between the two bounds depending on mouse pos
+                            const auto newStartTick = m_viewportStartTick + aznumeric_cast<AZStd::sys_time_t>(percentWindow * overallTickDelta);
+                            const auto newEndTick = m_viewportEndTick - aznumeric_cast<AZStd::sys_time_t>((1-percentWindow) * overallTickDelta);
 
                             // Avoid zooming too much, start tick should always be less than end tick
                             if (newStartTick < newEndTick)

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -504,7 +504,7 @@ namespace AZ
             }
         }
 
-        inline void ImGuiCpuProfiler::DrawBlock(const TimeRegion& block, u64 targetRow, AZStd::thread_id threadId)
+        inline void ImGuiCpuProfiler::DrawBlock(const TimeRegion& block, u64 targetRow, [[maybe_unused]] AZStd::thread_id threadId)
         {
             float wy = ImGui::GetWindowPos().y - ImGui::GetScrollY();
 
@@ -563,7 +563,6 @@ namespace AZ
 
                 ImGui::BeginTooltip();
                 ImGui::Text("%s::%s", block.m_groupRegionName->m_groupName, block.m_groupRegionName->m_regionName);
-                ImGui::Text("Thread %zu", static_cast<size_t>(threadId));
                 ImGui::Text("Execution time: %.3f ms", CpuProfilerImGuiHelper::TicksToMs(block.m_endTick - block.m_startTick));
                 ImGui::Text("%lld => %lld", block.m_startTick, block.m_endTick);
                 ImGui::EndTooltip();

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -294,8 +294,8 @@ namespace AZ
 
                     ImGui::Text("Viewport width: %.3f ms", CpuProfilerImGuiHelper::TicksToMs(GetViewportTickWidth()));
                     ImGui::Text("Recording %ld threads", RHI::CpuProfiler::Get()->GetTimeRegionMap().size());
-                    ImGui::Text("%ld profiling events saved", m_savedRegionCount);
-                    ImGui::Text("%ld => %ld", m_viewportStartTick, m_viewportEndTick);
+                    ImGui::Text("%llu profiling events saved", m_savedRegionCount);
+                    ImGui::Text("%lld => %lld", m_viewportStartTick, m_viewportEndTick);
 
                     ImGui::NextColumn();
 
@@ -563,9 +563,9 @@ namespace AZ
 
                 ImGui::BeginTooltip();
                 ImGui::Text("%s::%s", block.m_groupRegionName->m_groupName, block.m_groupRegionName->m_regionName);
-                ImGui::Text("Thread %lld", threadId);
+                ImGui::Text("Thread %zu", static_cast<size_t>(threadId));
                 ImGui::Text("Execution time: %.3f ms", CpuProfilerImGuiHelper::TicksToMs(block.m_endTick - block.m_startTick));
-                ImGui::Text("%ld => %ld", block.m_startTick, block.m_endTick);
+                ImGui::Text("%lld => %lld", block.m_startTick, block.m_endTick);
                 ImGui::EndTooltip();
             }
         }
@@ -622,7 +622,7 @@ namespace AZ
                         stat.m_record = !stat.m_record;
                     }
 
-                    ImGui::Text("Invocations: %ld", stat.m_invocations);
+                    ImGui::Text("Invocations: %llu", stat.m_invocations);
                     ImGui::Text("Average time: %.3f ms", stat.CalcAverageTimeMs());
 
                     ImGui::Separator();


### PR DESCRIPTION
This new profiling visualizer widget can be opened with a checkbox in the existing CPU profiler and is synced to the recording/paused state of that widget. The visualizer works well in both ASV and the editor when discrete input mode is on. Scrolling throughout time (horizontal) and through all of the recorded threads (vertical) is controlled by RMB and dragging the mouse. Zooming is currently bound to \<ctrl\> + mousewheel. Left clicking on a function block opens up the function statistics window, which has very basic aggregate information about the region across frames (which will be improved in future PRs).

Apologies about the big diff, most of it is just drawing-related code (converting "tick space" to pixel space) so it's not too involved. Had to lay the baseline first, future PRs will be more focused on a specific feature 😁

### Screenshots:
![image](https://user-images.githubusercontent.com/64656371/124523080-4fec5800-ddaa-11eb-8473-a21b939ca7b4.png)
![image](https://user-images.githubusercontent.com/64656371/124523121-84f8aa80-ddaa-11eb-975d-5dc96ef33cd0.png)


Known issues:
 - The last collected frame only has data from before the OnFrameBegin event, we should instead move to the CPU profiler updating its map when OnTick is broadcasted. 
 - The profiler reports empty data for threads that have been stopped (will include in another PR with above change) 
 - Frames to collect is not exact 
 
Tested on AtomTest @  `b59cc0c2d7d918c223e380d6a9bfa9ff54efe817`
and AtomSampleViewer @ `74a50636f3d0f66819f3f096421f075d128de714` 

Let me know if anyone has ideas for future features to include! Thanks 