### PR TITLE
[ATOM-15978] ShaderVariantAssetBuilder SRG fix for metal

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -95,7 +95,7 @@ namespace AZ
             shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
             // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
             // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-            shaderVariantAssetBuilderDescriptor.m_version = 23; // ATOM-15472
+            shaderVariantAssetBuilderDescriptor.m_version = 24; // ATOM-15978
             shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", RPI::ShaderVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();
             shaderVariantAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::CreateJobs, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/ShaderPlatformInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Edit/ShaderPlatformInterface.h
@@ -144,6 +144,12 @@ namespace AZ
                 const ShaderResourceGroupInfoList& srgInfoList,
                 const RootConstantsInfo& rootConstantsInfo,
                 const ShaderCompilerArguments& shaderCompilerArguments) = 0;
+            
+            //! In general, shader compilation doesn't require SRG Layout data, but RHIs like
+            //! Metal don't do well if unused resources (descriptors) are not bound. If this function returns TRUE
+            //! the ShaderVariantAssetBuilder will invoke BuildPipelineLayoutDescriptor() so the RHI gets the chance to
+            //! build SRG Layout data which will be useful when compiling MetalISL to Metal byte code.
+            virtual bool VariantCompilationRequiresSrgLayoutData() const { return false; }
 
             //! See AZ::RHI::Factory::GetAPIUniqueIndex() for details.
             //! See AZ::RHI::Limits::APIType::PerPlatformApiUniqueIndexMax.

--- a/Gems/Atom/RHI/Code/Source/RHI.Edit/ShaderCompilerArguments.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Edit/ShaderCompilerArguments.cpp
@@ -159,7 +159,13 @@ namespace AZ
                 arguments += " -Zi";  // Generate debug information
                 arguments += " -Zss"; // Compute Shader Hash considering source information
             }
-            arguments += " " + m_dxcAdditionalFreeArguments;
+            // strip spaces at both sides
+            AZStd::string dxcAdditionalFreeArguments = m_dxcAdditionalFreeArguments;
+            AzFramework::StringFunc::TrimWhiteSpace(dxcAdditionalFreeArguments, true, true);
+            if (!dxcAdditionalFreeArguments.empty())
+            {
+                arguments += " " + dxcAdditionalFreeArguments;
+            }
             return arguments;
         }
     }

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI.Builders/ShaderPlatformInterface.h
@@ -40,6 +40,8 @@ namespace AZ
                 const ShaderResourceGroupInfoList& srgInfoList,
                 const RootConstantsInfo& rootConstantsInfo,
                 const RHI::ShaderCompilerArguments& shaderCompilerArguments) override;
+            
+            bool VariantCompilationRequiresSrgLayoutData() const override { return true; }
 
             bool CompilePlatformInternal(
                 const AssetBuilderSDK::PlatformInfo& platform,


### PR DESCRIPTION
[ATOM-15978] ShaderVariantAssetBuilder needs to fill up ShaderPlatformInterface::m_srgLayouts for Metal

Added new API to ShaderPlatformInterface that returns true if the RHI requires SRG Layout data to build variants.
Only Metal returns true.

Signed-off-by: galibzon <garrieta@amazon.com>