### PR TITLE
EMotion FX: Root bone not initialized without opening Scene Settings

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
@@ -143,6 +143,7 @@ namespace EMotionFX
 
                 Group::ActorGroup* group = azrtti_cast<Group::ActorGroup*>(&target);
                 group->SetName(AZ::SceneAPI::DataTypes::Utilities::CreateUniqueName<Group::IActorGroup>(scene.GetName(), scene.GetManifest()));
+                group->SetBestMatchingRootBone(scene.GetGraph());
 
                 // LOD Rule need to be built first in the actor, so we know which mesh and bone belongs to LOD.
                 // After this call, LOD rule will be populated with all the LOD bones

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/ActorGroup.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/ActorGroup.h
@@ -45,8 +45,8 @@ namespace EMotionFX
 
                 // IActorGroup overrides
                 const AZStd::string& GetSelectedRootBone() const override;
-
                 void SetSelectedRootBone(const AZStd::string& selectedRootBone)  override;
+                void SetBestMatchingRootBone(const AZ::SceneAPI::Containers::SceneGraph& sceneGraph) override;
 
                 static void Reflect(AZ::ReflectContext* context);
                 static bool IActorGroupVersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement);

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/IActorGroup.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/IActorGroup.h
@@ -10,6 +10,11 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <SceneAPI/SceneCore/DataTypes/Groups/IGroup.h>
 
+namespace AZ::SceneAPI::Containers
+{
+    class SceneGraph;
+}
+
 namespace EMotionFX
 {
     namespace Pipeline
@@ -26,6 +31,7 @@ namespace EMotionFX
 
                 virtual const AZStd::string& GetSelectedRootBone() const = 0;
                 virtual void SetSelectedRootBone(const AZStd::string& selectedRootBone) = 0;
+                virtual void SetBestMatchingRootBone(const AZ::SceneAPI::Containers::SceneGraph& sceneGraph) = 0;
             };
         }
     }


### PR DESCRIPTION
**This change got cherry-picked from the stabilization branch and has already been reviewed with PR#2088.**

* User provided model was exporting correctly with an .assetinfo while it was not when just placing the .fbx file in the project folder.
* Turned out that the best matching root bone was set by opening the Scene Settings for the first time, so after saving it again it worked correctly.
* We're now chosing the best matching root bone when initializing the actor group, which fixes the issue.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>