### PR TITLE
Fix feature category spellings

### DIFF
--- a/Gems/AssetMemoryAnalyzer/gem.json
+++ b/Gems/AssetMemoryAnalyzer/gem.json
@@ -6,7 +6,7 @@
     "type": "Code",
     "summary": "The Asset Memory Analyzer Gem provides tools to profile asset memory usage in Open 3D Engine through ImGUI (Immediate Mode Graphical User Interface).",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Debug", "Utillity", "Tools"],
+    "user_tags": ["Debug", "Utility", "Tools"],
     "icon_path": "preview.png",
     "requirements": ""
 }

--- a/Gems/AudioEngineWwise/gem.json
+++ b/Gems/AudioEngineWwise/gem.json
@@ -6,7 +6,7 @@
     "type": "Code",
     "summary": "The Wwise Audio Engine Gem provides support for Audiokinetic Wave Works Interactive Sound Engine (Wwise).",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Audio", "Utiltity", "Tools"],
+    "user_tags": ["Audio", "Utility", "Tools"],
     "icon_path": "preview.png",
     "requirements": "Users will need to download WWise from the AudioKinetic web site: https://www.audiokinetic.com/download/"
 }

--- a/Gems/AudioSystem/gem.json
+++ b/Gems/AudioSystem/gem.json
@@ -6,7 +6,7 @@
     "type": "Code",
     "summary": "The Audio System Gem provides the Audio Translation Layer (ATL) and Audio Controls Editor, which add support for audio in Open 3D Engine.",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Audio", "Utiltity", "Tools"],
+    "user_tags": ["Audio", "Utility", "Tools"],
     "icon_path": "preview.png",
     "requirements": ""
 }

--- a/Gems/ExpressionEvaluation/gem.json
+++ b/Gems/ExpressionEvaluation/gem.json
@@ -6,7 +6,7 @@
     "type": "Code",
     "summary": "The Expression Evaluation Gem provides a method for parsing and executing string expressions in Open 3D Engine.",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Scripting", "Utiltity"],
+    "user_tags": ["Scripting", "Utility"],
     "icon_path": "preview.png",
     "requirements": ""
 }

--- a/Gems/GameStateSamples/gem.json
+++ b/Gems/GameStateSamples/gem.json
@@ -6,7 +6,7 @@
     "type": "Code",
     "summary": "The Game State Samples Gem provides a set of sample game states (built on top of the Game State Gem), including primary user selection, main menu, level loading, level running, and level paused.",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Gameplay", "Samples", "Assets"],
+    "user_tags": ["Gameplay", "Sample", "Assets"],
     "icon_path": "preview.png",
     "requirements": ""
 }

--- a/Gems/ScriptCanvas/gem.json
+++ b/Gems/ScriptCanvas/gem.json
@@ -6,7 +6,7 @@
   "type": "Tool",
   "summary": "The Script Canvas Gem provides Open 3D Engine's visual scripting environment, Script Canvas.",
   "canonical_tags": ["Gem"],
-  "user_tags": ["Scripting", "Tools", "Utiltiy"],
+  "user_tags": ["Scripting", "Tools", "Utility"],
   "icon_path": "preview.png",
   "requirements": ""
 }

--- a/Gems/SurfaceData/gem.json
+++ b/Gems/SurfaceData/gem.json
@@ -6,7 +6,7 @@
     "type": "Code",
     "summary": "The Surface Data Gem provides functionality to emit signals or tags from surfaces such as meshes and terrain.",
     "canonical_tags": ["Gem"],
-    "user_tags": ["Environment", "Utiltiy", "Design"],
+    "user_tags": ["Environment", "Utility", "Design"],
     "icon_path": "preview.png",
     "requirements": ""
 }


### PR DESCRIPTION
Fix some spelling errors in feature categories that were causing additional filters to appear.

![FixedCategories](https://user-images.githubusercontent.com/70403342/125335828-dd2b3180-e301-11eb-8166-74cf5fd42054.jpg)
