### PR TITLE
Added an option to character component not use auto-apply velocities on a physics tick

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Character.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Character.cpp
@@ -84,7 +84,7 @@ namespace Physics
         if (serializeContext)
         {
             serializeContext->Class<CharacterConfiguration, AzPhysics::SimulatedBodyConfiguration>()
-                ->Version(2)
+                ->Version(3)
                 ->Field("CollisionLayer", &CharacterConfiguration::m_collisionLayer)
                 ->Field("CollisionGroupId", &CharacterConfiguration::m_collisionGroupId)
                 ->Field("Material", &CharacterConfiguration::m_materialSelection)
@@ -94,6 +94,7 @@ namespace Physics
                 ->Field("MinDistance", &CharacterConfiguration::m_minimumMovementDistance)
                 ->Field("MaxSpeed", &CharacterConfiguration::m_maximumSpeed)
                 ->Field("ColliderTag", &CharacterConfiguration::m_colliderTag)
+                ->Field("ApplyMoveOnPhysicsTick", &CharacterConfiguration::m_applyMoveOnPhysicsTick)
             ;
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -127,6 +128,9 @@ namespace Physics
                         ->Attribute(AZ::Edit::Attributes::Step, 1.0f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterConfiguration::m_colliderTag,
                         "Collider Tag", "Used to identify the collider associated with the character controller")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterConfiguration::m_applyMoveOnPhysicsTick,
+                        "Apply Move On Tick", "Requests to add velocity will be accumulated and applied once on the physics pre-simulation tick "
+                        "If unticked, explicit call to apply requested velocity is required")
                 ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Character.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Character.h
@@ -76,6 +76,7 @@ namespace Physics
         AZStd::string m_colliderTag; //!< Used to identify the collider associated with the character controller.
         AZStd::shared_ptr<Physics::ShapeConfiguration> m_shapeConfig; //!< The shape to use when creating the character controller.
         AZStd::vector<AZStd::shared_ptr<Physics::Shape>> m_colliders; //!< The list of colliders to attach to the character controller.
+        bool m_applyMoveOnPhysicsTick = true; //!< Should accumulated velocity be applied on the physics tick.
     };
 
     /// Basic implementation of common character-style needs as a WorldBody. Is not a full-functional ship-ready

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterControllerComponent.cpp
@@ -520,16 +520,19 @@ namespace PhysX
 
         CharacterControllerRequestBus::Handler::BusConnect(GetEntityId());
 
-        m_preSimulateHandler = AzPhysics::SystemEvents::OnPresimulateEvent::Handler(
-            [this](float deltaTime)
-            {
-                OnPreSimulate(deltaTime);
-            }
-        );
-
-        if (auto* physXSystem = GetPhysXSystem())
+        if (m_characterConfig->m_applyMoveOnPhysicsTick)
         {
-            physXSystem->RegisterPreSimulateEvent(m_preSimulateHandler);
+            m_preSimulateHandler = AzPhysics::SystemEvents::OnPresimulateEvent::Handler(
+                [this](float deltaTime)
+                {
+                    OnPreSimulate(deltaTime);
+                }
+            );
+
+            if (auto* physXSystem = GetPhysXSystem())
+            {
+                physXSystem->RegisterPreSimulateEvent(m_preSimulateHandler);
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: pereslav <pereslav@amazon.com>