### PR TITLE
Include build failure root cause in email notification

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -577,13 +577,19 @@ finally {
             )
         }
         node('controller') {
-            step([
-                $class: 'Mailer',
-                notifyEveryUnstableBuild: true,
-                recipients: emailextrecipients([
+            if("${currentBuild.currentResult}" == "SUCCESS") {
+                emailBody = "${BUILD_URL}\nSuccess!"
+            } else {
+                buildFailure = tm('${BUILD_FAILURE_ANALYZER}')
+                emailBody = "${BUILD_URL}\n${buildFailure}!"
+            }
+            emailext (
+                body: "${emailBody}",
+                subject: "${currentBuild.currentResult}: ${JOB_NAME} - Build # ${BUILD_NUMBER}",
+                recipientProviders: [
                     [$class: 'RequesterRecipientProvider']
-                ])
-            ])
+                ]
+            )
         }
     } catch(Exception e) {
     }


### PR DESCRIPTION
Include build failure root cause in failed build email notification
Replace email notification plugin with extended email notification plugin.
Signed-off-by: shiranj <shiranj@amazon.com>