### PR TITLE
Added .vs/ (Visual Studio cache when using CMake builds instead of so…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .idea/
+.vs/
 .vscode/
 __pycache__
 AssetProcessorTemp/**
 [Bb]uild/**
+[Oo]ut/**
 [Cc]ache/
 /install/
 Editor/EditorEventLog.xml


### PR DESCRIPTION
…lutions) and out/. (Visual Studio uses this as default build directory when opening a folder with a CMakeLists.txt and immediately creates it) to .gitignore.

Signed-off-by: L4stR1t3s <frederik.decaster@gmail.com>