### PR TITLE
Project Manager: Feature tag filtering for header of the gem catalog

### DIFF
--- a/Code/Tools/ProjectManager/Resources/FeatureTagClose.svg
+++ b/Code/Tools/ProjectManager/Resources/FeatureTagClose.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2.55069 19.5506L19.5213 2.58008L21.289 4.34785L4.31845 21.3184L2.55069 19.5506Z" fill="#94D2FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4.28706 2.65039L21.2576 19.6209L19.4899 21.3887L2.51929 4.41815L4.28706 2.65039Z" fill="#94D2FF"/>
+</svg>

--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qrc
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qrc
@@ -34,5 +34,6 @@
         <file>Warning.svg</file>
         <file>Backgrounds/DefaultBackground.jpg</file>
         <file>Backgrounds/FtueBackground.jpg</file>
+        <file>FeatureTagClose.svg</file>
     </qresource>
 </RCC>

--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -478,6 +478,13 @@ QProgressBar::chunk {
     background-color: #333333;
 }
 
+/************** Filter tag widget **************/
+
+#FilterTagWidgetTextLabel {
+    color: #94D2FF;
+    font-size: 10px;
+}
+
 /************** Gem Catalog (Inspector) **************/
 
 #GemCatalogInspector {

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <GemCatalog/GemFilterTagWidget.h>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpacerItem>
+#include <QWidget>
+
+namespace O3DE::ProjectManager
+{
+    FilterTagWidget::FilterTagWidget(const QString& text, QWidget* parent)
+        : QFrame(parent)
+    {
+        setFrameShape(QFrame::NoFrame);
+
+        auto* layout = new QHBoxLayout();
+        layout->setContentsMargins(6, 5, 4, 4);
+        layout->setSpacing(2);
+        setLayout(layout);
+
+        setStyleSheet("background-color: #555555;");
+
+        m_textLabel = new QLabel();
+        m_textLabel->setObjectName("FilterTagWidgetTextLabel");
+        m_textLabel->setText(text);
+        layout->addWidget(m_textLabel);
+
+        m_closeButton = new QPushButton();
+        m_closeButton->setFlat(true);
+        m_closeButton->setIcon(QIcon(":/FeatureTagClose.svg"));
+        m_closeButton->setIconSize(QSize(12, 12));
+        m_closeButton->setStyleSheet("QPushButton { background-color: transparent; border: 0px }");
+        layout->addWidget(m_closeButton);
+        connect(m_closeButton, &QPushButton::clicked, this, [=]{ emit RemoveClicked(); });
+    }
+
+    QString FilterTagWidget::text() const
+    {
+        return m_textLabel->text();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    FilterTagWidgetContainer::FilterTagWidgetContainer(QWidget* parent)
+        : QWidget(parent)
+    {
+        m_layout = new QHBoxLayout();
+        m_layout->setMargin(0);
+        m_layout->setSpacing(0);
+        setLayout(m_layout);
+    }
+
+    void FilterTagWidgetContainer::Reinit(const QVector<QString>& tags)
+    {
+        if (m_widget)
+        {
+            // Hide the old widget and request deletion.
+            m_widget->hide();
+            m_widget->deleteLater();
+        }
+
+        m_widget = new QWidget(this);
+
+        QHBoxLayout* hLayout = new QHBoxLayout();
+        hLayout->setAlignment(Qt::AlignLeft);
+        hLayout->setMargin(0);
+        hLayout->setSpacing(8);
+
+        const int numTags = tags.count();
+        for (int i = 0; i < numTags; ++i)
+        {
+            FilterTagWidget* tagWidget = new FilterTagWidget(tags[i]);
+
+            // Add the tag widget to the current row.
+            hLayout->addWidget(tagWidget);
+
+            // Connect the clicked event of the close button of the tag widget to the remove tag function in the container.
+            connect(tagWidget, &FilterTagWidget::RemoveClicked, this, [this, tagWidget]{ emit TagRemoved(tagWidget->text()); });
+        }
+
+        QWidget* spacerWidget = new QWidget();
+        spacerWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Fixed);
+        hLayout->addWidget(spacerWidget);
+
+        m_widget->setLayout(hLayout);
+        m_layout->addWidget(m_widget);
+
+        setFixedHeight(30);
+    }
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterTagWidget.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <QFrame>
+#include <QString>
+#include <QVector>
+#endif
+
+QT_FORWARD_DECLARE_CLASS(QHBoxLayout)
+QT_FORWARD_DECLARE_CLASS(QLabel)
+QT_FORWARD_DECLARE_CLASS(QPushButton)
+QT_FORWARD_DECLARE_CLASS(QWidget)
+
+namespace O3DE::ProjectManager
+{
+    class FilterTagWidget
+        : public QFrame
+    {
+        Q_OBJECT
+
+    public:
+        FilterTagWidget(const QString& text, QWidget* parent = nullptr);
+        QString text() const;
+
+    signals:
+        void RemoveClicked();
+
+    private:
+        QLabel* m_textLabel = nullptr;
+        QPushButton* m_closeButton = nullptr;
+    };
+
+    // Horizontally expanding filter tag container widget
+    class FilterTagWidgetContainer
+        : public QWidget
+    {
+        Q_OBJECT
+
+    public:
+        FilterTagWidgetContainer(QWidget* parent = nullptr);
+        void Reinit(const QVector<QString>& tags);
+
+    signals:
+        void TagRemoved(QString tagName);
+
+    private:
+        QWidget* m_widget = nullptr;
+        QHBoxLayout* m_layout = nullptr;
+    };
+} // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
@@ -14,6 +14,7 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QPushButton>
+#include <QSignalBlocker>
 
 namespace O3DE::ProjectManager
 {
@@ -485,6 +486,7 @@ namespace O3DE::ProjectManager
             const QString& feature = elementNames[i];
             QAbstractButton* button = buttons[i];
 
+            // Adjust the proxy model and enable or disable the clicked feature used for filtering.
             connect(button, &QAbstractButton::toggled, this, [=](bool checked)
                 {
                     QSet<QString> features = m_filterProxyModel->GetFeatures();
@@ -497,6 +499,15 @@ namespace O3DE::ProjectManager
                         features.remove(feature);
                     }
                     m_filterProxyModel->SetFeatures(features);
+                });
+
+            // Sync the UI state with the proxy model filtering.
+            connect(m_filterProxyModel, &GemSortFilterProxyModel::OnInvalidated, this, [=]
+                {
+                    const QSet<QString>& filteredFeatureTags = m_filterProxyModel->GetFeatures();
+                    const bool isChecked = filteredFeatureTags.contains(button->text());
+                    QSignalBlocker signalsBlocker(button);
+                    button->setChecked(isChecked);
                 });
         }
     }

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemItemDelegate.cpp
@@ -102,9 +102,11 @@ namespace O3DE::ProjectManager
 
         // In case there are feature tags displayed at the bottom, decrease the size of the summary text field.
         const QStringList featureTags = GemModel::GetFeatures(modelIndex);
-        const int summaryHeight = contentRect.height() - (!featureTags.empty() * 30);
+        const int featureTagAreaHeight = 30;
+        const int summaryHeight = contentRect.height() - (!featureTags.empty() * featureTagAreaHeight);
 
-        const QSize summarySize = QSize(contentRect.width() - s_summaryStartX - s_buttonWidth - s_itemMargins.right() * 3,
+        const int additionalSummarySpacing = s_itemMargins.right() * 3;
+        const QSize summarySize = QSize(contentRect.width() - s_summaryStartX - s_buttonWidth - additionalSummarySpacing,
             summaryHeight);
         const QRect summaryRect = QRect(/*topLeft=*/QPoint(contentRect.left() + s_summaryStartX, contentRect.top()), summarySize);
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemListHeaderWidget.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemListHeaderWidget.h
@@ -8,9 +8,8 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <GemCatalog/GemFilterTagWidget.h>
 #include <GemCatalog/GemSortFilterProxyModel.h>
-#include <QAbstractItemModel>
-#include <QItemSelectionModel>
 #include <QFrame>
 #endif
 

--- a/Code/Tools/ProjectManager/project_manager_files.cmake
+++ b/Code/Tools/ProjectManager/project_manager_files.cmake
@@ -71,6 +71,8 @@ set(FILES
     Source/GemCatalog/GemCatalogHeaderWidget.cpp
     Source/GemCatalog/GemCatalogScreen.h
     Source/GemCatalog/GemCatalogScreen.cpp
+    Source/GemCatalog/GemFilterTagWidget.h
+    Source/GemCatalog/GemFilterTagWidget.cpp
     Source/GemCatalog/GemFilterWidget.h
     Source/GemCatalog/GemFilterWidget.cpp
     Source/GemCatalog/GemInfo.h


### PR DESCRIPTION
* Added close icon for feature tag header filter in gem catalog
* Added feature tag widget used for showing the filtered tags in the gem catalog header
* Added filter tag widget container to the gem catalog header and connected it to the gem model
* Syncing the feature tag filters on the left panel with the tag widgets in the header and styling the item delegates

![FeatureTags_Org](https://user-images.githubusercontent.com/43751992/124890013-e782be00-dfd7-11eb-95ea-6a147239403b.gif)