### PR TITLE
Disable GPU test that shouldn't be in main

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -51,4 +51,17 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AutomatedTesting.GameLauncher
             AutomatedTesting.Assets
     )
+
+#    ly_add_pytest(
+#        NAME AutomatedTesting::GameLauncherWithGPU
+#        TEST_REQUIRES gpu
+#        PATH ${CMAKE_CURRENT_LIST_DIR}/test_GameLauncher_EnterExitGameMode_Works.py
+#        TIMEOUT 100
+#        RUNTIME_DEPENDENCIES
+#            AZ::AssetProcessor
+#            AZ::PythonBindingsExample
+#            Legacy::Editor
+#            AutomatedTesting.GameLauncher
+#            AutomatedTesting.Assets
+#    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -52,16 +52,17 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AutomatedTesting.Assets
     )
 
-#    ly_add_pytest(
-#        NAME AutomatedTesting::GameLauncherWithGPU
-#        TEST_REQUIRES gpu
-#        PATH ${CMAKE_CURRENT_LIST_DIR}/test_GameLauncher_EnterExitGameMode_Works.py
-#        TIMEOUT 100
-#        RUNTIME_DEPENDENCIES
-#            AZ::AssetProcessor
-#            AZ::PythonBindingsExample
-#            Legacy::Editor
-#            AutomatedTesting.GameLauncher
-#            AutomatedTesting.Assets
-#    )
+    ly_add_pytest(
+        NAME AutomatedTesting::GameLauncherWithGPU
+        TEST_SUITE sandbox
+        TEST_REQUIRES gpu
+        PATH ${CMAKE_CURRENT_LIST_DIR}/test_GameLauncher_EnterExitGameMode_Works.py
+        TIMEOUT 100
+        RUNTIME_DEPENDENCIES
+            AZ::AssetProcessor
+            AZ::PythonBindingsExample
+            Legacy::Editor
+            AutomatedTesting.GameLauncher
+            AutomatedTesting.Assets
+    )
 endif()


### PR DESCRIPTION
- This test was supposed to be merged to `development` but it got merged to `stabilization/2106` instead. See https://github.com/o3de/o3de/pull/1547 for more context.
- Since it got merged to `stabilization/2106` it now exists in `main` and is failing, since it shouldn't be there (we wanted to place it into `development` first and make sure it isn't flaky, then promote it to `main`)