### PR TITLE
Profiler: listen to OnSystemTick instead of OnFrameBegin

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -9,13 +9,13 @@
 #include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI.Reflect/Base.h>
 
+#include <AzCore/Component/TickBus.h>
 #include <AzCore/Memory/OSAllocator.h>
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzCore/std/smart_ptr/intrusive_refcount.h>
 
-#include <Atom/RHI/FrameEventBus.h>
 
 namespace AZ
 {
@@ -83,7 +83,7 @@ namespace AZ
         //! cached regions, which are stored on a per thread frequency.
         class CpuProfilerImpl final
             : public CpuProfiler
-            , public FrameEventBus::Handler
+            , public SystemTickBus::Handler
         {
             friend class CpuTimingLocalStorage;
 
@@ -99,7 +99,10 @@ namespace AZ
             //! Unregisters the CpuProfilerImpl instance from the interface 
             void Shutdown();
 
-            void OnFrameBegin();
+            // SystemTickBus::Handler overrides
+            // When fired, the profiler collects all profiling data from registered threads and updates
+            // m_timeRegionMap so that the next frame has up-to-date profiling data.
+            void OnSystemTick() final override;
 
             //! CpuProfiler overrides...
             void BeginTimeRegion(TimeRegion& timeRegion) final;

--- a/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
@@ -79,8 +79,7 @@ namespace AZ
         {
             Interface<CpuProfiler>::Register(this);
             m_initialized = true;
-            Device* rhiDevice = GetRHIDevice().get();
-            FrameEventBus::Handler::BusConnect(rhiDevice);
+            SystemTickBus::Handler::BusConnect();
         }
 
         void CpuProfilerImpl::Shutdown()
@@ -101,7 +100,7 @@ namespace AZ
             m_registeredThreads.clear();
             m_timeRegionMap.clear();
             m_initialized = false;
-            FrameEventBus::Handler::BusDisconnect();
+            SystemTickBus::Handler::BusDisconnect();
         }
 
         void CpuProfilerImpl::BeginTimeRegion(TimeRegion& timeRegion)
@@ -173,7 +172,7 @@ namespace AZ
             return m_enabled;
         }
 
-        void CpuProfilerImpl::OnFrameBegin()
+        void CpuProfilerImpl::OnSystemTick()
         {
             if (!m_enabled)
             {
@@ -198,7 +197,6 @@ namespace AZ
             // Update our saved time regions to the last frame's collected data
             m_timeRegionMap = AZStd::move(newMap);
         }
-
 
         void CpuProfilerImpl::RegisterThreadStorage()
         {


### PR DESCRIPTION
The profiler is currently listening to the OnFrameBegin event as a signal to collect profiling data from all registered threads. This event only gets fired when the RHI begins working, which means that some RPI profiling data from the _current_ frame is included in a call to GetTimeRegionMap. Instead, update the saved profiling data when OnSystemTick is broadcasted since it is a better marker for frame boundaries. 

Also includes minor changes with the visual profiler to account for the changed data. Tested in Editor @ `cbc0f02386d47343a696fc584a617a9d7e8de8e7` and ASV @ `7630e13c3af33dceeece40888e1ed377114ce6e4` 

### Before
![image](https://user-images.githubusercontent.com/64656371/124967217-05045780-dfd9-11eb-85bc-ac5c1e9c92b6.png)
Notice how there's some regions after the last frame boundary that are drawn, even though they are not a part of the last collected frame. 
### After
![image](https://user-images.githubusercontent.com/64656371/124975239-acd25300-dfe2-11eb-95c4-b7770443d58f.png)
All regions are within the last frame's boundaries and there is no dangling frame at the end. 