### PR TITLE
Fix for rotation matching and resetting also scaling the entity transform

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -102,6 +102,7 @@
 AZ_CVAR(
     bool, ed_visibility_logTiming, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Output the timing of the new IVisibilitySystem query");
 AZ_CVAR(bool, ed_useNewCameraSystem, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Use the new Editor camera system");
+AZ_CVAR(bool, ed_showCursorCameraLook, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Show the cursor when using free look with the new camera system");
 
 namespace SandboxEditor
 {
@@ -1261,8 +1262,13 @@ AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateMod
             {
                 return SandboxEditor::CameraRotateSpeed();
             };
-            firstPersonRotateCamera->SetActivationBeganFn(hideCursor);
-            firstPersonRotateCamera->SetActivationEndedFn(showCursor);
+
+            if (!ed_showCursorCameraLook)
+            {
+                // default behavior is to hide the cursor but this can be disabled (useful for remote desktop)
+                firstPersonRotateCamera->SetActivationBeganFn(hideCursor);
+                firstPersonRotateCamera->SetActivationEndedFn(showCursor);
+            }
 
             auto firstPersonPanCamera =
                 AZStd::make_shared<AzFramework::PanCameraInput>(SandboxEditor::CameraFreePanChannelId(), AzFramework::LookPan);

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -33,6 +33,61 @@ namespace AzFramework
         return Dir[aznumeric_cast<int>(invert)];
     };
 
+    // maps a discrete motion input to a click detector click event (e.g. button down or up event)
+    static ClickDetector::ClickEvent ClickFromInput(const InputEvent& event, const AzFramework::InputChannelId& inputChannelId)
+    {
+        if (const auto& input = AZStd::get_if<DiscreteInputEvent>(&event))
+        {
+            if (input->m_channelId == inputChannelId)
+            {
+                if (input->m_state == InputChannel::State::Began)
+                {
+                    return ClickDetector::ClickEvent::Down;
+                }
+                else if (input->m_state == InputChannel::State::Ended)
+                {
+                    return ClickDetector::ClickEvent::Up;
+                }
+            }
+        }
+
+        return ClickDetector::ClickEvent::Nil;
+    }
+
+    // begins a camera input after a sufficient movement has occurred and ends a
+    // camera input once the initiating button is released
+    static void HandleActivationEvents(
+        const InputEvent& event,
+        const AzFramework::InputChannelId& inputChannelId,
+        const ScreenVector& cursorDelta,
+        ClickDetector& clickDetector,
+        CameraInput& cameraInput)
+    {
+        const auto clickEvent = ClickFromInput(event, inputChannelId);
+        switch (const auto outcome = clickDetector.DetectClick(clickEvent, cursorDelta); outcome)
+        {
+        case ClickDetector::ClickOutcome::Move:
+            cameraInput.BeginActivation();
+            break;
+        case ClickDetector::ClickOutcome::Release:
+            cameraInput.EndActivation();
+            break;
+        default:
+            // noop
+            break;
+        }
+    }
+
+    // returns true if a camera input is being updated after having been initiated from a
+    // motion input (e.g. mouse move while button held)
+    static bool CameraInputUpdatingAfterMotion(const CameraInput& cameraInput)
+    {
+        // note - must also check !ending to ensure the mouse up (release) event
+        // is not consumed and can be propagated to other systems.
+        // (don't swallow mouse up events)
+        return !cameraInput.Idle() && !cameraInput.Ending();
+    }
+
     // Based on paper by David Eberly - https://www.geometrictools.com/Documentation/EulerAngles.pdf
     AZ::Vector3 EulerAngles(const AZ::Matrix3x3& orientation)
     {
@@ -231,42 +286,8 @@ namespace AzFramework
 
     bool RotateCameraInput::HandleEvents(const InputEvent& event, const ScreenVector& cursorDelta, [[maybe_unused]] const float scrollDelta)
     {
-        const ClickDetector::ClickEvent clickEvent = [&event, this]
-        {
-            if (const auto& input = AZStd::get_if<DiscreteInputEvent>(&event))
-            {
-                if (input->m_channelId == m_rotateChannelId)
-                {
-                    if (input->m_state == InputChannel::State::Began)
-                    {
-                        return ClickDetector::ClickEvent::Down;
-                    }
-                    else if (input->m_state == InputChannel::State::Ended)
-                    {
-                        return ClickDetector::ClickEvent::Up;
-                    }
-                }
-            }
-            return ClickDetector::ClickEvent::Nil;
-        }();
-
-        switch (const auto outcome = m_clickDetector.DetectClick(clickEvent, cursorDelta); outcome)
-        {
-        case ClickDetector::ClickOutcome::Move:
-            BeginActivation();
-            break;
-        case ClickDetector::ClickOutcome::Release:
-            EndActivation();
-            break;
-        default:
-            // noop
-            break;
-        }
-
-        // note - must also check !ending to ensure the mouse up (release) event
-        // is not consumed and can be propagated to other systems.
-        // (don't swallow mouse up events)
-        return !Idle() && !Ending();
+        HandleActivationEvents(event, m_rotateChannelId, cursorDelta, m_clickDetector, *this);
+        return CameraInputUpdatingAfterMotion(*this);
     }
 
     Camera RotateCameraInput::StepCamera(
@@ -316,22 +337,8 @@ namespace AzFramework
     bool PanCameraInput::HandleEvents(
         const InputEvent& event, [[maybe_unused]] const ScreenVector& cursorDelta, [[maybe_unused]] const float scrollDelta)
     {
-        if (const auto& input = AZStd::get_if<DiscreteInputEvent>(&event))
-        {
-            if (input->m_channelId == m_panChannelId)
-            {
-                if (input->m_state == InputChannel::State::Began)
-                {
-                    BeginActivation();
-                }
-                else if (input->m_state == InputChannel::State::Ended)
-                {
-                    EndActivation();
-                }
-            }
-        }
-
-        return !Idle();
+        HandleActivationEvents(event, m_panChannelId, cursorDelta, m_clickDetector, *this);
+        return CameraInputUpdatingAfterMotion(*this);
     }
 
     Camera PanCameraInput::StepCamera(
@@ -638,22 +645,8 @@ namespace AzFramework
     bool OrbitDollyCursorMoveCameraInput::HandleEvents(
         const InputEvent& event, [[maybe_unused]] const ScreenVector& cursorDelta, [[maybe_unused]] const float scrollDelta)
     {
-        if (const auto& input = AZStd::get_if<DiscreteInputEvent>(&event))
-        {
-            if (input->m_channelId == m_dollyChannelId)
-            {
-                if (input->m_state == InputChannel::State::Began)
-                {
-                    BeginActivation();
-                }
-                else if (input->m_state == InputChannel::State::Ended)
-                {
-                    EndActivation();
-                }
-            }
-        }
-
-        return !Idle();
+        HandleActivationEvents(event, m_dollyChannelId, cursorDelta, m_clickDetector, *this);
+        return CameraInputUpdatingAfterMotion(*this);
     }
 
     Camera OrbitDollyCursorMoveCameraInput::StepCamera(

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -337,6 +337,7 @@ namespace AzFramework
     private:
         PanAxesFn m_panAxesFn; //!< Builder for the particular pan axes (provided in the constructor).
         InputChannelId m_panChannelId; //!< Input channel to begin the pan camera input.
+        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred to begin the input.
     };
 
     //! Axes to use while translating the camera.
@@ -489,7 +490,8 @@ namespace AzFramework
         AZStd::function<float()> m_cursorSpeedFn;
 
     private:
-        InputChannelId m_dollyChannelId;
+        InputChannelId m_dollyChannelId; //!< Input channel to begin the dolly cursor camera input.
+        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred to begin the input.
     };
 
     //! A camera input to handle discrete scroll events that can scroll (translate) the camera along its forward axis.

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -285,7 +285,8 @@ namespace AzFramework
 
     private:
         InputChannelId m_rotateChannelId; //!< Input channel to begin the rotate camera input.
-        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred to begin the input.
+        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred after an initial discrete input
+                                       //!< event has started (press and move event).
     };
 
     //! Axes to use while panning the camera.
@@ -337,7 +338,8 @@ namespace AzFramework
     private:
         PanAxesFn m_panAxesFn; //!< Builder for the particular pan axes (provided in the constructor).
         InputChannelId m_panChannelId; //!< Input channel to begin the pan camera input.
-        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred to begin the input.
+        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred after an initial discrete input
+                                       //!< event has started (press and move event).
     };
 
     //! Axes to use while translating the camera.
@@ -491,7 +493,8 @@ namespace AzFramework
 
     private:
         InputChannelId m_dollyChannelId; //!< Input channel to begin the dolly cursor camera input.
-        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred to begin the input.
+        ClickDetector m_clickDetector; //!< Used to determine when a sufficient motion delta has occurred after an initial discrete input
+                                       //!< event has started (press and move event).
     };
 
     //! A camera input to handle discrete scroll events that can scroll (translate) the camera along its forward axis.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -20,25 +20,19 @@ namespace AzToolsFramework
         if (mouseInteraction.m_mouseInteraction.m_mouseButtons.Right() &&
             mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Down)
         {
-            contextMenu.m_shouldOpen = true;
             contextMenu.m_clickPoint =
                 ViewportInteraction::QPointFromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
-        }
-
-        // disable shouldOpen if right clicking an moving the mouse
-        if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Move)
-        {
-            const QPoint currentScreenCoords =
-                ViewportInteraction::QPointFromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
-
-            contextMenu.m_shouldOpen = contextMenu.m_shouldOpen && (currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < 2;
         }
 
         // do show the context menu
         if (mouseInteraction.m_mouseInteraction.m_mouseButtons.Right() &&
             mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Up)
         {
-            if (contextMenu.m_shouldOpen)
+            const QPoint currentScreenCoords =
+                ViewportInteraction::QPointFromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
+
+            // if the mouse hasn't moved, open the pop-up menu
+            if ((currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < 2)
             {
                 QWidget* parent = nullptr;
                 ViewportInteraction::MainEditorViewportInteractionRequestBus::EventResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -5,9 +5,18 @@
  *
  */
 
+#include <AzCore/Console/IConsole.h>
 #include <AzToolsFramework/Viewport/EditorContextMenu.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <Editor/EditorContextMenuBus.h>
+
+AZ_CVAR(
+    int,
+    ed_contextMenuDisplayThreshold,
+    2,
+    nullptr,
+    AZ::ConsoleFunctorFlags::Null,
+    "The minimum 'Manhattan Distance' the mouse can move before the context menu will no longer trigger");
 
 namespace AzToolsFramework
 {
@@ -31,7 +40,7 @@ namespace AzToolsFramework
                 ViewportInteraction::QPointFromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
 
             // if the mouse hasn't moved, open the pop-up menu
-            if ((currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < 2)
+            if ((currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < ed_contextMenuDisplayThreshold)
             {
                 QWidget* parent = nullptr;
                 ViewportInteraction::MainEditorViewportInteractionRequestBus::EventResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -1,14 +1,13 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
 
-#include "EditorContextMenu.h"
-
-#include "AzToolsFramework/Viewport/ViewportMessages.h"
-#include "Editor/EditorContextMenuBus.h"
+#include <AzToolsFramework/Viewport/EditorContextMenu.h>
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
+#include <Editor/EditorContextMenuBus.h>
 
 namespace AzToolsFramework
 {
@@ -43,15 +42,16 @@ namespace AzToolsFramework
                 contextMenu.m_menu->setAttribute(Qt::WA_DeleteOnClose);
                 contextMenu.m_menu->setParent(parent);
 
-                // Populate global context menu.
+                // populate global context menu.
                 const int contextMenuFlag = 0;
-                AzToolsFramework::EditorContextMenuBus::Broadcast(&AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu, contextMenu.m_menu.data(),
+                AzToolsFramework::EditorContextMenuBus::Broadcast(
+                    &AzToolsFramework::EditorContextMenuEvents::PopulateEditorGlobalContextMenu, contextMenu.m_menu.data(),
                     AzFramework::Vector2FromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates),
                     contextMenuFlag);
 
                 if (!contextMenu.m_menu->isEmpty())
                 {
-                    // Use popup instead of exec; this avoids blocking input event processing while the menu dialog is active
+                    // use popup instead of exec; this avoids blocking input event processing while the menu dialog is active
                     contextMenu.m_menu->popup(QCursor::pos());
                 }
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <AzCore/std/smart_ptr/unique_ptr.h>
-
 #include <QMenu>
 #include <QPoint>
 #include <QPointer>
@@ -23,7 +21,6 @@ namespace AzToolsFramework
     //! State of when and where the right-click context menu should appear.
     struct EditorContextMenu final
     {
-        bool m_shouldOpen = false;
         QPoint m_clickPoint = QPoint(0, 0);
         QPointer<QMenu> m_menu;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -3097,17 +3097,10 @@ namespace AzToolsFramework
             // update orientations relative to initial
             for (AZ::EntityId entityId : manipulatorEntityIds.m_entityIds)
             {
-                ScopedUndoBatch::MarkEntityDirty(entityId);
-
-                const auto transformIt = transformsBefore.find(entityId);
-                if (transformIt != transformsBefore.end())
+                if (const auto transformIt = transformsBefore.find(entityId); transformIt != transformsBefore.end())
                 {
-                    AZ::Transform newWorldFromLocal = transformIt->second;
-                    const float scale = newWorldFromLocal.GetUniformScale();
-                    newWorldFromLocal.SetRotation(orientation);
-                    newWorldFromLocal *= AZ::Transform::CreateUniformScale(scale);
-
-                    SetEntityWorldTransform(entityId, newWorldFromLocal);
+                    ScopedUndoBatch::MarkEntityDirty(entityId);
+                    SetEntityLocalRotation(entityId, orientation);
                 }
             }
 
@@ -3733,6 +3726,11 @@ namespace AzToolsFramework
         ETCS::SetEntityLocalRotation(entityId, localRotation, m_transformChangedInternally);
     }
 
+    void EditorTransformComponentSelection::SetEntityLocalRotation(AZ::EntityId entityId, const AZ::Quaternion& localRotation)
+    {
+        ETCS::SetEntityLocalRotation(entityId, localRotation, m_transformChangedInternally);
+    }
+
     void EditorTransformComponentSelection::OnStartPlayInEditor()
     {
         SetAllViewportUiVisible(false);
@@ -3797,6 +3795,12 @@ namespace AzToolsFramework
         {
             ScopeSwitch sw(internal);
             AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetLocalRotation, localRotation);
+        }
+
+        void SetEntityLocalRotation(AZ::EntityId entityId, const AZ::Quaternion& localRotation, bool& internal)
+        {
+            ScopeSwitch sw(internal);
+            AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetLocalRotationQuaternion, localRotation);
         }
     } // namespace ETCS
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -297,6 +297,7 @@ namespace AzToolsFramework
         void SetEntityWorldTransform(AZ::EntityId entityId, const AZ::Transform& worldTransform);
         void SetEntityLocalScale(AZ::EntityId entityId, float localScale);
         void SetEntityLocalRotation(AZ::EntityId entityId, const AZ::Vector3& localRotation);
+        void SetEntityLocalRotation(AZ::EntityId entityId, const AZ::Quaternion& localRotation);
 
         //! Responsible for keeping the space cluster in sync with the current reference frame.
         void UpdateSpaceCluster(ReferenceFrame referenceFrame);
@@ -376,5 +377,6 @@ namespace AzToolsFramework
         void SetEntityWorldTransform(AZ::EntityId entityId, const AZ::Transform& worldTransform, bool& internal);
         void SetEntityLocalScale(AZ::EntityId entityId, float localScale, bool& internal);
         void SetEntityLocalRotation(AZ::EntityId entityId, const AZ::Vector3& localRotation, bool& internal);
+        void SetEntityLocalRotation(AZ::EntityId entityId, const AZ::Quaternion& localRotation, bool& internal);
     } // namespace ETCS
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -33,8 +33,6 @@
 #include <AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h>
 #include <AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.h>
 
-using namespace AzToolsFramework;
-
 namespace AZ
 {
     std::ostream& operator<<(std::ostream& os, const EntityId entityId)
@@ -66,9 +64,9 @@ namespace UnitTest
             m_cache.AddEntityIds(m_entityIds);
         }
 
-        EntityIdList m_entityIds;
+        AzToolsFramework::EntityIdList m_entityIds;
         AZ::EntityId m_layerId;
-        EditorVisibleEntityDataCache m_cache;
+        AzToolsFramework::EditorVisibleEntityDataCache m_cache;
     };
 
     TEST_F(EditorEntityVisibilityCacheFixture, LayerLockAffectsChildEntitiesInEditorEntityCache)
@@ -82,7 +80,7 @@ namespace UnitTest
         EXPECT_FALSE(m_cache.IsVisibleEntityLocked(m_cache.GetVisibleEntityIndexFromId(m_entityIds[2]).value()));
 
         // When
-        SetEntityLockState(m_layerId, true);
+        AzToolsFramework::SetEntityLockState(m_layerId, true);
 
         // Then
         EXPECT_TRUE(m_cache.IsVisibleEntityLocked(m_cache.GetVisibleEntityIndexFromId(m_entityIds[0]).value()));
@@ -101,7 +99,7 @@ namespace UnitTest
         EXPECT_TRUE(m_cache.IsVisibleEntityVisible(m_cache.GetVisibleEntityIndexFromId(m_entityIds[2]).value()));
 
         // When
-        SetEntityVisibility(m_layerId, false);
+        AzToolsFramework::SetEntityVisibility(m_layerId, false);
 
         // Then
         EXPECT_FALSE(m_cache.IsVisibleEntityVisible(m_cache.GetVisibleEntityIndexFromId(m_entityIds[0]).value()));
@@ -115,20 +113,20 @@ namespace UnitTest
     public:
         void SetUpEditorFixtureImpl() override
         {
-            m_entity1 = CreateDefaultEditorEntity("Entity1");
-            m_entityIds.push_back(m_entity1);
+            m_entityId1 = CreateDefaultEditorEntity("Entity1");
+            m_entityIds.push_back(m_entityId1);
         }
 
         void ArrangeIndividualRotatedEntitySelection(const AZ::Quaternion& orientation);
         AZStd::optional<AZ::Transform> GetManipulatorTransform() const;
-        void RefreshManipulators(EditorTransformComponentSelectionRequests::RefreshType refreshType);
-        void SetTransformMode(EditorTransformComponentSelectionRequests::Mode transformMode);
+        void RefreshManipulators(AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::RefreshType refreshType);
+        void SetTransformMode(AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::Mode transformMode);
         void OverrideManipulatorOrientation(const AZ::Quaternion& orientation);
         void OverrideManipulatorTranslation(const AZ::Vector3& translation);
 
     public:
-        AZ::EntityId m_entity1;
-        EntityIdList m_entityIds;
+        AZ::EntityId m_entityId1;
+        AzToolsFramework::EntityIdList m_entityIds;
     };
 
     void EditorTransformComponentSelectionFixture::ArrangeIndividualRotatedEntitySelection(const AZ::Quaternion& orientation)
@@ -141,34 +139,49 @@ namespace UnitTest
 
     AZStd::optional<AZ::Transform> EditorTransformComponentSelectionFixture::GetManipulatorTransform() const
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         AZStd::optional<AZ::Transform> manipulatorTransform;
         EditorTransformComponentSelectionRequestBus::EventResult(
-            manipulatorTransform, GetEntityContextId(), &EditorTransformComponentSelectionRequests::GetManipulatorTransform);
+            manipulatorTransform, AzToolsFramework::GetEntityContextId(),
+            &EditorTransformComponentSelectionRequestBus::Events::GetManipulatorTransform);
         return manipulatorTransform;
     }
 
-    void EditorTransformComponentSelectionFixture::RefreshManipulators(EditorTransformComponentSelectionRequests::RefreshType refreshType)
+    void EditorTransformComponentSelectionFixture::RefreshManipulators(
+        AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::RefreshType refreshType)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequests::RefreshManipulators, refreshType);
+            AzToolsFramework::GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::RefreshManipulators, refreshType);
     }
 
-    void EditorTransformComponentSelectionFixture::SetTransformMode(EditorTransformComponentSelectionRequests::Mode transformMode)
+    void EditorTransformComponentSelectionFixture::SetTransformMode(
+        AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::Mode transformMode)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequests::SetTransformMode, transformMode);
+            AzToolsFramework::GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::SetTransformMode, transformMode);
     }
 
     void EditorTransformComponentSelectionFixture::OverrideManipulatorOrientation(const AZ::Quaternion& orientation)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequests::OverrideManipulatorOrientation, orientation);
+            AzToolsFramework::GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::OverrideManipulatorOrientation,
+            orientation);
     }
 
     void EditorTransformComponentSelectionFixture::OverrideManipulatorTranslation(const AZ::Vector3& translation)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequests::OverrideManipulatorTranslation, translation);
+            AzToolsFramework::GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::OverrideManipulatorTranslation,
+            translation);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -176,14 +189,16 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionFixture, ManipulatorOrientationIsResetWhenEntityOrientationIsReset)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
-        AzToolsFramework::SelectEntity(m_entity1);
+        AzToolsFramework::SelectEntity(m_entityId1);
 
         ArrangeIndividualRotatedEntitySelection(AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)));
-        RefreshManipulators(EditorTransformComponentSelectionRequests::RefreshType::All);
+        RefreshManipulators(EditorTransformComponentSelectionRequestBus::Events::RefreshType::All);
 
-        SetTransformMode(EditorTransformComponentSelectionRequests::Mode::Rotation);
+        SetTransformMode(EditorTransformComponentSelectionRequestBus::Events::Mode::Rotation);
 
         const AZ::Transform manipulatorTransformBefore = GetManipulatorTransform().value_or(AZ::Transform::CreateIdentity());
 
@@ -220,9 +235,11 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionFixture, EntityOrientationRemainsConstantWhenOnlyManipulatorOrientationIsReset)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
-        AzToolsFramework::SelectEntity(m_entity1);
+        AzToolsFramework::SelectEntity(m_entityId1);
 
         const AZ::Quaternion initialEntityOrientation = AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f));
         ArrangeIndividualRotatedEntitySelection(initialEntityOrientation);
@@ -230,7 +247,7 @@ namespace UnitTest
         // assign new orientation to manipulator which does not match entity orientation
         OverrideManipulatorOrientation(AZ::Quaternion::CreateRotationZ(AZ::DegToRad(90.0f)));
 
-        SetTransformMode(EditorTransformComponentSelectionRequests::Mode::Rotation);
+        SetTransformMode(EditorTransformComponentSelectionRequestBus::Events::Mode::Rotation);
 
         const AZ::Transform manipulatorTransformBefore = GetManipulatorTransform().value_or(AZ::Transform::CreateIdentity());
 
@@ -266,6 +283,8 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionFixture, TestComponentPropertyNotificationIsSentAfterModifyingSlice)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         AUTO_RESULT_IF_SETTING_TRUE(UnitTest::prefabSystemSetting, true)
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -284,7 +303,7 @@ namespace UnitTest
         UnitTest::SliceAssets sliceAssets;
         const auto sliceAssetId = UnitTest::SaveAsSlice({ grandParent }, GetApplication(), sliceAssets);
 
-        EntityList instantiatedEntities = UnitTest::InstantiateSlice(sliceAssetId, sliceAssets);
+        AzToolsFramework::EntityList instantiatedEntities = UnitTest::InstantiateSlice(sliceAssetId, sliceAssets);
 
         const AZ::EntityId entityIdToMove = instantiatedEntities.back()->GetId();
         EditorEntityComponentChangeDetector editorEntityChangeDetector(entityIdToMove);
@@ -295,7 +314,8 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequests::CopyOrientationToSelectedEntitiesIndividual,
+            AzToolsFramework::GetEntityContextId(),
+            &EditorTransformComponentSelectionRequestBus::Events::CopyOrientationToSelectedEntitiesIndividual,
             AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisX(), AZ::DegToRad(90.0f)));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -307,6 +327,42 @@ namespace UnitTest
         UnitTest::DestroySlices(sliceAssets);
     }
 
+    TEST_F(EditorTransformComponentSelectionFixture, CopyOrientationToSelectedEntitiesIndividualDoesNotAffectScale)
+    {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+        using ::testing::FloatNear;
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Given
+        const auto expectedRotation = AZ::Quaternion::CreateFromAxisAngle(AZ::Vector3::CreateAxisZ(), AZ::DegToRad(45.0f));
+
+        AZ::TransformBus::Event(m_entityId1, &AZ::TransformBus::Events::SetWorldTranslation, AZ::Vector3::CreateAxisX(10.0f));
+        AZ::TransformBus::Event(m_entityId1, &AZ::TransformBus::Events::SetLocalUniformScale, 2.0f);
+        AZ::TransformBus::Event(m_entityId1, &AZ::TransformBus::Events::SetLocalRotationQuaternion, expectedRotation);
+
+        AzToolsFramework::SelectEntity(m_entityId1);
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // When
+        EditorTransformComponentSelectionRequestBus::Event(
+            AzToolsFramework::GetEntityContextId(),
+            &EditorTransformComponentSelectionRequestBus::Events::CopyOrientationToSelectedEntitiesIndividual, expectedRotation);
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        // Then
+        float scale = 0.0f;
+        AZ::Quaternion rotation = AZ::Quaternion::CreateIdentity();
+
+        AZ::TransformBus::EventResult(rotation, m_entityId1, &AZ::TransformBus::Events::GetLocalRotationQuaternion);
+        AZ::TransformBus::EventResult(scale, m_entityId1, &AZ::TransformBus::Events::GetLocalUniformScale);
+
+        EXPECT_THAT(rotation, IsClose(expectedRotation));
+        EXPECT_THAT(scale, FloatNear(2.0f, 0.001f));
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    }
+
     TEST_F(EditorTransformComponentSelectionFixture, InvertSelectionIgnoresLockedAndHiddenEntities)
     {
         using ::testing::UnorderedElementsAreArray;
@@ -314,7 +370,7 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
         // note: entity1 is created in the fixture setup
-        AzToolsFramework::SelectEntity(m_entity1);
+        AzToolsFramework::SelectEntity(m_entityId1);
 
         AZ::EntityId entity2 = CreateDefaultEditorEntity("Entity2");
         AZ::EntityId entity3 = CreateDefaultEditorEntity("Entity3");
@@ -322,8 +378,8 @@ namespace UnitTest
         AZ::EntityId entity5 = CreateDefaultEditorEntity("Entity5");
         AZ::EntityId entity6 = CreateDefaultEditorEntity("Entity6");
 
-        SetEntityVisibility(entity2, false);
-        SetEntityLockState(entity3, true);
+        AzToolsFramework::SetEntityVisibility(entity2, false);
+        AzToolsFramework::SetEntityLockState(entity3, true);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -335,7 +391,8 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
         AzToolsFramework::EntityIdList selectedEntities;
-        ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &ToolsApplicationRequestBus::Events::GetSelectedEntities);
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequestBus::Events::GetSelectedEntities);
 
         AzToolsFramework::EntityIdList expectedSelectedEntities = { entity4, entity5, entity6 };
 
@@ -355,8 +412,8 @@ namespace UnitTest
         AZ::EntityId entity5 = CreateDefaultEditorEntity("Entity5");
         AZ::EntityId entity6 = CreateDefaultEditorEntity("Entity6");
 
-        SetEntityVisibility(entity5, false);
-        SetEntityLockState(entity6, true);
+        AzToolsFramework::SetEntityVisibility(entity5, false);
+        AzToolsFramework::SetEntityLockState(entity6, true);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -368,9 +425,10 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
         AzToolsFramework::EntityIdList selectedEntities;
-        ToolsApplicationRequestBus::BroadcastResult(selectedEntities, &ToolsApplicationRequestBus::Events::GetSelectedEntities);
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntities, &AzToolsFramework::ToolsApplicationRequestBus::Events::GetSelectedEntities);
 
-        AzToolsFramework::EntityIdList expectedSelectedEntities = { m_entity1, entity2, entity3, entity4 };
+        AzToolsFramework::EntityIdList expectedSelectedEntities = { m_entityId1, entity2, entity3, entity4 };
 
         EXPECT_THAT(selectedEntities, UnorderedElementsAreArray(expectedSelectedEntities));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -392,13 +450,13 @@ namespace UnitTest
         const auto finalPositionScreen = AzFramework::WorldToScreen(finalTransformWorld.GetTranslation(), m_cameraState);
 
         // select the entity (this will cause the manipulators to appear in EditorTransformComponentSelection)
-        AzToolsFramework::SelectEntity(m_entity1);
+        AzToolsFramework::SelectEntity(m_entityId1);
         // move the entity to its starting position
-        AzToolsFramework::SetWorldTransform(m_entity1, initialTransformWorld);
+        AzToolsFramework::SetWorldTransform(m_entityId1, initialTransformWorld);
 
         // refresh the manipulators so that they update to the position of the entity
         // note: could skip this by selecting the entity after moving it but its useful to have this for reference
-        RefreshManipulators(EditorTransformComponentSelectionRequests::RefreshType::All);
+        RefreshManipulators(AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::RefreshType::All);
 
         // create an offset along the linear manipulator pointing along the x-axis (perpendicular to the camera view)
         const auto mouseOffsetOnManipulator = AzFramework::ScreenVector(10, 0);
@@ -414,7 +472,7 @@ namespace UnitTest
             ->MouseLButtonUp();
 
         // read back the position of the entity now
-        const AZ::Transform finalEntityTransform = AzToolsFramework::GetWorldTransform(m_entity1);
+        const AZ::Transform finalEntityTransform = AzToolsFramework::GetWorldTransform(m_entityId1);
 
         // ensure final world positions match
         EXPECT_TRUE(finalEntityTransform.IsClose(finalTransformWorld, 0.01f));
@@ -422,7 +480,7 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionManipulatorTestFixture, TranslatingEntityWithLinearManipulatorNotifiesOnEntityTransformChanged)
     {
-        EditorEntityComponentChangeDetector editorEntityChangeDetector(m_entity1);
+        EditorEntityComponentChangeDetector editorEntityChangeDetector(m_entityId1);
 
         // the initial starting position of the entity (in front and to the left of the camera)
         const auto initialTransformWorld = AZ::Transform::CreateTranslation(AZ::Vector3(-10.0f, 10.0f, 0.0f));
@@ -435,9 +493,9 @@ namespace UnitTest
         const auto finalPositionScreen = AzFramework::WorldToScreen(finalTransformWorld.GetTranslation(), m_cameraState);
 
         // move the entity to its starting position
-        AzToolsFramework::SetWorldTransform(m_entity1, initialTransformWorld);
+        AzToolsFramework::SetWorldTransform(m_entityId1, initialTransformWorld);
         // select the entity (this will cause the manipulators to appear in EditorTransformComponentSelection)
-        AzToolsFramework::SelectEntity(m_entity1);
+        AzToolsFramework::SelectEntity(m_entityId1);
 
         // create an offset along the linear manipulator pointing along the x-axis (perpendicular to the camera view)
         const auto mouseOffsetOnManipulator = AzFramework::ScreenVector(10, 0);
@@ -480,7 +538,7 @@ namespace UnitTest
 
             AzToolsFramework::EditorInteractionSystemViewportSelectionRequestBus::EventResult(
                 m_mouseInteractionResult, AzToolsFramework::GetEntityContextId(),
-                &EditorInteractionSystemViewportSelectionRequestBus::Events::InternalHandleAllMouseInteractions,
+                &AzToolsFramework::EditorInteractionSystemViewportSelectionRequestBus::Events::InternalHandleAllMouseInteractions,
                 vi::MouseInteractionEvent(mouseInteraction, ev->angleDelta().y()));
         }
 
@@ -491,18 +549,20 @@ namespace UnitTest
     {
         using ::testing::Eq;
         namespace vi = AzToolsFramework::ViewportInteraction;
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
 
         const auto transformMode = []()
         {
-            EditorTransformComponentSelectionRequests::Mode transformMode;
+            EditorTransformComponentSelectionRequestBus::Events::Mode transformMode;
             EditorTransformComponentSelectionRequestBus::EventResult(
-                transformMode, GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::GetTransformMode);
+                transformMode, AzToolsFramework::GetEntityContextId(),
+                &EditorTransformComponentSelectionRequestBus::Events::GetTransformMode);
             return transformMode;
         };
 
         // given
         // preconditions
-        EXPECT_THAT(transformMode(), EditorTransformComponentSelectionRequests::Mode::Translation);
+        EXPECT_THAT(transformMode(), EditorTransformComponentSelectionRequestBus::Events::Mode::Translation);
 
         auto wheelEventWidget = WheelEventWidget();
         // attach the global event filter to the placeholder widget
@@ -520,12 +580,13 @@ namespace UnitTest
 
         // then
         // transform mode has changed and mouse event was handled
-        EXPECT_THAT(transformMode(), Eq(EditorTransformComponentSelectionRequests::Mode::Rotation));
+        EXPECT_THAT(transformMode(), Eq(EditorTransformComponentSelectionRequestBus::Events::Mode::Rotation));
         EXPECT_THAT(wheelEventWidget.m_mouseInteractionResult, Eq(vi::MouseInteractionResult::Viewport));
     }
 
     TEST_F(EditorTransformComponentSelectionFixture, EntityPositionsCanBeSnappedToGrid)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
         using ::testing::Pointwise;
 
         m_entityIds.push_back(CreateDefaultEditorEntity("Entity2"));
@@ -540,14 +601,15 @@ namespace UnitTest
         AzToolsFramework::SelectEntities(m_entityIds);
 
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::SnapSelectedEntitiesToWorldGrid, 2.0f);
+            AzToolsFramework::GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::SnapSelectedEntitiesToWorldGrid,
+            2.0f);
 
         AZStd::vector<AZ::Vector3> entityPositionsAfterSnap;
         AZStd::transform(
             m_entityIds.cbegin(), m_entityIds.cend(), AZStd::back_inserter(entityPositionsAfterSnap),
             [](const AZ::EntityId& entityId)
             {
-                return GetWorldTranslation(entityId);
+                return AzToolsFramework::GetWorldTranslation(entityId);
             });
 
         const AZStd::vector<AZ::Vector3> expectedSnappedPositions = { AZ::Vector3(2.0f, 4.0f, 6.0f), AZ::Vector3(14.0f, 16.0f, 12.0f),
@@ -557,15 +619,18 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionFixture, ManipulatorStaysAlignedToEntityTranslationAfterSnap)
     {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
         const auto initialUnsnappedPosition = AZ::Vector3(1.2f, 3.5f, 6.7f);
         AZ::TransformBus::Event(m_entityIds[0], &AZ::TransformBus::Events::SetWorldTranslation, initialUnsnappedPosition);
 
         AzToolsFramework::SelectEntities(m_entityIds);
 
         EditorTransformComponentSelectionRequestBus::Event(
-            GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::SnapSelectedEntitiesToWorldGrid, 1.0f);
+            AzToolsFramework::GetEntityContextId(), &EditorTransformComponentSelectionRequestBus::Events::SnapSelectedEntitiesToWorldGrid,
+            1.0f);
 
-        const auto entityPositionAfterSnap = GetWorldTranslation(m_entity1);
+        const auto entityPositionAfterSnap = AzToolsFramework::GetWorldTranslation(m_entityId1);
         const AZ::Vector3 manipulatorPositionAfterSnap =
             GetManipulatorTransform().value_or(AZ::Transform::CreateIdentity()).GetTranslation();
 
@@ -578,7 +643,7 @@ namespace UnitTest
     // the reference frame, selection and entity hierarchy
     struct ReferenceFrameWithOrientation
     {
-        ReferenceFrame m_referenceFrame; // the input reference frame (Local/Parent/World)
+        AzToolsFramework::ReferenceFrame m_referenceFrame; // the input reference frame (Local/Parent/World)
         AZ::Quaternion m_orientation; // the orientation of the manipulator transform
     };
 
@@ -602,8 +667,8 @@ namespace UnitTest
 
     TEST_P(EditorTransformComponentSelectionSingleEntityPivotFixture, PivotOrientationMatchesReferenceFrameSingleEntity)
     {
-        using ETCS::CalculatePivotOrientation;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculatePivotOrientation;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -630,9 +695,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionSingleEntityPivotFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionSingleEntityWithParentPivotFixture
         : public EditorTransformComponentSelectionFixture
@@ -642,8 +707,8 @@ namespace UnitTest
 
     TEST_P(EditorTransformComponentSelectionSingleEntityWithParentPivotFixture, PivotOrientationMatchesReferenceFrameEntityWithParent)
     {
-        using ETCS::CalculatePivotOrientation;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculatePivotOrientation;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -679,9 +744,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionSingleEntityWithParentPivotFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, ParentExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, ParentExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionMultipleEntitiesPivotFixture
         : public EditorTransformComponentSelectionFixture
@@ -691,8 +756,8 @@ namespace UnitTest
 
     TEST_P(EditorTransformComponentSelectionMultipleEntitiesPivotFixture, PivotOrientationMatchesReferenceFrameMultipleEntities)
     {
-        using ETCS::CalculatePivotOrientationForEntityIds;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculatePivotOrientationForEntityIds;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -709,10 +774,11 @@ namespace UnitTest
         AZ::TransformBus::Event(
             m_entityIds[2], &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(AZ::Vector3::CreateAxisY(10.0f)));
 
+        using AzToolsFramework::EntityIdManipulatorLookup;
         // note: EntityIdManipulatorLookup{} is unused during this test
-        EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[1], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[2], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[1], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[2], EntityIdManipulatorLookup{} } };
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -735,9 +801,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionMultipleEntitiesPivotFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture
         : public EditorTransformComponentSelectionFixture
@@ -749,8 +815,8 @@ namespace UnitTest
         EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture,
         PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent)
     {
-        using ETCS::CalculatePivotOrientationForEntityIds;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculatePivotOrientationForEntityIds;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -771,10 +837,11 @@ namespace UnitTest
         AZ::TransformBus::Event(m_entityIds[1], &AZ::TransformBus::Events::SetParent, m_entityIds[0]);
         AZ::TransformBus::Event(m_entityIds[2], &AZ::TransformBus::Events::SetParent, m_entityIds[0]);
 
+        using AzToolsFramework::EntityIdManipulatorLookup;
         // note: EntityIdManipulatorLookup{} is unused during this test
         // only select second two entities that are children of m_entityIds[0]
-        EntityIdManipulatorLookups lookups{ { m_entityIds[1], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[2], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[1], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[2], EntityIdManipulatorLookup{} } };
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -797,9 +864,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, ParentExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, ParentExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, ParentExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, ParentExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture
         : public EditorTransformComponentSelectionFixture
@@ -811,8 +878,8 @@ namespace UnitTest
         EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture,
         PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent)
     {
-        using ETCS::CalculatePivotOrientationForEntityIds;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculatePivotOrientationForEntityIds;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -834,10 +901,11 @@ namespace UnitTest
         AZ::TransformBus::Event(m_entityIds[1], &AZ::TransformBus::Events::SetParent, m_entityIds[0]);
         AZ::TransformBus::Event(m_entityIds[2], &AZ::TransformBus::Events::SetParent, m_entityIds[3]);
 
+        using AzToolsFramework::EntityIdManipulatorLookup;
         // note: EntityIdManipulatorLookup{} is unused during this test
         // only select second two entities that are children of different m_entities
-        EntityIdManipulatorLookups lookups{ { m_entityIds[1], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[2], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[1], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[2], EntityIdManipulatorLookup{} } };
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -859,9 +927,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture
         : public EditorTransformComponentSelectionFixture
@@ -873,8 +941,8 @@ namespace UnitTest
         EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture,
         PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride)
     {
-        using ETCS::CalculateSelectionPivotOrientation;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculateSelectionPivotOrientation;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -887,10 +955,10 @@ namespace UnitTest
         // When
         const ReferenceFrameWithOrientation referenceFrameWithOrientation = GetParam();
 
-        EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[0], AzToolsFramework::EntityIdManipulatorLookup{} } };
 
         // set override frame (orientation only)
-        OptionalFrame optionalFrame;
+        AzToolsFramework::OptionalFrame optionalFrame;
         optionalFrame.m_orientationOverride = PivotOverrideLocalOrientationInWorldSpace;
 
         const PivotOrientationResult pivotResult =
@@ -909,9 +977,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, PivotOverrideLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, PivotOverrideLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture
         : public EditorTransformComponentSelectionFixture
@@ -923,8 +991,8 @@ namespace UnitTest
         EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture,
         PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride)
     {
-        using ETCS::CalculateSelectionPivotOrientation;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculateSelectionPivotOrientation;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -940,17 +1008,18 @@ namespace UnitTest
         AZ::TransformBus::Event(
             m_entityIds[2], &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(AZ::Vector3::CreateAxisY(10.0f)));
 
+        using AzToolsFramework::EntityIdManipulatorLookup;
         // note: EntityIdManipulatorLookup{} is unused during this test
-        EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[1], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[2], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[1], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[2], EntityIdManipulatorLookup{} } };
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         const ReferenceFrameWithOrientation referenceFrameWithOrientation = GetParam();
 
-        OptionalFrame optionalFrame;
+        AzToolsFramework::OptionalFrame optionalFrame;
         optionalFrame.m_orientationOverride = PivotOverrideLocalOrientationInWorldSpace;
 
         const PivotOrientationResult pivotResult =
@@ -968,9 +1037,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, PivotOverrideLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, PivotOverrideLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, PivotOverrideLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, PivotOverrideLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture
         : public EditorTransformComponentSelectionFixture
@@ -982,8 +1051,8 @@ namespace UnitTest
         EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture,
         PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride)
     {
-        using ETCS::CalculateSelectionPivotOrientation;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculateSelectionPivotOrientation;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -999,17 +1068,18 @@ namespace UnitTest
         AZ::TransformBus::Event(
             m_entityIds[2], &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(AZ::Vector3::CreateAxisY(10.0f)));
 
+        using AzToolsFramework::EntityIdManipulatorLookup;
         // note: EntityIdManipulatorLookup{} is unused during this test
-        EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[1], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[2], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[0], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[1], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[2], EntityIdManipulatorLookup{} } };
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         const ReferenceFrameWithOrientation referenceFrameWithOrientation = GetParam();
 
-        OptionalFrame optionalFrame;
+        AzToolsFramework::OptionalFrame optionalFrame;
         const PivotOrientationResult pivotResult =
             CalculateSelectionPivotOrientation(lookups, optionalFrame, referenceFrameWithOrientation.m_referenceFrame);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1025,9 +1095,9 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, AZ::Quaternion::CreateIdentity() },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture
         : public EditorTransformComponentSelectionFixture
@@ -1039,8 +1109,8 @@ namespace UnitTest
         EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture,
         PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride)
     {
-        using ETCS::CalculateSelectionPivotOrientation;
-        using ETCS::PivotOrientationResult;
+        using AzToolsFramework::ETCS::CalculateSelectionPivotOrientation;
+        using AzToolsFramework::ETCS::PivotOrientationResult;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Given
@@ -1061,16 +1131,17 @@ namespace UnitTest
         AZ::TransformBus::Event(m_entityIds[1], &AZ::TransformBus::Events::SetParent, m_entityIds[0]);
         AZ::TransformBus::Event(m_entityIds[2], &AZ::TransformBus::Events::SetParent, m_entityIds[0]);
 
+        using AzToolsFramework::EntityIdManipulatorLookup;
         // note: EntityIdManipulatorLookup{} is unused during this test
-        EntityIdManipulatorLookups lookups{ { m_entityIds[1], EntityIdManipulatorLookup{} },
-                                            { m_entityIds[2], EntityIdManipulatorLookup{} } };
+        AzToolsFramework::EntityIdManipulatorLookups lookups{ { m_entityIds[1], EntityIdManipulatorLookup{} },
+                                                              { m_entityIds[2], EntityIdManipulatorLookup{} } };
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         const ReferenceFrameWithOrientation referenceFrameWithOrientation = GetParam();
 
-        OptionalFrame optionalFrame;
+        AzToolsFramework::OptionalFrame optionalFrame;
         const PivotOrientationResult pivotResult =
             CalculateSelectionPivotOrientation(lookups, optionalFrame, referenceFrameWithOrientation.m_referenceFrame);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1087,40 +1158,40 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ ReferenceFrame::Local, ParentExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::Parent, ParentExpectedPivotLocalOrientationInWorldSpace },
-            ReferenceFrameWithOrientation{ ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, ParentExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, ParentExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 
     class EditorEntityModelVisibilityFixture
         : public ToolsApplicationFixture
-        , private EditorEntityVisibilityNotificationBus::Router
-        , private EditorEntityInfoNotificationBus::Handler
+        , private AzToolsFramework::EditorEntityVisibilityNotificationBus::Router
+        , private AzToolsFramework::EditorEntityInfoNotificationBus::Handler
     {
     public:
         void SetUpEditorFixtureImpl() override
         {
-            EditorEntityVisibilityNotificationBus::Router::BusRouterConnect();
-            EditorEntityInfoNotificationBus::Handler::BusConnect();
+            AzToolsFramework::EditorEntityVisibilityNotificationBus::Router::BusRouterConnect();
+            AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusConnect();
         }
 
         void TearDownEditorFixtureImpl() override
         {
-            EditorEntityInfoNotificationBus::Handler::BusDisconnect();
-            EditorEntityVisibilityNotificationBus::Router::BusRouterDisconnect();
+            AzToolsFramework::EditorEntityInfoNotificationBus::Handler::BusDisconnect();
+            AzToolsFramework::EditorEntityVisibilityNotificationBus::Router::BusRouterDisconnect();
         }
 
         bool m_entityInfoUpdatedVisibilityForLayer = false;
         AZ::EntityId m_layerId;
 
     private:
-        // EditorEntityVisibilityNotificationBus ...
-        void OnEntityVisibilityChanged(bool /*visibility*/) override
+        // EditorEntityVisibilityNotificationBus overrides ...
+        void OnEntityVisibilityChanged([[maybe_unused]] bool visibility) override
         {
             // for debug purposes
         }
 
-        // EditorEntityInfoNotificationBus ...
-        void OnEntityInfoUpdatedVisibility(AZ::EntityId entityId, bool /*visible*/) override
+        // EditorEntityInfoNotificationBus overrides ...
+        void OnEntityInfoUpdatedVisibility(AZ::EntityId entityId, [[maybe_unused]] bool visible) override
         {
             if (entityId == m_layerId)
             {
@@ -1148,26 +1219,26 @@ namespace UnitTest
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
-        SetEntityVisibility(a, false);
-        SetEntityVisibility(b, false);
-        SetEntityVisibility(c, false);
+        AzToolsFramework::SetEntityVisibility(a, false);
+        AzToolsFramework::SetEntityVisibility(b, false);
+        AzToolsFramework::SetEntityVisibility(c, false);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_FALSE(IsEntityVisible(a));
-        EXPECT_FALSE(IsEntityVisible(b));
-        EXPECT_FALSE(IsEntityVisible(c));
+        EXPECT_FALSE(AzToolsFramework::IsEntityVisible(a));
+        EXPECT_FALSE(AzToolsFramework::IsEntityVisible(b));
+        EXPECT_FALSE(AzToolsFramework::IsEntityVisible(c));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
-        SetEntityVisibility(m_layerId, false);
+        AzToolsFramework::SetEntityVisibility(m_layerId, false);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_FALSE(IsEntityVisible(m_layerId));
+        EXPECT_FALSE(AzToolsFramework::IsEntityVisible(m_layerId));
         EXPECT_TRUE(m_entityInfoUpdatedVisibilityForLayer);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -1176,7 +1247,7 @@ namespace UnitTest
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
-        SetEntityVisibility(m_layerId, true);
+        AzToolsFramework::SetEntityVisibility(m_layerId, true);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1224,60 +1295,60 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // hide top layer
-        SetEntityVisibility(m_layerId, false);
+        AzToolsFramework::SetEntityVisibility(m_layerId, false);
 
         // hide a and c (a and see are 'set' not to be visible and are not visible)
-        SetEntityVisibility(a, false);
-        SetEntityVisibility(c, false);
+        AzToolsFramework::SetEntityVisibility(a, false);
+        AzToolsFramework::SetEntityVisibility(c, false);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(!IsEntityVisible(a));
-        EXPECT_TRUE(!IsEntitySetToBeVisible(a));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityVisible(a));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeVisible(a));
 
         // b will not be visible but is not 'set' to be hidden
-        EXPECT_TRUE(!IsEntityVisible(b));
-        EXPECT_TRUE(IsEntitySetToBeVisible(b));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityVisible(b));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeVisible(b));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // same for nested layer
-        SetEntityVisibility(secondLayerId, false);
+        AzToolsFramework::SetEntityVisibility(secondLayerId, false);
 
-        SetEntityVisibility(d, false);
-        SetEntityVisibility(f, false);
+        AzToolsFramework::SetEntityVisibility(d, false);
+        AzToolsFramework::SetEntityVisibility(f, false);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(!IsEntityVisible(e));
-        EXPECT_TRUE(IsEntitySetToBeVisible(e));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityVisible(e));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeVisible(e));
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // set visibility of most nested entity to true
-        SetEntityVisibility(d, true);
+        AzToolsFramework::SetEntityVisibility(d, true);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(IsEntitySetToBeVisible(m_layerId));
-        EXPECT_TRUE(IsEntitySetToBeVisible(secondLayerId));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeVisible(m_layerId));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeVisible(secondLayerId));
 
         // a will still be set to be not visible and won't be visible as parent layer is now visible
-        EXPECT_TRUE(!IsEntitySetToBeVisible(a));
-        EXPECT_TRUE(!IsEntityVisible(a));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeVisible(a));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityVisible(a));
 
         // b will now be visible as it was not individually
         // set to be visible and the parent layer is now visible
-        EXPECT_TRUE(IsEntitySetToBeVisible(b));
-        EXPECT_TRUE(IsEntityVisible(b));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeVisible(b));
+        EXPECT_TRUE(AzToolsFramework::IsEntityVisible(b));
 
         // same story for e as for b
-        EXPECT_TRUE(IsEntitySetToBeVisible(e));
-        EXPECT_TRUE(IsEntityVisible(e));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeVisible(e));
+        EXPECT_TRUE(AzToolsFramework::IsEntityVisible(e));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     }
 
@@ -1320,60 +1391,60 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // lock top layer
-        SetEntityLockState(m_layerId, true);
+        AzToolsFramework::SetEntityLockState(m_layerId, true);
 
         // lock a and c (a and see are 'set' not to be visible and are not visible)
-        SetEntityLockState(a, true);
-        SetEntityLockState(c, true);
+        AzToolsFramework::SetEntityLockState(a, true);
+        AzToolsFramework::SetEntityLockState(c, true);
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(IsEntityLocked(a));
-        EXPECT_TRUE(IsEntitySetToBeLocked(a));
+        EXPECT_TRUE(AzToolsFramework::IsEntityLocked(a));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeLocked(a));
 
         // b will be locked but is not 'set' to be locked
-        EXPECT_TRUE(IsEntityLocked(b));
-        EXPECT_TRUE(!IsEntitySetToBeLocked(b));
+        EXPECT_TRUE(AzToolsFramework::IsEntityLocked(b));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeLocked(b));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // same for nested layer
-        SetEntityLockState(secondLayerId, true);
+        AzToolsFramework::SetEntityLockState(secondLayerId, true);
 
-        SetEntityLockState(d, true);
-        SetEntityLockState(f, true);
+        AzToolsFramework::SetEntityLockState(d, true);
+        AzToolsFramework::SetEntityLockState(f, true);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(IsEntityLocked(e));
-        EXPECT_TRUE(!IsEntitySetToBeLocked(e));
+        EXPECT_TRUE(AzToolsFramework::IsEntityLocked(e));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeLocked(e));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
         // set visibility of most nested entity to true
-        SetEntityLockState(d, false);
+        AzToolsFramework::SetEntityLockState(d, false);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(!IsEntitySetToBeLocked(m_layerId));
-        EXPECT_TRUE(!IsEntitySetToBeLocked(secondLayerId));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeLocked(m_layerId));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeLocked(secondLayerId));
 
         // a will still be set to be not visible and won't be visible as parent layer is now visible
-        EXPECT_TRUE(IsEntitySetToBeLocked(a));
-        EXPECT_TRUE(IsEntityLocked(a));
+        EXPECT_TRUE(AzToolsFramework::IsEntitySetToBeLocked(a));
+        EXPECT_TRUE(AzToolsFramework::IsEntityLocked(a));
 
         // b will now be visible as it was not individually
         // set to be visible and the parent layer is now visible
-        EXPECT_TRUE(!IsEntitySetToBeLocked(b));
-        EXPECT_TRUE(!IsEntityLocked(b));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeLocked(b));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityLocked(b));
 
         // same story for e as for b
-        EXPECT_TRUE(!IsEntitySetToBeLocked(e));
-        EXPECT_TRUE(!IsEntityLocked(e));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeLocked(e));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityLocked(e));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     }
 
@@ -1396,16 +1467,17 @@ namespace UnitTest
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // When
-        SetEntityVisibility(m_layerId, false);
+        AzToolsFramework::SetEntityVisibility(m_layerId, false);
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // Then
-        EXPECT_TRUE(!IsEntitySetToBeVisible(m_layerId));
-        EXPECT_TRUE(!IsEntityVisible(m_layerId));
+        EXPECT_TRUE(!AzToolsFramework::IsEntitySetToBeVisible(m_layerId));
+        EXPECT_TRUE(!AzToolsFramework::IsEntityVisible(m_layerId));
 
         bool flagSetVisible = false;
-        EditorVisibilityRequestBus::EventResult(flagSetVisible, m_layerId, &EditorVisibilityRequestBus::Events::GetVisibilityFlag);
+        AzToolsFramework::EditorVisibilityRequestBus::EventResult(
+            flagSetVisible, m_layerId, &AzToolsFramework::EditorVisibilityRequestBus::Events::GetVisibilityFlag);
 
         // even though a layer is set to not be visible, this is recorded by SetLayerChildrenVisibility
         // and AreLayerChildrenVisible - the visibility flag will not be modified and remains true
@@ -1423,12 +1495,14 @@ namespace UnitTest
 
         static void Reflect(AZ::ReflectContext* context);
 
-        // AZ::Component ...
+        // AZ::Component overrides ...
         void Activate() override
         {
             // ensure we can successfully read IsVisible and IsLocked (bus will be connected to in entity Init)
-            EditorEntityInfoRequestBus::EventResult(m_visible, GetEntityId(), &EditorEntityInfoRequestBus::Events::IsVisible);
-            EditorEntityInfoRequestBus::EventResult(m_locked, GetEntityId(), &EditorEntityInfoRequestBus::Events::IsLocked);
+            AzToolsFramework::EditorEntityInfoRequestBus::EventResult(
+                m_visible, GetEntityId(), &AzToolsFramework::EditorEntityInfoRequestBus::Events::IsVisible);
+            AzToolsFramework::EditorEntityInfoRequestBus::EventResult(
+                m_locked, GetEntityId(), &AzToolsFramework::EditorEntityInfoRequestBus::Events::IsLocked);
         }
 
         void Deactivate() override
@@ -1493,8 +1567,8 @@ namespace UnitTest
 
         AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetParent, layerId);
 
-        SetEntityVisibility(layerId, false);
-        SetEntityLockState(layerId, true);
+        AzToolsFramework::SetEntityVisibility(layerId, false);
+        AzToolsFramework::SetEntityLockState(layerId, true);
 
         entity->Deactivate();
         auto* entityInfoComponent = entity->CreateComponent<EditorEntityInfoRequestActivateTestComponent>();


### PR DESCRIPTION
This change fixes an issue where entity scale was unintentionally applied twice when using the 'ditto' operation to copy an entity rotation (LYN-1865).

There was also a bug with the new camera code where a DollyCameraInput would start before the ditto operation got a chance to run (we now ensure there's always a small threshold before starting any type of CameraInput driven by a motion).

There are a couple of other related fixes (removing a `using namespace` usage and some other tidy-up with the context menu).

See added test `CopyOrientationToSelectedEntitiesIndividualDoesNotAffectScale`

```
AzToolsFrameworkTests
[----------] Global test environment tear-down
[==========] 633 tests from 103 test cases ran. (52246 ms total)
[  PASSED  ] 633 tests.
```