### PR TITLE
{LYN-4514} Engine updates to enable PAB for the Blast Gem

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -116,7 +116,7 @@ namespace AZ
                 {
                     const char* uuidString = nullptr;
                     unsigned int uuidStringLength = 0;
-                    if (dc.ReadArg(0, uuidString) && dc.ReadValue(1, uuidStringLength))
+                    if (dc.ReadArg(0, uuidString) && dc.ReadArg(1, uuidStringLength))
                     {
                         dc.PushResult(Uuid(uuidString, uuidStringLength));
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorPythonConsoleBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorPythonConsoleBus.h
@@ -63,6 +63,9 @@ namespace AzToolsFramework
         //! Signal the Python handler to stop
         virtual bool StopPython(bool silenceWarnings = false) = 0;
 
+        //! Query for the Python active state
+        virtual bool IsPythonActive() = 0;
+
         //! Determines if the caller needs to wait for the Python VM to initialize (non-main thread only)
         virtual void WaitForInitialization() {}
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorPythonConsoleBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorPythonConsoleBus.h
@@ -63,7 +63,7 @@ namespace AzToolsFramework
         //! Signal the Python handler to stop
         virtual bool StopPython(bool silenceWarnings = false) = 0;
 
-        //! Query for the Python active state
+        //! Query to determine if the Python VM has been initialized indicating an active state 
         virtual bool IsPythonActive() = 0;
 
         //! Determines if the caller needs to wait for the Python VM to initialize (non-main thread only)

--- a/Code/Tools/SceneAPI/SceneCore/Components/ExportingComponent.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Components/ExportingComponent.cpp
@@ -7,6 +7,8 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <SceneAPI/SceneCore/Components/ExportingComponent.h>
+#include <SceneAPI/SceneCore/Events/ExportProductList.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AZ
 {
@@ -30,6 +32,12 @@ namespace AZ
                 if (serializeContext)
                 {
                     serializeContext->Class<ExportingComponent, AZ::Component>()->Version(2);
+                }
+
+                AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
+                if (behaviorContext)
+                {
+                    Events::ExportProductList::Reflect(behaviorContext);
                 }
             }
         } // namespace SceneCore

--- a/Code/Tools/SceneAPI/SceneCore/DllMain.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/DllMain.cpp
@@ -211,6 +211,7 @@ namespace AZ
                 AZ::SceneAPI::Containers::SceneGraph::Reflect(context);
                 AZ::SceneAPI::Containers::SceneManifest::Reflect(context);
                 AZ::SceneAPI::Containers::RuleContainer::Reflect(context);
+                AZ::SceneAPI::SceneCore::ExportingComponent::Reflect(context);
             }
 
             void Activate()

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -6,6 +6,8 @@
  */
 
 #include <SceneAPI/SceneCore/Events/ExportProductList.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/limits.h>
 
 namespace AZ
 {
@@ -47,6 +49,39 @@ namespace AZ
                 m_legacyPathDependencies = rhs.m_legacyPathDependencies;
                 m_productDependencies = rhs.m_productDependencies;
                 return *this;
+            }
+
+            void ExportProductList::Reflect(ReflectContext* context)
+            {
+                if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+                {
+                    behaviorContext->Class<ExportProduct>("ExportProduct")
+                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                        ->Attribute(AZ::Script::Attributes::Module, "scene")
+                        ->Property("filename", BehaviorValueProperty(&ExportProduct::m_filename))
+                        ->Property("sourceId", BehaviorValueProperty(&ExportProduct::m_id))
+                        ->Property("assetType", BehaviorValueProperty(&ExportProduct::m_assetType))
+                        ->Property("productDependencies", BehaviorValueProperty(&ExportProduct::m_productDependencies))
+                        ->Property("subId",
+                            [](ExportProduct* self) { return self->m_subId.has_value() ? self->m_subId.value() : 0; },
+                            [](ExportProduct* self, u32 subId) { self->m_subId = AZStd::optional<u32>(subId); });
+
+                    behaviorContext->Class<ExportProductList>("ExportProductList")
+                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                        ->Attribute(AZ::Script::Attributes::Module, "scene")
+                        ->Method("AddProduct", [](ExportProductList& self, ExportProduct& product)
+                        {
+                            self.AddProduct(
+                                product.m_filename,
+                                product.m_id,
+                                product.m_assetType,
+                                product.m_lod,
+                                product.m_subId,
+                                product.m_dependencyFlags);
+                        })
+                        ->Method("GetProducts", &ExportProductList::GetProducts)
+                        ->Method("AddDependencyToProduct", &ExportProductList::AddDependencyToProduct);
+                }
             }
 
             ExportProduct& ExportProductList::AddProduct(const AZStd::string& filename, Uuid id, Data::AssetType assetType, AZStd::optional<u8> lod, AZStd::optional<u32> subId,

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -53,6 +53,12 @@ namespace AZ
 
             void ExportProductList::Reflect(ReflectContext* context)
             {
+                if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+                {
+                    serializeContext->Class<ExportProduct>()->Version(1);
+                    serializeContext->Class<ExportProductList>()->Version(1);
+                }
+
                 if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
                 {
                     behaviorContext->Class<ExportProduct>("ExportProduct")

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.h
@@ -14,6 +14,8 @@
 
 namespace AZ
 {
+    class ReflectContext;
+
     namespace SceneAPI
     {
         namespace Events
@@ -24,6 +26,7 @@ namespace AZ
                     Data::ProductDependencyInfo::ProductDependencyFlags dependencyFlags = Data::ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad));
                 SCENE_CORE_API ExportProduct(AZStd::string&& filename, Uuid id, Data::AssetType assetType, AZStd::optional<u8> lod, AZStd::optional<u32> subId,
                     Data::ProductDependencyInfo::ProductDependencyFlags dependencyFlags = Data::ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad));
+                ExportProduct() = default;
                 ExportProduct(const ExportProduct& rhs) = default;
                 SCENE_CORE_API ExportProduct(ExportProduct&& rhs);
 
@@ -54,6 +57,8 @@ namespace AZ
             class ExportProductList
             {
             public:
+                static void Reflect(ReflectContext* context);
+
                 SCENE_CORE_API ExportProduct& AddProduct(const AZStd::string& filename, Uuid id, Data::AssetType assetType, AZStd::optional<u8> lod, AZStd::optional<u32> subId,
                     Data::ProductDependencyInfo::ProductDependencyFlags dependencyFlags = Data::ProductDependencyInfo::CreateFlags(Data::AssetLoadBehavior::NoLoad));
                 SCENE_CORE_API ExportProduct& AddProduct(AZStd::string&& filename, Uuid id, Data::AssetType assetType, AZStd::optional<u8> lod, AZStd::optional<u32> subId,
@@ -69,3 +74,9 @@ namespace AZ
         } // namespace Events
     } // namespace SceneAPI
 } // namespace AZ
+
+namespace AZ
+{
+    AZ_TYPE_INFO_SPECIALIZE(SceneAPI::Events::ExportProduct, "{6054EDCB-4C04-4D96-BF26-704999FFB725}");
+    AZ_TYPE_INFO_SPECIALIZE(SceneAPI::Events::ExportProductList, "{1C76A51F-431B-4987-B653-CFCC940D0D0F}");
+}

--- a/Code/Tools/SceneAPI/SceneCore/Import/ManifestImportRequestHandler.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Import/ManifestImportRequestHandler.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/IO/GenericStreams.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Utils/Utils.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <SceneAPI/SceneCore/Import/ManifestImportRequestHandler.h>
@@ -75,15 +76,16 @@ namespace AZ
                     filename += s_extension;
                     filename += s_generated;
 
-                    AZStd::string altManifestPath = path;
+                    AZStd::string altManifestFolder = path;
                     AzFramework::ApplicationRequests::Bus::Broadcast(
-                        &AzFramework::ApplicationRequests::Bus::Events::MakePathRootRelative,
-                        altManifestPath);
+                        &AzFramework::ApplicationRequests::Bus::Events::MakePathRelative,
+                        altManifestFolder,
+                        AZ::Utils::GetProjectPath().c_str());
 
-                    AZ::StringFunc::Path::GetFolderPath(altManifestPath.c_str(), altManifestPath);
+                    AZ::StringFunc::Path::GetFolderPath(altManifestFolder.c_str(), altManifestFolder);
 
                     AZStd::string generatedAssetInfoPath;
-                    AZ::StringFunc::Path::Join(assetCacheRoot.c_str(), altManifestPath.c_str(), generatedAssetInfoPath);
+                    AZ::StringFunc::Path::Join(assetCacheRoot.c_str(), altManifestFolder.c_str(), generatedAssetInfoPath);
                     AZ::StringFunc::Path::ConstructFull(generatedAssetInfoPath.c_str(), filename.c_str(), generatedAssetInfoPath);
 
                     if (!AZ::IO::FileIOBase::GetInstance()->Exists(generatedAssetInfoPath.c_str()))

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -28,710 +28,731 @@ extern "C" AZ_DLL_EXPORT void ReflectBehavior(AZ::BehaviorContext* context);
 // the DLL entry point for SceneCore to reflect its serialize context
 extern "C" AZ_DLL_EXPORT void ReflectTypes(AZ::SerializeContext* context);
 
-namespace AZ
+namespace AZ::SceneAPI::Containers
 {
-    namespace SceneAPI
+    class MockManifestRule : public DataTypes::IManifestObject
     {
-        namespace Containers
+    public:
+        AZ_RTTI(MockManifestRule, "{D6F96B48-4E6F-4EE8-A5A3-959B76F90DA8}", IManifestObject);
+        AZ_CLASS_ALLOCATOR(MockManifestRule, AZ::SystemAllocator, 0);
+
+        MockManifestRule() = default;
+
+        MockManifestRule(double value)
+            : m_value(value)
         {
-            class MockManifestRule : public DataTypes::IManifestObject
+        }
+
+        double GetValue() const
+        {
+            return m_value;
+        }
+
+        void SetValue(double value)
+        {
+            m_value = value;
+        }
+
+        static void Reflect(AZ::ReflectContext* context)
+        {
+            AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+            if (serializeContext)
             {
-            public:
-                AZ_RTTI(MockManifestRule, "{D6F96B48-4E6F-4EE8-A5A3-959B76F90DA8}", IManifestObject);
-                AZ_CLASS_ALLOCATOR(MockManifestRule, AZ::SystemAllocator, 0);
-
-                MockManifestRule() = default;
-
-                MockManifestRule(double value)
-                    : m_value(value)
-                {
-                }
-
-                double GetValue() const
-                {
-                    return m_value;
-                }
-
-                void SetValue(double value)
-                {
-                    m_value = value;
-                }
-
-                static void Reflect(AZ::ReflectContext* context)
-                {
-                    AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
-                    if (serializeContext)
-                    {
-                        serializeContext->Class<MockManifestRule, IManifestObject>()
-                            ->Version(1)
-                            ->Field("value", &MockManifestRule::m_value);
-                    }
-                }
-
-            private:
-                double m_value = 0.0;
-            };
-
-            struct MockBuilder final
-            {
-                AZ_TYPE_INFO(MockBuilder, "{ECF0FB2C-E5C0-4B89-993C-8511A7EF6894}");
-
-                AZStd::unique_ptr<AZ::SceneAPI::Containers::Scene> m_scene;
-
-                MockBuilder()
-                {
-                    m_scene = AZStd::make_unique<AZ::SceneAPI::Containers::Scene>("unit_scene");
-                }
-
-                ~MockBuilder()
-                {
-                    m_scene.reset();
-                }
-
-                void BuildSceneGraph()
-                {
-                    m_scene->SetManifestFilename("manifest_filename");
-                    m_scene->SetSource("unit_source_filename", azrtti_typeid<AZ::SceneAPI::Containers::Scene>());
-
-                    auto& graph = m_scene->GetGraph();
-
-                    /*----------------------------\
-                    |            Root             |
-                    |         /       \           |
-                    |        |         |          |
-                    |        A         B          |
-                    |        |        /|\         |
-                    |        C       I J K        |
-                    |      / | \          \       |
-                    |     D  E  F          L      |
-                    |       / \                   |
-                    |      G   H                  |
-                    \----------------------------*/
-
-                    //Build up the graph
-                    const auto indexA = graph.AddChild(graph.GetRoot(), "A", AZStd::make_shared<DataTypes::MockIGraphObject>(1));
-                    const auto indexC = graph.AddChild(indexA, "C", AZStd::make_shared<DataTypes::MockIGraphObject>(3));
-                    const auto indexE = graph.AddChild(indexC, "E", AZStd::make_shared<DataTypes::MockIGraphObject>(4));
-                    graph.AddChild(indexC, "D", AZStd::make_shared<DataTypes::MockIGraphObject>(5));
-                    graph.AddChild(indexC, "F", AZStd::make_shared<DataTypes::MockIGraphObject>(6));
-                    graph.AddChild(indexE, "G", AZStd::make_shared<DataTypes::MockIGraphObject>(7));
-                    graph.AddChild(indexE, "H", AZStd::make_shared<DataTypes::MockIGraphObject>(8));
-                    const auto indexB = graph.AddChild(graph.GetRoot(), "B", AZStd::make_shared<DataTypes::MockIGraphObject>(2));
-                    const auto indexK = graph.AddChild(indexB, "K", AZStd::make_shared<DataTypes::MockIGraphObject>(2));
-                    graph.AddChild(indexB, "I", AZStd::make_shared<DataTypes::MockIGraphObject>(9));
-                    graph.AddChild(indexB, "J", AZStd::make_shared<DataTypes::MockIGraphObject>(10));
-                    graph.AddChild(indexK, "L", AZStd::make_shared<DataTypes::MockIGraphObject>(12));
-
-                    m_scene->GetManifest().AddEntry(AZStd::make_shared<MockManifestRule>(0.1));
-                    m_scene->GetManifest().AddEntry(AZStd::make_shared<MockManifestRule>(2.3));
-                    m_scene->GetManifest().AddEntry(AZStd::make_shared<MockManifestRule>(4.5));
-                }
-
-                static void Reflect(ReflectContext* context)
-                {
-                    BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
-                    if (behaviorContext)
-                    {
-                        behaviorContext->Class<MockBuilder>()
-                            ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
-                            ->Attribute(AZ::Script::Attributes::Module, "scene")
-                            ->Method("BuildSceneGraph", [](MockBuilder& self)
-                            {
-                                return self.BuildSceneGraph();
-                            })
-                            ->Method("GetScene", [](MockBuilder& self)
-                            {
-                                return self.m_scene.get();
-                            });
-                    }
-                }
-            };
-
-            class SceneGraphBehaviorTest
-                : public ::testing::Test
-            {
-            public:
-                void SetUp() override
-                {
-                    m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
-                    ReflectBehavior(m_behaviorContext.get());
-                }
-
-                void TearDown() override
-                {
-                    m_behaviorContext.reset();
-                }
-
-                AZ::BehaviorClass* GetBehaviorClass(const AZ::TypeId& behaviorClassType)
-                {
-                    auto entry = m_behaviorContext->m_typeToClassMap.find(behaviorClassType);
-                    return (entry != m_behaviorContext->m_typeToClassMap.end()) ? entry->second : nullptr;
-                }
-
-                AZ::BehaviorProperty* GetBehaviorProperty(AZ::BehaviorClass& behaviorClass, AZStd::string_view propertyName)
-                {
-                    auto entry = behaviorClass.m_properties.find(propertyName);
-                    return (entry != behaviorClass.m_properties.end()) ? entry->second : nullptr;
-                }
-
-                bool HasBehaviorClass(const AZ::TypeId& behaviorClassType)
-                {
-                    return GetBehaviorClass(behaviorClassType) != nullptr;
-                }
-
-                bool HasProperty(AZ::BehaviorClass& behaviorClass, AZStd::string_view propertyName, const AZ::TypeId& propertyClassType)
-                {
-                    AZ::BehaviorProperty* behaviorProperty = GetBehaviorProperty(behaviorClass, propertyName);
-                    if (behaviorProperty)
-                    {
-                        return behaviorProperty->m_getter->GetResult()->m_typeId == propertyClassType;
-                    }
-                    return false;
-                }
-
-                using ArgList = AZStd::vector<AZ::TypeId>;
-
-                bool HasMethodWithInput(AZ::BehaviorClass& behaviorClass, AZStd::string_view methodName, const ArgList& input)
-                {
-                    auto entry = behaviorClass.m_methods.find(methodName);
-                    if (entry == behaviorClass.m_methods.end())
-                    {
-                        return false;
-                    }
-                    AZ::BehaviorMethod* method = entry->second;
-
-                    const size_t methodArgsCount = method->IsMember() ? method->GetNumArguments() - 1 : method->GetNumArguments();
-                    if (input.size() != methodArgsCount)
-                    {
-                        return false;
-                    }
-
-                    for (size_t argIndex = 0; argIndex < input.size(); ++argIndex)
-                    {
-                        const size_t thisPointerOffset = method->IsMember() ? 1 : 0;
-                        const auto argType = method->GetArgument(argIndex + thisPointerOffset)->m_typeId;
-                        const auto inputType = input[argIndex];
-                        if (inputType != argType)
-                        {
-                            return false;
-                        }
-                    }
-                    return true;
-                }
-
-                bool HasMethodWithOutput(AZ::BehaviorClass& behaviorClass, AZStd::string_view methodName, const AZ::TypeId& output, const ArgList& input)
-                {
-                    auto entry = behaviorClass.m_methods.find(methodName);
-                    if (entry == behaviorClass.m_methods.end())
-                    {
-                        return false;
-                    }
-                    AZ::BehaviorMethod* method = entry->second;
-                    if (method->HasResult())
-                    {
-                        if (method->GetResult()->m_typeId != output)
-                        {
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        return false;
-                    }
-                    return HasMethodWithInput(behaviorClass, methodName, input);
-                }
-
-                AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
-            };
-
-            TEST_F(SceneGraphBehaviorTest, SceneClass_BehaviorContext_Exists)
-            {
-                EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::Scene>()));
-            }
-
-            TEST_F(SceneGraphBehaviorTest, SceneClass_BehaviorContext_HasExpectedProperties)
-            {
-                AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::Scene>());
-                ASSERT_NE(nullptr, behaviorClass);
-                EXPECT_TRUE(HasProperty(*behaviorClass, "name", azrtti_typeid<AZStd::string>()));
-                EXPECT_TRUE(HasProperty(*behaviorClass, "manifestFilename", azrtti_typeid<AZStd::string>()));
-                EXPECT_TRUE(HasProperty(*behaviorClass, "sourceFilename", azrtti_typeid<AZStd::string>()));
-                EXPECT_TRUE(HasProperty(*behaviorClass, "sourceGuid", azrtti_typeid<AZ::Uuid>()));
-                EXPECT_TRUE(HasProperty(*behaviorClass, "graph", azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph>()));
-                EXPECT_TRUE(HasProperty(*behaviorClass, "manifest", azrtti_typeid<AZ::SceneAPI::Containers::SceneManifest>()));
-            }
-
-            TEST_F(SceneGraphBehaviorTest, SceneGraphClass_BehaviorContext_Exists)
-            {
-                EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph>()));
-                EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph::NodeIndex>()));
-                EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph::Name>()));
-            }
-
-            TEST_F(SceneGraphBehaviorTest, SceneGraphClass_BehaviorContext_HasExpectedProperties)
-            {
-                using namespace AZ::SceneAPI::Containers;
-
-                AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<SceneGraph>());
-                ASSERT_NE(nullptr, behaviorClass);
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetNodeName", azrtti_typeid<SceneGraph::Name>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetRoot", azrtti_typeid<SceneGraph::NodeIndex>(), {}));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeContent", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeSibling", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeChild", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeParent", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "IsNodeEndPoint", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetNodeCount", azrtti_typeid<size_t>(), {}));
-                EXPECT_TRUE(HasMethodWithOutput(
-                    *behaviorClass,
-                    "GetNodeParent",
-                    azrtti_typeid<SceneGraph::NodeIndex>(),
-                    { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>() }
-                ));
-                EXPECT_TRUE(HasMethodWithOutput(
-                    *behaviorClass,
-                    "GetNodeSibling",
-                    azrtti_typeid<SceneGraph::NodeIndex>(),
-                    { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>() }
-                ));
-                EXPECT_TRUE(HasMethodWithOutput(
-                    *behaviorClass,
-                    "GetNodeChild",
-                    azrtti_typeid<SceneGraph::NodeIndex>(),
-                    { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>() }
-                ));
-                EXPECT_TRUE(HasMethodWithOutput(
-                    *behaviorClass,
-                    "FindWithPath",
-                    azrtti_typeid<SceneGraph::NodeIndex>(),
-                    { azrtti_typeid<SceneGraph>(), azrtti_typeid<AZStd::string>() }
-                ));
-                EXPECT_TRUE(HasMethodWithOutput(
-                    *behaviorClass,
-                    "FindWithRootAndPath",
-                    azrtti_typeid<SceneGraph::NodeIndex>(),
-                    { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>(), azrtti_typeid<AZStd::string>() }
-                ));
-            }
-
-            TEST_F(SceneGraphBehaviorTest, SceneGraphNodeIndexClass_BehaviorContext_HasExpectedProperties)
-            {
-                using namespace AZ::SceneAPI::Containers;
-
-                AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<SceneGraph::NodeIndex>());
-                ASSERT_NE(nullptr, behaviorClass);
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "AsNumber", azrtti_typeid<uint32_t>(), {}));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "Distance", azrtti_typeid<AZ::s32>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "IsValid", azrtti_typeid<bool>(), {}));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "Equal", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
-            }
-
-            TEST_F(SceneGraphBehaviorTest, SceneGraphNameClass_BehaviorContext_HasExpectedProperties)
-            {
-                using namespace AZ::SceneAPI::Containers;
-
-                AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<SceneGraph::Name>());
-                ASSERT_NE(nullptr, behaviorClass);
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetPath", azrtti_typeid<const char*>(), {}));
-                EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetName", azrtti_typeid<const char*>(), {}));
-            }
-
-            class MockSceneComponentApplication
-                : public AZ::ComponentApplicationBus::Handler
-            {
-            public:
-                MockSceneComponentApplication()
-                {
-                    AZ::ComponentApplicationBus::Handler::BusConnect();
-                    AZ::Interface<AZ::ComponentApplicationRequests>::Register(this);
-                }
-
-                ~MockSceneComponentApplication()
-                {
-                    AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(this);
-                    AZ::ComponentApplicationBus::Handler::BusDisconnect();
-                }
-
-                MOCK_METHOD1(FindEntity, AZ::Entity* (const AZ::EntityId&));
-                MOCK_METHOD1(AddEntity, bool(AZ::Entity*));
-                MOCK_METHOD0(Destroy, void());
-                MOCK_METHOD1(RegisterComponentDescriptor, void(const AZ::ComponentDescriptor*));
-                MOCK_METHOD1(UnregisterComponentDescriptor, void(const AZ::ComponentDescriptor*));
-                MOCK_METHOD1(RegisterEntityAddedEventHandler, void(AZ::EntityAddedEvent::Handler&));
-                MOCK_METHOD1(RegisterEntityRemovedEventHandler, void(AZ::EntityRemovedEvent::Handler&));
-                MOCK_METHOD1(RegisterEntityActivatedEventHandler, void(AZ::EntityActivatedEvent::Handler&));
-                MOCK_METHOD1(RegisterEntityDeactivatedEventHandler, void(AZ::EntityDeactivatedEvent::Handler&));
-                MOCK_METHOD1(SignalEntityActivated, void(AZ::Entity*));
-                MOCK_METHOD1(SignalEntityDeactivated, void(AZ::Entity*));
-                MOCK_METHOD1(RemoveEntity, bool(AZ::Entity*));
-                MOCK_METHOD1(DeleteEntity, bool(const AZ::EntityId&));
-                MOCK_METHOD1(GetEntityName, AZStd::string(const AZ::EntityId&));
-                MOCK_METHOD1(EnumerateEntities, void(const ComponentApplicationRequests::EntityCallback&));
-                MOCK_METHOD0(GetApplication, AZ::ComponentApplication* ());
-                MOCK_METHOD0(GetSerializeContext, AZ::SerializeContext* ());
-                MOCK_METHOD0(GetJsonRegistrationContext, AZ::JsonRegistrationContext* ());
-                MOCK_METHOD0(GetBehaviorContext, AZ::BehaviorContext* ());
-                MOCK_CONST_METHOD0(GetAppRoot, const char*());
-                MOCK_CONST_METHOD0(GetEngineRoot, const char*());
-                MOCK_CONST_METHOD0(GetExecutableFolder, const char* ());
-                MOCK_METHOD0(GetDrillerManager, AZ::Debug::DrillerManager* ());
-                MOCK_CONST_METHOD1(QueryApplicationType, void(AZ::ApplicationTypeQuery&));
-            };
-
-            class MockEditorPythonConsoleInterface final
-                : public AzToolsFramework::EditorPythonConsoleInterface
-            {
-            public:
-                MockEditorPythonConsoleInterface()
-                {
-                    AZ::Interface<AzToolsFramework::EditorPythonConsoleInterface>::Register(this);
-                }
-
-                ~MockEditorPythonConsoleInterface()
-                {
-                    AZ::Interface<AzToolsFramework::EditorPythonConsoleInterface>::Unregister(this);
-                }
-
-                MOCK_CONST_METHOD1(GetModuleList, void(AZStd::vector<AZStd::string_view>&));
-                MOCK_CONST_METHOD1(GetGlobalFunctionList, void(GlobalFunctionCollection&));
-                MOCK_METHOD1(FetchPythonTypeName, AZStd::string(const AZ::BehaviorParameter&));
-            };
-
-            //
-            // SceneGraphBehaviorScriptTest
-            //
-            class SceneGraphBehaviorScriptTest
-                : public UnitTest::AllocatorsFixture
-            {
-            public:
-                AZStd::unique_ptr<MockSceneComponentApplication> m_componentApplication;
-                AZStd::unique_ptr<MockEditorPythonConsoleInterface> m_editorPythonConsoleInterface;
-                AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
-                AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
-                AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
-
-                static void TestExpectTrue(bool value)
-                {
-                    EXPECT_TRUE(value);
-                }
-
-                static void TestExpectEquals(AZ::s64 lhs, AZ::s64 rhs)
-                {
-                    EXPECT_EQ(lhs, rhs);
-                }
-
-                static void ReflectTestTypes(AZ::ReflectContext* context)
-                {
-                    AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
-                    if (behaviorContext)
-                    {
-                        behaviorContext->Class<DataTypes::MockIGraphObject>()
-                            ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
-                            ->Attribute(AZ::Script::Attributes::Module, "scene.graph.test")
-                            ->Method("GetId", [](const DataTypes::MockIGraphObject& self)
-                            {
-                                return self.m_id;
-                            })
-                            ->Method("SetId", [](DataTypes::MockIGraphObject& self, int value)
-                            {
-                                self.m_id = value;
-                            })
-                            ->Method("AddAndSet", [](DataTypes::MockIGraphObject& self, int lhs, int rhs)
-                            {
-                                self.m_id = lhs + rhs;
-                            });
-                    }
-                }
-
-                void SetUp() override
-                {
-                    UnitTest::AllocatorsFixture::SetUp();
-
-                    m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
-
-                    m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
-                    m_behaviorContext->Method("TestExpectTrue", &TestExpectTrue);
-                    m_behaviorContext->Method("TestExpectEquals", &TestExpectEquals);
-
-                    AZ::MathReflect(m_behaviorContext.get());
-                    ReflectBehavior(m_behaviorContext.get());
-                    ReflectTestTypes(m_behaviorContext.get());
-                    MockBuilder::Reflect(m_behaviorContext.get());
-
-                    m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
-                    m_scriptContext->BindTo(m_behaviorContext.get());
-
-                    m_componentApplication = AZStd::make_unique<::testing::NiceMock<MockSceneComponentApplication>>();
-
-                    ON_CALL(*m_componentApplication, GetBehaviorContext())
-                        .WillByDefault(::testing::Invoke([this]()
-                            {
-                                return this->m_behaviorContext.get();
-                            }));
-
-                    ON_CALL(*m_componentApplication, GetSerializeContext())
-                        .WillByDefault(::testing::Invoke([this]()
-                            {
-                                return this->m_serializeContext.get();
-                            }));
-
-                    m_editorPythonConsoleInterface = AZStd::make_unique<MockEditorPythonConsoleInterface>();
-                }
-
-                void SetupEditorPythonConsoleInterface()
-                {
-                    EXPECT_CALL(*m_editorPythonConsoleInterface, FetchPythonTypeName(::testing::_))
-                        .Times(4)
-                        .WillRepeatedly(::testing::Invoke([](const AZ::BehaviorParameter&) {return "int"; }));
-                }
-
-                void TearDown() override
-                {
-                    m_scriptContext.reset();
-                    m_serializeContext.reset();
-                    m_behaviorContext.reset();
-
-                    UnitTest::AllocatorsFixture::TearDown();
-                }
-
-                void ExpectExecute(AZStd::string_view script)
-                {
-                    EXPECT_TRUE(m_scriptContext->Execute(script.data()));
-                }
-            };
-
-            TEST_F(SceneGraphBehaviorScriptTest, Scene_ScriptContext_Access)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("TestExpectTrue(scene ~= nil)");
-                ExpectExecute("TestExpectTrue(scene.name == 'unit_scene')");
-                ExpectExecute("TestExpectTrue(scene.manifestFilename == 'manifest_filename')");
-                ExpectExecute("TestExpectTrue(scene.sourceFilename == 'unit_source_filename')");
-                ExpectExecute("TestExpectTrue(tostring(scene.sourceGuid) == '{1F2E6142-B0D8-42C6-A6E5-CD726DAA9EF0}')");
-                ExpectExecute("TestExpectTrue(scene:GetOriginalSceneOrientation() == Scene.SceneOrientation_YUp)");
-            }
-
-            TEST_F(SceneGraphBehaviorScriptTest, SceneGraph_ScriptContext_AccessMockNodes)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-
-                // instance methods
-                ExpectExecute("TestExpectTrue(scene.graph ~= nil)");
-                ExpectExecute("TestExpectTrue(scene.graph:GetRoot():IsValid())");
-                ExpectExecute("TestExpectEquals(scene.graph:GetNodeCount(), 13)");
-                ExpectExecute("nodeRoot = scene.graph:GetRoot()");
-                ExpectExecute("nodeA = scene.graph:GetNodeChild(nodeRoot); TestExpectTrue(nodeA:IsValid())");
-                ExpectExecute("TestExpectTrue(scene.graph:HasNodeContent(nodeA))");
-                ExpectExecute("nodeC = scene.graph:GetNodeChild(nodeA); TestExpectTrue(nodeC:IsValid())");
-                ExpectExecute("nodeNameC = scene.graph:GetNodeName(nodeC); TestExpectTrue(nodeNameC ~= nil)");
-                ExpectExecute("nodeE = scene.graph:GetNodeChild(nodeC); TestExpectTrue(nodeE:IsValid())");
-                ExpectExecute("TestExpectTrue(scene.graph:HasNodeSibling(nodeE))");
-                ExpectExecute("TestExpectTrue(scene.graph:HasNodeChild(nodeE))");
-                ExpectExecute("TestExpectTrue(scene.graph:HasNodeParent(nodeE))");
-                ExpectExecute("nodeG = scene.graph:GetNodeChild(nodeE); TestExpectTrue(nodeG:IsValid())");
-                ExpectExecute("TestExpectTrue(scene.graph:GetNodeParent(nodeG) == nodeE)");
-                ExpectExecute("nodeH = scene.graph:GetNodeSibling(nodeG); TestExpectTrue(nodeH:IsValid())");
-                ExpectExecute("TestExpectTrue(scene.graph:GetNodeName(nodeH):GetPath() == 'A.C.E.H')");
-                ExpectExecute("nodeB = scene.graph:GetNodeSibling(nodeA); TestExpectTrue(nodeB:IsValid())");
-                ExpectExecute("nodeK = scene.graph:GetNodeChild(nodeB); TestExpectTrue(nodeK:IsValid())");
-                ExpectExecute("TestExpectTrue(scene.graph:FindWithPath('B.K') == nodeK)");
-                ExpectExecute("nodeL = scene.graph:GetNodeChild(nodeK); TestExpectTrue(nodeL:IsValid())");
-                ExpectExecute("TestExpectTrue(scene.graph:FindWithRootAndPath(nodeK, 'L') == nodeL)");
-
-                // static methods
-                ExpectExecute("TestExpectTrue(scene.graph.IsValidName('A'))");
-                ExpectExecute("TestExpectTrue(scene.graph.GetNodeSeperationCharacter() == string.byte('.'))");
-            }
-
-            TEST_F(SceneGraphBehaviorScriptTest, SceneGraphNodeIndex_ScriptContext_AccessMockNodes)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("nodeA = scene.graph:GetNodeChild(scene.graph:GetRoot())");
-                ExpectExecute("TestExpectTrue(nodeA:IsValid())");
-                ExpectExecute("TestExpectEquals(nodeA:AsNumber(), 1)");
-                ExpectExecute("TestExpectEquals(scene.graph:GetRoot():Distance(nodeA), 1)");
-                ExpectExecute("TestExpectEquals(nodeA:Distance(scene.graph:GetRoot()), -1)");
-                ExpectExecute("TestExpectTrue(nodeA == scene.graph:FindWithPath('A'))");
-            }
-
-            TEST_F(SceneGraphBehaviorScriptTest, SceneGraphName_ScriptContext_AccessMockNodes)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
-                ExpectExecute("nodeNameG = scene.graph:GetNodeName(nodeG)");
-                ExpectExecute("TestExpectTrue(nodeNameG:GetPath() == 'A.C.E.G')");
-                ExpectExecute("TestExpectTrue(nodeNameG:GetName() == 'G')");
-            }
-
-            TEST_F(SceneGraphBehaviorScriptTest, SceneGraphIGraphNode_ScriptContext_AccessMockNodes)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
-                ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
-                ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
-                ExpectExecute("value = proxy:Invoke('GetId', vector_any())");
-                ExpectExecute("TestExpectEquals(value, 7)");
-                ExpectExecute("setIdArgs = vector_any(); setIdArgs:push_back(8);");
-                ExpectExecute("proxy:Invoke('SetId', setIdArgs)");
-                ExpectExecute("value = proxy:Invoke('GetId', vector_any())");
-                ExpectExecute("TestExpectEquals(value, 8)");
-                ExpectExecute("addArgs = vector_any(); addArgs:push_back(8); addArgs:push_back(9)");
-                ExpectExecute("proxy:Invoke('AddAndSet', addArgs)");
-                ExpectExecute("value = proxy:Invoke('GetId', vector_any())");
-                ExpectExecute("TestExpectEquals(value, 17)");
-            }
-
-            TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_GetClassInfo_Loads)
-            {
-                SetupEditorPythonConsoleInterface();
-
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
-                ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
-                ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
-                ExpectExecute("info = proxy:GetClassInfo()");
-                ExpectExecute("TestExpectTrue(info ~= nil)");
-            }
-
-            TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_GetClassInfo_CorrectFormats)
-            {
-                SetupEditorPythonConsoleInterface();
-
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
-                ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
-                ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
-                ExpectExecute("info = proxy:GetClassInfo()");
-                ExpectExecute("TestExpectTrue(info.className == 'MockIGraphObject')");
-                ExpectExecute("TestExpectTrue(info.classUuid == '{66A082CC-851D-4E1F-ABBD-45B58A216CFA}')");
-                ExpectExecute("TestExpectTrue(info.methodList[1] == 'def GetId(self) -> int')");
-                ExpectExecute("TestExpectTrue(info.methodList[2] == 'def SetId(self, arg1: int) -> None')");
-                ExpectExecute("TestExpectTrue(info.methodList[3] == 'def AddAndSet(self, arg1: int, arg2: int) -> None')");
-            }
-
-            //
-            // SceneManifestBehaviorScriptTest is meant to test the script abilities of the SceneManifest
-            //
-            class SceneManifestBehaviorScriptTest
-                : public UnitTest::AllocatorsFixture
-            {
-            public:
-                AZStd::unique_ptr<MockSceneComponentApplication> m_componentApplication;
-                AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
-                AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
-                AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
-                AZStd::unique_ptr<AZ::JsonRegistrationContext> m_jsonRegistrationContext;
-                AZStd::string_view m_jsonMockData = R"JSON('{"values":[{"$type":"MockManifestRule","value":0.1},{"$type":"MockManifestRule","value":2.3},{"$type":"MockManifestRule","value":4.5}]}')JSON";
-
-                static void TestAssertTrue(bool value)
-                {
-                    EXPECT_TRUE(value);
-                }
-
-                void SetUp() override
-                {
-                    UnitTest::AllocatorsFixture::SetUp();
-
-                    m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
-                    MockBuilder::Reflect(m_serializeContext.get());
-                    MockManifestRule::Reflect(m_serializeContext.get());
-                    ReflectTypes(m_serializeContext.get());
-
-                    m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
-                    m_behaviorContext->Method("TestAssertTrue", &TestAssertTrue);
-                    AZ::MathReflect(m_behaviorContext.get());
-                    MockBuilder::Reflect(m_behaviorContext.get());
-                    MockManifestRule::Reflect(m_behaviorContext.get());
-                    ReflectBehavior(m_behaviorContext.get());
-
-                    m_jsonRegistrationContext = AZStd::make_unique<AZ::JsonRegistrationContext>();
-                    AZ::JsonSystemComponent::Reflect(m_jsonRegistrationContext.get());
-
-                    m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
-                    m_scriptContext->BindTo(m_behaviorContext.get());
-
-                    m_componentApplication = AZStd::make_unique<::testing::NiceMock<MockSceneComponentApplication>>();
-
-                    ON_CALL(*m_componentApplication, GetBehaviorContext()).WillByDefault(::testing::Invoke([this]()
-                        {
-                            return this->m_behaviorContext.get();
-                        }));
-
-                    ON_CALL(*m_componentApplication, GetSerializeContext()).WillByDefault(::testing::Invoke([this]()
-                        {
-                            return this->m_serializeContext.get();
-                        }));
-
-                    ON_CALL(*m_componentApplication, GetJsonRegistrationContext()).WillByDefault(::testing::Invoke([this]()
-                        {
-                            return this->m_jsonRegistrationContext.get();
-                        }));
-                }
-
-                void TearDown() override
-                {
-                    m_jsonRegistrationContext->EnableRemoveReflection();
-                    AZ::JsonSystemComponent::Reflect(m_jsonRegistrationContext.get());
-                    m_jsonRegistrationContext->DisableRemoveReflection();
-
-                    m_jsonRegistrationContext.reset();
-                    m_serializeContext.reset();
-                    m_scriptContext.reset();
-                    m_behaviorContext.reset();
-                    m_componentApplication.reset();
-                    UnitTest::AllocatorsFixture::TearDown();
-                }
-
-                void ExpectExecute(AZStd::string_view script)
-                {
-                    EXPECT_TRUE(m_scriptContext->Execute(script.data()));
-                }
-            };
-
-            TEST_F(SceneManifestBehaviorScriptTest, SceneManifest_ScriptContext_GetDefaultJSON)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("manifest = scene.manifest:ExportToJson()");
-                ExpectExecute(R"JSON(TestAssertTrue(manifest == '{}'))JSON");
-            }
-
-            TEST_F(SceneManifestBehaviorScriptTest, SceneManifest_ScriptContext_GetComplexJSON)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("builder:BuildSceneGraph()");
-                ExpectExecute("manifest = scene.manifest:ExportToJson()");
-                auto read = AZStd::fixed_string<1024>::format("TestAssertTrue(manifest == %s)", m_jsonMockData.data());
-                ExpectExecute(read);
-            }
-
-            TEST_F(SceneManifestBehaviorScriptTest, SceneManifest_ScriptContext_SetComplexJSON)
-            {
-                ExpectExecute("builder = MockBuilder()");
-                ExpectExecute("scene = builder:GetScene()");
-                ExpectExecute("manifest = scene.manifest:ExportToJson()");
-                ExpectExecute(R"JSON(TestAssertTrue(manifest == '{}'))JSON");
-                auto load = AZStd::fixed_string<1024>::format("TestAssertTrue(scene.manifest:ImportFromJson(%s))", m_jsonMockData.data());
-                ExpectExecute(load);
-                ExpectExecute("manifest = scene.manifest:ExportToJson()");
-                auto read = AZStd::fixed_string<1024>::format("TestAssertTrue(manifest == %s)", m_jsonMockData.data());
-                ExpectExecute(read);
+                serializeContext->Class<MockManifestRule, IManifestObject>()
+                    ->Version(1)
+                    ->Field("value", &MockManifestRule::m_value);
             }
         }
+
+    private:
+        double m_value = 0.0;
+    };
+
+    struct MockBuilder final
+    {
+        AZ_TYPE_INFO(MockBuilder, "{ECF0FB2C-E5C0-4B89-993C-8511A7EF6894}");
+
+        AZStd::unique_ptr<AZ::SceneAPI::Containers::Scene> m_scene;
+
+        MockBuilder()
+        {
+            m_scene = AZStd::make_unique<AZ::SceneAPI::Containers::Scene>("unit_scene");
+        }
+
+        ~MockBuilder()
+        {
+            m_scene.reset();
+        }
+
+        void BuildSceneGraph()
+        {
+            m_scene->SetManifestFilename("manifest_filename");
+            m_scene->SetSource("unit_source_filename", azrtti_typeid<AZ::SceneAPI::Containers::Scene>());
+
+            auto& graph = m_scene->GetGraph();
+
+            /*----------------------------\
+            |            Root             |
+            |         /       \           |
+            |        |         |          |
+            |        A         B          |
+            |        |        /|\         |
+            |        C       I J K        |
+            |      / | \          \       |
+            |     D  E  F          L      |
+            |       / \                   |
+            |      G   H                  |
+            \----------------------------*/
+
+            //Build up the graph
+            const auto indexA = graph.AddChild(graph.GetRoot(), "A", AZStd::make_shared<DataTypes::MockIGraphObject>(1));
+            const auto indexC = graph.AddChild(indexA, "C", AZStd::make_shared<DataTypes::MockIGraphObject>(3));
+            const auto indexE = graph.AddChild(indexC, "E", AZStd::make_shared<DataTypes::MockIGraphObject>(4));
+            graph.AddChild(indexC, "D", AZStd::make_shared<DataTypes::MockIGraphObject>(5));
+            graph.AddChild(indexC, "F", AZStd::make_shared<DataTypes::MockIGraphObject>(6));
+            graph.AddChild(indexE, "G", AZStd::make_shared<DataTypes::MockIGraphObject>(7));
+            graph.AddChild(indexE, "H", AZStd::make_shared<DataTypes::MockIGraphObject>(8));
+            const auto indexB = graph.AddChild(graph.GetRoot(), "B", AZStd::make_shared<DataTypes::MockIGraphObject>(2));
+            const auto indexK = graph.AddChild(indexB, "K", AZStd::make_shared<DataTypes::MockIGraphObject>(2));
+            graph.AddChild(indexB, "I", AZStd::make_shared<DataTypes::MockIGraphObject>(9));
+            graph.AddChild(indexB, "J", AZStd::make_shared<DataTypes::MockIGraphObject>(10));
+            graph.AddChild(indexK, "L", AZStd::make_shared<DataTypes::MockIGraphObject>(12));
+
+            m_scene->GetManifest().AddEntry(AZStd::make_shared<MockManifestRule>(0.1));
+            m_scene->GetManifest().AddEntry(AZStd::make_shared<MockManifestRule>(2.3));
+            m_scene->GetManifest().AddEntry(AZStd::make_shared<MockManifestRule>(4.5));
+        }
+
+        static void Reflect(ReflectContext* context)
+        {
+            BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
+            if (behaviorContext)
+            {
+                behaviorContext->Class<MockBuilder>()
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Module, "scene")
+                    ->Method("BuildSceneGraph", [](MockBuilder& self)
+                    {
+                        return self.BuildSceneGraph();
+                    })
+                    ->Method("GetScene", [](MockBuilder& self)
+                    {
+                        return self.m_scene.get();
+                    });
+            }
+        }
+    };
+
+    class SceneGraphBehaviorTest
+        : public ::testing::Test
+    {
+    public:
+        void SetUp() override
+        {
+            m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            ReflectBehavior(m_behaviorContext.get());
+        }
+
+        void TearDown() override
+        {
+            m_behaviorContext.reset();
+        }
+
+        AZ::BehaviorClass* GetBehaviorClass(const AZ::TypeId& behaviorClassType)
+        {
+            auto entry = m_behaviorContext->m_typeToClassMap.find(behaviorClassType);
+            return (entry != m_behaviorContext->m_typeToClassMap.end()) ? entry->second : nullptr;
+        }
+
+        AZ::BehaviorProperty* GetBehaviorProperty(AZ::BehaviorClass& behaviorClass, AZStd::string_view propertyName)
+        {
+            auto entry = behaviorClass.m_properties.find(propertyName);
+            return (entry != behaviorClass.m_properties.end()) ? entry->second : nullptr;
+        }
+
+        bool HasBehaviorClass(const AZ::TypeId& behaviorClassType)
+        {
+            return GetBehaviorClass(behaviorClassType) != nullptr;
+        }
+
+        bool HasProperty(AZ::BehaviorClass& behaviorClass, AZStd::string_view propertyName, const AZ::TypeId& propertyClassType)
+        {
+            AZ::BehaviorProperty* behaviorProperty = GetBehaviorProperty(behaviorClass, propertyName);
+            if (behaviorProperty)
+            {
+                return behaviorProperty->m_getter->GetResult()->m_typeId == propertyClassType;
+            }
+            return false;
+        }
+
+        using ArgList = AZStd::vector<AZ::TypeId>;
+
+        bool HasMethodWithInput(AZ::BehaviorClass& behaviorClass, AZStd::string_view methodName, const ArgList& input)
+        {
+            auto entry = behaviorClass.m_methods.find(methodName);
+            if (entry == behaviorClass.m_methods.end())
+            {
+                return false;
+            }
+            AZ::BehaviorMethod* method = entry->second;
+
+            const size_t methodArgsCount = method->IsMember() ? method->GetNumArguments() - 1 : method->GetNumArguments();
+            if (input.size() != methodArgsCount)
+            {
+                return false;
+            }
+
+            for (size_t argIndex = 0; argIndex < input.size(); ++argIndex)
+            {
+                const size_t thisPointerOffset = method->IsMember() ? 1 : 0;
+                const auto argType = method->GetArgument(argIndex + thisPointerOffset)->m_typeId;
+                const auto inputType = input[argIndex];
+                if (inputType != argType)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool HasMethodWithOutput(AZ::BehaviorClass& behaviorClass, AZStd::string_view methodName, const AZ::TypeId& output, const ArgList& input)
+        {
+            auto entry = behaviorClass.m_methods.find(methodName);
+            if (entry == behaviorClass.m_methods.end())
+            {
+                return false;
+            }
+            AZ::BehaviorMethod* method = entry->second;
+            if (method->HasResult())
+            {
+                if (method->GetResult()->m_typeId != output)
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+            return HasMethodWithInput(behaviorClass, methodName, input);
+        }
+
+        AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+    };
+
+    TEST_F(SceneGraphBehaviorTest, SceneClass_BehaviorContext_Exists)
+    {
+        EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::Scene>()));
     }
-}
+
+    TEST_F(SceneGraphBehaviorTest, SceneClass_BehaviorContext_HasExpectedProperties)
+    {
+        AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::Scene>());
+        ASSERT_NE(nullptr, behaviorClass);
+        EXPECT_TRUE(HasProperty(*behaviorClass, "name", azrtti_typeid<AZStd::string>()));
+        EXPECT_TRUE(HasProperty(*behaviorClass, "manifestFilename", azrtti_typeid<AZStd::string>()));
+        EXPECT_TRUE(HasProperty(*behaviorClass, "sourceFilename", azrtti_typeid<AZStd::string>()));
+        EXPECT_TRUE(HasProperty(*behaviorClass, "sourceGuid", azrtti_typeid<AZ::Uuid>()));
+        EXPECT_TRUE(HasProperty(*behaviorClass, "graph", azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph>()));
+        EXPECT_TRUE(HasProperty(*behaviorClass, "manifest", azrtti_typeid<AZ::SceneAPI::Containers::SceneManifest>()));
+    }
+
+    TEST_F(SceneGraphBehaviorTest, SceneGraphClass_BehaviorContext_Exists)
+    {
+        EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph>()));
+        EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph::NodeIndex>()));
+        EXPECT_TRUE(HasBehaviorClass(azrtti_typeid<AZ::SceneAPI::Containers::SceneGraph::Name>()));
+    }
+
+    TEST_F(SceneGraphBehaviorTest, SceneGraphClass_BehaviorContext_HasExpectedProperties)
+    {
+        using namespace AZ::SceneAPI::Containers;
+
+        AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<SceneGraph>());
+        ASSERT_NE(nullptr, behaviorClass);
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetNodeName", azrtti_typeid<SceneGraph::Name>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetRoot", azrtti_typeid<SceneGraph::NodeIndex>(), {}));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeContent", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeSibling", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeChild", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "HasNodeParent", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "IsNodeEndPoint", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetNodeCount", azrtti_typeid<size_t>(), {}));
+        EXPECT_TRUE(HasMethodWithOutput(
+            *behaviorClass,
+            "GetNodeParent",
+            azrtti_typeid<SceneGraph::NodeIndex>(),
+            { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>() }
+        ));
+        EXPECT_TRUE(HasMethodWithOutput(
+            *behaviorClass,
+            "GetNodeSibling",
+            azrtti_typeid<SceneGraph::NodeIndex>(),
+            { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>() }
+        ));
+        EXPECT_TRUE(HasMethodWithOutput(
+            *behaviorClass,
+            "GetNodeChild",
+            azrtti_typeid<SceneGraph::NodeIndex>(),
+            { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>() }
+        ));
+        EXPECT_TRUE(HasMethodWithOutput(
+            *behaviorClass,
+            "FindWithPath",
+            azrtti_typeid<SceneGraph::NodeIndex>(),
+            { azrtti_typeid<SceneGraph>(), azrtti_typeid<AZStd::string>() }
+        ));
+        EXPECT_TRUE(HasMethodWithOutput(
+            *behaviorClass,
+            "FindWithRootAndPath",
+            azrtti_typeid<SceneGraph::NodeIndex>(),
+            { azrtti_typeid<SceneGraph>(), azrtti_typeid<SceneGraph::NodeIndex>(), azrtti_typeid<AZStd::string>() }
+        ));
+    }
+
+    TEST_F(SceneGraphBehaviorTest, SceneGraphNodeIndexClass_BehaviorContext_HasExpectedProperties)
+    {
+        using namespace AZ::SceneAPI::Containers;
+
+        AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<SceneGraph::NodeIndex>());
+        ASSERT_NE(nullptr, behaviorClass);
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "AsNumber", azrtti_typeid<uint32_t>(), {}));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "Distance", azrtti_typeid<AZ::s32>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "IsValid", azrtti_typeid<bool>(), {}));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "Equal", azrtti_typeid<bool>(), { azrtti_typeid<SceneGraph::NodeIndex>() }));
+    }
+
+    TEST_F(SceneGraphBehaviorTest, SceneGraphNameClass_BehaviorContext_HasExpectedProperties)
+    {
+        using namespace AZ::SceneAPI::Containers;
+
+        AZ::BehaviorClass* behaviorClass = GetBehaviorClass(azrtti_typeid<SceneGraph::Name>());
+        ASSERT_NE(nullptr, behaviorClass);
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetPath", azrtti_typeid<const char*>(), {}));
+        EXPECT_TRUE(HasMethodWithOutput(*behaviorClass, "GetName", azrtti_typeid<const char*>(), {}));
+    }
+
+    class MockSceneComponentApplication
+        : public AZ::ComponentApplicationBus::Handler
+    {
+    public:
+        MockSceneComponentApplication()
+        {
+            AZ::ComponentApplicationBus::Handler::BusConnect();
+            AZ::Interface<AZ::ComponentApplicationRequests>::Register(this);
+        }
+
+        ~MockSceneComponentApplication()
+        {
+            AZ::Interface<AZ::ComponentApplicationRequests>::Unregister(this);
+            AZ::ComponentApplicationBus::Handler::BusDisconnect();
+        }
+
+        MOCK_METHOD1(FindEntity, AZ::Entity* (const AZ::EntityId&));
+        MOCK_METHOD1(AddEntity, bool(AZ::Entity*));
+        MOCK_METHOD0(Destroy, void());
+        MOCK_METHOD1(RegisterComponentDescriptor, void(const AZ::ComponentDescriptor*));
+        MOCK_METHOD1(UnregisterComponentDescriptor, void(const AZ::ComponentDescriptor*));
+        MOCK_METHOD1(RegisterEntityAddedEventHandler, void(AZ::EntityAddedEvent::Handler&));
+        MOCK_METHOD1(RegisterEntityRemovedEventHandler, void(AZ::EntityRemovedEvent::Handler&));
+        MOCK_METHOD1(RegisterEntityActivatedEventHandler, void(AZ::EntityActivatedEvent::Handler&));
+        MOCK_METHOD1(RegisterEntityDeactivatedEventHandler, void(AZ::EntityDeactivatedEvent::Handler&));
+        MOCK_METHOD1(SignalEntityActivated, void(AZ::Entity*));
+        MOCK_METHOD1(SignalEntityDeactivated, void(AZ::Entity*));
+        MOCK_METHOD1(RemoveEntity, bool(AZ::Entity*));
+        MOCK_METHOD1(DeleteEntity, bool(const AZ::EntityId&));
+        MOCK_METHOD1(GetEntityName, AZStd::string(const AZ::EntityId&));
+        MOCK_METHOD1(EnumerateEntities, void(const ComponentApplicationRequests::EntityCallback&));
+        MOCK_METHOD0(GetApplication, AZ::ComponentApplication* ());
+        MOCK_METHOD0(GetSerializeContext, AZ::SerializeContext* ());
+        MOCK_METHOD0(GetJsonRegistrationContext, AZ::JsonRegistrationContext* ());
+        MOCK_METHOD0(GetBehaviorContext, AZ::BehaviorContext* ());
+        MOCK_CONST_METHOD0(GetAppRoot, const char*());
+        MOCK_CONST_METHOD0(GetEngineRoot, const char*());
+        MOCK_CONST_METHOD0(GetExecutableFolder, const char* ());
+        MOCK_METHOD0(GetDrillerManager, AZ::Debug::DrillerManager* ());
+        MOCK_CONST_METHOD1(QueryApplicationType, void(AZ::ApplicationTypeQuery&));
+    };
+
+    class MockEditorPythonConsoleInterface final
+        : public AzToolsFramework::EditorPythonConsoleInterface
+    {
+    public:
+        MockEditorPythonConsoleInterface()
+        {
+            AZ::Interface<AzToolsFramework::EditorPythonConsoleInterface>::Register(this);
+        }
+
+        ~MockEditorPythonConsoleInterface()
+        {
+            AZ::Interface<AzToolsFramework::EditorPythonConsoleInterface>::Unregister(this);
+        }
+
+        MOCK_CONST_METHOD1(GetModuleList, void(AZStd::vector<AZStd::string_view>&));
+        MOCK_CONST_METHOD1(GetGlobalFunctionList, void(GlobalFunctionCollection&));
+        MOCK_METHOD1(FetchPythonTypeName, AZStd::string(const AZ::BehaviorParameter&));
+    };
+
+    //
+    // SceneGraphBehaviorScriptTest
+    //
+    class SceneGraphBehaviorScriptTest
+        : public UnitTest::AllocatorsFixture
+    {
+    public:
+        AZStd::unique_ptr<MockSceneComponentApplication> m_componentApplication;
+        AZStd::unique_ptr<MockEditorPythonConsoleInterface> m_editorPythonConsoleInterface;
+        AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
+        AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+
+        static void TestExpectTrue(bool value)
+        {
+            EXPECT_TRUE(value);
+        }
+
+        static void TestExpectEquals(AZ::s64 lhs, AZ::s64 rhs)
+        {
+            EXPECT_EQ(lhs, rhs);
+        }
+
+        static void ReflectTestTypes(AZ::ReflectContext* context)
+        {
+            AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context);
+            if (behaviorContext)
+            {
+                behaviorContext->Class<DataTypes::MockIGraphObject>()
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Module, "scene.graph.test")
+                    ->Method("GetId", [](const DataTypes::MockIGraphObject& self)
+                    {
+                        return self.m_id;
+                    })
+                    ->Method("SetId", [](DataTypes::MockIGraphObject& self, int value)
+                    {
+                        self.m_id = value;
+                    })
+                    ->Method("AddAndSet", [](DataTypes::MockIGraphObject& self, int lhs, int rhs)
+                    {
+                        self.m_id = lhs + rhs;
+                    });
+            }
+        }
+
+        void SetUp() override
+        {
+            UnitTest::AllocatorsFixture::SetUp();
+
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+
+            m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            m_behaviorContext->Method("TestExpectTrue", &TestExpectTrue);
+            m_behaviorContext->Method("TestExpectEquals", &TestExpectEquals);
+
+            AZ::MathReflect(m_behaviorContext.get());
+            ReflectBehavior(m_behaviorContext.get());
+            ReflectTestTypes(m_behaviorContext.get());
+            MockBuilder::Reflect(m_behaviorContext.get());
+
+            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
+            m_scriptContext->BindTo(m_behaviorContext.get());
+
+            m_componentApplication = AZStd::make_unique<::testing::NiceMock<MockSceneComponentApplication>>();
+
+            ON_CALL(*m_componentApplication, GetBehaviorContext())
+                .WillByDefault(::testing::Invoke([this]()
+                    {
+                        return this->m_behaviorContext.get();
+                    }));
+
+            ON_CALL(*m_componentApplication, GetSerializeContext())
+                .WillByDefault(::testing::Invoke([this]()
+                    {
+                        return this->m_serializeContext.get();
+                    }));
+
+            m_editorPythonConsoleInterface = AZStd::make_unique<MockEditorPythonConsoleInterface>();
+        }
+
+        void SetupEditorPythonConsoleInterface()
+        {
+            EXPECT_CALL(*m_editorPythonConsoleInterface, FetchPythonTypeName(::testing::_))
+                .Times(4)
+                .WillRepeatedly(::testing::Invoke([](const AZ::BehaviorParameter&) {return "int"; }));
+        }
+
+        void TearDown() override
+        {
+            m_scriptContext.reset();
+            m_serializeContext.reset();
+            m_behaviorContext.reset();
+
+            UnitTest::AllocatorsFixture::TearDown();
+        }
+
+        void ExpectExecute(AZStd::string_view script)
+        {
+            EXPECT_TRUE(m_scriptContext->Execute(script.data()));
+        }
+    };
+
+    TEST_F(SceneGraphBehaviorScriptTest, Scene_ScriptContext_Access)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("TestExpectTrue(scene ~= nil)");
+        ExpectExecute("TestExpectTrue(scene.name == 'unit_scene')");
+        ExpectExecute("TestExpectTrue(scene.manifestFilename == 'manifest_filename')");
+        ExpectExecute("TestExpectTrue(scene.sourceFilename == 'unit_source_filename')");
+        ExpectExecute("TestExpectTrue(tostring(scene.sourceGuid) == '{1F2E6142-B0D8-42C6-A6E5-CD726DAA9EF0}')");
+        ExpectExecute("TestExpectTrue(scene:GetOriginalSceneOrientation() == Scene.SceneOrientation_YUp)");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, SceneGraph_ScriptContext_AccessMockNodes)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+
+        // instance methods
+        ExpectExecute("TestExpectTrue(scene.graph ~= nil)");
+        ExpectExecute("TestExpectTrue(scene.graph:GetRoot():IsValid())");
+        ExpectExecute("TestExpectEquals(scene.graph:GetNodeCount(), 13)");
+        ExpectExecute("nodeRoot = scene.graph:GetRoot()");
+        ExpectExecute("nodeA = scene.graph:GetNodeChild(nodeRoot); TestExpectTrue(nodeA:IsValid())");
+        ExpectExecute("TestExpectTrue(scene.graph:HasNodeContent(nodeA))");
+        ExpectExecute("nodeC = scene.graph:GetNodeChild(nodeA); TestExpectTrue(nodeC:IsValid())");
+        ExpectExecute("nodeNameC = scene.graph:GetNodeName(nodeC); TestExpectTrue(nodeNameC ~= nil)");
+        ExpectExecute("nodeE = scene.graph:GetNodeChild(nodeC); TestExpectTrue(nodeE:IsValid())");
+        ExpectExecute("TestExpectTrue(scene.graph:HasNodeSibling(nodeE))");
+        ExpectExecute("TestExpectTrue(scene.graph:HasNodeChild(nodeE))");
+        ExpectExecute("TestExpectTrue(scene.graph:HasNodeParent(nodeE))");
+        ExpectExecute("nodeG = scene.graph:GetNodeChild(nodeE); TestExpectTrue(nodeG:IsValid())");
+        ExpectExecute("TestExpectTrue(scene.graph:GetNodeParent(nodeG) == nodeE)");
+        ExpectExecute("nodeH = scene.graph:GetNodeSibling(nodeG); TestExpectTrue(nodeH:IsValid())");
+        ExpectExecute("TestExpectTrue(scene.graph:GetNodeName(nodeH):GetPath() == 'A.C.E.H')");
+        ExpectExecute("nodeB = scene.graph:GetNodeSibling(nodeA); TestExpectTrue(nodeB:IsValid())");
+        ExpectExecute("nodeK = scene.graph:GetNodeChild(nodeB); TestExpectTrue(nodeK:IsValid())");
+        ExpectExecute("TestExpectTrue(scene.graph:FindWithPath('B.K') == nodeK)");
+        ExpectExecute("nodeL = scene.graph:GetNodeChild(nodeK); TestExpectTrue(nodeL:IsValid())");
+        ExpectExecute("TestExpectTrue(scene.graph:FindWithRootAndPath(nodeK, 'L') == nodeL)");
+
+        // static methods
+        ExpectExecute("TestExpectTrue(scene.graph.IsValidName('A'))");
+        ExpectExecute("TestExpectTrue(scene.graph.GetNodeSeperationCharacter() == string.byte('.'))");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, SceneGraphNodeIndex_ScriptContext_AccessMockNodes)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeA = scene.graph:GetNodeChild(scene.graph:GetRoot())");
+        ExpectExecute("TestExpectTrue(nodeA:IsValid())");
+        ExpectExecute("TestExpectEquals(nodeA:AsNumber(), 1)");
+        ExpectExecute("TestExpectEquals(scene.graph:GetRoot():Distance(nodeA), 1)");
+        ExpectExecute("TestExpectEquals(nodeA:Distance(scene.graph:GetRoot()), -1)");
+        ExpectExecute("TestExpectTrue(nodeA == scene.graph:FindWithPath('A'))");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, SceneGraphName_ScriptContext_AccessMockNodes)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("nodeNameG = scene.graph:GetNodeName(nodeG)");
+        ExpectExecute("TestExpectTrue(nodeNameG:GetPath() == 'A.C.E.G')");
+        ExpectExecute("TestExpectTrue(nodeNameG:GetName() == 'G')");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, SceneGraphIGraphNode_ScriptContext_AccessMockNodes)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
+        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
+        ExpectExecute("value = proxy:Invoke('GetId', vector_any())");
+        ExpectExecute("TestExpectEquals(value, 7)");
+        ExpectExecute("setIdArgs = vector_any(); setIdArgs:push_back(8);");
+        ExpectExecute("proxy:Invoke('SetId', setIdArgs)");
+        ExpectExecute("value = proxy:Invoke('GetId', vector_any())");
+        ExpectExecute("TestExpectEquals(value, 8)");
+        ExpectExecute("addArgs = vector_any(); addArgs:push_back(8); addArgs:push_back(9)");
+        ExpectExecute("proxy:Invoke('AddAndSet', addArgs)");
+        ExpectExecute("value = proxy:Invoke('GetId', vector_any())");
+        ExpectExecute("TestExpectEquals(value, 17)");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_GetClassInfo_Loads)
+    {
+        SetupEditorPythonConsoleInterface();
+
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
+        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
+        ExpectExecute("info = proxy:GetClassInfo()");
+        ExpectExecute("TestExpectTrue(info ~= nil)");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, GraphObjectProxy_GetClassInfo_CorrectFormats)
+    {
+        SetupEditorPythonConsoleInterface();
+
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("nodeG = scene.graph:FindWithPath('A.C.E.G')");
+        ExpectExecute("proxy = scene.graph:GetNodeContent(nodeG)");
+        ExpectExecute("TestExpectTrue(proxy:CastWithTypeName('MockIGraphObject'))");
+        ExpectExecute("info = proxy:GetClassInfo()");
+        ExpectExecute("TestExpectTrue(info.className == 'MockIGraphObject')");
+        ExpectExecute("TestExpectTrue(info.classUuid == '{66A082CC-851D-4E1F-ABBD-45B58A216CFA}')");
+        ExpectExecute("TestExpectTrue(info.methodList[1] == 'def GetId(self) -> int')");
+        ExpectExecute("TestExpectTrue(info.methodList[2] == 'def SetId(self, arg1: int) -> None')");
+        ExpectExecute("TestExpectTrue(info.methodList[3] == 'def AddAndSet(self, arg1: int, arg2: int) -> None')");
+    }
+
+    TEST_F(SceneGraphBehaviorScriptTest, ExportProduct_ExpectedClassesAndFields_Work)
+    {
+        ExpectExecute("mockAssetType = Uuid.CreateString('{B7AD6A54-963F-4F0F-A70E-1CFC0364BE6B}')");
+        ExpectExecute("exportProduct = ExportProduct()");
+        ExpectExecute("exportProduct.filename = 'some/file.name'");
+        ExpectExecute("exportProduct.sourceId = Uuid.CreateString('{A19F5FDB-C5FB-478F-A0B0-B697D2C10DB5}', 0)");
+        ExpectExecute("exportProduct.assetType = mockAssetType");
+        ExpectExecute("exportProduct.subId = 10101");
+        ExpectExecute("TestExpectEquals(exportProduct.subId, 10101)");
+        ExpectExecute("TestExpectEquals(exportProduct.productDependencies:GetSize(), 0)");
+
+        ExpectExecute("exportProductDep = ExportProduct()");
+        ExpectExecute("exportProductDep.filename = 'some/file.dep'");
+        ExpectExecute("exportProductDep.sourceId = Uuid.CreateString('{A19F5FDB-C5FB-478F-A0B0-B697D2C10DB5}', 0)");
+        ExpectExecute("exportProductDep.assetType = mockAssetType");
+        ExpectExecute("exportProductDep.subId = 2");
+
+        ExpectExecute("exportProductList = ExportProductList()");
+        ExpectExecute("exportProductList:AddProduct(exportProduct)");
+        ExpectExecute("exportProductList:AddProduct(exportProductDep)");
+        ExpectExecute("productList = exportProductList:GetProducts()");
+        ExpectExecute("TestExpectEquals(productList:GetSize(), 2)");
+        ExpectExecute("exportProductList:AddDependencyToProduct(exportProduct.filename, exportProductDep)");
+        ExpectExecute("TestExpectEquals(productList:Front().productDependencies:GetSize(), 1)");
+    }
+
+    //
+    // SceneManifestBehaviorScriptTest is meant to test the script abilities of the SceneManifest
+    //
+    class SceneManifestBehaviorScriptTest
+        : public UnitTest::AllocatorsFixture
+    {
+    public:
+        AZStd::unique_ptr<MockSceneComponentApplication> m_componentApplication;
+        AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
+        AZStd::unique_ptr<AZ::BehaviorContext> m_behaviorContext;
+        AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
+        AZStd::unique_ptr<AZ::JsonRegistrationContext> m_jsonRegistrationContext;
+        AZStd::string_view m_jsonMockData = R"JSON('{"values":[{"$type":"MockManifestRule","value":0.1},{"$type":"MockManifestRule","value":2.3},{"$type":"MockManifestRule","value":4.5}]}')JSON";
+
+        static void TestAssertTrue(bool value)
+        {
+            EXPECT_TRUE(value);
+        }
+
+        void SetUp() override
+        {
+            UnitTest::AllocatorsFixture::SetUp();
+
+            m_serializeContext = AZStd::make_unique<AZ::SerializeContext>();
+            MockBuilder::Reflect(m_serializeContext.get());
+            MockManifestRule::Reflect(m_serializeContext.get());
+            ReflectTypes(m_serializeContext.get());
+
+            m_behaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
+            m_behaviorContext->Method("TestAssertTrue", &TestAssertTrue);
+            AZ::MathReflect(m_behaviorContext.get());
+            MockBuilder::Reflect(m_behaviorContext.get());
+            MockManifestRule::Reflect(m_behaviorContext.get());
+            ReflectBehavior(m_behaviorContext.get());
+
+            m_jsonRegistrationContext = AZStd::make_unique<AZ::JsonRegistrationContext>();
+            AZ::JsonSystemComponent::Reflect(m_jsonRegistrationContext.get());
+
+            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
+            m_scriptContext->BindTo(m_behaviorContext.get());
+
+            m_componentApplication = AZStd::make_unique<::testing::NiceMock<MockSceneComponentApplication>>();
+
+            ON_CALL(*m_componentApplication, GetBehaviorContext()).WillByDefault(::testing::Invoke([this]()
+                {
+                    return this->m_behaviorContext.get();
+                }));
+
+            ON_CALL(*m_componentApplication, GetSerializeContext()).WillByDefault(::testing::Invoke([this]()
+                {
+                    return this->m_serializeContext.get();
+                }));
+
+            ON_CALL(*m_componentApplication, GetJsonRegistrationContext()).WillByDefault(::testing::Invoke([this]()
+                {
+                    return this->m_jsonRegistrationContext.get();
+                }));
+        }
+
+        void TearDown() override
+        {
+            m_jsonRegistrationContext->EnableRemoveReflection();
+            AZ::JsonSystemComponent::Reflect(m_jsonRegistrationContext.get());
+            m_jsonRegistrationContext->DisableRemoveReflection();
+
+            m_jsonRegistrationContext.reset();
+            m_serializeContext.reset();
+            m_scriptContext.reset();
+            m_behaviorContext.reset();
+            m_componentApplication.reset();
+            UnitTest::AllocatorsFixture::TearDown();
+        }
+
+        void ExpectExecute(AZStd::string_view script)
+        {
+            EXPECT_TRUE(m_scriptContext->Execute(script.data()));
+        }
+    };
+
+    TEST_F(SceneManifestBehaviorScriptTest, SceneManifest_ScriptContext_GetDefaultJSON)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("manifest = scene.manifest:ExportToJson()");
+        ExpectExecute(R"JSON(TestAssertTrue(manifest == '{}'))JSON");
+    }
+
+    TEST_F(SceneManifestBehaviorScriptTest, SceneManifest_ScriptContext_GetComplexJSON)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("builder:BuildSceneGraph()");
+        ExpectExecute("manifest = scene.manifest:ExportToJson()");
+        auto read = AZStd::fixed_string<1024>::format("TestAssertTrue(manifest == %s)", m_jsonMockData.data());
+        ExpectExecute(read);
+    }
+
+    TEST_F(SceneManifestBehaviorScriptTest, SceneManifest_ScriptContext_SetComplexJSON)
+    {
+        ExpectExecute("builder = MockBuilder()");
+        ExpectExecute("scene = builder:GetScene()");
+        ExpectExecute("manifest = scene.manifest:ExportToJson()");
+        ExpectExecute(R"JSON(TestAssertTrue(manifest == '{}'))JSON");
+        auto load = AZStd::fixed_string<1024>::format("TestAssertTrue(scene.manifest:ImportFromJson(%s))", m_jsonMockData.data());
+        ExpectExecute(load);
+        ExpectExecute("manifest = scene.manifest:ExportToJson()");
+        auto read = AZStd::fixed_string<1024>::format("TestAssertTrue(manifest == %s)", m_jsonMockData.data());
+        ExpectExecute(read);
+    }
+
+} // namespace AZ::SceneAPI::Containers

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -25,213 +25,319 @@
 #include <SceneAPI/SceneCore/Containers/Views/PairIterator.h>
 #include <SceneAPI/SceneData/Rules/ScriptProcessorRule.h>
 #include <SceneAPI/SceneCore/Utilities/Reporting.h>
+#include <SceneAPI/SceneCore/Events/ExportProductList.h>
 
-namespace AZ
+namespace AZ::SceneAPI::Behaviors
 {
-    namespace SceneAPI
+    class EditorPythonConsoleNotificationHandler final
+        : protected AzToolsFramework::EditorPythonConsoleNotificationBus::Handler
     {
-        namespace Behaviors
+    public:
+        EditorPythonConsoleNotificationHandler()
         {
-            class EditorPythonConsoleNotificationHandler final
-                : protected AzToolsFramework::EditorPythonConsoleNotificationBus::Handler
+            BusConnect();
+        }
+
+        ~EditorPythonConsoleNotificationHandler()
+        {
+            BusDisconnect();
+        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        // AzToolsFramework::EditorPythonConsoleNotifications
+        void OnTraceMessage([[maybe_unused]] AZStd::string_view message) override
+        {
+            using namespace AZ::SceneAPI::Utilities;
+            AZ_TracePrintf(LogWindow, "%.*s \n", AZ_STRING_ARG(message));
+        }
+
+        void OnErrorMessage([[maybe_unused]] AZStd::string_view message) override
+        {
+            using namespace AZ::SceneAPI::Utilities;
+            AZ_TracePrintf(ErrorWindow, "[ERROR] %.*s \n", AZ_STRING_ARG(message));
+        }
+
+        void OnExceptionMessage([[maybe_unused]] AZStd::string_view message) override
+        {
+            using namespace AZ::SceneAPI::Utilities;
+            AZ_TracePrintf(ErrorWindow, "[EXCEPTION] %.*s \n", AZ_STRING_ARG(message));
+        }
+    };
+
+    using ExportProductList = AZ::SceneAPI::Events::ExportProductList;
+
+    // a event bus to signal during scene building
+    struct ScriptBuildingNotifications
+        : public AZ::EBusTraits
+    {
+        virtual AZStd::string OnUpdateManifest(Containers::Scene& scene) = 0;
+        virtual ExportProductList OnPrepareForExport(
+            const Containers::Scene& scene,
+            AZStd::string_view outputDirectory,
+            AZStd::string_view platformIdentifier,
+            const ExportProductList& productList) = 0;
+    };
+    using ScriptBuildingNotificationBus = AZ::EBus<ScriptBuildingNotifications>;
+
+    // a back end to handle scene builder events for a script
+    struct ScriptBuildingNotificationBusHandler final
+        : public ScriptBuildingNotificationBus::Handler
+        , public AZ::BehaviorEBusHandler
+    {
+        AZ_EBUS_BEHAVIOR_BINDER(
+            ScriptBuildingNotificationBusHandler,
+            "{DF2B51DE-A4D0-4139-B5D0-DF185832380D}",
+            AZ::SystemAllocator,
+            OnUpdateManifest,
+            OnPrepareForExport);
+
+        virtual ~ScriptBuildingNotificationBusHandler() = default;
+
+        AZStd::string OnUpdateManifest(Containers::Scene& scene) override
+        {
+            AZStd::string result;
+            CallResult(result, FN_OnUpdateManifest, scene);
+            return result;
+        }
+
+        ExportProductList OnPrepareForExport(
+            const Containers::Scene& scene,
+            AZStd::string_view outputDirectory,
+            AZStd::string_view platformIdentifier,
+            const ExportProductList& productList) override
+        {
+            ExportProductList result;
+            CallResult(result, FN_OnPrepareForExport, scene, outputDirectory, platformIdentifier, productList);
+            return result;
+        }
+
+        static void Reflect(AZ::ReflectContext* context)
+        {
+            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
-            public:
-                EditorPythonConsoleNotificationHandler()
-                {
-                    BusConnect();
-                }
+                behaviorContext->EBus<ScriptBuildingNotificationBus>("ScriptBuildingNotificationBus")
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Module, "scene")
+                    ->Handler<ScriptBuildingNotificationBusHandler>()
+                    ->Event("OnUpdateManifest", &ScriptBuildingNotificationBus::Events::OnUpdateManifest)
+                    ->Event("OnPrepareForExport", &ScriptBuildingNotificationBus::Events::OnPrepareForExport);
+            }
+        }
+    };
 
-                ~EditorPythonConsoleNotificationHandler()
-                {
-                    BusDisconnect();
-                }
+    struct ScriptProcessorRuleBehavior::ExportEventHandler final
+        : public AZ::SceneAPI::SceneCore::ExportingComponent
+    {
+        using PreExportEventContextFunction = AZStd::function<bool(Events::PreExportEventContext&)>;
+        PreExportEventContextFunction m_preExportEventContextFunction;
 
-                ////////////////////////////////////////////////////////////////////////////////////////////
-                // AzToolsFramework::EditorPythonConsoleNotifications
-                void OnTraceMessage([[maybe_unused]] AZStd::string_view message) override
-                {
-                    using namespace AZ::SceneAPI::Utilities;
-                    AZ_TracePrintf(LogWindow, "%.*s \n", AZ_STRING_ARG(message));
-                }
+        ExportEventHandler(PreExportEventContextFunction preExportEventContextFunction)
+            : m_preExportEventContextFunction(preExportEventContextFunction)
+        {
+            BindToCall(&ExportEventHandler::PrepareForExport);
+            AZ::SceneAPI::SceneCore::ExportingComponent::Activate();
+        }
 
-                void OnErrorMessage([[maybe_unused]] AZStd::string_view message) override
-                {
-                    using namespace AZ::SceneAPI::Utilities;
-                    AZ_TracePrintf(ErrorWindow, "[ERROR] %.*s \n", AZ_STRING_ARG(message));
-                }
+        ~ExportEventHandler()
+        {
+            AZ::SceneAPI::SceneCore::ExportingComponent::Deactivate();
+        }
 
-                void OnExceptionMessage([[maybe_unused]] AZStd::string_view message) override
-                {
-                    using namespace AZ::SceneAPI::Utilities;
-                    AZ_TracePrintf(ErrorWindow, "[EXCEPTION] %.*s \n", AZ_STRING_ARG(message));
-                }
-            };                        
+        // this allows a Python script to add product assets on "scene export"
+        Events::ProcessingResult PrepareForExport(Events::PreExportEventContext& context)
+        {
+            return m_preExportEventContextFunction(context) ? Events::ProcessingResult::Success : Events::ProcessingResult::Failure;
+        }
+    };
 
-            // a event bus to signal during scene building
-            struct ScriptBuildingNotifications
-                : public AZ::EBusTraits
+    void ScriptProcessorRuleBehavior::Activate()
+    {
+        Events::AssetImportRequestBus::Handler::BusConnect();
+        m_exportEventHandler = AZStd::make_shared<ExportEventHandler>([this](Events::PreExportEventContext& context)
+        {
+            return this->DoPrepareForExport(context);
+        });
+    }
+
+    void ScriptProcessorRuleBehavior::Deactivate()
+    {
+        m_exportEventHandler.reset();
+        Events::AssetImportRequestBus::Handler::BusDisconnect();
+        UnloadPython();
+    }
+
+    bool ScriptProcessorRuleBehavior::LoadPython(const AZ::SceneAPI::Containers::Scene& scene)
+    {
+        if (m_editorPythonEventsInterface && !m_scriptFilename.empty())
+        {
+            return true;
+        }
+
+        // get project folder
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ::IO::FixedMaxPath projectPath;
+        if (!settingsRegistry->Get(projectPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
+        {
+            return false;
+        }
+
+        const AZ::SceneAPI::Containers::SceneManifest& manifest = scene.GetManifest();
+        auto view = Containers::MakeDerivedFilterView<DataTypes::IScriptProcessorRule>(manifest.GetValueStorage());
+        for (const auto& scriptItem : view)
+        {
+            AZ::IO::FixedMaxPath scriptFilename(scriptItem.GetScriptFilename());
+            if (scriptFilename.empty())
             {
-                virtual AZStd::string OnUpdateManifest(Containers::Scene& scene) = 0;
+                AZ_Warning("scene", false, "Skipping an empty script filename in (%s)", scene.GetManifestFilename().c_str());
+                continue;
+            }
+
+            // check for file exist via absolute path
+            if (!IO::FileIOBase::GetInstance()->Exists(scriptFilename.c_str()))
+            {
+                // check for script in the project folder
+                AZ::IO::FixedMaxPath projectScriptPath = projectPath / scriptFilename;
+                if (!IO::FileIOBase::GetInstance()->Exists(projectScriptPath.c_str()))
+                {
+                    AZ_Warning("scene", false, "Skipping a missing script (%s) in manifest file (%s)",
+                        scriptFilename.c_str(),
+                        scene.GetManifestFilename().c_str());
+                    continue;
+                }
+                scriptFilename = AZStd::move(projectScriptPath);
+            }
+
+            // lazy load the Python interface
+            auto editorPythonEventsInterface = AZ::Interface<AzToolsFramework::EditorPythonEventsInterface>::Get();
+            if (editorPythonEventsInterface->IsPythonActive() == false)
+            {
+                const bool silenceWarnings = false;
+                if (editorPythonEventsInterface->StartPython(silenceWarnings) == false)
+                {
+                    editorPythonEventsInterface = nullptr;
+                }
+            }
+
+            // both Python and the script need to be ready
+            if (editorPythonEventsInterface == nullptr || scriptFilename.empty())
+            {
+                AZ_Warning("scene", false,"The scene manifest (%s) attempted to use script(%s) but Python is not enabled;"
+                    "please add the EditorPythonBinding gem & PythonAssetBuilder gem to your project.",
+                    scene.GetManifestFilename().c_str(), scriptFilename.c_str());
+
+                return false;
+            }
+
+            m_editorPythonEventsInterface = editorPythonEventsInterface;
+            m_scriptFilename = scriptFilename.c_str();
+            return true;
+        }
+        return false;
+    }
+
+    void ScriptProcessorRuleBehavior::UnloadPython()
+    {
+        if (m_editorPythonEventsInterface)
+        {
+            const bool silenceWarnings = true;
+            m_editorPythonEventsInterface->StopPython(silenceWarnings);
+            m_editorPythonEventsInterface = nullptr;
+        }
+    }
+
+    bool ScriptProcessorRuleBehavior::DoPrepareForExport(Events::PreExportEventContext& context)
+    {
+        using namespace AzToolsFramework;
+
+        auto executeCallback = [this, &context]()
+        {
+            // set up script's hook callback
+            EditorPythonRunnerRequestBus::Broadcast(&EditorPythonRunnerRequestBus::Events::ExecuteByFilename,
+                m_scriptFilename.c_str());
+
+            // call script's callback to allow extra products
+            ExportProductList extraProducts;
+            ScriptBuildingNotificationBus::BroadcastResult(extraProducts, &ScriptBuildingNotificationBus::Events::OnPrepareForExport,
+                context.GetScene(),
+                context.GetOutputDirectory(),
+                context.GetPlatformIdentifier(),
+                context.GetProductList()      
+            );
+
+            // add new products
+            for (const auto& product : extraProducts.GetProducts())
+            {
+                context.GetProductList().AddProduct(
+                    product.m_filename,
+                    product.m_id,
+                    product.m_assetType,
+                    product.m_lod,
+                    product.m_subId,
+                    product.m_dependencyFlags);
+            }
+        };
+
+        if (LoadPython(context.GetScene()))
+        {
+            EditorPythonConsoleNotificationHandler logger;
+            m_editorPythonEventsInterface->ExecuteWithLock(executeCallback);
+        }
+
+        return true;
+    }
+
+    void ScriptProcessorRuleBehavior::Reflect(ReflectContext* context)
+    {
+        ScriptBuildingNotificationBusHandler::Reflect(context);
+
+        SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<ScriptProcessorRuleBehavior, BehaviorComponent>()->Version(1);
+        }
+    }
+
+    Events::ProcessingResult ScriptProcessorRuleBehavior::UpdateManifest(
+        Containers::Scene& scene,
+        Events::AssetImportRequest::ManifestAction action,
+        [[maybe_unused]] Events::AssetImportRequest::RequestingApplication requester)
+    {
+        using namespace AzToolsFramework;
+
+        if (action != ManifestAction::Update)
+        {
+            return Events::ProcessingResult::Ignored;
+        }
+
+        if (LoadPython(scene))
+        {
+            AZStd::string manifestUpdate;
+            auto executeCallback = [this, &scene, &manifestUpdate]()
+            {
+                EditorPythonRunnerRequestBus::Broadcast(&EditorPythonRunnerRequestBus::Events::ExecuteByFilename,
+                    m_scriptFilename.c_str());
+
+                ScriptBuildingNotificationBus::BroadcastResult(manifestUpdate, &ScriptBuildingNotificationBus::Events::OnUpdateManifest,
+                    scene);
             };
-            using ScriptBuildingNotificationBus = AZ::EBus<ScriptBuildingNotifications>;
 
-            // a back end to handle scene builder events for a script
-            struct ScriptBuildingNotificationBusHandler final
-                : public ScriptBuildingNotificationBus::Handler
-                , public AZ::BehaviorEBusHandler
+            EditorPythonConsoleNotificationHandler logger;
+            m_editorPythonEventsInterface->ExecuteWithLock(executeCallback);
+
+            // attempt to load the manifest string back to a JSON-scene-manifest
+            auto sceneManifestLoader = AZStd::make_unique<AZ::SceneAPI::Containers::SceneManifest>();
+            auto loadOutcome = sceneManifestLoader->LoadFromString(manifestUpdate);
+            if (loadOutcome.IsSuccess())
             {
-                AZ_EBUS_BEHAVIOR_BINDER(
-                    ScriptBuildingNotificationBusHandler,
-                    "{DF2B51DE-A4D0-4139-B5D0-DF185832380D}",
-                    AZ::SystemAllocator,
-                    OnUpdateManifest);
-
-                virtual ~ScriptBuildingNotificationBusHandler() = default;
-
-                AZStd::string OnUpdateManifest(Containers::Scene& scene) override
+                scene.GetManifest().Clear();
+                for (size_t entryIndex = 0; entryIndex < sceneManifestLoader->GetEntryCount(); ++entryIndex)
                 {
-                    AZStd::string result;
-                    CallResult(result, FN_OnUpdateManifest, scene);
-                    return result;
+                    scene.GetManifest().AddEntry(sceneManifestLoader->GetValue(entryIndex));
                 }
-
-                static void Reflect(AZ::ReflectContext* context)
-                {
-                    if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-                    {
-                        behaviorContext->EBus<ScriptBuildingNotificationBus>("ScriptBuildingNotificationBus")
-                            ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                            ->Attribute(AZ::Script::Attributes::Module, "scene")
-                            ->Handler<ScriptBuildingNotificationBusHandler>()
-                            ->Event("OnUpdateManifest", &ScriptBuildingNotificationBus::Events::OnUpdateManifest);
-                    }
-                }
-            };
-
-            void ScriptProcessorRuleBehavior::Activate()
-            {
-                Events::AssetImportRequestBus::Handler::BusConnect();
+                return Events::ProcessingResult::Success;
             }
+        }
+        return Events::ProcessingResult::Ignored;
+    }
 
-            void ScriptProcessorRuleBehavior::Deactivate()
-            {
-                Events::AssetImportRequestBus::Handler::BusDisconnect();
-                if (m_editorPythonEventsInterface)
-                {
-                    const bool silenceWarnings = true;
-                    m_editorPythonEventsInterface->StopPython(silenceWarnings);
-                    m_editorPythonEventsInterface = nullptr;
-                        
-                }
-            }
-
-            void ScriptProcessorRuleBehavior::Reflect(ReflectContext* context)
-            {
-                ScriptBuildingNotificationBusHandler::Reflect(context);
-
-                SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
-                if (serializeContext)
-                {
-                    serializeContext->Class<ScriptProcessorRuleBehavior, BehaviorComponent>()->Version(1);
-                }
-            }
-
-            Events::ProcessingResult ScriptProcessorRuleBehavior::UpdateManifest(
-                Containers::Scene& scene,
-                Events::AssetImportRequest::ManifestAction action,
-                [[maybe_unused]] Events::AssetImportRequest::RequestingApplication requester)
-            {
-                using namespace AzToolsFramework;
-
-                if (action != ManifestAction::Update)
-                {
-                    return Events::ProcessingResult::Ignored;
-                }
-
-                // get project folder
-                auto settingsRegistry = AZ::SettingsRegistry::Get();
-                AZ::IO::FixedMaxPath projectPath;
-                if (!settingsRegistry->Get(projectPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
-                {
-                    return Events::ProcessingResult::Ignored;
-                }
-
-                auto& sceneManifest = scene.GetManifest();
-                auto view = Containers::MakeDerivedFilterView<DataTypes::IScriptProcessorRule>(sceneManifest.GetValueStorage());
-                for (const auto& scriptItem : view)
-                {
-                    AZ::IO::FixedMaxPath scriptFilename(scriptItem.GetScriptFilename());
-                    if (scriptFilename.empty())
-                    {
-                        AZ_Warning("scene", false, "Skipping an empty script filename in (%s)", scene.GetManifestFilename().c_str());
-                        continue;
-                    }
-
-                    // check for file exist via absolute path
-                    if (!IO::FileIOBase::GetInstance()->Exists(scriptFilename.c_str()))
-                    {
-                        // check for script in the project folder
-                        AZ::IO::FixedMaxPath projectScriptPath = projectPath / scriptFilename;
-                        if (!IO::FileIOBase::GetInstance()->Exists(projectScriptPath.c_str()))
-                        {
-                            AZ_Warning("scene", false, "Skipping a missing script (%s) in manifest file (%s)",
-                                scriptFilename.c_str(),
-                                scene.GetManifestFilename().c_str());
-
-                            continue;
-                        }
-                        scriptFilename = AZStd::move(projectScriptPath);
-                    }
-
-                    // lazy load the Python interface
-                    if (!m_editorPythonEventsInterface)
-                    {
-                        m_editorPythonEventsInterface = AZ::Interface<AzToolsFramework::EditorPythonEventsInterface>::Get();
-                        const bool silenceWarnings = true;
-                        m_editorPythonEventsInterface->StartPython(silenceWarnings);
-                    }
-
-                    if (!m_editorPythonEventsInterface && !scriptFilename.empty())
-                    {
-                        AZ_Warning("scene", false,
-                            "The scene manifest (%s) attempted to use script(%s) but Python is not enabled;"
-                            "please add the EditorPythonBinding gem & PythonAssetBuilder gem to your project.",
-                            scene.GetManifestFilename().c_str(), scriptFilename.c_str());
-
-                        return Events::ProcessingResult::Ignored;
-                    }
-
-                    AZStd::string manifestUpdate;
-                    auto executeCallback = [&scene, &scriptFilename, &manifestUpdate]()
-                    {
-                        EditorPythonRunnerRequestBus::Broadcast(
-                            &EditorPythonRunnerRequestBus::Events::ExecuteByFilename,
-                            scriptFilename.c_str());
-
-                        ScriptBuildingNotificationBus::BroadcastResult(
-                            manifestUpdate,
-                            &ScriptBuildingNotificationBus::Events::OnUpdateManifest,
-                            scene);
-                    };
-                    EditorPythonConsoleNotificationHandler logger;
-                    m_editorPythonEventsInterface->ExecuteWithLock(executeCallback);
-
-                    // attempt to load the manifest string back to a JSON-scene-manifest
-                    auto sceneManifestLoader = AZStd::make_unique<AZ::SceneAPI::Containers::SceneManifest>();
-                    auto loadOutcome = sceneManifestLoader->LoadFromString(manifestUpdate);
-                    if (loadOutcome.IsSuccess())
-                    {
-                        sceneManifest.Clear();
-                        for (size_t entryIndex = 0; entryIndex < sceneManifestLoader->GetEntryCount(); ++entryIndex)
-                        {
-                            sceneManifest.AddEntry(sceneManifestLoader->GetValue(entryIndex));
-                        }
-                        return Events::ProcessingResult::Success;
-                    }
-                }
-                return Events::ProcessingResult::Ignored;
-            }
-
-        } // namespace Behaviors
-    } // namespace SceneAPI
 } // namespace AZ

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h
@@ -11,40 +11,56 @@
 #include <AzCore/std/string/string.h>
 #include <SceneAPI/SceneCore/Components/BehaviorComponent.h>
 #include <SceneAPI/SceneCore/Events/AssetImportRequest.h>
+#include <SceneAPI/SceneCore/Components/ExportingComponent.h>
+#include <SceneAPI/SceneCore/Events/ExportEventContext.h>
 
 namespace AzToolsFramework
 {
     class EditorPythonEventsInterface;
 }
 
-namespace AZ
+namespace AZ::SceneAPI::Events
 {
-    namespace SceneAPI
+    class PreExportEventContext;
+}
+
+namespace AZ::SceneAPI::Containers
+{
+    class Scene;
+}
+
+namespace AZ::SceneAPI::Behaviors
+{
+    class SCENE_DATA_CLASS ScriptProcessorRuleBehavior
+        : public SceneCore::BehaviorComponent
+        , public Events::AssetImportRequestBus::Handler
     {
-        namespace Behaviors
-        {
-            class SCENE_DATA_CLASS ScriptProcessorRuleBehavior
-                : public SceneCore::BehaviorComponent
-                , public Events::AssetImportRequestBus::Handler
-            {
-            public:
-                AZ_COMPONENT(ScriptProcessorRuleBehavior, "{24054E73-1B92-43B0-AC13-174B2F0E3F66}", SceneCore::BehaviorComponent);
+    public:
+        AZ_COMPONENT(ScriptProcessorRuleBehavior, "{24054E73-1B92-43B0-AC13-174B2F0E3F66}", SceneCore::BehaviorComponent);
 
-                ~ScriptProcessorRuleBehavior() override = default;
+        ~ScriptProcessorRuleBehavior() override = default;
 
-                SCENE_DATA_API void Activate() override;
-                SCENE_DATA_API void Deactivate() override;
-                static void Reflect(ReflectContext* context);
+        SCENE_DATA_API void Activate() override;
+        SCENE_DATA_API void Deactivate() override;
+        static void Reflect(ReflectContext* context);
 
-                // AssetImportRequestBus::Handler
-                SCENE_DATA_API Events::ProcessingResult UpdateManifest(
-                    Containers::Scene& scene,
-                    ManifestAction action,
-                    RequestingApplication requester) override;
+        // AssetImportRequestBus::Handler
+        SCENE_DATA_API Events::ProcessingResult UpdateManifest(
+            Containers::Scene& scene,
+            ManifestAction action,
+            RequestingApplication requester) override;
 
-            private:
-                AzToolsFramework::EditorPythonEventsInterface* m_editorPythonEventsInterface = nullptr;
-            };
-        } // namespace SceneData
-    } // namespace SceneAPI
-} // namespace AZ
+
+    protected:
+        bool LoadPython(const AZ::SceneAPI::Containers::Scene& scene);
+        void UnloadPython();
+        bool DoPrepareForExport(Events::PreExportEventContext& context);
+
+    private:
+        AzToolsFramework::EditorPythonEventsInterface* m_editorPythonEventsInterface = nullptr;
+        AZStd::string m_scriptFilename;
+
+        struct ExportEventHandler;
+        AZStd::shared_ptr<ExportEventHandler> m_exportEventHandler;
+    };
+} // namespace AZ::SceneAPI::Behaviors

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -237,8 +237,8 @@ namespace EditorPythonBindings
             {
                 ec->Class<PythonSystemComponent>("PythonSystemComponent", "The Python interpreter")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("System"))
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ;
             }
         }
@@ -284,10 +284,10 @@ namespace EditorPythonBindings
             ReleaseFunction m_releaseFunction;
         };
         ReleaseInitalizeWaiterScope scope([this]()
-        {
-            m_initalizeWaiter.release(m_initalizeWaiterCount);
-            m_initalizeWaiterCount = 0;
-        });
+            {
+                m_initalizeWaiter.release(m_initalizeWaiterCount);
+                m_initalizeWaiterCount = 0;
+            });
 
         if (Py_IsInitialized())
         {
@@ -325,6 +325,11 @@ namespace EditorPythonBindings
         result = StopPythonInterpreter();
         EditorPythonBindingsNotificationBus::Broadcast(&EditorPythonBindingsNotificationBus::Events::OnPostFinalize);
         return result;
+    }
+
+    bool PythonSystemComponent::IsPythonActive()
+    {
+        return Py_IsInitialized() != 0;
     }
 
     void PythonSystemComponent::WaitForInitialization()

--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.h
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.h
@@ -44,6 +44,7 @@ namespace EditorPythonBindings
         // AzToolsFramework::EditorPythonEventsInterface
         bool StartPython(bool silenceWarnings = false) override;
         bool StopPython(bool silenceWarnings = false) override;
+        bool IsPythonActive() override;
         void WaitForInitialization() override;
         void ExecuteWithLock(AZStd::function<void()> executionCallback) override;
         ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* Engine updates to enable Python Asset Building for the Blast Gem
* added API to detect IsPythonActive()
* ExportProductList behavior
* scene manifest usage of generated assetinfo
* updated ScriptProcessorRuleBehavior to handle OnPrepareForExport

Tests: new tests for scene behavior via ExportProduct

Signed-off-by: Jackson <23512001+jackalbe@users.noreply.github.com>