### PR TITLE
{LYN-4996} Asset Processor is not reprocessing STL files after the setting file is edited/updated

### DIFF
--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -76,7 +76,8 @@
                     "animsettings": "i_caf",
                     "Animations/SkeletonList.xml": "i_caf",
                     "cbc": "abc",
-                    "fbx.assetinfo": "fbx"
+                    "fbx.assetinfo": "fbx",
+                    "stl.assetinfo": "stl"
                 },
 
                 // ---- add any folders to scan here.  The priority order is the order they appear here


### PR DESCRIPTION
{LYN-4996} Asset Processor is not reprocessing STL files after the setting file is edited/updated.
manual testing by editing settings using the asset browser and verifying stl file get reprocessed  