### PR TITLE
Set DiffuseProbeGrids to visible when baking textures.

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGrid.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGrid.cpp
@@ -259,6 +259,12 @@ namespace AZ
                 return true;
             }
 
+            // if a bake is in progress we need to make this DiffuseProbeGrid visible
+            if (!m_textureReadback.IsIdle())
+            {
+                return true;
+            }
+
             return m_cullable.m_isVisible;
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridTextureReadback.h
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridTextureReadback.h
@@ -20,6 +20,7 @@ namespace AZ
         enum class DiffuseProbeGridReadbackState
         {
             Idle,
+            Initializing,
             Irradiance,
             Distance,
             Relocation,
@@ -39,6 +40,8 @@ namespace AZ
             void Update(const AZ::Name& passName);
             void FrameBegin(AZ::RPI::Pass::FramePrepareParams& params);
 
+            bool IsIdle() const { return m_readbackState == DiffuseProbeGridReadbackState::Idle; }
+
         private:
 
             DiffuseProbeGrid* m_diffuseProbeGrid = nullptr;
@@ -50,6 +53,10 @@ namespace AZ
             AZ::RPI::AttachmentReadback::ReadbackResult m_distanceReadbackResult;
             AZ::RPI::AttachmentReadback::ReadbackResult m_relocationReadbackResult;
             AZ::RPI::AttachmentReadback::ReadbackResult m_classificationReadbackResult;
+
+            // number of frames to delay before starting the texture readbacks, this allows the textures to settle
+            static constexpr int32_t DefaultNumInitializationFrames = 50;
+            int32_t m_remainingInitializationFrames = DefaultNumInitializationFrames;
         };
     }   // namespace Render
 }   // namespace AZ


### PR DESCRIPTION
Set DiffuseProbeGrids to visible when baking textures.
Added an initialization delay before starting the DiffuseProbeGrid texture readbacks, to allow the textures to settle.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>