### PR TITLE
Issues/1971 PhysX Gem can't be used as build dependency in engine SDK

### DIFF
--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -380,12 +380,14 @@ function(ly_delayed_target_link_libraries)
             cmake_parse_arguments(ly_delayed_target_link_libraries "" "" "${visibilities}" ${delayed_link})
 
             foreach(visibility ${visibilities})
-                foreach(item ${ly_delayed_target_link_libraries_${visibility}})
+                foreach(alias_item ${ly_delayed_target_link_libraries_${visibility}})
 
-                    if(TARGET ${item})
-                        get_target_property(item_type ${item} TYPE)
+                    if(TARGET ${alias_item})
+                        get_target_property(item_type ${alias_item} TYPE)
+                        ly_de_alias_target(${alias_item} item)
                     else()
                         unset(item_type)
+                        set(item ${alias_item})
                     endif()
 
                     if(item_type STREQUAL MODULE_LIBRARY)


### PR DESCRIPTION
Fixes #1971