### PR TITLE
Fixed Project Manager to enable save/restore of the window geometry.

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
@@ -661,6 +661,10 @@ namespace AzQtComponents
         if (!restoreGeometryFromSettings())
         {
             show();
+
+            // If we failed to restore from settings (the first time this window is loaded),
+            // then center it on the screen by default
+            centerOnScreen(this);
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/Application.cpp
+++ b/Code/Tools/ProjectManager/Source/Application.cpp
@@ -170,7 +170,8 @@ namespace O3DE::ProjectManager
         // the decoration wrapper is intended to remember window positioning and sizing 
         auto wrapper = new AzQtComponents::WindowDecorationWrapper();
         wrapper->setGuest(m_mainWindow.data());
-        wrapper->show();
+        wrapper->enableSaveRestoreGeometry("O3DE", "ProjectManager", "mainWindowGeometry");
+        wrapper->showFromSettings();
         m_mainWindow->show();
 
         qApp->setQuitOnLastWindowClosed(true);


### PR DESCRIPTION
Fixes #2317 

There were two issues here. The first is that the Project Manager wasn't using the ```enableSaveRestoreGeometry``` on the ```WindowDecorationWrapper```, so the window position/sizing wasn't actually being restored after it was closed/re-launched. 

The other part though, is that even with that, the first time the window was opened it was still getting opened off-screen. So I also improved the ```WindowDecorationWrapper``` logic to center by default when using the showFromSettings API for first time launch.

Tested moving the Project Manager to various parts of the screen (and also maximized) and verified its position/size was restored on subsequent launches. Also made sure the first time it is launched (after clearing the saved setting) it gets centered in the screen.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>