### PR TITLE
Fix for PDO showing light culling artifacts

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
@@ -427,7 +427,7 @@ PixelDepthOffset CalcPixelDepthOffset(  float depthFactor,
     float4 clipOffsetPosition = mul(viewProjectionMatrix, float4(worldOffsetPosition, 1.0));
 
     PixelDepthOffset pdo;
-    pdo.m_depthCS = clipOffsetPosition.z;
+    pdo.m_depthCS = clipOffsetPosition.w;
     pdo.m_depthNDC = clipOffsetPosition.z / clipOffsetPosition.w;
     pdo.m_worldPosition = worldOffsetPosition;
     return pdo;


### PR DESCRIPTION
The light culling tile iterator needs a .w value which contains viewspace Z.

The original calculation was wrong, because after multiplication of a point by a projection matrix, the viewspace Z is in the .w position, not the .z position.

ATOM-15925

Before:
![before](https://user-images.githubusercontent.com/61609885/124990269-fc217f00-dff4-11eb-8d2f-e047e19e3657.png)
After:
![after](https://user-images.githubusercontent.com/61609885/124990271-fd52ac00-dff4-11eb-952f-5cefc6b71e22.JPG)