### PR TITLE
Add missing `*.hxx` pattern

### DIFF
--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -65,6 +65,7 @@ function(ly_setup_target OUTPUT_CONFIGURED_TARGET ALIAS_TARGET_NAME absolute_tar
                         PATTERN *.h
                         PATTERN *.hpp
                         PATTERN *.inl
+                        PATTERN *.hxx
                 )
             endif()
         endforeach()


### PR DESCRIPTION
Now `.hxx` header files can be copied to the install directory when building O3DE with the `INSTALL` target.