### PR TITLE
Fix positional desync of network objects plus related log spam

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocketManager_Select.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpSocketManager_Select.cpp
@@ -41,7 +41,7 @@ namespace AzNetworking
 
     void TcpSocketManager::ProcessEvents(AZ::TimeMs maxBlockMs, const SocketEventCallback& readCallback, const SocketEventCallback& writeCallback)
     {
-        if(static_cast<int32_t>(m_maxFd) <= 0 && m_socketFds.empty())
+        if(static_cast<int32_t>(m_maxFd) <= 0 || m_socketFds.empty())
         {
             // There are no available sockets to process
             return;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -178,6 +178,18 @@ namespace Multiplayer
 
     void MultiplayerEditorConnection::OnDisconnect([[maybe_unused]] AzNetworking::IConnection* connection, [[maybe_unused]] DisconnectReason reason, [[maybe_unused]] TerminationEndpoint endpoint)
     {
-        ;
+        bool editorLaunch = false;
+        if (auto console = AZ::Interface<AZ::IConsole>::Get(); console)
+        {
+            console->GetCvarValue("editorsv_launch", editorLaunch);
+        }
+
+        if (editorsv_isDedicated && editorLaunch && m_networkEditorInterface->GetConnectionSet().GetConnectionCount() == 1)
+        {
+            if (m_networkEditorInterface->GetPort() != 0)
+            {
+                m_networkEditorInterface->StopListening();
+            }
+        }
     }
 }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -151,7 +151,7 @@ namespace Multiplayer
         AZStd::queue<AZStd::string> m_pendingConnectionTickets;
 
         AZ::TimeMs m_lastReplicatedHostTimeMs = AZ::TimeMs{ 0 };
-        HostFrameId m_lastReplicatedHostFrameId = InvalidHostFrameId;
+        HostFrameId m_lastReplicatedHostFrameId = HostFrameId(0);
 
         double m_serverSendAccumulator = 0.0;
         float m_renderBlendFactor = 0.0f;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/PropertyPublisher.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/PropertyPublisher.cpp
@@ -123,20 +123,23 @@ namespace Multiplayer
 
     bool PropertyPublisher::PrepareUpdateEntityRecord()
     {
-        // If we reach the maximum outstanding records, reset the replication state
+        bool didPrepare = true;
         if (m_sentRecords.size() >= net_EntityReplicatorRecordsMax)
         {
-            return PrepareAddEntityRecord();
+            // If we reach the maximum outstanding records, reset the replication state
+            didPrepare = PrepareAddEntityRecord();
         }
-
-        // We need to clear out old records, and build up a list of everything that has changed since the last acked packet
-        m_sentRecords.push_front(m_pendingRecord);
-        auto iter = m_sentRecords.begin();
-        ++iter; // Consider everything after the record we are going to send
-        for (; iter != m_sentRecords.end(); ++iter)
+        else
         {
-            // Sequence wasn't acked, so we need to send these bits again
-            m_pendingRecord.Append(*iter);
+            // We need to clear out old records, and build up a list of everything that has changed since the last acked packet
+            m_sentRecords.push_front(m_pendingRecord);
+            auto iter = m_sentRecords.begin();
+            ++iter; // Consider everything after the record we are going to send
+            for (; iter != m_sentRecords.end(); ++iter)
+            {
+                // Sequence wasn't acked, so we need to send these bits again
+                m_pendingRecord.Append(*iter);
+            }
         }
 
         // Don't send predictable properties back to the Autonomous unless we correct them
@@ -145,7 +148,7 @@ namespace Multiplayer
             m_pendingRecord.Subtract(m_netBindComponent->GetPredictableRecord());
         }
 
-        return true;
+        return didPrepare;
     }
 
     bool PropertyPublisher::PrepareDeleteEntityRecord()

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/ReplicationRecord.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/ReplicationRecord.cpp
@@ -191,6 +191,8 @@ namespace Multiplayer
 
     bool ReplicationRecord::ContainsAuthorityToClientBits() const
     {
+        // Check != Authority here since several modes require information about client updates
+        // (i.e. Autonomous when performing corrections)
         return (m_remoteNetEntityRole != NetEntityRole::Authority)
             || (m_remoteNetEntityRole == NetEntityRole::InvalidRole);
     }


### PR DESCRIPTION
This changes fixes an edge case in which autonomous property sets are not subtracted from entity updates and interpolation and related time values were not occurring due to a misconfigured initial value. It also cleans up some log spam.

Signed-off-by: puvvadar <puvvadar@amazon.com>