### PR TITLE
Switch RenderViewportWidget to tick with the renderer

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -20,6 +20,7 @@
 #include <AzFramework/Windowing/WindowBus.h>
 #include <AzCore/Component/TickBus.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
+#include <Atom/RPI.Public/ViewportContextBus.h>
 
 namespace AtomToolsFramework
 {
@@ -33,7 +34,7 @@ namespace AtomToolsFramework
         , public AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Handler
         , public AzFramework::WindowRequestBus::Handler
         , protected AzFramework::InputChannelEventListener
-        , protected AZ::TickBus::Handler
+        , protected AZ::RPI::ViewportContextIdNotificationBus::Handler
     {
     public:
         //! Creates a RenderViewportWidget.
@@ -88,6 +89,10 @@ namespace AtomToolsFramework
         //! camera controller input processing wholesale to avoid competing input messages.
         //! Input processing is enabled by default.
         void SetInputProcessingEnabled(bool enabled);
+        //! Gets the time stamp of the last frame rendered by this viewport.
+        AZ::ScriptTimePoint GetLastRenderTime() const;
+        //! Gets the time between the last two frames rendered by this viewport, in seconds.
+        AzFramework::FloatSeconds GetLastRenderDeltaTime() const;
 
         // AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler ...
         AzFramework::CameraState GetCameraState() override;
@@ -125,8 +130,8 @@ namespace AtomToolsFramework
         // AzFramework::InputChannelEventListener ...
         bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
 
-        // AZ::TickBus::Handler ...
-        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        // AZ::RPI::ViewportContextIdNotificationBus::Handler ...
+        void OnRenderTick() override;
 
         // QWidget ...
         void resizeEvent(QResizeEvent *event) override;
@@ -157,6 +162,8 @@ namespace AtomToolsFramework
         QElapsedTimer m_renderTimer;
         // The time of the last recorded tick event from the system tick bus.
         AZ::ScriptTimePoint m_time;
+        // The time between the last two recorded frames, in seconds.
+        AzFramework::FloatSeconds m_lastDeltaTime = AzFramework::FloatSeconds(0.f);
         // Whether the Viewport is currently hiding and capturing the cursor position.
         bool m_capturingCursor = false;
         // The viewport settings (e.g. grid snapping, grid size) for this viewport.

--- a/Gems/LyShine/Code/Editor/ViewportWidget.cpp
+++ b/Gems/LyShine/Code/Editor/ViewportWidget.cpp
@@ -245,14 +245,12 @@ ViewportWidget::ViewportWidget(EditorWindow* parent)
         });
 
     FontNotificationBus::Handler::BusConnect();
-    AZ::TickBus::Handler::BusConnect();
 }
 
 ViewportWidget::~ViewportWidget()
 {
     AzToolsFramework::EditorPickModeNotificationBus::Handler::BusDisconnect();
     FontNotificationBus::Handler::BusDisconnect();
-    AZ::TickBus::Handler::BusDisconnect();
 
     m_uiRenderer.reset();
 
@@ -487,7 +485,7 @@ void ViewportWidget::EnableCanvasRender()
     RefreshTick();
 }
 
-void ViewportWidget::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+void ViewportWidget::OnRenderTick()
 {
     if (!m_uiRenderer->IsReady() || !m_canvasRenderIsEnabled)
     {
@@ -501,8 +499,7 @@ void ViewportWidget::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoin
     const float dpiScale = QtHelpers::GetHighDpiScaleFactor(*this);
     ViewportIcon::SetDpiScaleFactor(dpiScale);
 
-    // Set up to render a frame to this viewport's window
-    GetViewportContext()->RenderTick();
+    const float deltaTime = GetLastRenderDeltaTime().count();
 
     UiEditorMode editorMode = m_editorWindow->GetEditorMode();
     if (editorMode == UiEditorMode::Edit)

--- a/Gems/LyShine/Code/Editor/ViewportWidget.h
+++ b/Gems/LyShine/Code/Editor/ViewportWidget.h
@@ -137,9 +137,9 @@ private: // member functions
     void OnFontTextureUpdated(IFFont* font) override;
     // ~FontNotifications
 
-    // AZ::TickBus::Handler
-    void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
-    // ~AZ::TickBus::Handler
+    // AZ::RPI::ViewportContextIdNotificationBus::Handler
+    void OnRenderTick() override;
+    // ~AZ::RPI::ViewportContextIdNotificationBus::Handler
 
     //! Render the viewport when in edit mode
     void RenderEditMode(float deltaTime);


### PR DESCRIPTION
Creating this primarily for discussion purposes, as I'd like to dig in a bit on our VSync implementation before moving forward.

This is an attempt to rectify some stuttering behavior in the camera interpolation of the modular camera controller when ticking with the tick bus instead - on my machine, this considerably reduces the jagged camera behavior seen at high `rpi_sync_interval` values. This also correspondingly switches the UI Editor to update at the default render cadence for a render pipeline instead of manually queueing frames from the tick bus - looks fine to me, but I'll defer to @michabr if that's desirable.

In poking around to look at this, I did notice that for DX12, we seem to synchronously wait for VSync in CommandQueueContext::End. This means that we're not capturing valid frame timings anywhere (or, perhaps more accurately, our vsync throttled frame timings in the CPU profiler are accurate), and I believe it also means we're presently starving the system tick bus, as render tick is on the main thread at the moment. This may warrant further investigation.

As an example, this is output from the CPU profiler when running with `rpi_sync_interval 4` - the `CommandQueueContext::End` time taken is directly proportional to the frame limiting set by the vsync CVar.
![image](https://user-images.githubusercontent.com/760096/126019310-88f32437-e022-47b6-97ca-d3916e73f69a.png)

Signed-off-by: nvsickle <nvsickle@amazon.com>