### PR TITLE
Fixes resource selectors not showing

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorPlugin.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorPlugin.cpp
@@ -14,7 +14,7 @@
 #include <AudioControlsLoader.h>
 #include <AudioControlsWriter.h>
 
-#include <Include/IResourceSelectorHost.h>
+#include <AudioResourceSelectors.h>
 
 #include <IAudioSystem.h>
 #include <IAudioSystemEditor.h>
@@ -39,7 +39,7 @@ CAudioControlsEditorPlugin::CAudioControlsEditorPlugin(IEditor* editor)
     QtViewOptions options;
     options.canHaveMultipleInstances = true;
     RegisterQtViewPane<CAudioControlsEditorWindow>(editor, LyViewPane::AudioControlsEditor, LyViewPane::CategoryOther, options);
-    RegisterModuleResourceSelectors(GetIEditor()->GetResourceSelectorHost());
+    RegisterAudioControlsResourceSelectors();
 
     Audio::AudioSystemRequestBus::BroadcastResult(ms_pIAudioProxy, &Audio::AudioSystemRequestBus::Events::GetFreeAudioProxy);
 

--- a/Gems/AudioSystem/Code/Source/Editor/AudioResourceSelectors.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioResourceSelectors.cpp
@@ -7,13 +7,12 @@
  */
 
 
+#include <AudioResourceSelectors.h>
 #include <ATLControlsResourceDialog.h>
 #include <AudioControlsEditorPlugin.h>
 #include <Include/IResourceSelectorHost.h>
 #include <QAudioControlEditorIcons.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
-
-using namespace AudioControls;
 
 namespace AudioControls
 {
@@ -67,10 +66,32 @@ namespace AudioControls
     }
 
     //-------------------------------------------------------------------------------------------//
-    REGISTER_RESOURCE_SELECTOR("AudioTrigger", AudioTriggerSelector, ":/AudioControlsEditor/Icons/Trigger_Icon.png");
-    REGISTER_RESOURCE_SELECTOR("AudioSwitch", AudioSwitchSelector, ":/AudioControlsEditor/Icons/Switch_Icon.png");
-    REGISTER_RESOURCE_SELECTOR("AudioSwitchState", AudioSwitchStateSelector, ":/AudioControlsEditor/Icons/State_Icon.png");
-    REGISTER_RESOURCE_SELECTOR("AudioRTPC", AudioRTPCSelector, ":/AudioControlsEditor/Icons/RTPC_Icon.png");
-    REGISTER_RESOURCE_SELECTOR("AudioEnvironment", AudioEnvironmentSelector, ":/AudioControlsEditor/Icons/Environment_Icon.png");
-    REGISTER_RESOURCE_SELECTOR("AudioPreloadRequest", AudioPreloadRequestSelector, ":/AudioControlsEditor/Icons/Bank_Icon.png");
+    static SStaticResourceSelectorEntry audioTriggerSelector(
+        "AudioTrigger", AudioTriggerSelector, ":/Icons/Trigger_Icon.svg");
+    static SStaticResourceSelectorEntry audioSwitchSelector(
+        "AudioSwitch", AudioSwitchSelector, ":/Icons/Switch_Icon.svg");
+    static SStaticResourceSelectorEntry audioStateSelector(
+        "AudioSwitchState", AudioSwitchStateSelector, ":/Icons/Property_Icon.png");
+    static SStaticResourceSelectorEntry audioRtpcSelector(
+        "AudioRTPC", AudioRTPCSelector, ":/Icons/RTPC_Icon.svg");
+    static SStaticResourceSelectorEntry audioEnvironmentSelector(
+        "AudioEnvironment", AudioEnvironmentSelector, ":/Icons/Environment_Icon.svg");
+    static SStaticResourceSelectorEntry audioPreloadSelector(
+        "AudioPreloadRequest", AudioPreloadRequestSelector, ":/Icons/Bank_Icon.png");
+
+    //-------------------------------------------------------------------------------------------//
+    void RegisterAudioControlsResourceSelectors()
+    {
+        if (IResourceSelectorHost* host = GetIEditor()->GetResourceSelectorHost();
+            host != nullptr)
+        {
+            host->RegisterResourceSelector(&audioTriggerSelector);
+            host->RegisterResourceSelector(&audioSwitchSelector);
+            host->RegisterResourceSelector(&audioStateSelector);
+            host->RegisterResourceSelector(&audioRtpcSelector);
+            host->RegisterResourceSelector(&audioEnvironmentSelector);
+            host->RegisterResourceSelector(&audioPreloadSelector);
+        }
+    }
+
 } // namespace AudioControls

--- a/Gems/AudioSystem/Code/Source/Editor/AudioResourceSelectors.h
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioResourceSelectors.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AudioControls
+{
+    void RegisterAudioControlsResourceSelectors();
+}

--- a/Gems/AudioSystem/Code/audiosystem_editor_files.cmake
+++ b/Gems/AudioSystem/Code/audiosystem_editor_files.cmake
@@ -54,6 +54,7 @@ set(FILES
     Source/Editor/AudioControlsEditorWindow.h
     Source/Editor/AudioControlsLoader.h
     Source/Editor/AudioControlsWriter.h
+    Source/Editor/AudioResourceSelectors.h
     Source/Editor/AudioSystemPanel.h
     Source/Editor/ImplementationManager.h
     Source/Editor/InspectorPanel.h


### PR DESCRIPTION
These statics were getting dead-stripped by the compiler, so removed
some of the macro magic and just do direct registration instead.
