### PR TITLE
Removed slice based context menu options from the RPE when prefabs are enabled.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1951,12 +1951,13 @@ namespace AzToolsFramework
             return;
         }
 
+        // If prefabs are enabled, there will be no root slice so bail out here since we don't need
+        // to show any slice options in the menu
         AZ::SliceComponent* rootSlice = nullptr;
         AzFramework::SliceEntityOwnershipServiceRequestBus::EventResult(rootSlice, contextId,
             &AzFramework::SliceEntityOwnershipServiceRequestBus::Events::GetRootSlice);
         if (!rootSlice)
         {
-            AZ_Error("PropertyEditor", false, "Entity context has no root slice");
             return;
         }
 
@@ -2105,10 +2106,6 @@ namespace AzToolsFramework
     {
         QMenu* revertMenu = nullptr;
 
-        revertMenu = menu.addMenu(tr("Revert overrides"));
-        revertMenu->setToolTipsVisible(true);
-        revertMenu->setEnabled(false);
-
         //check for changes on selected property
         if (componentClassData)
         {
@@ -2127,6 +2124,11 @@ namespace AzToolsFramework
             {
                 return;
             }
+
+            // Only add the "Revert overrides" menu option if it belongs to a slice
+            revertMenu = menu.addMenu(tr("Revert overrides"));
+            revertMenu->setToolTipsVisible(true);
+            revertMenu->setEnabled(false);
 
             if (fieldNode)
             {


### PR DESCRIPTION
Fixes #2347 

There were several menu options in the right-click context menu of the RPE that were specific to slices. These were being processed even with prefabs enabled, which resulted in errors being logged to the console inadvertently. Updated the logic to not show the menu options at all if prefabs are enabled.

Tested with prefabs enabled and verified that the menu options no longer appear and no errors are logged to the console. Tested with prefabs disabled and verified the menu options still appear and are functional. 

Signed-off-by: Chris Galvan <chgalvan@amazon.com>