### PR TITLE
DiffuseProbeGridRenderPass should always be enabled

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
@@ -607,13 +607,6 @@ namespace AZ
                 {
                     pass->SetEnabled(false);
                 }
-
-                RPI::PassHierarchyFilter renderPassFilter(AZ::Name("DiffuseProbeGridRenderPass"));
-                const AZStd::vector<RPI::Pass*>& renderPasses = RPI::PassSystemInterface::Get()->FindPasses(renderPassFilter);
-                for (RPI::Pass* pass : renderPasses)
-                {
-                    pass->SetEnabled(false);
-                }
             }
         }
 

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRenderPass.cpp
@@ -52,15 +52,6 @@ namespace AZ
                 return;
             }
 
-            RayTracingFeatureProcessor* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
-            AZ_Assert(rayTracingFeatureProcessor, "DiffuseProbeGridRenderPass requires the RayTracingFeatureProcessor");
-
-            if (!rayTracingFeatureProcessor->GetSubMeshCount())
-            {
-                // empty scene
-                return;
-            }
-
             // get output attachment size
             AZ_Assert(GetInputOutputCount() > 0, "DiffuseProbeGridRenderPass: Could not find output bindings");
             RPI::PassAttachment* m_outputAttachment = GetInputOutputBinding(0).m_attachment.get();


### PR DESCRIPTION
The DiffuseProbeGridRenderPass is now always enabled to allow Baked GI to render on non-raytracing hardware.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>