### PR TITLE
Fixed RootAssetBrowserEntry setting of child AssetBrowserEntries

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Entries/RootAssetBrowserEntry.cpp
@@ -403,7 +403,7 @@ namespace AzToolsFramework
         void RootAssetBrowserEntry::UpdateChildPaths(AssetBrowserEntry* child) const
         {
             child->m_relativePath = child->m_name;
-            child->m_fullPath = child->m_name;
+            child->m_fullPath = m_fullPath / child->m_name;
             AssetBrowserEntry::UpdateChildPaths(child);
         }
 


### PR DESCRIPTION
The issue is due to RootAssetBrowserEntry::UpdateChildPaths not taking
the RootAssetBrowserEntry fullpath into account when appending the child
path entry

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>