### PR TITLE
Allow running scripts using msys2/mingw/git bash

### DIFF
--- a/python/python.sh
+++ b/python/python.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 
@@ -15,9 +15,10 @@ while [[ -h "$SOURCE" ]]; do
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-if [[ "$OSTYPE" = *"darwin"* ]];
-then
+if [[ "$OSTYPE" == *"darwin"* ]]; then
     PYTHON=$DIR/runtime/python-3.7.10-rev1-darwin/Python.framework/Versions/3.7/bin/python3
+elif [[ "$OSTYPE" == "msys" ]]; then
+    PYTHON=$DIR/runtime/python-3.7.10-rev1-windows/python/python.exe
 else
     PYTHON=$DIR/runtime/python-3.7.10-rev2-linux/python/bin/python
 fi


### PR DESCRIPTION
Quick fix to choose the right python distro.

This was all that was necessary to allow invoking o3de.sh when using msys bash.