### PR TITLE
Add Vcpkg settings to map configs to what vcpkg expects 

### DIFF
--- a/cmake/Platform/Common/Directory.Build.props
+++ b/cmake/Platform/Common/Directory.Build.props
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
     <PropertyGroup>
         <UseMultiToolTask>true</UseMultiToolTask>
         <EnforceProcessCountAcrossBuilds>true</EnforceProcessCountAcrossBuilds>
+@VCPKG_CONFIGURATION_MAPPING@
     </PropertyGroup>
     <ItemDefinitionGroup>
         <ClCompile>

--- a/cmake/Platform/Common/VisualStudio_common.cmake
+++ b/cmake/Platform/Common/VisualStudio_common.cmake
@@ -6,5 +6,15 @@
 #
 
 if(CMAKE_GENERATOR MATCHES "Visual Studio 16")
-    configure_file("${CMAKE_CURRENT_LIST_DIR}/Directory.Build.props" "${CMAKE_BINARY_DIR}/Directory.Build.props" COPYONLY)
+
+    foreach(conf IN LISTS CMAKE_CONFIGURATION_TYPES)
+        if(conf STREQUAL debug)
+            string(APPEND VCPKG_CONFIGURATION_MAPPING "        <VcpkgConfiguration Condition=\"'$(Configuration)' == '${conf}'\">Debug</VcpkgConfiguration>\n")
+        else()
+            string(APPEND VCPKG_CONFIGURATION_MAPPING "        <VcpkgConfiguration Condition=\"'$(Configuration)' == '${conf}'\">Release</VcpkgConfiguration>\n")
+        endif()
+    endforeach()
+    
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/Directory.Build.props" "${CMAKE_BINARY_DIR}/Directory.Build.props" @ONLY)
+
 endif()


### PR DESCRIPTION
this prevents a message from being issue when vcpkg is installed

Fixes #2030