### PR TITLE
Reduce SerializeContext.h header weight.

### DIFF
--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedPropertyCtrl.cpp
@@ -26,6 +26,9 @@
 #include <AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx>
 #include <AzToolsFramework/Editor/EditorSettingsAPIBus.h>
 
+// AzCore
+#include <AzCore/Component/ComponentApplicationBus.h>
+
 // Editor
 #include "Clipboard.h"
 

--- a/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVar.h
+++ b/Code/Editor/Controls/ReflectedPropertyControl/ReflectedVar.h
@@ -10,14 +10,16 @@
 #define CRYINCLUDE_EDITOR_UTILS_REFLECTEDVAR_H
 #pragma once
 
-#include <AzCore/Serialization/SerializeContext.h>
-#include <algorithm>
-#include <limits>
 #include "Util/VariablePropertyType.h"
+
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
+#include <algorithm>
+#include <limits>
 
 //Base class for generic reflected variables
 class CReflectedVar

--- a/Code/Editor/EditorPreferencesTreeWidgetItem.cpp
+++ b/Code/Editor/EditorPreferencesTreeWidgetItem.cpp
@@ -12,6 +12,9 @@
 // AzToolsFramework
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 
+// AzCore
+#include <AzCore/Component/ComponentApplicationBus.h>
+
 // Editor
 #include "IPreferencesPage.h"
 

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -29,6 +29,7 @@ AZ_POP_DISABLE_WARNING
 // AzCore
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Utils/Utils.h>

--- a/Code/Editor/PythonEditorFuncs.cpp
+++ b/Code/Editor/PythonEditorFuncs.cpp
@@ -21,6 +21,9 @@
 #include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
 #include <AzToolsFramework/UI/UICore/WidgetHelpers.h>
 
+// AzCore
+#include <AzCore/RTTI/BehaviorContext.h>
+
 // Editor
 #include "CryEdit.h"
 #include "GameEngine.h"

--- a/Code/Editor/TrackView/TrackViewPythonFuncs.cpp
+++ b/Code/Editor/TrackView/TrackViewPythonFuncs.cpp
@@ -19,6 +19,8 @@
 // Editor
 #include "AnimationContext.h"
 
+#include <AzCore/RTTI/BehaviorContext.h>
+
 
 namespace
 {

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -41,6 +41,7 @@
 
 #include <AzCore/std/algorithm.h>
 #include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING

--- a/Code/Framework/AtomCore/AtomCore/Serialization/Json/JsonUtils.h
+++ b/Code/Framework/AtomCore/AtomCore/Serialization/Json/JsonUtils.h
@@ -13,6 +13,7 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/JSON/document.h>
 #include <AzCore/JSON/writer.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Serialization/Json/JsonSerializationResult.h>
 
 namespace AZ

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManagerComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Preprocessor/EnumReflectUtils.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>

--- a/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/IO/SystemFile.h>

--- a/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetSerializer.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ {
     struct Uuid;

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/BlockCache.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/IO/Streamer/FileRequest.h>
 #include <AzCore/IO/Streamer/StreamerContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 

--- a/Code/Framework/AzCore/AzCore/IO/Streamer/ReadSplitter.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/ReadSplitter.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/IO/Streamer/ReadSplitter.h>
 #include <AzCore/IO/Streamer/StreamerContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/std/smart_ptr/make_shared.h>
 
 namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/MathReflection.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 
 #include <AzCore/Script/ScriptContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 
 #include <AzCore/Math/Uuid.h>

--- a/Code/Framework/AzCore/AzCore/Math/MathScriptHelpers.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathScriptHelpers.h
@@ -12,6 +12,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/std/string/string.h>
 
 namespace AZ

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+
 namespace AZ
 {
     namespace Internal

--- a/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector2.cpp
@@ -12,6 +12,8 @@
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Math/MathScriptHelpers.h>
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+
 namespace AZ
 {
     namespace Internal

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.cpp
@@ -14,6 +14,8 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+
 namespace AZ
 {
     namespace ScriptCanvas

--- a/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Vector4.cpp
@@ -13,6 +13,8 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector4.h>
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+
 namespace AZ
 {
     namespace Internal

--- a/Code/Framework/AzCore/AzCore/Module/ModuleManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/ModuleManager.cpp
@@ -23,6 +23,7 @@
 
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/std/string/tokenize.h>
 
 namespace
 {

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/Component/EntityBus.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -4875,8 +4875,3 @@ namespace AZ
 #if defined(AZ_COMPILER_MSVC)
 #   pragma warning(pop)
 #endif
-
-// pull AzStd on demand reflection
-#include <AzCore/RTTI/AzStdOnDemandPrettyName.inl>
-#include <AzCore/RTTI/AzStdOnDemandReflection.inl>
-

--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContextUtilities.cpp
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContextUtilities.cpp
@@ -10,9 +10,11 @@
 
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/RTTI/AttributeReader.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
+#include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/containers/vector.h>
-#include <AzCore/StringFunc/StringFunc.h>
+#include <AzCore/std/string/conversions.h>
 
 namespace BehaviorContextUtilitiesCPP
 {

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContextAttributes.h
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContextAttributes.h
@@ -82,7 +82,7 @@ namespace AZ
             };
 
             static constexpr AZ::Crc32 Operator = AZ_CRC_CE("ScriptOperator");
-            enum class OperatorType
+            enum class OperatorType : int // specifying underlying type to allow using this enum in declarations.
             {
                 // note storage policy can be T*,T (only if we store raw pointers), shared_ptr<T>, intrusive pointer<T>
                 Add,       // '+'      StoragePolicy<T> add(const StoragePolicy<T>& rhs)

--- a/Code/Framework/AzCore/AzCore/ScriptCanvas/ScriptCanvasAttributes.h
+++ b/Code/Framework/AzCore/AzCore/ScriptCanvas/ScriptCanvasAttributes.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <AzCore/Math/Crc.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/containers/vector.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/Serialization/DataPatch.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/DataPatch.cpp
@@ -6,12 +6,17 @@
  *
  */
 
+
 #include <cinttypes>
 
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 #include <AzCore/Serialization/DataPatch.h>
 #include <AzCore/Serialization/DataPatchBus.h>
 #include <AzCore/Serialization/DataPatchUpgradeManager.h>
 #include <AzCore/Serialization/Utils.h>
+#include <AzCore/Asset/AssetSerializer.h>
+
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Debug/Profiler.h>
@@ -19,6 +24,8 @@
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/std/containers/unordered_map.h>
+
+#include <AzCore/Serialization/Internal/AddressTypeSerializer.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/Serialization/DataPatch.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/DataPatch.h
@@ -115,32 +115,6 @@ namespace AZ
 
         template<typename... Types>
         using has_common_type = has_common_type_helper<void, Types...>;
-
-        /**
-        * Custom serializer for our address type, as we want to be more space efficient and not store every element of the container
-        * separately.
-        */
-        class AddressTypeSerializer
-            : public AZ::Internal::AZBinaryData
-        {
-        public:
-
-            AddressTypeElement LoadAddressElementFromPath(const AZStd::string& pathElement) const;
-
-        private:
-            bool Load(void* classPtr, IO::GenericStream& stream, unsigned int version, bool isDataBigEndian = false) override;
-
-            void LoadElementFinalize(AddressTypeElement& addressElement, const AZStd::string& pathElement, const AZStd::string& version) const;
-            void LoadLegacyElement(AddressTypeElement& addressElement, const AZStd::string& pathElement, const size_t pathDelimLength) const;
-
-            size_t Save(const void* classPtr, IO::GenericStream& stream, bool isDataBigEndian = false) override;
-
-            size_t DataToText(IO::GenericStream& in, IO::GenericStream& out, bool isDataBigEndian) override;
-
-            size_t TextToData(const char* text, unsigned int textVersion, IO::GenericStream& stream, bool isDataBigEndian = false) override;
-
-            bool CompareValueData(const void* lhs, const void* rhs) override;
-        };
     }
 }
 

--- a/Code/Framework/AzCore/AzCore/Serialization/Internal/AddressTypeSerializer.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Internal/AddressTypeSerializer.h
@@ -1,0 +1,41 @@
+﻿/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/DataPatch.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
+namespace AZ
+{
+    inline namespace DataPatchInternal
+    {
+        /**
+        * Custom serializer for our address type, as we want to be more space efficient and not store every element of the container
+        * separately.
+        */
+        class AddressTypeSerializer
+            : public AZ::Internal::AZBinaryData
+        {
+        public:
+
+            AddressTypeElement LoadAddressElementFromPath(const AZStd::string& pathElement) const;
+
+        private:
+            bool Load(void* classPtr, IO::GenericStream& stream, unsigned int version, bool isDataBigEndian = false) override;
+
+            void LoadElementFinalize(AddressTypeElement& addressElement, const AZStd::string& pathElement, const AZStd::string& version) const;
+            void LoadLegacyElement(AddressTypeElement& addressElement, const AZStd::string& pathElement, const size_t pathDelimLength) const;
+
+            size_t Save(const void* classPtr, IO::GenericStream& stream, bool isDataBigEndian = false) override;
+
+            size_t DataToText(IO::GenericStream& in, IO::GenericStream& out, bool isDataBigEndian) override;
+
+            size_t TextToData(const char* text, unsigned int textVersion, IO::GenericStream& stream, bool isDataBigEndian = false) override;
+
+            bool CompareValueData(const void* lhs, const void* rhs) override;
+        };
+    }
+}   // namespace AZ

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonDeserializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonDeserializer.cpp
@@ -14,6 +14,9 @@
 #include <AzCore/Serialization/Json/JsonStringConversionUtils.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/StackedString.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
+
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/string/string.h>

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/JsonSerializer.cpp
@@ -6,12 +6,16 @@
  *
  */
 
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/Serialization/Json/JsonSerializer.h>
 #include <AzCore/Serialization/Json/BaseJsonSerializer.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/StackedString.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
+
 #include <AzCore/std/any.h>
 #include <AzCore/std/utils.h>
 #include <AzCore/std/string/string.h>

--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Serialization/DynamicSerializableField.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetManager.h>
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Slice/SliceAsset.h>
 #include <AzCore/std/functional.h>

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializationUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Serialization/ObjectStream.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 
 #include <AzCore/Component/ComponentApplicationBus.h>
 

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Serialization/DataOverlay.h>
 #include <AzCore/Serialization/DynamicSerializableField.h>
 #include <AzCore/Serialization/Utils.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 #include <AzCore/Asset/AssetSerializer.h>
 
 /// include AZStd any serializer support

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -197,7 +197,7 @@ namespace AZ
         // Deprecate a previously reflected class so that on load any instances will be silently dropped without the need
         // to keep the original class around.
         // Use of this function should be considered temporary and should be removed as soon as possible.
-        void            ClassDeprecate(const char* name, const AZ::Uuid& typeUuid, VersionConverter converter = nullptr);
+        void ClassDeprecate(const char* name, const AZ::Uuid& typeUuid, VersionConverter converter = nullptr);
         // @}
 
         /**
@@ -2558,5 +2558,6 @@ namespace AZ
     template <typename, bool, bool> \
     friend struct AZ::Serialize::InstanceFactory;
 
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #endif // AZCORE_SERIALIZE_CONTEXT_H
 #pragma once

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.h
@@ -2558,15 +2558,5 @@ namespace AZ
     template <typename, bool, bool> \
     friend struct AZ::Serialize::InstanceFactory;
 
-/// include AZStd containers generics
-#include <AzCore/Serialization/AZStdContainers.inl>
-#include <AzCore/Serialization/std/VariantReflection.inl>
-
-/// include asset generics
-#include <AzCore/Asset/AssetSerializer.h>
-
-/// include implementation of SerializeContext::EnumBuilder
-#include <AzCore/Serialization/SerializeContextEnum.inl>
-
 #endif // AZCORE_SERIALIZE_CONTEXT_H
 #pragma once

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContextEnum.inl
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+#pragma once
 
 namespace AZ
 {

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryScriptUtils.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -483,6 +483,7 @@ set(FILES
     Serialization/EditContextConstants.inl
     Serialization/IdUtils.inl
     Serialization/IdUtils.h
+    Serialization/Internal/AddressTypeSerializer.h    
     Serialization/Utils.h
     Serialization/SerializationUtils.cpp
     Serialization/ObjectStream.cpp

--- a/Code/Framework/AzCore/Tests/BehaviorContext.cpp
+++ b/Code/Framework/AzCore/Tests/BehaviorContext.cpp
@@ -8,6 +8,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Outcome/Outcome.h>
+#include <AzCore/Script/ScriptContext.h>
 
 namespace UnitTest
 {

--- a/Code/Framework/AzCore/Tests/Patching.cpp
+++ b/Code/Framework/AzCore/Tests/Patching.cpp
@@ -9,6 +9,7 @@
 #include "FileIOBaseTestTypes.h"
 
 #include <AzCore/Serialization/DataPatch.h>
+#include <AzCore/Serialization/Internal/AddressTypeSerializer.h>
 #include <AzCore/Serialization/DynamicSerializableField.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/UnitTest/TestTypes.h>

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -19,6 +19,8 @@
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/DataPatch.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/fixed_vector.h>

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonSerializerConformityTests.h
@@ -9,6 +9,7 @@
 
 #include <iostream> // Used for pretty printing.
 #include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>

--- a/Code/Framework/AzCore/Tests/Settings/SettingsRegistryScriptUtilsTests.cpp
+++ b/Code/Framework/AzCore/Tests/Settings/SettingsRegistryScriptUtilsTests.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryScriptUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/containers/variant.h>
 
 namespace SettingsRegistryScriptUtilsTests
 {

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetCatalog.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetTypeInfoBus.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/IO/FileIO.h>

--- a/Code/Framework/AzFramework/AzFramework/Asset/XmlSchemaAsset.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/XmlSchemaAsset.h
@@ -12,6 +12,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Asset/AssetCommon.h>
 
 namespace AzFramework
 {

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Quaternion.h>
+#include <AzCore/Script/ScriptContext.h>
 
 namespace AZ
 {

--- a/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/BehaviorEntity.cpp
@@ -7,6 +7,7 @@
  */
 #include "BehaviorEntity.h"
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Serialization/EditContext.h>
 
 namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Entity/EntityOwnershipServiceBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Entity/EntityOwnershipServiceBus.h
@@ -10,6 +10,11 @@
 
 #include <AzCore/EBus/EBus.h>
 
+namespace AZ
+{
+    class Entity;
+}
+
 namespace AzFramework
 {
     using EntityContextId = AZ::Uuid;

--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionEvents.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionEvents.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 
 namespace AzPhysics

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.cpp
@@ -9,7 +9,9 @@
 #include <AzFramework/Physics/Collision/CollisionGroups.h>
 
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 #include <AzFramework/Physics/CollisionBus.h>
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 #include <AzFramework/Physics/CollisionBus.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>

--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsScene.cpp
@@ -9,7 +9,7 @@
 
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/Configuration/SceneConfiguration.h>
-
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AzPhysics
 {

--- a/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystem.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/PhysicsSystem.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzFramework/Physics/PhysicsSystem.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AzPhysics
 {

--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Physics/PropertyTypes.h>
 #include <AzFramework/Physics/SystemBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace Physics
 {

--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
@@ -11,6 +11,7 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Asset/AssetCommon.h>
 
 namespace Physics
 {

--- a/Code/Framework/AzFramework/AzFramework/Physics/Utils.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Utils.cpp
@@ -15,7 +15,6 @@
 #include <AzFramework/Physics/Character.h>
 #include <AzFramework/Physics/Ragdoll.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Physics/CollisionBus.h>
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
 #include <AzFramework/Physics/WindBus.h>
@@ -31,6 +30,8 @@
 #include <AzFramework/Physics/Configuration/SimulatedBodyConfiguration.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
 #include <AzFramework/Physics/Common/PhysicsJoint.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace Physics
 {

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
@@ -8,6 +8,9 @@
 
 #include "TerrainDataRequestBus.h"
 
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
 namespace AzFramework
 {
     namespace SurfaceData

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -11,7 +11,6 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Aabb.h>
-#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AzFramework
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorEntityAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/EditorEntityAPI.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Serialization/SerializeContext.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Asset/AssetSystemComponent.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/IO/FileIO.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzFramework/Asset/AssetProcessorMessages.h>
 #include <AzFramework/Network/AssetProcessorConnection.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBundle/AssetBundleComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBundle/AssetBundleComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Asset/AssetManagerBus.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorBus.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>
-#include <AzCore/UserSettings/UserSettings.h>
-#include <AzCore/Asset/AssetCommon.h>
-#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/UserSettings/UserSettings.h>
+#include <AzCore/std/containers/unordered_map.h>
 
 namespace AZ { namespace Data { class AssetData; } }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
@@ -8,9 +8,11 @@
 
 #pragma once
 
+#include <AzCore/Component/EntityId.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabCatchmentProcessor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabCatchmentProcessor.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/RTTI/TypeInfo.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/Serialization/Utils.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabConversionPipeline.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabConversionPipeline.cpp
@@ -6,9 +6,11 @@
  *
  */
 
+#include <AzToolsFramework/Prefab/Spawnable/PrefabConversionPipeline.h>
+
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistry.h>
-#include <AzToolsFramework/Prefab/Spawnable/PrefabConversionPipeline.h>
 
 namespace AzToolsFramework::Prefab::PrefabConversionUtils
 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.h
@@ -7,8 +7,10 @@
  */
 #pragma once
 
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/unordered_map.h>
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -31,6 +31,7 @@ AZ_PUSH_DISABLE_WARNING(4244 4251, "-Wunknown-warning-option")
 AZ_POP_DISABLE_WARNING
 
 #include <AzCore/Asset/AssetManager.h>
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Asset/AssetTypeInfoBus.h>
 #include <AzCore/Utils/Utils.h>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/UserSettings/UserSettings.h>
 #include <AzCore/std/containers/set.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Math/Sfmt.h>
 #include <AzToolsFramework/Slice/SliceUtilities.h>

--- a/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
@@ -17,6 +17,7 @@
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzToolsFramework/UI/PropertyEditor/InstanceDataHierarchy.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 #include <AzCore/Serialization/ObjectStream.h>
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/UnitTest/TestTypes.h>

--- a/Code/Legacy/CryCommon/Maestro/Bus/SequenceComponentBus.h
+++ b/Code/Legacy/CryCommon/Maestro/Bus/SequenceComponentBus.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/AssetBuilderSDK.cpp
@@ -19,6 +19,7 @@
 #include <AzCore/Component/Entity.h> // so we can have the entity UUID type.
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Slice/SliceAsset.h> // For slice asset sub ids
 //////////////////////////////////////////////////////////////////////////
 

--- a/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/SerializationDependencies.cpp
+++ b/Code/Tools/AssetProcessor/AssetBuilderSDK/AssetBuilderSDK/SerializationDependencies.cpp
@@ -8,6 +8,8 @@
 
 #include <AssetBuilderSDK/SerializationDependencies.h>
 
+#include <AzCore/Asset/AssetSerializer.h>
+
 namespace AssetBuilderSDK
 {
     bool UpdateDependenciesFromClassData(

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetCatalog.cpp
@@ -9,7 +9,9 @@
 #include "native/AssetManager/AssetCatalog.h"
 
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/std/string/wildcard.h>
+#include <AzCore/std/string/tokenize.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/FileTag/FileTagBus.h>
 #include <AzFramework/FileTag/FileTag.h>

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -11,6 +11,7 @@
 #include <QDir>
 #include <QTimer>
 #include <AzToolsFramework/ToolsComponents/ToolsAssetCatalogBus.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
 
 using namespace AssetProcessor;
 

--- a/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
+++ b/Code/Tools/AssetProcessor/native/InternalBuilders/SettingsRegistryBuilder.cpp
@@ -8,6 +8,7 @@
 
 #include <limits>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Utils/Utils.h>

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBlendShapeImporter.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/containers/bitset.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzToolsFramework/Debug/TraceContext.h>

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.h
@@ -12,6 +12,11 @@
 
 namespace AZ
 {
+
+    class BehaviorClass;
+    struct BehaviorParameter;
+    struct BehaviorValueParameter;
+
     namespace Python
     {
         class PythonBehaviorInfo;

--- a/Code/Tools/SceneAPI/SceneCore/Containers/SceneManifest.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/SceneManifest.cpp
@@ -18,6 +18,7 @@
 #include <AzCore/JSON/document.h>
 #include <AzCore/JSON/prettywriter.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonSerializationResult.h>

--- a/Code/Tools/SceneAPI/SceneCore/DllMain.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/DllMain.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Module/Environment.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 #include <SceneAPI/SceneCore/Components/BehaviorComponent.h>

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportProductList.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneCore/Events/ExportProductList.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/limits.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {

--- a/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Tests/Containers/SceneBehaviorTests.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/RTTI/ReflectionManager.h>
 #include <AzCore/Math/MathReflection.h>
 #include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -9,6 +9,7 @@
 #include <SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>

--- a/Code/Tools/SceneAPI/SceneData/GraphData/BlendShapeData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/BlendShapeData.cpp
@@ -10,6 +10,7 @@
 #include <SceneAPI/SceneData/GraphData/BlendShapeData.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/containers/bitset.h>
 
 namespace AZ
 {

--- a/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/ReflectionManager.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>

--- a/Gems/AWSClientAuth/Code/Include/Public/Authorization/ClientAuthAWSCredentials.h
+++ b/Gems/AWSClientAuth/Code/Include/Public/Authorization/ClientAuthAWSCredentials.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/string.h>
 
 #include <aws/core/auth/AWSCredentialsProvider.h>

--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
@@ -13,6 +13,7 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 #include <AWSNativeSDKInit/AWSNativeSDKInit.h>
 

--- a/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Jobs/JobManagerBus.h>
 #include <AzCore/Jobs/JobCancelGroup.h>
 #include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzTest/AzTest.h>

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionOnQueueRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionOnQueueRequest.cpp
@@ -6,10 +6,11 @@
  *
  */
 
+#include <Request/AWSGameLiftCreateSessionOnQueueRequest.h>
+
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-
-#include <Request/AWSGameLiftCreateSessionOnQueueRequest.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AWSGameLift
 {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionRequest.cpp
@@ -6,10 +6,11 @@
  *
  */
 
+#include <Request/AWSGameLiftCreateSessionRequest.h>
+
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-
-#include <Request/AWSGameLiftCreateSessionRequest.h>
 
 namespace AWSGameLift
 {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftJoinSessionRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftJoinSessionRequest.cpp
@@ -6,10 +6,11 @@
  *
  */
 
+#include <Request/AWSGameLiftJoinSessionRequest.h>
+
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-
-#include <Request/AWSGameLiftJoinSessionRequest.h>
 
 namespace AWSGameLift
 {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftSearchSessionsRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftSearchSessionsRequest.cpp
@@ -6,12 +6,15 @@
  *
  */
 
+#include <Request/AWSGameLiftSearchSessionsRequest.h>
+
+#include <AWSGameLiftSessionConstants.h>
+
+#include <AzFramework/Session/SessionConfig.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/Session/SessionConfig.h>
 
-#include <Request/AWSGameLiftSearchSessionsRequest.h>
-#include <AWSGameLiftSessionConstants.h>
 
 namespace AWSGameLift
 {

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerSystemComponentTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerSystemComponentTest.cpp
@@ -10,6 +10,7 @@
 #include <AWSGameLiftServerMocks.h>
 
 #include <AzCore/Component/Entity.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/UnitTest/TestTypes.h>

--- a/Gems/Atom/Component/DebugCamera/Code/Source/ArcBallControllerComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/ArcBallControllerComponent.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Component/TransformBus.h>
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h>

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
+#include <AzCore/std/containers/map.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DisplayMapper/DisplayMapperConfigurationDescriptor.cpp
@@ -7,10 +7,13 @@
  */
 
 
-#include <AzCore/Serialization/SerializeContext.h>
 
 #include <Atom/Feature/DisplayMapper/DisplayMapperConfigurationDescriptor.h>
+
 #include <Atom/Feature/ACES/AcesDisplayMapperFeatureProcessor.h>
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SMAAConfigurationDescriptor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SMAAConfigurationDescriptor.cpp
@@ -8,6 +8,8 @@
 
 #include <PostProcessing/SMAAConfigurationDescriptor.h>
 
+#include <AzCore/Serialization/SerializeContext.h>
+
 namespace AZ
 {
     namespace Render

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ConstantsLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ConstantsLayout.h
@@ -9,6 +9,7 @@
 
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/NameIdReflectionMap.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AtomCore/std/containers/array_view.h>
 #include <AzCore/std/smart_ptr/intrusive_base.h>
 #include <AzCore/Utils/TypeHash.h>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Handle.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/Handle.h
@@ -8,10 +8,12 @@
 #pragma once
 
 #include <AzCore/base.h>
-#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/TypeInfo.h>
 
 namespace AZ
 {
+    class ReflectContext;
+
     namespace RHI
     {
         struct DefaultNamespaceType {
@@ -87,27 +89,6 @@ namespace AZ
 
             T m_index = NullIndex;
         };
-
-        template <typename T, typename NamespaceType>
-        void Handle<T, NamespaceType>::Reflect(AZ::ReflectContext* context)
-        {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
-            {
-                serializeContext->Class<Handle<T, NamespaceType>>()
-                    ->Version(1)
-                    ->Field("m_index", &Handle<T, NamespaceType>::m_index);
-            }
-
-            if (BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context))
-            {
-                behaviorContext->Class<Handle<T, NamespaceType>>()
-                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
-                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
-                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
-                    ->Method("IsValid", &Handle<T, NamespaceType>::IsValid)
-                    ;
-            }
-        }
 
         template <typename HandleType, typename NamespaceType>
         const Handle<HandleType, NamespaceType> Handle<HandleType, NamespaceType>::Null(

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/HandleReflectImpl.inl
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/HandleReflectImpl.inl
@@ -1,0 +1,40 @@
+﻿/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/base.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        template <typename T, typename NamespaceType>
+        void Handle<T, NamespaceType>::Reflect(AZ::ReflectContext* context)
+        {
+            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            {
+                serializeContext->Class<Handle<T, NamespaceType>>()
+                    ->Version(1)
+                    ->Field("m_index", &Handle<T, NamespaceType>::m_index);
+            }
+
+            if (BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context))
+            {
+                behaviorContext->Class<Handle<T, NamespaceType>>()
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                    ->Attribute(AZ::Script::Attributes::Category, "RHI")
+                    ->Attribute(AZ::Script::Attributes::Module, "rhi")
+                    ->Method("IsValid", &Handle<T, NamespaceType>::IsValid)
+                    ;
+            }
+        }
+
+    }
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndirectBufferLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/IndirectBufferLayout.h
@@ -7,12 +7,11 @@
  */
 #pragma once
 
-#include <Atom/RHI.Reflect/Handle.h>
-
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Utils/TypeHash.h>
 #include <AtomCore/std/containers/array_view.h>
+#include <AzCore/std/containers/unordered_map.h>
 
 namespace AZ
 {
@@ -20,6 +19,9 @@ namespace AZ
 
     namespace RHI
     {
+        template <typename T, typename NamespaceType>
+        struct Handle;
+
         //! Command types that can be used when doing Indirect Rendering.
         enum class IndirectCommandType : uint32_t
         {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/NameIdReflectionMap.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/NameIdReflectionMap.h
@@ -7,12 +7,12 @@
  */
 
 #pragma once
-
 #include <Atom/RHI.Reflect/Handle.h>
 #include <AzCore/Name/Name.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/sort.h>
+#include <AzCore/std/containers/vector.h>
 
 namespace AZ
 {
@@ -88,23 +88,6 @@ namespace AZ
 
             AZStd::vector<ReflectionPair> m_reflectionMap;
         };
-
-        template <typename IndexType>
-        void NameIdReflectionMap<IndexType>::Reflect(AZ::ReflectContext* context)
-        {
-            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
-            {
-                serializeContext->Class<typename NameIdReflectionMap<IndexType>::ReflectionPair>()
-                    ->Version(2)
-                    ->Field("Name", &ReflectionPair::m_name)
-                    ->Field("Index", &ReflectionPair::m_index);
-
-                serializeContext->Class<NameIdReflectionMap<IndexType>>()
-                    ->Version(0)
-                    ->template EventHandler<typename NameIdReflectionMap<IndexType>::NameIdReflectionMapSerializationEvents>()
-                    ->Field("ReflectionMap", &NameIdReflectionMap<IndexType>::m_reflectionMap);
-            }
-        }
 
         template <typename IndexType>
         void NameIdReflectionMap<IndexType>::Clear()

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl
@@ -1,0 +1,39 @@
+﻿/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <Atom/RHI.Reflect/Handle.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/std/algorithm.h>
+#include <AzCore/std/sort.h>
+
+namespace AZ
+{
+    namespace RHI
+    {
+        template <typename IndexType>
+        void NameIdReflectionMap<IndexType>::Reflect(AZ::ReflectContext* context)
+        {
+            if (SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context))
+            {
+                serializeContext->Class<typename NameIdReflectionMap<IndexType>::ReflectionPair>()
+                    ->Version(2)
+                    ->Field("Name", &ReflectionPair::m_name)
+                    ->Field("Index", &ReflectionPair::m_index);
+
+                serializeContext->Class<NameIdReflectionMap<IndexType>>()
+                    ->Version(0)
+                    ->template EventHandler<typename NameIdReflectionMap<IndexType>::NameIdReflectionMapSerializationEvents>()
+                    ->Field("ReflectionMap", &NameIdReflectionMap<IndexType>::m_reflectionMap);
+            }
+        }
+    }
+}

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayout.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayout.h
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <Atom/RHI.Reflect/ConstantsLayout.h>
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/NameIdReflectionMap.h>
 #include <AtomCore/std/containers/array_view.h>
@@ -22,6 +21,7 @@ namespace AZ
 
     namespace RHI
     {
+        class ConstantsLayout;
         /**
          * ShaderResourceGroupLayout defines a set of valid shader inputs to a ShaderResourceGroup.
          *

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h
@@ -9,7 +9,6 @@
 
 #include <Atom/RHI.Reflect/SamplerState.h>
 #include <Atom/RHI.Reflect/Interval.h>
-#include <Atom/RHI.Reflect/Handle.h>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ
@@ -18,6 +17,8 @@ namespace AZ
 
     namespace RHI
     {
+        template <typename T, typename NamespaceType>
+        struct Handle;
         /**
          * A "ShaderInput" describes an input into a ShaderResourceGroup. Shader inputs are comprised of
          * Buffers, Images, Samplers, and Constants. The former three shader inputs each contain an array

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/AsyncWorkQueue.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/AsyncWorkQueue.h
@@ -15,6 +15,7 @@
 #include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/containers/deque.h>
+#include <AzCore/std/functional.h>
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateCache.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/PipelineStateCache.h
@@ -11,6 +11,7 @@
 #include <Atom/RHI/PipelineLibrary.h>
 #include <Atom/RHI/ThreadLocalContext.h>
 #include <AzCore/std/containers/bitset.h>
+#include <AzCore/std/containers/variant.h>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace UnitTest

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ClearValue.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ClearValue.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI.Reflect/ClearValue.h>
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ConstantsLayout.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ConstantsLayout.cpp
@@ -6,6 +6,8 @@
  *
  */
 #include <Atom/RHI.Reflect/ConstantsLayout.h>
+#include <Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Utils/TypeHash.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/IndirectBufferLayout.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/IndirectBufferLayout.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
+#include <Atom/RHI.Reflect/Handle.h>
 
 #include <AzCore/Utils/TypeHash.h>
 #include <AzCore/std/containers/unordered_set.h>

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/IndirectBufferLayout.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/IndirectBufferLayout.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RHI.Reflect/Base.h>
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
 #include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
 
 #include <AzCore/Utils/TypeHash.h>
 #include <AzCore/std/containers/unordered_set.h>

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/PhysicalDeviceDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/PhysicalDeviceDescriptor.cpp
@@ -6,10 +6,13 @@
  *
  */
 #include <Atom/RHI.Reflect/PhysicalDeviceDescriptor.h>
+
 #include <Atom/RHI.Reflect/PhysicalDeviceDriverInfoSerializer.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Preprocessor/EnumReflectUtils.h>
+
 #include <sstream>
 
 namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ReflectSystemComponent.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ReflectSystemComponent.cpp
@@ -15,6 +15,7 @@
 #include <Atom/RHI.Reflect/ClearValue.h>
 #include <Atom/RHI.Reflect/Format.h>
 #include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
 #include <Atom/RHI.Reflect/ImageDescriptor.h>
 #include <Atom/RHI.Reflect/ImagePoolDescriptor.h>
 #include <Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h>

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ReflectSystemComponent.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ReflectSystemComponent.cpp
@@ -40,6 +40,9 @@
 #include <Atom/RHI.Reflect/PhysicalDeviceDescriptor.h>
 
 #include <AzCore/Serialization/SerializeContext.h>
+//#include <AzCore/RTTI/BehaviorContext.h>
+
+//#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderStates.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/RenderStates.cpp
@@ -7,6 +7,7 @@
  */
 #include <Atom/RHI.Reflect/RenderStates.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/Preprocessor/EnumReflectUtils.h>
 #include <AzCore/Utils/TypeHash.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/SamplerState.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/SamplerState.cpp
@@ -7,6 +7,7 @@
  */
 #include <Atom/RHI.Reflect/SamplerState.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/Utils/TypeHash.h>
 
 namespace AZ

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ShaderResourceGroupLayout.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ShaderResourceGroupLayout.cpp
@@ -6,6 +6,13 @@
  *
  */
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayout.h>
+
+#include <Atom/RHI.Reflect/ConstantsLayout.h>
+#include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
+#include <Atom/RHI.Reflect/NameIdReflectionMap.h>
+#include <Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl>
+
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Utils/TypeHash.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.cpp
@@ -8,6 +8,10 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Utils/TypeHash.h>
+#include <Atom/RHI.Reflect/Handle.h>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
+#include <Atom/RHI.Reflect/NameIdReflectionMap.h>
+#include <Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl>
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/ShaderSemantic.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/ShaderSemantic.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RHI.Reflect/ShaderSemantic.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/Utils/TypeHash.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
@@ -8,6 +8,8 @@
 
 #include <Atom/RHI/Fence.h>
 
+#include <AzCore/std/functional.h>
+
 namespace AZ
 {
     namespace RHI

--- a/Gems/Atom/RHI/Code/atom_rhi_reflect_files.cmake
+++ b/Gems/Atom/RHI/Code/atom_rhi_reflect_files.cmake
@@ -17,8 +17,10 @@ set(FILES
     Include/Atom/RHI.Reflect/ClearValue.h
     Include/Atom/RHI.Reflect/Format.h
     Include/Atom/RHI.Reflect/Handle.h
+    Include/Atom/RHI.Reflect/HandleReflectImpl.inl
     Include/Atom/RHI.Reflect/Interval.h
     Include/Atom/RHI.Reflect/NameIdReflectionMap.h
+    Include/Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl
     Include/Atom/RHI.Reflect/Origin.h
     Include/Atom/RHI.Reflect/Size.h
     Source/RHI.Reflect/Base.cpp

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/LuaMaterialFunctorSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/LuaMaterialFunctorSourceData.h
@@ -17,6 +17,8 @@ namespace UnitTest
 
 namespace AZ
 {
+    class ScriptContext;
+    
     namespace RPI
     {
         //! Builds a LuaMaterialFunctor.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantKey.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantKey.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <AzCore/std/containers/bitset.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Memory/SystemAllocator.h>
 
 #include <Atom/RHI.Reflect/Handle.h>
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/LuaMaterialFunctorSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/LuaMaterialFunctorSourceData.cpp
@@ -11,6 +11,7 @@
 #include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Script/ScriptAsset.h>
+#include <AzCore/Script/ScriptContext.h>
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantListSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Shader/ShaderVariantListSourceData.cpp
@@ -9,6 +9,7 @@
 #include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
 #include <Atom/RPI.Edit/Common/JsonUtils.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuQueryTypes.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuQueryTypes.cpp
@@ -10,6 +10,7 @@
 
 #include <Atom/RHI/RHIUtils.h>
 
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/algorithm.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderSystem.cpp
@@ -19,6 +19,8 @@
 #include <Atom/RPI.Reflect/Shader/ShaderVariantTreeAsset.h>
 #include <Atom/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.h>
 
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
+
 #include <AtomCore/Instance/InstanceDatabase.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAsset.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialDynamicMetadata.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialDynamicMetadata.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RPI.Reflect/Material/MaterialDynamicMetadata.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertiesLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertiesLayout.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RPI.Reflect/Material/MaterialPropertiesLayout.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl>
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertyDescriptor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialPropertyDescriptor.cpp
@@ -7,7 +7,9 @@
  */
 
 #include <Atom/RPI.Reflect/Material/MaterialPropertyDescriptor.h>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/Math/Vector4.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -8,6 +8,7 @@
 
 #include <AtomCore/std/containers/vector_set.h>
 #include <Atom/RPI.Reflect/Material/ShaderCollection.h>
+#include <Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI/DrawListTagRegistry.h>
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
@@ -8,9 +8,11 @@
 
 #include <math.h>
 
-#include <AzFramework/StringFunc/StringFunc.h>
 #include <Atom/RPI.Reflect/Pass/PassAttachmentReflect.h>
 #include <Atom/RPI.Reflect/Pass/PassName.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
+#include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
 {

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroup.cpp
@@ -8,6 +8,7 @@
 
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderOptionGroupLayout.cpp
@@ -8,6 +8,8 @@
 
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroupLayout.h>
 #include <Atom/RPI.Reflect/Shader/ShaderOptionGroup.h>
+#include <Atom/RHI.Reflect/NameIdReflectionMapReflectImpl.inl>
+#include <Atom/RHI.Reflect/HandleReflectImpl.inl>
 
 #include <Atom/RHI.Reflect/Bits.h>
 
@@ -15,6 +17,7 @@
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/Utils/TypeHash.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 #include <AzFramework/StringFunc/StringFunc.h>
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderStageType.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderStageType.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/SerializeContextEnum.inl>
 #include <Atom/RPI.Reflect/Shader/ShaderCommonTypes.h>
 
 namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantKey.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantKey.cpp
@@ -8,6 +8,9 @@
 
 #include <Atom/RPI.Reflect/Shader/ShaderVariantKey.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
 namespace AZ
 {
     namespace RPI

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorPropertyGroupWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorPropertyGroupWidget.cpp
@@ -9,6 +9,7 @@
 #include <AtomToolsFramework/Inspector/InspectorPropertyGroupWidget.h>
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
 
 namespace AtomToolsFramework
 {

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/Utils.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/Utils.h
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include <AzCore/std/containers/vector.h>
 #include <Atom/RHI/Buffer.h>
 #include <Atom/RHI/BufferPool.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/Asset/AssetCommon.h>
 
 //! This file holds useful utility functions for working with the RPI.
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/GradientWeightModifier/GradientWeightModifierComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/GradientWeightModifier/GradientWeightModifierComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <PostProcess/GradientWeightModifier/GradientWeightModifierComponent.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
+
 namespace AZ
 {
     namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/RadiusWeightModifier/RadiusWeightModifierComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/RadiusWeightModifier/RadiusWeightModifierComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <PostProcess/RadiusWeightModifier/RadiusWeightModifierComponent.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
+
 namespace AZ
 {
     namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/RadiusWeightModifier/RadiusWeightModifierComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/RadiusWeightModifier/RadiusWeightModifierComponentController.cpp
@@ -8,6 +8,7 @@
 
 #include <PostProcess/RadiusWeightModifier/RadiusWeightModifierComponentController.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
 {

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ShapeWeightModifier/ShapeWeightModifierComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ShapeWeightModifier/ShapeWeightModifierComponent.cpp
@@ -8,6 +8,8 @@
 
 #include <PostProcess/ShapeWeightModifier/ShapeWeightModifierComponent.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
+
 namespace AZ
 {
     namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ShapeWeightModifier/ShapeWeightModifierComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ShapeWeightModifier/ShapeWeightModifierComponentController.cpp
@@ -8,6 +8,7 @@
 
 #include <PostProcess/ShapeWeightModifier/ShapeWeightModifierComponentController.h>
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace AZ
@@ -77,7 +78,7 @@ namespace AZ
             float distance = 0.0f;
             LmbrCentral::ShapeComponentRequestsBus::EventResult(distance, m_entityId, &LmbrCentral::ShapeComponentRequestsBus::Events::DistanceFromPoint, influencerPosition);
 
-            // In the special case of 0 falloff, make sure that all points inside the shape (0 distance) return 
+            // In the special case of 0 falloff, make sure that all points inside the shape (0 distance) return
             // 1.0, and all points outside the shape return 0.
             if (m_configuration.m_falloffDistance == 0.0f)
             {

--- a/Gems/Blast/Code/Source/Asset/BlastSliceAsset.cpp
+++ b/Gems/Blast/Code/Source/Asset/BlastSliceAsset.cpp
@@ -8,6 +8,7 @@
 
 #include <Asset/BlastSliceAsset.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace Blast
 {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/EventData.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/EventData.h
@@ -16,6 +16,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Memory/Memory.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 
 namespace EMotionFX
 {

--- a/Gems/EditorPythonBindings/Code/Source/PythonReflectionComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonReflectionComponent.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzCore/Serialization/SerializeContext.h>
 
 #include <AzCore/PlatformDef.h>
 #include <AzCore/IO/SystemFile.h>

--- a/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonUtility.cpp
@@ -13,6 +13,7 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <EditorPythonBindings/CustomTypeBindingBus.h>
 #include <pybind11/embed.h>

--- a/Gems/EditorPythonBindings/Code/Tests/PythonReflectionComponentTests.cpp
+++ b/Gems/EditorPythonBindings/Code/Tests/PythonReflectionComponentTests.cpp
@@ -16,6 +16,7 @@
 #include <Source/PythonReflectionComponent.h>
 #include <Source/PythonMarshalComponent.h>
 
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Vector4.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzFramework/StringFunc/StringFunc.h>

--- a/Gems/GraphCanvas/Code/Source/Translation/TranslationAsset.cpp
+++ b/Gems/GraphCanvas/Code/Source/Translation/TranslationAsset.cpp
@@ -8,6 +8,8 @@
 
 #include <AzCore/PlatformIncl.h>
 
+#include <AzCore/Component/ComponentApplicationBus.h>
+
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
 

--- a/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYEntityOutliner.cpp
+++ b/Gems/ImGui/Code/Source/LYCommonMenu/ImGuiLYEntityOutliner.cpp
@@ -10,6 +10,7 @@
 
 #ifdef IMGUI_ENABLED
 
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/std/string/conversions.h>

--- a/Gems/LmbrCentral/Code/Source/Builders/LuaBuilder/LuaBuilderWorker.h
+++ b/Gems/LmbrCentral/Code/Source/Builders/LuaBuilder/LuaBuilderWorker.h
@@ -12,6 +12,12 @@
 #include <AssetBuilderSDK/AssetBuilderBusses.h>
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 
+
+namespace AZ
+{
+    class ScriptContext;
+} // namespace AZ
+
 namespace LuaBuilder
 {
     class LuaBuilderWorker

--- a/Gems/LmbrCentral/Code/Source/Scripting/TagComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/TagComponent.cpp
@@ -6,10 +6,12 @@
  *
  */
 
-#include <AzCore/Serialization/SerializeContext.h>
+#include "TagComponent.h"
+
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/RTTI/BehaviorContext.h>
-#include "TagComponent.h"
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 
 namespace LmbrCentral
 {

--- a/Gems/LmbrCentral/Code/Source/Shape/ShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/ShapeComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
 
 namespace LmbrCentral

--- a/Gems/LyShineExamples/Code/Source/LyShineExamplesSerialize.cpp
+++ b/Gems/LyShineExamples/Code/Source/LyShineExamplesSerialize.cpp
@@ -13,6 +13,7 @@
 #include <LyShineExamples/UiCustomImageBus.h>
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Script/ScriptContext.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // NAMESPACE FUNCTIONS

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -18,6 +18,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/sort.h>
 
 namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -25,6 +25,7 @@
 #include <AzCore/Math/ShapeIntersection.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetManagerBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzFramework/Components/CameraBus.h>
 #include <AzFramework/Session/ISessionRequests.h>

--- a/Gems/NvCloth/Code/Source/Editor/MeshNodeHandler.h
+++ b/Gems/NvCloth/Code/Source/Editor/MeshNodeHandler.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+#include <AzCore/Asset/AssetCommon.h>
 #include <Editor/ComboBoxEditButtonPair.h>
 #include <QObject>
 #endif

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/CharacterGameplayComponent.cpp
@@ -10,6 +10,7 @@
 #include <AzFramework/Physics/CharacterBus.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <PhysX/PhysXLocks.h>
 #include <PhysX/Utils.h>
 #include <PhysX/Debug/PhysXDebugConfiguration.h>

--- a/Gems/PythonAssetBuilder/Code/Source/PythonBuilderNotificationHandler.h
+++ b/Gems/PythonAssetBuilder/Code/Source/PythonBuilderNotificationHandler.h
@@ -9,6 +9,7 @@
 
 #include <PythonAssetBuilder/PythonBuilderNotificationBus.h>
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 
 namespace PythonAssetBuilder
 {

--- a/Gems/PythonAssetBuilder/Code/Source/PythonBuilderWorker.cpp
+++ b/Gems/PythonAssetBuilder/Code/Source/PythonBuilderWorker.cpp
@@ -8,6 +8,7 @@
 
 #include <PythonBuilderWorker.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzToolsFramework/API/EditorPythonConsoleBus.h>
 #include <Source/PythonAssetBuilderSystemComponent.h>

--- a/Gems/SceneProcessing/Code/Source/Config/Components/SceneProcessingConfigSystemComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Config/Components/SceneProcessingConfigSystemComponent.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Module/DynamicModuleHandle.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <Source/SceneProcessingModule.h>
 

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeUtils.cpp
@@ -11,8 +11,8 @@
 #include <GraphCanvas/Components/Nodes/NodeBus.h>
 #include <GraphCanvas/Components/Slots/SlotBus.h>
 #include <GraphCanvas/Components/DynamicOrderingDynamicSlotComponent.h>
-
 #include <ScriptCanvas/Core/NodeBus.h>
+#include <AzCore/std/string/tokenize.h>
 
 namespace
 {

--- a/Gems/ScriptCanvas/Code/Editor/Settings.h
+++ b/Gems/ScriptCanvas/Code/Editor/Settings.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/UserSettings/UserSettings.h>
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/AssetGraphSceneDataBus.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/AssetGraphSceneDataBus.h
@@ -10,6 +10,8 @@
 
 #include <AzCore/Math/Uuid.h>
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/EntityId.h>
 
 namespace ScriptCanvasEditor
 {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/RTTI/BehaviorContextUtilities.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/MethodConfiguration.cpp
@@ -8,6 +8,7 @@
 
 #include "MethodConfiguration.h"
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <ScriptCanvas/Utils/BehaviorContextUtils.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -11,6 +11,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/std/tuple.h>
 #include <AzCore/std/typetraits/add_pointer.h>
 #include <AzCore/std/typetraits/function_traits.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Nodeable.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Nodeable.cpp
@@ -8,6 +8,7 @@
 
 #include "Nodeable.h"
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <ScriptCanvas/Core/SubgraphInterface.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
@@ -9,6 +9,7 @@
 #include "Data.h"
 #include <ScriptCanvas/Data/DataTrait.h>
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Component/EntityBus.h>
 #include <AzCore/RTTI/AttributeReader.h>
 #include <AzCore/RTTI/BehaviorContext.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Data/Data.cpp
@@ -15,6 +15,7 @@
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Utils.h>
+#include <AzCore/Serialization/AZStdContainers.inl>
 
 namespace DataCpp
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionState.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionState.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <ScriptCanvas/Core/Core.h>
 #include <ScriptCanvas/Execution/RuntimeComponent.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.h
@@ -21,6 +21,7 @@ struct lua_State;
 namespace AZ
 {
     class SerializeContext;
+    using StackVariableAllocator = AZStd::static_buffer_allocator<256, 16>;
 }
 
 namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpreted.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpreted.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Script/ScriptSystemBus.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 
 #include "Execution/Interpreted/ExecutionStateInterpretedUtility.h"
 #include "Execution/RuntimeComponent.h"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/DebugMap.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/DebugMap.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Script/ScriptContext.h>
 
 #include <ScriptCanvas/Core/Core.h>
 #include <ScriptCanvas/Core/Datum.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/ParsingUtilities.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/ParsingUtilities.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/RTTI/BehaviorContextUtilities.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzFramework/Entity/GameEntityContextBus.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/Node.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionDefinitionNode.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionDefinitionNode.cpp
@@ -14,6 +14,7 @@
 #include <ScriptCanvas/Libraries/Core/FunctionBus.h>
 
 #include <ScriptCanvas/Debugger/ValidationEvents/DataValidation/InvalidPropertyEvent.h>
+#include <AzCore/std/string/regex.h>
 
 namespace FunctionDefinitionNodeCpp
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Method.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Method.cpp
@@ -9,6 +9,7 @@
 #include "Method.h"
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Serialization/Utils.h>
 #include <Core/SlotConfigurationDefaults.h> 
 #include <Core/SlotExecutionMap.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/MethodOverloaded.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/MethodOverloaded.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/BehaviorContextUtilities.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <Libraries/Core/MethodUtility.h>
 #include <ScriptCanvas/Core/Contracts/MethodOverloadContract.h>
 #include <ScriptCanvas/Core/SlotConfigurations.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/MethodUtility.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/MethodUtility.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/std/containers/map.h>
 #include <ScriptCanvas/Libraries/Core/MethodUtility.h>
 #include <ScriptCanvas/Libraries/Core/Method.h>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/UnitTesting/UnitTestBusSender.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/UnitTesting/UnitTestBusSender.cpp
@@ -9,6 +9,7 @@
 #include "UnitTestBusSender.h"
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/BehaviorContextUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Utils/BehaviorContextUtils.cpp
@@ -9,6 +9,7 @@
 #include "BehaviorContextUtils.h"
 
 #include <AzCore/std/containers/map.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/RTTI/BehaviorContextUtilities.h>
 #include <ScriptCanvas/Core/GraphData.h>
 #include <ScriptCanvas/Libraries/Core/Method.h>

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 
 #include <AzCore/Component/EntityUtils.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/Mock.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/Mock.cpp
@@ -8,6 +8,7 @@
 
 
 #include <AzCore/std/containers/set.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <Editor/Nodes/NodeUtils.h>
 #include <GraphCanvas/Components/Nodes/NodeTitleBus.h>
 #include <GraphCanvas/Components/Slots/SlotBus.h>

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/BehaviorContextObjectTestNode.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/BehaviorContextObjectTestNode.h
@@ -10,6 +10,9 @@
 
 #include <ScriptCanvas/Core/Attributes.h>
 
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
 namespace ScriptCanvasTestingNodes
 {
     //! This object is used to test the use of BehaviorContext classes

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventBroadcast.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Math/Crc.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
 

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/BehaviorContextBinding/ScriptEventMethod.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Math/Crc.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
 

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventMethod.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventMethod.cpp
@@ -1,0 +1,147 @@
+﻿#include "ScriptEventMethod.h"
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/std/string/regex.h>
+
+
+namespace ScriptEvents
+{
+    void Method::FromScript(AZ::ScriptDataContext& dc)
+    {
+        if (dc.GetNumArguments() > 0)
+        {
+            AZStd::string name;
+            if (dc.IsString(0) && dc.ReadArg(0, name))
+            {
+                m_name.Set(name.c_str());
+            }
+
+            if (dc.GetNumArguments() > 1)
+            {
+                AZ::Uuid returnType;
+                if (dc.ReadArg(1, returnType))
+                {
+                    m_returnType.Set(returnType);
+                }
+            }
+        }
+
+        // AZ_TracePrintf("Script Events", "Added Script Method: %s (return type: %s)\n", GetName().c_str(), m_returnType.IsEmpty() ? "none"
+        // : GetReturnType().ToString<AZStd::string>().c_str());
+    }
+
+    void Method::AddParameter(AZ::ScriptDataContext& dc)
+    {
+        Parameter& parameter = NewParameter();
+        parameter.FromScript(dc);
+        dc.PushResult(parameter);
+    }
+
+    void Method::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<Method>()
+                ->Field("m_name", &Method::m_name)
+                ->Field("m_tooltip", &Method::m_tooltip)
+                ->Field("m_returnType", &Method::m_returnType)
+                ->Field("m_parameters", &Method::m_parameters);
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<Method>("Script Event", "A script event's definition")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &Method::m_name, "Name",
+                        "The specified name for this event, represents a callable function (i.e. MyScriptEvent())")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Method::m_tooltip, "Tooltip", "A description of this event")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::ComboBox, &Method::m_returnType, "Return value type",
+                        "the typeid of the return value, ex. AZ::type_info<int>::Uuid foo()")
+                    ->Attribute(AZ::Edit::Attributes::GenericValueList, &Types::GetValidReturnTypes)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &Method::m_parameters, "Parameters",
+                        "A list of parameters for the EBus event, ex. void foo(Parameter1, Parameter2)");
+            }
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<Method>("Method")
+                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                ->Method("AddParameter", &Method::AddParameter)
+                ->Property("Name", BehaviorValueProperty(&Method::m_name))
+                ->Property("ReturnType", BehaviorValueProperty(&Method::m_returnType))
+                ->Property("Parameters", BehaviorValueProperty(&Method::m_parameters));
+        }
+    }
+
+    AZ::Outcome<bool, AZStd::string> Method::Validate() const
+    {
+        const AZStd::string name = GetName();
+        const AZ::Uuid returnType = GetReturnType();
+
+        // Validate address type
+        if (!Types::IsValidReturnType(returnType))
+        {
+            return AZ::Failure(AZStd::string::format(
+                "The specified type %s is not valid as return type for Script Event: %s", returnType.ToString<AZStd::string>().c_str(),
+                name.c_str()));
+        }
+
+        // Definition name cannot be empty
+        if (name.empty())
+        {
+            return AZ::Failure(AZStd::string("Definition name cannot be empty"));
+        }
+
+        // Name cannot start with a number
+        if (isdigit(name.at(0)))
+        {
+            return AZ::Failure(AZStd::string::format("%s, names cannot start with a number", name.c_str()));
+        }
+
+        // Conform to valid function names
+        AZStd::smatch match;
+
+        // Ascii-only
+        AZStd::regex asciionly_regex("[^\x0A\x0D\x20-\x7E]");
+        AZStd::regex_match(name, match, asciionly_regex);
+        if (!match.empty())
+        {
+            return AZ::Failure(AZStd::string::format("%s, invalid name, names may only contain ASCII characters", name.c_str()));
+        }
+
+        AZStd::regex validate_regex("[_[:alpha:]][_[:alnum:]]*");
+        AZStd::regex_match(name, match, validate_regex);
+        if (match.empty())
+        {
+            return AZ::Failure(AZStd::string::format("%s, invalid name specified", name.c_str()));
+        }
+
+        AZStd::string parameterName;
+        int parameterIndex = 0;
+        for (const Parameter& parameter : m_parameters)
+        {
+            auto outcome = parameter.Validate();
+            if (!outcome.IsSuccess())
+            {
+                return outcome;
+            }
+
+            if (parameter.GetName().compare(parameterName) == 0)
+            {
+                return AZ::Failure(AZStd::string::format(
+                    "Cannot have duplicate parameter names (%d: %s) make sure each parameter name is unique", parameterIndex,
+                    parameterName.c_str()));
+            }
+
+            parameterName = parameter.GetName();
+            ++parameterIndex;
+        }
+
+        return AZ::Success(true);
+    }
+
+} // namespace ScriptEvents

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventMethod.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventMethod.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <ScriptEvents/ScriptEventParameter.h>
-#include <AzCore/RTTI/ReflectContext.h>
-#include <AzCore/RTTI/BehaviorContext.h>
 #include <ScriptEvents/ScriptEventTypes.h>
 
 namespace ScriptEvents
@@ -67,41 +65,14 @@ namespace ScriptEvents
             FromScript(dc);
         }
 
-        void FromScript(AZ::ScriptDataContext& dc)
-        {
-            if (dc.GetNumArguments() > 0)
-            {
-                AZStd::string name;
-                if (dc.IsString(0) && dc.ReadArg(0, name))
-                {
-                    m_name.Set(name.c_str());
-                }
-
-                if (dc.GetNumArguments() > 1)
-                {
-                    AZ::Uuid returnType;
-                    if (dc.ReadArg(1, returnType))
-                    {
-                        m_returnType.Set(returnType);
-                    }
-                }
-            }
-
-            //AZ_TracePrintf("Script Events", "Added Script Method: %s (return type: %s)\n", GetName().c_str(), m_returnType.IsEmpty() ? "none" : GetReturnType().ToString<AZStd::string>().c_str());
-
-        }
+        void FromScript(AZ::ScriptDataContext& dc);
 
         ~Method()
         {
             m_parameters.clear();
         }
 
-        void AddParameter(AZ::ScriptDataContext& dc)
-        {
-            Parameter& parameter = NewParameter();
-            parameter.FromScript(dc);
-            dc.PushResult(parameter);
-        }
+        void AddParameter(AZ::ScriptDataContext& dc);
 
         bool IsValid() const;
 
@@ -111,40 +82,7 @@ namespace ScriptEvents
             return m_parameters.back();
         }
 
-        static void Reflect(AZ::ReflectContext* context)
-        {
-            if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-            {
-                serializeContext->Class<Method>()
-                    ->Field("m_name", &Method::m_name)
-                    ->Field("m_tooltip", &Method::m_tooltip)
-                    ->Field("m_returnType", &Method::m_returnType)
-                    ->Field("m_parameters", &Method::m_parameters)
-                    ;
-
-                if (AZ::EditContext* editContext = serializeContext->GetEditContext())
-                {
-                    editContext->Class<Method>("Script Event", "A script event's definition")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &Method::m_name, "Name", "The specified name for this event, represents a callable function (i.e. MyScriptEvent())")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &Method::m_tooltip, "Tooltip", "A description of this event")
-                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &Method::m_returnType, "Return value type", "the typeid of the return value, ex. AZ::type_info<int>::Uuid foo()")
-                        ->Attribute(AZ::Edit::Attributes::GenericValueList, &Types::GetValidReturnTypes)
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &Method::m_parameters, "Parameters", "A list of parameters for the EBus event, ex. void foo(Parameter1, Parameter2)")
-                        ;
-                }
-            }
-
-            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-            {
-                behaviorContext->Class<Method>("Method")
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                    ->Method("AddParameter", &Method::AddParameter)
-                    ->Property("Name", BehaviorValueProperty(&Method::m_name))
-                    ->Property("ReturnType", BehaviorValueProperty(&Method::m_returnType))
-                    ->Property("Parameters", BehaviorValueProperty(&Method::m_parameters))
-                    ;
-            }
-        }
+        static void Reflect(AZ::ReflectContext* context);
 
         AZStd::string GetName() const { return m_name.Get<AZStd::string>() ? *m_name.Get<AZStd::string>() : ""; }
         AZStd::string GetTooltip() const { return m_tooltip.Get<AZStd::string>() ? *m_tooltip.Get<AZStd::string>() : ""; }
@@ -162,68 +100,7 @@ namespace ScriptEvents
         AZ::Crc32 GetEventId() const { return AZ::Crc32(GetNameProperty().GetId().ToString<AZStd::string>().c_str()); }
 
         //! Validates that the asset data being stored is valid and supported.
-        AZ::Outcome<bool, AZStd::string> Validate() const
-        {
-            const AZStd::string name = GetName();
-            const AZ::Uuid returnType = GetReturnType();
-
-            // Validate address type
-            if (!Types::IsValidReturnType(returnType))
-            {
-                return AZ::Failure(AZStd::string::format("The specified type %s is not valid as return type for Script Event: %s", returnType.ToString<AZStd::string>().c_str(), name.c_str()));
-            }
-
-            // Definition name cannot be empty
-            if (name.empty())
-            {
-                return AZ::Failure(AZStd::string("Definition name cannot be empty"));
-            }
-
-            // Name cannot start with a number
-            if (isdigit(name.at(0)))
-            {
-                return AZ::Failure(AZStd::string::format("%s, names cannot start with a number", name.c_str()));
-            }
-
-            // Conform to valid function names
-            AZStd::smatch match;
-
-            // Ascii-only
-            AZStd::regex asciionly_regex("[^\x0A\x0D\x20-\x7E]");
-            AZStd::regex_match(name, match, asciionly_regex);
-            if (!match.empty())
-            {
-                return AZ::Failure(AZStd::string::format("%s, invalid name, names may only contain ASCII characters", name.c_str()));
-            }
-
-            AZStd::regex validate_regex("[_[:alpha:]][_[:alnum:]]*");
-            AZStd::regex_match(name, match, validate_regex);
-            if (match.empty())
-            {
-                return AZ::Failure(AZStd::string::format("%s, invalid name specified", name.c_str()));
-            }
-
-            AZStd::string parameterName;
-            int parameterIndex = 0;
-            for (const Parameter& parameter : m_parameters)
-            {
-                auto outcome = parameter.Validate();
-                if (!outcome.IsSuccess())
-                {
-                    return outcome;
-                }
-
-                if (parameter.GetName().compare(parameterName) == 0)
-                {
-                    return AZ::Failure(AZStd::string::format("Cannot have duplicate parameter names (%d: %s) make sure each parameter name is unique", parameterIndex, parameterName.c_str()));
-                }
-
-                parameterName = parameter.GetName();
-                ++parameterIndex;
-            }
-
-            return AZ::Success(true);
-        }
+        AZ::Outcome<bool, AZStd::string> Validate() const;
 
         void PreSave()
         {
@@ -255,6 +132,6 @@ namespace ScriptEvents
         ScriptEventData::VersionedProperty m_returnType;
         AZStd::vector<Parameter> m_parameters;
 
-        };
+    };
 
 }

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventParameter.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventParameter.cpp
@@ -1,0 +1,120 @@
+﻿/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ScriptEventParameter.h"
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/std/string/regex.h>
+
+namespace ScriptEvents
+{
+    void Parameter::FromScript(AZ::ScriptDataContext& dc)
+    {
+        if (dc.GetNumArguments() > 0)
+        {
+            AZStd::string name;
+            if (dc.ReadArg(0, name))
+            {
+                m_name.Set(name.c_str());
+            }
+
+            if (dc.GetNumArguments() > 1)
+            {
+                AZ::Uuid parameterType;
+                if (dc.ReadArg(1, parameterType))
+                {
+                    m_type.Set(parameterType);
+                }
+            }
+        }
+
+        // AZ_TracePrintf("Script Events", "Added Parameter: %s (type: %s)\n", GetName().c_str(), GetType().ToString<AZStd::string>()
+        // .c_str());
+    }
+
+    void Parameter::Reflect(AZ::ReflectContext *context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<Parameter>()
+                    ->Field("m_name", &Parameter::m_name)
+                    ->Field("m_tooltip", &Parameter::m_tooltip)
+                    ->Field("m_type", &Parameter::m_type)
+                    ;
+
+            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<Parameter>("A Script Event's method parameter", "A parameter to a Script Event's event definition")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &Parameter::m_name, "Name", "Name of the parameter, ex. void foo(int thisIsTheParameterName)")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &Parameter::m_tooltip, "Tooltip", "A description of this parameter")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &Parameter::m_type, "Type", "The typeid of the parameter, ex. void foo(AZ::type_info<int>::Uuid())")
+                        ->Attribute(AZ::Edit::Attributes::GenericValueList, &Types::GetValidParameterTypes)
+                        ;
+            }
+        }
+
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<Parameter>("Parameter")
+                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                    ->Property("Name", BehaviorValueProperty(&Parameter::m_name))
+                    ->Property("Type", BehaviorValueProperty(&Parameter::m_type))
+                    ;
+        }
+    }
+
+    AZ::Outcome<bool, AZStd::string> Parameter::Validate() const
+    {
+        const AZStd::string& name = GetName();
+        const AZ::Uuid* parameterType = m_type.Get<const AZ::Uuid>();
+
+        AZ_Assert(parameterType && !parameterType->IsNull(), "The Parameter type should not be null");
+
+        // Validate address type
+        if (!Types::IsValidParameterType(*parameterType))
+        {
+            return AZ::Failure(AZStd::string::format("The specified type %s is not valid as parameter type for Script Event: %s", (*parameterType).ToString<AZStd::string>().c_str(), name.c_str()));
+        }
+
+        // Definition name cannot be empty
+        if (name.empty())
+        {
+            return AZ::Failure(AZStd::string("Definition name cannot be empty"));
+        }
+
+        // Name cannot start with a number
+        if (isdigit(name.at(0)))
+        {
+            return AZ::Failure(AZStd::string::format("%s, names cannot start with a number", name.c_str()));
+        }
+
+        // Conform to valid function names
+        AZStd::smatch match;
+
+        // Ascii-only
+        AZStd::regex asciionly_regex("[^\x0A\x0D\x20-\x7E]");
+        AZStd::regex_match(name, match, asciionly_regex);
+        if (match.size() > 0)
+        {
+            return AZ::Failure(AZStd::string::format("%s, invalid name, names may only contain ASCII characters", name.c_str()));
+        }
+
+        // Function name syntax
+        AZStd::regex validate_regex("[_[:alpha:]][_[:alnum:]]*");
+        AZStd::regex_match(name, match, validate_regex);
+        if (match.size() == 0)
+        {
+            return AZ::Failure(AZStd::string::format("%s, invalid name specified", name.c_str()));
+        }
+
+        return AZ::Success(true);
+
+    }
+
+} // namespace ScriptEvents

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventParameter.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventParameter.h
@@ -10,9 +10,8 @@
 
 #include <ScriptEvents/Internal/VersionedProperty.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Outcome/Outcome.h>
 #include <ScriptEvents/ScriptEventTypes.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/std/string/regex.h>
 
 namespace ScriptEvents
 {
@@ -45,108 +44,11 @@ namespace ScriptEvents
             FromScript(dc);
         }
 
-        void FromScript(AZ::ScriptDataContext& dc)
-        {
-            if (dc.GetNumArguments() > 0)
-            {
-                AZStd::string name;
-                if (dc.ReadArg(0, name))
-                {
-                    m_name.Set(name.c_str());
-                }
+        void FromScript(AZ::ScriptDataContext& dc);
 
-                if (dc.GetNumArguments() > 1)
-                {
-                    AZ::Uuid parameterType;
-                    if (dc.ReadArg(1, parameterType))
-                    {
-                        m_type.Set(parameterType);
-                    }
-                }
-            }
+        static void Reflect(AZ::ReflectContext* context);
 
-            //AZ_TracePrintf("Script Events", "Added Parameter: %s (type: %s)\n", GetName().c_str(), GetType().ToString<AZStd::string>() .c_str());
-
-        }
-
-        static void Reflect(AZ::ReflectContext* context)
-        {
-            if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-            {
-                serializeContext->Class<Parameter>()
-                    ->Field("m_name", &Parameter::m_name)
-                    ->Field("m_tooltip", &Parameter::m_tooltip)
-                    ->Field("m_type", &Parameter::m_type)
-                    ;
-
-                if (AZ::EditContext* editContext = serializeContext->GetEditContext())
-                {
-                    editContext->Class<Parameter>("A Script Event's method parameter", "A parameter to a Script Event's event definition")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &Parameter::m_name, "Name", "Name of the parameter, ex. void foo(int thisIsTheParameterName)")
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &Parameter::m_tooltip, "Tooltip", "A description of this parameter")
-                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &Parameter::m_type, "Type", "The typeid of the parameter, ex. void foo(AZ::type_info<int>::Uuid())")
-                            ->Attribute(AZ::Edit::Attributes::GenericValueList, &Types::GetValidParameterTypes)
-                        ;
-                }
-            }
-
-            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-            {
-                behaviorContext->Class<Parameter>("Parameter")
-                    ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
-                    ->Property("Name", BehaviorValueProperty(&Parameter::m_name))
-                    ->Property("Type", BehaviorValueProperty(&Parameter::m_type))
-                    ;
-            }
-        }
-
-        AZ::Outcome<bool, AZStd::string> Validate() const
-        {
-            const AZStd::string& name = GetName();
-            const AZ::Uuid* parameterType = m_type.Get<const AZ::Uuid>();
-
-            AZ_Assert(parameterType && !parameterType->IsNull(), "The Parameter type should not be null");
-
-            // Validate address type
-            if (!Types::IsValidParameterType(*parameterType))
-            {
-                return AZ::Failure(AZStd::string::format("The specified type %s is not valid as parameter type for Script Event: %s", (*parameterType).ToString<AZStd::string>().c_str(), name.c_str()));
-            }
-
-            // Definition name cannot be empty
-            if (name.empty())
-            {
-                return AZ::Failure(AZStd::string("Definition name cannot be empty"));
-            }
-
-            // Name cannot start with a number
-            if (isdigit(name.at(0)))
-            {
-                return AZ::Failure(AZStd::string::format("%s, names cannot start with a number", name.c_str()));
-            }
-
-            // Conform to valid function names
-            AZStd::smatch match;
-
-            // Ascii-only
-            AZStd::regex asciionly_regex("[^\x0A\x0D\x20-\x7E]");
-            AZStd::regex_match(name, match, asciionly_regex);
-            if (match.size() > 0)
-            {
-                return AZ::Failure(AZStd::string::format("%s, invalid name, names may only contain ASCII characters", name.c_str()));
-            }
-
-            // Function name syntax
-            AZStd::regex validate_regex("[_[:alpha:]][_[:alnum:]]*");
-            AZStd::regex_match(name, match, validate_regex);
-            if (match.size() == 0)
-            {
-                return AZ::Failure(AZStd::string::format("%s, invalid name specified", name.c_str()));
-            }
-
-            return AZ::Success(true);
-
-        }
+        AZ::Outcome<bool, AZStd::string> Validate() const;
 
         AZStd::string GetName() const { return m_name.Get<AZStd::string>() ? *m_name.Get<AZStd::string>() : ""; }
         AZStd::string GetTooltip() const { return m_tooltip.Get<AZStd::string>() ? *m_tooltip.Get<AZStd::string>() : ""; }

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventTypes.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventTypes.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Math/Matrix4x4.h>
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/ScriptCanvas/ScriptCanvasAttributes.h>
 #include <AzCore/std/sort.h>
 
 namespace ScriptEvents

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventTypes.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventTypes.h
@@ -10,6 +10,18 @@
 
 #include <ScriptEvents/Internal/VersionedProperty.h>
 
+namespace AZ
+{
+    class BehaviorClass;
+    class BehaviorMethod;
+    namespace Script
+    {
+        namespace Attributes
+        {
+            enum class OperatorType : int;
+        }
+    }
+}
 namespace ScriptEvents
 {
     namespace Types

--- a/Gems/ScriptEvents/Code/scriptevents_common_files.cmake
+++ b/Gems/ScriptEvents/Code/scriptevents_common_files.cmake
@@ -21,8 +21,10 @@ set(FILES
     Include/ScriptEvents/ScriptEventDefinition.cpp
     Include/ScriptEvents/ScriptEvent.h
     Include/ScriptEvents/ScriptEventMethod.h
+    Include/ScriptEvents/ScriptEventMethod.cpp
     Include/ScriptEvents/ScriptEvent.cpp
     Include/ScriptEvents/ScriptEventParameter.h
+    Include/ScriptEvents/ScriptEventParameter.cpp
     Include/ScriptEvents/ScriptEventSystem.h
     Include/ScriptEvents/ScriptEventSystem.cpp
     Include/ScriptEvents/ScriptEventTypes.h

--- a/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp
+++ b/Gems/StartingPointInput/Code/Source/StartingPointInputGem.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
@@ -11,11 +11,11 @@
 #include "InputEventMap.h"
 #include "InputLibrary.h"
 
-#include <AzCore/Module/Module.h>
-#include <AzCore/Serialization/SerializeContext.h>
-
-#include <AzCore/Module/Environment.h>
 #include <AzCore/Component/Component.h>
+#include <AzCore/Module/Environment.h>
+#include <AzCore/Module/Module.h>
+#include <AzCore/Script/ScriptContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 #include <AzFramework/Asset/GenericAssetHandler.h>
 

--- a/Gems/WhiteBox/Code/Include/WhiteBox/WhiteBoxToolApi.h
+++ b/Gems/WhiteBox/Code/Include/WhiteBox/WhiteBoxToolApi.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/vector.h>
 

--- a/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxDefaultMode.h
+++ b/Gems/WhiteBox/Code/Source/SubComponentModes/EditorWhiteBoxDefaultMode.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "EditorWhiteBoxComponentModeTypes.h"
+#include "AzCore/std/containers/variant.h"
 #include "SubComponentModes/EditorWhiteBoxDefaultModeBus.h"
 
 #include <EditorWhiteBoxEdgeModifierBus.h>

--- a/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
+++ b/Gems/WhiteBox/Code/Source/WhiteBoxToolApiReflection.cpp
@@ -10,6 +10,7 @@
 #include "WhiteBoxToolApiReflection.h"
 
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <WhiteBox/EditorWhiteBoxComponentBus.h>
 #include <WhiteBox/WhiteBoxComponentBus.h>
 #include <WhiteBox/WhiteBoxToolApi.h>

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxTestUtil.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxTestUtil.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "WhiteBoxTestUtil.h"
+#include <AzCore/std/string/string.h>
 
 namespace WhiteBox
 {

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxTestUtil.h
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxTestUtil.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Math/Transform.h>
+#include <AzCore/std/string/string.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
 #include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzTest/AzTest.h>


### PR DESCRIPTION
The 'SerializeContext.h' was including inline implementations of few types by including:

* AZStd containers generics
    * `#include <AzCore/Serialization/AZStdContainers.inl>`
    * `#include <AzCore/Serialization/std/VariantReflection.inl>`
* asset generics
    * `#include <AzCore/Asset/AssetSerializer.h>`
* implementation of SerializeContext::EnumBuilder
    * `#include <AzCore/Serialization/SerializeContextEnum.inl>`

This caused template instantiations to take place in every file including 'SerializeContext.h'.

The 'fix' is using the removed `#include`s only in places that need them and reduces non-unity build time by ~ 10% under clang. The build size is also reduced by ~1.5% (likely caused by smaller debug data segments ).

Other changes:
* In `ScriptContextAttributes.h` added explicit underlying type to `enum class OperatorType` to allow it's forward declaration.
* Moved `DataPatchInternal::AddressTypeSerializer` class to separate file (Serialization/Internal/AddressTypeSerializer.h) to reduce number of required includes
* Introduced ScriptEventMethod.cpp and ScriptEventParameter.cpp and moved larger methods to those cpp files ( done to prevent `::Reflect` from requiring additional includes in header )
* Introduced `HandleReflectImpl.inl` and `NameIdReflectionMapReflectImpl.inl` that contain implementation of reflection code and can be included only when needed.

Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>