### PR TITLE
Remove unneeded fields from Entity and EditorTransform JsonSerializers

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
@@ -90,15 +90,6 @@ namespace AZ
         }
 
         {
-            JSR::ResultCode dependencyReadyLoadResult =
-                ContinueLoadingFromJsonObjectField(&entityInstance->m_isDependencyReady,
-                    azrtti_typeid<decltype(entityInstance->m_isDependencyReady)>(),
-                    inputValue, "IsDependencyReady", context);
-
-            result.Combine(dependencyReadyLoadResult);
-        }
-
-        {
             JSR::ResultCode runtimeActiveLoadResult =
                 ContinueLoadingFromJsonObjectField(&entityInstance->m_isRuntimeActiveByDefault,
                     azrtti_typeid<decltype(entityInstance->m_isRuntimeActiveByDefault)>(),
@@ -182,20 +173,6 @@ namespace AZ
                     azrtti_typeid<decltype(componentMap)>(), context);
 
             result.Combine(resultComponents);
-        }
-
-        {
-            AZ::ScopedContextPath subPathDependencyReady(context, "m_isDependencyReady");
-            const bool* dependencyReady = &entityInstance->m_isDependencyReady;
-            const bool* dependencyReadyDefault =
-                defaultEntityInstance ? &defaultEntityInstance->m_isDependencyReady : nullptr;
-
-            JSR::ResultCode resultDependencyReady =
-                ContinueStoringToJsonObjectField(outputValue, "IsDependencyReady",
-                    dependencyReady, dependencyReadyDefault,
-                    azrtti_typeid<decltype(entityInstance->m_isDependencyReady)>(), context);
-
-            result.Combine(resultDependencyReady);
         }
 
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponentSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponentSerializer.cpp
@@ -68,14 +68,6 @@ namespace AzToolsFramework
             }
 
             {
-                JSR::ResultCode netSyncEnabledLoadResult = ContinueLoadingFromJsonObjectField(
-                    &transformComponentInstance->m_netSyncEnabled, azrtti_typeid<decltype(transformComponentInstance->m_netSyncEnabled)>(),
-                    inputValue, "Sync Enabled", context);
-
-                result.Combine(netSyncEnabledLoadResult);
-            }
-
-            {
                 JSR::ResultCode interpolatePositionLoadResult = ContinueLoadingFromJsonObjectField(
                     &transformComponentInstance->m_interpolatePosition, azrtti_typeid<decltype(transformComponentInstance->m_interpolatePosition)>(),
                     inputValue, "InterpolatePosition", context);
@@ -170,18 +162,6 @@ namespace AzToolsFramework
                     azrtti_typeid<decltype(transformComponentInstance->m_isStatic)>(), context);
 
                 result.Combine(resultIsStatic);
-            }
-
-            {
-                AZ::ScopedContextPath subPathName(context, "m_netSyncEnabled");
-                const bool* netSyncEnabled = &transformComponentInstance->m_netSyncEnabled;
-                const bool* defaultNetSyncEnabled = defaultTransformComponentInstance ? &defaultTransformComponentInstance->m_netSyncEnabled : nullptr;
-
-                JSR::ResultCode resultNetSyncEnabled = ContinueStoringToJsonObjectField(
-                    outputValue, "Sync Enabled", netSyncEnabled, defaultNetSyncEnabled, azrtti_typeid<decltype(transformComponentInstance->m_netSyncEnabled)>(),
-                    context);
-
-                result.Combine(resultNetSyncEnabled);
             }
 
             {


### PR DESCRIPTION
Removed the IsDependencyReady field from being serialized in/out for Prefab entities. As prefabs can be scripted/generated outside the Editor we can make no guarantees about if an entity truly IsDependencyReady. Removing this field also reduces the line count of a serialized entity by 1 in Prefabs written to disk. Which adds up in multi entity Prefabs.

Removed the "Sync Enabled" field from being serialized in/out for Prefab EditorTransforms. The field has been deprecated and is not needed when storing/loading an EditorTransform.

Tested that a prefab that was created before this change could be loaded. Could then save that prefab showing that the IsDependencyReady is now gone from its file. Prefab could then be loaded again with no errors.

Signed-off-by: sconel <sconel@amazon.com>