### PR TITLE
[stabilization/2106] update desktop shortcuts created by the installer

### DIFF
--- a/cmake/Platform/Windows/Packaging/Shortcuts.wxs
+++ b/cmake/Platform/Windows/Packaging/Shortcuts.wxs
@@ -26,10 +26,15 @@
         <DirectoryRef Id="DesktopFolder">
             <Component Id="DesktopShortcuts" Guid="{2600B54A-65FB-4507-A7CD-3CE4817C7173}">
 
-                <Shortcut Id="DesktopShortcut_Launcher"
+                <Shortcut Id="DesktopShortcut_Editor"
+                    Target="[root.bin.Windows.profile]Editor.exe"
+                    WorkingDirectory="root.bin.Windows.profile"
+                    Name="$(var.CPACK_PACKAGE_NAME) Editor" />
+
+                <Shortcut Id="DesktopShortcut_ProjectManager"
                     Target="[root.bin.Windows.profile]o3de.exe"
                     WorkingDirectory="root.bin.Windows.profile"
-                    Name="$(var.CPACK_PACKAGE_NAME) $(var.CPACK_PACKAGE_VERSION)" />
+                    Name="$(var.CPACK_PACKAGE_NAME) Project Manager" />
 
                 <RemoveFolder Id="DesktopFolder" On="uninstall"/>
 


### PR DESCRIPTION
- Changed the existing desktop shortcut for Project Manager to include tool name and dropped version number for consistent branding
- Added desktop shortcut for the Editor

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>