### PR TITLE
Improve job system throughput by 1.5x

### DIFF
--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.h
@@ -18,7 +18,7 @@
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/parallel/semaphore.h>
-#include <AzCore/std/parallel/binary_semaphore.h>
+#include <AzCore/std/parallel/condition_variable.h>
 #include <AzCore/std/parallel/thread.h>
 
 namespace AZ
@@ -96,7 +96,8 @@ namespace AZ
                 // valid only on workers (TODO: Use some lazy initialization as we don't need that data for non worker threads)
                 AZStd::thread m_thread;
                 AZStd::atomic_bool m_isAvailable{false};
-                AZStd::binary_semaphore m_waitEvent;
+                AZStd::condition_variable m_waitEvent;
+                AZStd::mutex m_waitMutex;
                 WorkQueue m_pendingJobs;
                 unsigned int m_workerId = JobManagerBase::InvalidWorkerThreadId;
 

--- a/Code/Framework/AzCore/Tests/Jobs.cpp
+++ b/Code/Framework/AzCore/Tests/Jobs.cpp
@@ -23,6 +23,7 @@
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/fixed_list.h>
 #include <AzCore/std/containers/unordered_set.h>
+#include <AzCore/std/parallel/binary_semaphore.h>
 #include <AzCore/std/parallel/containers/concurrent_vector.h>
 
 #include <AzCore/Memory/SystemAllocator.h>

--- a/Gems/AWSMetrics/Code/Include/Private/MetricsManager.h
+++ b/Gems/AWSMetrics/Code/Include/Private/MetricsManager.h
@@ -18,6 +18,7 @@
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/parallel/binary_semaphore.h>
 #include <AzCore/std/parallel/mutex.h>
 
 namespace AWSMetrics


### PR DESCRIPTION
The mechanism used to notify threads that work is available is driven
by AZStd::binary_semaphore which on Windows is backed by a Win32 event.
Win32 events are a kernel space object that can be shared across
processes, and are generally expensive. In contrast,
AZStd::condition_variable is backed by a Win32 CONDITION_VARIABLE. While
a mutex is needed to wait on the condition variable, the mutex is
generally uncontended. More importantly, the CONDITION_VARIABLE is a
userspace object (instead of a kernel space object), and the uncontended
mutex will often be released immediately without entering the kernel.

The result of a simple microbenchmark demonstrates that enqueueing a
single job based on the old mechanism takes on the order of 400 ns. However,
changing the notification mechanism to use AZStd::condition_variable
instead drops this time to ~285 ns.

More complete benchmarking results are provided below, based on the
existing benchmarking tests. The columns correspond to Total Time(ns),
CPU(ns), and iteration count per Google's benchmark library. The second
column is the important one to compare (lower is better).

## OLD RESULTS (binary_semaphore)

JobBenchmarkFixture/RunSmallNumberOfLightWeightJobsWithDefaultPriority 33179 ns        32959 ns        21333
JobBenchmarkFixture/RunMediumNumberOfLightWeightJobsWithDefaultPriority 3362169 ns      3370098 ns          204
JobBenchmarkFixture/RunLargeNumberOfLightWeightJobsWithDefaultPriority 55392209 ns     55397727 ns           11
JobBenchmarkFixture/RunSmallNumberOfMediumWeightJobsWithDefaultPriority 32737 ns        32226 ns        20364
JobBenchmarkFixture/RunMediumNumberOfMediumWeightJobsWithDefaultPriority 3321626 ns      3293505 ns          204
JobBenchmarkFixture/RunLargeNumberOfMediumWeightJobsWithDefaultPriority 52722218 ns     52556818 ns           11
JobBenchmarkFixture/RunSmallNumberOfHeavyWeightJobsWithDefaultPriority 1798466 ns      1765971 ns          407
JobBenchmarkFixture/RunMediumNumberOfHeavyWeightJobsWithDefaultPriority 117518267 ns    117187500 ns            6
JobBenchmarkFixture/RunLargeNumberOfHeavyWeightJobsWithDefaultPriority 1864236000 ns   1828125000 ns            1
JobBenchmarkFixture/RunSmallNumberOfRandomWeightJobsWithDefaultPriority 916962 ns       899431 ns          747
JobBenchmarkFixture/RunMediumNumberOfRandomWeightJobsWithDefaultPriority 57428870 ns     54687500 ns           10
JobBenchmarkFixture/RunLargeNumberOfRandomWeightJobsWithDefaultPriority 925064600 ns    890625000 ns            1
JobBenchmarkFixture/RunSmallNumberOfLightWeightJobsWithRandomPriorities 33970 ns        34528 ns        20364
JobBenchmarkFixture/RunMediumNumberOfLightWeightJobsWithRandomPriorities 3526404 ns      3523284 ns          204
JobBenchmarkFixture/RunLargeNumberOfLightWeightJobsWithRandomPriorities 54560909 ns     53977273 ns           11
JobBenchmarkFixture/RunSmallNumberOfMediumWeightJobsWithRandomPriorities 34157 ns        34424 ns        21333
JobBenchmarkFixture/RunMediumNumberOfMediumWeightJobsWithRandomPriorities 3398680 ns      3446691 ns          204
JobBenchmarkFixture/RunLargeNumberOfMediumWeightJobsWithRandomPriorities 58225940 ns     57812500 ns           10
JobBenchmarkFixture/RunSmallNumberOfHeavyWeightJobsWithRandomPriorities 1903216 ns      1881143 ns          407
JobBenchmarkFixture/RunMediumNumberOfHeavyWeightJobsWithRandomPriorities 118144683 ns    114583333 ns            6
JobBenchmarkFixture/RunLargeNumberOfHeavyWeightJobsWithRandomPriorities 1869486300 ns   1671875000 ns            1
JobBenchmarkFixture/RunSmallNumberOfRandomWeightJobsWithRandomPriorities 928852 ns       941265 ns          747
JobBenchmarkFixture/RunMediumNumberOfRandomWeightJobsWithRandomPriorities 58163618 ns     53977273 ns           11
JobBenchmarkFixture/RunLargeNumberOfRandomWeightJobsWithRandomPriorities 932691200 ns    843750000 ns            1

## NEW RESULTS (condition_variable)

JobBenchmarkFixture/RunSmallNumberOfLightWeightJobsWithDefaultPriority 25129 ns        24902 ns        26353
JobBenchmarkFixture/RunMediumNumberOfLightWeightJobsWithDefaultPriority 2234018 ns      2247074 ns          299
JobBenchmarkFixture/RunLargeNumberOfLightWeightJobsWithDefaultPriority 33588352 ns     34226190 ns           21
JobBenchmarkFixture/RunSmallNumberOfMediumWeightJobsWithDefaultPriority 27176 ns        27274 ns        26353
JobBenchmarkFixture/RunMediumNumberOfMediumWeightJobsWithDefaultPriority 2179414 ns      2176339 ns          280
JobBenchmarkFixture/RunLargeNumberOfMediumWeightJobsWithDefaultPriority 33352230 ns     33593750 ns           20
JobBenchmarkFixture/RunSmallNumberOfHeavyWeightJobsWithDefaultPriority 1971620 ns      1947464 ns          345
JobBenchmarkFixture/RunMediumNumberOfHeavyWeightJobsWithDefaultPriority 119505200 ns    113839286 ns            7
JobBenchmarkFixture/RunLargeNumberOfHeavyWeightJobsWithDefaultPriority 1913765800 ns   1828125000 ns            1
JobBenchmarkFixture/RunSmallNumberOfRandomWeightJobsWithDefaultPriority 978376 ns       976562 ns          640
JobBenchmarkFixture/RunMediumNumberOfRandomWeightJobsWithDefaultPriority 58535218 ns     46875000 ns           11
JobBenchmarkFixture/RunLargeNumberOfRandomWeightJobsWithDefaultPriority 944719700 ns    703125000 ns            1
JobBenchmarkFixture/RunSmallNumberOfLightWeightJobsWithRandomPriorities 25626 ns        25844 ns        23579
JobBenchmarkFixture/RunMediumNumberOfLightWeightJobsWithRandomPriorities 2156639 ns      2142559 ns          299
JobBenchmarkFixture/RunLargeNumberOfLightWeightJobsWithRandomPriorities 34256847 ns     33717105 ns           19
JobBenchmarkFixture/RunSmallNumberOfMediumWeightJobsWithRandomPriorities 27427 ns        27169 ns        23579
JobBenchmarkFixture/RunMediumNumberOfMediumWeightJobsWithRandomPriorities 2210968 ns      2247074 ns          299
JobBenchmarkFixture/RunLargeNumberOfMediumWeightJobsWithRandomPriorities 33389135 ns     33593750 ns           20
JobBenchmarkFixture/RunSmallNumberOfHeavyWeightJobsWithRandomPriorities 2001554 ns      1992754 ns          345
JobBenchmarkFixture/RunMediumNumberOfHeavyWeightJobsWithRandomPriorities 121427817 ns    109375000 ns            6
JobBenchmarkFixture/RunLargeNumberOfHeavyWeightJobsWithRandomPriorities 1931018800 ns   1562500000 ns            1
JobBenchmarkFixture/RunSmallNumberOfRandomWeightJobsWithRandomPriorities 999190 ns      1004016 ns          747
JobBenchmarkFixture/RunMediumNumberOfRandomWeightJobsWithRandomPriorities 58714218 ns     49715909 ns           11
JobBenchmarkFixture/RunLargeNumberOfRandomWeightJobsWithRandomPriorities 947552300 ns    671875000 ns            1

Signed-off-by: Jeremy Ong <jcong@amazon.com>