### PR TITLE
Remove container entity from all maps when entities are cleared from a prefab instance

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -237,7 +237,6 @@ namespace AzToolsFramework
 
             if (m_containerEntity)
             {
-                m_instanceEntityMapper->UnregisterEntity(m_containerEntity->GetId());
                 m_containerEntity.reset(aznew AZ::Entity());
                 RegisterEntity(m_containerEntity->GetId(), GenerateEntityAlias());
             }
@@ -265,6 +264,11 @@ namespace AzToolsFramework
 
         void Instance::ClearEntities()
         {
+            if (m_containerEntity)
+            {
+                m_instanceEntityMapper->UnregisterEntity(m_containerEntity->GetId());
+            }
+
             for (const auto&[entityAlias, entity] : m_entities)
             {
                 if (entity)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -168,7 +168,6 @@ namespace AzToolsFramework
 
             if (instance->m_containerEntity)
             {
-                instance->m_instanceEntityMapper->UnregisterEntity(instance->m_containerEntity->GetId());
                 instance->m_containerEntity.reset();
             }
 


### PR DESCRIPTION
**Problem:**
Previously in Instance::ClearEntities(), we cleared out m_templateToInstanceEntityIdMap and m_instanceToTemplateEntityIdMap , which removes the container entity of a prefab from those maps. But we did not remove container entity from m_instanceEntityMapper. This task was left for the caller of ClearEntities(). But if a call comes to m_templateToInstanceEntityIdMap  or m_instanceToTemplateEntityIdMap before the caller clears the container entity from m_instanceEntityMapper, that could lead to undefined behavior.

**What uncovered this:**
This occurs in a rare scenario where an entity destructor triggers some component calls wrapped in undo-redo calls, which eventually tries to update dirty entities. General prefab editor workflow testing didn't run into this so far. But it can happen when using certain components and certain hierarchies.

**Solution:**
To fix this, we now Clear all the maps at one place in Instance::ClearEntities(), there by ensuring that the container entity doesn't get updated because of being present in some maps but being absent in others.