### PR TITLE
[stabilization/2106] Auto generate installer 3rd party license URL from version string

### DIFF
--- a/Code/Tools/CrashHandler/CMakeLists.txt
+++ b/Code/Tools/CrashHandler/CMakeLists.txt
@@ -38,8 +38,19 @@ ly_add_target(
 string(REPLACE "." ";" version_list "${LY_VERSION_STRING}")
 list(GET version_list 0 EXE_VERSION_INFO_0)
 list(GET version_list 1 EXE_VERSION_INFO_1)
-list(GET version_list 2 EXE_VERSION_INFO_2)
-list(GET version_list 3 EXE_VERSION_INFO_3)
+
+list(LENGTH version_list version_component_count)
+if(${version_component_count} GREATER_EQUAL 3)
+    list(GET version_list 2 EXE_VERSION_INFO_2)
+else()
+    set(EXE_VERSION_INFO_2 0)
+endif()
+
+if(${version_component_count} GREATER_EQUAL 4)
+    list(GET version_list 3 EXE_VERSION_INFO_3)
+else()
+    set(EXE_VERSION_INFO_3 0)
+endif()
 
 ly_add_source_properties(
     SOURCES Shared/CrashHandler.cpp


### PR DESCRIPTION
- 3rd party license URL is now auto generated from the version string (which should be synchronized with the GitHub release tags) and pulled directly from the source repo it originated from, but only when the version is non-zero
  - This also fixes an issue where configure would fail when the previous 3rd party URL wasn't supplied
- Fixed an issue where CrashHandler required version strings to be 4 components

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>