### PR TITLE
Fix EBS unmounting error.

### DIFF
--- a/scripts/build/bootstrap/incremental_build_util.py
+++ b/scripts/build/bootstrap/incremental_build_util.py
@@ -318,7 +318,7 @@ def unmount_volume():
         f.write("""
           select disk 1
           offline disk
-          """)
+          """.encode('utf-8'))
         f.close()
         subprocess.call('diskpart /s %s' % f.name)
         os.unlink(f.name)


### PR DESCRIPTION
Fix unmounting error due to tempfile.NamedTemporaryFile.write() requires byte argument instead of string in Python3