### PR TITLE
Properly handle creation of TIAF historic workspace directory

### DIFF
--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -93,7 +93,7 @@ class TestImpact:
                 self.__has_src_commit = True
 
     def __write_last_run_hash(self, last_run_hash):
-        os.mkdir(self.__historic_workspace)
+        os.makedirs(self.__historic_workspace, exist_ok=True)
         f = open(self.__last_commit_hash_path, "w")
         f.write(last_run_hash)
         f.close()

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -64,3 +64,4 @@ if __name__ == "__main__":
         # Non-gating will be removed from this script and handled at the job level in SPEC-7413
         print("Exception caught by TIAF driver")
         sys.exit(0)
+        

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -64,4 +64,3 @@ if __name__ == "__main__":
         # Non-gating will be removed from this script and handled at the job level in SPEC-7413
         print("Exception caught by TIAF driver")
         sys.exit(0)
-        

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -60,7 +60,6 @@ if __name__ == "__main__":
         # Non-gating will be removed from this script and handled at the job level in SPEC-7413
         #sys.exit(return_code)
         sys.exit(0)
-    except:
+    except Exception as e:
         # Non-gating will be removed from this script and handled at the job level in SPEC-7413
-        print("Exception caught by TIAF driver")
-        sys.exit(0)
+        print(f"Exception caught by TIAF driver: {e}")

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -62,4 +62,5 @@ if __name__ == "__main__":
         sys.exit(0)
     except:
         # Non-gating will be removed from this script and handled at the job level in SPEC-7413
+        print("Exception caught by TIAF driver")
         sys.exit(0)


### PR DESCRIPTION
Under certain conditions the creation of the TIAF historic workspace directory was throwing an exception, causing the last commit hash to not be written. This has been fixed by using the pertinent Python direction creation function that handles the preexistence of said directory gracefully.