### PR TITLE
TSpace setting for MikkT tangent generation

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBitangentStreamImporter.cpp
@@ -87,7 +87,7 @@ namespace AZ
                 // AssImp only has one bitangentStream per mesh.
                 bitangentStream->SetBitangentSetIndex(0);
 
-                bitangentStream->SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace::FromSourceScene);
+                bitangentStream->SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene);
                 bitangentStream->ReserveContainerSpace(vertexCount);
                 for (int sdkMeshIndex = 0; sdkMeshIndex < currentNode->mNumMeshes; ++sdkMeshIndex)
                 {

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpTangentStreamImporter.cpp
@@ -89,7 +89,7 @@ namespace AZ
                 // AssImp only has one tangentStream per mesh.
                 tangentStream->SetTangentSetIndex(0);
 
-                tangentStream->SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace::FromSourceScene);
+                tangentStream->SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene);
                 tangentStream->ReserveContainerSpace(vertexCount);
                 for (int sdkMeshIndex = 0; sdkMeshIndex < currentNode->mNumMeshes; ++sdkMeshIndex)
                 {

--- a/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexBitangentData.h
+++ b/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexBitangentData.h
@@ -17,32 +17,24 @@ namespace AZ
     class Vector3;
 }
 
-namespace AZ
+namespace AZ::SceneAPI::DataTypes
 {
-    namespace SceneAPI
+    class IMeshVertexBitangentData
+        : public IGraphObject
     {
-        namespace DataTypes
-        {
+    public:                                
+        AZ_RTTI(IMeshVertexBitangentData, "{6C8F6109-B0BD-49D1-A998-4A4946557DF9}", IGraphObject);
 
-            class IMeshVertexBitangentData
-                : public IGraphObject
-            {
-            public:                                
-                AZ_RTTI(IMeshVertexBitangentData, "{6C8F6109-B0BD-49D1-A998-4A4946557DF9}", IGraphObject);
+        virtual ~IMeshVertexBitangentData() override = default;
 
-                virtual ~IMeshVertexBitangentData() override = default;
+        void CloneAttributesFrom([[maybe_unused]] const IGraphObject* sourceObject) override {}
 
-                void CloneAttributesFrom([[maybe_unused]] const IGraphObject* sourceObject) override {}
-
-                virtual size_t GetCount() const = 0;
-                virtual const AZ::Vector3& GetBitangent(size_t index) const = 0;
-                virtual void SetBitangent(size_t vertexIndex, const AZ::Vector3& bitangent) = 0;
-                virtual void SetBitangentSetIndex(size_t setIndex) = 0;
-                virtual size_t GetBitangentSetIndex() const = 0;
-                virtual TangentSpace GetTangentSpace() const = 0;
-                virtual void SetTangentSpace(TangentSpace space) = 0;
-            };
-
-        }  // DataTypes
-    }  // SceneAPI
-}  // AZ
+        virtual size_t GetCount() const = 0;
+        virtual const AZ::Vector3& GetBitangent(size_t index) const = 0;
+        virtual void SetBitangent(size_t vertexIndex, const AZ::Vector3& bitangent) = 0;
+        virtual void SetBitangentSetIndex(size_t setIndex) = 0;
+        virtual size_t GetBitangentSetIndex() const = 0;
+        virtual TangentGenerationMethod GetGenerationMethod() const = 0;
+        virtual void SetGenerationMethod(TangentGenerationMethod method) = 0;
+    };
+}  // AZ::SceneAPI::DataTypes

--- a/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexTangentData.h
+++ b/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexTangentData.h
@@ -16,42 +16,36 @@ namespace AZ
     class Vector4;
 }
 
-namespace AZ
+namespace AZ::SceneAPI::DataTypes
 {
-    namespace SceneAPI
+    enum class TangentGenerationMethod
     {
-        namespace DataTypes
-        {
-            enum class TangentSpace
-            {
-                FromSourceScene = 0,
-                MikkT           = 1
-            };
+        FromSourceScene = 0,
+        MikkT = 1
+    };
 
-            enum class BitangentMethod
-            {
-                UseFromTangentSpace = 0,
-                Orthogonal          = 1
-            };
+    enum class MikkTSpaceMethod
+    {
+        TSpace = 0,
+        TSpaceBasic = 1
+    };
 
-            class IMeshVertexTangentData
-                : public IGraphObject
-            {
-            public:
-                AZ_RTTI(IMeshVertexTangentData, "{B24084FF-09B1-4EE5-BA5B-2D392E92ECC1}", IGraphObject);
+    class IMeshVertexTangentData
+        : public IGraphObject
+    {
+    public:
+        AZ_RTTI(IMeshVertexTangentData, "{B24084FF-09B1-4EE5-BA5B-2D392E92ECC1}", IGraphObject);
 
-                virtual ~IMeshVertexTangentData() override = default;
+        virtual ~IMeshVertexTangentData() override = default;
 
-                void CloneAttributesFrom([[maybe_unused]] const IGraphObject* sourceObject) override {}
+        void CloneAttributesFrom([[maybe_unused]] const IGraphObject* sourceObject) override {}
 
-                virtual size_t GetCount() const = 0;
-                virtual const AZ::Vector4& GetTangent(size_t index) const = 0;
-                virtual void SetTangent(size_t vertexIndex, const AZ::Vector4& tangent) = 0;
-                virtual void SetTangentSetIndex(size_t setIndex) = 0;
-                virtual size_t GetTangentSetIndex() const = 0;
-                virtual TangentSpace GetTangentSpace() const = 0;
-                virtual void SetTangentSpace(TangentSpace space) = 0;
-            };
-        }  // DataTypes
-    }  // SceneAPI
-}  // AZ
+        virtual size_t GetCount() const = 0;
+        virtual const AZ::Vector4& GetTangent(size_t index) const = 0;
+        virtual void SetTangent(size_t vertexIndex, const AZ::Vector4& tangent) = 0;
+        virtual void SetTangentSetIndex(size_t setIndex) = 0;
+        virtual size_t GetTangentSetIndex() const = 0;
+        virtual TangentGenerationMethod GetGenerationMethod() const = 0;
+        virtual void SetGenerationMethod(TangentGenerationMethod method) = 0;
+    };
+}  // AZ::SceneAPI::DataTypes

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.cpp
@@ -10,110 +10,95 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 
-namespace AZ
+namespace AZ::SceneData::GraphData
 {
-    namespace SceneData
+    void MeshVertexBitangentData::Reflect(ReflectContext* context)
     {
-        namespace GraphData
+        SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
+        if (serializeContext)
         {
-            void MeshVertexBitangentData::Reflect(ReflectContext* context)
-            {
-                SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
-                if (serializeContext)
-                {
-                    serializeContext->Class<MeshVertexBitangentData>()->Version(2);
-                }
+            serializeContext->Class<MeshVertexBitangentData>()->Version(2);
+        }
 
-                BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
-                if (behaviorContext)
-                {
-                    behaviorContext->Class<MeshVertexBitangentData>()
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
-                        ->Attribute(AZ::Script::Attributes::Module, "scene")
-                        ->Method("GetCount", &MeshVertexBitangentData::GetCount)
-                        ->Method("GetBitangent", &MeshVertexBitangentData::GetBitangent)
-                        ->Method("GetBitangentSetIndex", &MeshVertexBitangentData::GetBitangentSetIndex)
-                        ->Method("GetTangentSpace", &MeshVertexBitangentData::GetTangentSpace)
-                        ->Enum<(int)SceneAPI::DataTypes::TangentSpace::FromSourceScene>("FromSourceScene")
-                        ->Enum<(int)SceneAPI::DataTypes::TangentSpace::MikkT>("MikkT");
-                }
-            }
+        BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
+        if (behaviorContext)
+        {
+            behaviorContext->Class<MeshVertexBitangentData>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "scene")
+                ->Method("GetCount", &MeshVertexBitangentData::GetCount)
+                ->Method("GetBitangent", &MeshVertexBitangentData::GetBitangent)
+                ->Method("GetBitangentSetIndex", &MeshVertexBitangentData::GetBitangentSetIndex)
+                ->Method("GetGenerationMethod", &MeshVertexBitangentData::GetGenerationMethod)
+                ->Enum<(int)SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene>("FromSourceScene")
+                ->Enum<(int)SceneAPI::DataTypes::TangentGenerationMethod::MikkT>("MikkT");
+        }
+    }
 
-            void MeshVertexBitangentData::CloneAttributesFrom(const IGraphObject* sourceObject)
-            {
-                IMeshVertexBitangentData::CloneAttributesFrom(sourceObject);
-                if (const auto* typedSource = azrtti_cast<const MeshVertexBitangentData*>(sourceObject))
-                {
-                    SetTangentSpace(typedSource->GetTangentSpace());
-                    SetBitangentSetIndex(typedSource->GetBitangentSetIndex());
-                }
-            }
+    void MeshVertexBitangentData::CloneAttributesFrom(const IGraphObject* sourceObject)
+    {
+        IMeshVertexBitangentData::CloneAttributesFrom(sourceObject);
+        if (const auto* typedSource = azrtti_cast<const MeshVertexBitangentData*>(sourceObject))
+        {
+            SetGenerationMethod(typedSource->GetGenerationMethod());
+            SetBitangentSetIndex(typedSource->GetBitangentSetIndex());
+        }
+    }
 
-            size_t MeshVertexBitangentData::GetCount() const
-            {
-                return m_bitangents.size();
-            }
+    size_t MeshVertexBitangentData::GetCount() const
+    {
+        return m_bitangents.size();
+    }
 
+    const AZ::Vector3& MeshVertexBitangentData::GetBitangent(size_t index) const
+    {
+        AZ_Assert(index < m_bitangents.size(), "Invalid index %i for mesh bitangents.", index);
+        return m_bitangents[index];
+    }
 
-            const AZ::Vector3& MeshVertexBitangentData::GetBitangent(size_t index) const
-            {
-                AZ_Assert(index < m_bitangents.size(), "Invalid index %i for mesh bitangents.", index);
-                return m_bitangents[index];
-            }
+    void MeshVertexBitangentData::ReserveContainerSpace(size_t numVerts)
+    {
+        m_bitangents.reserve(numVerts);
+    }
 
+    void MeshVertexBitangentData::Resize(size_t numVerts)
+    {
+        m_bitangents.resize(numVerts);
+    }
 
-            void MeshVertexBitangentData::ReserveContainerSpace(size_t numVerts)
-            {
-                m_bitangents.reserve(numVerts);
-            }
+    void MeshVertexBitangentData::AppendBitangent(const AZ::Vector3& bitangent)
+    {
+        m_bitangents.push_back(bitangent);
+    }
 
+    void MeshVertexBitangentData::SetBitangent(size_t vertexIndex, const AZ::Vector3& bitangent)
+    {
+        m_bitangents[vertexIndex] = bitangent;
+    }
 
-            void MeshVertexBitangentData::Resize(size_t numVerts)
-            {
-                m_bitangents.resize(numVerts);
-            }
+    void MeshVertexBitangentData::SetBitangentSetIndex(size_t setIndex)
+    {
+        m_setIndex = setIndex;
+    }
 
+    size_t MeshVertexBitangentData::GetBitangentSetIndex() const
+    {
+        return m_setIndex;
+    }
 
-            void MeshVertexBitangentData::AppendBitangent(const AZ::Vector3& bitangent)
-            {
-                m_bitangents.push_back(bitangent);
-            }
+    AZ::SceneAPI::DataTypes::TangentGenerationMethod MeshVertexBitangentData::GetGenerationMethod() const
+    { 
+        return m_generationMethod;
+    }
 
+    void MeshVertexBitangentData::SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod method)
+    { 
+        m_generationMethod = method;
+    }
 
-            void MeshVertexBitangentData::SetBitangent(size_t vertexIndex, const AZ::Vector3& bitangent)
-            {
-                m_bitangents[vertexIndex] = bitangent;
-            }
-
-
-            void MeshVertexBitangentData::SetBitangentSetIndex(size_t setIndex)
-            {
-                m_setIndex = setIndex;
-            }
-
-
-            size_t MeshVertexBitangentData::GetBitangentSetIndex() const
-            {
-                return m_setIndex;
-            }
-
-
-            AZ::SceneAPI::DataTypes::TangentSpace MeshVertexBitangentData::GetTangentSpace() const
-            { 
-                return m_tangentSpace;
-            }
-
-
-            void MeshVertexBitangentData::SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace space)
-            {
-                m_tangentSpace = space;
-            }
-
-            void MeshVertexBitangentData::GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const
-            {
-                output.Write("Bitangents", m_bitangents);
-                output.Write("TangentSpace", aznumeric_cast<int64_t>(m_tangentSpace));
-            }
-        } // GraphData
-    } // SceneData
-} // AZ
+    void MeshVertexBitangentData::GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const
+    {
+        output.Write("Bitangents", m_bitangents);
+        output.Write("GenerationMethod", aznumeric_cast<int64_t>(m_generationMethod));
+    }
+} // AZ::SceneData::GraphData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexBitangentData.h
@@ -10,51 +10,41 @@
 
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/containers/vector.h>
-
 #include <SceneAPI/SceneData/SceneDataConfiguration.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexBitangentData.h>
 
-
-namespace AZ
+namespace AZ::SceneData::GraphData
 {
-    namespace SceneData
+    class SCENE_DATA_CLASS MeshVertexBitangentData
+        : public AZ::SceneAPI::DataTypes::IMeshVertexBitangentData
     {
-        namespace GraphData
-        {
+    public:                
+        AZ_RTTI(MeshVertexBitangentData, "{F56FB088-4C92-4453-AFE9-4E820F03FA90}", AZ::SceneAPI::DataTypes::IMeshVertexBitangentData);
 
-            class SCENE_DATA_CLASS MeshVertexBitangentData
-                : public AZ::SceneAPI::DataTypes::IMeshVertexBitangentData
-            {
-            public:                
-                AZ_RTTI(MeshVertexBitangentData, "{F56FB088-4C92-4453-AFE9-4E820F03FA90}", AZ::SceneAPI::DataTypes::IMeshVertexBitangentData);
+        static void Reflect(ReflectContext* context);
 
-                static void Reflect(ReflectContext* context);
+        SCENE_DATA_API ~MeshVertexBitangentData() override = default;
 
-                SCENE_DATA_API ~MeshVertexBitangentData() override = default;
+        SCENE_DATA_API void CloneAttributesFrom(const IGraphObject* sourceObject) override;
 
-                SCENE_DATA_API void CloneAttributesFrom(const IGraphObject* sourceObject) override;
+        SCENE_DATA_API size_t GetCount() const override;
+        SCENE_DATA_API const AZ::Vector3& GetBitangent(size_t index) const override;
+        SCENE_DATA_API void SetBitangent(size_t vertexIndex, const AZ::Vector3& bitangent) override;
 
-                SCENE_DATA_API size_t GetCount() const override;
-                SCENE_DATA_API const AZ::Vector3& GetBitangent(size_t index) const override;
-                SCENE_DATA_API void SetBitangent(size_t vertexIndex, const AZ::Vector3& bitangent) override;
+        SCENE_DATA_API void SetBitangentSetIndex(size_t setIndex) override;
+        SCENE_DATA_API size_t GetBitangentSetIndex() const override;
 
-                SCENE_DATA_API void SetBitangentSetIndex(size_t setIndex) override;
-                SCENE_DATA_API size_t GetBitangentSetIndex() const override;
+        SCENE_DATA_API void Resize(size_t numVerts);
+        SCENE_DATA_API void ReserveContainerSpace(size_t numVerts);
+        SCENE_DATA_API void AppendBitangent(const AZ::Vector3& bitangent);
 
-                SCENE_DATA_API void Resize(size_t numVerts);
-                SCENE_DATA_API void ReserveContainerSpace(size_t numVerts);
-                SCENE_DATA_API void AppendBitangent(const AZ::Vector3& bitangent);
+        SCENE_DATA_API AZ::SceneAPI::DataTypes::TangentGenerationMethod GetGenerationMethod() const override;
+        SCENE_DATA_API void SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod method) override;
 
-                SCENE_DATA_API AZ::SceneAPI::DataTypes::TangentSpace GetTangentSpace() const override;
-                SCENE_DATA_API void SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace space) override;
-
-                SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
-            protected:
-                AZStd::vector<AZ::Vector3>              m_bitangents;
-                AZ::SceneAPI::DataTypes::TangentSpace   m_tangentSpace = AZ::SceneAPI::DataTypes::TangentSpace::FromSourceScene;
-                size_t                                  m_setIndex = 0;
-            };
-
-        } // GraphData
-    } // SceneData
-} // AZ
+        SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
+    protected:
+        AZStd::vector<AZ::Vector3> m_bitangents;
+        AZ::SceneAPI::DataTypes::TangentGenerationMethod m_generationMethod = AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene;
+        size_t m_setIndex = 0;
+    };
+} // AZ::SceneData::GraphData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.cpp
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.cpp
@@ -10,112 +10,96 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 
-namespace AZ
+namespace AZ::SceneData::GraphData
 {
-    namespace SceneData
+    void MeshVertexTangentData::Reflect(ReflectContext* context)
     {
-        namespace GraphData
+        SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
+        if (serializeContext)
         {
-            void MeshVertexTangentData::Reflect(ReflectContext* context)
-            {
-                SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
-                if (serializeContext)
-                {
-                    serializeContext->Class<MeshVertexTangentData>()->Version(2);
-                }
+            serializeContext->Class<MeshVertexTangentData>()->Version(2);
+        }
 
-                BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
-                if (behaviorContext)
-                {
-                    behaviorContext->Class<MeshVertexTangentData>()
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
-                        ->Attribute(AZ::Script::Attributes::Module, "scene")
-                        ->Method("GetCount", &MeshVertexTangentData::GetCount)
-                        ->Method("GetTangent", &MeshVertexTangentData::GetTangent)
-                        ->Method("GetTangentSetIndex", &MeshVertexTangentData::GetTangentSetIndex)
-                        ->Method("GetTangentSpace", &MeshVertexTangentData::GetTangentSpace)
-                        ->Enum<(int)SceneAPI::DataTypes::TangentSpace::FromSourceScene>("FromSourceScene")
-                        ->Enum<(int)SceneAPI::DataTypes::TangentSpace::MikkT>("MikkT");
-                }
-            }
+        BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
+        if (behaviorContext)
+        {
+            behaviorContext->Class<MeshVertexTangentData>()
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "scene")
+                ->Method("GetCount", &MeshVertexTangentData::GetCount)
+                ->Method("GetTangent", &MeshVertexTangentData::GetTangent)
+                ->Method("GetTangentSetIndex", &MeshVertexTangentData::GetTangentSetIndex)
+                ->Method("GetGenerationMethod", &MeshVertexTangentData::GetGenerationMethod)
+                ->Enum<(int)SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene>("FromSourceScene")
+                ->Enum<(int)SceneAPI::DataTypes::TangentGenerationMethod::MikkT>("MikkT");
+        }
+    }
 
-            void MeshVertexTangentData::CloneAttributesFrom(const IGraphObject* sourceObject)
-            {
-                IMeshVertexTangentData::CloneAttributesFrom(sourceObject);
-                if (const auto* typedSource = azrtti_cast<const MeshVertexTangentData*>(sourceObject))
-                {
-                    SetTangentSpace(typedSource->GetTangentSpace());
-                    SetTangentSetIndex(typedSource->GetTangentSetIndex());
-                }
-            }
+    void MeshVertexTangentData::CloneAttributesFrom(const IGraphObject* sourceObject)
+    {
+        IMeshVertexTangentData::CloneAttributesFrom(sourceObject);
+        if (const auto* typedSource = azrtti_cast<const MeshVertexTangentData*>(sourceObject))
+        {
+            SetGenerationMethod(typedSource->GetGenerationMethod());
+            SetTangentSetIndex(typedSource->GetTangentSetIndex());
+        }
+    }
 
-            size_t MeshVertexTangentData::GetCount() const
-            {
-                return m_tangents.size();
-            }
+    size_t MeshVertexTangentData::GetCount() const
+    {
+        return m_tangents.size();
+    }
 
+    const AZ::Vector4& MeshVertexTangentData::GetTangent(size_t index) const
+    {
+        AZ_Assert(index < m_tangents.size(), "Invalid index %i for mesh tangents.", index);
+        return m_tangents[index];
+    }
 
-            const AZ::Vector4& MeshVertexTangentData::GetTangent(size_t index) const
-            {
-                AZ_Assert(index < m_tangents.size(), "Invalid index %i for mesh tangents.", index);
-                return m_tangents[index];
-            }
+    void MeshVertexTangentData::ReserveContainerSpace(size_t numVerts)
+    {
+        m_tangents.reserve(numVerts);
+    }
 
+    void MeshVertexTangentData::Resize(size_t numVerts)
+    {
+        m_tangents.resize(numVerts);
+    }
 
-            void MeshVertexTangentData::ReserveContainerSpace(size_t numVerts)
-            {
-                m_tangents.reserve(numVerts);
-            }
+    void MeshVertexTangentData::AppendTangent(const AZ::Vector4& tangent)
+    {
+        m_tangents.push_back(tangent);
+    }
 
+    void MeshVertexTangentData::GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const
+    {
+        output.Write("Tangents", m_tangents);
+        output.Write("GenerationMethod", aznumeric_cast<int64_t>(m_generationMethod));
+        output.Write("SetIndex", aznumeric_cast<uint64_t>(m_setIndex));
+    }
 
-            void MeshVertexTangentData::Resize(size_t numVerts)
-            {
-                m_tangents.resize(numVerts);
-            }
+    void MeshVertexTangentData::SetTangent(size_t vertexIndex, const AZ::Vector4& tangent)
+    {
+        m_tangents[vertexIndex] = tangent;
+    }
 
+    void MeshVertexTangentData::SetTangentSetIndex(size_t setIndex)
+    {
+        m_setIndex = setIndex;
+    }
 
-            void MeshVertexTangentData::AppendTangent(const AZ::Vector4& tangent)
-            {
-                m_tangents.push_back(tangent);
-            }
+    size_t MeshVertexTangentData::GetTangentSetIndex() const
+    {
+        return m_setIndex;
+    }
 
-            void MeshVertexTangentData::GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const
-            {
-                output.Write("Tangents", m_tangents);
-                output.Write("TangentSpace", aznumeric_cast<int64_t>(m_tangentSpace));
-                output.Write("SetIndex", aznumeric_cast<uint64_t>(m_setIndex));
-            }
+    AZ::SceneAPI::DataTypes::TangentGenerationMethod MeshVertexTangentData::GetGenerationMethod() const
+    { 
+        return m_generationMethod;
+    }
 
-
-            void MeshVertexTangentData::SetTangent(size_t vertexIndex, const AZ::Vector4& tangent)
-            {
-                m_tangents[vertexIndex] = tangent;
-            }
-
-
-            void MeshVertexTangentData::SetTangentSetIndex(size_t setIndex)
-            {
-                m_setIndex = setIndex;
-            }
-
-
-            size_t MeshVertexTangentData::GetTangentSetIndex() const
-            {
-                return m_setIndex;
-            }
-
-
-            AZ::SceneAPI::DataTypes::TangentSpace MeshVertexTangentData::GetTangentSpace() const
-            { 
-                return m_tangentSpace;
-            }
-
-
-            void MeshVertexTangentData::SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace space)
-            { 
-                m_tangentSpace = space;
-            }
-
-        } // GraphData
-    } // SceneData
-} // AZ
+    void MeshVertexTangentData::SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod method)
+    { 
+        m_generationMethod = method;
+    }
+} // AZ::SceneData::GraphData

--- a/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.h
+++ b/Code/Tools/SceneAPI/SceneData/GraphData/MeshVertexTangentData.h
@@ -14,46 +14,39 @@
 #include <SceneAPI/SceneData/SceneDataConfiguration.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexTangentData.h>
 
-namespace AZ
+namespace AZ::SceneData::GraphData
 {
-    namespace SceneData
+    class SCENE_DATA_CLASS MeshVertexTangentData
+        : public AZ::SceneAPI::DataTypes::IMeshVertexTangentData
     {
-        namespace GraphData
-        {
+    public:
+        AZ_RTTI(MeshVertexTangentData, "{C16F0F38-8F8F-45A2-A33B-F2758922A7C4}", AZ::SceneAPI::DataTypes::IMeshVertexTangentData);
 
-            class SCENE_DATA_CLASS MeshVertexTangentData
-                : public AZ::SceneAPI::DataTypes::IMeshVertexTangentData
-            {
-            public:                
-                AZ_RTTI(MeshVertexTangentData, "{C16F0F38-8F8F-45A2-A33B-F2758922A7C4}", AZ::SceneAPI::DataTypes::IMeshVertexTangentData);
+        static void Reflect(ReflectContext* context);
 
-                static void Reflect(ReflectContext* context);
+        SCENE_DATA_API ~MeshVertexTangentData() override = default;
 
-                SCENE_DATA_API ~MeshVertexTangentData() override = default;
+        SCENE_DATA_API void CloneAttributesFrom(const IGraphObject* sourceObject) override;
 
-                SCENE_DATA_API void CloneAttributesFrom(const IGraphObject* sourceObject) override;
+        SCENE_DATA_API size_t GetCount() const override;
+        SCENE_DATA_API const AZ::Vector4& GetTangent(size_t index) const override;
+        SCENE_DATA_API void SetTangent(size_t vertexIndex, const AZ::Vector4& tangent) override;
 
-                SCENE_DATA_API size_t GetCount() const override;
-                SCENE_DATA_API const AZ::Vector4& GetTangent(size_t index) const override;
-                SCENE_DATA_API void SetTangent(size_t vertexIndex, const AZ::Vector4& tangent) override;
+        SCENE_DATA_API void SetTangentSetIndex(size_t setIndex) override;
+        SCENE_DATA_API size_t GetTangentSetIndex() const override;
 
-                SCENE_DATA_API void SetTangentSetIndex(size_t setIndex) override;
-                SCENE_DATA_API size_t GetTangentSetIndex() const override;
+        SCENE_DATA_API AZ::SceneAPI::DataTypes::TangentGenerationMethod GetGenerationMethod() const override;
+        SCENE_DATA_API void SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod method) override;
 
-                SCENE_DATA_API AZ::SceneAPI::DataTypes::TangentSpace GetTangentSpace() const override;
-                SCENE_DATA_API void SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace space) override;
+        SCENE_DATA_API void Resize(size_t numVerts);
+        SCENE_DATA_API void ReserveContainerSpace(size_t numVerts);
+        SCENE_DATA_API void AppendTangent(const AZ::Vector4& tangent);
 
-                SCENE_DATA_API void Resize(size_t numVerts);
-                SCENE_DATA_API void ReserveContainerSpace(size_t numVerts);
-                SCENE_DATA_API void AppendTangent(const AZ::Vector4& tangent);
+        SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
 
-                SCENE_DATA_API void GetDebugOutput(AZ::SceneAPI::Utilities::DebugOutput& output) const override;
-            protected:
-                AZStd::vector<AZ::Vector4>              m_tangents;
-                AZ::SceneAPI::DataTypes::TangentSpace   m_tangentSpace = AZ::SceneAPI::DataTypes::TangentSpace::FromSourceScene;
-                size_t                                  m_setIndex = 0;
-            };
-
-        } // GraphData
-    } // SceneData
-} // AZ
+    protected:
+        AZStd::vector<AZ::Vector4> m_tangents;
+        AZ::SceneAPI::DataTypes::TangentGenerationMethod m_generationMethod = AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene;
+        size_t m_setIndex = 0;
+    };
+} // AZ::SceneData::GraphData

--- a/Code/Tools/SceneAPI/SceneData/Rules/TangentsRule.h
+++ b/Code/Tools/SceneAPI/SceneData/Rules/TangentsRule.h
@@ -45,12 +45,17 @@ namespace AZ
                 SCENE_DATA_API TangentsRule();
                 SCENE_DATA_API ~TangentsRule() override = default;
 
-                SCENE_DATA_API AZ::SceneAPI::DataTypes::TangentSpace GetTangentSpace() const;
+                SCENE_DATA_API AZ::SceneAPI::DataTypes::TangentGenerationMethod GetGenerationMethod() const;
+                SCENE_DATA_API AZ::SceneAPI::DataTypes::MikkTSpaceMethod GetMikkTSpaceMethod() const;
 
                 static void Reflect(ReflectContext* context);
 
             protected:
-                AZ::SceneAPI::DataTypes::TangentSpace m_tangentSpace;     /**< Specifies how to handle tangents. Either generate them, or import them. */
+                AZ::SceneAPI::DataTypes::TangentGenerationMethod m_generationMethod = AZ::SceneAPI::DataTypes::TangentGenerationMethod::MikkT; /**< Specifies how to handle tangents. Either generate them, or import them. */
+
+                // MikkT specific settings
+                AZ::Crc32 GetSpaceMethodVisibility() const;
+                AZ::SceneAPI::DataTypes::MikkTSpaceMethod m_tSpaceMethod = AZ::SceneAPI::DataTypes::MikkTSpaceMethod::TSpace;
             };
         } // SceneData
     } // SceneAPI

--- a/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Tests/GraphData/GraphDataBehaviorTests.cpp
@@ -84,7 +84,7 @@ namespace AZ
                         auto* bitangentData = AZStd::any_cast<AZ::SceneData::GraphData::MeshVertexBitangentData>(&data);
                         bitangentData->AppendBitangent(AZ::Vector3{0.12f, 0.34f, 0.56f});
                         bitangentData->AppendBitangent(AZ::Vector3{0.77f, 0.88f, 0.99f});
-                        bitangentData->SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace::FromSourceScene);
+                        bitangentData->SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod::FromSourceScene);
                         bitangentData->SetBitangentSetIndex(1);
                         return true;
                     }
@@ -94,7 +94,7 @@ namespace AZ
                         tangentData->AppendTangent(AZ::Vector4{0.12f, 0.34f, 0.56f, 0.78f});
                         tangentData->AppendTangent(AZ::Vector4{0.18f, 0.28f, 0.19f, 0.29f});
                         tangentData->AppendTangent(AZ::Vector4{0.21f, 0.43f, 0.65f, 0.87f});
-                        tangentData->SetTangentSpace(AZ::SceneAPI::DataTypes::TangentSpace::MikkT);
+                        tangentData->SetGenerationMethod(AZ::SceneAPI::DataTypes::TangentGenerationMethod::MikkT);
                         tangentData->SetTangentSetIndex(2);
                         return true;
                     }
@@ -318,7 +318,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(bitangentData.y, 0.88)");
                 ExpectExecute("TestExpectFloatEquals(bitangentData.z, 0.99)");
                 ExpectExecute("TestExpectIntegerEquals(meshVertexBitangentData:GetBitangentSetIndex(), 1)");
-                ExpectExecute("TestExpectTrue(meshVertexBitangentData:GetTangentSpace(), MeshVertexBitangentData.FromSourceScene)");
+                ExpectExecute("TestExpectTrue(meshVertexBitangentData:GetGenerationMethod(), MeshVertexBitangentData.FromSourceScene)");
             }
 
             TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_MeshVertexTangentData_AccessWorks)
@@ -337,7 +337,7 @@ namespace AZ
                 ExpectExecute("TestExpectFloatEquals(tangentData.z, 0.19)");
                 ExpectExecute("TestExpectFloatEquals(tangentData.w, 0.29)");
                 ExpectExecute("TestExpectIntegerEquals(meshVertexTangentData:GetTangentSetIndex(), 2)");
-                ExpectExecute("TestExpectTrue(meshVertexTangentData:GetTangentSpace(), MeshVertexTangentData.EMotionFX)");
+                ExpectExecute("TestExpectTrue(meshVertexTangentData:GetGenerationMethod(), MeshVertexTangentData.EMotionFX)");
             }
 
             TEST_F(GrapDatahBehaviorScriptTest, SceneGraph_AnimationData_AccessWorks)

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerateComponent.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerateComponent.h
@@ -10,6 +10,7 @@
 
 #include <SceneAPI/SceneCore/Components/GenerationComponent.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
+#include <SceneAPI/SceneData/Rules/TangentsRule.h>
 #include <AzCore/RTTI/RTTI.h>
 
 namespace AZ::SceneAPI::DataTypes { class IMeshData; }
@@ -59,7 +60,7 @@ namespace AZ::SceneGenerationComponents
             AZStd::vector<AZ::SceneData::GraphData::BlendShapeData*>& outBlendShapes) const;
         bool GenerateTangentsForMesh(AZ::SceneAPI::Containers::Scene& scene, const AZ::SceneAPI::Containers::SceneGraph::NodeIndex& nodeIndex, AZ::SceneAPI::DataTypes::IMeshData* meshData);
         void UpdateFbxTangentWValues(AZ::SceneAPI::Containers::SceneGraph& graph, const AZ::SceneAPI::Containers::SceneGraph::NodeIndex& nodeIndex, const AZ::SceneAPI::DataTypes::IMeshData* meshData);
-        AZ::SceneAPI::DataTypes::TangentSpace GetTangentSpaceFromRule(const AZ::SceneAPI::Containers::Scene& scene) const;
+        const AZ::SceneAPI::SceneData::TangentsRule* GetTangentRule(const AZ::SceneAPI::Containers::Scene& scene) const;
 
         size_t CalcUvSetCount(AZ::SceneAPI::Containers::SceneGraph& graph, const AZ::SceneAPI::Containers::SceneGraph::NodeIndex& nodeIndex) const;
         AZ::SceneAPI::DataTypes::IMeshVertexUVData* FindUvData(AZ::SceneAPI::Containers::SceneGraph& graph, const AZ::SceneAPI::Containers::SceneGraph::NodeIndex& nodeIndex, AZ::u64 uvSet) const;
@@ -69,7 +70,7 @@ namespace AZ::SceneGenerationComponents
             const AZ::SceneAPI::Containers::SceneGraph::NodeIndex& nodeIndex,
             size_t numVerts,
             size_t uvSetIndex,
-            AZ::SceneAPI::DataTypes::TangentSpace tangentSpace,
+            AZ::SceneAPI::DataTypes::TangentGenerationMethod generationMethod,
             AZ::SceneAPI::Containers::SceneGraph& graph,
             AZ::SceneAPI::DataTypes::IMeshVertexTangentData** outTangentData);
 
@@ -78,7 +79,7 @@ namespace AZ::SceneGenerationComponents
             const AZ::SceneAPI::Containers::SceneGraph::NodeIndex& nodeIndex,
             size_t numVerts,
             size_t uvSetIndex,
-            AZ::SceneAPI::DataTypes::TangentSpace tangentSpace,
+            AZ::SceneAPI::DataTypes::TangentGenerationMethod generationMethod,
             AZ::SceneAPI::Containers::SceneGraph& graph,
             AZ::SceneAPI::DataTypes::IMeshVertexBitangentData** outBitangentData);
     };

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/BlendShapeMikkTGenerator.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/BlendShapeMikkTGenerator.cpp
@@ -76,33 +76,47 @@ namespace AZ::TangentGeneration::BlendShape::MikkT
         const AZ::Vector4 tangentVec(tangent[0]*magS, tangent[1]*magS, tangent[2]*magS, flipSign);
         const AZ::Vector3 bitangentVec(bitangent[0]*magT, bitangent[1]*magT, bitangent[2]*magT);
 
-        // Set the tangent and bitangent back to the blendshape
+        // Set the tangent and bitangent back to the blend shape
         AZStd::vector<AZ::Vector4>& tangents = customData->m_blendShapeData->GetTangents();
         AZStd::vector<AZ::Vector3>& bitangents = customData->m_blendShapeData->GetBitangents();
         tangents[vertexIndex] = tangentVec;
         bitangents[vertexIndex] = bitangentVec;
     }
 
-    bool GenerateTangents(AZ::SceneData::GraphData::BlendShapeData* blendShapeData, size_t uvSetIndex)
+    void SetTSpaceBasic(const SMikkTSpaceContext* context, const float tangent[], const float signValue, const int face, const int vert)
+    {
+        MikktCustomData* customData = static_cast<MikktCustomData*>(context->m_pUserData);
+        const AZ::u32 vertexIndex = customData->m_blendShapeData->GetFaceVertexIndex(face, vert);
+        AZ::Vector3 tangentVec3(tangent[0], tangent[1], tangent[2]);
+        tangentVec3.NormalizeSafe();
+        AZ::Vector3 normal = customData->m_blendShapeData->GetNormal(vertexIndex);
+        normal.NormalizeSafe();
+        const AZ::Vector3 bitangent = normal.Cross(tangentVec3) * signValue;
+
+        // Set the tangent and bitangent back to the blend shape
+        AZStd::vector<AZ::Vector4>& tangents = customData->m_blendShapeData->GetTangents();
+        AZStd::vector<AZ::Vector3>& bitangents = customData->m_blendShapeData->GetBitangents();
+        tangents[vertexIndex] = AZ::Vector4(tangentVec3.GetX(), tangentVec3.GetY(), tangentVec3.GetZ(), signValue);
+        bitangents[vertexIndex] = bitangent;
+    }
+
+    bool GenerateTangents(AZ::SceneData::GraphData::BlendShapeData* blendShapeData,
+        size_t uvSetIndex,
+        AZ::SceneAPI::DataTypes::MikkTSpaceMethod tSpaceMethod)
     {
         // Create tangent and bitangent data sets and relate them to the given UV set.
         const AZStd::vector<AZ::Vector2>& uvSet = blendShapeData->GetUVs(uvSetIndex);
         if (uvSet.empty())
         {
-            AZ_TracePrintf(AZ::SceneAPI::Utilities::ErrorWindow, "Cannot find UV data (set index=%d) to generate tangents and bitangents from in MikkT generator!\n", uvSetIndex);
-            return false;
-        }
-
-        AZStd::vector<AZ::Vector4>& tangents = blendShapeData->GetTangents();
-        AZStd::vector<AZ::Vector3>& bitangents = blendShapeData->GetBitangents();
-        if (!tangents.empty() || !bitangents.empty())
-        {
-            AZ_TracePrintf(
-                AZ::SceneAPI::Utilities::WarningWindow, "Cannot generate tangents and bitangents because existing tangent or bitangent data has been found.\n");
+            AZ_Error(AZ::SceneAPI::Utilities::ErrorWindow, false,
+                "Cannot find UV data (set index=%d) to generate tangents and bitangents from in MikkT generator.\n",
+                uvSetIndex);
             return false;
         }
 
         // Pre-allocate the tangent and bitangent data.
+        AZStd::vector<AZ::Vector4>& tangents = blendShapeData->GetTangents();
+        AZStd::vector<AZ::Vector3>& bitangents = blendShapeData->GetBitangents();
         tangents.resize(blendShapeData->GetVertexCount());
         bitangents.resize(blendShapeData->GetVertexCount());
 
@@ -114,9 +128,23 @@ namespace AZ::TangentGeneration::BlendShape::MikkT
         mikkInterface.m_getNormal           = GetNormal;
         mikkInterface.m_getPosition         = GetPosition;
         mikkInterface.m_getTexCoord         = GetTexCoord;
-        mikkInterface.m_setTSpace           = SetTSpace;
-        mikkInterface.m_setTSpaceBasic      = nullptr;
         mikkInterface.m_getNumVerticesOfFace= GetNumVerticesOfFace;
+
+        switch (tSpaceMethod)
+        {
+            case AZ::SceneAPI::DataTypes::MikkTSpaceMethod::TSpaceBasic:
+            {
+                mikkInterface.m_setTSpace = nullptr;
+                mikkInterface.m_setTSpaceBasic = SetTSpaceBasic;
+                break;
+            }
+            default:
+            {
+                mikkInterface.m_setTSpace = SetTSpace;
+                mikkInterface.m_setTSpaceBasic = nullptr;
+                break;
+            }
+        }
 
         // Set the MikkT custom data.
         MikktCustomData customData;

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/BlendShapeMikkTGenerator.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/BlendShapeMikkTGenerator.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <SceneAPI/SceneCore/Containers/Scene.h>
+#include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexBitangentData.h>
 
 namespace AZ::SceneData::GraphData
 {
@@ -24,5 +25,7 @@ namespace AZ::TangentGeneration::BlendShape::MikkT
     };
 
     // The main generation method.
-    bool GenerateTangents(AZ::SceneData::GraphData::BlendShapeData* blendShapeData, size_t uvSetIndex);
+    bool GenerateTangents(AZ::SceneData::GraphData::BlendShapeData* blendShapeData,
+        size_t uvSetIndex,
+        AZ::SceneAPI::DataTypes::MikkTSpaceMethod tSpaceMethod = AZ::SceneAPI::DataTypes::MikkTSpaceMethod::TSpace);
 } // namespace AZ::TangentGeneration::MikkT

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/MikkTGenerator.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/MikkTGenerator.cpp
@@ -108,7 +108,8 @@ namespace AZ::TangentGeneration::Mesh::MikkT
     bool GenerateTangents(const AZ::SceneAPI::DataTypes::IMeshData* meshData,
         const AZ::SceneAPI::DataTypes::IMeshVertexUVData* uvData,
         AZ::SceneAPI::DataTypes::IMeshVertexTangentData* outTangentData,
-        AZ::SceneAPI::DataTypes::IMeshVertexBitangentData* outBitangentData)
+        AZ::SceneAPI::DataTypes::IMeshVertexBitangentData* outBitangentData,
+        AZ::SceneAPI::DataTypes::MikkTSpaceMethod tSpaceMethod)
     {
         // Provide the MikkT interface.
         SMikkTSpaceInterface mikkInterface;
@@ -116,9 +117,23 @@ namespace AZ::TangentGeneration::Mesh::MikkT
         mikkInterface.m_getNormal           = GetNormal;
         mikkInterface.m_getPosition         = GetPosition;
         mikkInterface.m_getTexCoord         = GetTexCoord;
-        mikkInterface.m_setTSpace           = SetTSpace;
-        mikkInterface.m_setTSpaceBasic      = nullptr;//SetTSpaceBasic;
         mikkInterface.m_getNumVerticesOfFace= GetNumVerticesOfFace;
+
+        switch (tSpaceMethod)
+        {
+        case AZ::SceneAPI::DataTypes::MikkTSpaceMethod::TSpaceBasic:
+        {
+            mikkInterface.m_setTSpace = nullptr;
+            mikkInterface.m_setTSpaceBasic = SetTSpaceBasic;
+            break;
+        }
+        default:
+        {
+            mikkInterface.m_setTSpace = SetTSpace;
+            mikkInterface.m_setTSpaceBasic = nullptr;
+            break;
+        }
+        }
 
         // Set the MikkT custom data.
         MikktCustomData customData;

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/MikkTGenerator.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/TangentGenerator/TangentGenerators/MikkTGenerator.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshVertexBitangentData.h>
 #include <SceneAPI/SceneCore/Containers/Scene.h>
 
 namespace AZ::SceneAPI::DataTypes { class IMeshData; }
@@ -28,5 +29,6 @@ namespace AZ::TangentGeneration::Mesh::MikkT
     bool GenerateTangents(const AZ::SceneAPI::DataTypes::IMeshData* meshData,
         const AZ::SceneAPI::DataTypes::IMeshVertexUVData* uvData,
         AZ::SceneAPI::DataTypes::IMeshVertexTangentData* outTangentData,
-        AZ::SceneAPI::DataTypes::IMeshVertexBitangentData* outBitangentData);
+        AZ::SceneAPI::DataTypes::IMeshVertexBitangentData* outBitangentData,
+        AZ::SceneAPI::DataTypes::MikkTSpaceMethod tSpaceMethod = AZ::SceneAPI::DataTypes::MikkTSpaceMethod::TSpace);
 } // namespace AZ::TangentGeneration::MikkT


### PR DESCRIPTION
* Added TSpace method setting which is only visible for MikkT generation.
* Fixed a bug with generating tangents for blend shapes.
* Renamed tangent space into generation method.
* Some code cleaning

![image](https://user-images.githubusercontent.com/43751992/126767389-bc9600f5-ee71-4ec9-8de3-c52fb6a2bd71.png)
Related issue #2229

Signed-off-by: Benjamin Jillich <jillich@amazon.com>