### PR TITLE
Fixed cmake Python so it correctly reinstalls a local python package if its setup.py changes

### DIFF
--- a/cmake/LYPython.cmake
+++ b/cmake/LYPython.cmake
@@ -143,7 +143,10 @@ function(ly_pip_install_local_package_editable package_folder_path pip_package_n
     # we only ever need to do this once per runtime install, since its a link
     # not an actual install:
 
-    if(EXISTS ${stamp_file})
+    # If setup.py changes we must reinstall the package in case its dependencies changed
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${package_folder_path}/setup.py)
+
+    if(EXISTS ${stamp_file} AND ${stamp_file} IS_NEWER_THAN ${package_folder_path}/setup.py)
         ly_package_is_newer_than(${LY_PYTHON_PACKAGE_NAME} ${stamp_file} package_is_newer)
         if (NOT package_is_newer)
             # no need to run the command again, as the package is older than the stamp file


### PR DESCRIPTION
This was something that I found out when updating ly test tools setup.py.
For adding a new pytest plugin, its required to edit the setup.py file, however python needs to re-install it as it has changed.
With this change now if setup.py is updated, and then build/configure o3de, it will re-install it

Signed-off-by: Garcia Ruiz