### PR TITLE
Fix "GameLauncher Log is Saved with Wrong File Extension" (LYN-3972).

### DIFF
--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1043,7 +1043,7 @@ string GetUniqueLogFileName(string logFileName)
         logFileNamePrefix = logFileName.substr(0, extensionIndex);
     }
 
-    logFileName.Format("%s(%d)%s", logFileNamePrefix.c_str(), instance, logFileExtension.c_str());
+    logFileName = AZStd::string::format("%s(%d)%s", logFileNamePrefix.c_str(), instance, logFileExtension.c_str()).c_str();
 
     return logFileName;
 }


### PR DESCRIPTION
I'm pretty sure that CryString::Format is broken, but it's slated for removal along with the rest of CrySystem, so I'm just addressing the symptom rather than the likely cause (mainly to save time, but also out of an abundance of caution in case other code is inadvertently depending on the existing behaviour of CryString::Format).