### PR TITLE
Updated gem.json for all top-level Gems.  (#1715)

### DIFF
--- a/AutomatedTesting/Gem/gem.json
+++ b/AutomatedTesting/Gem/gem.json
@@ -1,16 +1,12 @@
 {
-    "GemFormatVersion": 4,
-    "Uuid": "afc25e1593194d6283d9ff744ab6d5a1",
-    "Name": "AutomatedTesting",
-    "DisplayName": "AutomatedTesting",
-    "Version": "0.1.0",
-    "Summary": "A short description of my Gem.",
-    "Tags": ["Game"],
-    "IconPath": "preview.png",
-    "IsGameGem": true,
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "gem_name": "AutomatedTesting",
+    "display_name": "AutomatedTesting",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Amazon Web Services, Inc.",
+    "type": "Code",
+    "summary": "Project Gem for customizing the AutomatedTesting project functionality.",
+    "canonical_tags": ["Gem"],
+    "user_tags": [],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -648,10 +648,10 @@ namespace O3DE::ProjectManager
                 gemInfo.m_name = Py_To_String(data["gem_name"]);
 
                 // optional
-                gemInfo.m_displayName = Py_To_String_Optional(data, "DisplayName", gemInfo.m_name);
-                gemInfo.m_summary = Py_To_String_Optional(data, "Summary", "");
-                gemInfo.m_version = Py_To_String_Optional(data, "Version", "");
-                gemInfo.m_requirement = Py_To_String_Optional(data, "Requirements", "");
+                gemInfo.m_displayName = Py_To_String_Optional(data, "display_name", gemInfo.m_name);
+                gemInfo.m_summary = Py_To_String_Optional(data, "summary", "");
+                gemInfo.m_version = "";
+                gemInfo.m_requirement = Py_To_String_Optional(data, "requirements", "");
                 gemInfo.m_creator = Py_To_String_Optional(data, "origin", "");
 
                 if (gemInfo.m_creator.contains("Open 3D Engine"))
@@ -659,12 +659,26 @@ namespace O3DE::ProjectManager
                     gemInfo.m_gemOrigin = GemInfo::GemOrigin::Open3DEEngine;
                 }
 
-                if (data.contains("Tags"))
+                if (data.contains("user_tags"))
                 {
-                    for (auto tag : data["Tags"])
+                    for (auto tag : data["user_tags"])
                     {
                         gemInfo.m_features.push_back(Py_To_String(tag));
                     }
+                }
+
+                QString gemType = Py_To_String_Optional(data, "type", "");
+                if (gemType == "Asset")
+                {
+                    gemInfo.m_types |= GemInfo::Type::Asset;
+                }
+                if (gemType == "Code")
+                {
+                    gemInfo.m_types |= GemInfo::Type::Code;
+                }
+                if (gemType == "Tool")
+                {
+                    gemInfo.m_types |= GemInfo::Type::Tool;
                 }
             }
             catch ([[maybe_unused]] const std::exception& e)

--- a/Gems/AWSClientAuth/gem.json
+++ b/Gems/AWSClientAuth/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "AWSClientAuth",
-    "GemFormatVersion": 3,
-    "Uuid": "c74f2756f5874c0d8d29646dfc9cb0ad",
-    "Name": "AWSClientAuth",
-    "DisplayName": "AWS Client Auth",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "AWS Client Auth provides client authentication and AWS authorization solution",
-    "Tags": ["AWS", "Amazon Cognito", "Authentication", "Authorization"],
-    "IconPath": "preview.png"
+    "display_name": "AWS Client Authorization",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Amazon Web Services, Inc.",
+    "type": "Code",
+    "summary": "AWS Client Auth provides client authentication and AWS authorization solution.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["AWS", "Network", "SDK"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AWSCore/gem.json
+++ b/Gems/AWSCore/gem.json
@@ -1,18 +1,12 @@
 {
     "gem_name": "AWSCore",
-    "GemFormatVersion": 4,
-    "Uuid": "c3710872891c4401b0cbdabfca066cb5",
-    "Name": "AWSCore",
-    "DisplayName": "AWS Core",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "This Gem is automatically enabled when selecting any of the AWS Feature Gems. It provides basic shared functionalities such as AWS SDK initialization and client configuration.",
-    "Tags": [
-        "AWS",
-        "API",
-        "AWSCore",
-        "Cloud",
-        "Connected"
-    ],
-    "IconPath": "preview.png"
+    "display_name": "AWS Core",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Amazon Web Services, Inc.",
+    "type": "Code",
+    "summary": "The AWS Core Gem provides basic shared AWS functionality such as AWS SDK initialization and client configuration, and is automatically added when selecting any AWS feature Gem.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["AWS", "Network", "SDK"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AWSMetrics/gem.json
+++ b/Gems/AWSMetrics/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "AWSMetrics",
-    "GemFormatVersion": 4,
-    "Uuid": "cc6fc7a18fc047039a369a26100fcbbe",
-    "Name": "AWSMetrics",
-    "DisplayName": "AWS Metrics",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "AWS Metrics provides metrics submission and analytics solution.",
-    "Tags": [
-        "AWS",
-        "AWSMetrics",
-        "Cloud"
-    ],
-    "IconPath": "preview.png"
+    "display_name": "AWS Metrics",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Amazon Web Services, Inc.",
+    "type": "Code",
+    "summary": "The AWS Metrics Gem provides a solution for AWS metrics submission and analytics.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["AWS", "Network", "SDK"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Achievements/gem.json
+++ b/Gems/Achievements/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "Achievements",
-    "GemFormatVersion": 4,
-    "Uuid": "6f8d953dd4fc4bb6ad34c9118a7b789f",
-    "Name": "Achievements",
-    "DisplayName": "Achievements",
-    "Version": "0.1.0",
-    "Summary": "Platform agnostic interface for retrieving achievement details and unlocking achievements.",
-    "Tags": ["Achievement", "Achievements", "Trophy", "Trophies"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Achievements",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Achievements Gem provides a target platform agnostic interface for retrieving achievement details and unlocking achievements.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Gameplay", "Achievements"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AssetMemoryAnalyzer/gem.json
+++ b/Gems/AssetMemoryAnalyzer/gem.json
@@ -1,25 +1,12 @@
 {
     "gem_name": "AssetMemoryAnalyzer",
-    "GemFormatVersion": 4,
-    "Uuid": "35414634480a4d4c8412c60fe62f4c81",
-    "Name": "AssetMemoryAnalyzer",
-    "DisplayName": "AssetMemoryAnalyzer",
-    "Version": "0.1.0",
-    "Summary": "Provides debug visualization of the AssetMemoryDriller to show how individual assets are consuming memory.",
-    "Tags": ["debug"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "bab8807a1bc646b3909f3cc200ffeedf",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "ImGui GEM"
-        }
-    ]
+    "display_name": "Asset Memory Analyzer",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Asset Memory Analyzer Gem provides tools to profile asset memory usage in Open 3D Engine through ImGUI (Immediate Mode Graphical User Interface).",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "Utillity", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AssetValidation/gem.json
+++ b/Gems/AssetValidation/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "AssetValidation",
-    "GemFormatVersion": 4,
-    "Uuid": "5a5c3c10b91d4b4ea8baef474c5b5d49",
-    "Name": "AssetValidation",
-    "DisplayName": "AssetValidation",
-    "Version": "0.1.0",
-    "Summary": "Tools for managing your assets and their dependencies during development",
-    "Tags": ["Untagged"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Asset Validation",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Asset Validation Gem provides seed-related commands to ensure assets have valid seeds for asset bundling.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Utility", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Atom/Asset/ImageProcessingAtom/gem.json
+++ b/Gems/Atom/Asset/ImageProcessingAtom/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "ImageProcessingAtom",
     "display_name": "Atom Image Processing",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/Asset/Shader/gem.json
+++ b/Gems/Atom/Asset/Shader/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "AtomShader",
     "display_name": "Atom Shader Builder",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/Bootstrap/gem.json
+++ b/Gems/Atom/Bootstrap/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_Bootstrap",
     "display_name": "Atom Bootstrap",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/Component/DebugCamera/gem.json
+++ b/Gems/Atom/Component/DebugCamera/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_Component_DebugCamera",
     "display_name": "Atom Debug Camera Component",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/Feature/Common/gem.json
+++ b/Gems/Atom/Feature/Common/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_Feature_Common",
     "display_name": "Atom Feature Common",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/RHI/DX12/gem.json
+++ b/Gems/Atom/RHI/DX12/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_RHI_DX12",
     "display_name": "Atom RHI DX12",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/RHI/Metal/gem.json
+++ b/Gems/Atom/RHI/Metal/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_RHI_Metal",
     "display_name": "Atom RHI Metal",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/RHI/Null/gem.json
+++ b/Gems/Atom/RHI/Null/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_RHI_Null",
     "display_name": "Atom RHI Null",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/RHI/Vulkan/gem.json
+++ b/Gems/Atom/RHI/Vulkan/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_RHI_Vulkan",
     "display_name": "Atom RHI Vulkan",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/RHI/gem.json
+++ b/Gems/Atom/RHI/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_RHI",
     "display_name": "Atom RHI",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/RPI/gem.json
+++ b/Gems/Atom/RPI/gem.json
@@ -2,9 +2,13 @@
     "gem_name": "Atom_RPI",
     "display_name": "Atom API",
     "summary": "",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/Tools/AtomToolsFramework/gem.json
+++ b/Gems/Atom/Tools/AtomToolsFramework/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "AtomToolsFramework",
     "display_name": "Atom Tools Framework",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/Tools/MaterialEditor/gem.json
+++ b/Gems/Atom/Tools/MaterialEditor/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "MaterialEditor",
     "display_name": "Atom Material Editor",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
     "summary": "Editor for creating, modifying, and previewing materials",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/Atom/gem.json
+++ b/Gems/Atom/gem.json
@@ -1,5 +1,12 @@
 {
     "gem_name": "Atom",
-    "display_name": "Atom",
-    "summary": "Next-Gen Rendering Package for the O3DE engine"
+    "display_name": "Atom Renderer",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Atom Renderer Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Core"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AtomContent/ReferenceMaterials/gem.json
+++ b/Gems/AtomContent/ReferenceMaterials/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "ReferenceMaterials",
-    "GemFormatVersion": 3,
-    "Uuid": "99eac95298d847a6914d7b9e69db6f84",
-    "Name": "ReferenceMaterials",
-    "DisplayName": "ReferenceMaterials",
-    "Version": "0.1.0",
-    "LinkType": "NoCode",
-    "Summary": "Atom Asset Gem with a library of reference materials for StandardPBR (and others in the future)",
-    "Tags": ["Asset"],
-    "IconPath": "preview.png"
+    "display_name": "ReferenceMaterials",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "Atom Asset Gem with a library of reference materials for StandardPBR (and others in the future)",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AtomContent/Sponza/gem.json
+++ b/Gems/AtomContent/Sponza/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "Sponza",
-    "GemFormatVersion": 3,
-    "Uuid": "860d8ef2aec5425ab197adc4484c09f1",
-    "Name": "Sponza",
-    "DisplayName": "Sponza",
-    "Version": "0.1.0",
-    "LinkType": "NoCode",
-    "Summary": "A standard test scene for Global Illumination (forked from crytek sponza scene)",
-    "Tags": ["Asset"],
-    "IconPath": "preview.png"
+    "display_name": "Sponza",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "A standard test scene for Global Illumination (forked from crytek sponza scene)",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AtomContent/gem.json
+++ b/Gems/AtomContent/gem.json
@@ -1,14 +1,12 @@
 {
     "gem_name": "AtomContent",
-    "origin": "The primary repo for Atom goes here: i.e. http://www.mydomain.com",
-    "license": "What license Atom uses goes here: i.e. https://opensource.org/licenses/MIT",
     "display_name": "Atom Content",
-    "summary": "ontains multiple packages containing source Assets that can be used with Atom",
-    "canonical_tags": [
-        "Gem"
-    ],
-    "user_tags": [
-        "AtomContent"
-    ],
-    "icon_path": "preview.png"
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The Atom Content Gem provides assets for Atom Renderer and a modified version of the Pixar Look Development Studio (https://renderman.pixar.com/look-development-studio).",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Assets", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/AtomBridge/gem.json
+++ b/Gems/AtomLyIntegration/AtomBridge/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "Atom_AtomBridge",
     "display_name": "Atom Bridge",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/AtomFont/gem.json
+++ b/Gems/AtomLyIntegration/AtomFont/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "AtomFont",
     "display_name": "Atom Font",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/AtomImGuiTools/gem.json
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/gem.json
@@ -1,10 +1,16 @@
 {
     "gem_name": "AtomImGuiTools",
     "display_name": "Atom ImGui",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+        "Debug",
+        "Rendering"
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "AtomViewportDisplayIcons",
     "display_name": "Atom Viewport Display Icons",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/gem.json
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "AtomViewportDisplayInfo",
     "display_name": "Atom Viewport Display Info",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/gem.json
+++ b/Gems/AtomLyIntegration/CommonFeatures/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "CommonFeaturesAtom",
     "display_name": "Common Features Atom",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/gem.json
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "EMotionFX_Atom",
     "display_name": "EMotionFX Atom",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/ImguiAtom/gem.json
+++ b/Gems/AtomLyIntegration/ImguiAtom/gem.json
@@ -1,10 +1,14 @@
 {
     "gem_name": "ImguiAtom",
     "display_name": "Imgui Atom",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "summary": "",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/gem.json
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/gem.json
@@ -2,6 +2,9 @@
     "gem_name": "DccScriptingInterface",
     "display_name": "Atom DccScriptingInterface (DCCsi)",
     "summary": "A python framework for working with various DCC tools and workflows.",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
     "canonical_tags": [
         "Gem"
     ],
@@ -10,5 +13,6 @@
 	"Digital",
 	"Content",
 	"Creation"
-    ]
+    ],
+    "requirements": ""
 }

--- a/Gems/AtomLyIntegration/gem.json
+++ b/Gems/AtomLyIntegration/gem.json
@@ -1,5 +1,12 @@
 {
     "gem_name": "AtomLyIntegration",
     "display_name": "Atom O3DE Integration",
-    "summary": "Collection of module targets for integrating Atom with the O3DE engine"
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Atom O3DE Integration Gem provides components, libraries, and functionality to support and integrate Atom Renderer in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Core", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AtomTressFX/gem.json
+++ b/Gems/AtomTressFX/gem.json
@@ -1,13 +1,12 @@
 {
     "gem_name": "AtomTressFX",
-    "GemFormatVersion": 3,
-    "Uuid": "d4a3e3d6b9b14e12982c774f35f48a7c",
-    "Name": "AtomTressFX",
-    "DisplayName": "AtomTressFX [PREVIEW]",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "The AtomTressFX is a cutting edge hair technology based on TressFX 4.1 SDK from AMD.  It was altered to integrate into Atom harnessing Atom's design and pipeline.",
-    "Tags": ["Hair", "TressFX"],
-    "IconPath": "preview.png",
-    "EditorModule": true
+    "display_name": "Atom TressFX",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Atom TressFX Gem provides realistic hair and fur simulation and rendering in Atom and Open 3D Engine with AMD TressFX.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Physics", "Animation"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AudioEngineWwise/gem.json
+++ b/Gems/AudioEngineWwise/gem.json
@@ -1,28 +1,12 @@
 {
     "gem_name": "AudioEngineWwise",
-    "GemFormatVersion": 4,
-    "Uuid": "67a80e2ac865406c990f2715feb55f7f",
-    "Name": "AudioEngineWwise",
-    "DisplayName": "Wwise Audio Integration",
-    "Version": "0.1.0",
-    "Summary": "Wwise engine integration and plugin to Audio Controls Editor.",
-    "Tags": ["Audio", "Sound", "Wwise"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "6f63f2b6d07f4b89b4b7c86ebee7feb8",
-            "VersionConstraints": [">=0.1.0"],
-            "_comment": "AudioSystem"
-        }
-    ]
+    "display_name": "Wwise Audio Engine",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Wwise Audio Engine Gem provides support for Audiokinetic Wave Works Interactive Sound Engine (Wwise).",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Audio", "Utiltity", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": "Users will need to download WWise from the AudioKinetic web site: https://www.audiokinetic.com/download/"
 }

--- a/Gems/AudioSystem/gem.json
+++ b/Gems/AudioSystem/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "AudioSystem",
-    "GemFormatVersion": 4,
-    "Uuid": "6f63f2b6d07f4b89b4b7c86ebee7feb8",
-    "Name": "AudioSystem",
-    "DisplayName": "Audio System",
-    "Version": "0.1.0",
-    "Summary": "Contains CrySoundSystem, the Audio Translation Layer (ATL), and the Audio Controls Editor",
-    "Tags": ["Audio", "Sound"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ]
+    "display_name": "Audio System",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Audio System Gem provides the Audio Translation Layer (ATL) and Audio Controls Editor, which add support for audio in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Audio", "Utiltity", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/AutomatedLauncherTesting/gem.json
+++ b/Gems/AutomatedLauncherTesting/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "AutomatedLauncherTesting",
-    "GemFormatVersion": 4,
-    "Uuid": "69504dac61f84a11bf895b8f05e4227f",
-    "Name": "AutomatedLauncherTesting",
-    "DisplayName": "Automated Launcher Testing",
-    "Version": "0.1.0",
-    "Summary": "This GEM is used to manage running of Automated Launcher Tests",
-    "Tags": ["Untagged"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Automated Launcher Testing",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Automated Launcher Testing Gem manages automated Open 3D Engine (O3DE) launcher tests.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Blast/gem.json
+++ b/Gems/Blast/gem.json
@@ -1,37 +1,12 @@
 {
     "gem_name": "Blast",
-    "GemFormatVersion": 4,
-    "Uuid": "414bd211c99d4f74aef3a266b9ca208c",
-    "Name": "Blast",
-    "DisplayName": "NVIDIA Blast [Experimental]",
-    "Version": "0.1.0",
-    "Summary": "Enables support for NVIDIA Blast objects in Lumberyard for high-fidelity destruction.",
-    "Tags": [ "Physics" ],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "4e08125824434932a0fe3717259caa47",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "PhysX"
-        }
-    ]
+    "display_name": "NVIDIA Blast",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The NVIDIA Blast Gem provides tools to author fractured mesh assets in Houdini, and functionality to create realistic destruction simulations in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Physics", "Simulation", "Animation"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Camera/gem.json
+++ b/Gems/Camera/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "Camera",
-    "GemFormatVersion": 4,
-    "Uuid": "f910686b6725452fbfc4671f95f733c6",
-    "Name": "Camera",
-    "Version": "0.1.0",
-    "DisplayName": "Camera",
-    "Tags": ["Camera"],
-    "Summary": "The Camera Gem includes a basic camera component that defines a frustum for runtime rendering.",
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ]
+    "display_name": "Camera",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Camera Gem provides a basic camera component that defines a frustum for runtime rendering.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/CameraFramework/gem.json
+++ b/Gems/CameraFramework/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "CameraFramework",
-    "Dependencies": [
-        {
-            "Uuid": "f910686b6725452fbfc4671f95f733c6", 
-            "VersionConstraints": [
-                "~>0.1"
-            ], 
-            "_comment": "Camera"
-        }
-    ], 
-    "GemFormatVersion": 3,
-    "Uuid": "54f2763fe191432fa681ce4a354eedf5",
-    "Name": "CameraFramework",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "DisplayName": "Camera Framework [PREVIEW]",
-    "Tags": ["Camera", "Framework"],
-    "Summary": "The Camera Framework Gem includes the camera rig component which drives an entity through camera behaviors. Behaviors are provided in the Starting Point Camera Gem.",
-    "IconPath": "preview.png"
+    "display_name": "Camera Framework",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Camera Framework Gem provides a base for implementing more complex camera systems.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Framework", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/CertificateManager/gem.json
+++ b/Gems/CertificateManager/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "CertificateManager",
-    "GemFormatVersion": 3,
-    "Uuid": "659CFFFF33B14A10835BAFC6EA623F98",
-    "Name": "CertificateManager",
-    "DisplayName": "Amazon Certificate Manager",
-    "Version": "0.0.1",
-    "LinkType": "Dynamic",
-    "Summary": "The Amazon Certificate Manager Gem provides access to authentication files for secure game connections from S3, files on disk, and other 3rd party sources",
-    "Tags": ["Amazon Certificate Manager","Security","Multiplayer","Networking"],
-    "IconPath": "preview.png"
+    "display_name": "Certificate Manager",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Certificate Manager Gem provides access to authentication files for secure game connections from Amazon S3, files on disk, and other 3rd party sources.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Network", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/CrashReporting/gem.json
+++ b/Gems/CrashReporting/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "CrashReporting",
-    "GemFormatVersion": 4,
-    "Uuid": "089562a2cbbd41749b359f85fa04f1c9",
-    "Name": "CrashReporting",
-    "DisplayName": "CrashReporting",
-    "Version": "0.1.0",
-    "Summary": "Enable external crash reporting for a game project",
-    "Tags": ["Untagged"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "StaticLib",
-            "Name": "StaticLibrary"
-        },
-        {
-            "Type": "Standalone",
-            "Name": "Uploader"
-        }
-    ]
+    "display_name": "Crash Reporting",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Crash Reporting Gem provides support for external crash reporting for Open 3D Engine projects.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/CustomAssetExample/gem.json
+++ b/Gems/CustomAssetExample/gem.json
@@ -1,19 +1,12 @@
 {
     "gem_name": "CustomAssetExample",
-    "GemFormatVersion": 3,
-    "Uuid": "ad082dd50c6545849729e9afeaaeaa1d",
-    "Name": "CustomAssetExample",
-    "DisplayName": "CustomAssetExample",
-    "Version": "0.1.0",
-    "Summary": "Contians example code for creating a custom asset in Lumberyard's asset pipeline",
-    "Tags": ["Assets, Example"],
-    "LinkType": "Dynamic",
-    "IconPath": "preview.png",
-    "EditorModule": true,
-    "Modules": [
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ]
+    "display_name": "Custom Asset Example",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Custom Asset Example Gem provides example code for creating a custom asset for Open 3D Engine's asset pipeline.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/DebugDraw/gem.json
+++ b/Gems/DebugDraw/gem.json
@@ -1,13 +1,12 @@
 {
     "gem_name": "DebugDraw",
-    "GemFormatVersion": 3,
-    "Uuid": "66239f50bf754354b514c850c8b841fb",
-    "Name": "DebugDraw",
-    "DisplayName": "DebugDraw [PREVIEW]",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "The DebugDraw Gem provides editor and game runtime debug visualization features.",
-    "Tags": ["Debugging"],
-    "IconPath": "preview.png",
-    "EditorModule": true
+    "display_name": "Debug Draw",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Debug Draw Gem provides Editor and runtime debug visualization features for Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "Tools", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/DevTextures/gem.json
+++ b/Gems/DevTextures/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "DevTextures",
-    "GemFormatVersion": 3,
-    "Uuid": "2c227161447b4d77a5b07c093e214fe3",
-    "Name": "DevTextures",
-    "DisplayName": "DevTextures",
-    "Version": "0.1.0",
-    "LinkType": "NoCode",
-    "Summary": "Collection of general purpose textures useful for prototypes and preproduction. ",
-    "Tags": ["Asset"],
-    "IconPath": "preview.png"
+    "display_name": "Dev Textures",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The Dev Textures Gem provides a collection of general purpose texture assets useful for prototypes and preproduction.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Debug", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/EMotionFX/gem.json
+++ b/Gems/EMotionFX/gem.json
@@ -1,23 +1,12 @@
 {
     "gem_name": "EMotionFX",
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        }
-    ],
-    "GemFormatVersion": 3,
-    "Uuid": "044a63ea67d04479aa5daf62ded9d9ca",
-    "Name": "EMotionFX",
-    "DisplayName": "EMotion FX Animation",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "EMotion FX is a character animation system used to set up animated controllable characters inside your project.\n",
-    "Tags": ["Animation"],
-    "IconPath": "EMotionFX.png",
-    "EditorModule" : true,
-    "DisableGemAutoUselib": true
+    "display_name": "EMotion FX Animation",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The EMotion FX Animation Gem provides Open 3D Engine's animation system for rigged actors and includes Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Animation", "Tools", "Simulation"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/EditorPythonBindings/gem.json
+++ b/Gems/EditorPythonBindings/gem.json
@@ -1,17 +1,12 @@
 {
-    "gem_name": "EditorPythonBindings",
-    "GemFormatVersion": 4,
-    "Uuid": "b658359393884c4381c2fe2952b1472a",
-    "Name": "EditorPythonBindings",
-    "DisplayName": "EditorPythonBindings",
-    "Version": "0.1.0",
-    "Summary": "A gem to bind Editor commands via Python scripts.",
-    "Tags": ["Editor", "Assets", "Asset Pipeline", "Python"],
-    "IconPath": "preview.png",
-    "Modules": [
-      {
-        "Name": "Editor",
-        "Type": "EditorModule"
-      }
-    ]
+  "gem_name": "EditorPythonBindings",
+  "display_name": "Editor Python Bindings",
+  "license": "Apache-2.0 Or MIT",
+  "origin": "Open 3D Engine - o3de.org",
+  "type": "Tool",
+  "summary": "The Editor Python Bindings Gem provides Python commands for Open 3D Engine Editor functions.",
+  "canonical_tags": ["Gem"],
+  "user_tags": ["Scripting", "Utility"],
+  "icon_path": "preview.png",
+  "requirements": ""
 }

--- a/Gems/ExpressionEvaluation/gem.json
+++ b/Gems/ExpressionEvaluation/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "ExpressionEvaluation",
-    "GemFormatVersion": 4,
-    "Uuid": "4c6f9df57ca2468f93c8d860ee6a1167",
-    "Name": "ExpressionEvaluation",
-    "DisplayName": "Expression Evaluation",
-    "Version": "0.1.0",
-    "Summary": "Provides a method for parsing and executing various string expressions(e.g. 1+1 or 2>3).",
-    "Tags": ["Untagged"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Expression Evaluation",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Expression Evaluation Gem provides a method for parsing and executing string expressions in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Scripting", "Utiltity"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/FastNoise/gem.json
+++ b/Gems/FastNoise/gem.json
@@ -1,37 +1,12 @@
 {
     "gem_name": "FastNoise",
-    "GemFormatVersion": 4,
-    "Uuid": "c5f23032407f49ca8d8de1733423565c",
-    "Name": "FastNoise",
-    "DisplayName": "Fast Noise Gradient [PREVIEW]",
-    "Version": "0.1.0",
-    "Summary": "A Lumberyard Gem that provides a Gradient Signal component for FastNoise.  FastNoise is a realtime noise generation library with a large collection of different noise algorithms.",
-    "Tags": ["Gradient"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "8825563d9d964ec3be3bab681f3bd9f2",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "GradientSignal"
-        },
-        {
-          "Uuid": "5de82d29d6094bfe97c1a4d35fcd5fbe",
-          "VersionConstraints": [
-              "~>0.1"
-          ],
-          "_comment": "SurfaceData"
-        }
-    ]
+    "display_name": "Fast Noise",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The FastNoise Gradient Gem uses the third-party, open source FastNoise library to provide a variety of high-performance noise generation algorithms.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Utility", "Tools", "Design"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/GameState/gem.json
+++ b/Gems/GameState/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "GameState",
-    "GemFormatVersion": 4,
-    "Uuid": "1a557ac19dc34f5697fe03f30be5b6e4",
-    "Name": "GameState",
-    "DisplayName": "GameState",
-    "Version": "0.1.0",
-    "Summary": "Provides a generic framework for managing game states and the transitions between them. Some sample game states are provided in the GameStateSamples Gem.",
-    "Tags": ["Game State"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Game State",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Game State Gem provides a generic framework to determine and manage game states and game state transitions in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Gameplay", "Framework", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/GameStateSamples/gem.json
+++ b/Gems/GameStateSamples/gem.json
@@ -1,49 +1,12 @@
 {
     "gem_name": "GameStateSamples",
-    "Dependencies":
-    [
-        {
-            "Uuid" : "1a557ac19dc34f5697fe03f30be5b6e4",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "GameState"
-        },
-        {
-            "Uuid" : "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "LmbrCentral"
-        },
-        {
-            "Uuid" : "93ccb44a96b142f7942a3fb6b9ca36e1",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "LocalUser"
-        },
-        {
-            "Uuid" : "c7935ecf5e8047fe8ca947b34b11cadb",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "LyShineExamples"
-        },
-        {
-            "Uuid" : "89225422672547deaca9e7a22b883973",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "MessagePopup"
-        },
-        {
-            "Uuid" : "d96ab03f53d14c9e83f9b4528c8576d7",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "SaveData"
-        }
-    ],
-    "GemFormatVersion": 4,
-    "Uuid": "76db0b1bcff84224a92cbceb373f4a85",
-    "Name": "GameStateSamples",
-    "DisplayName": "GameStateSamples",
-    "Version": "0.1.0",
-    "Summary": "Provides a set of sample game states (built on top of the generic GameState Gem), including primary user selection, main menu, level loading, level running, and level paused.",
-    "Tags": ["Game State", "Main Menu", "Level Loading", "Pause Menu", "Primary User", "Local Multiplayer", "Local Co-op", "Split Screen"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Game State Samples",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Game State Samples Gem provides a set of sample game states (built on top of the Game State Gem), including primary user selection, main menu, level loading, level running, and level paused.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Gameplay", "Samples", "Assets"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Gestures/gem.json
+++ b/Gems/Gestures/gem.json
@@ -1,11 +1,12 @@
 {
     "gem_name": "Gestures",
-    "GemFormatVersion": 3,
-    "Uuid": "6056556b6088413984309c4a413593ad",
-    "Name": "Gestures",
-    "Version": "1.0.0",
-    "LinkType": "Dynamic",
-    "Summary": "Gesture-based input, including click/tap, drag, hold, pinch, rotate, and swipe.",
-    "IconPath": "preview.png",
-    "Tags": ["Input", "Gestures"]
+    "display_name": "Gestures",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Gestures Gem provides detection for common gesture-based input actions on iOS and Android devices.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Input", "Gameplay", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/GradientSignal/gem.json
+++ b/Gems/GradientSignal/gem.json
@@ -1,37 +1,12 @@
 {
     "gem_name": "GradientSignal",
-    "GemFormatVersion": 4,
-    "Uuid": "8825563d9d964ec3be3bab681f3bd9f2",
-    "Name": "GradientSignal",
-    "DisplayName": "Gradient Signal [PREVIEW]",
-    "Version": "0.1.0",
-    "Summary": "A Lumberyard Gem that provides a number of components for generating (ex: Random, Perlin), modifying (ex: Levels, Threshold), and mixing gradient signals.",
-    "Tags": ["Gradient", "Surface"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "5de82d29d6094bfe97c1a4d35fcd5fbe",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "SurfaceData"
-        }
-    ]
+    "display_name": "Gradient Signal",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Gradient Signal Gem provides a number of components for generating, modifying, and mixing gradient signals.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Utility", "Tools", "Design"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/GraphCanvas/gem.json
+++ b/Gems/GraphCanvas/gem.json
@@ -1,13 +1,12 @@
 {
     "gem_name": "GraphCanvas",
-    "GemFormatVersion": 3,
-    "Uuid": "875b6fcbdeea44deaae7984ad9bb6cdc",
-    "Name": "GraphCanvas",
-    "DisplayName": "GraphCanvas",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "The Graph Canvas Gem includes a C++ framework for creating custom graphical node based editors.",
-    "Tags": ["GraphCanvas"],
-    "IconPath": "preview.png",
-    "EditorModule" : true
+    "display_name": "Graph Canvas",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Graph Canvas Gem provides a C++ framework for creating custom graphical node based editors for Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Framework", "Tools", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/GraphModel/gem.json
+++ b/Gems/GraphModel/gem.json
@@ -1,26 +1,12 @@
 {
     "gem_name": "GraphModel",
-    "GemFormatVersion": 4,
-    "Uuid": "0844f64a3acf4f5abf3a535dc9b63bc9",
-    "Name": "GraphModel",
-    "DisplayName": "GraphModel",
-    "Version": "0.1.0",
-    "Summary": "A generic node graph data model framework.",
-    "Tags": ["GraphModel", "Scripting", "Vegetation"],
-    "IconPath": "graphModelIcon.svg",
-    "Modules": [
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "875b6fcbdeea44deaae7984ad9bb6cdc",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "GraphCanvas"
-        }
-    ]
+    "display_name": "Graph Model",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Graph Model Gem provides a generic node graph data model framework for Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Framework", "Tools", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/HttpRequestor/gem.json
+++ b/Gems/HttpRequestor/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "HttpRequestor",
-    "GemFormatVersion": 3,
-    "Uuid": "28479e255bde466e91fc34eec808d9c7",
-    "Name": "HttpRequestor",
-    "DisplayName": "HttpRequestor",
-    "Version": "1.0.0",
-    "LinkType": "Dynamic",
-    "Summary": "A Gem to handle HTTP/HTTPs requests.",
-    "Tags": ["http", "https", "rest"],
-    "IconPath": "preview.png"
+    "display_name": "HTTP Requestor",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The HTTP Requestor Gem provides functionality to make asynchronous HTTP/HTTPS requests and return data through a user-provided call back function.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Network", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/ImGui/gem.json
+++ b/Gems/ImGui/gem.json
@@ -1,30 +1,12 @@
 {
     "gem_name": "ImGui",
-    "GemFormatVersion": 4,
-    "Uuid": "bab8807a1bc646b3909f3cc200ffeedf",
-    "Name": "ImGui",
-    "DisplayName": "ImGui",
-    "Version": "0.1.0",
-    "Summary": "A GEM that houses 3rdParty lib IMGUI. Great for quick programmer art GUI fit for debug type menus.",
-    "Tags": ["Debug"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        }
-    ]
+    "display_name": "Immediate Mode GUI (IMGUI)",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Immediate Mode GUI Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "Rendering", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/InAppPurchases/gem.json
+++ b/Gems/InAppPurchases/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "InAppPurchases",
-    "GemFormatVersion": 3,
-    "Uuid": "92fe57eae7d3402a90761973678c079a",
-    "Name": "InAppPurchases",
-    "DisplayName": "In-App Purchases",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Provides the in-app purchasing API for iOS and Android",
-    "Tags": ["InAppPurchases", "iOS", "Android"],
-    "IconPath": "preview.png"
+    "display_name": "In-App Purchases",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The In-App Purchases Gem provides functionality for in app purchases for iOS and Android.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["SDK", "Network"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/LandscapeCanvas/gem.json
+++ b/Gems/LandscapeCanvas/gem.json
@@ -1,61 +1,12 @@
 {
     "gem_name": "LandscapeCanvas",
-    "GemFormatVersion": 4,
-    "Uuid": "19c2b2d5018940108baf252934b8e6bf",
-    "Name": "LandscapeCanvas",
-    "DisplayName": "LandscapeCanvas",
-    "Version": "0.1.0",
-    "Summary": "A node-based Editor for authoring Dynamic Vegetation.",
-    "Tags": ["Vegetation"],
-    "IconPath": "landscapeCanvasIcon.svg",
-    "Modules": [
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "f394e7cf54424bba89615381bba9511b",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "Vegetation"
-        },
-        {
-            "Uuid": "875b6fcbdeea44deaae7984ad9bb6cdc",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "GraphCanvas"
-        },
-        {
-            "Uuid" : "0844f64a3acf4f5abf3a535dc9b63bc9",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment" : "GraphModel"
-        },
-        {
-          "Uuid": "8825563d9d964ec3be3bab681f3bd9f2",
-          "VersionConstraints": [
-              "~>0.1"
-          ],
-          "_comment": "GradientSignal"
-        },
-        {
-          "Uuid": "5de82d29d6094bfe97c1a4d35fcd5fbe",
-          "VersionConstraints": [
-              "~>0.1"
-          ],
-          "_comment": "SurfaceData"
-        }
-    ]
+    "display_name": "Landscape Canvas",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Landscape Canvas Gem provides the Landscape Canvas editor, a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Environment", "Design", "Tools"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/LmbrCentral/gem.json
+++ b/Gems/LmbrCentral/gem.json
@@ -1,14 +1,13 @@
 {
     "gem_name": "LmbrCentral",
-    "GemFormatVersion": 3,
-    "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-    "Name": "LmbrCentral",
-    "DisplayName": "LmbrCentral",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Required LmbrCentral Engine Gem.",
-    "Tags": ["Required"],
-    "IconPath": "preview.png",
-    "EditorModule": true,
-    "IsRequired": true
+    "display_name": "O3DE Core (LmbrCentral)",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The O3DE Core (LmbrCentral) Gem provides required code and assets for running Open 3D Engine Editor.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Core", "Framework", "Assets"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }
+

--- a/Gems/LocalUser/gem.json
+++ b/Gems/LocalUser/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "LocalUser",
-    "GemFormatVersion": 4,
-    "Uuid": "93ccb44a96b142f7942a3fb6b9ca36e1",
-    "Name": "LocalUser",
-    "DisplayName": "LocalUser",
-    "Version": "0.1.0",
-    "Summary": "Provides functionality for mapping local user ids to local player slots and managing local user profiles.",
-    "Tags": ["User", "Local User", "Local User Profile", "Primary User", "Local Multiplayer", "Local Co-op", "Split Screen"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Local User",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Local User Gem provides functionality for mapping local user ids to local player slots and managing local user profiles.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Input", "Gameplay", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/LyShine/gem.json
+++ b/Gems/LyShine/gem.json
@@ -1,39 +1,12 @@
 {
     "gem_name": "LyShine",
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "5a149b6b3c964064bd4970f0e92f72e2",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "Texture Atlas"
-        }
-    ],
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends":  "GameModule"
-        }
-    ],
-    "GemFormatVersion": 4,
-    "Uuid": "0fefab3f13364722b2eab3b96ce2bf20",
-    "Name": "LyShine",
-    "DisplayName": "LyShine",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "LyShine is the in-game UI system for Lumberyard",
-    "Tags": ["UI","Required"],
-    "IconPath": "preview.png",
-    "IsRequired": true
+    "display_name": "LyShine",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The LyShine Gem provides the runtime UI system and creation tools for Open 3D Engine projects.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["UI", "Tools", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/LyShineExamples/gem.json
+++ b/Gems/LyShineExamples/gem.json
@@ -1,26 +1,12 @@
 {
     "gem_name": "LyShineExamples",
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "6bb61c9e547043f0afc5019d6d460b78",
-            "VersionConstraints": [ "~>0.1.0" ],
-            "_comment": "UiBasics"
-        }
-    ],
-    "GemFormatVersion": 3,
-    "Uuid": "c7935ecf5e8047fe8ca947b34b11cadb",
-    "Name": "LyShineExamples",
-    "DisplayName": "LyShineExamples",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Provides example code for using LyShine.",
-    "Tags": ["UI", "LyShine", "Example"],
-    "IconPath": "preview.png"
+    "display_name": "LyShine Examples",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The LyShine Examples Gem provides example code and assets for LyShine, the runtime UI system and editor for Open 3D Engine projects.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["UI", "Sample", "Assets"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Maestro/gem.json
+++ b/Gems/Maestro/gem.json
@@ -1,14 +1,13 @@
 {
     "gem_name": "Maestro",
-    "GemFormatVersion": 3,
-    "Uuid": "3b9a978ed6f742a1acb99f74379a342c",
-    "Name": "Maestro",
-    "DisplayName": "Maestro",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Lumberyard Cinematics Module",
-    "Tags": ["Cinematics","Required"],
-    "IconPath": "preview.png",
-    "EditorModule": true,
-    "IsRequired": true
+    "display_name": "Maestro Cinematics",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Maestro Cinematics Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Animation", "Tools", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }
+

--- a/Gems/MessagePopup/gem.json
+++ b/Gems/MessagePopup/gem.json
@@ -1,25 +1,12 @@
 {
     "gem_name": "MessagePopup",
-    "GemFormatVersion": 4,
-    "Uuid": "89225422672547deaca9e7a22b883973",
-    "Name": "MessagePopup",
-    "DisplayName": "MessagePopup",
-    "Version": "0.1.0",
-    "Summary": "Show a message popup ",
-    "Tags": ["Untagged"],
-    "IconPath": "preview.png",
-    "Dependencies": [
-        {
-            "Uuid": "6bb61c9e547043f0afc5019d6d460b78",
-            "VersionConstraints": [
-                "~>0.1.0"
-            ],
-            "_comment": "UiBasics"
-        }
-    ],
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Message Popup",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Message Popup Gem provides an example implementation of popup messages using LyShine in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Gameplay", "Sample"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Metastream/gem.json
+++ b/Gems/Metastream/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "Metastream",
-    "GemFormatVersion": 3,
-    "Uuid": "c02d7efe05134983b5699d9ee7594c3a",
-    "Name": "Metastream",
-    "DisplayName": "Metastream",
-    "Version": "1.0.0",
-    "LinkType": "Dynamic",
-    "Summary": "When the Metastream Gem is installed, it will set up a project to run an HTTP server that can service requests for the purpose of allowing broadcasters to customize game streams with overlays of statistics and event data from a game session creating a more engaging experience for the viewer.",
-    "Tags": ["Twitch", "Metastream", "Streaming", "Broadcasting", "Overlay"],
-    "IconPath": "preview.png"
+    "display_name": "Metastream",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Metastream Gem provides functionality for an HTTP server that allows broadcasters to customize game streams with overlays of statistics and event data from a game session.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Gameplay", "Network", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Microphone/gem.json
+++ b/Gems/Microphone/gem.json
@@ -1,19 +1,12 @@
 {
     "gem_name": "Microphone",
-    "GemFormatVersion": 3,
-    "Uuid": "e70dd59f02f14ea49e6b38434e86ebf1",
-    "Name": "Microphone",
-    "DisplayName": "Microphone",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Provides access to connected Microphone Devices and ability to read their input.",
-    "Tags": ["Audio", "Microphone"],
-    "IconPath": "preview.png",
-    "Dependencies": [
-        {
-            "Uuid": "6f63f2b6d07f4b89b4b7c86ebee7feb8",
-            "VersionConstraints": [">=0.1.0"],
-            "_comment": "AudioSystem"
-        }
-    ]
+    "display_name": "Microphone",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Microphone Gem provides support for audio input through microphones.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Audio", "Input"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Multiplayer/gem.json
+++ b/Gems/Multiplayer/gem.json
@@ -1,11 +1,12 @@
 {
     "gem_name": "Multiplayer",
-    "GemFormatVersion": 3,
-    "Uuid": "9524EBD3E64D4D13A9764A18DB9A564F",
-    "Name": "Multiplayer",
-    "Version": "1.0.0",
-    "LinkType": "Dynamic",
-    "Tags": ["Multiplayer","Networking"],
-    "Summary": "The Multiplayer Gem provides high level advanced multiplayer gameplay functionality such as entity replication, local prediction, and server side backward reconciliation",
-    "IconPath": "preview.png"
+    "display_name": "Multiplayer",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Multiplayer Gem provides a public API for multiplayer functionality such as connecting and hosting.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Multiplayer", "Network", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/MultiplayerCompression/gem.json
+++ b/Gems/MultiplayerCompression/gem.json
@@ -1,10 +1,12 @@
 {
     "gem_name": "MultiplayerCompression",
     "display_name": "Multiplayer Compression",
-    "summary": "The Multiplayer Compression gem provides an open source Compressor for use with AzNetworking's transport layer.",
-    "canonical_tags": ["Multiplayer", "Networking", "Utility"],
-    "user_tags": ["MultiplayerCompression"],
-    "icon_path": "preview.png",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
-    "provider": "Open 3D Foundation"
+    "summary": "The Multiplayer Compression Gem provides an open source Compressor for use with AzNetworking's transport layer.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Multiplayer", "Network", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/NvCloth/gem.json
+++ b/Gems/NvCloth/gem.json
@@ -1,8 +1,12 @@
 {
     "gem_name": "NvCloth",
-    "display_name": "NVIDIA Cloth [PREVIEW]",
-    "summary": "Provides the functionality needed to add cloth simulation.",
+    "display_name": "NVIDIA Cloth (NvCloth)",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The NVIDIA Cloth Gem provides functionality to create fast, realistic cloth simulation with the NVIDIA Cloth library.",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Physics"],
-    "icon_path": "preview.png"
+    "user_tags": ["Physics", "Simulation", "SDK"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/PBSreferenceMaterials/gem.json
+++ b/Gems/PBSreferenceMaterials/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "PBSreferenceMaterials",
-    "GemFormatVersion": 3,
-    "Uuid": "07375b61b1a2424bb03088bbdf28b2c8",
-    "Name": "PBSreferenceMaterials",
-    "DisplayName": "PBSreferenceMaterials",
-    "Version": "0.1.0",
-    "LinkType": "NoCode",
-    "Summary": "A set of Physically Based Shading reference materials and texture assets",
-    "Tags": ["Asset"],
-    "IconPath": "preview.png"
+    "display_name": "PBS Reference Materials",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The PBS Reference Materials Gem provides physically based reference materials for Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Sample", "Assets"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/PhysX/gem.json
+++ b/Gems/PhysX/gem.json
@@ -1,22 +1,12 @@
 {
     "gem_name": "PhysX",
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        }
-    ],
-    "GemFormatVersion": 3,
-    "Uuid": "4e08125824434932a0fe3717259caa47",
-    "Name": "PhysX",
-    "DisplayName": "PhysX",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "The PhysX Gem enables the NVIDIA PhysX SDK to provide physics simulation for Lumberyard. The PhysX system is not compatible with the legacy physics system. You cannot use components interchangeably between each system.",
-    "Tags": ["Physics"],
-    "IconPath": "preview.png",
-    "EditorModule": true
+    "display_name": "PhysX",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The PhysX Gem provides physics simulation with NVIDIA PhysX including static and dynamic rigid body simulation, force regions, ragdolls, and dynamic PhysX joints.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Physics", "Simulation", "SDK"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/PhysXDebug/gem.json
+++ b/Gems/PhysXDebug/gem.json
@@ -1,29 +1,12 @@
 {
     "gem_name": "PhysXDebug",
-    "Dependencies": [
-        {
-            "Uuid": "4e08125824434932a0fe3717259caa47",
-            "VersionConstraints": [
-                ">=0.1"
-            ],
-            "_comment": "PhysX Gem"
-        },
-        {
-            "Uuid": "bab8807a1bc646b3909f3cc200ffeedf",
-            "VersionConstraints": [
-                ">=0.1.0"
-            ],
-            "_comment": "ImGui Gem"
-        }
-    ],
-    "GemFormatVersion": 3,
-    "Uuid": "516145e2d9904b13813f1b54605e26a6",
-    "Name": "PhysXDebug",
-    "DisplayName": "PhysX Debug [PREVIEW]",
-    "Version": "0.1.0",	
-    "LinkType": "Dynamic",
-    "Summary": "Debug features for the PhysX gem.",
-    "Tags": ["Physics", "Debug"],
-    "IconPath": "preview.png",
-    "EditorModule": true
+    "display_name": "PhysX Debug",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The PhysX Debug Gem provides debugging functionality and visualizations for NVIDIA PhysX in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Physics", "Simulation", "Debug"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/PhysXSamples/gem.json
+++ b/Gems/PhysXSamples/gem.json
@@ -1,42 +1,12 @@
 {
     "gem_name": "PhysXSamples",
-     "Dependencies": [
-        {
-            "Uuid": "ed07631f95fb4be1bd10cd37298ec697",
-            "VersionConstraints": [
-                ">=0.1"
-            ],
-            "_comment": "Uses mesh assets from primatives gem"
-        },
-		{
-            "Uuid": "2c227161447b4d77a5b07c093e214fe3",
-            "VersionConstraints": [
-                ">=0.1"
-            ],
-            "_comment": "Uses textures from DevTextures gem"
-        },
-		{
-            "Uuid": "4e08125824434932a0fe3717259caa47",
-            "VersionConstraints": [
-                ">=0.1"
-            ],
-            "_comment": "Requires PhysX"
-        },
-		{
-            "Uuid": "66239f50bf754354b514c850c8b841fb",
-            "VersionConstraints": [
-                ">=0.1"
-            ],
-            "_comment": "Uses debug draw Script Canvas nodes"
-        }
-    ],
-	"GemFormatVersion": 3,
-    "Uuid": "c4a4aadba44241ae9f0141e145def7f7",
-    "Name": "PhysXSamples",
-    "DisplayName": "PhysXSamples",
-    "Version": "0.1.0",
-    "LinkType": "NoCode",
-    "Summary": "Collection of samples that demostrate PhysX features.",
-    "Tags": ["Asset"],
-    "IconPath": "preview.png"
+    "display_name": "PhysX Samples",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The PhysX Samples Gem provides sample assets and scripts that demonstrate PhysX Gem features in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Physics", "Simulation", "Sample"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Prefab/PrefabBuilder/gem.json
+++ b/Gems/Prefab/PrefabBuilder/gem.json
@@ -1,17 +1,12 @@
 {
     "gem_name": "PrefabBuilder",
-    "GemFormatVersion": 4,
-    "Uuid": "88500802311C4793B03484BE2091B607",
-    "Name": "PrefabBuilder",
-    "DisplayName": "PrefabBuilder",
-    "Version": "0.1.0",
-    "Summary": "Asset Processor builder module for Prefabs",
-    "Tags": ["Prefabs"],
-    "IconPath": "preview.png",
-    "Modules": [ 
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ]
+    "display_name": "Prefab Builder",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Prefab Builder Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Utility", "Core"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Presence/gem.json
+++ b/Gems/Presence/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "Presence",
-    "GemFormatVersion": 4,
-    "Uuid": "903ce283760647049efaef70d9368eeb",
-    "Name": "Presence",
-    "DisplayName": "Presence",
-    "Version": "0.1.0",
-    "Summary": "Platform agnostic interface for Presence services",
-    "Tags": [ "Presence", "Rich Presence" ],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Presence",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Presence Gem provides a target platform agnostic interface for Presence services.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Network", "Gameplay", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/PrimitiveAssets/gem.json
+++ b/Gems/PrimitiveAssets/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "PrimitiveAssets",
-    "GemFormatVersion": 3,
-    "Uuid": "ed07631f95fb4be1bd10cd37298ec697",
-    "Name": "PrimitiveAssets",
-    "DisplayName": "Primitive Assets",
-    "Version": "1.0.0",
-    "LinkType": "NoCode",
-    "Summary": "Provides simple primitive shape assets useful for quickly building a basic scene.",
-    "Tags": ["Getting Started", "Asset"],
-    "IconPath": "preview.png"
+    "display_name": "Primitive Assets",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The Primitive Assets Gem provides primitive shape mesh assets with physics enabled.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Sample", "Debug"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/PythonAssetBuilder/gem.json
+++ b/Gems/PythonAssetBuilder/gem.json
@@ -1,17 +1,12 @@
 {
-    "gem_name": "PythonAssetBuilder",
-    "GemFormatVersion": 4,
-    "Uuid": "0a5fda05323649009444bb7c3ee2b9c4",
-    "Name": "PythonAssetBuilder",
-    "DisplayName": "PythonAssetBuilder",
-    "Version": "0.1.0",
-    "Summary": "Runs asset builders written in Python scripts.",
-    "Tags": ["asset"],
-    "IconPath": "preview.png",
-    "Modules": [
-      {
-        "Name": "Editor",
-        "Type": "EditorModule"
-      }
-    ]
+  "gem_name": "PythonAssetBuilder",
+  "display_name": "Python Asset Builder",
+  "license": "Apache-2.0 Or MIT",
+  "origin": "Open 3D Engine - o3de.org",
+  "type": "Code",
+  "summary": "The Python Asset Builder Gem provides functionality to implement custom asset builders in Python for Asset Processor.",
+  "canonical_tags": ["Gem"],
+  "user_tags": ["Scripting", "Assets", "Utility"],
+  "icon_path": "preview.png",
+  "requirements": ""
 }

--- a/Gems/QtForPython/gem.json
+++ b/Gems/QtForPython/gem.json
@@ -1,26 +1,12 @@
 {
     "gem_name": "QtForPython",
-    "GemFormatVersion": 4,
-    "Uuid": "cd50c7a1e31f4c9495dcffdacc3bde92",
-    "Name": "QtForPython",
-    "DisplayName": "QtForPython",
-    "Version": "0.1.0",
-    "Summary": "Adds the ability to use the PySide2 Python libraries to manage Qt widgets.",
-    "Tags": ["Editor"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "b658359393884c4381c2fe2952b1472a",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "EditorPythonBindings"
-        }
-    ]
-}
+    "display_name": "Qt for Python",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Qt for Python Gem provides the PySide2 Python libraries to manage Qt widgets.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Scripting", "UI", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/RADTelemetry/gem.json
+++ b/Gems/RADTelemetry/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "RADTelemetry",
-    "GemFormatVersion": 3,
-    "Uuid": "bdaf32823406492686e35200afc555b3",
-    "Name": "RADTelemetry",
-    "DisplayName": "RAD Telemetry",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "The RAD Telemetry Gem allows licensors of RAD Telemetry 3 to quickly integrate RAD Telemetry 3 with Lumberyard. For instructions on enabling RAD Telemetry Gem, visit https://docs.aws.amazon.com/lumberyard/latest/userguide/gems-system-gem-rad-telemetry.html",
-    "Tags": ["Profile", "Profiler", "Profiling"],
-    "IconPath": "preview.png"
+    "display_name": "RAD Telemetry",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The RAD Telemetry Gem provides support for RAD Telemetry, a performance profiling and visualization middleware, in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "SDK"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/SaveData/gem.json
+++ b/Gems/SaveData/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "SaveData",
-    "GemFormatVersion": 4,
-    "Uuid": "d96ab03f53d14c9e83f9b4528c8576d7",
-    "Name": "SaveData",
-    "DisplayName": "SaveData",
-    "Version": "0.1.0",
-    "Summary": "Provides a simple, platform agnostic API for saving and loading persistent user data.",
-    "Tags": ["Save", "Load", "Save Data", "Save Game", "Persistent Data"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
-}
+    "display_name": "Save Data",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Save Data Gem provides a platform independent API to save and load persistent user data in Open 3D Engine projects.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Utility", "Gameplay"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/SceneLoggingExample/gem.json
+++ b/Gems/SceneLoggingExample/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "SceneLoggingExample",
-    "GemFormatVersion": 3,
-    "Uuid": "35d8f6e49ae04c9382c61a42d4355c2f",
-    "Name": "SceneLoggingExample",
-    "DisplayName": "Scene Logging Example",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "This example Gem demonstrates the basics of extending the SceneAPI by adding additional logging to the pipeline. Please read ReadMe.txt for further details.",
-    "Tags": ["Scene", "FBX"],
-    "IconPath": "preview.png"
-}
+    "display_name": "Scene Logging Example",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The Scene Logging Example Gem demonstrates the basics of extending the Open 3D Engine Scene API by adding additional logging to the pipeline.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Debug", "Sample"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/SceneProcessing/gem.json
+++ b/Gems/SceneProcessing/gem.json
@@ -1,20 +1,12 @@
 {
     "gem_name": "SceneProcessing",
-    "GemFormatVersion": 3,
-    "Uuid": "7c2578f634df4345aca98d671e39b8ab",
-    "Name": "SceneProcessing",
-    "DisplayName": "Scene Processing (PREVIEW)",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Use this gem to fine tune the defaults for processing of scene files like Fbx.",
-    "Tags": ["Scene", "FBX", "Assets"],
-    "IconPath": "preview.png",
-    "EditorModule": true,
-    "IsRequired": false,
-    "Modules": [
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ]
-}
+    "display_name": "Scene Processing",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Scene Processing Gem provides Scene Settings, a tool you can use to specify the default settings for processing asset files for actors, meshes, motions, and PhysX.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Tools", "Core"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/ScriptCanvas/gem.json
+++ b/Gems/ScriptCanvas/gem.json
@@ -1,30 +1,12 @@
 {
-    "gem_name": "ScriptCanvas",
-    "GemFormatVersion": 3,
-    "Uuid": "869a0d0ec11a45c299917d45c81555e6",
-    "Name": "ScriptCanvas",
-    "DisplayName": "Script Canvas",
-    "Version": "0.1.0",
-    "LinkType": "DynamicStatic",
-    "EditorModule": true,
-    "Summary": "The Script Canvas Gem contains Lumberyard's visual scripting environment that enables content creators with little to no engineering experience to build game logic.",
-    "Tags": ["Scripting", "Game"],
-    "IconPath": "preview.png",
-    "Dependencies" : [
-      {
-        "Uuid": "875b6fcbdeea44deaae7984ad9bb6cdc",
-        "VersionConstraints": [ ">=0.1.0" ],
-        "_comment": "GraphCanvas"
-      },
-      {
-        "Uuid": "32d8ba21703e4bbbb08487366e48dd69",
-        "VersionConstraints": [ ">=0.1.0" ],
-        "_comment": "ScriptEvents"
-      },
-      {
-        "Uuid": "4c6f9df57ca2468f93c8d860ee6a1167",
-        "VersionConstraints": [ ">=0.1.0" ],
-        "_comment": "ExpressionEvaluation"
-      }
-    ]
+  "gem_name": "ScriptCanvas",
+  "display_name": "Script Canvas",
+  "license": "Apache-2.0 Or MIT",
+  "origin": "Open 3D Engine - o3de.org",
+  "type": "Tool",
+  "summary": "The Script Canvas Gem provides Open 3D Engine's visual scripting environment, Script Canvas.",
+  "canonical_tags": ["Gem"],
+  "user_tags": ["Scripting", "Tools", "Utiltiy"],
+  "icon_path": "preview.png",
+  "requirements": ""
 }

--- a/Gems/ScriptCanvasDeveloper/gem.json
+++ b/Gems/ScriptCanvasDeveloper/gem.json
@@ -1,30 +1,12 @@
 {
     "gem_name": "ScriptCanvasDeveloperGem",
-    "GemFormatVersion": 3,
-    "Uuid": "f905c05883b94fd6bddc91052c3c5a86",
-    "Name": "ScriptCanvasDeveloperGem",
-    "DisplayName": "Script Canvas Developer Tools",
-    "Version": "0.1.0",
-    "LinkType": "DynamicStatic",
-    "EditorModule": true,
-    "Summary": "The Script Canvas Developer Gem contains a suite of utility features that aids in the development and debugging of Script Canvas systems.",
-    "Tags": ["Scripting", "Editor"],
-    "IconPath": "preview.png",
-    "Dependencies" : [
-        {
-            "Uuid" : "bab8807a1bc646b3909f3cc200ffeedf",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "ImGui"
-        },
-        {
-            "Uuid" : "869a0d0ec11a45c299917d45c81555e6",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "ScriptCanvas"
-        },
-        {
-            "Uuid" : "875b6fcbdeea44deaae7984ad9bb6cdc",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "GraphCanvas"
-        }
-    ]
-}
+    "display_name": "Script Canvas Developer",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Script Canvas Developer Gem provides a suite of utility features for the development and debugging of Script Canvas systems.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Scripting", "Utility", "Debug"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/ScriptCanvasPhysics/gem.json
+++ b/Gems/ScriptCanvasPhysics/gem.json
@@ -1,32 +1,12 @@
 {
     "gem_name": "ScriptCanvasPhysics",
-    "GemFormatVersion": 4,
-    "Uuid": "1c27519a4dda4ffaaeebf91514e5b1e8",
-    "Name": "ScriptCanvasPhysics",
-    "DisplayName": "Script Canvas - Physics",
-    "Version": "0.1.0",
-    "Summary": "Exposes legacy physics features to scripting through the Behavior Context to Lua and Script Canvas.",
-    "Tags": ["Scripting", "Physics"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                ">=0.1.0"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "869a0d0ec11a45c299917d45c81555e6",
-            "VersionConstraints": [
-                ">=0.1.0"
-            ],
-            "_comment": "ScriptCanvas"
-        }
-    ]
-}
+    "display_name": "Script Canvas Physics",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Script Canvas Physics Gem provides Script Canvas nodes for physics scene queries such as raycasts.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Scripting", "Physics", "Simulation"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/ScriptCanvasTesting/gem.json
+++ b/Gems/ScriptCanvasTesting/gem.json
@@ -1,29 +1,12 @@
 {
-    "gem_name": "ScriptCanvasTesting",
-    "GemFormatVersion": 4,
-    "Uuid": "387b1b2d39ce45fbbfbb6faa5f902cac",
-    "Name": "ScriptCanvasTesting",
-    "DisplayName": "Script Canvas Testing",
-    "Version": "0.1.0",
-    "Summary": "Provides a framework for testing for and with ScriptCanvas",
-    "Tags": ["Scripting", "Testing"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "EditorModule",
-            "Name": "Editor"
-        }
-    ],
-    "Dependencies" : [
-      {
-        "Uuid": "875b6fcbdeea44deaae7984ad9bb6cdc",
-        "VersionConstraints": [ ">=0.1.0" ],
-        "_comment": "GraphCanvas"
-      },
-      {
-        "Uuid": "869a0d0ec11a45c299917d45c81555e6",
-        "VersionConstraints": [ ">=0.1.0" ],
-        "_comment": "ScriptCanvas"
-      }
-    ]
+  "gem_name": "ScriptCanvasTesting",
+  "display_name": "Script Canvas Testing",
+  "license": "Apache-2.0 Or MIT",
+  "origin": "Open 3D Engine - o3de.org",
+  "type": "Tool",
+  "summary": "The Script Canvas Testing Gem provides a framework for testing for and with Script Canvas.",
+  "canonical_tags": ["Gem"],
+  "user_tags": ["Scripting", "Debug", "Framework"],
+  "icon_path": "preview.png",
+  "requirements": ""
 }

--- a/Gems/ScriptEvents/gem.json
+++ b/Gems/ScriptEvents/gem.json
@@ -1,21 +1,12 @@
 {
   "gem_name": "ScriptEvents",
-  "GemFormatVersion": 4,
-  "Uuid": "32d8ba21703e4bbbb08487366e48dd69",
-  "Name": "ScriptEvents",
-  "DisplayName": "Script Events",
-  "Version": "0.1.0",
-  "Summary": "Provides a framework for creating event assets usable from any scripting solution.",
-  "Tags": [ "Script", "Events", "Lua", "Script", "Canvas", "EBus", "Behavior Context" ],
-  "IconPath": "preview.png",
-  "Modules": [
-    {
-      "Type": "GameModule"
-    },
-    {
-      "Name": "Editor",
-      "Type": "EditorModule",
-      "Extends": "GameModule"
-    }
-  ]
+  "display_name": "Script Events",
+  "license": "Apache-2.0 Or MIT",
+  "origin": "Open 3D Engine - o3de.org",
+  "type": "Code",
+  "summary": "The Script Events Gem provides a framework for creating event assets usable from any scripting solution in Open 3D Engine.",
+  "canonical_tags": ["Gem"],
+  "user_tags": ["Scripting", "Framework", "Gameplay"],
+  "icon_path": "preview.png",
+  "requirements": ""
 }

--- a/Gems/ScriptedEntityTweener/gem.json
+++ b/Gems/ScriptedEntityTweener/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "ScriptedEntityTweener",
-    "GemFormatVersion": 3,
-    "Uuid": "0d1f5f05559c4a99aaefd30633a0158e",
-    "Name": "ScriptedEntityTweener",
-    "DisplayName": "Scripted Entity Tweener",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "Entity Animator can be used to transform entity properties in Lumberyard",
-    "Tags": ["UI"],
-    "IconPath": "preview.png"
-}
+    "display_name": "Scripted Entity Tweener",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Scripted Entity Tweener Gem provides a script driven animation system for Open 3D Engine projects.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Scripting", "UI", "Animation"],
+    "icon_path": "preview.png",
+    "requirements": ""
+  }

--- a/Gems/SliceFavorites/gem.json
+++ b/Gems/SliceFavorites/gem.json
@@ -1,17 +1,11 @@
 {
     "gem_name": "SliceFavorites",
-    "GemFormatVersion": 4,
-    "Uuid": "1bfc7270d4a1490daac8aa8b072c4489",
-    "Name": "SliceFavorites",
-    "DisplayName": "SliceFavorites",
-    "Version": "0.1.0",
-    "Summary": "Add the ability to favorite a slice to allow easy access and instantiation",
-    "Tags": ["Editor", "Slices"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-          "Type": "EditorModule",
-          "Name":  "Editor"
-        }
-    ]
+    "display_name": "SliceFavorites",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "Add the ability to favorite a slice to allow easy access and instantiation",
+    "user_tags": ["Editor", "Slices"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/StartingPointCamera/gem.json
+++ b/Gems/StartingPointCamera/gem.json
@@ -1,35 +1,12 @@
 {
     "gem_name": "StartingPointCamera",
-    "Dependencies": [
-        {
-            "Uuid": "54f2763fe191432fa681ce4a354eedf5", 
-            "VersionConstraints": [
-                "~>0.1"
-            ], 
-            "_comment": "CameraFramework"
-        },
-        {
-            "Uuid": "f910686b6725452fbfc4671f95f733c6", 
-            "VersionConstraints": [
-                "~>0.1"
-            ], 
-            "_comment": "Camera"
-        },
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        }
-    ],
-    "GemFormatVersion": 3,
-    "Uuid": "834070b9537d44df83559e2045c3859f",
-    "Name": "StartingPointCamera",
-    "DisplayName": "Starting Point Camera [PREVIEW]",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "Summary": "The Starting Point Camera Gem includes the behaviors used with the Camera Framework Gem to define a camera rig.",
-    "Tags": ["Camera", "Starting Point"],
-    "IconPath": "preview.png"
+    "display_name": "Starting Point Camera",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Starting Point Camera Gem provides the behaviors used with the Camera Framework Gem to define a camera rig.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Gameplay", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/StartingPointInput/gem.json
+++ b/Gems/StartingPointInput/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "StartingPointInput",
-    "Dependencies": [
-        {
-            "Uuid" : "869a0d0ec11a45c299917d45c81555e6",
-            "VersionConstraints" : [">=0.1.0"],
-            "_comment" : "ScriptCanvas"
-        }
-    ],
-    
-    "GemFormatVersion": 3,
-    "Uuid": "09f4bedeee614358bc36788e77f97e51",
-    "Name": "StartingPointInput",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "EditorModule": true,
-    "DisplayName": "Starting Point Input",
-    "Tags": ["Input","Starting Point"],
-    "Summary": "The Starting Point Input Gem builds on top of the AzFramework/Input system to map raw input into higher level gameplay events specified by the user.",
-    "IconPath": "preview.png"
+    "display_name": "Starting Point Input",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Starting Point Input Gem provides functionality to map low-level input events to high-level actions.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Input", "Gameplay", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/StartingPointMovement/gem.json
+++ b/Gems/StartingPointMovement/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "StartingPointMovement",
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        }
-    ],
-    "GemFormatVersion": 3,
-    "Uuid": "73d8779dc28a4123b7c9ed76217464af",
-    "Name": "StartingPointMovement",
-    "Version": "0.1.0",
-    "LinkType": "Dynamic",
-    "DisplayName": "Starting Point Movement [PREVIEW]",
-    "Summary": "The Starting Point Movement Gem includes a series of Lua scripts that listens for input events that then triggers a transform operation such as movement or rotation.",
-    "Tags": ["Movement", "Starting Point"],
-    "IconPath": "preview.png"
+    "display_name": "Starting Point Movement",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Starting Point Movement Gem provides a series of Lua scripts that listen and respond to input events and trigger transform operations such as translation and rotation.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Input", "Gameplay", "Scripting"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/SurfaceData/gem.json
+++ b/Gems/SurfaceData/gem.json
@@ -1,30 +1,12 @@
 {
     "gem_name": "SurfaceData",
-    "GemFormatVersion": 4,
-    "Uuid": "5de82d29d6094bfe97c1a4d35fcd5fbe",
-    "Name": "SurfaceData",
-    "DisplayName": "Surface Data [PREVIEW]",
-    "Version": "0.1.0",
-    "Summary": "A Lumberyard Gem that allows you to attach user-defined tags to surfaces and volumes, and fetch data like positions, normals, and tags for those surfaces.",
-    "Tags": ["Surface", "Geometry", "Tags"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ],
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        }
-    ]
+    "display_name": "Surface Data",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Surface Data Gem provides functionality to emit signals or tags from surfaces such as meshes and terrain.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Environment", "Utiltiy", "Design"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/TestAssetBuilder/gem.json
+++ b/Gems/TestAssetBuilder/gem.json
@@ -1,17 +1,12 @@
 {
     "gem_name": "TestAssetBuilder",
-    "GemFormatVersion": 4,
-    "Uuid": "f5c92f1560714010ba30467d93feecef",
-    "Name": "TestAssetBuilder",
-    "DisplayName": "Test Asset Builder",
-    "Version": "0.1.0",
-    "Summary": "This builder is used for feature testing the asset processor.",
-    "Tags": ["Assets", "Pipeline", "Feature Test", "Asset Builder", "Asset Processor"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Name": "Editor",
-            "Type": "EditorModule"
-        }
-    ]
+    "display_name": "Test Asset Builder",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Test Asset Builder Gem is used to feature test Asset Processor.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Assets", "Debug", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/TextureAtlas/gem.json
+++ b/Gems/TextureAtlas/gem.json
@@ -1,17 +1,12 @@
 {
     "gem_name": "TextureAtlas",
-    "GemFormatVersion": 4,
-    "Uuid": "5a149b6b3c964064bd4970f0e92f72e2",
-    "Name": "TextureAtlas",
-    "DisplayName": "Texture Atlas",
-    "Version": "0.1.0",
-    "Summary": "Includes the formatting for Texture Atlases",
-    "Tags": ["Required", "Asset Processor Builder", "Texture Atlas"],
-    "IconPath": "preview.png",
-    "IsRequired": true,
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Texture Atlas",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Texture Atlas Gem provides the formatting for texture atlases from 2D textures for LyShine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Assets", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/TickBusOrderViewer/gem.json
+++ b/Gems/TickBusOrderViewer/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "TickBusOrderViewer",
-    "GemFormatVersion": 4,
-    "Uuid": "937fc4d2b2a94291bdeea06261c501b3",
-    "Name": "TickBusOrderViewer",
-    "DisplayName": "Tick Bus Order Console Variable",
-    "Version": "1.0.0",
-    "Summary": "Provides the console variable, print_tickbus_handlers, which displays the order of all tick events to the console. If you specify an entityId, it will only display the tick events for that entity.",
-    "Tags": ["Console Variable", "CVAR"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Tick Bus Order Viewer",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The Tick Bus Order Viewer Gem provides a console variable that displays the order of runtime tick events.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Gameplay", "Simulation", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Twitch/gem.json
+++ b/Gems/Twitch/gem.json
@@ -1,19 +1,12 @@
 {
     "gem_name": "Twitch",
-    "GemFormatVersion": 3,
-    "Uuid": "b63e64141fab40b791211ba257632e84",
-    "Name": "Twitch",
-    "DisplayName": "Twitch",
-    "Version": "1.0.0",
-    "LinkType": "Dynamic",
-    "Summary": "Provides access to the Twitch API v5 SDK including social functions, channels, and other APIs.",
-    "Tags": ["Twitch","SDK","Social"],
-    "IconPath": "preview.png",
-    "Dependencies": [
-        {
-            "Uuid": "28479e255bde466e91fc34eec808d9c7",
-            "VersionConstraints": [ "~>1.0" ],
-            "_comment": "HttpRequestor"
-        }
-    ]
+    "display_name": "Twitch",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Twitch Gem provides access to the Twitch API v5 SDK including social functions, channels, and other APIs.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Network", "SDK", "Multiplayer"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/UiBasics/gem.json
+++ b/Gems/UiBasics/gem.json
@@ -1,12 +1,12 @@
 {
     "gem_name": "UiBasics",
-    "GemFormatVersion": 3,
-    "LinkType": "NoCode",
-    "Name": "UiBasics",
-    "DisplayName": "UI Basics",
-    "Summary": "Provides basic UI prefabs: image, text, button, and text input, as well as the textures that those prefabs require.",
-    "Uuid": "6bb61c9e547043f0afc5019d6d460b78",
-    "Version": "0.1.0",
-    "IconPath": "preview.png",
-    "Tags": ["UI", "Prefab", "Button", "Image"]
+    "display_name": "UI Basics",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Asset",
+    "summary": "The UI Basics Gem provides a collection of basic UI prefabs such as image, text, and button, that can be used with LyShine, the Open 3D Engine runtime User Interface system and editor.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["UI", "Assets", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/Vegetation/gem.json
+++ b/Gems/Vegetation/gem.json
@@ -1,44 +1,12 @@
 {
     "gem_name": "Vegetation",
-    "Dependencies": [
-        {
-            "Uuid": "ff06785f7145416b9d46fde39098cb0c",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "LmbrCentral"
-        },
-        {
-            "Uuid": "8825563d9d964ec3be3bab681f3bd9f2",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "GradientSignal"
-        },
-        {
-            "Uuid": "5de82d29d6094bfe97c1a4d35fcd5fbe",
-            "VersionConstraints": [
-                "~>0.1"
-            ],
-            "_comment": "SurfaceData"
-        }
-    ],
-    "GemFormatVersion": 4,
-    "Uuid": "f394e7cf54424bba89615381bba9511b",
-    "Name": "Vegetation",
-    "DisplayName": "Vegetation [PREVIEW]",
-    "Version": "0.1.0",
-    "Summary": "A Lumberyard Gem for authoring Dynamic Procedural Vegetation (A real-time planting engine).<br/><b><u>NOTE:</u></b> The Landscape Canvas gem is an optional node-based Editor that provides the recommended workflows for authoring/editing Dynamic Vegetation content.",
-    "Tags": ["Vegetation"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ]
+    "display_name": "Vegetation",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Vegetation Gem provides tools to place natural-looking vegetation in Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Environment", "Tools", "Design"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/VideoPlaybackFramework/gem.json
+++ b/Gems/VideoPlaybackFramework/gem.json
@@ -1,16 +1,12 @@
 {
     "gem_name": "VideoPlaybackFramework",
-    "GemFormatVersion": 4,
-    "Uuid": "560d69cbaafd40bea8a09bccfe7f77e6",
-    "Name": "VideoPlaybackFramework",
-    "DisplayName": "Video Playback Framework",
-    "Version": "0.1.0",
-    "Summary": "The Video Playback Framework Gem provides the interface to play back video during gameplay. This gem is automatically enabled when selecting any of the Video Playback Gems.",
-    "Tags": ["Video"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "display_name": "Video Playback Framework",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Video Playback Framework Gem provides the interface to play back video.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Rendering", "Framework"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/VirtualGamepad/gem.json
+++ b/Gems/VirtualGamepad/gem.json
@@ -1,16 +1,12 @@
 {
-    "gem_name": "VirtualGampad",
-    "GemFormatVersion": 4,
-    "Uuid": "8aa9a66015804d6d9c809ce306e7d913",
-    "Name": "VirtualGamepad",
-    "DisplayName": "VirtualGamepad",
-    "Version": "0.1.0",
-    "Summary": "Example of a virtual gamepad that can be used by mobile devices with touch screens in place of a physical gamepad.",
-    "Tags": ["Input", "Mobile"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        }
-    ]
+    "gem_name": "VirtualGamepad",
+    "display_name": "Virtual Gamepad",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Code",
+    "summary": "The Virtual Gamepad Gem provides controls that emulate a gamepad on touch screen devices.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Input", "Gameplay"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Gems/WhiteBox/gem.json
+++ b/Gems/WhiteBox/gem.json
@@ -1,21 +1,12 @@
 {
     "gem_name": "WhiteBox",
-    "GemFormatVersion": 4,
-    "Uuid": "c5833dbda2e045d3a5f16b7414280c27",
-    "Name": "WhiteBox",
-    "DisplayName": "White Box",
-    "Version": "0.1.0",
-    "Summary": "A tool for quickly prototyping levels in the editor.",
-    "Tags": ["Editor"],
-    "IconPath": "preview.png",
-    "Modules": [
-        {
-            "Type": "GameModule"
-        },
-        {
-            "Name": "Editor",
-            "Type": "EditorModule",
-            "Extends": "GameModule"
-        }
-    ]
+    "display_name": "White Box",
+    "license": "Apache-2.0 Or MIT",
+    "origin": "Open 3D Engine - o3de.org",
+    "type": "Tool",
+    "summary": "The White Box Gem provides White Box rapid design components for Open 3D Engine.",
+    "canonical_tags": ["Gem"],
+    "user_tags": ["Design", "Tools", "Utility"],
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Templates/AssetGem/Template/gem.json
+++ b/Templates/AssetGem/Template/gem.json
@@ -1,14 +1,17 @@
 {
     "gem_name": "${Name}",
-    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
     "display_name": "${Name}",
+    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
+    "type": "Asset",
     "summary": "A short description of ${Name}.",
     "canonical_tags": [
         "Gem"
     ],
     "user_tags": [
+        "Assets",
         "${Name}"
     ],
-    "icon_path": "preview.png"
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Templates/DefaultGem/Template/gem.json
+++ b/Templates/DefaultGem/Template/gem.json
@@ -1,8 +1,9 @@
 {
     "gem_name": "${Name}",
-    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
     "display_name": "${Name}",
+    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
+    "type": "Code",
     "summary": "A short description of ${Name}.",
     "canonical_tags": [
         "Gem"
@@ -10,5 +11,6 @@
     "user_tags": [
         "${Name}"
     ],
-    "icon_path": "preview.png"
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Templates/DefaultProject/Template/Code/gem.json
+++ b/Templates/DefaultProject/Template/Code/gem.json
@@ -1,8 +1,9 @@
 {
     "gem_name": "${Name}",
-    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
     "display_name": "${Name}",
+    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
+    "type": "Code",
     "summary": "A short description of ${Name}.",
     "canonical_tags": [
         "Gem"
@@ -10,5 +11,6 @@
     "user_tags": [
         "${Name}"
     ],
-    "icon_path": "preview.png"
+    "icon_path": "preview.png",
+    "requirements": ""
 }

--- a/Templates/MinimalProject/Template/Code/gem.json
+++ b/Templates/MinimalProject/Template/Code/gem.json
@@ -1,8 +1,9 @@
 {
     "gem_name": "${Name}",
-    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
     "display_name": "${Name}",
+    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
+    "type": "Code",
     "summary": "A short description of ${Name}.",
     "canonical_tags": [
         "Gem"
@@ -10,5 +11,6 @@
     "user_tags": [
         "${Name}"
     ],
-    "icon_path": "preview.png"
+    "icon_path": "preview.png",
+    "requirements": ""
 }


### PR DESCRIPTION
* Updated gem.json for all top-level Gems. All the top level gems now have identical gem.json formats based on the DefautlGem template gem.json. Two additional fields have been added, a type: field and a requirements: field. These fields are for display in Project Mananger. All gem.json files have a default requirements: value of None. Devs are responsible for providing requirements. Gem descriptions and tags have been signed off by developers.

Signed-off-by: Cronin <mikecro@amazon.com>

* Fixed minor formatting issues with RADTelemetry gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to QtForPython gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the Twitch gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to AWSCore gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the AtomTressFX gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the end of the AudioEngineWwise gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the end of the CertificateManager gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Removing extra whitespace in summary of CrashReporting gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the end of the CustomAssetExample gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Removing extra whitespace in editorPythonBindings gem summary

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the end of the ScriptedEntityTweener gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the end of the Gestures gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Removing extra whitetspace in the summary of the GameStateSamples gem

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Adding newline to the end of the ExpressionEvaluation gem.json

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Updated the ProjectManager PythonBindings.cpp code to reference the
newer fields in the gem.json files

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Updating the Gem and Project templates gem.json files to include the
"type" and the "requirements" field.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Updated the default "requirments" field value to be empty string instead
of "None"

This works better with the ProjectManager GemInfoFromPath function.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Correcting "summary" field name

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

* Added the requirements text to the AudioEngineWwise Gem

This gem requires downloading the Wwise 3rdParty library from AudioKinetic's website

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>

Co-authored-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>