### PR TITLE
Fixing simple light types appearing back at 0,0,0 after hiding/unhiding.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateBase.inl
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateBase.inl
@@ -134,6 +134,11 @@ namespace AZ
                     // For lights that get their transform from the shape bus, force an OnShapeChanged to update the transform.
                     OnShapeChanged(ShapeChangeReasons::TransformChanged);
                 }
+                else
+                {
+                    // OnShapeChanged() already calls this for delegates with a shape bus
+                    HandleShapeChanged();
+                }
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>