### PR TITLE
Fix unused variable warning-as-error when compiling Release build

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/PhysicalDevice.cpp
@@ -261,7 +261,7 @@ namespace AZ
                 VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME
             } };
 
-            uint32_t optionalExtensionCount = sizeof(optionalExtensions) / sizeof(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME);
+            [[maybe_unused]] uint32_t optionalExtensionCount = sizeof(optionalExtensions) / sizeof(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME);
 
             AZ_Assert(optionalExtensionCount == static_cast<uint32_t>(OptionalDeviceExtension::Count), "The order and size must match the enum OptionalDeviceExtensions.");
 


### PR DESCRIPTION
Addresses the usage of `optionalExtensionCount` exclusively in AZ_Asserts.