### PR TITLE
Fixed Event Handler's copy constructor and copy assignments.

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/Event.inl
+++ b/Code/Framework/AzCore/AzCore/EBus/Event.inl
@@ -27,11 +27,17 @@ namespace AZ
     template <typename... Params>
     EventHandler<Params...>::EventHandler(const EventHandler& rhs)
         : m_callback(rhs.m_callback)
+        , m_event(rhs.m_event)
     {
-        // Copy the callback function, then perform a Connect with the new event
-        if (rhs.m_event)
+        // Copy the callback and event, then perform a Connect to the event
+        if (m_callback && m_event)
         {
-            rhs.m_event->Connect(*this);
+            m_event->Connect(*this);
+        }
+        else
+        {
+            // It was not possible to connect to the event, set it to nullptr
+            m_event = nullptr;
         }
     }
 
@@ -65,9 +71,16 @@ namespace AZ
         {
             Disconnect();
             m_callback = rhs.m_callback;
-            if (rhs.m_event)
+            m_event = rhs.m_event;
+            // Copy the callback and event, then perform a Connect to the event
+            if (m_callback && m_event)
             {
-                rhs.m_event->Connect(*this);
+                m_event->Connect(*this);
+            }
+            else
+            {
+                // It was not possible to connect to the event, set it to nullptr
+                m_event = nullptr;
             }
         }
 

--- a/Code/Framework/AzCore/Tests/EventTests.cpp
+++ b/Code/Framework/AzCore/Tests/EventTests.cpp
@@ -257,6 +257,48 @@ namespace UnitTest
         EXPECT_FALSE(testEvent1.HasHandlerConnected());
         EXPECT_TRUE(testEvent2.HasHandlerConnected());
     }
+
+    TEST_F(EventTests, TestHandlerCopyConstructorOperator)
+    {
+        int32_t invokedCounter = 0;
+
+        AZ::Event<> testEvent;
+        AZ::Event<>::Handler testHandler([&invokedCounter]() { invokedCounter++; });
+
+        testHandler.Connect(testEvent);
+
+        AZ::Event<>::Handler testHandler2(testHandler);
+
+        EXPECT_TRUE(testHandler.IsConnected());
+        EXPECT_TRUE(testHandler2.IsConnected());
+
+        EXPECT_TRUE(invokedCounter == 0);
+        testEvent.Signal();
+        EXPECT_TRUE(invokedCounter == 2);
+    }
+
+    TEST_F(EventTests, TestHandlerCopyAssignmentOperator)
+    {
+        int32_t invokedCounter = 0;
+
+        AZ::Event<> testEvent;
+        AZ::Event<>::Handler testHandler([&invokedCounter]() { invokedCounter++; });
+
+        testHandler.Connect(testEvent);
+
+        AZ::Event<>::Handler testHandler2;
+
+        EXPECT_TRUE(testHandler.IsConnected());
+        EXPECT_FALSE(testHandler2.IsConnected());
+
+        testHandler2 = testHandler;
+
+        EXPECT_TRUE(testHandler2.IsConnected());
+
+        EXPECT_TRUE(invokedCounter == 0);
+        testEvent.Signal();
+        EXPECT_TRUE(invokedCounter == 2);
+    }
 }
 
 #if defined(HAVE_BENCHMARK)


### PR DESCRIPTION
The handler's copy constructor and copy assignment operator were missing to set the event to its `m_event` member before connecting to the event. This was causing a crash when later the event is signaled.

Added unit tests to cover this, they fail without the fix.

Signed-off-by: moraaar <moraaar@amazon.com>