### PR TITLE
Fix the home key popping up ImGui when it shouldn't.

### DIFF
--- a/Code/Editor/Core/QtEditorApplication.cpp
+++ b/Code/Editor/Core/QtEditorApplication.cpp
@@ -415,33 +415,37 @@ namespace Editor
         }
 
         // Ensure that the Windows WM_INPUT messages get passed through to the AzFramework input system.
-        // These events are now consumed both in and out of game mode.
-        if (msg->message == WM_INPUT)
+        // These events are only broadcast in game mode. In Editor mode, RenderViewportWidget creates synthetic
+        // keyboard and mouse events via Qt.
+        if (GetIEditor()->IsInGameMode())
         {
-            UINT rawInputSize;
-            const UINT rawInputHeaderSize = sizeof(RAWINPUTHEADER);
-            GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, NULL, &rawInputSize, rawInputHeaderSize);
-
-            AZStd::array<BYTE, sizeof(RAWINPUT)> rawInputBytesArray;
-            LPBYTE rawInputBytes = rawInputBytesArray.data();
-
-            const UINT bytesCopied = GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, rawInputBytes, &rawInputSize, rawInputHeaderSize);
-            CRY_ASSERT(bytesCopied == rawInputSize);
-
-            RAWINPUT* rawInput = (RAWINPUT*)rawInputBytes;
-            CRY_ASSERT(rawInput);
-
-            AzFramework::RawInputNotificationBusWindows::Broadcast(&AzFramework::RawInputNotificationsWindows::OnRawInputEvent, *rawInput);
-
-            return false;
-        }
-        else if (msg->message == WM_DEVICECHANGE)
-        {
-            if (msg->wParam == 0x0007) // DBT_DEVNODES_CHANGED
+            if (msg->message == WM_INPUT)
             {
-                AzFramework::RawInputNotificationBusWindows::Broadcast(&AzFramework::RawInputNotificationsWindows::OnRawInputDeviceChangeEvent);
+                UINT rawInputSize;
+                const UINT rawInputHeaderSize = sizeof(RAWINPUTHEADER);
+                GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, NULL, &rawInputSize, rawInputHeaderSize);
+
+                AZStd::array<BYTE, sizeof(RAWINPUT)> rawInputBytesArray;
+                LPBYTE rawInputBytes = rawInputBytesArray.data();
+
+                const UINT bytesCopied = GetRawInputData((HRAWINPUT)msg->lParam, RID_INPUT, rawInputBytes, &rawInputSize, rawInputHeaderSize);
+                CRY_ASSERT(bytesCopied == rawInputSize);
+
+                RAWINPUT* rawInput = (RAWINPUT*)rawInputBytes;
+                CRY_ASSERT(rawInput);
+
+                AzFramework::RawInputNotificationBusWindows::Broadcast(&AzFramework::RawInputNotificationsWindows::OnRawInputEvent, *rawInput);
+
+                return false;
             }
-            return true;
+            else if (msg->message == WM_DEVICECHANGE)
+            {
+                if (msg->wParam == 0x0007) // DBT_DEVNODES_CHANGED
+                {
+                    AzFramework::RawInputNotificationBusWindows::Broadcast(&AzFramework::RawInputNotificationsWindows::OnRawInputDeviceChangeEvent);
+                }
+                return true;
+            }
         }
 
         return false;

--- a/Gems/ImGui/Code/Source/ImGuiManager.cpp
+++ b/Gems/ImGui/Code/Source/ImGuiManager.cpp
@@ -452,7 +452,7 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
     const InputDeviceId& inputDeviceId = inputChannel.GetInputDevice().GetInputDeviceId();
 
     // Handle Keyboard Hotkeys
-    if (inputDeviceId == InputDeviceKeyboard::Id && inputChannel.IsStateBegan())
+    if (InputDeviceKeyboard::IsKeyboardDevice(inputDeviceId) && inputChannel.IsStateBegan())
     {
         // Cycle through ImGui Menu Bar States on Home button press
         if (inputChannelId == InputDeviceKeyboard::Key::NavigationHome)
@@ -477,7 +477,7 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
     }
 
     // Handle Keyboard Modifier Keys
-    if (inputDeviceId == InputDeviceKeyboard::Id)
+    if (InputDeviceKeyboard::IsKeyboardDevice(inputDeviceId))
     {
         if (inputChannelId == InputDeviceKeyboard::Key::ModifierShiftL
             || inputChannelId == InputDeviceKeyboard::Key::ModifierShiftR)
@@ -506,14 +506,10 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
     // Handle Controller Inputs
     int inputControllerIndex = -1;
     bool controllerInput = false;
-    for (int i = 0; i < MaxControllerNumber; ++i)
+    if (InputDeviceGamepad::IsGamepadDevice(inputDeviceId))
     {
-        //Allow only one controller navigating ImGui at the same time. After menu bar dismissed, other controllers could take over
-        if (inputDeviceId == InputDeviceGamepad::IdForIndexN(i))
-        {
-            inputControllerIndex = i;
-            controllerInput = true;
-        }
+        inputControllerIndex = inputDeviceId.GetIndex();
+        controllerInput = true;
     }
 
     
@@ -570,7 +566,7 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
     }
 
     // Handle Mouse Inputs
-    if (inputDeviceId == InputDeviceMouse::Id)
+    if (InputDeviceMouse::IsMouseDevice(inputDeviceId))
     {
         const int mouseButtonIndex = GetAzMouseButtonIndex(inputChannelId);
         if (0 <= mouseButtonIndex && mouseButtonIndex < AZ_ARRAY_SIZE(io.MouseDown))
@@ -584,7 +580,7 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
     }
 
     // Handle Touch Inputs
-    if (inputDeviceId == InputDeviceTouch::Id)
+    if (InputDeviceTouch::IsTouchDevice(inputDeviceId))
     {
         const int touchIndex = GetAzTouchIndex(inputChannelId);
         if (0 <= touchIndex && touchIndex < AZ_ARRAY_SIZE(io.MouseDown))
@@ -605,7 +601,7 @@ bool ImGuiManager::OnInputChannelEventFiltered(const InputChannel& inputChannel)
     }
 
     // Handle Virtual Keyboard Inputs
-    if (inputDeviceId == InputDeviceVirtualKeyboard::Id)
+    if (InputDeviceVirtualKeyboard::IsVirtualKeyboardDevice(inputDeviceId))
     {
         if (inputChannelId == AzFramework::InputDeviceVirtualKeyboard::Command::EditEnter)
         {


### PR DESCRIPTION
This disables WM_INPUT forwarding to the input system while in game mode and makes ImGui listen to the synthetic keyboard events from the viewport instead - these synthetic events go through Qt's event system, so will only show up when the viewport "sees" a home key press.

![imgui_key](https://user-images.githubusercontent.com/760096/127538319-938efee4-be51-47f0-86c1-7613891d3cc0.gif)
