### PR TITLE
Fixing missing definition of GpuCrashTracker for Aftermath.

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/Device_Windows.h
@@ -9,6 +9,10 @@
 
 #include <Atom/RHI/Device.h>
 
+#if defined(USE_NSIGHT_AFTERMATH)
+    #include <RHI/NsightAftermathGpuCrashTracker_Windows.h>
+#endif
+
 namespace AZ
 {
     namespace DX12


### PR DESCRIPTION
 Recently some changes were made to pch, and this was probably missed. This will just include the file directly when Aftermath is enabled.