### PR TITLE
Fixed Material Editor not launching

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -130,12 +130,11 @@ namespace AZ
                 arguments.append(QString("--rhi=%1").arg(apiName.GetCStr()));
             }
 
-            AZStd::string projectPath(AZ::Utils::GetProjectPath().c_str());
-            if (projectPath != "")
+            AZ::IO::FixedMaxPathString projectPath(AZ::Utils::GetProjectPath());
+            if (!projectPath.empty())
             {
                 arguments.append(QString("--project-path=%1").arg(projectPath.c_str()));
             }
-
             AtomToolsFramework::LaunchTool("MaterialEditor", ".exe", arguments);
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -130,6 +130,12 @@ namespace AZ
                 arguments.append(QString("--rhi=%1").arg(apiName.GetCStr()));
             }
 
+            AZStd::string projectPath(AZ::Utils::GetProjectPath().c_str());
+            if (projectPath != "")
+            {
+                arguments.append(QString("--project-path=%1").arg(projectPath.c_str()));
+            }
+
             AtomToolsFramework::LaunchTool("MaterialEditor", ".exe", arguments);
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -135,6 +135,7 @@ namespace AZ
             {
                 arguments.append(QString("--project-path=%1").arg(projectPath.c_str()));
             }
+
             AtomToolsFramework::LaunchTool("MaterialEditor", ".exe", arguments);
         }
 


### PR DESCRIPTION
Launching the Material Editor via the Editor (without setting the global project) fails, with an error message saying it cannot connect to the AP.  Launching the MaterialEditor.exe with the "project-path" parameter resolves this issue.  Fix here is to add the project-path in the launch parameters.

I am unsure if this is the correct fix given settings registries in user directories and the like, would like some insight there.