### PR TITLE
Viewport UI focus/shortut fix

### DIFF
--- a/Code/Editor/ShortcutDispatcher.cpp
+++ b/Code/Editor/ShortcutDispatcher.cpp
@@ -346,7 +346,6 @@ bool ShortcutDispatcher::eventFilter(QObject* obj, QEvent* ev)
 
     case QEvent::Shortcut:
         return shortcutFilter(obj, static_cast<QShortcutEvent*>(ev));
-        break;
 
     case QEvent::MouseButtonPress:
         if (!s_lastFocus || !IsAContainerForB(qobject_cast<QWidget*>(obj), s_lastFocus))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ButtonGroup.cpp
@@ -45,11 +45,11 @@ namespace AzToolsFramework::ViewportUi::Internal
 
         if (name.empty())
         {
-            m_buttons.insert({buttonId, AZStd::make_unique<Button>(icon, buttonId)});
+            m_buttons.insert({ buttonId, AZStd::make_unique<Button>(icon, buttonId) });
         }
         else
         {
-            m_buttons.insert({buttonId, AZStd::make_unique<Button>(icon, name, buttonId)});
+            m_buttons.insert({ buttonId, AZStd::make_unique<Button>(icon, name, buttonId) });
         }
         return buttonId;
     }
@@ -73,7 +73,8 @@ namespace AzToolsFramework::ViewportUi::Internal
         return buttons;
     }
 
-    void ButtonGroup::ConnectEventHandler(AZ::Event<ButtonId>::Handler& handler) {
+    void ButtonGroup::ConnectEventHandler(AZ::Event<ButtonId>::Handler& handler)
+    {
         handler.Connect(m_buttonTriggeredEvent);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiCluster.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiCluster.cpp
@@ -15,13 +15,12 @@ namespace AzToolsFramework::ViewportUi::Internal
 {
     ViewportUiCluster::ViewportUiCluster(AZStd::shared_ptr<ButtonGroup> buttonGroup)
         : QToolBar(nullptr)
-        , m_buttonGroup(buttonGroup)
+        , m_buttonGroup(AZStd::move(buttonGroup))
     {
         setOrientation(Qt::Orientation::Vertical);
         setStyleSheet("background: black;");
 
-        const AZStd::vector<Button*> buttons = buttonGroup->GetButtons();
-        for (auto button : buttons)
+        for (auto button : m_buttonGroup->GetButtons())
         {
             RegisterButton(button);
         }
@@ -35,10 +34,12 @@ namespace AzToolsFramework::ViewportUi::Internal
 
         AddClusterAction(
             action,
-            [this, button]() {
+            [this, button]()
+            {
                 m_buttonGroup->PressButton(button->m_buttonId);
             },
-            [button](QAction* action) {
+            [button](QAction* action)
+            {
                 action->setChecked(button->m_state == Button::State::Selected);
             });
 
@@ -47,8 +48,7 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     void ViewportUiCluster::RemoveButton(ButtonId buttonId)
     {
-        if (auto actionEntry = m_buttonActionMap.find(buttonId);
-            actionEntry != m_buttonActionMap.end())
+        if (auto actionEntry = m_buttonActionMap.find(buttonId); actionEntry != m_buttonActionMap.end())
         {
             auto action = actionEntry->second;
             RemoveClusterAction(action);
@@ -57,8 +57,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     }
 
     void ViewportUiCluster::AddClusterAction(
-        QAction* action, const AZStd::function<void()>& callback,
-        const AZStd::function<void(QAction*)>& updateCallback)
+        QAction* action, const AZStd::function<void()>& callback, const AZStd::function<void(QAction*)>& updateCallback)
     {
         if (!action)
         {
@@ -81,10 +80,12 @@ namespace AzToolsFramework::ViewportUi::Internal
         }
 
         // register the action
-        m_widgetCallbacks.AddWidget(action, [updateCallback](QPointer<QObject> object)
-        {
-            updateCallback(static_cast<QAction*>(object.data()));
-        });
+        m_widgetCallbacks.AddWidget(
+            action,
+            [updateCallback](QPointer<QObject> object)
+            {
+                updateCallback(static_cast<QAction*>(object.data()));
+            });
     }
 
     void ViewportUiCluster::RemoveClusterAction(QAction* action)
@@ -112,10 +113,13 @@ namespace AzToolsFramework::ViewportUi::Internal
         if (m_lockedButtonId.has_value() && isLocked)
         {
             // find the button to extract the old icon (without overlay)
-            auto findLocked = [this](const Button* button) { return (button->m_buttonId == m_lockedButtonId); };
+            auto findLocked = [this](const Button* button)
+            {
+                return (button->m_buttonId == m_lockedButtonId);
+            };
             if (auto lockedButtonIt = AZStd::find_if(buttons.begin(), buttons.end(), findLocked); lockedButtonIt != buttons.end())
             {
-                // get the action corresponding to the lockedButtonId 
+                // get the action corresponding to the lockedButtonId
                 if (auto actionEntry = m_buttonActionMap.find(m_lockedButtonId.value()); actionEntry != m_buttonActionMap.end())
                 {
                     // remove the overlay
@@ -125,14 +129,18 @@ namespace AzToolsFramework::ViewportUi::Internal
             }
         }
 
-        auto found = [buttonId](Button* button) { return (button->m_buttonId == buttonId); };
+        auto found = [buttonId](Button* button)
+        {
+            return (button->m_buttonId == buttonId);
+        };
+
         if (auto buttonIt = AZStd::find_if(buttons.begin(), buttons.end(), found); buttonIt != buttons.end())
         {
             QIcon newIcon;
 
             if (isLocked)
             {
-                // overlay the locked icon ontop of the button's icon
+                // overlay the locked icon on top of the button's icon
                 QPixmap comboPixmap(24, 24);
                 comboPixmap.fill(Qt::transparent);
                 QPixmap firstImage(QString((*buttonIt)->m_icon.c_str()));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiCluster.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiCluster.h
@@ -12,16 +12,16 @@
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzToolsFramework/ViewportUi/Button.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiWidgetCallbacks.h>
-#include <QToolBar>
+
 #include <QPainter>
+#include <QToolBar>
 
 namespace AzToolsFramework::ViewportUi::Internal
 {
     class ButtonGroup;
 
     //! Helper class to make clusters (toolbars) for display in Viewport UI.
-    class ViewportUiCluster
-        : public QToolBar
+    class ViewportUiCluster : public QToolBar
     {
         Q_OBJECT
 
@@ -45,8 +45,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     private:
         //! Adds an action to the Viewport UI Cluster.
         void AddClusterAction(
-            QAction* action, const AZStd::function<void()>& callback = {},
-            const AZStd::function<void(QAction*)>& updateCallback = {});
+            QAction* action, const AZStd::function<void()>& callback = {}, const AZStd::function<void(QAction*)>& updateCallback = {});
         //! Removes an action from the Viewport UI Cluster.
         void RemoveClusterAction(QAction* action);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -370,7 +370,6 @@ namespace AzToolsFramework::ViewportUi::Internal
     void ViewportUiDisplay::PrepareWidgetForViewportUi(QPointer<QWidget> widget)
     {
         widget->setAttribute(Qt::WA_ShowWithoutActivating);
-        // widget->setWindowFlags(Qt::WindowDoesNotAcceptFocus);
         widget->setParent(&m_uiOverlay);
         widget->setStyleSheet("border: none;");
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -12,8 +12,8 @@
 #include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
-#include <AzToolsFramework/ViewportUi/ViewportUiDisplay.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiCluster.h>
+#include <AzToolsFramework/ViewportUi/ViewportUiDisplay.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiSwitcher.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiTextField.h>
 #include <QWidget>
@@ -35,9 +35,9 @@ namespace AzToolsFramework::ViewportUi::Internal
         }
     }
 
-    static Qt::Alignment GetQtAlignment(Alignment align)
+    static Qt::Alignment GetQtAlignment(const Alignment alignment)
     {
-        switch (align)
+        switch (alignment)
         {
         case Alignment::TopRight:
             return Qt::AlignTop | Qt::AlignRight;
@@ -53,7 +53,7 @@ namespace AzToolsFramework::ViewportUi::Internal
             return Qt::AlignBottom;
         }
 
-        AZ_Assert(false, "ViewportUI", "Unhandled ViewportUI Alignment %d", static_cast<int>(align));
+        AZ_Assert(false, "ViewportUI", "Unhandled ViewportUI Alignment %d", static_cast<int>(alignment));
         return Qt::AlignTop;
     }
 
@@ -72,7 +72,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         UnparentWidgets(m_viewportUiElements);
     }
 
-    void ViewportUiDisplay::AddCluster(AZStd::shared_ptr<ButtonGroup> buttonGroup, const Alignment align)
+    void ViewportUiDisplay::AddCluster(AZStd::shared_ptr<ButtonGroup> buttonGroup, const Alignment alignment)
     {
         if (!buttonGroup.get())
         {
@@ -82,11 +82,10 @@ namespace AzToolsFramework::ViewportUi::Internal
         auto viewportUiCluster = AZStd::make_shared<ViewportUiCluster>(buttonGroup);
         auto id = AddViewportUiElement(viewportUiCluster);
         buttonGroup->SetViewportUiElementId(id);
-        PositionViewportUiElementAnchored(id, GetQtAlignment(align));
+        PositionViewportUiElementAnchored(id, GetQtAlignment(alignment));
     }
 
-    void ViewportUiDisplay::AddClusterButton(
-        const ViewportUiElementId clusterId, Button* button)
+    void ViewportUiDisplay::AddClusterButton(const ViewportUiElementId clusterId, Button* button)
     {
         if (auto viewportUiCluster = qobject_cast<ViewportUiCluster*>(GetViewportUiElement(clusterId).get()))
         {
@@ -102,7 +101,8 @@ namespace AzToolsFramework::ViewportUi::Internal
         }
     }
 
-    void ViewportUiDisplay::SetClusterButtonTooltip(const ViewportUiElementId clusterId, const ButtonId buttonId, const AZStd::string& tooltip)
+    void ViewportUiDisplay::SetClusterButtonTooltip(
+        const ViewportUiElementId clusterId, const ButtonId buttonId, const AZStd::string& tooltip)
     {
         if (auto viewportUiCluster = qobject_cast<ViewportUiCluster*>(GetViewportUiElement(clusterId).get()))
         {
@@ -126,7 +126,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         }
     }
 
-    void ViewportUiDisplay::AddSwitcher(AZStd::shared_ptr<ButtonGroup> buttonGroup, const Alignment align)
+    void ViewportUiDisplay::AddSwitcher(AZStd::shared_ptr<ButtonGroup> buttonGroup, const Alignment alignment)
     {
         if (!buttonGroup.get())
         {
@@ -136,7 +136,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         auto viewportUiSwitcher = AZStd::make_shared<ViewportUiSwitcher>(buttonGroup);
         auto id = AddViewportUiElement(viewportUiSwitcher);
         buttonGroup->SetViewportUiElementId(id);
-        PositionViewportUiElementAnchored(id, GetQtAlignment(align));
+        PositionViewportUiElementAnchored(id, GetQtAlignment(alignment));
     }
 
     void ViewportUiDisplay::AddSwitcherButton(const ViewportUiElementId clusterId, Button* button)
@@ -199,11 +199,12 @@ namespace AzToolsFramework::ViewportUi::Internal
             const ViewportUiElementInfo& elementInfo = element.second;
             if (!elementInfo.m_anchored)
             {
-                const auto screenPoint = AzFramework::WorldToScreen(
-                    elementInfo.m_worldPosition, AzToolsFramework::GetCameraState(m_viewportId));
+                const auto screenPoint =
+                    AzFramework::WorldToScreen(elementInfo.m_worldPosition, AzToolsFramework::GetCameraState(m_viewportId));
                 elementInfo.m_widget->move(screenPoint.m_x, screenPoint.m_y);
             }
         }
+
         PositionUiOverlayOverRenderViewport();
     }
 
@@ -217,7 +218,6 @@ namespace AzToolsFramework::ViewportUi::Internal
         ViewportUiElementId newId = ViewportUiElementId(++m_numViewportElements);
         ViewportUiElementInfo newElement{ widget, newId, true };
         m_viewportUiElements.insert({ newId, newElement });
-        SetUiOverlayContents(widget.get());
         return newId;
     }
 
@@ -234,8 +234,11 @@ namespace AzToolsFramework::ViewportUi::Internal
     ViewportUiElementId ViewportUiDisplay::GetViewportUiElementId(QPointer<QWidget> widget)
     {
         if (auto element = AZStd::find_if(
-            m_viewportUiElements.begin(), m_viewportUiElements.end(),
-            [widget](const auto& it) { return it.second.m_widget.get() == widget; });
+                m_viewportUiElements.begin(), m_viewportUiElements.end(),
+                [widget](const auto& it)
+                {
+                    return it.second.m_widget.get() == widget;
+                });
             element != m_viewportUiElements.end())
         {
             return element->second.m_viewportUiElementId;
@@ -246,7 +249,8 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     void ViewportUiDisplay::RemoveViewportUiElement(ViewportUiElementId elementId)
     {
-        AZ_Assert(elementId != AzToolsFramework::ViewportUi::InvalidViewportUiElementId,
+        AZ_Assert(
+            elementId != AzToolsFramework::ViewportUi::InvalidViewportUiElementId,
             "Tried to remove a Viewport UI element using an invalid or removed ViewportUiElementId.");
 
         auto viewportUiMapElement = m_viewportUiElements.find(elementId);
@@ -265,8 +269,7 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     void ViewportUiDisplay::ShowViewportUiElement(ViewportUiElementId elementId)
     {
-        if (ViewportUiElementInfo element = GetViewportUiElementInfo(elementId);
-            element.m_widget)
+        if (ViewportUiElementInfo element = GetViewportUiElementInfo(elementId); element.m_widget)
         {
             element.m_widget->setVisible(true);
         }
@@ -274,8 +277,7 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     void ViewportUiDisplay::HideViewportUiElement(ViewportUiElementId elementId)
     {
-        if (ViewportUiElementInfo element = GetViewportUiElementInfo(elementId);
-            element.m_widget)
+        if (ViewportUiElementInfo element = GetViewportUiElementInfo(elementId); element.m_widget)
         {
             element.m_widget->setVisible(false);
         }
@@ -283,8 +285,7 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     bool ViewportUiDisplay::IsViewportUiElementVisible(ViewportUiElementId elementId)
     {
-        if (ViewportUiElementInfo element = GetViewportUiElementInfo(elementId);
-            element.m_widget)
+        if (ViewportUiElementInfo element = GetViewportUiElementInfo(elementId); element.m_widget)
         {
             return element.IsValid() && element.m_widget->isVisible();
         }
@@ -294,12 +295,12 @@ namespace AzToolsFramework::ViewportUi::Internal
     void ViewportUiDisplay::CreateComponentModeBorder(const AZStd::string& borderTitle)
     {
         AZStd::string styleSheet = AZStd::string::format(
-            "border: %dpx solid %s; border-top: %dpx solid %s;", HighlightBorderSize,
-            HighlightBorderColor, TopHighlightBorderSize, HighlightBorderColor);
+            "border: %dpx solid %s; border-top: %dpx solid %s;", HighlightBorderSize, HighlightBorderColor, TopHighlightBorderSize,
+            HighlightBorderColor);
         m_uiOverlay.setStyleSheet(styleSheet.c_str());
-        m_uiOverlayLayout.setContentsMargins(HighlightBorderSize + ViewportUiOverlayMargin,
-            TopHighlightBorderSize + ViewportUiOverlayMargin, HighlightBorderSize + ViewportUiOverlayMargin,
-            HighlightBorderSize + ViewportUiOverlayMargin);
+        m_uiOverlayLayout.setContentsMargins(
+            HighlightBorderSize + ViewportUiOverlayMargin, TopHighlightBorderSize + ViewportUiOverlayMargin,
+            HighlightBorderSize + ViewportUiOverlayMargin, HighlightBorderSize + ViewportUiOverlayMargin);
         m_componentModeBorderText.setVisible(true);
         m_componentModeBorderText.setText(borderTitle.c_str());
     }
@@ -315,8 +316,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     {
         auto viewportUiMapElement = m_viewportUiElements.find(elementId);
 
-        if (viewportUiMapElement != m_viewportUiElements.end() &&
-            viewportUiMapElement->second.m_widget)
+        if (viewportUiMapElement != m_viewportUiElements.end() && viewportUiMapElement->second.m_widget)
         {
             viewportUiMapElement->second.m_anchored = false;
             viewportUiMapElement->second.m_worldPosition = pos;
@@ -329,48 +329,25 @@ namespace AzToolsFramework::ViewportUi::Internal
     {
         auto viewportUiMapElement = m_viewportUiElements.find(elementId);
 
-        if (viewportUiMapElement != m_viewportUiElements.end() &&
-            viewportUiMapElement->second.m_widget)
+        if (viewportUiMapElement != m_viewportUiElements.end() && viewportUiMapElement->second.m_widget)
         {
             viewportUiMapElement->second.m_anchored = true;
             SetUiOverlayContentsAnchored(viewportUiMapElement->second.m_widget.get(), alignment);
         }
     }
 
-    void ViewportUiDisplay::AddMaximumSizeViewportUiElement(QPointer<QWidget> widget)
-    {
-        if (widget)
-        {
-            return;
-        }
-
-        if (m_fullScreenWidget)
-        {
-            AZ_Warning(
-                "ViewportUi", false,
-                "Attaching a maximum size element when one already exists. Removing the previously attached element.");
-            RemoveViewportUiElement(GetViewportUiElementId(m_fullScreenWidget));
-        }
-
-        widget->setAttribute(Qt::WA_ShowWithoutActivating);
-        widget->setParent(&m_uiOverlay);
-        m_fullScreenWidget = widget;
-        m_fullScreenLayout.addWidget(m_fullScreenWidget, 0, 0, 1, 1);
-        m_renderOverlay->setFocus();
-    }
-
     // disables system background for widget and gives a transparent background
-    static void ConfigureWidgetForViewportUi(QPointer<QWidget> widget)
+    static void ConfigureWindowForViewportUi(QPointer<QMainWindow> mainWindow)
     {
-        // no background for the widget else each set of buttons/textfields/etc would have a black box around them
-        SetTransparentBackground(widget);
-        widget->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+        // no background for the widget else each set of buttons/text-fields/etc would have a black box around them
+        SetTransparentBackground(mainWindow);
+        mainWindow->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
     }
 
     void ViewportUiDisplay::InitializeUiOverlay()
     {
         m_uiMainWindow.setObjectName(m_uiMainWindow.windowTitle());
-        ConfigureWidgetForViewportUi(&m_uiMainWindow);
+        ConfigureWindowForViewportUi(&m_uiMainWindow);
         m_uiMainWindow.setVisible(false);
 
         m_uiOverlay.setObjectName(m_uiOverlay.windowTitle());
@@ -383,8 +360,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         m_fullScreenLayout.addLayout(&m_uiOverlayLayout, 0, 0, 1, 1);
 
         // format the label which will appear on top of the highlight border
-        AZStd::string styleSheet = AZStd::string::format(
-            "background-color: %s; border: none;", HighlightBorderColor);
+        AZStd::string styleSheet = AZStd::string::format("background-color: %s; border: none;", HighlightBorderColor);
         m_componentModeBorderText.setStyleSheet(styleSheet.c_str());
         m_componentModeBorderText.setFixedHeight(TopHighlightBorderSize);
         m_componentModeBorderText.setVisible(false);
@@ -394,6 +370,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     void ViewportUiDisplay::PrepareWidgetForViewportUi(QPointer<QWidget> widget)
     {
         widget->setAttribute(Qt::WA_ShowWithoutActivating);
+        // widget->setWindowFlags(Qt::WindowDoesNotAcceptFocus);
         widget->setParent(&m_uiOverlay);
         widget->setStyleSheet("border: none;");
     }
@@ -409,7 +386,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         m_renderOverlay->setFocus();
     }
 
-    void ViewportUiDisplay::SetUiOverlayContentsAnchored(QPointer<QWidget> widget, Qt::Alignment alignment)
+    void ViewportUiDisplay::SetUiOverlayContentsAnchored(QPointer<QWidget> widget, const Qt::Alignment alignment)
     {
         if (!widget)
         {
@@ -430,13 +407,8 @@ namespace AzToolsFramework::ViewportUi::Internal
             // get the border region by taking the entire region and subtracting the non-border area
             region += m_uiOverlay.rect();
             region -= QRect(
-                QPoint(
-                    m_uiOverlay.rect().left() + HighlightBorderSize,
-                    m_uiOverlay.rect().top() + TopHighlightBorderSize),
-                QPoint(
-                    m_uiOverlay.rect().right() - HighlightBorderSize,
-                    m_uiOverlay.rect().bottom() - HighlightBorderSize)
-            );
+                QPoint(m_uiOverlay.rect().left() + HighlightBorderSize, m_uiOverlay.rect().top() + TopHighlightBorderSize),
+                QPoint(m_uiOverlay.rect().right() - HighlightBorderSize, m_uiOverlay.rect().bottom() - HighlightBorderSize));
         }
 
         // add all children widget regions
@@ -466,8 +438,7 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     ViewportUiElementInfo ViewportUiDisplay::GetViewportUiElementInfo(const ViewportUiElementId elementId)
     {
-        if (auto element = m_viewportUiElements.find(elementId);
-            element != m_viewportUiElements.end())
+        if (auto element = m_viewportUiElements.find(elementId); element != m_viewportUiElements.end())
         {
             return element->second;
         }
@@ -489,7 +460,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         return &m_uiOverlayLayout;
     }
 
-    void SetTransparentBackground(QWidget * widget)
+    void SetTransparentBackground(QWidget* widget)
     {
         widget->setAttribute(Qt::WA_TranslucentBackground);
         widget->setAutoFillBackground(false);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.h
@@ -11,11 +11,12 @@
 #include <AzToolsFramework/ViewportUi/Button.h>
 #include <AzToolsFramework/ViewportUi/ButtonGroup.h>
 #include <AzToolsFramework/ViewportUi/TextField.h>
-#include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiDisplayLayout.h>
+#include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>
+
+#include <QLabel>
 #include <QMainWindow>
 #include <QPointer>
-#include <QLabel>
 
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
 #include <QGridLayout>
@@ -28,10 +29,10 @@ namespace AzToolsFramework::ViewportUi::Internal
     //! Used to track info for each widget in the Viewport UI.
     struct ViewportUiElementInfo
     {
-        AZStd::shared_ptr<QWidget> m_widget; //<! Reference to the widget.
-        ViewportUiElementId m_viewportUiElementId; //<! Corresponding ViewportUiElementId of the widget.
-        bool m_anchored = true; //<! Whether the widget is anchored to one position or moves with camera/entity.
-        AZ::Vector3 m_worldPosition; //<! If not anchored, use this to project widget position to screen space.
+        AZStd::shared_ptr<QWidget> m_widget; //!< Reference to the widget.
+        ViewportUiElementId m_viewportUiElementId; //!< Corresponding ViewportUiElementId of the widget.
+        bool m_anchored = true; //!< Whether the widget is anchored to one position or moves with camera/entity.
+        AZ::Vector3 m_worldPosition; //!< If not anchored, use this to project widget position to screen space.
 
         bool IsValid() const
         {
@@ -52,14 +53,14 @@ namespace AzToolsFramework::ViewportUi::Internal
         ViewportUiDisplay(QWidget* parent, QWidget* renderOverlay);
         ~ViewportUiDisplay();
 
-        void AddCluster(AZStd::shared_ptr<ButtonGroup> buttonGroup, Alignment align);
+        void AddCluster(AZStd::shared_ptr<ButtonGroup> buttonGroup, Alignment alignment);
         void AddClusterButton(ViewportUiElementId clusterId, Button* button);
         void SetClusterButtonLocked(ViewportUiElementId clusterId, ButtonId buttonId, bool isLocked);
         void SetClusterButtonTooltip(ViewportUiElementId clusterId, ButtonId buttonId, const AZStd::string& tooltip);
         void RemoveClusterButton(ViewportUiElementId clusterId, ButtonId buttonId);
         void UpdateCluster(const ViewportUiElementId clusterId);
 
-        void AddSwitcher(AZStd::shared_ptr<ButtonGroup> buttonGroup, Alignment align);
+        void AddSwitcher(AZStd::shared_ptr<ButtonGroup> buttonGroup, Alignment alignment);
         void AddSwitcherButton(ViewportUiElementId switcherId, Button* button);
         void RemoveSwitcherButton(ViewportUiElementId switcherId, ButtonId buttonId);
         void UpdateSwitcher(ViewportUiElementId switcherId);
@@ -90,13 +91,12 @@ namespace AzToolsFramework::ViewportUi::Internal
 
         void CreateComponentModeBorder(const AZStd::string& borderTitle);
         void RemoveComponentModeBorder();
-        
+
     private:
         void PrepareWidgetForViewportUi(QPointer<QWidget> widget);
 
         ViewportUiElementId AddViewportUiElement(AZStd::shared_ptr<QWidget> widget);
         ViewportUiElementId GetViewportUiElementId(QPointer<QWidget> widget);
-        void AddMaximumSizeViewportUiElement(QPointer<QWidget> widget);
 
         void PositionViewportUiElementFromWorldSpace(ViewportUiElementId elementId, const AZ::Vector3& pos);
         void PositionViewportUiElementAnchored(ViewportUiElementId elementId, const Qt::Alignment alignment);
@@ -109,16 +109,16 @@ namespace AzToolsFramework::ViewportUi::Internal
 
         ViewportUiElementInfo GetViewportUiElementInfo(const ViewportUiElementId elementId);
 
-        QMainWindow m_uiMainWindow; //<! The window which contains the UI Overlay.
-        QWidget m_uiOverlay; //<! The UI Overlay which displays Viewport UI Elements.
-        QGridLayout m_fullScreenLayout; //<! The layout which extends across the full screen.
-        ViewportUiDisplayLayout m_uiOverlayLayout; //<! The layout used for optionally anchoring Viewport UI Elements.
-        QLabel m_componentModeBorderText; //<! The text used for the Component Mode border.
+        QMainWindow m_uiMainWindow; //!< The window which contains the UI Overlay.
+        QWidget m_uiOverlay; //!< The UI Overlay which displays Viewport UI Elements.
+        QGridLayout m_fullScreenLayout; //!< The layout which extends across the full screen.
+        ViewportUiDisplayLayout m_uiOverlayLayout; //!< The layout used for optionally anchoring Viewport UI Elements.
+        QLabel m_componentModeBorderText; //!< The text used for the Component Mode border.
 
         QWidget* m_renderOverlay;
-        QPointer<QWidget> m_fullScreenWidget; //<! Reference to the widget attached to m_fullScreenLayout if any.
-        int m_viewportId;
-        int64_t m_numViewportElements = 0; 
+        QPointer<QWidget> m_fullScreenWidget; //!< Reference to the widget attached to m_fullScreenLayout if any.
+        int64_t m_numViewportElements = 0;
+        int m_viewportId = 0;
 
         ViewportUiElementIdInfoLookup m_viewportUiElements;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiWidgetCallbacks.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiWidgetCallbacks.h
@@ -29,7 +29,7 @@ namespace AzToolsFramework::ViewportUi::Internal
         //! Must call ViewportUiWidgetCallbacks::Update to execute the callback.
         void RegisterUpdateCallback(QPointer<QObject> widget, const AZStd::function<void(QPointer<QObject>)>& callback);
         void Update();
-        const AZStd::vector<QPointer<QObject>> GetWidgets() const { return m_widgets; }
+        const AZStd::vector<QPointer<QObject>>& GetWidgets() const { return m_widgets; }
 
     protected:
         //! A map of all update callbacks and their respective widgets.


### PR DESCRIPTION
This is a fix for focus being removed from the main viewport widget when interacting with viewport ui elements. This would result in viewport shortcuts not firing (e.g. R to reset rotation/scale etc...) after having clicked a viewport ui element, it would be necessary to click back in the viewport again to fix things (an incredibly irritating bug).

The crux of the fix is in `ViewportUiDisplay.cpp` - we now pass `Qt::WindowDoesNotAcceptFocus` to the `windowFlags` in `ConfigureWindowForViewportUi` (see below)

```
static void ConfigureWindowForViewportUi(QPointer<QMainWindow> mainWindow)
{
    // no background for the widget else each set of buttons/text-fields/etc would have a black box around them
    SetTransparentBackground(mainWindow);
    mainWindow->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
}
```

I'm going to also look into writing an integration test (we already have a few for Viewport Ui) to see if we can reproduce and verify the fix. This investigation took a while though so I'd like to get this posted as-is for now. There's also a few other minor fixes and some formatting updates (using `clang-format`).