### PR TITLE
Fix Registry installation with capitalized profile

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/CMakeLists.txt
+++ b/Code/Tools/SceneAPI/SDKWrapper/CMakeLists.txt
@@ -26,4 +26,5 @@ ly_add_target(
             AZ::AzToolsFramework
         PUBLIC
             3rdParty::assimplib
+            3rdParty::poly2tri
 )

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
@@ -113,7 +113,7 @@ namespace ScriptCanvas
             return;
         }
 #else
-        AZ_Assert(m_runtimeAsset.Get(), "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+        AZ_Assert(m_runtimeOverrides.m_runtimeAsset.Get(), "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
 #endif
 
         AZ_PROFILE_SCOPE_DYNAMIC(AZ::Debug::ProfileCategory::ScriptCanvas, "RuntimeComponent::InitializeExecution (%s)", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().c_str());
@@ -127,7 +127,7 @@ namespace ScriptCanvas
             return;
         }
 #else
-        AZ_Assert(m_executionState, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run", m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+        AZ_Assert(m_executionState, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
 #endif
 
         AZ::EntityBus::Handler::BusConnect(GetEntityId());

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -11,6 +11,7 @@ ly_associate_package(PACKAGE_NAME ilmbase-2.3.0-rev4-multiplatform              
 ly_associate_package(PACKAGE_NAME hdf5-1.0.11-rev2-multiplatform                    TARGETS hdf5                        PACKAGE_HASH 11d5e04df8a93f8c52a5684a4cacbf0d9003056360983ce34f8d7b601082c6bd)
 ly_associate_package(PACKAGE_NAME alembic-1.7.11-rev3-multiplatform                 TARGETS alembic                     PACKAGE_HASH ba7a7d4943dd752f5a662374f6c48b93493df1d8e2c5f6a8d101f3b50700dd25)
 ly_associate_package(PACKAGE_NAME assimp-5.0.1-rev11-multiplatform                  TARGETS assimplib                   PACKAGE_HASH 1a9113788b893ef4a2ee63ac01eb71b981a92894a5a51175703fa225f5804dec)
+ly_associate_package(PACKAGE_NAME poly2tri-0.3.3-rev2-multiplatform                 TARGETS poly2tri                    PACKAGE_HASH 04092d06716f59b936b61906eaf3647db23b685d81d8b66131eb53e0aeaa1a38)
 ly_associate_package(PACKAGE_NAME squish-ccr-20150601-rev3-multiplatform            TARGETS squish-ccr                  PACKAGE_HASH c878c6c0c705e78403c397d03f5aa7bc87e5978298710e14d09c9daf951a83b3)
 ly_associate_package(PACKAGE_NAME ASTCEncoder-2017_11_14-rev2-multiplatform         TARGETS ASTCEncoder                 PACKAGE_HASH c240ffc12083ee39a5ce9dc241de44d116e513e1e3e4cc1d05305e7aa3bdc326)
 ly_associate_package(PACKAGE_NAME md5-2.0-multiplatform                             TARGETS md5                         PACKAGE_HASH 29e52ad22c78051551f78a40c2709594f0378762ae03b417adca3f4b700affdf)

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -509,7 +509,7 @@ function(ly_setup_others)
 
     # Registry
     install(DIRECTORY
-        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/Registry
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<LOWER_CASE:$<CONFIG>>/Registry
         DESTINATION ./${runtime_output_directory}/${PAL_PLATFORM_NAME}/$<CONFIG>
     )
     install(DIRECTORY


### PR DESCRIPTION
When compiling with a capitalized profile ("Release" e.g.),
Registry will be generated in a lowercase folder ("bin/release" e.g.),
but installation will still look for a capitalized folder ("bin/Release" e.g.).

Fix this by lowercasing the installation profile folder.

Signed-off-by: Manuel Bachmann <manuel.bachmann@intech.lu>