### PR TITLE
Motion data integrity issue, keyframe times need to be ascending

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionData/NonUniformMotionData.cpp
@@ -412,25 +412,24 @@ namespace EMotionFX
 
     void NonUniformMotionData::UpdateDuration()
     {
+        m_duration = 0.0f;
+
         for (const JointData& jointData : m_jointData)
         {
             if (!jointData.m_positionTrack.m_times.empty())
             {
-                m_duration = jointData.m_positionTrack.m_times.back();
-                return;
+                m_duration = AZ::GetMax(m_duration, jointData.m_positionTrack.m_times.back());
             }
 
             if (!jointData.m_rotationTrack.m_times.empty())
             {
-                m_duration = jointData.m_rotationTrack.m_times.back();
-                return;
+                m_duration = AZ::GetMax(m_duration, jointData.m_rotationTrack.m_times.back());
             }
 
 #ifndef EMFX_SCALE_DISABLED
             if (!jointData.m_scaleTrack.m_times.empty())
             {
-                m_duration = jointData.m_scaleTrack.m_times.back();
-                return;
+                m_duration = AZ::GetMax(m_duration, jointData.m_scaleTrack.m_times.back());
             }
 #endif
         }
@@ -439,8 +438,7 @@ namespace EMotionFX
         {
             if (!morphData.m_track.m_times.empty())
             {
-                m_duration = morphData.m_track.m_times.back();
-                return;
+                m_duration = AZ::GetMax(m_duration, morphData.m_track.m_times.back());
             }
         }
 
@@ -448,12 +446,9 @@ namespace EMotionFX
         {
             if (!floatData.m_track.m_times.empty())
             {
-                m_duration = floatData.m_track.m_times.back();
-                return;
+                m_duration = AZ::GetMax(m_duration, floatData.m_track.m_times.back());
             }
         }
-
-        m_duration = 0.0f;
     }
 
     void NonUniformMotionData::AllocateJointPositionSamples(size_t jointDataIndex, size_t numSamples)


### PR DESCRIPTION
* User provided animation resulted in a data integrity error.
* The first track had 0.66 as max time while another had a keyframe more resulting in 0.69.
* When updating the duration before fixing up the last keyframe for each of the tracks, the duration was returned early with 0.66 while there were other tracks having a keyframe more.
* We're now crawling through all tracks to determine the maximum duration.
* This results in a correct fixup of the last frame.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>