### PR TITLE
Undoing change from review feedback as it led to an incorrect result in some cases

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Lights/Ltc.azsli
@@ -111,13 +111,9 @@ float IntegrateEdge(float3 v1, float3 v2)
 float IntegrateEdgeDiffuse(float3 v1, float3 v2)
 {
     float cosTheta = dot(v1, v2);
-    float theta_sinTheta = 0.0;
-    if (cosTheta > 0.0)
-    {
-        float absCosTheta = abs(cosTheta);
-        theta_sinTheta = 1.5708 + (-0.879406 + 0.308609 * absCosTheta) * absCosTheta;
-    }
-    else
+    float absCosTheta = abs(cosTheta);
+    float theta_sinTheta = 1.5708 + (-0.879406 + 0.308609 * absCosTheta) * absCosTheta;
+    if (cosTheta < 0.0)
     {
         theta_sinTheta = PI * rsqrt(1.0 - cosTheta * cosTheta) - theta_sinTheta;
     }


### PR DESCRIPTION
The earlier change to swap to if-else was incorrect since the first version of theta_sinTheta is needed in both cases. Using a single if is correct because it's additional work that needs to be done when cosTheta > 0.0