### PR TITLE
fix for lightculling / pdo artifacts

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/ParallaxMapping.azsli
@@ -427,7 +427,7 @@ PixelDepthOffset CalcPixelDepthOffset(  float depthFactor,
     float4 clipOffsetPosition = mul(viewProjectionMatrix, float4(worldOffsetPosition, 1.0));
 
     PixelDepthOffset pdo;
-    pdo.m_depthCS = clipOffsetPosition.z;
+    pdo.m_depthCS = clipOffsetPosition.w;
     pdo.m_depthNDC = clipOffsetPosition.z / clipOffsetPosition.w;
     pdo.m_worldPosition = worldOffsetPosition;
     return pdo;


### PR DESCRIPTION
The light culling tile iterator needs a .w value which contains viewspace Z.

The original calculation was wrong, because after multiplication of a point by a projection matrix, the viewspace Z is in the .w position, not the .z position.

ATOM-15925