### PR TITLE
Integrate visualizer widget into ASV CPU profiler

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -67,17 +67,14 @@ namespace AZ
             void Draw(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
 
             //! Draws the statistical view of the CPU profiling data
-            void DrawStatisticsView(const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
+            void DrawStatisticsView();
 
             //! Draws the CPU profiling visualizer in a new window. 
-            void DrawVisualizer(const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
+            void DrawVisualizer();
 
         private:
             static constexpr float RowHeight = 50.0;
             static constexpr int DefaultFramesToCollect = 50;
-
-            // Update the GroupRegionMap with the latest cached time regions
-            void UpdateGroupRegionMap();
 
             // Draw the shared header between the two windows
             void DrawCommonHeader();
@@ -85,12 +82,13 @@ namespace AZ
             // ImGui filter used to filter TimedRegions.
             ImGuiTextFilter m_timedRegionFilter;
 
+            // Saves statistical view data organized by group name -> region name -> regions
             GroupRegionMap m_groupRegionMap;
 
             // Pause cpu profiling. The profiler will show the statistics of the last frame before pause
             bool m_paused = false;
 
-            // Export the profiling data to a local file
+            // Export the profiling data from a single frame to a local file
             bool m_captureToFile = false;
 
             // Toggle between the normal statistical view and the visual profiling view

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -63,11 +63,14 @@ namespace AZ
             ImGuiCpuProfiler() = default;
             ~ImGuiCpuProfiler() = default;
 
-            //! Draws the provided Cpu statistics.
+            //! Draws the overall CPU profiling window, defaults to the statistical view
             void Draw(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
 
+            //! Draws the statistical view of the CPU profiling data
+            void DrawStatisticsView(const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
+
             //! Draws the CPU profiling visualizer in a new window. 
-            void DrawVisualizer(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& currentCpuTimingStatistics);
+            void DrawVisualizer(const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
 
         private:
             static constexpr float RowHeight = 50.0;
@@ -76,6 +79,9 @@ namespace AZ
             // Update the GroupRegionMap with the latest cached time regions
             void UpdateGroupRegionMap();
 
+            // Draw the shared header between the two windows
+            void DrawCommonHeader();
+
             // ImGui filter used to filter TimedRegions.
             ImGuiTextFilter m_timedRegionFilter;
 
@@ -83,6 +89,12 @@ namespace AZ
 
             // Pause cpu profiling. The profiler will show the statistics of the last frame before pause
             bool m_paused = false;
+
+            // Export the profiling data to a local file
+            bool m_captureToFile = false;
+
+            // Toggle between the normal statistical view and the visual profiling view
+            bool m_enableVisualizer = false;
 
             // Total frames need to be saved
             int m_captureFrameCount = 1;
@@ -130,8 +142,6 @@ namespace AZ
             virtual void OnSystemTick() override;
 
             // Visualizer state
-
-            bool m_showVisualizer = false;
 
             int m_framesToCollect = DefaultFramesToCollect;
 

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -160,9 +160,9 @@ namespace AZ
                     ImGui::BeginTooltip();
                     ImGui::PushTextWrapPos(ImGui::GetFontSize() * 60.0f);
 
-					for (ThreadRegionEntry& entry : entries)
-					{
-						ImGui::Text(CpuProfilerImGuiHelper::TextThreadId(entry.m_threadId.m_id).c_str());
+                    for (ThreadRegionEntry& entry : entries)
+                    {
+                        ImGui::Text(CpuProfilerImGuiHelper::TextThreadId(entry.m_threadId.m_id).c_str());
 
                         const AZStd::sys_time_t elapsed = entry.m_endTick - entry.m_startTick;
                         ShowTimeInMs(elapsed);

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -86,8 +86,10 @@ namespace AZ
                 AZStd::sys_time_t timeNow = AZStd::GetTimeNowSecond();
                 AZStd::string timeString;
                 AZStd::to_string(timeString, timeNow);
-                u64 currentTick = AZ::RPI::RPISystemInterface::Get()->GetCurrentTick();
-                AZStd::string frameDataFilePath = AZStd::string::format("@user@/CpuProfiler/%s_%llu.json", timeString.c_str(), currentTick);
+                const AZStd::string frameDataFilePath = AZStd::string::format(
+                    "@user@/CpuProfiler/%s_%llu.json",
+                    timeString.c_str(),
+                    AZ::RPI::RPISystemInterface::Get()->GetCurrentTick());
                 char resolvedPath[AZ::IO::MaxPathLength];
                 AZ::IO::FileIOBase::GetInstance()->ResolvePath(frameDataFilePath.c_str(), resolvedPath, AZ::IO::MaxPathLength);
                 m_lastCapturedFilePath = resolvedPath;
@@ -311,10 +313,9 @@ namespace AZ
             {
                 // Find the next frame boundary after the viewport's right bound and draw until that tick
                 auto nextFrameBoundaryItr = AZStd::lower_bound(m_frameEndTicks.begin(), m_frameEndTicks.end(), m_viewportEndTick);
-                if (nextFrameBoundaryItr == m_frameEndTicks.end() &&
-                    m_frameEndTicks.size() != 0) // lower_bound returns end() if not found
+                if (nextFrameBoundaryItr == m_frameEndTicks.end() && m_frameEndTicks.size() != 0)
                 {
-                    nextFrameBoundaryItr--;
+                    --nextFrameBoundaryItr;
                 }
                 const AZStd::sys_time_t nextFrameBoundary = *nextFrameBoundaryItr;
 
@@ -322,7 +323,7 @@ namespace AZ
                 auto startTickItr = AZStd::lower_bound(m_frameEndTicks.begin(), m_frameEndTicks.end(), m_viewportStartTick);
                 if (startTickItr != m_frameEndTicks.begin())
                 {
-                    startTickItr--;
+                    --startTickItr;
                 }
 
                 // Main draw loop
@@ -353,7 +354,7 @@ namespace AZ
 
                         DrawBlock(region, targetRow);
 
-                        regionItr++;
+                        ++regionItr;
                     }
 
                     // Draw UI details
@@ -656,7 +657,7 @@ namespace AZ
             {
                 const float horizontalPixel = ConvertTickToPixelSpace(*endTickItr);
                 drawList->AddLine({ horizontalPixel, wy }, { horizontalPixel, wy + windowHeight }, red);
-                endTickItr++;
+                ++endTickItr;
             }
         }
 
@@ -667,7 +668,7 @@ namespace AZ
             auto nextFrameBoundaryItr = lastFrameBoundaryItr;
             if (lastFrameBoundaryItr != m_frameEndTicks.begin()) 
             {
-                lastFrameBoundaryItr--;
+                --lastFrameBoundaryItr;
             }
 
             const auto [wx, wy] = ImGui::GetWindowPos();
@@ -732,7 +733,7 @@ namespace AZ
                     IM_COL32_WHITE);
 
                 lastFrameBoundaryItr = nextFrameBoundaryItr;
-                nextFrameBoundaryItr++;
+                ++nextFrameBoundaryItr;
             }
         }
 

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -86,10 +86,11 @@ namespace AZ
                 AZStd::sys_time_t timeNow = AZStd::GetTimeNowSecond();
                 AZStd::string timeString;
                 AZStd::to_string(timeString, timeNow);
+                u64 currentTick = AZ::RPI::RPISystemInterface::Get()->GetCurrentTick();
                 const AZStd::string frameDataFilePath = AZStd::string::format(
                     "@user@/CpuProfiler/%s_%llu.json",
                     timeString.c_str(),
-                    AZ::RPI::RPISystemInterface::Get()->GetCurrentTick());
+                    currentTick);
                 char resolvedPath[AZ::IO::MaxPathLength];
                 AZ::IO::FileIOBase::GetInstance()->ResolvePath(frameDataFilePath.c_str(), resolvedPath, AZ::IO::MaxPathLength);
                 m_lastCapturedFilePath = resolvedPath;


### PR DESCRIPTION
This PR integrates the visualizer widget more cleanly into the existing CPU profiler. Instead of having two separate windows, we can now instead toggle between the two views within the same window. The state of the two views are also better synchronized, with the statistics view showing data from the last frame shown in the visualizer. 

The diff is pretty messy, but the main change that I made was moving drawing code for the statistical view out from Draw() into DrawStatisticsView(). The functionality for UpdateGroupRegionMap() was also moved to CollectFrameData() so we don't need to traverse the TimeRegionMap twice. 

### Before
https://user-images.githubusercontent.com/64656371/125341444-74938300-e308-11eb-8e91-38ea8afa47eb.mp4

### After 
https://user-images.githubusercontent.com/64656371/125341542-912fbb00-e308-11eb-9b3d-666f323b560c.mp4



Completes ATOM-15687