### PR TITLE
Open editor button and new project and failed warnings.

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilderController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderController.cpp
@@ -92,10 +92,18 @@ namespace O3DE::ProjectManager
                     // Open application assigned to this file type
                     QDesktopServices::openUrl(QUrl("file:///" + m_worker->GetLogFilePath()));
                 }
+
+                m_projectInfo.m_buildFailed = true;
+                m_projectInfo.m_logUrl = QUrl("file:///" + m_worker->GetLogFilePath());
+                emit NotifyBuildProject(m_projectInfo);
             }
             else
             {
                 QMessageBox::critical(m_parent, tr("Project Failed to Build!"), result);
+
+                m_projectInfo.m_buildFailed = true;
+                m_projectInfo.m_logUrl = QUrl();
+                emit NotifyBuildProject(m_projectInfo);
             }
 
             emit Done(false);

--- a/Code/Tools/ProjectManager/Source/ProjectBuilderController.h
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderController.h
@@ -38,6 +38,7 @@ namespace O3DE::ProjectManager
 
     signals:
         void Done(bool success = true);
+        void NotifyBuildProject(const ProjectInfo& projectInfo);
 
     private:
         ProjectInfo m_projectInfo;

--- a/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
@@ -14,7 +14,7 @@
 
 namespace O3DE::ProjectManager
 {
-    const QString ProjectBuilderWorker::BuildCancelled = ProjectBuilderWorker::tr("Build Cancelled.");
+    const QString ProjectBuilderWorker::BuildCancelled = QObject::tr("Build Cancelled.");
 
     ProjectBuilderWorker::ProjectBuilderWorker(const ProjectInfo& projectInfo)
         : QObject()

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
@@ -20,6 +20,9 @@
 QT_FORWARD_DECLARE_CLASS(QPixmap)
 QT_FORWARD_DECLARE_CLASS(QAction)
 QT_FORWARD_DECLARE_CLASS(QProgressBar)
+QT_FORWARD_DECLARE_CLASS(QLayout)
+QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
+QT_FORWARD_DECLARE_CLASS(QEvent)
 
 namespace O3DE::ProjectManager
 {
@@ -34,21 +37,32 @@ namespace O3DE::ProjectManager
 
         void SetEnabled(bool enabled);
         void SetOverlayText(const QString& text);
+        void SetLogUrl(const QUrl& url);
 
         QLabel* GetOverlayLabel();
         QProgressBar* GetProgressBar();
+        QPushButton* GetOpenEditorButton();
         QPushButton* GetActionButton();
+        QLabel* GetWarningLabel();
+        QLabel* GetWarningIcon();
+        QLayout* GetBuildOverlayLayout();
 
     signals:
         void triggered();
 
     public slots:
         void mousePressEvent(QMouseEvent* event) override;
+        void OnLinkActivated(const QString& link);
 
     private:
+        QVBoxLayout* m_buildOverlayLayout;
         QLabel* m_overlayLabel;
         QProgressBar* m_progressBar;
+        QPushButton* m_openEditorButton;
         QPushButton* m_actionButton;
+        QLabel* m_warningText;
+        QLabel* m_warningIcon;
+        QUrl m_logUrl;
         bool m_enabled = true;
     };
 
@@ -63,6 +77,7 @@ namespace O3DE::ProjectManager
 
         void SetProjectButtonAction(const QString& text, AZStd::function<void()> lambda);
         void SetProjectBuildButtonAction();
+        void ShowBuildFailed(bool show, const QUrl& logUrl);
 
         void SetLaunchButtonEnabled(bool enabled);
         void SetButtonOverlayText(const QString& text);
@@ -81,11 +96,14 @@ namespace O3DE::ProjectManager
         void BaseSetup();
         void ProcessingSetup();
         void ReadySetup();
+        void enterEvent(QEvent* event) override;
+        void leaveEvent(QEvent* event) override;
         void BuildThisProject();
 
         ProjectInfo m_projectInfo;
         LabelButton* m_projectImageLabel;
         QFrame* m_projectFooter;
+        QLayout* m_requiresBuildLayout;
 
         QMetaObject::Connection m_actionButtonConnection;
     };

--- a/Code/Tools/ProjectManager/Source/ProjectInfo.h
+++ b/Code/Tools/ProjectManager/Source/ProjectInfo.h
@@ -9,6 +9,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzCore/Math/Uuid.h>
+#include <QUrl>
 #include <QString>
 #include <QStringList>
 #endif
@@ -54,5 +55,7 @@ namespace O3DE::ProjectManager
 
         // Used in project creation
         bool m_needsBuild = false; //! Does this project need to be built
+        bool m_buildFailed = false;
+        QUrl m_logUrl;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -193,7 +193,19 @@ namespace O3DE::ProjectManager
                     }
                     else if (RequiresBuildProjectIterator(project.m_path) != m_requiresBuild.end())
                     {
-                        projectButtonWidget->SetProjectBuildButtonAction();
+                        auto buildProjectIterator = RequiresBuildProjectIterator(project.m_path);
+                        if (buildProjectIterator != m_requiresBuild.end())
+                        {
+                            if (buildProjectIterator->m_buildFailed)
+                            {
+                                projectButtonWidget->ShowBuildFailed(true, buildProjectIterator->m_logUrl);
+                            }
+                            else
+                            {
+                                projectButtonWidget->SetProjectBuildButtonAction();
+                            }
+                        }
+                        
                     }
                 }
 
@@ -418,7 +430,7 @@ namespace O3DE::ProjectManager
 
     void ProjectsScreen::SuggestBuildProjectMsg(const ProjectInfo& projectInfo, bool showMessage)
     {
-        if (RequiresBuildProjectIterator(projectInfo.m_path) == m_requiresBuild.end())
+        if (RequiresBuildProjectIterator(projectInfo.m_path) == m_requiresBuild.end() || projectInfo.m_buildFailed)
         {
             m_requiresBuild.append(projectInfo);
         }
@@ -517,6 +529,7 @@ namespace O3DE::ProjectManager
                 m_currentBuilder = new ProjectBuilderController(projectInfo, nullptr, this);
                 ResetProjectsContent();
                 connect(m_currentBuilder, &ProjectBuilderController::Done, this, &ProjectsScreen::ProjectBuildDone);
+                connect(m_currentBuilder, &ProjectBuilderController::NotifyBuildProject, this, &ProjectsScreen::SuggestBuildProject);
 
                 m_currentBuilder->Start();
             }


### PR DESCRIPTION
NOTE: This is a re-post of https://github.com/o3de/o3de/pull/1671 to work around issues pushing with that branch. To save time the changes were recreated on a new branch off stabilization.

Added an open editor button and warnings when it is detected that the project should be built (new project/build failed).

![NewProjectProjectFailedDesign](https://user-images.githubusercontent.com/70403342/124335712-15877e80-db50-11eb-86bf-5f2482b886f4.jpg)

![OpenEditorButton](https://user-images.githubusercontent.com/70403342/124335717-191b0580-db50-11eb-87e3-02ddbc634376.PNG)

