### PR TITLE
tick system while in track view batch render mode

### DIFF
--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -13,6 +13,7 @@
 
 #include "SequenceBatchRenderDialog.h"
 
+#include <AzCore/Component/ComponentApplication.h>
 #include <AzFramework/Windowing/WindowBus.h>
 
 // Qt
@@ -1214,6 +1215,18 @@ void CSequenceBatchRenderDialog::OnKickIdleTimout()
     {
         // All done with our custom OnKickIdle, restore editor idle.
         SetEnableEditorIdleProcessing(true);
+    }
+
+    //When we disable the editor idle processing. system tick is no longer invoked.
+    //so we call it here to ensure rendering + other systems are updated.
+    if (!m_editorIdleProcessingEnabled)
+    {
+        AZ::ComponentApplication* componentApplication = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(componentApplication, &AZ::ComponentApplicationRequests::GetApplication);
+        if (componentApplication)
+        {
+            componentApplication->TickSystem();
+        }
     }
 }
 


### PR DESCRIPTION
As the batch render will disable Editor idle processing which normally handles the system tick.

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>