### PR TITLE
Update Instructions to include better WWise information

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ If you have the Git credential manager core or other credential helpers installe
 #### Optional
 
 *   WWise - 2019.2.8.7432 minimum: [https://www.audiokinetic.com/download/](https://www.audiokinetic.com/download/)
-    *   Note: This requires registration and installation of a client to download
+    *   Note: This requires registration and installation of a Launcher to download
+    *   Ensure you select the SDK (C++) Package when installing your WWise version in the Launcher
     *   You will also need to set a environment variable: `set LY_WWISE_INSTALL_PATH=<path to WWise version>`
     *   For example: `set LY_WWISE_INSTALL_PATH="C:\Program Files (x86)\Audiokinetic\Wwise 2019.2.8.7432"`
 


### PR DESCRIPTION
WWise SDK needs to be installed from the packages selection when installing the WWise version. 