### PR TITLE
Viewport UI focus/shortcut fix only

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -364,7 +364,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     {
         // no background for the widget else each set of buttons/textfields/etc would have a black box around them
         SetTransparentBackground(widget);
-        widget->setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
+        widget->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
     }
 
     void ViewportUiDisplay::InitializeUiOverlay()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -369,11 +369,11 @@ namespace AzToolsFramework::ViewportUi::Internal
 
     void ViewportUiDisplay::InitializeUiOverlay()
     {
-        m_uiMainWindow.setObjectName(m_uiMainWindow.windowTitle());
+        m_uiMainWindow.setObjectName(QString("ViewportUiWindow"));
         ConfigureWidgetForViewportUi(&m_uiMainWindow);
         m_uiMainWindow.setVisible(false);
 
-        m_uiOverlay.setObjectName(m_uiOverlay.windowTitle());
+        m_uiOverlay.setObjectName(QString("ViewportUiOverlay"));
         m_uiMainWindow.setCentralWidget(&m_uiOverlay);
         m_uiOverlay.setVisible(false);
 


### PR DESCRIPTION
This is a follow-up from https://github.com/o3de/o3de/pull/2302 to include only the relevant changes to fix the bug. A follow-up PR will be posted with the other clean-up work after this is merged (fixes LYN-1866).

There were two changes required, the first was to add `Qt::WindowDoesNotAcceptFocus` to `m_uiMainWindow` in `ViewportUiDisplay` to ensure it never received focus from Qt. The second was setting a valid name for but `m_uiMainWindow` and `m_uiOverlay` which before were using `windowTitle()` which was empty (this prevented some shortcuts from working, e.g. Undo/Redo as they go through `PatchedAction` and the `focusWindowName` check was failing because it was empty.

```c++
// line 122, ActionManager.cpp
QString focusWindowName = focusWindow->objectName();
if (focusWindowName.isEmpty())
{
    continue;
}
```