### PR TITLE
[SPEC-7592] Running Linux asset_profile 

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Linux/RHI.Builders/BuilderModule_Linux.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Linux/RHI.Builders/BuilderModule_Linux.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/DX12/ReflectSystemComponent.h>
+#include <Atom/RHI.Reflect/ReflectSystemComponent.h>
+#include <AzCore/Module/Module.h>
+
+namespace AZ
+{
+    namespace DX12
+    {
+        //! Exposes DX12 RHI Building components to the Asset Processor.
+        class BuilderModule final
+            : public AZ::Module
+        {
+        public:
+            AZ_RTTI(BuilderModule, "{5A01F206-87C7-419A-9E37-43E4AD51B070}", AZ::Module);
+
+            BuilderModule()
+            {
+                m_descriptors.insert(m_descriptors.end(), {
+                    ReflectSystemComponent::CreateDescriptor()
+                });
+            }
+        };
+    } // namespace DX12
+} // namespace AZ
+
+// DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
+// The first parameter should be GemName_GemIdLower
+// The second should be the fully qualified name of the class above
+AZ_DECLARE_MODULE_CLASS(Gem_Atom_RHI_DX12_Builders, AZ::DX12::BuilderModule);

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Linux/platform_builders_linux_files.cmake
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Linux/platform_builders_linux_files.cmake
@@ -6,4 +6,5 @@
 #
 
 set(FILES
+    RHI.Builders/BuilderModule_Linux.cpp
 )

--- a/Gems/Atom/RHI/Metal/Code/Source/Platform/Linux/RHI.Builders/BuilderModule_Linux.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/Platform/Linux/RHI.Builders/BuilderModule_Linux.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/RHI.Reflect/Metal/ReflectSystemComponent.h>
+#include <Atom/RHI.Reflect/ReflectSystemComponent.h>
+#include <AzCore/Module/Module.h>
+
+namespace AZ
+{
+    namespace Metal
+    {  
+        //! Exposes Metal RHI Building components to the Asset Processor.
+        class BuilderModule final
+            : public AZ::Module
+        {
+        public:
+            AZ_RTTI(BuilderModule, "{B5D96879-3772-4079-A030-AE3EB0BC22D2}", AZ::Module);
+
+            BuilderModule()
+            {
+                m_descriptors.insert(m_descriptors.end(), {
+                    ReflectSystemComponent::CreateDescriptor()
+                });
+            }
+        };
+    } // namespace Metal
+} // namespace AZ
+
+// DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
+// The first parameter should be GemName_GemIdLower
+// The second should be the fully qualified name of the class above
+AZ_DECLARE_MODULE_CLASS(Gem_Atom_RHI_Metal_Builders, AZ::Metal::BuilderModule);

--- a/Gems/Atom/RHI/Metal/Code/Source/Platform/Linux/platform_builders_linux_files.cmake
+++ b/Gems/Atom/RHI/Metal/Code/Source/Platform/Linux/platform_builders_linux_files.cmake
@@ -6,4 +6,5 @@
 #
 
 set(FILES
+    RHI.Builders/BuilderModule_Linux.cpp
 )


### PR DESCRIPTION
- AP Failed to process assests - Trace::Error: Failed to load dynamic library at path

Fixes the following harmless errors that occur when running
AssetProcessorBatch on Linux:
1. Module: Unable to locate required entry point
   'InitializeDynamicModule' within module
   '/home/garrieta/GIT/o3de/build/linux_profile/bin/profile/libAtom_RHI_DX12.Builders.so'.
2. Module: Unable to locate required entry point
   'InitializeDynamicModule' within module
   '/home/garrieta/GIT/o3de/build/linux_profile/bin/profile/libAtom_RHI_Metal.Builders.so'.

Signed-off-by: garrieta <garrieta@amazon.com>