### PR TITLE
Use the proper undo sequence so that viewport camera changes are saved properly.

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1896,7 +1896,7 @@ void EditorViewportWidget::SetViewTM(const Matrix34& viewTM, bool bMoveOnly)
 
         if (m_pressedKeyState != KeyPressedState::PressedInPreviousFrame)
         {
-            CUndo undo("Move Camera");
+            AzToolsFramework::ScopedUndoBatch undo("Move Camera");
             if (bMoveOnly)
             {
                 // specify eObjectUpdateFlags_UserInput so that an undo command gets logged
@@ -1932,7 +1932,7 @@ void EditorViewportWidget::SetViewTM(const Matrix34& viewTM, bool bMoveOnly)
 
         if (m_pressedKeyState != KeyPressedState::PressedInPreviousFrame)
         {
-            CUndo undo("Move Camera");
+            AzToolsFramework::ScopedUndoBatch undo("Move Camera");
             if (bMoveOnly)
             {
                 AZ::TransformBus::Event(
@@ -1945,6 +1945,8 @@ void EditorViewportWidget::SetViewTM(const Matrix34& viewTM, bool bMoveOnly)
                     m_viewEntityId, &AZ::TransformInterface::SetWorldTM,
                     LYTransformToAZTransform(camMatrix));
             }
+
+            AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequests::AddDirtyEntity, m_viewEntityId);
         }
         else
         {


### PR DESCRIPTION
Fixes #2158 

Found that the logic for updating the camera transform when in the "Be this camera" mode was using CUndo directly instead of the scoped undo from AzToolsFramework, so it wasn't hitting the prefab propagation logic. Another way to reproduce this was if you moved the camera around as "Be this camera" and then saved the level, if you switched to a different level and then re-opened it, then the camera transform change wouldn't be saved either.

Another note is that I added similar logic in the lower "else if". The top branch (which is what gets executed) is currently retrieving a CBaseObject for the camera and then setting the transform on it. This in turn is triggering the AddDirtyEntity. At some point in the near future we (hopefully) will be getting rid of CBaseObject, so that path won't be valid anymore, so I made sure to fix in both places with the addition of setting the AddDirtyEntity in the bottom case. As a test I commented out the CBaseObject path and verified that it still works when it falls through.

![SaveBeThisCameraChanges](https://user-images.githubusercontent.com/7519264/125664338-2a22dd73-8db9-49fe-99d4-b97045c069ea.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>