### PR TITLE
Animation Tool : Setting to just view selected bone names. 

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.cpp
@@ -1281,6 +1281,16 @@ namespace EMStudio
 
             renderUtil->RenderNodeNames(actorInstance, camera, screenWidth, screenHeight, renderOptions->GetNodeNameColor(), renderOptions->GetSelectedObjectColor(), visibleJointIndices, selectedJointIndices);
         }
+        else if (widget->GetRenderFlag(RenderViewWidget::RENDER_SELECTED_NODENAMES) && !selectedJointIndices.empty())
+        {
+            MCommon::Camera* camera = widget->GetRenderWidget()->GetCamera();
+            const uint32 screenWidth = widget->GetRenderWidget()->GetScreenWidth();
+            const uint32 screenHeight = widget->GetRenderWidget()->GetScreenHeight();
+
+            renderUtil->RenderNodeNames(
+                actorInstance, camera, screenWidth, screenHeight, renderOptions->GetNodeNameColor(),
+                renderOptions->GetSelectedObjectColor(), selectedJointIndices, selectedJointIndices);
+        }
     }
 
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderUpdateCallback.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderUpdateCallback.cpp
@@ -273,5 +273,15 @@ namespace EMStudio
 
             renderUtil->RenderNodeNames(actorInstance, camera, screenWidth, screenHeight, renderOptions->GetNodeNameColor(), renderOptions->GetSelectedObjectColor(), visibleJointIndices, selectedJointIndices);
         }
+        else if (widget->GetRenderFlag(RenderViewWidget::RENDER_SELECTED_NODENAMES) && !selectedJointIndices.empty())
+        {
+            MCommon::Camera* camera = widget->GetRenderWidget()->GetCamera();
+            const uint32 screenWidth = widget->GetRenderWidget()->GetScreenWidth();
+            const uint32 screenHeight = widget->GetRenderWidget()->GetScreenHeight();
+
+            renderUtil->RenderNodeNames(
+                actorInstance, camera, screenWidth, screenHeight, renderOptions->GetNodeNameColor(),
+                renderOptions->GetSelectedObjectColor(), selectedJointIndices, selectedJointIndices);
+        }
     }
 } // namespace EMStudio

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderViewWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderViewWidget.cpp
@@ -113,6 +113,7 @@ namespace EMStudio
             CreateViewOptionEntry(contextMenu, "Line Skeleton", RENDER_LINESKELETON);
             CreateViewOptionEntry(contextMenu, "Solid Skeleton", RENDER_SKELETON);
             CreateViewOptionEntry(contextMenu, "Joint Names", RENDER_NODENAMES);
+            CreateViewOptionEntry(contextMenu, "Selected Joint Names", RENDER_SELECTED_NODENAMES);
             CreateViewOptionEntry(contextMenu, "Joint Orientations", RENDER_NODEORIENTATION);
             CreateViewOptionEntry(contextMenu, "Actor Bind Pose", RENDER_ACTORBINDPOSE);
             contextMenu->addSeparator();
@@ -245,6 +246,7 @@ namespace EMStudio
         SetRenderFlag(RENDER_LINESKELETON, false);
         SetRenderFlag(RENDER_NODEORIENTATION, false);
         SetRenderFlag(RENDER_NODENAMES, false);
+        SetRenderFlag(RENDER_SELECTED_NODENAMES, false);
         SetRenderFlag(RENDER_ACTORBINDPOSE, false);
         SetRenderFlag(RENDER_MOTIONEXTRACTION, false);
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderViewWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderViewWidget.h
@@ -68,7 +68,8 @@ namespace EMStudio
             RENDER_CLOTH_COLLIDERS          = 23,
             RENDER_SIMULATEDOBJECT_COLLIDERS= 24,
             RENDER_SIMULATEJOINTS           = 25,
-            NUM_RENDER_OPTIONS              = 26
+            RENDER_SELECTED_NODENAMES       = 26,
+            NUM_RENDER_OPTIONS              = 27
         };
 
         MCORE_INLINE bool GetRenderFlag(ERenderFlag option)     { return mActions[(uint32)option] ? mActions[(uint32)option]->isChecked() : false; }


### PR DESCRIPTION
This is useful when there's a large number of overlapping bones, the setting to view all bone names can get messy. Adding this to help me debug an issue with a skeleton that has some incorrect transforms.