### PR TITLE
Reduce inclusion overhead a little bit

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/Event.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Event.h
@@ -9,11 +9,12 @@
 #pragma once
 
 #include <AzCore/base.h>
+#include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/stack.h>
-#include <AzCore/std/function/function_fwd.h>
+#include <AzCore/std/function/function_template.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/Math/Frustum.h
+++ b/Code/Framework/AzCore/AzCore/Math/Frustum.h
@@ -14,6 +14,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Plane.h>
 #include <AzCore/Math/SimdMath.h>
+#include <AzCore/std/containers/array.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/Math/Transform.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Transform.cpp
@@ -13,9 +13,32 @@
 #include <AzCore/Math/Obb.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/MathScriptHelpers.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {
+    namespace 
+    {
+        class TransformSerializer
+            : public SerializeContext::IDataSerializer
+        {
+        public:
+            // number of floats in the serialized representation, 4 for rotation, 1 for scale and 3 for translation
+            static constexpr int NumFloats = 8;
+
+            // number of floats in version 1, which used 4 for rotation, 3 for scale and 3 for translation
+            static constexpr int NumFloatsVersion1 = 10;
+
+            // number of floats in version 0, which stored a 3x4 matrix
+            static constexpr int NumFloatsVersion0 = 12;
+
+            size_t Save(const void* classPtr, IO::GenericStream& stream, bool isDataBigEndian) override;
+            size_t DataToText(IO::GenericStream& in, IO::GenericStream& out, bool isDataBigEndian) override;
+            size_t TextToData(const char* text, unsigned int textVersion, IO::GenericStream& stream, bool isDataBigEndian) override;
+            bool Load(void* classPtr, IO::GenericStream& stream, unsigned int version, bool isDataBigEndian) override;
+            bool CompareValueData(const void* lhs, const void* rhs) override;
+        };
+    }
     namespace Internal
     {
         void TransformDefaultConstructor(Transform* thisPtr)

--- a/Code/Framework/AzCore/AzCore/Math/Transform.h
+++ b/Code/Framework/AzCore/AzCore/Math/Transform.h
@@ -13,30 +13,9 @@
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/MathUtils.h>
-#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {
-    class TransformSerializer
-        : public SerializeContext::IDataSerializer
-    {
-    public:
-        // number of floats in the serialized representation, 4 for rotation, 1 for scale and 3 for translation
-        static constexpr int NumFloats = 8;
-
-        // number of floats in version 1, which used 4 for rotation, 3 for scale and 3 for translation
-        static constexpr int NumFloatsVersion1 = 10;
-
-        // number of floats in version 0, which stored a 3x4 matrix
-        static constexpr int NumFloatsVersion0 = 12;
-
-        size_t Save(const void* classPtr, IO::GenericStream& stream, bool isDataBigEndian) override;
-        size_t DataToText(IO::GenericStream& in, IO::GenericStream& out, bool isDataBigEndian) override;
-        size_t TextToData(const char* text, unsigned int textVersion, IO::GenericStream& stream, bool isDataBigEndian) override;
-        bool Load(void* classPtr, IO::GenericStream& stream, unsigned int version, bool isDataBigEndian) override;
-        bool CompareValueData(const void* lhs, const void* rhs) override;
-    };
-
     //! Limits for transform scale values.
     //! The scale should not be zero to avoid problems with inverting.
     //! @{

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/Math/Internal/MathTypes.h>
 #include <AzCore/RTTI/TypeInfo.h>
-#include <AzCore/std/algorithm.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Memory/Memory.h>

--- a/Code/Framework/AzFramework/AzFramework/UnitTest/TestDebugDisplayRequests.h
+++ b/Code/Framework/AzFramework/AzFramework/UnitTest/TestDebugDisplayRequests.h
@@ -7,6 +7,8 @@
  */
 
 #pragma once
+
+#include <AzCore/std/containers/stack.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 
 namespace UnitTest

--- a/Code/Framework/AzFramework/AzFramework/Visibility/OctreeSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OctreeSystemComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AzFramework/Visibility/OctreeSystemComponent.h>
 #include <AzCore/Math/ShapeIntersection.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AzFramework
 {

--- a/Code/Framework/AzFramework/Platform/Common/Default/AzFramework/Input/User/LocalUserId_Default.h
+++ b/Code/Framework/AzFramework/Platform/Common/Default/AzFramework/Input/User/LocalUserId_Default.h
@@ -9,7 +9,12 @@
 #pragma once
 
 #include <AzCore/base.h>
-#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/string/string.h>
+
+namespace AZ
+{
+    class ReflectContext;
+} // namespace Az
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace AzFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorSpace.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorSpace.h
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <AzCore/Math/Transform.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestComponent.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Prefab/PrefabTestComponent.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace UnitTest
 {

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/CoordinateSystemConverter.h
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/CoordinateSystemConverter.h
@@ -11,6 +11,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Quaternion.h>
+#include <AzCore/RTTI/RTTI.h>
 #include <SceneAPI/SceneCore/SceneCoreConfiguration.h>
 
 namespace AZ::SceneAPI

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "DebugOutput.h"
+#include <AzCore/std/optional.h>
 
 namespace AZ::SceneAPI::Utilities
 {

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.h
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.h
@@ -11,6 +11,8 @@
 #include <SceneAPI/SceneCore/SceneCoreConfiguration.h>
 #include <SceneAPI/SceneCore/DataTypes/MatrixType.h>
 #include <SceneAPI/SceneCore/Utilities/HashHelper.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/std/containers/vector.h>
 #include <cinttypes>
 
 namespace AZ::SceneAPI::Utilities

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/DrawItem.h
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <Atom/RHI.Reflect/Handle.h>
 #include <Atom/RHI.Reflect/Limits.h>
 #include <Atom/RHI/StreamBufferView.h>
 #include <Atom/RHI/IndexBufferView.h>
@@ -23,6 +22,10 @@ namespace AZ
         class ShaderResourceGroup;
         struct Scissor;
         struct Viewport;
+        struct DefaultNamespaceType;
+        // Forward declaration to
+        template <typename T , typename NamespaceType>
+        struct Handle;
 
         struct DrawLinear
         {
@@ -149,13 +152,13 @@ namespace AZ
         };
 
         using DrawItemSortKey = int64_t;
-                
+
         // A filter associate to a DrawItem which can be used to filter the DrawItem when submitting to command list
-        using DrawFilterTag = Handle<uint8_t>;
+        using DrawFilterTag = Handle<uint8_t, DefaultNamespaceType>;
         using DrawFilterMask = uint32_t; // AZStd::bitset's impelmentation is too expensive.
         constexpr uint32_t DrawFilterMaskDefaultValue = uint32_t(-1);  // Default all bit to 1.
         static_assert(sizeof(DrawFilterMask) * 8 >= Limits::Pipeline::DrawFilterTagCountMax, "DrawFilterMask doesn't have enough bits for maximum tag count");
-     
+
         struct DrawItemProperties
         {
             DrawItemProperties() = default;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/GradientWeightModifier/GradientWeightModifierController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/GradientWeightModifier/GradientWeightModifierController.cpp
@@ -6,7 +6,9 @@
  *
  */
 
+
 #include <PostProcess/GradientWeightModifier/GradientWeightModifierController.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/RadiusWeightModifier/RadiusWeightModifierComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/RadiusWeightModifier/RadiusWeightModifierComponentController.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <PostProcess/RadiusWeightModifier/RadiusWeightModifierComponentController.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AZ
 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ShapeWeightModifier/ShapeWeightModifierComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ShapeWeightModifier/ShapeWeightModifierComponentController.cpp
@@ -8,6 +8,7 @@
 
 #include <PostProcess/ShapeWeightModifier/ShapeWeightModifierComponentController.h>
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Scripting/EntityReferenceComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Scripting/EntityReferenceComponentController.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Scripting/EntityReferenceComponentController.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {

--- a/Gems/AudioSystem/Code/Platform/Common/Default/AudioSystemGemSystemComponent_default.cpp
+++ b/Gems/AudioSystem/Code/Platform/Common/Default/AudioSystemGemSystemComponent_default.cpp
@@ -9,6 +9,7 @@
 #include <AudioAllocators.h>
 #include <AudioLogger.h>
 #include <SoundCVars.h>
+#include <AzCore/Memory/OSAllocator.h>
 
 namespace Audio::Platform
 {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.h
@@ -10,6 +10,7 @@
 
 #include "EMotionFXConfig.h"
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/string/string.h>
 #include "BaseObject.h"
 #include "VertexAttributeLayer.h"

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYAssetExplorer.h
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYAssetExplorer.h
@@ -14,6 +14,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/std/containers/map.h>
 
 namespace ImGui
 {

--- a/Gems/LmbrCentral/Code/Source/Asset/AssetSystemDebugComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Asset/AssetSystemDebugComponent.cpp
@@ -12,6 +12,7 @@
 #include "AzCore/Asset/AssetManager.h"
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/Jobs/JobFunction.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace LmbrCentral
 {

--- a/Gems/LyShine/Code/Source/UiFlipbookAnimationComponent.cpp
+++ b/Gems/LyShine/Code/Source/UiFlipbookAnimationComponent.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 #include <LyShine/Bus/UiGameEntityContextBus.h>
 #include <LyShine/Bus/UiElementBus.h>
@@ -131,6 +132,29 @@ public:
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+static bool UiFlipbookAnimationComponentVersionConverter(AZ::SerializeContext& context,
+    AZ::SerializeContext::DataElementNode& classElement)
+{
+    // conversion from version 2:
+    // - Rename "frame delay" to "framerate"
+    // - Set "framerate unit" to seconds (default moving forward is FPS, but we use seconds for legacy compatibility)
+    if (classElement.GetVersion() <= 2)
+    {
+        if (!ConvertFrameDelayToFramerate(context, classElement))
+        {
+            return false;
+        }
+
+        if (!ConvertFramerateUnitToSeconds(context, classElement))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void UiFlipbookAnimationComponent::Reflect(AZ::ReflectContext* context)
 {
@@ -138,7 +162,7 @@ void UiFlipbookAnimationComponent::Reflect(AZ::ReflectContext* context)
     if (serializeContext)
     {
         serializeContext->Class<UiFlipbookAnimationComponent, AZ::Component>()
-            ->Version(3, &VersionConverter)
+            ->Version(3, &UiFlipbookAnimationComponentVersionConverter)
             ->Field("Start Frame", &UiFlipbookAnimationComponent::m_startFrame)
             ->Field("End Frame", &UiFlipbookAnimationComponent::m_endFrame)
             ->Field("Loop Start Frame", &UiFlipbookAnimationComponent::m_loopStartFrame)
@@ -266,29 +290,6 @@ void UiFlipbookAnimationComponent::Reflect(AZ::ReflectContext* context)
             ->Enum<(int)UiFlipbookAnimationInterface::FramerateUnits::SecondsPerFrame>("eUiFlipbookAnimationFramerateUnits_SecondsPerFrame")
             ;
     }
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-bool UiFlipbookAnimationComponent::VersionConverter(AZ::SerializeContext& context,
-    AZ::SerializeContext::DataElementNode& classElement)
-{
-    // conversion from version 2:
-    // - Rename "frame delay" to "framerate"
-    // - Set "framerate unit" to seconds (default moving forward is FPS, but we use seconds for legacy compatibility)
-    if (classElement.GetVersion() <= 2)
-    {
-        if (!ConvertFrameDelayToFramerate(context, classElement))
-        {
-            return false;
-        }
-
-        if (!ConvertFramerateUnitToSeconds(context, classElement))
-        {
-            return false;
-        }
-    }
-
-    return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Source/UiFlipbookAnimationComponent.h
+++ b/Gems/LyShine/Code/Source/UiFlipbookAnimationComponent.h
@@ -107,9 +107,6 @@ protected: // static functions
     static void Reflect(AZ::ReflectContext* context);
     //////////////////////////////////////////////////////////////////////////
 
-    static bool VersionConverter(AZ::SerializeContext& context,
-        AZ::SerializeContext::DataElementNode& classElement);
-
 protected: // functions
 
     //! Returns a string representation of the indices used to index sprite-sheet types.

--- a/Gems/PhysX/Code/Source/System/PhysXJointInterface.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXJointInterface.cpp
@@ -8,6 +8,7 @@
 
 #include <System/PhysXJointInterface.h>
 #include <AzFramework/Physics/Configuration/JointConfiguration.h>
+#include <AzCore/std/optional.h>
 
 #include <PhysX/Joint/Configuration/PhysXJointConfiguration.h>
 #include <PhysX/Debug/PhysXDebugConfiguration.h>


### PR DESCRIPTION
This is based on non-unity Clang Build Analyzer [run](https://pastebin.com/raw/gagdrq9k)

The main reductions are:

AzCore/Serialization/SerializeContext.h/ and AzCore/RTTI/BehaviorContext.h no longer included through LocalUserId_Default.h
AzCore/Serialization/SerializeContext.h no longer included from Transform.h

Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>