### PR TITLE
Moving load level test from sandbox to smoke with fixes

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -41,7 +41,6 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessor
             AZ::PythonBindingsExample
-            Legacy::Editor
             AutomatedTesting.GameLauncher
             AutomatedTesting.Assets
         COMPONENT

--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -32,12 +32,12 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
     )
 
     ly_add_pytest(
-        NAME AutomatedTesting::SandboxTest
-        TEST_SUITE sandbox
+        NAME AutomatedTesting::LoadLevelGPU
+        TEST_SUITE smoke
         TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}
-        PYTEST_MARKS "SUITE_sandbox"
-        TIMEOUT 1500
+        TEST_REQUIRES gpu
+        PATH ${CMAKE_CURRENT_LIST_DIR}/test_RemoteConsole_GPULoadLevel_Works.py
+        TIMEOUT 100
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessor
             AZ::PythonBindingsExample
@@ -45,7 +45,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AutomatedTesting.GameLauncher
             AutomatedTesting.Assets
         COMPONENT
-            Sandbox
+            Smoke
     )
 
     ly_add_pytest(
@@ -74,4 +74,5 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
             AutomatedTesting.GameLauncher
             AutomatedTesting.Assets
     )
+
 endif()

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_CPULoadLevel_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_CPULoadLevel_Works.py
@@ -13,8 +13,6 @@ Test should run in both gpu and non gpu
 import pytest
 import psutil
 
-# Bail on the test if ly_test_tools doesn't exist.
-pytest.importorskip("ly_test_tools")
 import ly_test_tools.environment.waiter as waiter
 import editor_python_test_tools.hydra_test_utils as editor_test_utils
 from ly_remote_console.remote_console_commands import RemoteConsole as RemoteConsole

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_CPULoadLevel_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_CPULoadLevel_Works.py
@@ -1,0 +1,105 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+
+UI Apps: AutomatedTesting.GameLauncher
+Launch AutomatedTesting.GameLauncher with Simple level
+Test should run in both gpu and non gpu
+"""
+
+import pytest
+import psutil
+
+# Bail on the test if ly_test_tools doesn't exist.
+pytest.importorskip("ly_test_tools")
+import ly_test_tools.environment.waiter as waiter
+from ly_remote_console.remote_console_commands import RemoteConsole as RemoteConsole
+from ly_remote_console.remote_console_commands import (
+    send_command_and_expect_response as send_command_and_expect_response,
+)
+
+
+@pytest.mark.parametrize("launcher_platform", ["windows"])
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("level", ["Simple"])
+@pytest.mark.SUITE_smoke
+class TestRemoteConsoleLoadLevelWorks(object):
+    @pytest.fixture
+    def remote_console_instance(self, request):
+        console = RemoteConsole()
+
+        def teardown():
+            if console.connected:
+                console.stop()
+
+        request.addfinalizer(teardown)
+
+        return console
+
+    def test_RemoteConsole_LoadLevel_Works(self, launcher, level, remote_console_instance, launcher_platform):
+        expected_lines = ['Level system is loading "Simple"']
+
+        self.launch_and_validate_results_launcher(launcher, level, remote_console_instance, expected_lines)
+
+    def launch_and_validate_results_launcher(
+        self,
+        launcher,
+        level,
+        remote_console_instance,
+        expected_lines,
+        null_renderer=True,
+        port_listener_timeout=120,
+        log_monitor_timeout=300,
+        remote_console_port=4600,
+    ):
+        """
+        Runs the launcher with the specified level, and monitors Game.log for expected lines.
+        :param launcher: Configured launcher object to run test against.
+        :param level: The level to load in the launcher.
+        :param remote_console_instance: Configured Remote Console object.
+        :param expected_lines: Expected lines to search log for.
+        :oaram null_renderer: Specifies the test does not require the renderer. Defaults to True.
+        :param port_listener_timeout: Timeout for verifying successful connection to Remote Console.
+        :param log_monitor_timeout: Timeout for monitoring for lines in Game.log
+        :param remote_console_port: The port used to communicate with the Remote Console.
+        """
+
+        def _check_for_listening_port(port):
+            """
+            Checks to see if the connection to the designated port was established.
+            :param port: Port to listen to.
+            :return: True if port is listening.
+            """
+            port_listening = False
+            for conn in psutil.net_connections():
+                if "port={}".format(port) in str(conn):
+                    port_listening = True
+            return port_listening
+
+        if null_renderer:
+            launcher.args.extend(["-rhi=Null"])
+
+        # Start the Launcher
+        with launcher.start():
+
+            # Ensure Remote Console can be reached
+            waiter.wait_for(
+                lambda: _check_for_listening_port(remote_console_port),
+                port_listener_timeout,
+                exc=AssertionError("Port {} not listening.".format(remote_console_port)),
+            )
+            remote_console_instance.start(timeout=30)
+
+            # Load the specified level in the launcher
+            send_command_and_expect_response(
+                remote_console_instance, f"loadlevel {level}", "LEVEL_LOAD_END", timeout=30
+            )
+
+            # Monitor the console for expected lines
+            for line in expected_lines:
+                assert remote_console_instance.expect_log_line(
+                    line, log_monitor_timeout
+                ), f"Expected line not found: {line}"

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_CPULoadLevel_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_CPULoadLevel_Works.py
@@ -16,6 +16,7 @@ import psutil
 # Bail on the test if ly_test_tools doesn't exist.
 pytest.importorskip("ly_test_tools")
 import ly_test_tools.environment.waiter as waiter
+import editor_python_test_tools.hydra_test_utils as editor_test_utils
 from ly_remote_console.remote_console_commands import RemoteConsole as RemoteConsole
 from ly_remote_console.remote_console_commands import (
     send_command_and_expect_response as send_command_and_expect_response,
@@ -42,64 +43,4 @@ class TestRemoteConsoleLoadLevelWorks(object):
     def test_RemoteConsole_LoadLevel_Works(self, launcher, level, remote_console_instance, launcher_platform):
         expected_lines = ['Level system is loading "Simple"']
 
-        self.launch_and_validate_results_launcher(launcher, level, remote_console_instance, expected_lines)
-
-    def launch_and_validate_results_launcher(
-        self,
-        launcher,
-        level,
-        remote_console_instance,
-        expected_lines,
-        null_renderer=True,
-        port_listener_timeout=120,
-        log_monitor_timeout=300,
-        remote_console_port=4600,
-    ):
-        """
-        Runs the launcher with the specified level, and monitors Game.log for expected lines.
-        :param launcher: Configured launcher object to run test against.
-        :param level: The level to load in the launcher.
-        :param remote_console_instance: Configured Remote Console object.
-        :param expected_lines: Expected lines to search log for.
-        :oaram null_renderer: Specifies the test does not require the renderer. Defaults to True.
-        :param port_listener_timeout: Timeout for verifying successful connection to Remote Console.
-        :param log_monitor_timeout: Timeout for monitoring for lines in Game.log
-        :param remote_console_port: The port used to communicate with the Remote Console.
-        """
-
-        def _check_for_listening_port(port):
-            """
-            Checks to see if the connection to the designated port was established.
-            :param port: Port to listen to.
-            :return: True if port is listening.
-            """
-            port_listening = False
-            for conn in psutil.net_connections():
-                if "port={}".format(port) in str(conn):
-                    port_listening = True
-            return port_listening
-
-        if null_renderer:
-            launcher.args.extend(["-rhi=Null"])
-
-        # Start the Launcher
-        with launcher.start():
-
-            # Ensure Remote Console can be reached
-            waiter.wait_for(
-                lambda: _check_for_listening_port(remote_console_port),
-                port_listener_timeout,
-                exc=AssertionError("Port {} not listening.".format(remote_console_port)),
-            )
-            remote_console_instance.start(timeout=30)
-
-            # Load the specified level in the launcher
-            send_command_and_expect_response(
-                remote_console_instance, f"loadlevel {level}", "LEVEL_LOAD_END", timeout=30
-            )
-
-            # Monitor the console for expected lines
-            for line in expected_lines:
-                assert remote_console_instance.expect_log_line(
-                    line, log_monitor_timeout
-                ), f"Expected line not found: {line}"
+        editor_test_utils.launch_and_validate_results_launcher(launcher, level, remote_console_instance, expected_lines, null_renderer=True)

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_GPULoadLevel_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_GPULoadLevel_Works.py
@@ -13,8 +13,6 @@ Test should run in both gpu and non gpu
 import pytest
 import psutil
 
-# Bail on the test if ly_test_tools doesn't exist.
-pytest.importorskip("ly_test_tools")
 import ly_test_tools.environment.waiter as waiter
 import editor_python_test_tools.hydra_test_utils as editor_test_utils
 from ly_remote_console.remote_console_commands import RemoteConsole as RemoteConsole

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_GPULoadLevel_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_GPULoadLevel_Works.py
@@ -16,6 +16,7 @@ import psutil
 # Bail on the test if ly_test_tools doesn't exist.
 pytest.importorskip("ly_test_tools")
 import ly_test_tools.environment.waiter as waiter
+import editor_python_test_tools.hydra_test_utils as editor_test_utils
 from ly_remote_console.remote_console_commands import RemoteConsole as RemoteConsole
 from ly_remote_console.remote_console_commands import (
     send_command_and_expect_response as send_command_and_expect_response,
@@ -41,64 +42,4 @@ class TestRemoteConsoleLoadLevelWorks(object):
     def test_RemoteConsole_LoadLevel_Works(self, launcher, level, remote_console_instance, launcher_platform):
         expected_lines = ['Level system is loading "Simple"']
 
-        self.launch_and_validate_results_launcher(launcher, level, remote_console_instance, expected_lines)
-
-    def launch_and_validate_results_launcher(
-        self,
-        launcher,
-        level,
-        remote_console_instance,
-        expected_lines,
-        null_renderer=False,
-        port_listener_timeout=120,
-        log_monitor_timeout=300,
-        remote_console_port=4600,
-    ):
-        """
-        Runs the launcher with the specified level, and monitors Game.log for expected lines.
-        :param launcher: Configured launcher object to run test against.
-        :param level: The level to load in the launcher.
-        :param remote_console_instance: Configured Remote Console object.
-        :param expected_lines: Expected lines to search log for.
-        :oaram null_renderer: Specifies the test does not require the renderer. Defaults to True.
-        :param port_listener_timeout: Timeout for verifying successful connection to Remote Console.
-        :param log_monitor_timeout: Timeout for monitoring for lines in Game.log
-        :param remote_console_port: The port used to communicate with the Remote Console.
-        """
-
-        def _check_for_listening_port(port):
-            """
-            Checks to see if the connection to the designated port was established.
-            :param port: Port to listen to.
-            :return: True if port is listening.
-            """
-            port_listening = False
-            for conn in psutil.net_connections():
-                if "port={}".format(port) in str(conn):
-                    port_listening = True
-            return port_listening
-
-        if null_renderer:
-            launcher.args.extend(["-rhi=Null"])
-
-        # Start the Launcher
-        with launcher.start():
-
-            # Ensure Remote Console can be reached
-            waiter.wait_for(
-                lambda: _check_for_listening_port(remote_console_port),
-                port_listener_timeout,
-                exc=AssertionError("Port {} not listening.".format(remote_console_port)),
-            )
-            remote_console_instance.start(timeout=30)
-
-            # Load the specified level in the launcher
-            send_command_and_expect_response(
-                remote_console_instance, f"loadlevel {level}", "LEVEL_LOAD_END", timeout=30
-            )
-
-            # Monitor the console for expected lines
-            for line in expected_lines:
-                assert remote_console_instance.expect_log_line(
-                    line, log_monitor_timeout
-                ), f"Expected line not found: {line}"
+        editor_test_utils.launch_and_validate_results_launcher(launcher, level, remote_console_instance, expected_lines, null_renderer=False)

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_GPULoadLevel_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_RemoteConsole_GPULoadLevel_Works.py
@@ -25,7 +25,6 @@ from ly_remote_console.remote_console_commands import (
 @pytest.mark.parametrize("launcher_platform", ["windows"])
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("level", ["Simple"])
-@pytest.mark.SUITE_sandbox
 class TestRemoteConsoleLoadLevelWorks(object):
     @pytest.fixture
     def remote_console_instance(self, request):
@@ -80,7 +79,7 @@ class TestRemoteConsoleLoadLevelWorks(object):
             return port_listening
 
         if null_renderer:
-            launcher.args.extend(["-NullRenderer"])
+            launcher.args.extend(["-rhi=Null"])
 
         # Start the Launcher
         with launcher.start():


### PR DESCRIPTION
Signed-off-by: evanchia <evanchia@amazon.com>

Fixed the nullrenderer flag. Added new test that enables the flag with separate CTest registrations. Moved the test from sandbox to smoke suite