### PR TITLE
Add handling for integrity failures when applying and resolving change lists

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp
@@ -398,7 +398,7 @@ namespace TestImpact
                     if (sourceDependency->GetNumCoveringTestTargets())
                     {
                         AZ_Printf(
-                            "File Update", AZStd::string::format("Source file ''%s'' is potentially an orphan (used by build targets "
+                            "File Update", AZStd::string::format("Source file '%s' is potentially an orphan (used by build targets "
                             "without explicitly being added to the build system, e.g. an include directive pulling in a header from the "
                             "repository). Running the covering tests for this file with instrumentation will confirm whether or nor this "
                             "is the case.\n", updatedFile.c_str()).c_str());

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp
@@ -346,7 +346,8 @@ namespace TestImpact
         return orphans;
     }
 
-    ChangeDependencyList DynamicDependencyMap::ApplyAndResoveChangeList(const ChangeList& changeList)
+    ChangeDependencyList DynamicDependencyMap::ApplyAndResoveChangeList(
+        const ChangeList& changeList, Policy::IntegrityFailure integrityFailurePolicy)
     {
         AZStd::vector<SourceDependency> createDependencies;
         AZStd::vector<SourceDependency> updateDependencies;
@@ -364,11 +365,15 @@ namespace TestImpact
             {
                 if (sourceDependency->GetNumCoveringTestTargets())
                 {
-                    const AZStd::string msg = AZStd::string::format("The newly-created file %s belongs to a build target yet "
+                    const AZStd::string msg = AZStd::string::format("The newly-created file '%s' belongs to a build target yet "
                         "still has coverage data in the source covering test list implying that a delete CRUD operation has been "
-                        "missed, thus the integrity of the source covering test list has been compromised", createdFile.c_str());
+                        "missed, thus the integrity of the source covering test list has been compromised.", createdFile.c_str());
                     AZ_Error("File Creation", false, msg.c_str());
-                    throw DependencyException(msg);
+
+                    if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
+                    {
+                        throw DependencyException(msg);
+                    }
                 }
 
                 if (sourceDependency->GetNumParentTargets())
@@ -393,7 +398,7 @@ namespace TestImpact
                     if (sourceDependency->GetNumCoveringTestTargets())
                     {
                         AZ_Printf(
-                            "File Update", AZStd::string::format("Source file '%s' is potentially an orphan (used by build targets "
+                            "File Update", AZStd::string::format("Source file ''%s'' is potentially an orphan (used by build targets "
                             "without explicitly being added to the build system, e.g. an include directive pulling in a header from the "
                             "repository). Running the covering tests for this file with instrumentation will confirm whether or nor this "
                             "is the case.\n", updatedFile.c_str()).c_str());
@@ -418,18 +423,26 @@ namespace TestImpact
             {
                 if (sourceDependency->GetNumCoveringTestTargets())
                 {
-                    const AZStd::string msg = AZStd::string::format("The deleted file %s still belongs to a build target and still "
+                    const AZStd::string msg = AZStd::string::format("The deleted file '%s' still belongs to a build target and still "
                         "has coverage data in the source covering test list, implying that the integrity of both the source to target "
-                        "mappings and the source covering test list has been compromised", deletedFile.c_str());
+                        "mappings and the source covering test list has been compromised.", deletedFile.c_str());
                     AZ_Error("File Delete", false, msg.c_str());
-                    throw DependencyException(msg);
+
+                    if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
+                    {
+                        throw DependencyException(msg);
+                    }
                 }
                 else
                 {
-                    const AZStd::string msg = AZStd::string::format("The deleted file %s still belongs to a build target implying "
-                        "that the integrity of the source to target mappings has been compromised", deletedFile.c_str());
+                    const AZStd::string msg = AZStd::string::format("The deleted file '%s' still belongs to a build target implying "
+                        "that the integrity of the source to target mappings has been compromised.", deletedFile.c_str());
                     AZ_Error("File Delete", false, msg.c_str());
-                    throw DependencyException(msg);
+
+                    if (integrityFailurePolicy == Policy::IntegrityFailure::Abort)
+                    {
+                        throw DependencyException(msg);
+                    }
                 }
             }
             else

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <TestImpactFramework/TestImpactChangeList.h>
+#include <TestImpactFramework/TestImpactTestSequence.h>
 
 #include <Artifact/Static/TestImpactProductionTargetDescriptor.h>
 #include <Artifact/Static/TestImpactTestTargetDescriptor.h>
@@ -91,8 +92,10 @@ namespace TestImpact
         //! Applies the specified change list to the dependency map and resolves the change list to a change dependency list
         //! containing the updated source dependencies for each source file in the change list.
         //! @param changeList The change list to apply and resolve.
+        //! @param integrityFailurePolicy The policy to use for handling integrity errors in the source dependency map.
         //! @returns The change list as resolved to the appropriate source dependencies.
-        [[nodiscard]] ChangeDependencyList ApplyAndResoveChangeList(const ChangeList& changeList);
+        [[nodiscard]] ChangeDependencyList ApplyAndResoveChangeList(
+            const ChangeList& changeList, Policy::IntegrityFailure integrityFailurePolicy);
 
         //! Removes the specified test target from all source coverage.
         void RemoveTestTargetFromSourceCoverage(const TestTarget* testTarget);

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -205,7 +205,7 @@ namespace TestImpact
         AZStd::vector<const TestTarget*> discardedTestTargets;
 
         // Select and prioritize the test targets pertinent to this change list
-        const auto changeDependencyList = m_dynamicDependencyMap->ApplyAndResoveChangeList(changeList);
+        const auto changeDependencyList = m_dynamicDependencyMap->ApplyAndResoveChangeList(changeList, m_integrationFailurePolicy);
         const auto selectedTestTargets = m_testSelectorAndPrioritizer->SelectTestTargets(changeDependencyList, testPrioritizationPolicy);
 
         // Populate a set with the selected test targets so that we can infer the discarded test target not selected for this change list

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -192,6 +192,9 @@ class TestImpact:
                     # Sequence type
                     args.append("--sequence=tianowrite")
                     print("Sequence type is set to 'tianowrite'.")
+                    # Integrity failure policy
+                    args.append("--ipolicy=continue")
+                    print("Integration failure policy is set to 'continue'.")
                     # Safe mode
                     if safe_mode:
                         args.append("--safemode=on")

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -49,12 +49,13 @@ class TestImpact:
         # Config
         self.__parse_config_file(config_file)
         # Sequence
-        if self.__use_test_impact_analysis:
-            if self.__is_seeding_branch and self.__is_seeding_pipeline:
-                self.__is_seeding = True
-            else:
-                self.__is_seeding = False
-                self.__generate_change_list()
+        if self.__is_seeding_branch and self.__is_seeding_pipeline:
+            self.__is_seeding = True
+        else:
+            self.__is_seeding = False
+        print(f"Is seeding: '{self.__is_seeding}'.")
+        if self.__use_test_impact_analysis and not self.__is_seeding:
+            self.__generate_change_list()
 
     # Parse the configuration file and retrieve the data needed for launching the test impact analysis runtime
     def __parse_config_file(self, config_file):
@@ -213,12 +214,12 @@ class TestImpact:
              # Sequence type
             args.append("--sequence=regular")
             print("Sequence type is set to 'regular'.")
-            # Pipeline of truth sequence
-            if self.__is_pipeline_of_truth:
+            # Seeding job
+            if self.__is_seeding:
                 # Test failure policy
                 args.append(f"--fpolicy={seed_sequence_test_failure_policy}")
                 print(f"Test failure policy is set to '{seed_sequence_test_failure_policy}'.")
-            # Non pipeline of truth sequence
+            # Non seeding job
             else:
                 # Test failure policy
                 args.append(f"--fpolicy={test_failure_policy}")
@@ -230,7 +231,7 @@ class TestImpact:
         # If the sequence completed (with or without failures) we will update the historical meta-data
         if result.returncode == 0 or result.returncode == 7:
             print("Test impact analysis runtime returned successfully.")
-            if self.__is_pipeline_of_truth:
+            if self.__is_seeding:
                 print("Writing historical meta-data...")
                 self.__write_last_run_hash(self.__dst_commit)
             print("Complete!")

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -53,6 +53,7 @@ def parse_args():
     return args
 
 if __name__ == "__main__":
+    args = parse_args()
     try:
         args = parse_args()
         tiaf = TestImpact(args.config, args.dst_commit, args.src_branch, args.dst_branch, args.pipeline, args.seeding_branches, args.seeding_pipelines)

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -53,7 +53,6 @@ def parse_args():
     return args
 
 if __name__ == "__main__":
-    args = parse_args()
     try:
         args = parse_args()
         tiaf = TestImpact(args.config, args.dst_commit, args.src_branch, args.dst_branch, args.pipeline, args.seeding_branches, args.seeding_pipelines)


### PR DESCRIPTION
**UPDATE**

The commit hash in question (`81f9afdf13c2361e09691cd85ae2ef62ed017786`) associated with the seeding of the test impact data _was_ in fact out of sync, instead referring to a commit from 3 days prior to the seed snapshot. This was due to the fact that the TIAF script was incorrectly handling the updating of the last commit hash resulting in a stale hash being used instead of that from which the binary used to seed was built.

***

**Background**

The PR build for PR-1960 caused the TIAF runtime to abort due to the newly created file `Gems\ScriptCanvas\Code\Builder\ScriptCanvasBuilder.h` already having an entry in the source dependency map, implying that a previous change list containing a CRUD delete for this file has been missed, resulting in a compromised source dependency map. 

**Reproduction of the Bug**

1. I checked out commit `81f9afdf13c2361e09691cd85ae2ef62ed017786` where the seeding took place and ran the TIAF driver script with the same args as that of the TIAF job linked above to generate the test impact data in the `Persistent/active` directory and the last commit hash in the `Persistent/historic` directory of the TIAF working directory . 
2. I checked out commit `ea0e38aaf4b58d7142e2033d9daeeef9fd5fb58b` as per the job above and ran the TIAF driver script to construct the change list between these two commits and run the TIAF console. 

I could not re-create the bug above because `Gems\ScriptCanvas\Code\Builder\ScriptCanvasBuilder.h` did not have an entry in the test impact data when Step 1 (above) was run, thus the call to `ApplyAndResoveChangeList` did not fail. As there is currently no way to access the test impact data generated by the seeding on the `development` branch that was subsequently captured in the nightly snapshot I cannot conclusively determine what the cause is. As the aforementioned file does appear to be newly created in commit `ea0e38aaf4b58d7142e2033d9daeeef9fd5fb58b` one possible explanation is that for whatever reason the test impact data was updated at some indeterminate point but the last commit hash was not. 

**Solution**

Immediate: Prior to this PR, such compromises to the integrity of the source dependency were considered hard failures and would throw a `DependencyException`, causing the TIAF runtime to abort. The integrity failure policy used by the TIAF runtime is now also used by the dynamic dependency map for handling integrity failures during `ApplyAndResoveChangeList`, allowing the client to override the failure and force the change list application and resolution to continue. The default policy for  test impact analysis sequences (not seed sequences) is now `continue`.

Future: I will store the last commit hash and test impact data together. This will be achieved by the TIAF driver rolling the last commit hash and the test impact data together in a JSON file upon seeding to be unpacked each time for test impact analysis sequences. This, along with a time stamp and any other pertinent data, will allow the state of the test impact data to be inspected in more detail to allow for a more accurate reproduction of future integrity failure issues.

**Log Output of PR-1960**
```[2021-07-08T14:19:02.305Z] D:\workspace\o3de>python\python.cmd -u scripts\build\ci_build.py --platform Windows --type test_impact_analysis_profile_vs2019 

[2021-07-08T14:19:02.305Z] [ci_build] Executing "D:\workspace\o3de\scripts\build\Platform/Windows/python_windows.cmd"

[2021-07-08T14:19:02.305Z]   cwd = D:\workspace\o3de

[2021-07-08T14:19:02.305Z]   engine_dir = D:\workspace\o3de

[2021-07-08T14:19:02.305Z]   paramaters:

[2021-07-08T14:19:02.305Z]     OUTPUT_DIRECTORY = build/windows_vs2019 

[2021-07-08T14:19:02.305Z]     CONFIGURATION = profile 

[2021-07-08T14:19:02.305Z]     SCRIPT_PATH = scripts/build/TestImpactAnalysis/tiaf_driver.py 

[2021-07-08T14:19:02.305Z]     SCRIPT_PARAMETERS = --config="!OUTPUT_DIRECTORY!/bin/TestImpactFramework/persistent/tiaf.profile.json" --suite=main --test-failure-policy=continue --src-branch=!BRANCH_NAME! --dst-branch=!CHANGE_TARGET! --pipeline=!PIPELINE_NAME! --dest-commit=!CHANGE_ID! --seeding-branches=!BUILD_SNAPSHOTS! --seeding-pipelines=default 

[2021-07-08T14:19:02.305Z] --------------------------------------------------------------------------------

[2021-07-08T14:19:02.305Z] [ci_build] python/python.cmd -u scripts/build/TestImpactAnalysis/tiaf_driver.py --config="build/windows_vs2019/bin/TestImpactFramework/persistent/tiaf.profile.json" --suite=main --test-failure-policy=continue --src-branch=PR-1960 --dst-branch=development --pipeline=default --dest-commit=ea0e38aaf4b58d7142e2033d9daeeef9fd5fb58b --seeding-branches=development,stabilization/2106 --seeding-pipelines=default

[2021-07-08T14:19:04.211Z] Commit: 'ea0e38aaf4b58d7142e2033d9daeeef9fd5fb58b'.

[2021-07-08T14:19:04.211Z] Source branch: 'PR-1960'.

[2021-07-08T14:19:04.211Z] Destination branch: 'development'.

[2021-07-08T14:19:04.211Z] Seeding branches: '['development', 'stabilization/2106']'.

[2021-07-08T14:19:04.211Z] Is seeding branch: 'False'.

[2021-07-08T14:19:04.211Z] Pipeline: 'default'.

[2021-07-08T14:19:04.211Z] Seeding pipelines: '['default']'.

[2021-07-08T14:19:04.211Z] Is seeding pipeline: 'True'.

[2021-07-08T14:19:04.211Z] Attempting to parse configuration file 'build/windows_vs2019/bin/TestImpactFramework/persistent/tiaf.profile.json'...

[2021-07-08T14:19:04.211Z] Is using test impact analysis: 'True'.

[2021-07-08T14:19:04.211Z] The configuration file was parsed successfully.

[2021-07-08T14:19:04.211Z] Previous commit hash found at 'D:/workspace/o3de/build/windows_vs2019/bin/TestImpactFramework/Persistent/historic\last_run.hash'.

[2021-07-08T14:19:04.470Z] Generated diff between commits '81f9afdf13c2361e09691cd85ae2ef62ed017786' and 'ea0e38aaf4b58d7142e2033d9daeeef9fd5fb58b': 'D:/workspace/o3de/build/windows_vs2019/bin/TestImpactFramework/Temp\changelist.diff'.

[2021-07-08T14:19:04.730Z] Change list constructed successfully: 'D:/workspace/o3de/build/windows_vs2019/bin/TestImpactFramework/Temp\changelist.json'.

[2021-07-08T14:19:04.730Z] 17 created files, 202 updated files and 203 deleted files.

[2021-07-08T14:19:04.730Z] Test suite is set to 'main'.

[2021-07-08T14:19:04.730Z] Test impact analysis is enabled.

[2021-07-08T14:19:04.730Z] Change list is set to 'D:/workspace/o3de/build/windows_vs2019/bin/TestImpactFramework/Temp\changelist.json'.

[2021-07-08T14:19:04.730Z] Sequence type is set to 'tianowrite'.

[2021-07-08T14:19:04.730Z] Safe mode set to 'off'.

[2021-07-08T14:19:04.730Z] Test failure policy is set to 'continue'.

[2021-07-08T14:19:04.730Z] Args: --suite=main --changelist=D:/workspace/o3de/build/windows_vs2019/bin/TestImpactFramework/Temp\changelist.json --sequence=tianowrite --safemode=off --fpolicy=continue

[2021-07-08T14:19:06.639Z] Constructing in-memory model of source tree and test coverage for test suite main, this may take a moment...

[2021-07-08T14:19:06.639Z] Test impact analysis data for this repository was found.

[2021-07-08T14:19:06.639Z] File Creation: 

[2021-07-08T14:19:06.639Z] ==================================================================

[2021-07-08T14:19:06.639Z] File Creation: Trace::Error

[2021-07-08T14:19:06.639Z]  D:/workspace/o3de/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp(370): 'class TestImpact::ChangeDependencyList __cdecl TestImpact::DynamicDependencyMap::ApplyAndResoveChangeList(const struct TestImpact::ChangeList &)'

[2021-07-08T14:19:06.639Z] File Creation: The newly-created file Gems\ScriptCanvas\Code\Builder\ScriptCanvasBuilder.h belongs to a build target yet still has coverage data in the source covering test list implying that a delete CRUD operation has been missed, thus the integrity of the source covering test list has been compromised

[2021-07-08T14:19:06.639Z] File Creation: ==================================================================

[2021-07-08T14:19:06.639Z] The newly-created file Gems\ScriptCanvas\Code\Builder\ScriptCanvasBuilder.h belongs to a build target yet still has coverage data in the source covering test list implying that a delete CRUD operation has been missed, thus the integrity of the source covering test list has been compromised

[2021-07-08T14:19:06.639Z] The test impact analysis runtime returned with error: '5'.
```