### PR TITLE
Ensure camera system correctly consumes events when it is active

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -147,7 +147,9 @@ namespace AzFramework
             m_scrollDelta = scroll->m_delta;
         }
 
-        return m_cameras.HandleEvents(event, m_motionDelta, m_scrollDelta);
+        m_handlingEvents = m_cameras.HandleEvents(event, m_motionDelta, m_scrollDelta);
+
+        return m_handlingEvents;
     }
 
     Camera CameraSystem::StepCamera(const Camera& targetCamera, const float deltaTime)

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -262,12 +262,14 @@ namespace AzFramework
     public:
         bool HandleEvents(const InputEvent& event);
         Camera StepCamera(const Camera& targetCamera, float deltaTime);
+        bool HandlingEvents() const { return m_handlingEvents; }
 
         Cameras m_cameras; //!< Represents a collection of camera inputs that together provide a camera controller.
 
     private:
         ScreenVector m_motionDelta; //!< The delta used for look/orbit/pan (rotation + translation) - two dimensional.
         float m_scrollDelta = 0.0f; //!< The delta used for dolly/movement (translation) - one dimensional.
+        bool m_handlingEvents = false; //!< Is the camera system currently handling events (events are consumed and not propagated).
     };
 
     //! A camera input to handle motion deltas that can rotate or orbit the camera.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -128,7 +128,7 @@ namespace AtomToolsFramework
             return AzFramework::ViewportControllerPriority::Highest;
         }
 
-        // otherwise it should also respond to normal priority events
+        // otherwise it should only respond to normal priority events
         return AzFramework::ViewportControllerPriority::Normal;
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -118,18 +118,20 @@ namespace AtomToolsFramework
     }
 
     // should the camera system respond to this particular event
-    static bool ShouldHandle(const AzFramework::ViewportControllerPriority priority, const bool exclusive)
+    static bool ShouldHandle(const AzFramework::ViewportControllerPriority priority, const bool exclusive, const bool handling)
     {
-        // ModernViewportCameraControllerInstance receives events at all priorities, it should only respond
-        // to normal priority events if it is not in 'exclusive' mode and when in 'exclusive' mode it should
-        // only respond to the highest priority events
+        // ModernViewportCameraControllerInstance receives events at all priorities, it should only respond to normal priority
+        // events if it is not in 'exclusive' mode and when in 'exclusive' mode it should only respond to the highest priority
+        // events, it should also respond to highest priority events while handling events (essentially when the camera system
+        // is 'active' and responding to inputs)
         return !exclusive && priority == AzFramework::ViewportControllerPriority::Normal ||
-            exclusive && priority == AzFramework::ViewportControllerPriority::Highest;
+            exclusive && priority == AzFramework::ViewportControllerPriority::Highest ||
+            handling && priority == AzFramework::ViewportControllerPriority::Highest;
     }
 
     bool ModernViewportCameraControllerInstance::HandleInputChannelEvent(const AzFramework::ViewportControllerInputEvent& event)
     {
-        if (ShouldHandle(event.m_priority, m_cameraSystem.m_cameras.Exclusive()))
+        if (ShouldHandle(event.m_priority, m_cameraSystem.m_cameras.Exclusive(), m_cameraSystem.HandlingEvents()))
         {
             return m_cameraSystem.HandleEvents(AzFramework::BuildInputEvent(event.m_inputChannel));
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -88,7 +88,7 @@ namespace AtomToolsFramework
             [this](const AzFramework::InputChannel* inputChannel, QEvent* event)
         {
             AzFramework::NativeWindowHandle windowId = reinterpret_cast<AzFramework::NativeWindowHandle>(winId());
-            if (m_controllerList->HandleInputChannelEvent({GetId(), windowId, *inputChannel}))
+            if (m_controllerList->HandleInputChannelEvent(AzFramework::ViewportControllerInputEvent{GetId(), windowId, *inputChannel}))
             {
                 // If the controller handled the input event, mark the event as accepted so it doesn't continue to propagate.
                 if (event)


### PR DESCRIPTION
This change resolves this issue - https://github.com/o3de/o3de/issues/2266

We ensure that when the camera system is handling events (it is active) no events are propagated to other systems handling input at a lower priority. To do this we effectively bump the priority of the camera while it is running. @amzn-jillich has tested out these changes and has noted a massive performance improvement.

There may be instances where we need to be more granular about what makes the camera 'active' (this would be possible to add) but should be a big improvement for now).