### PR TITLE
Updated the SettingsRegistry Specialization tag name max size to 64

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.cpp
@@ -32,6 +32,15 @@ namespace AZ
     {
         if (m_hashes.size() < m_hashes.max_size())
         {
+            constexpr size_t MaxTagSize = TagName{}.max_size();
+            if (specialization.size() > MaxTagSize)
+            {
+                AZ_Error("Settings Registry", false, R"(Cannot append Specialization tag of "%.*s.")"
+                    " It is longer than the MaxTagNameSize of %zu", AZ_STRING_ARG(specialization),
+                    MaxTagSize);
+                return false;
+            }
+
             m_names.push_back(TagName{ specialization });
             TagName& tag = m_names.back();
             AZStd::to_lower(tag.begin(), tag.end());

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistry.h
@@ -49,7 +49,7 @@ namespace AZ
         class Specializations
         {
         public:
-            static constexpr size_t MaxTagNameSize = 32;
+            static constexpr size_t MaxTagNameSize = 64;
             static constexpr size_t MaxCount = 15;
             static constexpr size_t NotFound = static_cast<size_t>(-1);
             using TagName = AZStd::fixed_string<MaxTagNameSize>;


### PR DESCRIPTION
#1962 The tag name max size should match the maximum size of a project name,
since the project name is automatically added as a specialization tag in
the settings registry when loading .setreg files from within the
<ExecutableDirectory>/Registry directory

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>