### PR TITLE
Fix issue where game and editor entities could exist simultaneously while exiting game mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -597,22 +597,23 @@ namespace AzToolsFramework
     {
         if (m_rootInstance && m_playInEditorData.m_isEnabled)
         {
-            auto end = m_playInEditorData.m_deactivatedEntities.rend();
-            for (auto it = m_playInEditorData.m_deactivatedEntities.rbegin(); it != end; ++it)
-            {
-                AZ_Assert(*it, "Invalid entity added to list for re-activation after play-in-editor stopped.");
-                (*it)->Activate();
-            }
-            m_playInEditorData.m_deactivatedEntities.clear();
-
             AZ_Assert(m_playInEditorData.m_entities.IsSet(),
                 "Invalid Game Mode Entities Container encountered after play-in-editor stopped. "
                 "Confirm that the container was initialized correctly");
 
             m_playInEditorData.m_entities.DespawnAllEntities();
             m_playInEditorData.m_entities.Alert(
-                [assets = AZStd::move(m_playInEditorData.m_assets)]([[maybe_unused]]uint32_t generation) mutable
+                [assets = AZStd::move(m_playInEditorData.m_assets),
+                 deactivatedEntities = AZStd::move(m_playInEditorData.m_deactivatedEntities)]
+                ([[maybe_unused]]uint32_t generation) mutable
                 {
+                    auto end = deactivatedEntities.rend();
+                    for (auto it = deactivatedEntities.rbegin(); it != end; ++it)
+                    {
+                        AZ_Assert(*it, "Invalid entity added to list for re-activation after play-in-editor stopped.");
+                        (*it)->Activate();
+                    }
+
                     for (auto& asset : assets)
                     {
                         if (asset)
@@ -624,12 +625,20 @@ namespace AzToolsFramework
                         }
                     }
                     AZ::ScriptSystemRequestBus::Broadcast(&AZ::ScriptSystemRequests::GarbageCollect);
+
+                    // This is a workaround until the replacement for GameEntityContext is done
+                    AzFramework::GameEntityContextEventBus::Broadcast(&AzFramework::GameEntityContextEventBus::Events::OnGameEntitiesReset);
                 });
             m_playInEditorData.m_entities.Clear();
-
-            // This is a workaround until the replacement for GameEntityContext is done
-            AzFramework::GameEntityContextEventBus::Broadcast(&AzFramework::GameEntityContextEventBus::Events::OnGameEntitiesReset);
         }
+
+        // Game entity cleanup is queued onto the next tick via the DespawnEntities call.
+        // To avoid both game entities and Editor entities active at the same time
+        // we flush the tick queue to ensure the game entities are cleared first.
+        // The Alert callback that follows the DespawnEntities call will then reactivate the editor entities
+        // This should be considered temporary as a move to a less rigid event sequence that supports async entity clean up
+        // is the desired direction forward.
+        AZ::TickBus::ExecuteQueuedEvents();
 
         m_playInEditorData.m_isEnabled = false;
     }


### PR DESCRIPTION
Game entities are cleaned up via the SpawnableEntityManager when DespawnEntities is called. This however queues up the delete which is actioned on the next tick. Issues were occurring with graphics and vegetation components where we would reactivate EditorEntities before we destroyed game mode entities. Causing the Editor environment to be setup but then have shared resources/systems receive deactivation events from their mirrored game entity counterparts shortly after that a frame later.

This change ensures that we sequentially destroy game entities before reactivating Editor Entities by placing the Editor reactivate within a callback that only fires after DespawnEntities finishes.

Note: The TickBus::ExecuteQueuedEvents call is there to remove the one tick delay. Ideally however we'd want to move towards a more asynchronous approach for destroying entities on this transition. The scope/impact of introducing that fully though is beyond this bug fix and would need to be well considered since many systems depend on events firing from game mode transitions.

Signed-off-by: sconel <sconel@amazon.com>