### PR TITLE
Added missing EMotionFX.Editor target as a runtime dependency of the …

### DIFF
--- a/Gems/AtomContent/CMakeLists.txt
+++ b/Gems/AtomContent/CMakeLists.txt
@@ -6,3 +6,7 @@
 #
 add_subdirectory(ReferenceMaterials)
 add_subdirectory(Sponza)
+
+if(PAL_TRAIT_BUILD_HOST_TOOLS)
+    ly_create_alias(NAME AtomContent.Builders NAMESPACE Gem TARGETS Gem::AtomContent_ReferenceMaterials.Builders Gem::AtomContent_Sponza.Builders)
+endif()

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/CMakeLists.txt
@@ -57,5 +57,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PRIVATE
                 AZ::AzCore
                 Gem::EMotionFX_Atom.Static
+        RUNTIME_DEPENDENCIES
+            Gem::EMotionFX.Editor
     )
 endif()


### PR DESCRIPTION
…EMotionFXAtom.Editor target to fix launching of the Editor when the EMotionFX gem isn't explictly enabled. #2128 #2129

Filled the dependencies of the AtomContent.Builders gem with the AtomConent_ReferenceMaterial and AtomContent_Sponza gem

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>