### PR TITLE
[LYN-4439] Added tags to gem item delegate

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -99,7 +99,13 @@ namespace O3DE::ProjectManager
         painter->drawText(gemCreatorRect, Qt::TextSingleLine, gemCreator);
 
         // Gem summary
-        const QSize summarySize = QSize(contentRect.width() - s_summaryStartX - s_buttonWidth - s_itemMargins.right() * 3, contentRect.height());
+
+        // In case there are feature tags displayed at the bottom, decrease the size of the summary text field.
+        const QStringList featureTags = GemModel::GetFeatures(modelIndex);
+        const int summaryHeight = contentRect.height() - (!featureTags.empty() * 30);
+
+        const QSize summarySize = QSize(contentRect.width() - s_summaryStartX - s_buttonWidth - s_itemMargins.right() * 3,
+            summaryHeight);
         const QRect summaryRect = QRect(/*topLeft=*/QPoint(contentRect.left() + s_summaryStartX, contentRect.top()), summarySize);
 
         painter->setFont(standardFont);
@@ -108,9 +114,9 @@ namespace O3DE::ProjectManager
         const QString summary = GemModel::GetSummary(modelIndex);
         painter->drawText(summaryRect, Qt::AlignLeft | Qt::TextWordWrap, summary);
 
-
         DrawButton(painter, contentRect, modelIndex);
         DrawPlatformIcons(painter, contentRect, modelIndex);
+        DrawFeatureTags(painter, contentRect, featureTags, standardFont, summaryRect);
 
         painter->restore();
     }
@@ -203,6 +209,46 @@ namespace O3DE::ProjectManager
                     startX += s_platformIconSize * aspectRatio + s_platformIconSize / 2.5;
                 }
             }
+        }
+    }
+
+    void GemItemDelegate::DrawFeatureTags(QPainter* painter, const QRect& contentRect, const QStringList& featureTags, const QFont& standardFont, const QRect& summaryRect) const
+    {
+        QFont gemFeatureTagFont(standardFont);
+        gemFeatureTagFont.setPixelSize(s_featureTagFontSize);
+        gemFeatureTagFont.setBold(false);
+        painter->setFont(gemFeatureTagFont);
+
+        int x = s_summaryStartX;
+        for (const QString& featureTag : featureTags)
+        {
+            QRect featureTagRect = GetTextRect(gemFeatureTagFont, featureTag, s_featureTagFontSize);
+            featureTagRect.moveTo(contentRect.left() + x + s_featureTagBorderMarginX,
+                contentRect.top() + 47);
+            featureTagRect = painter->boundingRect(featureTagRect, Qt::TextSingleLine, featureTag);
+
+            QRect backgroundRect = featureTagRect;
+            backgroundRect = backgroundRect.adjusted(/*left=*/-s_featureTagBorderMarginX,
+                /*top=*/-s_featureTagBorderMarginY,
+                /*right=*/s_featureTagBorderMarginX,
+                /*bottom=*/s_featureTagBorderMarginY);
+
+            // Skip drawing all following feature tags as there is no more space available.
+            if (backgroundRect.right() > summaryRect.right())
+            {
+                break;
+            }
+
+            // Draw border.
+            painter->setPen(m_textColor);
+            painter->setBrush(Qt::NoBrush);
+            painter->drawRect(backgroundRect);
+
+            // Draw text within the border.
+            painter->setPen(m_textColor);
+            painter->drawText(featureTagRect, Qt::TextSingleLine, featureTag);
+
+            x += backgroundRect.width() + s_featureTagSpacing;
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.h
@@ -57,12 +57,19 @@ namespace O3DE::ProjectManager
         inline constexpr static int s_buttonCircleRadius = s_buttonBorderRadius - 2;
         inline constexpr static qreal s_buttonFontSize = 10.0;
 
+        // Feature tags
+        inline constexpr static int s_featureTagFontSize = 10;
+        inline constexpr static int s_featureTagBorderMarginX = 3;
+        inline constexpr static int s_featureTagBorderMarginY = 3;
+        inline constexpr static int s_featureTagSpacing = 7;
+
     protected:
         void CalcRects(const QStyleOptionViewItem& option, QRect& outFullRect, QRect& outItemRect, QRect& outContentRect) const;
         QRect GetTextRect(QFont& font, const QString& text, qreal fontSize) const;
         QRect CalcButtonRect(const QRect& contentRect) const;
         void DrawPlatformIcons(QPainter* painter, const QRect& contentRect, const QModelIndex& modelIndex) const;
         void DrawButton(QPainter* painter, const QRect& contentRect, const QModelIndex& modelIndex) const;
+        void DrawFeatureTags(QPainter* painter, const QRect& contentRect, const QStringList& featureTags, const QFont& standardFont, const QRect& summaryRect) const;
 
         QAbstractItemModel* m_model = nullptr;
 


### PR DESCRIPTION
* Added new helper function to draw the feature tags below the summary for each gem item.
* In case no feature tags belong to a gem, the available space will be used by the summary.

![image](https://user-images.githubusercontent.com/43751992/124489071-e1f75f00-ddb0-11eb-9fa7-a00273d8ca61.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>