### PR TITLE
[development] Mobile settings tool validator and save fixes

### DIFF
--- a/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/ProjectSettingsToolWindow.cpp
@@ -585,31 +585,11 @@ namespace ProjectSettingsTool
                     ShowAllErrorsThenExitIfInvalid();
 
                     m_ui->reconfigureLog->setText("");
-                    int result = QMessageBox::question
-                        (
-                        this,
-                        tr("Reconfigure Project"),
-                        tr("For new settings to be applied the project must be reconfigured. Would you like run configure now?"),
-                        QMessageBox::Yes,
-                        QMessageBox::No
-                        );
+                    QMessageBox::information(this, tr("Project Settings Saved"),
+                        tr("The project may need to be manually reconfigured for the new settings to be applied."));
 
-                    if (QMessageBox::Yes == result)
-                    {
-                        m_ui->reconfigureLog->show();
-                    #if defined(AZ_PLATFORM_WINDOWS)
-                        m_reconfigureProcess.start("cmd.exe", { QString("/C %1").arg("lmbr_waf.bat configure") });
-                    #elif defined(AZ_PLATFORM_MAC) || defined(AZ_PLATFORM_LINUX)
-                        m_reconfigureProcess.start("/bin/sh", { QString("%1").arg("lmbr_waf.sh configure") });
-                    #else
-                        #error "Needs to be implemented"
-                    #endif
-                    }
-                    else
-                    {
-                        m_ui->reloadButton->setEnabled(true);
-                        m_ui->saveButton->setEnabled(true);
-                    }
+                    m_ui->reloadButton->setEnabled(true);
+                    m_ui->saveButton->setEnabled(true);
                 }
                 // Show a message box telling user settings failed to save
                 else

--- a/Code/Editor/Plugins/ProjectSettingsTool/Validators.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/Validators.cpp
@@ -172,8 +172,9 @@ namespace ProjectSettingsTool
         // Returns true if valid ios version number
         RetType IOSVersionNumber(const QString& value)
         {
+            // support up to 4-component numerical-only version strings
             return RegularExpressionValidator
-                       ("(0|[1-9][0-9]{0,8}|[1-2][0-1][0-9]{0,8})(\\.(0|[1-9][0-9]{0,8}|[1-2][0-1][0-9]{0,8})){0,2}",
+                       ("^(\\d+)(\\.\\d+){0,3}$",
                        value,
                        maxIosVersionLength);
         }


### PR DESCRIPTION
- Updated and simplified the version number validation regex to support 4-component numerical only version strings
- Removed stale WAF reconfigure and replaced save notification dialog to inform the user a manual reconfigure of the project may be required for the settings to be propagated