### PR TITLE
Fixed Vegetation Debugger to work with Atom rendering and AZ::Console.

### DIFF
--- a/Gems/Vegetation/Code/Source/Debugger/DebugComponent.h
+++ b/Gems/Vegetation/Code/Source/Debugger/DebugComponent.h
@@ -54,7 +54,7 @@ namespace Vegetation
 
     class DebugComponent
         : public AZ::Component
-        , private AzFramework::DebugDisplayEventBus::Handler
+        , private AzFramework::EntityDebugDisplayEventBus::Handler
         , private DebugRequestBus::Handler
         , private DebugNotificationBus::Handler
         , private SystemConfigurationRequestBus::Handler
@@ -79,7 +79,8 @@ namespace Vegetation
 
         //////////////////////////////////////////////////////////////////////////
         // EntityDebugDisplayEventBus
-        void DrawGlobalDebugInfo() override;
+        void DisplayEntityViewport(
+            const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
 
         //////////////////////////////////////////////////////////////////////////
         // DebugNotifications
@@ -112,10 +113,9 @@ namespace Vegetation
     protected:
         void PrepareNextReport();
         void CopyReportToSortedList();
-        void AddConsoleVariables();
-        void RemoveConsoleVariables();
-        void DrawDebugStats();
-        void DrawInstanceDebug();
+        void DrawSectorTimingData(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay);
+        void DrawDebugStats(AzFramework::DebugDisplayRequests& debugDisplay);
+        void DrawInstanceDebug(AzFramework::DebugDisplayRequests& debugDisplay);
 
     private:
         AZStd::atomic_bool m_exportCurrentReport{ false };


### PR DESCRIPTION
The previous implementation used Cry rendering and CVars and had been left in a commented-out state.  These changes restore it back to full functionality.