### PR TITLE
Updating/re-enabling skipped/xfailed Dynamic Vegetation automated tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_test_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_test_utils.py
@@ -89,7 +89,7 @@ def launch_and_validate_results_launcher(launcher, level, remote_console_instanc
         :return: True if port is listening.
         """
         port_listening = False
-        for conn in psutil.net_connections():
+        for conn in process_utils.psutil.net_connections():
             if 'port={}'.format(port) in str(conn):
                 port_listening = True
         return port_listening
@@ -110,8 +110,8 @@ def launch_and_validate_results_launcher(launcher, level, remote_console_instanc
 
         # Load the specified level in the launcher
         send_command_and_expect_response(remote_console_instance,
-                                         f"map {level}",
-                                         "LEVEL_LOAD_COMPLETE", timeout=30)
+                                         f"LoadLevel {level}",
+                                         "LEVEL_LOAD_END", timeout=30)
 
         # Monitor the console for expected lines
         for line in expected_lines:

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/AltitudeFilter_FilterStageToggle.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/AltitudeFilter_FilterStageToggle.py
@@ -36,8 +36,8 @@ class TestAltitudeFilterFilterStageToggle(EditorTestHelper):
         :return: None
         """
 
-        PREPROCESS_INSTANCE_COUNT = 24
-        POSTPROCESS_INSTANCE_COUNT = 18
+        PREPROCESS_INSTANCE_COUNT = 44
+        POSTPROCESS_INSTANCE_COUNT = 34
 
         # Create empty level
         self.test_success = self.create_level(
@@ -62,25 +62,7 @@ class TestAltitudeFilterFilterStageToggle(EditorTestHelper):
         dynveg.create_surface_entity("Surface_Entity_Parent", position, 16.0, 16.0, 1.0)
 
         # Add entity with Mesh to replicate creation of hills
-        hill_entity = dynveg.create_mesh_surface_entity_with_slopes("hill", position, 40.0, 40.0, 40.0)
-
-        # Disable/Re-enable Mesh component due to ATOM-14299
-        general.idle_wait(1.0)
-        editor.EditorComponentAPIBus(bus.Broadcast, 'DisableComponents', [hill_entity.components[0]])
-        is_enabled = editor.EditorComponentAPIBus(bus.Broadcast, 'IsComponentEnabled', hill_entity.components[0])
-        if is_enabled:
-            print("Mesh component is still enabled")
-        else:
-            print("Mesh component was disabled")
-        editor.EditorComponentAPIBus(bus.Broadcast, 'EnableComponents', [hill_entity.components[0]])
-        is_enabled = editor.EditorComponentAPIBus(bus.Broadcast, 'IsComponentEnabled', hill_entity.components[0])
-        if is_enabled:
-            print("Mesh component is now enabled")
-        else:
-            print("Mesh component is still disabled")
-
-        # Increase Box Shape size to encompass the hills
-        vegetation.get_set_test(1, "Box Shape|Box Configuration|Dimensions", math.Vector3(100.0, 100.0, 100.0))
+        hill_entity = dynveg.create_mesh_surface_entity_with_slopes("hill", position, 10.0)
 
         # Set a Min Altitude of 38 and Max of 40 in Vegetation Altitude Filter
         vegetation.get_set_test(3, "Configuration|Altitude Min", 38.0)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_Embedded_E2E.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/DynamicSliceInstanceSpawner_Embedded_E2E.py
@@ -9,9 +9,10 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import azlmbr.asset as asset
+import azlmbr.components as components
 import azlmbr.legacy.general as general
 import azlmbr.bus as bus
-import azlmbr.entity as EntityId
+import azlmbr.entity as entity
 import azlmbr.editor as editor
 import azlmbr.math as math
 import azlmbr.paths
@@ -83,18 +84,12 @@ class TestDynamicSliceInstanceSpawnerEmbeddedEditor(EditorTestHelper):
         self.log(f"Expected {num_expected_instances} instances - Found {num_found} instances")
         self.test_success = self.test_success and num_found == num_expected_instances
 
-        # 5) Create a new entity with a Camera component for testing in the launcher
+        # 5) Move the default Camera entity for testing in the launcher
         cam_position = math.Vector3(512.0, 500.0, 35.0)
-        camera_component = ["Camera"]
-        new_entity_id2 = editor.ToolsApplicationRequestBus(
-            bus.Broadcast, "CreateNewEntityAtPosition", cam_position, EntityId.EntityId()
-        )
-        if new_entity_id2.IsValid():
-            self.log("Camera entity created")
-        camera_entity = hydra.Entity("Camera Entity", new_entity_id2)
-        camera_entity.components = []
-        for component in camera_component:
-            camera_entity.components.append(hydra.add_component(component, new_entity_id2))
+        search_filter = entity.SearchFilter()
+        search_filter.names = ["Camera"]
+        search_entity_ids = entity.SearchBus(bus.Broadcast, 'SearchEntities', search_filter)
+        components.TransformBus(bus.Event, "MoveEntity", search_entity_ids[0], cam_position)
 
         # 6) Save and export to engine
         general.save_level()

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/test_DynamicSliceInstanceSpawner.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/test_DynamicSliceInstanceSpawner.py
@@ -90,7 +90,6 @@ class TestDynamicSliceInstanceSpawner(object):
     @pytest.mark.SUITE_periodic
     @pytest.mark.dynveg_area
     @pytest.mark.parametrize("launcher_platform", ['windows'])
-    @pytest.mark.skip      # ATOM-14703
     def test_DynamicSliceInstanceSpawner_Embedded_E2E_Launcher(self, workspace, launcher, level,
                                                                remote_console_instance, project, launcher_platform):
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
@@ -34,7 +34,7 @@ def create_surface_entity(name, center_point, box_size_x, box_size_y, box_size_z
     return surface_entity
 
 
-def create_mesh_surface_entity_with_slopes(name, center_point, scale_x, scale_y, scale_z):
+def create_mesh_surface_entity_with_slopes(name, center_point, uniform_scale):
     # Creates an entity with the assigned mesh_asset as the specified scale and sets up as a planting surface
     mesh_asset_path = os.path.join("models", "sphere.azmodel")
     mesh_asset = asset.AssetCatalogRequestBus(bus.Broadcast, "GetAssetIdByPath", mesh_asset_path, math.Uuid(),
@@ -47,7 +47,7 @@ def create_mesh_surface_entity_with_slopes(name, center_point, scale_x, scale_y,
     if surface_entity.id.IsValid():
         print(f"'{surface_entity.name}' created")
     hydra.get_set_test(surface_entity, 0, "Controller|Configuration|Mesh Asset", mesh_asset)
-    components.TransformBus(bus.Event, "SetLocalScale", surface_entity.id, math.Vector3(scale_x, scale_y, scale_z))
+    components.TransformBus(bus.Event, "SetLocalUniformScale", surface_entity.id, uniform_scale)
     return surface_entity
 
 


### PR DESCRIPTION
- Fixed process_utils connection in hydra_test_utils
- Updated expected level load response in Launcher test function
- Updated calls from deprecated SetLocalScale to SetLocalUniformScale
- Re-positioned cameras for DynamicSliceInstanceSpawner launcher tests
- Updated expected instance counts for Altitude test with new scale values