### PR TITLE
Improved auto-resizing when centering dialogs when they are first displayed.

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
@@ -240,15 +240,51 @@ namespace AzQtComponents
 
             // Center within the parent
             QRect geo = geometry();
+
+            // If the base size of the guest widget is larger than the screen,
+            // then we need to resize it so that it will fit by either using
+            // the minimum size (if one is set), or fallback to the screen size.
+            if (m_guestWidget)
+            {
+                if (auto screen = m_guestWidget->screen())
+                {
+                    const QRect screenGeometry = screen->availableGeometry();
+                    if (geo.width() > screenGeometry.width())
+                    {
+                        auto guestMinimumWidth = m_guestWidget->minimumWidth();
+                        if (guestMinimumWidth && guestMinimumWidth <= screenGeometry.width())
+                        {
+                            geo.setWidth(guestMinimumWidth);
+                        }
+                        else
+                        {
+                            geo.setWidth(screenGeometry.width());
+                        }
+                    }
+                    else if (geo.height() > screenGeometry.height())
+                    {
+                        auto guestMinimumHeight = m_guestWidget->minimumHeight();
+                        if (guestMinimumHeight && guestMinimumHeight <= screenGeometry.height())
+                        {
+                            geo.setHeight(guestMinimumHeight);
+                        }
+                        else
+                        {
+                            geo.setHeight(screenGeometry.height());
+                        }
+                    }
+                }
+            }
+
             geo.moveCenter(parentWindowCenter);
 
-            QWindow *w = topLevelWidget->windowHandle();
+            QWindow* w = topLevelWidget->windowHandle();
             if (!w)
             {
                 return;
             }
 
-            QScreen *screen = w->screen();
+            QScreen* screen = w->screen();
             if (!screen)
             {
                 // defensive, shouldn't happen

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/WindowDecorationWrapper.cpp
@@ -261,7 +261,7 @@ namespace AzQtComponents
                             geo.setWidth(screenGeometry.width());
                         }
                     }
-                    else if (geo.height() > screenGeometry.height())
+                    if (geo.height() > screenGeometry.height())
                     {
                         auto guestMinimumHeight = m_guestWidget->minimumHeight();
                         if (guestMinimumHeight && guestMinimumHeight <= screenGeometry.height())


### PR DESCRIPTION
Fixes #2192 

The above issue was filed specifically for the Texture Settings Editor, but this could be reproduced with any dialog/window being displayed that has a base size bigger than the current screen. In this instance, you can reproduce on a resolution of 1280x1024 or smaller, because the Texture Settings Editor has a base (preferred) size of 580x1200.

When we try to center the dialog, if it is bigger than the screen then it winds up off-screen, and in this case made it very difficult to interact with because all the top buttons were hidden, which I took a gif of here:

![EditTextureSettingsBEFORE](https://user-images.githubusercontent.com/7519264/126683846-89c5c9a5-05bf-4d5d-b953-1b1a3287c12e.gif)

I have updated the logic when centering a dialog the first time it's shown to resize it based on the minimum size (if one was set), or by the screen size if it was going to be larger than the screen size, which now works like this:

![EditTextureSettingsAFTER](https://user-images.githubusercontent.com/7519264/126684025-156ba696-5ac1-4032-a681-865d7f96350c.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>