### PR TITLE
[GHI #2165] GPU Buffer/Image memory visualizer

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/BufferDescriptor.h
@@ -10,6 +10,8 @@
 
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/AttachmentEnums.h>
+
+#include <AzCore/Preprocessor/Enum.h>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ
@@ -22,47 +24,44 @@ namespace AZ
          * A set of combinable flags which inform the system how a buffer is to be
          * bound to the pipeline at all stages of its lifetime.
          */
-        enum class BufferBindFlags : uint32_t
-        {
-            None            = 0,
+        AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(BufferBindFlags, uint32_t,
+            (None            , 0),
 
             /// Supports input assembly access through a IndexBufferView or StreamBufferView. This flag is for buffers that are not updated often
-            InputAssembly   = AZ_BIT(0),
+            (InputAssembly   , AZ_BIT(0)),
             
             /// Supports input assembly access through a IndexBufferView or StreamBufferView. This flag is for buffers that are updated frequently
-            DynamicInputAssembly = AZ_BIT(1),
+            (DynamicInputAssembly , AZ_BIT(1)),
             
             /// Supports constant access through a ShaderResourceGroup.
-            Constant        = AZ_BIT(2),
+            (Constant        , AZ_BIT(2)),
 
             /// Supports read access through a ShaderResourceGroup.
-            ShaderRead      = AZ_BIT(3),
+            (ShaderRead      , AZ_BIT(3)),
 
             /// Supports write access through ShaderResourceGroup.
-            ShaderWrite     = AZ_BIT(4),
+            (ShaderWrite     , AZ_BIT(4)),
 
             /// Supports read-write access through a ShaderResourceGroup.
-            ShaderReadWrite = ShaderRead | ShaderWrite,
+            (ShaderReadWrite , ShaderRead | ShaderWrite),
 
             /// Supports read access for GPU copy operations.
-            CopyRead        = AZ_BIT(5),
+            (CopyRead        , AZ_BIT(5)),
 
             /// Supports write access for GPU copy operations.
-            CopyWrite       = AZ_BIT(6),
+            (CopyWrite       , AZ_BIT(6)),
 
             /// Supports predication access for conditional rendering.
-            Predication     = AZ_BIT(7),
+            (Predication     , AZ_BIT(7)),
 
             /// Supports indirect buffer access for indirect draw/dispatch.
-            Indirect        = AZ_BIT(8),
+            (Indirect        , AZ_BIT(8)),
 
             /// Supports ray tracing acceleration structure usage.
-            RayTracingAccelerationStructure = AZ_BIT(9),
+            (RayTracingAccelerationStructure , AZ_BIT(9)),
 
             /// Supports ray tracing shader table usage.
-            RayTracingShaderTable = AZ_BIT(10)
-
-        };
+            (RayTracingShaderTable , AZ_BIT(10)));
 
         AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::BufferBindFlags);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageEnums.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ImageEnums.h
@@ -9,43 +9,43 @@
 
 #include <Atom/RHI.Reflect/Base.h>
 
+#include <AzCore/Preprocessor/Enum.h>
+
 namespace AZ
 {
     namespace RHI
     {
          //! A set of combinable flags which inform the system how an image is to be
          //! bound to the pipeline at all stages of its lifetime.
-        enum class ImageBindFlags : uint32_t
-        {
-            None = 0,
+        AZ_ENUM_CLASS_WITH_UNDERLYING_TYPE(ImageBindFlags, uint32_t,
+            (None, 0),
 
             /// Supports read access through a ShaderResourceGroup.
-            ShaderRead = AZ_BIT(0),
+            (ShaderRead, AZ_BIT(0)),
 
             /// Supports write access through a ShaderResourceGroup.
-            ShaderWrite = AZ_BIT(1),
+            (ShaderWrite, AZ_BIT(1)),
 
             /// Supports read-write access through a ShaderResourceGroup.
-            ShaderReadWrite = ShaderRead | ShaderWrite,
+            (ShaderReadWrite, ShaderRead | ShaderWrite),
 
             /// Supports use as a color attachment on a scope.
-            Color = AZ_BIT(2),
+            (Color, AZ_BIT(2)),
 
             /// Supports use as depth attachment on a scope.
-            Depth = AZ_BIT(3),
+            (Depth, AZ_BIT(3)),
 
             /// Supports use as stencil attachment on a scope.
-            Stencil = AZ_BIT(4),
+            (Stencil, AZ_BIT(4)),
 
             /// Supports use as a depth stencil attachment on a scope.
-            DepthStencil = Depth | Stencil,
+            (DepthStencil, Depth | Stencil),
 
             /// Supports read access for GPU copy operations.
-            CopyRead = AZ_BIT(5),
+            (CopyRead, AZ_BIT(5)),
 
             /// Supports write access for GPU copy operations.
-            CopyWrite = AZ_BIT(6),
-        };
+            (CopyWrite, AZ_BIT(6)));
 
         AZ_DEFINE_ENUM_BITWISE_OPERATORS(AZ::RHI::ImageBindFlags);
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystem.h
@@ -51,6 +51,7 @@ namespace AZ
             void ModifyFrameSchedulerStatisticsFlags(RHI::FrameSchedulerStatisticsFlags statisticsFlags, bool enableFlags) override;
             const RHI::CpuTimingStatistics* GetCpuTimingStatistics() const override;
             const RHI::TransientAttachmentStatistics* GetTransientAttachmentStatistics() const override;
+            const RHI::MemoryStatistics* GetMemoryStatistics() const override;
             const RHI::TransientAttachmentPoolDescriptor* GetTransientAttachmentPoolDescriptor() const override;
             ConstPtr<PlatformLimitsDescriptor> GetPlatformLimitsDescriptor() const override;
             void QueueRayTracingShaderTableForBuild(RayTracingShaderTable* rayTracingShaderTable) override;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -13,6 +13,7 @@
 #include <Atom/RHI.Reflect/FrameSchedulerEnums.h>
 #include <Atom/RHI/DrawListTagRegistry.h>
 
+#include <Atom/RHI.Reflect/MemoryStatistics.h>
 namespace AZ
 {
     namespace RHI
@@ -54,6 +55,8 @@ namespace AZ
             virtual const RHI::CpuTimingStatistics* GetCpuTimingStatistics() const = 0;
 
             virtual const RHI::TransientAttachmentStatistics* GetTransientAttachmentStatistics() const = 0;
+
+            virtual const RHI::MemoryStatistics* GetMemoryStatistics() const = 0;
 
             virtual const RHI::TransientAttachmentPoolDescriptor* GetTransientAttachmentPoolDescriptor() const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHISystemInterface.h
@@ -11,9 +11,9 @@
 #include <AzCore/Name/Name.h>
 #include <AzCore/EBus/EBus.h>
 #include <Atom/RHI.Reflect/FrameSchedulerEnums.h>
+#include <Atom/RHI.Reflect/MemoryStatistics.h>
 #include <Atom/RHI/DrawListTagRegistry.h>
 
-#include <Atom/RHI.Reflect/MemoryStatistics.h>
 namespace AZ
 {
     namespace RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -281,6 +281,11 @@ namespace AZ
             return m_frameScheduler.GetTransientAttachmentStatistics();
         }
 
+        const RHI::MemoryStatistics* RHISystem::GetMemoryStatistics() const
+        {
+            return m_frameScheduler.GetMemoryStatistics();
+        }
+
         const AZ::RHI::TransientAttachmentPoolDescriptor* RHISystem::GetTransientAttachmentPoolDescriptor() const
         {
             return m_frameScheduler.GetTransientAttachmentPoolDescriptor();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -23,6 +23,7 @@ namespace AZ
     namespace RHI
     {
         class ScopeAttachment;
+        // NOTE: see BufferDescriptor.h, AZ_ENUM... macro wraps enum within an outer inline namespace.
         inline namespace BufferBindFlagsNamespace
         {
             enum class BufferBindFlags : uint32_t;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -23,7 +23,10 @@ namespace AZ
     namespace RHI
     {
         class ScopeAttachment;
-        enum class BufferBindFlags : uint32_t;
+        inline namespace BufferBindFlagsNamespace
+        {
+            enum class BufferBindFlags : uint32_t;
+        }
         class BufferView;
         class ImageView;
         struct BufferSubresourceRange;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -8,17 +8,13 @@
 
 #pragma once
 
+#include <Atom/RHI.Reflect/MemoryStatistics.h>
 #include <Atom/RPI.Public/GpuQuery/GpuQueryTypes.h>
 
-#include <AzCore/std/containers/array.h>
-#include <AzCore/std/string/string.h>
-
-
-
 #include <AzCore/Name/Name.h>
-#include <Atom/RHI/MemoryStatisticsBus.h>
-#include <Atom/RHI/MemoryStatisticsBuilder.h>
-#include "../../../../../RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h"
+#include <AzCore/std/containers/array.h>
+#include <AzCore/std/containers/variant.h>
+#include <AzCore/std/string/string.h>
 
 namespace AZ
 {
@@ -260,19 +256,27 @@ namespace AZ
         class ImGuiGpuMemoryView
         {
         public:
+            // Draw the overall GPU memory profiling window.
             void DrawGpuMemoryWindow(bool& draw);
-            void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
-            void UpdateTableEntries();
-            void DrawTable();
-        private:
 
+            // Draw the heap usage pie chart
+            void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
+
+            // Update the saved pointers in m_tableRows according to new data/filters
+            void UpdateTableRows();
+
+            void DrawTable();
+
+            // Sort the table according to the appropriate column.
+            void SortTable(ImGuiTableSortSpecs* sortSpecs);
+        private:
             using Buffer = AZ::RHI::MemoryStatistics::Buffer;
             using Image = AZ::RHI::MemoryStatistics::Image;
-            using TableEntryVariant = AZStd::variant<Buffer*, Image*>;
+            using TableRowVariant = AZStd::variant<Buffer*, Image*>;
 
-            struct TableEntry {
+            struct TableRow {
                 Name m_parentPoolName;
-                TableEntryVariant m_variant;
+                TableRowVariant m_variant;
             };
 
             // Table settings
@@ -282,10 +286,11 @@ namespace AZ
 
             ImGuiTextFilter m_nameFilter;
 
-            AZStd::vector<TableEntry> m_tableEntries;
+            AZStd::vector<TableRow> m_tableRows;
             AZStd::vector<AZ::RHI::MemoryStatistics::Pool> m_savedPools;
             AZStd::vector<AZ::RHI::MemoryStatistics::Heap> m_savedHeaps;
         };
+
         class ImGuiGpuProfiler
         {
         public:

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -271,7 +271,8 @@ namespace AZ
             // Sort the table according to the appropriate column.
             void SortTable(ImGuiTableSortSpecs* sortSpecs);
 
-            struct TableRow {
+            struct TableRow
+            {
                 Name m_parentPoolName;
                 Name m_bufImgName;
                 size_t m_sizeInBytes = 0;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -270,13 +270,11 @@ namespace AZ
             // Sort the table according to the appropriate column.
             void SortTable(ImGuiTableSortSpecs* sortSpecs);
         private:
-            using Buffer = AZ::RHI::MemoryStatistics::Buffer;
-            using Image = AZ::RHI::MemoryStatistics::Image;
-            using TableRowVariant = AZStd::variant<Buffer*, Image*>;
-
             struct TableRow {
                 Name m_parentPoolName;
-                TableRowVariant m_variant;
+                Name m_bufImgName;
+                size_t m_sizeInBytes = 0;
+                AZStd::string m_bindFlags;
             };
 
             // Table settings

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -261,6 +261,7 @@ namespace AZ
         {
         public:
             void DrawGpuMemoryWindow(bool& draw);
+            void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
         private:
             bool m_paused = true;
             AZStd::vector<AZ::RHI::MemoryStatistics::Pool> m_savedPools;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -262,8 +262,27 @@ namespace AZ
         public:
             void DrawGpuMemoryWindow(bool& draw);
             void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
+            void UpdateTableEntries();
+            void DrawTable();
         private:
-            bool m_paused = true;
+
+            using Buffer = AZ::RHI::MemoryStatistics::Buffer;
+            using Image = AZ::RHI::MemoryStatistics::Image;
+            using TableEntryVariant = AZStd::variant<Buffer*, Image*>;
+
+            struct TableEntry {
+                Name m_parentPoolName;
+                TableEntryVariant m_variant;
+            };
+
+            // Table settings
+            bool m_includeBuffers = true;
+            bool m_includeImages = true;
+            bool m_includeTransientAttachments = true;
+
+            ImGuiTextFilter m_nameFilter;
+
+            AZStd::vector<TableEntry> m_tableEntries;
             AZStd::vector<AZ::RHI::MemoryStatistics::Pool> m_savedPools;
             AZStd::vector<AZ::RHI::MemoryStatistics::Heap> m_savedHeaps;
         };

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -13,6 +13,13 @@
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/string/string.h>
 
+
+
+#include <AzCore/Name/Name.h>
+#include <Atom/RHI/MemoryStatisticsBus.h>
+#include <Atom/RHI/MemoryStatisticsBuilder.h>
+#include "../../../../../RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h"
+
 namespace AZ
 {
     namespace Render
@@ -250,6 +257,15 @@ namespace AZ
 
         };
 
+        class ImGuiGpuMemoryView
+        {
+        public:
+            void DrawGpuMemoryWindow(bool& draw);
+        private:
+            bool m_paused = true;
+            AZStd::vector<AZ::RHI::MemoryStatistics::Pool> m_savedPools;
+            AZStd::vector<AZ::RHI::MemoryStatistics::Heap> m_savedHeaps;
+        };
         class ImGuiGpuProfiler
         {
         public:
@@ -275,9 +291,11 @@ namespace AZ
 
             bool m_drawTimestampView = false;
             bool m_drawPipelineStatisticsView = false;
+            bool m_drawGpuMemoryView = false;
 
             ImGuiTimestampView m_timestampView;
             ImGuiPipelineStatisticsView m_pipelineStatisticsView;
+            ImGuiGpuMemoryView m_gpuMemoryView;
         };
     } //namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -259,6 +259,7 @@ namespace AZ
             // Draw the overall GPU memory profiling window.
             void DrawGpuMemoryWindow(bool& draw);
 
+        private:
             // Draw the heap usage pie chart
             void DrawPieChart(const AZ::RHI::MemoryStatistics::Heap& heap);
 
@@ -269,7 +270,7 @@ namespace AZ
 
             // Sort the table according to the appropriate column.
             void SortTable(ImGuiTableSortSpecs* sortSpecs);
-        private:
+
             struct TableRow {
                 Name m_parentPoolName;
                 Name m_bufImgName;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -1081,7 +1081,8 @@ namespace AZ
                 break;
             case (1): // Sort by buffer/image name
                 AZStd::sort(m_tableRows.begin(), m_tableRows.end(),
-                    [ascending](const TableRow& lhs, const TableRow& rhs){
+                    [ascending](const TableRow& lhs, const TableRow& rhs)
+                    {
                         const auto lhsName = lhs.m_bufImgName.GetStringView();
                         const auto rhsName = rhs.m_bufImgName.GetStringView();
                         return ascending ? lhsName < rhsName : lhsName > rhsName;
@@ -1089,7 +1090,8 @@ namespace AZ
                 break;
             case (2): // Sort by memory usage
                 AZStd::sort(m_tableRows.begin(), m_tableRows.end(),
-                    [ascending](const TableRow& lhs, const TableRow& rhs){
+                    [ascending](const TableRow& lhs, const TableRow& rhs)
+                    {
                         const float lhsSize = lhs.m_sizeInBytes;
                         const float rhsSize = rhs.m_sizeInBytes;
                         return ascending ? lhsSize < rhsSize : lhsSize > rhsSize;
@@ -1111,12 +1113,14 @@ namespace AZ
                 ImGui::TableNextColumn();
 
                 ImGuiTableSortSpecs* sortSpecs = ImGui::TableGetSortSpecs();
-                if (sortSpecs && sortSpecs->SpecsDirty){
+                if (sortSpecs && sortSpecs->SpecsDirty)
+                {
                     SortTable(sortSpecs);
                 }
 
                 // Draw each row in the table
-                for (const auto& tableRow : m_tableRows) {
+                for (const auto& tableRow : m_tableRows)
+                {
                     // Don't draw the row if none of the row's text fields pass the filter
                     if (!m_nameFilter.PassFilter(tableRow.m_parentPoolName.GetCStr())
                         && !m_nameFilter.PassFilter(tableRow.m_bufImgName.GetCStr())

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -94,7 +94,7 @@ namespace AZ
             inline static AZStd::string GetImageBindStrings(AZ::RHI::ImageBindFlags imageBindFlags)
             {
                 AZStd::string imageBindStrings;
-                for (auto& flag : AZ::RHI::ImageBindFlagsMembers)
+                for (const auto& flag : AZ::RHI::ImageBindFlagsMembers)
                 {
                     if (flag.m_value != AZ::RHI::ImageBindFlags::None && AZ::RHI::CheckBitsAll(imageBindFlags, flag.m_value))
                     {
@@ -108,7 +108,7 @@ namespace AZ
             inline static AZStd::string GetBufferBindStrings(AZ::RHI::BufferBindFlags bufferBindFlags)
             {
                 AZStd::string bufferBindStrings;
-                for (auto& flag : AZ::RHI::BufferBindFlagsMembers)
+                for (const auto& flag : AZ::RHI::BufferBindFlagsMembers)
                 {
                     if (flag.m_value != AZ::RHI::BufferBindFlags::None && AZ::RHI::CheckBitsAll(bufferBindFlags, flag.m_value))
                     {
@@ -1142,7 +1142,7 @@ namespace AZ
         {
             // Update the table according to the latest filters applied
             m_tableRows.clear();
-            for (auto& pool : m_savedPools)
+            for (const auto& pool : m_savedPools)
             {
                 Name poolName = pool.m_name.IsEmpty() ? Name("Unnamed pool") : pool.m_name;
 
@@ -1154,27 +1154,21 @@ namespace AZ
 
                 if (m_includeBuffers)
                 {
-                    for (auto& buf : pool.m_buffers)
+                    for (const auto& buf : pool.m_buffers)
                     {
-                        if (buf.m_name.IsEmpty())
-                        {
-                            buf.m_name = Name("Unnamed Buffer");
-                        }
+                        const Name bufName = buf.m_name.IsEmpty() ? Name("Unnamed Buffer") : buf.m_name;
                         const AZStd::string flags = GpuProfilerImGuiHelper::GetBufferBindStrings(buf.m_bindFlags);
-                        m_tableRows.push_back({ poolName, buf.m_name, buf.m_sizeInBytes, flags });
+                        m_tableRows.push_back({ poolName, bufName, buf.m_sizeInBytes, flags });
                     }
                 }
 
                 if (m_includeImages)
                 {
-                    for (auto& img : pool.m_images)
+                    for (const auto& img : pool.m_images)
                     {
-                        if (img.m_name.IsEmpty())
-                        {
-                            img.m_name = Name("Unnamed Image");
-                        }
+                        const Name imgName = img.m_name.IsEmpty() ? Name("Unnamed Image") : img.m_name;
                         const AZStd::string flags = GpuProfilerImGuiHelper::GetImageBindStrings(img.m_bindFlags);
-                        m_tableRows.push_back({ poolName, img.m_name, img.m_sizeInBytes, flags });
+                        m_tableRows.push_back({ poolName, imgName, img.m_sizeInBytes, flags });
                     }
                 }
             }

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -93,86 +93,28 @@ namespace AZ
 
             inline static AZStd::string GetImageBindStrings(AZ::RHI::ImageBindFlags imageBindFlags)
             {
-                // FIXME: any more elegant way to pull binding strings from the enum? Maybe through RTTI? ReflectSystemComponent.cpp L262
                 AZStd::string imageBindStrings;
-                if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::Color))
+                for (auto& flag : AZ::RHI::ImageBindFlagsMembers)
                 {
-                    imageBindStrings.append("Color,");
-                }
-                else if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::ShaderRead))
-                {
-                    imageBindStrings.append("ShaderRead,");
-                }
-                else if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::ShaderWrite))
-                {
-                    imageBindStrings.append("ShaderWrite,");
-                }
-                else if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::Depth))
-                {
-                    imageBindStrings.append("Depth,");
-                }
-                else if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::Stencil))
-                {
-                    imageBindStrings.append("Stencil,");
-                }
-                else if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::CopyRead))
-                {
-                    imageBindStrings.append("CopyRead,");
-                }
-                else if (AZ::RHI::CheckBitsAll(imageBindFlags, AZ::RHI::ImageBindFlags::CopyWrite))
-                {
-                    imageBindStrings.append("CopyWrite,");
+                    if (flag.m_value != AZ::RHI::ImageBindFlags::None && AZ::RHI::CheckBitsAll(imageBindFlags, flag.m_value))
+                    {
+                        imageBindStrings.append(flag.m_string);
+                        imageBindStrings.append(", ");
+                    }
                 }
                 return imageBindStrings;
             }
 
             inline static AZStd::string GetBufferBindStrings(AZ::RHI::BufferBindFlags bufferBindFlags)
             {
-                //FIXME as well, easier way to pull strings?
                 AZStd::string bufferBindStrings;
-                if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::InputAssembly))
+                for (auto& flag : AZ::RHI::BufferBindFlagsMembers)
                 {
-                    bufferBindStrings.append("InputAssembly,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::DynamicInputAssembly))
-                {
-                    bufferBindStrings.append("DynamicInputAssembly,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::Constant))
-                {
-                    bufferBindStrings.append("Constant,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::ShaderRead))
-                {
-                    bufferBindStrings.append("ShaderRead,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::ShaderWrite))
-                {
-                    bufferBindStrings.append("ShaderWrite,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::CopyRead))
-                {
-                    bufferBindStrings.append("CopyRead,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::CopyWrite))
-                {
-                    bufferBindStrings.append("CopyWrite,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::Predication))
-                {
-                    bufferBindStrings.append("Predication,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::RayTracingAccelerationStructure))
-                {
-                    bufferBindStrings.append("RayTracingAccelerationStructure,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::Indirect))
-                {
-                    bufferBindStrings.append("Indirect,");
-                }
-                else if (AZ::RHI::CheckBitsAll(bufferBindFlags, AZ::RHI::BufferBindFlags::RayTracingShaderTable))
-                {
-                    bufferBindStrings.append("RayTracingShaderTable,");
+                    if (flag.m_value != AZ::RHI::BufferBindFlags::None && AZ::RHI::CheckBitsAll(bufferBindFlags, flag.m_value))
+                    {
+                        bufferBindStrings.append(flag.m_string);
+                        bufferBindStrings.append(", ");
+                    }
                 }
                 return bufferBindStrings;
             }


### PR DESCRIPTION
### Please kick off a build [here](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-2242/), thanks!

This new widget visualizes the RHI's memory instrumentation compiled by GetMemoryStatistics(). While we do have a transient memory visualizer,  it does not handle non-transient buffers and images. This widget shows the overall heap usage on both the host and the device, along with specific pools and buffers/images. The table is sortable and searchable. There are also additional  filters that can be applied (show buffers, show images, show transient attachments). 


### Images
![image](https://user-images.githubusercontent.com/64656371/126017472-365eb70c-f641-4495-a910-f0ef9c8b7018.png)
![image](https://user-images.githubusercontent.com/64656371/126017874-fbb6e2b5-5dce-47f8-88f5-0d783f0e52a4.png)

Tested in Editor @ `d8077594cf7f747bb7e8411481491257b23e55b2` and ASV @ `c377756591d9d05d132047fc6ddfca4219bb7808` 

Completes #2165 