### PR TITLE
Refresh cached transforms before saving.

### DIFF
--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -330,6 +330,7 @@ namespace AZ
             prefabPlaceholderEntities.clear();
             for (size_t curEntityIdx = 0; curEntityIdx < sliceEntities.size(); curEntityIdx++)
             {
+                UpdateCachedTransform(*(sliceEntities[curEntityIdx]));
                 sourceInstance->AddEntity(*(sliceEntities[curEntityIdx]), entityAliases[curEntityIdx]);
             }
 
@@ -631,12 +632,14 @@ namespace AZ
                             AZ_Assert(false, "Couldn't find nested instance %s", it->c_str());
                         }
                     }
+                    UpdateCachedTransform(*entity);
                     addingInstance->AddEntity(*entity, mappingStruct.m_entityAlias);
                     addedEntityList.emplace_back(entity, addingInstance);
                 }
                 else
                 {
                     AZ_Assert(false, "Failed to find entity alias.");
+                    UpdateCachedTransform(*entity);
                     nestedInstance->AddEntity(*entity);
                     addedEntityList.emplace_back(entity, nestedInstance.get());
                 }
@@ -778,6 +781,16 @@ namespace AZ
                     transformComponent->SetParent(parentId);
                     transformComponent->UpdateCachedWorldTransform();
                 }
+            }
+        }
+
+        void SliceConverter::UpdateCachedTransform(const AZ::Entity& entity)
+        {
+            AzToolsFramework::Components::TransformComponent* transformComponent =
+                entity.FindComponent<AzToolsFramework::Components::TransformComponent>();
+            if (transformComponent)
+            {
+                transformComponent->UpdateCachedWorldTransform();
             }
         }
 

--- a/Code/Tools/SerializeContextTools/SliceConverter.h
+++ b/Code/Tools/SerializeContextTools/SliceConverter.h
@@ -72,6 +72,7 @@ namespace AZ
             bool ConvertSliceInstance(
                 AZ::SliceComponent::SliceInstance& instance, AZ::Data::Asset<AZ::SliceAsset>& sliceAsset,
                 AzToolsFramework::Prefab::TemplateReference nestedTemplate, AzToolsFramework::Prefab::Instance* topLevelInstance);
+            void UpdateCachedTransform(const AZ::Entity& entity);
             void SetParentEntity(const AZ::Entity& entity, const AZ::EntityId& parentId, bool onlySetIfInvalid);
             void PrintPrefab(AzToolsFramework::Prefab::TemplateId templateId);
             bool SavePrefab(AZ::IO::PathView outputPath, AzToolsFramework::Prefab::TemplateId templateId);


### PR DESCRIPTION
If the prefab template saves default values for a cached transform, but *shouldn't* have default values, it will get patch application errors at runtime due to missing cached transform fields.

Signed-off-by: mbalfour <mbalfour@amazon.com>