### PR TITLE
[ATOM-16017] Implement frame time histogram in visualizer 

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -31,12 +31,6 @@ namespace AZ
             AZStd::sys_time_t m_endTick = 0;
         };
 
-        struct FrameHistogramEntry
-        {
-            AZStd::sys_time_t m_endTick;
-            AZStd::sys_time_t m_frameTime;
-        };
-
         // Stores data about a region that is agreggated from all collected frames
         // Data collection can be toggled on and off through m_record. 
         struct RegionStatistics
@@ -81,6 +75,8 @@ namespace AZ
         private:
             static constexpr float RowHeight = 50.0;
             static constexpr int DefaultFramesToCollect = 50;
+            static constexpr float MediumFrameTimeLimit = 16.6; // 60 fps
+            static constexpr float HighFrameTimeLimit = 33.3; // 30 fps
 
             // Draw the shared header between the two windows
             void DrawCommonHeader();
@@ -133,11 +129,11 @@ namespace AZ
             // Draw the ruler with frame time labels
             void DrawRuler();
 
-            // Draw the frame time histogram and handle input
+            // Draw the frame time histogram 
             void DrawFrameTimeHistogram();
 
             // Converts raw ticks to a pixel value suitable to give to ImDrawList, handles window scrolling
-            float ConvertTickToPixelSpace(AZStd::sys_time_t tick) const;
+            float ConvertTickToPixelSpace(AZStd::sys_time_t tick, AZStd::sys_time_t leftBound, AZStd::sys_time_t rightBound) const;
 
             AZStd::sys_time_t GetViewportTickWidth() const;
 
@@ -172,9 +168,6 @@ namespace AZ
             // For now we default allocate for all regions on the first render frame and then use RegionStatistics.m_draw to determine
             // if we should draw the window or not. FIXME(ATOM-15948) this should be changed once RegionStatistics gets heavier. 
             AZStd::unordered_map<const GroupRegionName*, RegionStatistics> m_regionStatisticsMap;
-
-            // Keeps track of frame bounds and their tick so that we can draw the frame time histogram.
-            AZStd::vector<FrameHistogramEntry> m_frameTimes;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -31,6 +31,12 @@ namespace AZ
             AZStd::sys_time_t m_endTick = 0;
         };
 
+        struct FrameHistogramEntry
+        {
+            AZStd::sys_time_t m_endTick;
+            AZStd::sys_time_t m_frameTime;
+        };
+
         // Stores data about a region that is agreggated from all collected frames
         // Data collection can be toggled on and off through m_record. 
         struct RegionStatistics
@@ -127,6 +133,9 @@ namespace AZ
             // Draw the ruler with frame time labels
             void DrawRuler();
 
+            // Draw the frame time histogram and handle input
+            void DrawFrameTimeHistogram();
+
             // Converts raw ticks to a pixel value suitable to give to ImDrawList, handles window scrolling
             float ConvertTickToPixelSpace(AZStd::sys_time_t tick) const;
 
@@ -163,6 +172,9 @@ namespace AZ
             // For now we default allocate for all regions on the first render frame and then use RegionStatistics.m_draw to determine
             // if we should draw the window or not. FIXME(ATOM-15948) this should be changed once RegionStatistics gets heavier. 
             AZStd::unordered_map<const GroupRegionName*, RegionStatistics> m_regionStatisticsMap;
+
+            // Keeps track of frame bounds and their tick so that we can draw the frame time histogram.
+            AZStd::vector<FrameHistogramEntry> m_frameTimes;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -810,6 +810,21 @@ namespace AZ
 
                 lastFrameEndTick = frameEndTick;
             }
+
+            // Handle input
+            ImGui::InvisibleButton("HistogramInputCapture", { ImGui::GetWindowWidth(), ImGui::GetWindowHeight() });
+            ImGuiIO& io = ImGui::GetIO();
+            if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+            {
+                const float mousePixelX = io.MousePos.x;
+                const float percentWindow = (mousePixelX - wx) / ImGui::GetWindowWidth();
+                const AZStd::sys_time_t newViewportCenterTick = leftHistogramBound +
+                    aznumeric_cast<AZStd::sys_time_t>((rightHistogramBound - leftHistogramBound) * percentWindow);
+
+                const AZStd::sys_time_t viewportWidth = GetViewportTickWidth();
+                m_viewportEndTick = newViewportCenterTick + viewportWidth / 2;
+                m_viewportStartTick = newViewportCenterTick - viewportWidth / 2;
+            }
         }
 
         inline AZStd::sys_time_t ImGuiCpuProfiler::GetViewportTickWidth() const


### PR DESCRIPTION
### **Please start a build [here](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-2378/)! (and request sig/presentation)**

This PR implements a basic histogram of frame times in the visualizer. It's similar to the existing framerate histogram, but adds a few QOL features like coloring, target frame time lines, viewport reference, and a "jump to" feature so engineers can easily find outlier frames and begin detailed profiling to determine the root cause. The target frame time lines are hardcoded to 60 fps and 30 fps, let me know if this works or should be user-controllable. 

Also includes an increase of the maximum frames to capture, because why not! I did some preliminary profiling and performance/memory impact is still bearable up to around 1.5 million recorded regions. Everything is logarithmic time, but the one expensive call that contributes to most of the performance impact is a call to vec.erase() on the front of a large vector (which requires many shifts). I looked into using erase-remove instead and the performance impact is much lower (since erase-remove only shifts elements once), but I'll leave that for a separate PR. 


### Images 
Vsync off: 
![vsync off](https://user-images.githubusercontent.com/64656371/126722102-a2c23436-7acd-4c34-989a-37382df14013.png)

Vsync on: 
![vsync on](https://user-images.githubusercontent.com/64656371/126722201-a0041167-6971-461c-bb21-52630002559c.png)

note: I'm clicking on the histogram to jump around here
![Demo video](https://user-images.githubusercontent.com/64656371/126723004-8db32aec-83d3-4287-96b8-5a10cfeeb77d.mp4)