### PR TITLE
Ensured EditContext is created for the legacy tools framework application (Lua) so that settings are able to be displayed

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -151,6 +151,12 @@ namespace LegacyFramework
         specializations.Append("tools");
     }
 
+    void Application::CreateReflectionManager()
+    {
+        AZ::ComponentApplication::CreateReflectionManager();
+        GetSerializeContext()->CreateEditContext();
+    }
+
     int Application::Run(const ApplicationDesc& desc)
     {
         if (!AZ::AllocatorInstance<AZ::OSAllocator>::IsReady())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.h
@@ -56,6 +56,8 @@ namespace LegacyFramework
         virtual int Run(const ApplicationDesc& desc);
         Application();
 
+        void CreateReflectionManager() override;
+
     protected:
 
         // ------------------------------------------------------------------


### PR DESCRIPTION
The settings dialog for the Lua Editor displays a bunch of properties using an RPE. At some point, the legacy tools framework application (which is only used by Lua and Profiler) was modified such that it no longer created an EditContext. This prevented the Lua settings dialog from working because there was no EditContext data loaded in to display in the RPE. I added the same line done in our base Editor ToolsApplication (and in other tools applications that don't use the base) to ensure the EditContext gets created.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>