### PR TITLE
[LYN-3913] Fix conversion to unsupported photometric unit on light type change

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -263,7 +263,23 @@ namespace AZ
 
             // Update the cached light type.
             m_lightType = m_controller.m_configuration.m_lightType;
+            
+            // Check to see if the current photometric type is supported by the light type. If not, convert to lumens before deactivating.
+            auto supportedPhotometricUnits = m_controller.m_configuration.GetValidPhotometricUnits();
+            auto foundIt = AZStd::find_if(
+                supportedPhotometricUnits.begin(),
+                supportedPhotometricUnits.end(),
+                [&](const Edit::EnumConstant<PhotometricUnit>& entry) -> bool
+                {
+                    return AZStd::RemoveEnum<PhotometricUnit>::type(m_controller.m_configuration.m_intensityMode) == entry.m_value;
+                }
+            );
 
+            if (foundIt == supportedPhotometricUnits.end())
+            {
+                m_controller.ConvertToIntensityMode(PhotometricUnit::Lumen);
+            }
+            
             // componets may be removed or added here, so deactivate now and reactivate the entity when everything is done shifting around.
             GetEntity()->Deactivate();
 
@@ -320,7 +336,7 @@ namespace AZ
                 // Some light types don't require a shape, this is ok. 
                 break;
             }
-                
+            
             GetEntity()->Activate();
 
             // Set more reasonable default values for certain shapes.
@@ -333,7 +349,12 @@ namespace AZ
                 LmbrCentral::DiskShapeComponentRequestBus::Event(GetEntityId(), &LmbrCentral::DiskShapeComponentRequests::SetRadius, 0.05f);
                 break;
             }
-            
+
+            if (foundIt == supportedPhotometricUnits.end())
+            {
+                m_controller.ConvertToIntensityMode(PhotometricUnit::Lumen);
+            }
+
             return true;
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -350,11 +350,6 @@ namespace AZ
                 break;
             }
 
-            if (foundIt == supportedPhotometricUnits.end())
-            {
-                m_controller.ConvertToIntensityMode(PhotometricUnit::Lumen);
-            }
-
             return true;
         }
 


### PR DESCRIPTION
When converting to a light type that doesn't support the currently used photometric unit, the editor component will convert the photometric unit to the universally supported lumen.

Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>