### PR TITLE
Remove Cry -> Atom camera sync.

### DIFF
--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -505,7 +505,6 @@ protected:
 
     CPredefinedAspectRatios m_predefinedAspectRatios;
 
-    IVariable* m_pCameraFOVVariable = nullptr;
     bool m_bCursorHidden = false;
 
     void OnMenuResolutionCustom();


### PR DESCRIPTION
This is meant to avoid a situation in which we inadvertently overwrite a camera component's transform when switching between cameras in-Editor. This is a difficult edge case for me to reproduce locally, but Apocalypse is confident the issue stems from the sync, which is a distinct source of possible camera transform issues.

As this synchronization is purely for the purposes of legacy compatibility, I've gone ahead and removed it - after auditing as much Editor functionality as I could, all other camera logic I've been able to find has now been ported to talk directly to the default viewport context. Additionally, the sync was already disabled for the new camera controller, which has been running without issue in development for more than a week.

This also clarifies FOV change behavior to avoid syncing every frame in favor of directly getting and setting the FOV from either the Editor camera or active Camera entity to avoid any matrix trampling on a per-frame basis.

Signed-off-by: nvsickle <nvsickle@amazon.com>