### PR TITLE
Fix Atom GPU test by enabling autotest_mode

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_GPUTests.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_GPUTests.py
@@ -77,7 +77,6 @@ class TestAllComponentsIndepthTests(object):
             unexpected_lines=unexpected_lines,
             halt_on_unexpected=True,
             cfg_args=[level],
-            auto_test_mode=False,
             null_renderer=False,
         )
 


### PR DESCRIPTION
- This was easy to fix but easily missed. `--autotest_mode=False` was set which stops the suppression of help pop-up dialogue boxes. Simply removing this sets it back to the default state of `True`.
- I didn't see it locally because my Editor already has help dialogue boxes disabled, so even with `--autotest_mode=False` it would pass for me. Something to keep in mind for the future.