### PR TITLE
Fixing typos in comments in AffineParts.h file

### DIFF
--- a/Code/Editor/Util/AffineParts.h
+++ b/Code/Editor/Util/AffineParts.h
@@ -20,11 +20,11 @@ struct AffineParts
     Vec3 scale;         //!< Stretch factors.
     float fDet;         //!< Sign of determinant.
 
-    /** Decompose matrix to its affnie parts.
+    /** Decompose matrix to its affine parts.
     */
     void Decompose(const Matrix34& mat);
 
-    /** Decompose matrix to its affnie parts.
+    /** Decompose matrix to its affine parts.
             Assume there`s no stretch rotation.
     */
     void SpectralDecompose(const Matrix34& mat);


### PR DESCRIPTION
Noticed these when browsing through the source code, figured I may as well contribute and fix them.