### PR TITLE
Add a CMAKE function used to check if a gem is available in the project for a given variant

### DIFF
--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -259,7 +259,7 @@ endfunction()
 # \arg:VARIANT name of the project variant if which to check for availability. Defaults to 'Clients'.
 function(ly_is_gem_available)
     set(options)
-    set(oneValueArgs NAME OUTPUT_VARIABLE VALUE_IF_FOUND VALUE_IF_NOT_FOUND VARIANT)
+    set(oneValueArgs NAME OUTPUT_VARIABLE VARIANT)
     set(multiValueArgs)
 
     cmake_parse_arguments(ly_is_gem_available "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -277,6 +277,8 @@ function(ly_is_gem_available)
         return()
     endif()
 
+    set("${ly_is_gem_available_OUTPUT_VARIABLE}" FALSE PARENT_SCOPE)
+
     get_property(ly_delayed_enable_gems GLOBAL PROPERTY LY_DELAYED_ENABLE_GEMS)
     foreach(project_target_variant ${ly_delayed_enable_gems})
         # we expect a colon separated list of
@@ -314,5 +316,4 @@ function(ly_is_gem_available)
             endif()
         endforeach()
     endforeach()
-    set("${ly_is_gem_available_OUTPUT_VARIABLE}" FALSE PARENT_SCOPE)
 endfunction()

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -255,13 +255,11 @@ endfunction()
 
 #! ly_is_gem_available: Check if a gem is available in the current project configuration.
 # \arg:NAME name of the gem to check for availability.
-# \arg:RETURN_VARIABLE name of the variable in which to set the returned value.
-# \arg:VALUE_IF_FOUND value to set in the RETURN_VARIABLE when the gem is available. Defaults to TRUE.
-# \arg:VALUE_IF_NOT_FOUND value to set in the RETURN_VARIABLE when the gem is not available. Defaults to FALSE.
+# \arg:OUTPUT_VARIABLE name of the variable in which to set the returned value (either TRUE or FALSE).
 # \arg:VARIANT name of the project variant if which to check for availability. Defaults to 'Clients'.
 function(ly_is_gem_available)
     set(options)
-    set(oneValueArgs NAME RETURN_VARIABLE VALUE_IF_FOUND VALUE_IF_NOT_FOUND VARIANT)
+    set(oneValueArgs NAME OUTPUT_VARIABLE VALUE_IF_FOUND VALUE_IF_NOT_FOUND VARIANT)
     set(multiValueArgs)
 
     cmake_parse_arguments(ly_is_gem_available "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -274,16 +272,8 @@ function(ly_is_gem_available)
         set(ly_is_gem_available_VARIANT "Clients")
     endif()
 
-    if (NOT ly_is_gem_available_VALUE_IF_FOUND)
-        set(ly_is_gem_available_VALUE_IF_FOUND TRUE)
-    endif()
-
-    if (NOT ly_is_gem_available_VALUE_IF_NOT_FOUND)
-        set(ly_is_gem_available_VALUE_IF_NOT_FOUND FALSE)
-    endif()
-
-    if (NOT ly_is_gem_available_RETURN_VARIABLE)
-        message(WARNING "Call to 'ly_is_gem_available' without specifying the RETURN_VARIABLE argument. The call was ignored.")
+    if (NOT ly_is_gem_available_OUTPUT_VARIABLE)
+        message(WARNING "Call to 'ly_is_gem_available' without specifying the OUTPUT_VARIABLE argument. The call was ignored.")
         return()
     endif()
 
@@ -319,10 +309,10 @@ function(ly_is_gem_available)
         # Fetch for the wanted gem dependency.
         foreach(gem_name ${gem_dependencies})
             if (gem_name STREQUAL ${ly_is_gem_available_NAME})
-                set("${ly_is_gem_available_RETURN_VARIABLE}" "${ly_is_gem_available_VALUE_IF_FOUND}" PARENT_SCOPE)
+                set("${ly_is_gem_available_OUTPUT_VARIABLE}" TRUE PARENT_SCOPE)
                 return()
             endif()
         endforeach()
     endforeach()
-    set("${ly_is_gem_available_RETURN_VARIABLE}" "${ly_is_gem_available_VALUE_IF_NOT_FOUND}" PARENT_SCOPE)
+    set("${ly_is_gem_available_OUTPUT_VARIABLE}" FALSE PARENT_SCOPE)
 endfunction()

--- a/cmake/Gems.cmake
+++ b/cmake/Gems.cmake
@@ -316,30 +316,11 @@ function(ly_is_gem_available)
             continue()
         endif()
 
-        if (NOT TARGET ${target})
-            message(FATAL_ERROR "ly_enable_gems specified TARGET '${target}' but no such target was found.")
-        endif()
-
-        # Fetch for the searched gem dependency.
+        # Fetch for the wanted gem dependency.
         foreach(gem_name ${gem_dependencies})
-            # the gem name may already have a namespace.  If it does, we use that one
-            ly_strip_target_namespace(TARGET ${gem_name} OUTPUT_VARIABLE unaliased_gem_name)
-            if (${unaliased_gem_name} STREQUAL ${gem_name})
-                # if stripping a namespace had no effect, it had no namespace
-                # and we supply the default Gem:: namespace.
-                set(gem_name_with_namespace Gem::${gem_name})
-            else()
-                # if stripping the namespace had an effect then we use the original
-                # with the namespace, instead of assuming Gem::
-                set(gem_name_with_namespace ${gem_name})
-            endif()
-            
-            # if the target exists, add it.
-            if (TARGET ${gem_name_with_namespace}.${variant})
-                if (gem_name STREQUAL ${ly_is_gem_available_NAME})
-                    set("${ly_is_gem_available_RETURN_VARIABLE}" "${ly_is_gem_available_VALUE_IF_FOUND}" PARENT_SCOPE)
-                    return()
-                endif()
+            if (gem_name STREQUAL ${ly_is_gem_available_NAME})
+                set("${ly_is_gem_available_RETURN_VARIABLE}" "${ly_is_gem_available_VALUE_IF_FOUND}" PARENT_SCOPE)
+                return()
             endif()
         endforeach()
     endforeach()


### PR DESCRIPTION
This PR add the `ly_is_gem_available` function in the `cmake/Gems.cmake` file.

This function can be useful when a gem can use another gem to supercharge its feature, without having that gem as a mandatory dependency.

Simple usage :
```cmake
ly_is_gem_available(
    NAME EMotionFX
    RETURN_VARIABLE EMOTIONFX_DEF
    VALUE_IF_FOUND EMOTIONFX_ENABLED
    VALUE_IF_NOT_FOUND EMOTIONFX_DISABLED
    VARIANT Clients
)
```
With that we can now for example use the `EMOTIONFX_DEF` variable in the compile definitions of the gem, so the `EMOTIONFX_ENABLED` define will enable some parts of the gem code optimized for the use with the EMotionFX gem.