### PR TITLE
CCryEditDoc: fix GetActivePathName and SaveLevel + style fixes.

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -95,7 +95,7 @@ namespace Internal
 {
     bool SaveLevel()
     {
-        if (!GetIEditor()->GetDocument()->DoSave(GetIEditor()->GetDocument()->GetActivePathName(), TRUE))
+        if (!GetIEditor()->GetDocument()->DoSave(GetIEditor()->GetDocument()->GetActivePathName(), true))
         {
             return false;
         }
@@ -108,21 +108,11 @@ namespace Internal
 // CCryEditDoc construction/destruction
 
 CCryEditDoc::CCryEditDoc()
-    : doc_validate_surface_types(0)
-    , m_modifiedModuleFlags(eModifiedNothing)
-    // It assumes loaded levels have already been exported. Can be a big fat lie, though.
-    // The right way would require us to save to the level folder the export status of the
-    // level.
-    , m_boLevelExported(true)
-    , m_modified(false)
-    , m_envProbeHeight(200.0f)
-    , m_envProbeSliceRelativePath("EngineAssets/Slices/DefaultLevelSetup.slice")
+    : m_modifiedModuleFlags(eModifiedNothing)
 {
     ////////////////////////////////////////////////////////////////////////
     // Set member variables to initial values
     ////////////////////////////////////////////////////////////////////////
-    m_bLoadFailed = false;
-    m_waterColor = QColor(0, 0, 255);
 
     m_fogTemplate = GetIEditor()->FindTemplate("Fog");
     m_environmentTemplate = GetIEditor()->FindTemplate("Environment");
@@ -136,7 +126,6 @@ CCryEditDoc::CCryEditDoc()
         m_environmentTemplate = XmlHelpers::CreateXmlNode("Environment");
     }
 
-    m_bDocumentReady = false;
     GetIEditor()->SetDocument(this);
     CLogFile::WriteLine("Document created");
     RegisterConsoleVariables();
@@ -195,7 +184,7 @@ CCryEditDoc::DocumentEditingMode CCryEditDoc::GetEditMode() const
 
 QString CCryEditDoc::GetActivePathName() const
 {
-    return DocumentEditingMode() == CCryEditDoc::DocumentEditingMode::SliceEdit ? GetSlicePathName() : GetLevelPathName();
+    return GetEditMode() == CCryEditDoc::DocumentEditingMode::SliceEdit ? GetSlicePathName() : GetLevelPathName();
 }
 
 QString CCryEditDoc::GetTitle() const
@@ -260,9 +249,9 @@ void CCryEditDoc::DeleteContents()
     GetIEditor()->FlushUndo();
 
     // Notify listeners.
-    for (std::list<IDocListener*>::iterator it = m_listeners.begin(); it != m_listeners.end(); ++it)
+    for (IDocListener* listener : m_listeners)
     {
-        (*it)->OnCloseDocument();
+        listener->OnCloseDocument();
     }
 
     GetIEditor()->ResetViews();
@@ -271,7 +260,7 @@ void CCryEditDoc::DeleteContents()
     GetIEditor()->GetObjectManager()->DeleteAllObjects();
 
     // Load scripts data
-    SetModifiedFlag(FALSE);
+    SetModifiedFlag(false);
     SetModifiedModules(eModifiedNothing);
     // Clear error reports if open.
     CErrorReportDialog::Clear();
@@ -313,7 +302,7 @@ void CCryEditDoc::Save(TDocMultiArchive& arrXmlAr)
     {
         CAutoDocNotReady autoDocNotReady;
 
-        if (arrXmlAr[DMAS_GENERAL] != NULL)
+        if (arrXmlAr[DMAS_GENERAL] != nullptr)
         {
             (*arrXmlAr[DMAS_GENERAL]).root = XmlHelpers::CreateXmlNode("Level");
             (*arrXmlAr[DMAS_GENERAL]).root->setAttr("WaterColor", m_waterColor);
@@ -458,7 +447,7 @@ void CCryEditDoc::Load(TDocMultiArchive& arrXmlAr, const QString& szFilename)
             //////////////////////////////////////////////////////////////////////////
             // Load water color.
             //////////////////////////////////////////////////////////////////////////
-                (*arrXmlAr[DMAS_GENERAL]).root->getAttr("WaterColor", m_waterColor);
+            (*arrXmlAr[DMAS_GENERAL]).root->getAttr("WaterColor", m_waterColor);
 
             //////////////////////////////////////////////////////////////////////////
             // Load View Settings
@@ -491,7 +480,7 @@ void CCryEditDoc::Load(TDocMultiArchive& arrXmlAr, const QString& szFilename)
 
                     if (!pObj)
                     {
-                        pObj = GetIEditor()->GetObjectManager()->NewObject("SequenceObject", 0, fullname);
+                        GetIEditor()->GetObjectManager()->NewObject("SequenceObject", nullptr, fullname);
                     }
                 }
             }
@@ -507,9 +496,9 @@ void CCryEditDoc::Load(TDocMultiArchive& arrXmlAr, const QString& szFilename)
             CAutoLogTime logtime("Post Load");
 
             // Notify listeners.
-            for (std::list<IDocListener*>::iterator it = m_listeners.begin(); it != m_listeners.end(); ++it)
+            for (IDocListener* listener : m_listeners)
             {
-                (*it)->OnLoadDocument();
+                listener->OnLoadDocument();
             }
         }
 
@@ -616,7 +605,7 @@ void CCryEditDoc::SerializeFogSettings(CXmlArchive& xmlAr)
     {
         CLogFile::WriteLine("Loading Fog settings...");
 
-        XmlNodeRef fog = xmlAr.root->findChild("Fog");
+        const XmlNodeRef fog = xmlAr.root->findChild("Fog");
 
         if (!fog)
         {
@@ -675,7 +664,7 @@ int CCryEditDoc::GetModifiedModule()
     return m_modifiedModuleFlags;
 }
 
-BOOL CCryEditDoc::CanCloseFrame()
+bool CCryEditDoc::CanCloseFrame()
 {
     // Ask the base class to ask for saving, which also includes the save
     // status of the plugins. Additionaly we query if all the plugins can exit
@@ -684,21 +673,21 @@ BOOL CCryEditDoc::CanCloseFrame()
     // are not serialized in the project file
     if (!SaveModified())
     {
-        return FALSE;
+        return false;
     }
 
     if (!GetIEditor()->GetPluginManager()->CanAllPluginsExitNow())
     {
-        return FALSE;
+        return false;
     }
 
     // If there is an export in process, exiting will corrupt it
     if (CGameExporter::GetCurrentExporter() != nullptr)
     {
-        return FALSE;
+        return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::SaveModified()
@@ -708,7 +697,9 @@ bool CCryEditDoc::SaveModified()
         return true;
     }
 
-    auto button = QMessageBox::question(AzToolsFramework::GetActiveWindow(), QString(), tr("Save changes to %1?").arg(GetTitle()), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+    auto button = QMessageBox::question(AzToolsFramework::GetActiveWindow(), QString(), tr("Save changes to %1?").arg(GetTitle()),
+        QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+
     switch (button)
     {
     case QMessageBox::Cancel:
@@ -742,7 +733,7 @@ bool CCryEditDoc::OnOpenDocument(const QString& lpszPathName)
     TOpenDocContext context;
     if (!BeforeOpenDocument(lpszPathName, context))
     {
-        return FALSE;
+        return false;
     }
     return DoOpenDocument(context);
 }
@@ -785,7 +776,7 @@ bool CCryEditDoc::BeforeOpenDocument(const QString& lpszPathName, TOpenDocContex
         context.absoluteLevelPath = absolutePath;
         context.absoluteSlicePath = "";
     }
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
@@ -822,7 +813,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
         if (!LoadXmlArchiveArray(arrXmlAr, levelFilePath, levelFolderAbsolutePath))
         {
             m_bLoadFailed = true;
-            return FALSE;
+            return false;
         }
     }
     if (!LoadLevel(arrXmlAr, context.absoluteLevelPath))
@@ -834,7 +825,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
 
     if (m_bLoadFailed)
     {
-        return FALSE;
+        return false;
     }
 
     // Load AZ entities for the editor.
@@ -855,7 +846,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
 
     if (m_bLoadFailed)
     {
-        return FALSE;
+        return false;
     }
 
     StartStreamingLoad();
@@ -872,7 +863,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
     // level.
     SetLevelExported(true);
 
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::OnNewDocument()
@@ -933,8 +924,7 @@ bool CCryEditDoc::OnSaveDocument(const QString& lpszPathName)
         }
 
         TSaveDocContext context;
-        if (shouldSaveLevel &&
-            BeforeSaveDocument(lpszPathName, context))
+        if (shouldSaveLevel && BeforeSaveDocument(lpszPathName,context))
         {
             DoSaveDocument(lpszPathName, context);
             saveSuccess = AfterSaveDocument(lpszPathName, context);
@@ -969,10 +959,10 @@ bool CCryEditDoc::BeforeSaveDocument(const QString& lpszPathName, TSaveDocContex
     bool bSaved(true);
 
     context.bSaved = bSaved;
-    return TRUE;
+    return true;
 }
 
-bool CCryEditDoc::HasLayerNameConflicts()
+bool CCryEditDoc::HasLayerNameConflicts() const
 {
     AZStd::vector<AZ::Entity*> editorEntities;
     AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
@@ -1004,35 +994,37 @@ bool CCryEditDoc::HasLayerNameConflicts()
 bool CCryEditDoc::DoSaveDocument(const QString& filename, TSaveDocContext& context)
 {
     bool& bSaved = context.bSaved;
-    if (bSaved)
+    if (!bSaved)
     {
-        // Paranoia - we shouldn't get this far into the save routine without a level loaded (empty levelPath)
-        // If nothing is loaded, we don't need to save anything
-        if (filename.isEmpty())
+        return bSaved;
+    }
+
+    // Paranoia - we shouldn't get this far into the save routine without a level loaded (empty levelPath)
+    // If nothing is loaded, we don't need to save anything
+    if (filename.isEmpty())
+    {
+        bSaved = false;
+    }
+    else
+    {
+        // Save Tag Point locations to file if auto save of tag points disabled
+        if (!gSettings.bAutoSaveTagPoints)
         {
-            bSaved = false;
+            CCryEditApp::instance()->SaveTagLocations();
+        }
+
+        QString normalizedPath = Path::ToUnixPath(filename);
+        if (IsSliceFile(normalizedPath))
+        {
+            bSaved = SaveSlice(normalizedPath);
         }
         else
         {
-            // Save Tag Point locations to file if auto save of tag points disabled
-            if (!gSettings.bAutoSaveTagPoints)
-            {
-                CCryEditApp::instance()->SaveTagLocations();
-            }
-
-            QString normalizedPath = Path::ToUnixPath(filename);
-            if (IsSliceFile(normalizedPath))
-            {
-                bSaved = SaveSlice(normalizedPath);
-            }
-            else
-            {
-                bSaved = SaveLevel(normalizedPath);
-            }
-
-            // Changes filename for this document.
-            SetPathName(normalizedPath);
+            bSaved = SaveLevel(normalizedPath);
         }
+
+        // Changes filename for this document.
+        SetPathName(normalizedPath);
     }
 
     return bSaved;
@@ -1040,7 +1032,7 @@ bool CCryEditDoc::DoSaveDocument(const QString& filename, TSaveDocContext& conte
 
 bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName, TSaveDocContext& context, bool bShowPrompt)
 {
-    bool& bSaved = context.bSaved;
+    bool bSaved = context.bSaved;
 
     GetIEditor()->Notify(eNotify_OnEndSceneSave);
 
@@ -1055,7 +1047,7 @@ bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName
     else
     {
         CLogFile::WriteLine("$3Document successfully saved");
-        SetModifiedFlag(FALSE);
+        SetModifiedFlag(false);
         SetModifiedModules(eModifiedNothing);
         MainWindow::instance()->ResetAutoSaveTimers();
     }
@@ -1067,8 +1059,7 @@ bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName
 static void GetUserSettingsFile(const QString& levelFolder, QString& userSettings)
 {
     const char* pUserName = GetISystem()->GetUserName();
-    QString fileName;
-    fileName = QStringLiteral("%1_usersettings.editor_xml").arg(pUserName);
+    QString fileName = QStringLiteral("%1_usersettings.editor_xml").arg(pUserName);
     userSettings = Path::Make(levelFolder, fileName);
 }
 
@@ -1182,9 +1173,9 @@ bool CCryEditDoc::SaveLevel(const QString& filename)
                 }
 
                 QString oldFilePath = QDir(oldLevelFolder).absoluteFilePath(sourceName);
-                QString newFilePath = QDir(newLevelFolder).absoluteFilePath(sourceName);
+                QString newFilePath = QDir(newLevelFolder).absoluteFilePath(destName);
                 CFileUtil::CopyFile(oldFilePath, newFilePath);
-            } while (findHandle = pIPak->FindNext(findHandle));
+            } while ((findHandle = pIPak->FindNext(findHandle)));
             pIPak->FindClose(findHandle);
         }
 
@@ -1506,7 +1497,7 @@ bool CCryEditDoc::LoadEntitiesFromLevel(const QString& levelPakFile)
             {
                 AZStd::vector<char> fileBuffer;
                 fileBuffer.resize(entitiesFile.GetLength());
-                if (fileBuffer.size() > 0)
+                if (!fileBuffer.empty())
                 {
                     if (fileBuffer.size() == entitiesFile.ReadRaw(fileBuffer.begin(), fileBuffer.size()))
                     {
@@ -1547,7 +1538,8 @@ bool CCryEditDoc::LoadEntitiesFromLevel(const QString& levelPakFile)
         AZ_Assert(fileIO, "No File IO implementation available");
 
         AZ::IO::HandleType fileHandle;
-        AZ::IO::Result openResult = fileIO->Open(levelPakFile.toUtf8().data(), AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeBinary, fileHandle);
+        AZ::IO::Result openResult = fileIO->Open(levelPakFile.toUtf8().data(), AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeBinary,
+            fileHandle);
         if (openResult)
         {
             AZ::IO::FileIOStream stream(fileHandle, AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeBinary, false);
@@ -1608,7 +1600,7 @@ bool CCryEditDoc::LoadLevel(TDocMultiArchive& arrXmlAr, const QString& absoluteC
     // Set level path directly *after* DeleteContents(), since that will unload the previous level and clear the level path.
     GetIEditor()->GetGameEngine()->SetLevelPath(folderPath);
 
-    SetModifiedFlag(TRUE);  // dirty during de-serialize
+    SetModifiedFlag(true);  // dirty during de-serialize
     SetModifiedModules(eModifiedAll);
     Load(arrXmlAr, absoluteCryFilePath);
 
@@ -1618,7 +1610,7 @@ bool CCryEditDoc::LoadLevel(TDocMultiArchive& arrXmlAr, const QString& absoluteC
     {
         pIPak->GetResourceList(AZ::IO::IArchive::RFOM_NextLevel)->Clear();
     }
-    SetModifiedFlag(FALSE); // start off with unmodified
+    SetModifiedFlag(false); // start off with unmodified
     SetModifiedModules(eModifiedNothing);
     SetDocumentReady(true);
     GetIEditor()->Notify(eNotify_OnEndLoad);
@@ -1768,7 +1760,7 @@ namespace {
                     ft.creationTime = handle.m_fileDesc.tCreate;
                     outputFolders.push_back(ft);
                 }
-            } while (handle = gEnv->pCryPak->FindNext(handle));
+            } while ((handle = gEnv->pCryPak->FindNext(handle)));
 
             gEnv->pCryPak->FindClose(handle);
         }
@@ -1910,7 +1902,7 @@ void CCryEditDoc::UnregisterListener(IDocListener* listener)
     m_listeners.remove(listener);
 }
 
-void CCryEditDoc::LogLoadTime(int time)
+void CCryEditDoc::LogLoadTime(int time) const
 {
     QString appFilePath = QDir::toNativeSeparators(QCoreApplication::applicationFilePath());
     QString exePath = Path::GetPath(appFilePath);
@@ -1922,21 +1914,18 @@ void CCryEditDoc::LogLoadTime(int time)
     SetFileAttributes(filename.toUtf8().data(), FILE_ATTRIBUTE_ARCHIVE);
 #endif
 
-    FILE* file = nullptr;
-    azfopen(&file, filename.toUtf8().data(), "at");
-
-    if (file)
+    QFile file(filename);
+    if (!file.open(QFile::Append | QFile::Text))
     {
-        char version[50];
-        GetIEditor()->GetFileVersion().ToShortString(version, AZ_ARRAY_SIZE(version));
-
-        QString text;
-
-        time = time / 1000;
-        text = QStringLiteral("\n[%1] Level %2 loaded in %3 seconds").arg(version, level).arg(time);
-        fwrite(text.toUtf8().data(), text.toUtf8().length(), 1, file);
-        fclose(file);
+        return;
     }
+
+    char version[50];
+    GetIEditor()->GetFileVersion().ToShortString(version);
+
+    time = time / 1000;
+    QString text = QStringLiteral("\n[%1] Level %2 loaded in %3 seconds").arg(version, level).arg(time);
+    file.write(text.toUtf8());
 }
 
 void CCryEditDoc::SetDocumentReady(bool bReady)
@@ -1944,7 +1933,7 @@ void CCryEditDoc::SetDocumentReady(bool bReady)
     m_bDocumentReady = bReady;
 }
 
-void CCryEditDoc::GetMemoryUsage(ICrySizer* pSizer)
+void CCryEditDoc::GetMemoryUsage(ICrySizer* pSizer) const
 {
     {
         SIZER_COMPONENT_NAME(pSizer, "UndoManager(estimate)");
@@ -1997,7 +1986,7 @@ void CCryEditDoc::OnStartLevelResourceList()
     gEnv->pCryPak->GetResourceList(AZ::IO::IArchive::RFOM_Level)->Clear();
 }
 
-BOOL CCryEditDoc::DoFileSave()
+bool CCryEditDoc::DoFileSave()
 {
     if (GetEditMode() == CCryEditDoc::DocumentEditingMode::LevelEdit)
     {
@@ -2015,15 +2004,15 @@ BOOL CCryEditDoc::DoFileSave()
                     QString newLevelPath = filename.left(filename.lastIndexOf('/') + 1);
                     GetIEditor()->GetDocument()->SetPathName(filename);
                     GetIEditor()->GetGameEngine()->SetLevelPath(newLevelPath);
-                    return TRUE;
+                    return true;
                 }
             }
-            return FALSE;
+            return false;
         }
     }
     if (!IsDocumentReady())
     {
-        return FALSE;
+        return false;
     }
 
     return Internal::SaveLevel();
@@ -2068,11 +2057,11 @@ void CCryEditDoc::InitEmptyLevel(int /*resolution*/, int /*unitSize*/, bool /*bU
     {
         // Notify listeners.
         std::list<IDocListener*> listeners = m_listeners;
-        std::list<IDocListener*>::iterator it, next;
-        for (it = listeners.begin(); it != listeners.end(); it = next)
+        std::list<IDocListener*>::iterator next;
+        for (std::list<IDocListener*>::iterator it = listeners.begin(); it != listeners.end(); it = next)
         {
             next = it;
-            next++;
+            ++next;
             (*it)->OnNewDocument();
         }
     }
@@ -2081,7 +2070,7 @@ void CCryEditDoc::InitEmptyLevel(int /*resolution*/, int /*unitSize*/, bool /*bU
     GetISystem()->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_LEVEL_LOAD_END, 0, 0);
 
     GetIEditor()->Notify(eNotify_OnEndNewScene);
-    SetModifiedFlag(FALSE);
+    SetModifiedFlag(false);
     SetLevelExported(false);
     SetModifiedModules(eModifiedNothing);
 
@@ -2095,13 +2084,13 @@ void CCryEditDoc::CreateDefaultLevelAssets([[maybe_unused]] int resolution, [[ma
 
 void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
 {
-    if (pVar == NULL)
+    if (pVar == nullptr)
     {
         return;
     }
 
     XmlNodeRef node = GetEnvironmentTemplate();
-    if (node == NULL)
+    if (node == nullptr)
     {
         return;
     }
@@ -2119,7 +2108,7 @@ void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
 
     XmlNodeRef groupNode = node->getChild(nGroup);
 
-    if (groupNode == NULL)
+    if (groupNode == nullptr)
     {
         return;
     }
@@ -2130,36 +2119,36 @@ void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
     }
 
     XmlNodeRef childNode = groupNode->getChild(nChild);
-    if (childNode == NULL)
+    if (childNode == nullptr)
     {
         return;
     }
+
+    QString childValue;
 
     if (pVar->GetDataType() == IVariable::DT_COLOR)
     {
         Vec3 value;
         pVar->Get(value);
-        QString buff;
+
         QColor gammaColor = ColorLinearToGamma(ColorF(value.x, value.y, value.z));
-        buff = QStringLiteral("%1,%2,%3").arg(gammaColor.red()).arg(gammaColor.green()).arg(gammaColor.blue());
-        childNode->setAttr("value", buff.toUtf8().data());
+        childValue = QStringLiteral("%1,%2,%3").arg(gammaColor.red()).arg(gammaColor.green()).arg(gammaColor.blue());
     }
     else
     {
-        QString value;
-        pVar->Get(value);
-        childNode->setAttr("value", value.toUtf8().data());
+        pVar->Get(childValue);
     }
+    childNode->setAttr("value", childValue.toUtf8().data());
 }
 
-QString CCryEditDoc::GetCryIndexPath(const LPCTSTR levelFilePath)
+QString CCryEditDoc::GetCryIndexPath(const LPCTSTR levelFilePath) const
 {
     QString levelPath = Path::GetPath(levelFilePath);
     QString levelName = Path::GetFileName(levelFilePath);
     return Path::AddPathSlash(levelPath + levelName + "_editor");
 }
 
-BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath)
+bool CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath)
 {
     auto pIPak = GetIEditor()->GetSystem()->GetIPak();
 
@@ -2168,7 +2157,7 @@ BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString&
         CXmlArchive* pXmlAr = new CXmlArchive();
         if (!pXmlAr)
         {
-            return FALSE;
+            return false;
         }
 
         CXmlArchive& xmlAr = *pXmlAr;
@@ -2179,22 +2168,21 @@ BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString&
         bool openLevelPakFileSuccess = pIPak->OpenPack(levelPath.toUtf8().data(), absoluteLevelPath.toUtf8().data());
         if (!openLevelPakFileSuccess)
         {
-            return FALSE;
+            return false;
         }
 
         CPakFile pakFile;
-        bool loadFromPakSuccess;
-        loadFromPakSuccess = xmlAr.LoadFromPak(levelPath, pakFile);
+        bool loadFromPakSuccess = xmlAr.LoadFromPak(levelPath, pakFile);
         pIPak->ClosePack(absoluteLevelPath.toUtf8().data());
         if (!loadFromPakSuccess)
         {
-            return FALSE;
+            return false;
         }
 
         FillXmlArArray(arrXmlAr, &xmlAr);
     }
 
-    return TRUE;
+    return true;
 }
 
 void CCryEditDoc::ReleaseXmlArchiveArray(TDocMultiArchive& arrXmlAr)

--- a/Code/Editor/CryEditDoc.h
+++ b/Code/Editor/CryEditDoc.h
@@ -45,7 +45,7 @@ public: // Create from serialization only
 
     Q_INVOKABLE CCryEditDoc();
 
-    virtual ~CCryEditDoc();
+    ~CCryEditDoc() override;
 
     bool IsModified() const;
     void SetModifiedFlag(bool modified);
@@ -81,7 +81,7 @@ public: // Create from serialization only
 
     bool DoSave(const QString& pathName, bool replace);
     SANDBOX_API bool Save();
-    virtual BOOL DoFileSave();
+    virtual bool DoFileSave();
     bool SaveModified();
 
     virtual bool BackupBeforeSave(bool bForce = false);
@@ -90,7 +90,7 @@ public: // Create from serialization only
     // ClassWizard generated virtual function overrides
     virtual bool OnOpenDocument(const QString& lpszPathName);
 
-    const bool IsLevelLoadFailed() const { return m_bLoadFailed; }
+    bool IsLevelLoadFailed() const { return m_bLoadFailed; }
 
     //! Marks this document as having errors.
     void SetHasErrors() { m_hasErrors = true; }
@@ -101,7 +101,7 @@ public: // Create from serialization only
     bool IsLevelExported() const;
     void SetLevelExported(bool boExported = true);
 
-    BOOL CanCloseFrame();
+    bool CanCloseFrame();
 
     enum class FetchPolicy
     {
@@ -120,7 +120,7 @@ public: // Create from serialization only
 
     CClouds* GetClouds() { return m_pClouds; }
     void SetWaterColor(const QColor& col) { m_waterColor = col; }
-    QColor GetWaterColor() { return m_waterColor; }
+    QColor GetWaterColor() const { return m_waterColor; }
     XmlNodeRef& GetFogTemplate() { return m_fogTemplate; }
     XmlNodeRef& GetEnvironmentTemplate() { return m_environmentTemplate; }
     void OnEnvironmentPropertyChanged(IVariable* pVar);
@@ -128,7 +128,7 @@ public: // Create from serialization only
     void RegisterListener(IDocListener* listener);
     void UnregisterListener(IDocListener* listener);
 
-    void GetMemoryUsage(ICrySizer* pSizer);
+    void GetMemoryUsage(ICrySizer* pSizer) const;
 
     static bool IsBackupOrTempLevelSubdirectory(const QString& folderName);
 protected:
@@ -143,7 +143,7 @@ protected:
     };
     bool BeforeOpenDocument(const QString& lpszPathName, TOpenDocContext& context);
     bool DoOpenDocument(TOpenDocContext& context);
-    virtual BOOL LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath);
+    virtual bool LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath);
     virtual void ReleaseXmlArchiveArray(TDocMultiArchive& arrXmlAr);
 
     virtual void Load(TDocMultiArchive& arrXmlAr, const QString& szFilename);
@@ -160,14 +160,14 @@ protected:
     void SerializeFogSettings(CXmlArchive& xmlAr);
     virtual void SerializeViewSettings(CXmlArchive& xmlAr);
     void SerializeNameSelection(CXmlArchive& xmlAr);
-    void LogLoadTime(int time);
+    void LogLoadTime(int time) const;
 
     struct TSaveDocContext
     {
         bool bSaved;
     };
     bool BeforeSaveDocument(const QString& lpszPathName, TSaveDocContext& context);
-    bool HasLayerNameConflicts();
+    bool HasLayerNameConflicts() const;
     bool DoSaveDocument(const QString& lpszPathName, TSaveDocContext& context);
     bool AfterSaveDocument(const QString& lpszPathName, TSaveDocContext& context, bool bShowPrompt = true);
 
@@ -179,7 +179,7 @@ protected:
     void OnStartLevelResourceList();
     static void OnValidateSurfaceTypesChanged(ICVar*);
 
-    QString GetCryIndexPath(const LPCTSTR levelFilePath);
+    QString GetCryIndexPath(LPCTSTR levelFilePath) const;
 
     //////////////////////////////////////////////////////////////////////////
     // SliceEditorEntityOwnershipServiceNotificationBus::Handler
@@ -187,24 +187,26 @@ protected:
     void OnSliceInstantiationFailed(const AZ::Data::AssetId& sliceAssetId, const AzFramework::SliceInstantiationTicket& /*ticket*/) override;
     //////////////////////////////////////////////////////////////////////////
 
-    bool m_bLoadFailed;
-    QColor m_waterColor;
+    bool m_bLoadFailed = false;
+    QColor m_waterColor  = QColor(0, 0, 255);
     XmlNodeRef m_fogTemplate;
     XmlNodeRef m_environmentTemplate;
     CClouds* m_pClouds;
     std::list<IDocListener*> m_listeners;
-    bool m_bDocumentReady;
-    ICVar* doc_validate_surface_types;
+    bool m_bDocumentReady = false;
+    ICVar* doc_validate_surface_types = nullptr;
     int m_modifiedModuleFlags;
-    bool m_boLevelExported;
-    bool m_modified;
+    // On construction, it assumes loaded levels have already been exported. Can be a big fat lie, though.
+    // The right way would require us to save to the level folder the export status of the level.
+    bool m_boLevelExported = true;
+    bool m_modified = false;
     QString m_pathName;
     QString m_slicePathName;
     QString m_title;
     AZ::Data::AssetId m_envProbeSliceAssetId;
     float m_terrainSize;
-    const char* m_envProbeSliceRelativePath;
-    const float m_envProbeHeight;
+    const char* m_envProbeSliceRelativePath = "EngineAssets/Slices/DefaultLevelSetup.slice";
+    const float m_envProbeHeight = 200.0f;
     bool m_hasErrors = false; ///< This is used to warn the user that they may lose work when they go to save.
 };
 


### PR DESCRIPTION
`GetActivePathName` was using default - constructed enum `DocumentEditingMode()` - likely incorrect

`SaveLevel` was not using `destName` when constructing `newFilePath`

Code changes:
* LogLoadTime is simplified by using QFile
* reduce nesting in DoSaveDocument by using early return.
* marked a few eligible methods as `const`
* Simplified `OnEnvironmentPropertyChanged` a bit

Style changes:
* use standard c++ `bool,true,false` instead of old 'C'
`BOOL,TRUE,FALSE`
* use `nullptr` instead of `NULL`
* moved member variable initialization from constructor to the class body
initializers.
* use range-based for when it doesn't impact semantics.
* add `(``)` around while expression that uses assignment to appease
clang

Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>