### PR TITLE
[ATOM-16021] Initial continuous capture support 

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ProfilingCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ProfilingCaptureBus.h
@@ -25,8 +25,14 @@ namespace AZ
             //! Dump the PipelineStatistics from passes to a json file.
             virtual bool CapturePassPipelineStatistics(const AZStd::string& outputFilePath) = 0;
 
-            //! Dump the Cpu Profiling Statistics to a json file.
+            //! Dump a single frame of Cpu profiling data 
             virtual bool CaptureCpuProfilingStatistics(const AZStd::string& outputFilePath) = 0;
+
+            //! Start a multiframe capture of CPU profiling data.
+            virtual bool BeginContinuousCpuProfilingCapture() = 0;
+
+            //! End and dump an in-progress continuous capture.
+            virtual bool EndContinuousCpuProfilingCapture(const AZStd::string& outputFilePath) = 0;
 
             //! Dump the benchmark metadata to a json file.
             virtual bool CaptureBenchmarkMetadata(const AZStd::string& benchmarkName, const AZStd::string& outputFilePath) = 0;

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
@@ -642,6 +642,7 @@ namespace AZ
             
             // If the thread object already exists (ex. we have already serialized data), join. This will not block since
             // m_cpuDataSerializationInProgress is false, meaning the IO thread has already completed execution.
+            // TODO Use a reusable thread implementation over repeated creation + destruction of threads [ATOM-16214]
             if (m_cpuDataSerializationThread.joinable())
             {
                 m_cpuDataSerializationThread.join();

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -90,6 +90,8 @@ namespace AZ
 
             // Flag passed by reference to the CPU profiling data serialization job, blocks new continuous capture requests when set.
             AZStd::atomic_bool m_cpuDataSerializationInProgress = false;
+            
+            AZStd::thread m_cpuDataSerializationThread;
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -78,8 +78,6 @@ namespace AZ
         private:
             void OnTick(float deltaTime, ScriptTimePoint time) override;
 
-            bool SerializeCpuProfilingData(AZStd::deque<RHI::CpuProfiler::TimeRegionMap>&& data, const AZStd::string& outputFilePath, bool wasEnabled);
-
             // Recursively collect all the passes from the root pass.
             AZStd::vector<const RPI::Pass*> CollectPassesRecursively(const RPI::Pass* root) const;
 
@@ -89,6 +87,13 @@ namespace AZ
             DelayedQueryCaptureHelper m_pipelineStatisticsCapture;
             DelayedQueryCaptureHelper m_cpuProfilingStatisticsCapture;
             DelayedQueryCaptureHelper m_benchmarkMetadataCapture;
+
+            // Stores the last continuous capture data so that the IO thread can access it by reference. 
+            // Ensure that this is not cleared until m_cpuDataSerializationInProgress is false. 
+            AZStd::deque<RHI::CpuProfiler::TimeRegionMap> m_lastContinuousCapture;
+            AZStd::atomic_bool m_cpuDataSerializationInProgress = false;
+
+            AZStd::thread m_cpuStatisticsIoThread;
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -12,6 +12,7 @@
 #include <AzCore/Component/TickBus.h>
 
 #include <Atom/Feature/Utils/ProfilingCaptureBus.h>
+#include <Atom/RHI/CpuProfiler.h>
 
 namespace AZ
 {
@@ -70,10 +71,14 @@ namespace AZ
             bool CapturePassTimestamp(const AZStd::string& outputFilePath) override;
             bool CapturePassPipelineStatistics(const AZStd::string& outputFilePath) override;
             bool CaptureCpuProfilingStatistics(const AZStd::string& outputFilePath) override;
+            bool BeginContinuousCpuProfilingCapture() override;
+            bool EndContinuousCpuProfilingCapture(const AZStd::string& outputFilePath) override;
             bool CaptureBenchmarkMetadata(const AZStd::string& benchmarkName, const AZStd::string& outputFilePath) override;
 
         private:
             void OnTick(float deltaTime, ScriptTimePoint time) override;
+
+            bool SerializeCpuProfilingData(AZStd::deque<RHI::CpuProfiler::TimeRegionMap>&& data, const AZStd::string& outputFilePath, bool wasEnabled);
 
             // Recursively collect all the passes from the root pass.
             AZStd::vector<const RPI::Pass*> CollectPassesRecursively(const RPI::Pass* root) const;

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -88,12 +88,8 @@ namespace AZ
             DelayedQueryCaptureHelper m_cpuProfilingStatisticsCapture;
             DelayedQueryCaptureHelper m_benchmarkMetadataCapture;
 
-            // Stores the last continuous capture data so that the IO thread can access it by reference. 
-            // Ensure that this is not cleared until m_cpuDataSerializationInProgress is false. 
-            AZStd::deque<RHI::CpuProfiler::TimeRegionMap> m_lastContinuousCapture;
+            // Flag passed by reference to the CPU profiling data serialization job, blocks new continuous capture requests when set.
             AZStd::atomic_bool m_cpuDataSerializationInProgress = false;
-
-            AZStd::thread m_cpuStatisticsIoThread;
         };
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/Debug/EventTrace.h>
 #include <AzCore/RTTI/RTTI.h>
-#include <AzCore/std/containers/deque.h>
+#include <AzCore/std/containers/ring_buffer.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/string/string.h>
 
@@ -86,8 +86,8 @@ namespace AZ
             //! Begin a continuous capture. Blocks the profiler from being toggled off until EndContinuousCapture is called. 
             virtual bool BeginContinuousCapture() = 0;
 
-            //! Flush the CPU Profiler's saved data into the passed deque.
-            virtual bool EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) = 0;
+            //! Flush the CPU Profiler's saved data into the passed ring buffer .
+            virtual bool EndContinuousCapture(AZStd::ring_buffer<TimeRegionMap>& flushTarget) = 0;
 
             virtual bool IsContinuousCaptureInProgress() const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -84,10 +84,10 @@ namespace AZ
             virtual const TimeRegionMap& GetTimeRegionMap() const = 0;
 
             //! Begin a continuous capture. Blocks the profiler from being toggled off until EndContinuousCapture is called. 
-            virtual bool BeginContinuousCapture() = 0;
+            [[nodiscard]] virtual bool BeginContinuousCapture() = 0;
 
             //! Flush the CPU Profiler's saved data into the passed ring buffer .
-            virtual bool EndContinuousCapture(AZStd::ring_buffer<TimeRegionMap>& flushTarget) = 0;
+            [[nodiscard]] virtual bool EndContinuousCapture(AZStd::ring_buffer<TimeRegionMap>& flushTarget) = 0;
 
             virtual bool IsContinuousCaptureInProgress() const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -84,10 +84,10 @@ namespace AZ
             virtual const TimeRegionMap& GetTimeRegionMap() const = 0;
 
             //! Begin a continuous capture. Blocks the profiler from being toggled off until EndContinuousCapture is called. 
-            virtual void BeginContinuousCapture() = 0;
+            virtual bool BeginContinuousCapture() = 0;
 
             //! Flush the CPU Profiler's saved data into the passed deque.
-            virtual void EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) = 0;
+            virtual bool EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) = 0;
 
             virtual bool IsContinuousCaptureInProgress() const = 0;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Debug/EventTrace.h>
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/string/string.h>
 
@@ -81,6 +82,14 @@ namespace AZ
 
             //! Get the last frame's TimeRegionMap
             virtual const TimeRegionMap& GetTimeRegionMap() const = 0;
+
+            //! Begin a continuous capture. Blocks the profiler from being toggled off until EndContinuousCapture is called. 
+            virtual void BeginContinuousCapture() = 0;
+
+            //! Flush the CPU Profiler's saved data into the passed deque.
+            virtual void EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) = 0;
+
+            virtual bool IsContinuousCaptureInProgress() const = 0;
 
             //! Enable/Disable the CpuProfiler
             virtual void SetProfilerEnabled(bool enabled) = 0;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -140,7 +140,9 @@ namespace AZ
 
             bool m_initialized = false;
 
-            bool m_continuousCaptureInProgress = false;
+            AZStd::mutex m_continuousCaptureEndingMutex;
+
+            AZStd::atomic_bool m_continuousCaptureInProgress;
 
             // Stores multiple frames of profiling data, size is controlled by MaxFramesToSave. Flushed when EndContinuousCapture is called.
             // Ring buffer so that we can have fast append of new data + removal of old profiling data with good cache locality.

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -110,13 +110,13 @@ namespace AZ
             void EndTimeRegion() final override;
             const TimeRegionMap& GetTimeRegionMap() const final override;
             bool BeginContinuousCapture() final override;
-            bool EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) final override;
+            bool EndContinuousCapture(AZStd::ring_buffer<TimeRegionMap>& flushTarget) final override;
             bool IsContinuousCaptureInProgress() const final override;
             void SetProfilerEnabled(bool enabled) final override;
             bool IsProfilerEnabled() const final override;
 
         private:
-            static constexpr u32 MaxFramesToSave = 2 * 60 * 120; // 2 minutes of 120fps
+            static constexpr AZStd::size_t MaxFramesToSave = 2 * 60 * 120; // 2 minutes of 120fps
 
             // Lazily create and register the local thread data
             void RegisterThreadStorage();
@@ -143,8 +143,8 @@ namespace AZ
             bool m_continuousCaptureInProgress = false;
 
             // Stores multiple frames of profiling data, size is controlled by MaxFramesToSave. Flushed when EndContinuousCapture is called.
-            // Deque so that we can have fast append of new data + removal of old profiling data.
-            AZStd::deque<TimeRegionMap> m_continuousCaptureData;
+            // Ring buffer so that we can have fast append of new data + removal of old profiling data with good cache locality.
+            AZStd::ring_buffer<TimeRegionMap> m_continuousCaptureData;
         };
 
     }; // namespace RPI

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -109,14 +109,14 @@ namespace AZ
             void BeginTimeRegion(TimeRegion& timeRegion) final override;
             void EndTimeRegion() final override;
             const TimeRegionMap& GetTimeRegionMap() const final override;
-            void BeginContinuousCapture() final override;
-            void EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) final override;
+            bool BeginContinuousCapture() final override;
+            bool EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget) final override;
             bool IsContinuousCaptureInProgress() const final override;
             void SetProfilerEnabled(bool enabled) final override;
             bool IsProfilerEnabled() const final override;
 
         private:
-            static constexpr u32 MaxFramesToSave = 60 * 120; // 1 minute of 120fps
+            static constexpr u32 MaxFramesToSave = 2 * 60 * 120; // 2 minutes of 120fps
 
             // Lazily create and register the local thread data
             void RegisterThreadStorage();

--- a/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
@@ -143,20 +143,34 @@ namespace AZ
             return m_timeRegionMap;
         }
 
-        void CpuProfilerImpl::BeginContinuousCapture()
+        bool CpuProfilerImpl::BeginContinuousCapture()
         {
-            AZ_Warning("Profiler", !m_continuousCaptureInProgress, "Attempting to start a continuous capture while one already in progress");
+            if (m_continuousCaptureInProgress)
+            {
+                AZ_TracePrintf("Profiler", "Attempting to start a continuous capture while one already in progress");
+                return false;
+            }
+
+            m_enabled = true;
             m_continuousCaptureInProgress = true;
-            AZ_TracePrintf("Profiler", "Continuous capture started");
+            AZ_TracePrintf("Profiler", "Continuous capture started\n");
+            return true;
         }
 
-        void CpuProfilerImpl::EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget)
+        bool CpuProfilerImpl::EndContinuousCapture(AZStd::deque<TimeRegionMap>& flushTarget)
         {
-            AZ_Warning("Profiler", m_continuousCaptureInProgress, "Attempting to end a continuous capture while one not in progress");
+            if (!m_continuousCaptureInProgress)
+            {
+                AZ_TracePrintf("Profiler", "Attempting to end a continuous capture while one not in progress");
+                return false;
+            }
+
+            m_enabled = false;
             m_continuousCaptureInProgress = false;
             flushTarget = AZStd::move(m_continuousCaptureData);
             m_continuousCaptureData.clear();
-            AZ_TracePrintf("Profiler", "Continuous capture ended");
+            AZ_TracePrintf("Profiler", "Continuous capture ended\n");
+            return true;
         }
 
         bool CpuProfilerImpl::IsContinuousCaptureInProgress() const

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -129,6 +129,34 @@ namespace AZ
                 m_captureToFile = true;
             }
 
+            ImGui::SameLine();
+            bool isInProgress = RHI::CpuProfiler::Get()->IsContinuousCaptureInProgress();
+            if (ImGui::Button(isInProgress ? "End" : "Begin"))
+            {
+                if (isInProgress)
+                {
+                    AZStd::sys_time_t timeNow = AZStd::GetTimeNowSecond();
+                    AZStd::string timeString;
+                    AZStd::to_string(timeString, timeNow);
+                    u64 currentTick = AZ::RPI::RPISystemInterface::Get()->GetCurrentTick();
+                    const AZStd::string frameDataFilePath = AZStd::string::format(
+                        "@user@/CpuProfiler/%s_%llu.json",
+                        timeString.c_str(),
+                        currentTick);
+                    char resolvedPath[AZ::IO::MaxPathLength];
+                    AZ::IO::FileIOBase::GetInstance()->ResolvePath(frameDataFilePath.c_str(), resolvedPath, AZ::IO::MaxPathLength);
+                    m_lastCapturedFilePath = resolvedPath;
+                    AZ::Render::ProfilingCaptureRequestBus::Broadcast(
+                        &AZ::Render::ProfilingCaptureRequestBus::Events::EndContinuousCpuProfilingCapture, frameDataFilePath);
+                }
+
+                else
+                {
+                    AZ::Render::ProfilingCaptureRequestBus::Broadcast(
+                        &AZ::Render::ProfilingCaptureRequestBus::Events::BeginContinuousCpuProfilingCapture);
+                }
+            }
+
             if (!m_lastCapturedFilePath.empty())
             {
                 ImGui::SameLine();


### PR DESCRIPTION
### Please [start a build](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-2624/) and request sig-presentation!

This PR implements capturing multiple frames of CPU profiling data and saving it to disk so that it can be analyzed offline (which will be implemented in the visualizer in a future PR). Now, the ProfilingCaptureSystemComponent offers endpoints for capturing one frame of profiling data (with a blocking IO call) in addition to an arbitrary amount of frames (using an IO thread). 


### Demo
https://user-images.githubusercontent.com/64656371/127545500-06bed756-0d15-48ff-8966-6ddf402af690.mp4
![image](https://user-images.githubusercontent.com/64656371/127545626-4b6b4e27-bce1-4370-a228-65fc5d584750.png)
Resulting file size on disk was 70 MB from ~3000 frames of data. 
