### PR TITLE
[MeshOptimizer] Return the correct size from the position map when there are blendshapes

### DIFF
--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
@@ -35,7 +35,7 @@ namespace AZ::MeshBuilder
 
         MeshBuilderSkinningInfo(size_t numOrgVertices);
 
-        void AddInfluence(size_t orgVtxNr, const Influence& influence)             { mInfluences.resize(AZStd::max(mInfluences.size(), orgVtxNr)); mInfluences.at(orgVtxNr).emplace_back(influence); }
+        void AddInfluence(size_t orgVtxNr, const Influence& influence)             { mInfluences.resize(AZStd::max(mInfluences.size(), orgVtxNr + 1)); mInfluences.at(orgVtxNr).emplace_back(influence); }
         void RemoveInfluence(size_t orgVtxNr, size_t influenceNr)                  { mInfluences.at(orgVtxNr).erase(mInfluences.at(orgVtxNr).begin() + influenceNr); }
         const Influence& GetInfluence(size_t orgVtxNr, size_t influenceNr) const   { return mInfluences.at(orgVtxNr).at(influenceNr); }
         size_t GetNumInfluences(size_t orgVtxNr) const                             { return mInfluences.at(orgVtxNr).size(); }


### PR DESCRIPTION
The previous version returned the incorrect size from the position map when
blendshapes are present in the model. When there are blendshapes, the
vertex welding is disabled, and nothing is inserted into the position map.
However, the position map's size was being used to dictate how many
elements to create in the skinning info. The skinning info tries to
compensate for an incorrect max vertex index by resizing its underlying
vector when adding an influence, but that was using the index as the new
size of the vector, so it was off by one. This fixes both errors.