### PR TITLE
ly_create_alias() now adds the directory it was called from to the LY_ALL_TARGET_DIRECTORIES property 

### DIFF
--- a/Gems/Atom/CMakeLists.txt
+++ b/Gems/Atom/CMakeLists.txt
@@ -14,11 +14,3 @@ add_subdirectory(RPI)
 add_subdirectory(Tools)
 add_subdirectory(Utils)
 
-# The "Atom" Gem will alias the real Atom_AtomBridge target variants
-# allows the enabling and disabling the "Atom" Gem to build the pre-requisite dependencies
-ly_create_alias(NAME Atom.Clients NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Clients)
-ly_create_alias(NAME Atom.Servers NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Servers)
-if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME Atom.Builders NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Builders)
-    ly_create_alias(NAME Atom.Tools    NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Tools)
-endif()

--- a/Gems/AtomLyIntegration/AtomBridge/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/CMakeLists.txt
@@ -115,3 +115,18 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_create_alias(NAME Atom_AtomBridge.Builders NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Editor)
     ly_create_alias(NAME Atom_AtomBridge.Tools    NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Editor)
 endif()
+
+# The "Atom" Gem will alias the real Atom_AtomBridge target variants
+# allows the enabling and disabling the "Atom" Gem to build the pre-requisite dependencies
+# The "AtomLyIntegration" Gem will also alias the real Atom_AtomBridge target variants
+# The Atom Gem does the same at the moment.
+ly_create_alias(NAME Atom.Clients NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Clients)
+ly_create_alias(NAME Atom.Servers NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Servers)
+ly_create_alias(NAME AtomLyIntegration.Clients NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Clients)
+ly_create_alias(NAME AtomLyIntegration.Servers NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Servers)
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    ly_create_alias(NAME Atom.Builders NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Builders)
+    ly_create_alias(NAME Atom.Tools    NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Tools)
+    ly_create_alias(NAME AtomLyIntegration.Builders NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Builders)
+    ly_create_alias(NAME AtomLyIntegration.Tools    NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Tools)
+endif()

--- a/Gems/AtomLyIntegration/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/CMakeLists.txt
@@ -15,11 +15,3 @@ add_subdirectory(AtomBridge)
 add_subdirectory(AtomViewportDisplayInfo)
 add_subdirectory(AtomViewportDisplayIcons)
 
-# The "AtomLyIntegration" Gem will also alias the real Atom_AtomBridge target variants
-# The Atom Gem does the same at the moment.
-ly_create_alias(NAME AtomLyIntegration.Clients NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Clients)
-ly_create_alias(NAME AtomLyIntegration.Servers NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Servers)
-if(PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME AtomLyIntegration.Builders NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Builders)
-    ly_create_alias(NAME AtomLyIntegration.Tools    NAMESPACE Gem TARGETS Gem::Atom_AtomBridge.Tools)
-endif()

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -90,6 +90,13 @@ function(ly_create_alias)
     # Replace the CMake list separator with a space to replicate the space separated TARGETS arguments
     string(REPLACE ";" " " create_alias_args "${ly_create_alias_NAME},${ly_create_alias_NAMESPACE},${ly_create_alias_TARGETS}")
     set_property(DIRECTORY APPEND PROPERTY LY_CREATE_ALIAS_ARGUMENTS "${create_alias_args}")
+
+    # Store the directory path in the GLOBAL property so that it can be accessed
+    # in the layout install logic. Skip if the directory has already been added
+    get_property(ly_all_target_directories GLOBAL PROPERTY LY_ALL_TARGET_DIRECTORIES)
+    if(NOT CMAKE_CURRENT_SOURCE_DIR IN_LIST ly_all_target_directories)
+        set_property(GLOBAL APPEND PROPERTY LY_ALL_TARGET_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
+    endif()
 endfunction()
 
 # ly_enable_gems


### PR DESCRIPTION
If that directory has not already been added

This addresses an issue where if a CMakeLists.txt contains a call to
ly_create_alias(), but NOT a call to ly_add_target, it would not be
added to the generated CMakeLists.txt for the install layout

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>