### PR TITLE
[ATOM-15689] Add function statistics view to CPU Profiler

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -165,9 +165,11 @@ namespace AZ
             AZStd::vector<AZStd::sys_time_t> m_frameEndTicks = { INT64_MIN };
 
             // Main data structure for storing function statistics to be shown in the popup windows.
-            // For now we default allocate for all regions on the first render frame and then use RegionStatistics.m_draw to determine
-            // if we should draw the window or not. FIXME(ATOM-15948) this should be changed once RegionStatistics gets heavier. 
-            AZStd::unordered_map<const GroupRegionName*, RegionStatistics> m_regionStatisticsMap;
+            // Uses the group name + region name as a key - just the region name does not suffice since there are collisions (ex. GarbageCollect)
+            AZStd::unordered_map<AZStd::string, RegionStatistics> m_regionStatisticsMap;
+
+            // Filter for highlighting regions on the visualizer
+            ImGuiTextFilter m_regionHighlightFilter;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Math/Random.h>
-#include <AzCore/std/containers/set.h>
 
 #include <Atom/RHI.Reflect/CpuTimingStatistics.h>
 #include <Atom/RHI/CpuProfiler.h>
@@ -25,41 +24,50 @@ namespace AZ
 
     namespace Render
     {
-        struct ThreadRegionEntry
-        {
-            AZStd::thread_id m_threadId;
-            AZStd::sys_time_t m_startTick = 0;
-            AZStd::sys_time_t m_endTick = 0;
-        };
-
+        //! Stores all the data associated with a row in the table. 
         struct TableRow
         {
+            // Update running statistics with new region data 
             void RecordRegion(const AZ::RHI::CachedTimeRegion& region, AZStd::thread_id threadId);
-            double GetAverageInvocationsPerFrame() const;
+
+            void ResetPerFrameStatistics();
+
+            // Get a string of all threads that this region executed in during the last frame
             AZStd::string TableRow::GetExecutingThreadsLabel() const;
                
             AZStd::string m_groupName;
             AZStd::string m_regionName;
-            AZStd::sys_time_t m_maxTicks;
-            AZStd::sys_time_t m_runningAverageTicks;
-            u64 m_invocations;
 
+            // --- Per frame statistics ---
+
+            u64 m_invocationsLastFrame = 0;
+
+            // NOTE: set over unordered_set so the threads can be shown in increasing order in tooltip.
             AZStd::set<AZStd::thread_id> m_executingThreads;
+
+            AZStd::sys_time_t m_lastFrameTotalTicks = 0;
+
+            // Maximum execution time of a region in the last frame.
+            AZStd::sys_time_t m_maxTicks = 0;
+
+            // --- Aggregate statistics ---
+
+            u64 m_invocationsTotal = 0;
+
+            // Running average of Mean Time Per Call
+            AZStd::sys_time_t m_runningAverageTicks = 0;
         };
 
-        //! Visual profiler for Cpu statistics.
-        //! It uses ImGui as the library for displaying the Attachments and Heaps.
-        //! It shows all heaps that are being used by the RHI and how the FIXME
-        //! resources are allocated in each heap.
+        //! ImGui widget for examining Atom CPU Profiling instrumentation.
+        //! Offers both a statistical view (with sorting and searching capability) and a visualizer
+        //! similar to RAD and other profiling tools. 
         class ImGuiCpuProfiler
             : SystemTickBus::Handler
         {
-            friend struct TableRow;
-
-            // Region Name -> Array of ThreadRegion entries
-            using RegionEntryMap = AZStd::map<AZStd::string, TableRow>;
-            // Group Name -> RegionEntryMap
-            using GroupRegionMap = AZStd::map<AZStd::string, RegionEntryMap>;
+            // Region Name -> statistical view row data
+            using RegionRowMap = AZStd::map<AZStd::string, TableRow>;
+            // Group Name -> RegionRowMap
+            using GroupRegionMap = AZStd::map<AZStd::string, RegionRowMap>;
 
             using TimeRegion = AZ::RHI::CachedTimeRegion;
             using GroupRegionName = AZ::RHI::CachedTimeRegion::GroupRegionName;
@@ -71,55 +79,26 @@ namespace AZ
             //! Draws the overall CPU profiling window, defaults to the statistical view
             void Draw(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
 
-            //! Draws the statistical view of the CPU profiling data
-            void DrawStatisticsView();
-
-            //! Draws the CPU profiling visualizer in a new window. 
-            void DrawVisualizer();
-
         private:
             static constexpr float RowHeight = 50.0;
             static constexpr int DefaultFramesToCollect = 50;
             static constexpr float MediumFrameTimeLimit = 16.6; // 60 fps
             static constexpr float HighFrameTimeLimit = 33.3; // 30 fps
 
-            static u64 ms_framesActive;
+            //! Draws the statistical view of the CPU profiling data.
+            void DrawStatisticsView();
 
-            // Draw the shared header between the two windows
+            //! Draws the CPU profiling visualizer.
+            void DrawVisualizer();
+
+            // Draw the shared header between the two windows. 
             void DrawCommonHeader();
 
-            // Draw the region statstics table in the order specified by the pointers in m_tableData
+            // Draw the region statistics table in the order specified by the pointers in m_tableData. 
             void DrawTable();
 
-            // Sort the table by a given column, rearranges the pointers in m_tableData
+            // Sort the table by a given column, rearranges the pointers in m_tableData. 
             void SortTable(ImGuiTableSortSpecs* sortSpecs);
-
-            // ImGui filter used to filter TimedRegions.
-            ImGuiTextFilter m_timedRegionFilter;
-
-            // Saves statistical view data organized by group name -> region name -> row data
-            GroupRegionMap m_groupRegionMap;
-
-            // Saves pointers to objects in m_groupRegionMap, order reflects table ordering
-            AZStd::vector<TableRow*> m_tableData;
-
-            // Pause cpu profiling. The profiler will show the statistics of the last frame before pause
-            bool m_paused = false;
-
-            // Export the profiling data from a single frame to a local file
-            bool m_captureToFile = false;
-
-            // Toggle between the normal statistical view and the visual profiling view
-            bool m_enableVisualizer = false;
-
-            // Total frames need to be saved
-            int m_captureFrameCount = 1;
-
-            AZ::RHI::CpuTimingStatistics m_cpuTimingStatisticsWhenPause;
-
-            AZStd::string m_lastCapturedFilePath;
-
-            // Visualizer methods
 
             // Get the profiling data from the last frame, only called when the profiler is not paused.
             void CollectFrameData();
@@ -127,7 +106,7 @@ namespace AZ
             // Cull old data from internal storage, only called when profiler is not paused.
             void CullFrameData(const AZ::RHI::CpuTimingStatistics& currentCpuTimingStatistics);
 
-            // Draws a single block onto the timeline
+            // Draws a single block onto the timeline into the specified row 
             void DrawBlock(const TimeRegion& block, u64 targetRow);
 
             // Draw horizontal lines between threads in the timeline
@@ -150,14 +129,14 @@ namespace AZ
 
             AZStd::sys_time_t GetViewportTickWidth() const;
 
-            // Gets the color for a block using the GroupRegionName as a key into the cache
-            // Generates a random ImU32 if the block does not yet have a color
+            // Gets the color for a block using the GroupRegionName as a key into the cache. 
+            // Generates a random ImU32 if the block does not yet have a color.
             ImU32 GetBlockColor(const TimeRegion& block);
 
             // System tick bus overrides
             virtual void OnSystemTick() override;
 
-            // Visualizer state
+            //  --- Visualizer Members ---
 
             int m_framesToCollect = DefaultFramesToCollect;
 
@@ -179,6 +158,32 @@ namespace AZ
 
             // Filter for highlighting regions on the visualizer
             ImGuiTextFilter m_visualizerHighlightFilter;
+
+            // --- Tabular view members --- 
+
+            // ImGui filter used to filter TimedRegions.
+            ImGuiTextFilter m_timedRegionFilter;
+
+            // Saves statistical view data organized by group name -> region name -> row data
+            GroupRegionMap m_groupRegionMap;
+
+            // Saves pointers to objects in m_groupRegionMap, order reflects table ordering. 
+            // Non-owning, will be cleared when m_groupRegionMap is cleared. 
+            AZStd::vector<TableRow*> m_tableData;
+
+            // Pause cpu profiling. The profiler will show the statistics of the last frame before pause. 
+            bool m_paused = false;
+
+            // Export the profiling data from a single frame to a local file.
+            bool m_captureToFile = false;
+
+            // Toggle between the normal statistical view and the visual profiling view.
+            bool m_enableVisualizer = false;
+
+            // Last captured CPU timing statistics
+            AZ::RHI::CpuTimingStatistics m_cpuTimingStatisticsWhenPause;
+
+            AZStd::string m_lastCapturedFilePath;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -27,6 +27,20 @@ namespace AZ
         //! Stores all the data associated with a row in the table. 
         struct TableRow
         {
+            template <typename T>
+            struct TableRowCompareFunctor
+            {
+                TableRowCompareFunctor(T memberPointer, bool isAscending) : m_memberPointer(memberPointer), m_ascending(isAscending){};
+
+                bool operator()(const TableRow* lhs, const TableRow* rhs)
+                {
+                    return m_ascending ? lhs->*m_memberPointer < rhs->*m_memberPointer : lhs->*m_memberPointer > rhs->*m_memberPointer;
+                }
+
+                T m_memberPointer;
+                bool m_ascending;
+            };
+
             // Update running statistics with new region data 
             void RecordRegion(const AZ::RHI::CachedTimeRegion& region, AZStd::thread_id threadId);
 

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -33,7 +33,7 @@ namespace AZ
             void ResetPerFrameStatistics();
 
             // Get a string of all threads that this region executed in during the last frame
-            AZStd::string TableRow::GetExecutingThreadsLabel() const;
+            AZStd::string GetExecutingThreadsLabel() const;
                
             AZStd::string m_groupName;
             AZStd::string m_regionName;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -208,39 +208,22 @@ namespace AZ
             switch (columnToSort)
             {
             case (0): // Sort by group name
-                AZStd::sort(m_tableData.begin(), m_tableData.end(), [ascending](const TableRow* lhs, const TableRow* rhs){
-                    return ascending ? lhs->m_groupName < rhs->m_groupName : lhs->m_groupName > rhs->m_groupName;
-                });
+                AZStd::sort(m_tableData.begin(), m_tableData.end(), TableRow::TableRowCompareFunctor(&TableRow::m_groupName, ascending));
                 break;
             case (1): // Sort by region name
-                AZStd::sort(m_tableData.begin(), m_tableData.end(),[ascending](const TableRow* lhs, const TableRow* rhs){
-                    return ascending ? lhs->m_regionName < rhs->m_regionName
-                                     : lhs->m_regionName > rhs->m_regionName;
-                });
+                AZStd::sort(m_tableData.begin(), m_tableData.end(), TableRow::TableRowCompareFunctor(&TableRow::m_regionName, ascending));
                 break;
             case (2): // Sort by average time
-                AZStd::sort(m_tableData.begin(), m_tableData.end(), [ascending](const TableRow* lhs, const TableRow* rhs){
-                    return ascending ? lhs->m_runningAverageTicks < rhs->m_runningAverageTicks
-                                     : lhs->m_runningAverageTicks > rhs->m_runningAverageTicks;
-                });
+                AZStd::sort(m_tableData.begin(), m_tableData.end(), TableRow::TableRowCompareFunctor(&TableRow::m_runningAverageTicks, ascending));
                 break;
             case (3): // Sort by max time
-                AZStd::sort(m_tableData.begin(), m_tableData.end(), [ascending](const TableRow* lhs, const TableRow* rhs){
-                    return ascending ? lhs->m_maxTicks < rhs->m_maxTicks
-                                     : lhs->m_maxTicks > rhs->m_maxTicks;
-                });
+                AZStd::sort(m_tableData.begin(), m_tableData.end(), TableRow::TableRowCompareFunctor(&TableRow::m_maxTicks, ascending));
                 break;
             case (4): // Sort by invocations
-                AZStd::sort(m_tableData.begin(), m_tableData.end(), [ascending](const TableRow* lhs, const TableRow* rhs){
-                    return ascending ? lhs->m_invocationsLastFrame < rhs->m_invocationsLastFrame
-                                     : lhs->m_invocationsLastFrame > rhs->m_invocationsLastFrame;
-                });
+                AZStd::sort(m_tableData.begin(), m_tableData.end(), TableRow::TableRowCompareFunctor(&TableRow::m_invocationsLastFrame, ascending));
                 break;
             case (5): // Sort by total time 
-                AZStd::sort(m_tableData.begin(), m_tableData.end(), [ascending](const TableRow* lhs, const TableRow* rhs){
-                    return ascending ? lhs->m_lastFrameTotalTicks < rhs->m_lastFrameTotalTicks
-                                     : lhs->m_lastFrameTotalTicks > rhs->m_lastFrameTotalTicks;
-                });
+                AZStd::sort(m_tableData.begin(), m_tableData.end(), TableRow::TableRowCompareFunctor(&TableRow::m_lastFrameTotalTicks, ascending));
                 break;
             }
             sortSpecs->SpecsDirty = false;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -279,8 +279,8 @@ namespace AZ
             if (ImGui::BeginChild("Options and Statistics", { 0, 0 }, true))
             {
                 ImGui::Columns(3, "Options", true);
-                ImGui::Text("Frames To Collect:");
-                ImGui::SliderInt("", &m_framesToCollect, 10, 10000, "%d", ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_Logarithmic);
+                ImGui::SliderInt("Saved Frames", &m_framesToCollect, 10, 10000, "%d", ImGuiSliderFlags_AlwaysClamp | ImGuiSliderFlags_Logarithmic);
+                m_regionHighlightFilter.Draw("Find Region");
 
                 ImGui::NextColumn();
 
@@ -522,6 +522,12 @@ namespace AZ
 
         inline void ImGuiCpuProfiler::DrawBlock(const TimeRegion& block, u64 targetRow)
         {
+            // Don't draw anything if the user is searching for regions and this block doesn't pass the filter
+            if (!m_regionHighlightFilter.PassFilter(block.m_groupRegionName->m_regionName))
+            {
+                return;
+            }
+
             float wy = ImGui::GetWindowPos().y - ImGui::GetScrollY();
 
             ImDrawList* drawList = ImGui::GetWindowDrawList();

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -180,7 +180,7 @@ namespace AZ
                     ImGui::Text("%.2f", CpuProfilerImGuiHelper::TicksToMs(statistics->m_maxTicks));
                     ImGui::TableNextColumn();
 
-                    ImGui::Text("%ld", statistics->m_invocationsLastFrame);
+                    ImGui::Text("%llu", statistics->m_invocationsLastFrame);
                     ImGui::TableNextColumn();
 
                     ImGui::Text("%.2f", CpuProfilerImGuiHelper::TicksToMs(statistics->m_lastFrameTotalTicks));

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -880,7 +880,7 @@ namespace AZ
             const AZStd::sys_time_t deltaTime = region.m_endTick - region.m_startTick;
 
             // Update per frame statistics
-            m_invocationsLastFrame++;
+            ++m_invocationsLastFrame;
             m_executingThreads.insert(threadId);
             m_lastFrameTotalTicks += deltaTime;
             m_maxTicks = AZStd::max(m_maxTicks, deltaTime);


### PR DESCRIPTION
### **Please start a build [here](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-2403/) and request sig/presentation**

This PR augments the existing statistical view in the CPU Profiler widget to provide greater utility. Namely, instead of a tree view, region statistics are now searchable + sortable in an ImGui table. The new implementation also provides more metrics (MTPC, total time, invocations, threads, and max time). 

Also includes minor QOL improvements to the visualizer - a search feature for regions (see below) and a "jump to" feature for going from the visualizer to the statistical view easily. 

### **Media** 

Basic overview 
![image](https://user-images.githubusercontent.com/64656371/126847897-6e9e1292-6221-4465-9574-5ad6f62f1580.png)

Statistics search + filtering 
https://user-images.githubusercontent.com/64656371/126848228-fee756d1-5c39-45db-804c-5425304d3730.mp4



Visualizer find region + jump-to-statistics
https://user-images.githubusercontent.com/64656371/126848087-2e0cca43-2d32-4247-a60b-15f4722fa701.mp4



Tested on ASV @ `5dcb206d366c888f89659a1602aec40fa7d34a91` and Editor  @ `5bb165b903202d1a2104ddcdab41a56a4cecfd1a` 