### PR TITLE
Meshes using forward-pass IBL do not update when a ReflectionProbe is baked

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -256,6 +256,10 @@ namespace AZ
         {
             AZ_Assert(probe.get(), "SetProbeCubeMap called with an invalid handle");
             probe->SetCubeMapImage(cubeMapImage, relativePath);
+
+            // notify the MeshFeatureProcessor that the reflection probe changed
+            MeshFeatureProcessor* meshFeatureProcessor = GetParentScene()->GetFeatureProcessor<MeshFeatureProcessor>();
+            meshFeatureProcessor->UpdateMeshReflectionProbes();
         }
 
         void ReflectionProbeFeatureProcessor::SetProbeTransform(const ReflectionProbeHandle& probe, const AZ::Transform& transform)


### PR DESCRIPTION
Notified the MeshFeatureProcessor when a ReflectionProbe is baked.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>