### PR TITLE
Increase test timeout for AutomatedTesting::AtomRenderer_HydraTests_GPUTests to diagnose AR node issue (might require RDP to fix).

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
@@ -38,7 +38,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
         TEST_SUITE main
         TEST_REQUIRES gpu
         TEST_SERIAL
-        TIMEOUT 400
+        TIMEOUT 800
         PATH ${CMAKE_CURRENT_LIST_DIR}/test_Atom_GPUTests.py
         RUNTIME_DEPENDENCIES
             AssetProcessor

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_GPUTests.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_GPUTests.py
@@ -17,7 +17,7 @@ import editor_python_test_tools.hydra_test_utils as hydra
 
 logger = logging.getLogger(__name__)
 DEFAULT_SUBFOLDER_PATH = 'user/PythonTests/Automated/Screenshots'
-EDITOR_TIMEOUT = 300
+EDITOR_TIMEOUT = 600
 TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "atom_hydra_scripts")
 
 


### PR DESCRIPTION
- This GPU test is timing out in our AR runs with no clear indication as to why. Past experience with logs like these usually mean its a pop-up or alert that halts the animation and prevents it from continuing.
- If this issue remains even after increasing the timeout, I am going to need to find a way to gain RDP access or get into the node to figure out what is truly going wrong.
- Any Assertions, Errors, or Python errors should be caught by the unexpected_lines below (which is already part of the test). It seems something other than an assert or error is blocking it and we can't see it without being on the node.
```
        unexpected_lines = [
            "Trace::Assert",
            "Trace::Error",
            "Traceback (most recent call last):",
        ]
```
- Passes locally every time:
```
--- Expected lines ---
[ FOUND ] Viewport is set to the expected size: True
[ FOUND ] Basic level created
Found 2/2 expected lines
120483.66785049438 - INFO - [MainThread] - ly_test_tools.environment.file_system - Restoring backup of C:\git\o3de\system_windows_pc.cfg from C:\Users\jromnoa\AppData\Local\Temp\tmpc3bu5pk4\system_windows_pc.cfg.bak
120487.21718788147 - WARNING - [MainThread] - ly_test_tools.environment.file_system - Backup file C:\Users\jromnoa\AppData\Local\Temp\tmpc3bu5pk4\config.ini.bak does not exist, aborting backup restoration.
120487.21718788147 - INFO - [MainThread] - ly_test_tools.o3de.asset_processor - Sent input quit
PASSED126562.67809867859 - INFO - [MainThread] - ly_test_tools.environment.process_utils - Killing all processes named ['AssetProcessor.exe']
127099.16925430298 - INFO - [MainThread] - ly_test_tools.environment.file_system - Restoring backup of C:\git\o3de\system_windows_pc.cfg from C:\Users\jromnoa\AppData\Local\Temp\tmpc3bu5pk4\system_windows_pc.cfg.bak
127103.16753387451 - WARNING - [MainThread] - ly_test_tools.environment.file_system - Backup file C:\Users\jromnoa\AppData\Local\Temp\tmpc3bu5pk4\config.ini.bak does not exist, aborting backup restoration.
127104.16722297668 - WARNING - [MainThread] - ly_test_tools.o3de.asset_processor - Attempting to quit AP but none running
127114.67576026917 - INFO - [crash_log_watchdog] - ly_test_tools.environment.watchdog - Shutting down watchdog: crash_log_watchdog

1 passed in 126.60s (0:02:06)
```