### PR TITLE
Fix gesture recognizer spamming errors when clicking the mouse

### DIFF
--- a/Gems/Gestures/Code/Include/Gestures/IGestureRecognizer.h
+++ b/Gems/Gestures/Code/Include/Gestures/IGestureRecognizer.h
@@ -209,12 +209,17 @@ namespace Gestures
     ////////////////////////////////////////////////////////////////////////////////////////////////
     inline uint32_t IRecognizer::GetGesturePointerIndex(const AzFramework::InputChannel& inputChannel)
     {
-        const auto& mouseButtonIt = AZStd::find(AzFramework::InputDeviceMouse::Button::All.cbegin(),
-                                                AzFramework::InputDeviceMouse::Button::All.cend(),
-                                                inputChannel.GetInputChannelId());
-        if (mouseButtonIt != AzFramework::InputDeviceMouse::Button::All.cend())
+        // Only recognize gestures for the default mouse input device. The Editor may register synthetic
+        // mouse input devices with the same mouse input channels, which can confuse gesture recognition.
+        if (inputChannel.GetInputDevice().GetInputDeviceId() == AzFramework::InputDeviceMouse::Id)
         {
-            return static_cast<uint32_t>(mouseButtonIt - AzFramework::InputDeviceMouse::Button::All.cbegin());
+            const auto& mouseButtonIt = AZStd::find(AzFramework::InputDeviceMouse::Button::All.cbegin(),
+                                                    AzFramework::InputDeviceMouse::Button::All.cend(),
+                                                    inputChannel.GetInputChannelId());
+            if (mouseButtonIt != AzFramework::InputDeviceMouse::Button::All.cend())
+            {
+                return static_cast<uint32_t>(mouseButtonIt - AzFramework::InputDeviceMouse::Button::All.cbegin());
+            }
         }
 
         const auto& touchIndexIt = AZStd::find(AzFramework::InputDeviceTouch::Touch::All.cbegin(),


### PR DESCRIPTION
The synthetic input devices created by the Qt -> AZ input system were being detected by the gesture recognizer, which confused it - this is a potential general issue for anything listening to the AZ input system out of game mode, but this is the only recorded issue so far. I've added a check in this case to ensure the event comes from the real, physical mouse device instead of one of our synthetic ones, stopping the spam.

Fixes https://github.com/o3de/o3de/issues/2177

Signed-off-by: nvsickle <nvsickle@amazon.com>