### PR TITLE
Mac m1 fixes

### DIFF
--- a/Code/Editor/Platform/Mac/gui_info.plist
+++ b/Code/Editor/Platform/Mac/gui_info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Editor</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Amazon.Lumberyard.Editor</string>
+	<string>org.O3DE.Editor</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>

--- a/Code/Editor/Plugins/EditorCommon/CMakeLists.txt
+++ b/Code/Editor/Plugins/EditorCommon/CMakeLists.txt
@@ -46,4 +46,8 @@ ly_add_target(
             AZ::AzCore
             AZ::AzToolsFramework
             AZ::AzQtComponents
+    RUNTIME_DEPENDENCIES
+        AZ::AzCore
+        AZ::AzToolsFramework
+        AZ::AzQtComponents
 )

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandListBase.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandListBase.cpp
@@ -30,6 +30,7 @@ namespace AZ
         {
             AZ_UNUSED(device);
             m_hardwareQueueClass = hardwareQueueClass;
+            m_supportsInterDrawTimestamps = AZ::RHI::QueryTypeFlags::Timestamp == (device->GetFeatures().m_queryTypesMask[static_cast<uint32_t>(hardwareQueueClass)] & AZ::RHI::QueryTypeFlags::Timestamp);
         }
         
         void CommandListBase::Reset()
@@ -64,7 +65,10 @@ namespace AZ
                 [m_encoder endEncoding];
                 m_encoder = nil;
 #if AZ_TRAIT_ATOM_METAL_COUNTER_SAMPLING
-                m_timeStampQueue.clear();
+                if (m_supportsInterDrawTimestamps)
+                {
+                    m_timeStampQueue.clear();
+                }
 #endif
             }
         }
@@ -144,9 +148,12 @@ namespace AZ
             m_isEncoded = true;
             
 #if AZ_TRAIT_ATOM_METAL_COUNTER_SAMPLING
-            for(auto& timeStamp: m_timeStampQueue)
+            if (m_supportsInterDrawTimestamps)
             {
-                SampleCounters(timeStamp.m_counterSampleBuffer, timeStamp.m_timeStampIndex);
+                for(auto& timeStamp: m_timeStampQueue)
+                {
+                    SampleCounters(timeStamp.m_counterSampleBuffer, timeStamp.m_timeStampIndex);
+                }
             }
 #endif
         }
@@ -195,6 +202,11 @@ namespace AZ
 #if AZ_TRAIT_ATOM_METAL_COUNTER_SAMPLING
         void CommandListBase::SampleCounters(id<MTLCounterSampleBuffer> counterSampleBuffer, uint32_t sampleIndex)
         {
+            if (!m_supportsInterDrawTimestamps)
+            {
+                return;
+            }
+
             AZ_Assert(sampleIndex >= 0, "Invalid sample index");
             //useBarrier - Inserting a barrier ensures that encoded work is complete before the GPU samples the hardware counters.
             //If it is true there is a performance penalty but you will get consistent results
@@ -231,6 +243,11 @@ namespace AZ
     
         void CommandListBase::SamplePassCounters(id<MTLCounterSampleBuffer> counterSampleBuffer, uint32_t sampleIndex)
         {
+            if (!m_supportsInterDrawTimestamps)
+            {
+                return;
+            }
+
             if(m_encoder == nil)
             {
                 //Queue the query to be activated upon encoder creation. Applies to timestamp queries

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandListBase.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandListBase.h
@@ -101,6 +101,8 @@ namespace AZ
             
             const AZStd::set<id<MTLHeap>>* m_residentHeaps = nullptr;
 
+            bool m_supportsInterDrawTimestamps                  = AZ_TRAIT_ATOM_METAL_COUNTER_SAMPLING; // iOS/TVOS = false, MacOS = defaults to true
+
 #if AZ_TRAIT_ATOM_METAL_COUNTER_SAMPLING
             struct TimeStampData
             {

--- a/Gems/EMotionFX/Code/CMakeLists.txt
+++ b/Gems/EMotionFX/Code/CMakeLists.txt
@@ -111,6 +111,10 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 EMFX_EMSTUDIOLYEMBEDDED
                 EMOTIONFXANIMATION_EDITOR
+        RUNTIME_DEPENDENCIES
+            AZ::SceneCore
+            AZ::SceneData
+            AZ::SceneUI
     )
 
     ly_add_target(

--- a/Gems/EMotionFX/Code/CMakeLists.txt
+++ b/Gems/EMotionFX/Code/CMakeLists.txt
@@ -111,10 +111,6 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 EMFX_EMSTUDIOLYEMBEDDED
                 EMOTIONFXANIMATION_EDITOR
-        RUNTIME_DEPENDENCIES
-            AZ::SceneCore
-            AZ::SceneData
-            AZ::SceneUI
     )
 
     ly_add_target(

--- a/Gems/SceneProcessing/Code/CMakeLists.txt
+++ b/Gems/SceneProcessing/Code/CMakeLists.txt
@@ -61,6 +61,7 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
         RUNTIME_DEPENDENCIES
             AZ::SceneCore
             AZ::SceneData
+            AZ::SceneUI
     )
     # the SceneProcessing.Editor module above is only used in Builders and Tools.
     ly_create_alias(NAME SceneProcessing.Builders NAMESPACE Gem TARGETS Gem::SceneProcessing.Editor)


### PR DESCRIPTION
Detect if metal device supports interdraw timestamps and disable queries if it doesn't.
Mark some gems as runtime dependencies so they are correctly added to the Editor.app bundle on Mac
Fix the Mac editor application identifier to be o3de.