### PR TITLE
Job system improvements

### DIFF
--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerBase.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerBase.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZCORE_JOBS_INTERNAL_JOBMANAGER_BASE_H
-#define AZCORE_JOBS_INTERNAL_JOBMANAGER_BASE_H 1
+#pragma once
 
 namespace AZ
 {
@@ -20,9 +19,12 @@ namespace AZ
             static const AZ::u32 InvalidWorkerThreadId = ~0u;
         protected:
             void Process(Job* job);
+
+            // The purpose of this method is to allow jobs queued past a natural limit to have a place to
+            // go. Generally, queuing jobs past some implementation defined size may result in a slower
+            // path protected by locks.
+            virtual void QueueUnbounded(Job* job, bool shouldActivateWorker) = 0;
         };
     }
 }
-
-#endif
 

--- a/Code/Framework/AzCore/AzCore/Jobs/Job.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/Job.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#ifndef AZCORE_JOBS_JOB_H
-#define AZCORE_JOBS_JOB_H 1
+#pragma once
 
 #include <AzCore/base.h>
 #include <AzCore/Jobs/JobCancelGroup.h>
@@ -53,6 +52,18 @@ namespace AZ
         };
 
         /**
+         * Priorities MAY be used to queue jobs ahead of all currently queued jobs with lower priority. This should
+         * be done only after profiling demonstrates which jobs lie on the critical path of a representative frame.
+         */
+        enum class Priority : uint8_t
+        {
+            CRITICAL,
+            HIGH,
+            MEDIUM, // Default
+            LOW,
+        };
+
+        /**
          * If a JobContext is not specified, then the currently processing job's context will be
          * used, or the global context from JobContext::SetGlobalContext will be used if this is a top-level job.
          * isAutoDelete if true will call delete on the job after it's complete.
@@ -61,7 +72,7 @@ namespace AZ
          *          The valid range is -128 (lowest priority) to 127 (highest priority), the default is 0,
          *          and jobs with equal priority values will be run in the same order as added to the queue.
          */
-        Job(bool isAutoDelete, JobContext* context, bool isCompletion = false, AZ::s8 priority = 0);
+        Job(bool isAutoDelete, JobContext* context, bool isCompletion = false, Priority priority = Priority::MEDIUM);
 
         virtual ~Job() { }
 
@@ -239,7 +250,7 @@ namespace AZ
     //============================================================================================================
     //============================================================================================================
 
-    inline Job::Job(bool isAutoDelete, JobContext* context, bool isCompletion, AZ::s8 priority)
+    inline Job::Job(bool isAutoDelete, JobContext* context, bool isCompletion, Priority priority)
     {
         if (context)
         {
@@ -259,7 +270,7 @@ namespace AZ
         {
             countAndFlags |= (unsigned int)FLAG_COMPLETION;
         }
-        countAndFlags |= (unsigned int)((priority << FLAG_PRIORITY_START_BIT) & FLAG_PRIORITY_MASK);
+        countAndFlags |= (unsigned int)((static_cast<uint32_t>(priority) << FLAG_PRIORITY_START_BIT) & FLAG_PRIORITY_MASK);
         SetDependentCountAndFlags(countAndFlags);
         StoreDependent(NULL);
 
@@ -548,5 +559,3 @@ namespace AZ
 #endif
 }
 
-#endif
-#pragma once

--- a/Code/Framework/AzCore/AzCore/Jobs/Job.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/Job.h
@@ -301,7 +301,7 @@ namespace AZ
 #ifdef AZ_DEBUG_JOB_STATE
                 AZ_Assert(dependent->m_state == STATE_SETUP, ("Dependent must be in setup state before it can be re-initialized"));
 #endif
-                dependent->IncrementDependentCount();
+                dependent->Reset(false);
             }
         }
     }

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManager.cpp
@@ -18,7 +18,3 @@ JobManager::JobManager(const JobManagerDesc& desc)
     : m_impl(desc)
 {
 }
-
-JobManager::~JobManager()
-{
-}

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManager.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManager.h
@@ -41,8 +41,8 @@ namespace AZ
         AZ_CLASS_ALLOCATOR_DECL
 
         JobManager(const JobManagerDesc& desc);
-
-        ~JobManager();
+        JobManager(const JobManager& manager) = delete;
+        JobManager& operator=(const JobManager& manager) = delete;
 
         /// Check if we have multiple threads for parallel processing.
         AZ_FORCE_INLINE bool    IsAsynchronous() const { return m_impl.IsAsynchronous(); }
@@ -78,14 +78,21 @@ namespace AZ
         AZ::u32 GetWorkerThreadId() const { return m_impl.GetWorkerThreadId(); }
 
     private:
-        //non-copyable
-        JobManager(const JobManager& manager);
-        JobManager& operator=(const JobManager& manager);
 
         //called internally by Job class when it becomes available to run
         friend class Job;
         friend class Internal::JobNotify;
         AZ_FORCE_INLINE void AddPendingJob(Job* job) { m_impl.AddPendingJob(job); }
+
+        friend class Internal::JobQueue;
+        void QueueUnbounded(Job* job, bool shouldActivateWorker)
+        {
+            m_impl.QueueUnbounded(job, shouldActivateWorker);
+        }
+        void ActivateWorker()
+        {
+            m_impl.ActivateWorker();
+        }
 
         //called internally by Job class to suspend itself until child jobs are complete
         AZ_FORCE_INLINE void SuspendJobUntilReady(Job* job) { m_impl.SuspendJobUntilReady(job); }


### PR DESCRIPTION
- Change the number of available priorities from 255 to 4 (low, medium, high, critical) with medium being the default.
- 1.6x throughput increase.
- Resolve bug where resetting a job didn't recursively reset its children.