### PR TITLE
[ATOM] Case sensitive shader paths

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/ContrastAdaptiveSharpening.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ContrastAdaptiveSharpening.pass
@@ -58,7 +58,7 @@
             "PassData": {
                 "$type": "ComputePassData",
                 "ShaderAsset": {
-                    "FilePath": "Shaders/Postprocessing/ContrastAdaptiveSharpening.shader"
+                    "FilePath": "Shaders/PostProcessing/ContrastAdaptiveSharpening.shader"
                 },
                 "Make Fullscreen Pass": true,
                 "ShaderDataMappings": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapSkyBox.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapSkyBox.pass
@@ -54,7 +54,7 @@
             "PassData": {
                 "$type": "FullscreenTrianglePassData",
                 "ShaderAsset": {
-                    "FilePath": "shaders/skybox/skybox.shader"
+                    "FilePath": "Shaders/SkyBox/SkyBox.shader"
                 },
                 "PipelineViewTag": "MainCamera",
                 "ShaderDataMappings": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/Reflections.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Reflections.pass
@@ -90,7 +90,7 @@
                         "DrawListTag": "reflectionprobeblendweight",
                         "PipelineViewTag": "MainCamera",
                         "PassSrgShaderAsset": {
-                            "FilePath": "shaders/reflections/reflectionprobeblendweight.shader"
+                            "FilePath": "Shaders/Reflections/ReflectionProbeBlendWeight.shader"
                         }
                     }
                 },
@@ -204,7 +204,7 @@
                         "DrawListTag": "reflectionproberenderouter",
                         "PipelineViewTag": "MainCamera",
                         "PassSrgShaderAsset": {
-                            "FilePath": "shaders/reflections/reflectionproberenderouter.shader"
+                            "FilePath": "Shaders/Reflections/ReflectionProbeRenderOuter.shader"
                         }
                     }
                 },
@@ -254,7 +254,7 @@
                         "DrawListTag": "reflectionproberenderinner",
                         "PipelineViewTag": "MainCamera",
                         "PassSrgShaderAsset": {
-                            "FilePath": "shaders/reflections/reflectionproberenderinner.shader"
+                            "FilePath": "Shaders/Reflections/ReflectionProbeRenderInner.shader"
                         }
                     }
                 },

--- a/Gems/Atom/Feature/Common/Assets/Passes/Reflections_nomsaa.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Reflections_nomsaa.pass
@@ -85,7 +85,7 @@
                         "DrawListTag": "reflectionprobeblendweight",
                         "PipelineViewTag": "MainCamera",
                         "PassSrgShaderAsset": {
-                            "FilePath": "shaders/reflections/reflectionprobeblendweight.shader"
+                            "FilePath": "Shaders/Reflections/ReflectionProbeBlendWeight.shader"
                         }
                     }
                 },
@@ -192,7 +192,7 @@
                         "DrawListTag": "reflectionproberenderouter",
                         "PipelineViewTag": "MainCamera",
                         "PassSrgShaderAsset": {
-                            "FilePath": "shaders/reflections/reflectionproberenderouter.shader"
+                            "FilePath": "Shaders/Reflections/ReflectionProbeRenderOuter.shader"
                         }
                     }
                 },
@@ -242,7 +242,7 @@
                         "DrawListTag": "reflectionproberenderinner",
                         "PipelineViewTag": "MainCamera",
                         "PassSrgShaderAsset": {
-                            "FilePath": "shaders/reflections/reflectionproberenderinner.shader"
+                            "FilePath": "Shaders/Reflections/ReflectionProbeRenderInner.shader"
                         }
                     }
                 },

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyBox.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyBox.pass
@@ -21,7 +21,7 @@
             "PassData": {
                 "$type": "FullscreenTrianglePassData",
                 "ShaderAsset": {
-                    "FilePath": "shaders/skybox/skybox.shader"
+                    "FilePath": "Shaders/SkyBox/SkyBox.shader"
                 },
                 "PipelineViewTag": "MainCamera",
                 "ShaderDataMappings": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/SkyBox_TwoOutputs.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SkyBox_TwoOutputs.pass
@@ -26,7 +26,7 @@
             "PassData": {
                 "$type": "FullscreenTrianglePassData",
                 "ShaderAsset": {
-                    "FilePath": "shaders/skybox/skybox_twooutputs.shader"
+                    "FilePath": "Shaders/SkyBox/SkyBox_TwoOutputs.shader"
                 },
                 "PipelineViewTag": "MainCamera",
                 "ShaderDataMappings": {

--- a/Gems/Atom/Feature/Common/Assets/Passes/Taa.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/Taa.pass
@@ -87,7 +87,7 @@
             "PassData": {
                 "$type": "TaaPassData",
                 "ShaderAsset": {
-                    "FilePath": "Shaders/Postprocessing/Taa.shader"
+                    "FilePath": "Shaders/PostProcessing/Taa.shader"
                 },
                 "Make Fullscreen Pass": true,
                 "ShaderDataMappings": {


### PR DESCRIPTION
On systems with case-sensitive file systems (e.g. Linux, some macOS installations) compilation of shaders fail if the referenced files do not have the same cases as on the filesystem.

Maybe some kind of test could check if that is the case for newly added passes?