### PR TITLE
make class MotionMetaDataRule final

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MotionMetaDataRule.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Rules/MotionMetaDataRule.h
@@ -37,7 +37,7 @@ namespace EMotionFX::Pipeline::Rule
         AZStd::unique_ptr<EMotionFX::MotionEventTable> m_motionEventTable;
     };
 
-    class MotionMetaDataRule
+    class MotionMetaDataRule final
         : public ExternalToolRule<AZStd::shared_ptr<MotionMetaData>>
     {
     public:


### PR DESCRIPTION
Signed-off-by: Tom spot Callaway <spotaws@amazon.com>

As described [here](https://reviews.llvm.org/D66711):
`Marking a class' destructor final prevents the class from being inherited from. However, it is a subtle and awkward way to express that at best, and unintended at worst. It may also generate worse code (in other compilers) than marking the class itself final. `

Accordingly, in clang 10+, there is a warning thrown for nonfinal classes with final destructors. This Pull Request makes the MotionMetaDataRule class into a final class (since it has a final destructor), and resolves the clang warning.