### PR TITLE
[LYN-4065] Expose GameLift server api to notify server process ready

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
@@ -16,6 +16,8 @@ ly_add_target(
     FILES_CMAKE
         awsgamelift_server_files.cmake
     INCLUDE_DIRECTORIES
+        PUBLIC
+            Include
         PRIVATE
             ../AWSGameLiftCommon/Source
             Source

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Include/Request/IAWSGameLiftServerRequests.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Include/Request/IAWSGameLiftServerRequests.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/string/string.h>
+#include <AzFramework/Session/ISessionRequests.h>
+
+namespace AWSGameLift
+{
+    //! IAWSGameLiftServerRequests
+    //! Server interfaces to expose Amazon GameLift Server SDK
+    class IAWSGameLiftServerRequests
+    {
+    public:
+        AZ_RTTI(IAWSGameLiftServerRequests, "{D76CD98D-4C37-4C25-82C4-4E8772706D70}");
+
+        IAWSGameLiftServerRequests() = default;
+        virtual ~IAWSGameLiftServerRequests() = default;
+
+        //! Notify GameLift that the server process is ready to host a game session.
+        //! @return Whether the ProcessReady notification is sent to GameLift.
+        virtual bool NotifyGameLiftProcessReady() = 0;
+    };
+
+    // IAWSGameLiftServerRequests EBus wrapper for scripting
+    class AWSGameLiftServerRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        using MutexType = AZStd::recursive_mutex;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+    };
+    using AWSGameLiftServerRequestBus = AZ::EBus<IAWSGameLiftServerRequests, AWSGameLiftServerRequests>;
+} // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.h
@@ -16,6 +16,7 @@
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzFramework/Session/ISessionHandlingRequests.h>
 #include <AzFramework/Session/SessionConfig.h>
+#include <Request/IAWSGameLiftServerRequests.h>
 
 namespace AWSGameLift
 {
@@ -31,7 +32,8 @@ namespace AWSGameLift
 
     //! Manage the server process for hosting game sessions via GameLiftServerSDK.
     class AWSGameLiftServerManager
-        : public AzFramework::ISessionHandlingProviderRequests
+        : public AWSGameLiftServerRequestBus::Handler
+        , public AzFramework::ISessionHandlingProviderRequests
     {
     public:
         static constexpr const char AWSGameLiftServerManagerName[] = "AWSGameLiftServerManager";
@@ -68,14 +70,14 @@ namespace AWSGameLift
         AWSGameLiftServerManager();
         virtual ~AWSGameLiftServerManager();
 
-        //! Initialize GameLift API client by calling InitSDK().
-        //! @return Whether the initialization is successful.
-        bool InitializeGameLiftServerSDK();
+        void ActivateManager();
+        void DeactivateManager();
 
-        //! Notify GameLift that the server process is ready to host a game session.
-        //! @param desc GameLift server process settings.
-        //! @return Whether the ProcessReady notification is sent to GameLift.
-        bool NotifyGameLiftProcessReady(const GameLiftServerProcessDesc& desc);
+        //! Initialize GameLift API client by calling InitSDK().
+        void InitializeGameLiftServerSDK();
+
+        // AWSGameLiftServerRequestBus interface implementation
+        bool NotifyGameLiftProcessReady() override;
 
         // ISessionHandlingProviderRequests interface implementation
         void HandleDestroySession() override;
@@ -91,6 +93,9 @@ namespace AWSGameLift
         bool AddConnectedPlayer(const AzFramework::PlayerConnectionConfig& playerConnectionConfig);
 
     private:
+        //! Build the serverProcessDesc with appropriate server port number and log paths.
+        GameLiftServerProcessDesc BuildGameLiftServerProcessDesc();
+
         //! Build session config by using AWS GameLift Server GameSession Model.
         AzFramework::SessionConfig BuildSessionConfig(const Aws::GameLift::Server::Model::GameSession& gameSession);
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.cpp
@@ -74,47 +74,14 @@ namespace AWSGameLift
 
     void AWSGameLiftServerSystemComponent::Activate()
     {
-        if (m_gameLiftServerManager->InitializeGameLiftServerSDK())
-        {
-            GameLiftServerProcessDesc serverProcessDesc;
-            UpdateGameLiftServerProcessDesc(serverProcessDesc);
-            m_gameLiftServerManager->NotifyGameLiftProcessReady(serverProcessDesc);
-        }
+        m_gameLiftServerManager->InitializeGameLiftServerSDK();
+        m_gameLiftServerManager->ActivateManager();
     }
 
     void AWSGameLiftServerSystemComponent::Deactivate()
     {
+        m_gameLiftServerManager->DeactivateManager();
         m_gameLiftServerManager->HandleDestroySession();
-    }
-
-    void AWSGameLiftServerSystemComponent::UpdateGameLiftServerProcessDesc(GameLiftServerProcessDesc& serverProcessDesc)
-    {
-        AZ::IO::FileIOBase* fileIO = AZ::IO::FileIOBase::GetDirectInstance();
-        if (fileIO)
-        {
-            const char pathToLogFolder[] = "@log@/";
-            char resolvedPath[AZ_MAX_PATH_LEN];
-            if (fileIO->ResolvePath(pathToLogFolder, resolvedPath, AZ_ARRAY_SIZE(resolvedPath)))
-            {
-                serverProcessDesc.m_logPaths.push_back(resolvedPath);
-            }
-            else
-            {
-                AZ_Error("AWSGameLift", false, "Failed to resolve the path to the log folder.");
-            }
-        }
-        else
-        {
-            AZ_Error("AWSGameLift", false, "Failed to get File IO.");
-        }
-
-        if (auto console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
-        {
-            [[maybe_unused]] AZ::GetValueResult getCvarResult = console->GetCvarValue("sv_port", serverProcessDesc.m_port);
-            AZ_Error(
-                "AWSGameLift", getCvarResult == AZ::GetValueResult::Success, "Lookup of 'sv_port' console variable failed with error %s",
-                AZ::GetEnumString(getCvarResult));
-        }
     }
 
     void AWSGameLiftServerSystemComponent::SetGameLiftServerManager(AZStd::unique_ptr<AWSGameLiftServerManager> gameLiftServerManager)

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerSystemComponent.h
@@ -43,10 +43,6 @@ namespace AWSGameLift
         void SetGameLiftServerManager(AZStd::unique_ptr<AWSGameLiftServerManager> gameLiftServerManager);
 
     private:
-        //! Update the serverProcessDesc with appropriate server port number and log paths.
-        //! @param serverProcessDesc Desc object to update.
-        void UpdateGameLiftServerProcessDesc(GameLiftServerProcessDesc& serverProcessDesc);
-
         AZStd::unique_ptr<AWSGameLiftServerManager> m_gameLiftServerManager;
     };
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerSystemComponentTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerSystemComponentTest.cpp
@@ -13,7 +13,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/UnitTest/TestTypes.h>
-#include <AzFramework/IO/LocalFileIO.h>
 #include <AzTest/AzTest.h>
 
 namespace UnitTest
@@ -37,22 +36,10 @@ namespace UnitTest
 
             m_AWSGameLiftServerSystemsComponent = aznew NiceMock<AWSGameLiftServerSystemComponentMock>();
             m_entity->AddComponent(m_AWSGameLiftServerSystemsComponent);
-
-            // Set up the file IO and alias
-            m_localFileIO = aznew AZ::IO::LocalFileIO();
-            m_priorFileIO = AZ::IO::FileIOBase::GetInstance();
-
-            AZ::IO::FileIOBase::SetInstance(nullptr);
-            AZ::IO::FileIOBase::SetInstance(m_localFileIO);
-            m_localFileIO->SetAlias("@log@", AZ_TRAIT_TEST_ROOT_FOLDER);
         }
 
         void TearDown() override
         {
-            AZ::IO::FileIOBase::SetInstance(nullptr);
-            delete m_localFileIO;
-            AZ::IO::FileIOBase::SetInstance(m_priorFileIO);
-
             m_entity->RemoveComponent(m_AWSGameLiftServerSystemsComponent);
             delete m_AWSGameLiftServerSystemsComponent;
             delete m_entity;
@@ -70,9 +57,6 @@ namespace UnitTest
 
         AZ::Entity* m_entity;      
         NiceMock<AWSGameLiftServerSystemComponentMock>* m_AWSGameLiftServerSystemsComponent;
-
-        AZ::IO::FileIOBase* m_priorFileIO;
-        AZ::IO::FileIOBase* m_localFileIO;
     };
 
     TEST_F(AWSGameLiftServerSystemComponentTest, ActivateDeactivateComponent_ExecuteInOrder_Success)

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/awsgamelift_server_files.cmake
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/awsgamelift_server_files.cmake
@@ -8,6 +8,7 @@
 
 set(FILES
     ../AWSGameLiftCommon/Source/AWSGameLiftSessionConstants.h
+    Include/Request/IAWSGameLiftServerRequests.h
     Source/AWSGameLiftServerManager.cpp
     Source/AWSGameLiftServerManager.h
     Source/AWSGameLiftServerSystemComponent.cpp


### PR DESCRIPTION
## Details
As title descriped, add server public interface so multiplayer developer can decide when to notify server process on GameLift instance is ready.

## Testing
Pass unit test coverage 92% without gamelift sdk wrapper
Pass manual local testing with GameLiftLocal

Signed-off-by: onecent1101 <liug@amazon.com>