### PR TITLE
Adding rapidjson.natvis file to the AzCore project to Visualizers to VS

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
+++ b/Code/Framework/AzCore/Platform/Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+	<!-- rapidjson::GenericValue - basic support -->
+	<Type Name="rapidjson_ly::GenericValue&lt;*,*&gt;">
+		<DisplayString Condition="(data_.f.flags &amp; kTypeMask) == kNullType">null</DisplayString>
+		<DisplayString Condition="data_.f.flags == kTrueFlag">true</DisplayString>
+		<DisplayString Condition="data_.f.flags == kFalseFlag">false</DisplayString>
+		<DisplayString Condition="data_.f.flags == kShortStringFlag">{data_.ss.str}</DisplayString>
+		<DisplayString Condition="(data_.f.flags &amp; kTypeMask) == kStringType">{(const char*)((size_t)data_.s.str &amp; 0x0000FFFFFFFFFFFF)}</DisplayString>
+		<DisplayString Condition="(data_.f.flags &amp; kNumberIntFlag) == kNumberIntFlag">{data_.n.i.i}</DisplayString>
+		<DisplayString Condition="(data_.f.flags &amp; kNumberUintFlag) == kNumberUintFlag">{data_.n.u.u}</DisplayString>
+		<DisplayString Condition="(data_.f.flags &amp; kNumberInt64Flag) == kNumberInt64Flag">{data_.n.i64}</DisplayString>
+		<DisplayString Condition="(data_.f.flags &amp; kNumberUint64Flag) == kNumberUint64Flag">{data_.n.u64}</DisplayString>
+		<DisplayString Condition="(data_.f.flags &amp; kNumberDoubleFlag) == kNumberDoubleFlag">{data_.n.d}</DisplayString>
+		<DisplayString Condition="data_.f.flags == kObjectType">Object members={data_.o.size}</DisplayString>
+		<DisplayString Condition="data_.f.flags == kArrayType">Array members={data_.a.size}</DisplayString>
+		<Expand>
+			<Item Condition="data_.f.flags == kObjectType" Name="[size]">data_.o.size</Item>
+			<Item Condition="data_.f.flags == kObjectType" Name="[capacity]">data_.o.capacity</Item>
+			<ArrayItems Condition="data_.f.flags == kObjectType">
+				<Size>data_.o.size</Size>
+				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
+				<ValuePointer>(rapidjson_ly::GenericMember&lt;$T1,$T2&gt;*)(((size_t)data_.o.members) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+			</ArrayItems>
+
+			<Item Condition="data_.f.flags == kArrayType" Name="[size]">data_.a.size</Item>
+			<Item Condition="data_.f.flags == kArrayType" Name="[capacity]">data_.a.capacity</Item>
+			<ArrayItems Condition="data_.f.flags == kArrayType">
+				<Size>data_.a.size</Size>
+				<!-- NOTE: Rapidjson stores some extra data in the high bits of pointers, which is why the mask -->
+				<ValuePointer>(rapidjson_ly::GenericValue&lt;$T1,$T2&gt;*)(((size_t)data_.a.elements) &amp; 0x0000FFFFFFFFFFFF)</ValuePointer>
+			</ArrayItems>
+
+		</Expand>
+	</Type>
+
+</AutoVisualizer>
+

--- a/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Framework/AzCore/Platform/Windows/platform_windows_files.cmake
@@ -29,6 +29,7 @@ set(FILES
     ../Common/VisualStudio/AzCore/Natvis/azcore.natvis
     ../Common/VisualStudio/AzCore/Natvis/azcore.natstepfilter
     ../Common/VisualStudio/AzCore/Natvis/azcore.natjmc
+    ../Common/VisualStudio/AzCore/Natvis/rapidjson.natvis
     AzCore/Debug/StackTracer_Windows.cpp
     ../Common/WinAPI/AzCore/Debug/Trace_WinAPI.cpp
     ../Common/WinAPI/AzCore/IO/Streamer/StreamerContext_WinAPI.cpp


### PR DESCRIPTION
By adding the natvis to a vcxproj Visual Studio automatically loads it
when using the source engine
Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>