### PR TITLE
Fix for Linux/Vulkan/Editor crash on startup

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/API/ApplicationAPI_Linux.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/API/ApplicationAPI_Linux.h
@@ -35,7 +35,7 @@ namespace AzFramework
     class LinuxXcbConnectionManager
     {
     public:
-        AZ_RTTI(LinuxXcbConnectionManager, "{649951316-3626-4C9D-9DCA-2E7ABF84C0A9}");
+        AZ_RTTI(LinuxXcbConnectionManager, "{1F756E14-8D74-42FD-843C-4863307710DB}");
 
         virtual ~LinuxXcbConnectionManager() = default;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -81,6 +81,13 @@ namespace AZ
 
             AZ_RTTI(SwapChain, "{888B64A5-D956-406F-9C33-CF6A54FC41B0}", Object);
 
+#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
+            // On Linux platforms that uses XCB, a resize may occur in the swap chain but the command queue may still
+            // reference the original surface. This flag is a temporary fix to make sure that all the swap chains
+            // have finished their resize events before presenting the command queue.
+            AZStd::atomic_bool m_resized = { false };
+#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
+
         protected:
             SwapChain();
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -85,7 +85,9 @@ namespace AZ
             // On Linux platforms that uses XCB, a resize may occur in the swap chain but the command queue may still
             // reference the original surface. This flag is a temporary fix to make sure that all the swap chains
             // have finished their resize events before presenting the command queue.
-            AZStd::atomic_bool m_resized = { false };
+
+            // [GFX TODO][GHI - 2678]
+            AZStd::atomic_bool m_resized{ false };
 #endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
 
         protected:

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -164,6 +164,10 @@ namespace AZ
                 m_currentImageIndex = 0;
             }
 
+#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
+            m_resized.store(true);
+#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
+
             return resultCode;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -42,6 +42,15 @@ namespace AZ
 
         void CommandQueue::ExecuteWork(const RHI::ExecuteWorkRequest& rhiRequest)
         {
+#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
+            for (RHI::SwapChain* swapChain : rhiRequest.m_swapChainsToPresent)
+            {
+                if (!swapChain->m_resized)
+                {
+                    return;
+                }
+            }
+#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
             const ExecuteWorkRequest& request = static_cast<const ExecuteWorkRequest&>(rhiRequest);
             QueueCommand([=](void* queue) 
             {


### PR DESCRIPTION
Temporary fix for Linux/Vulkan/XCB where the swap chain is not ready to present until the resize is complete. Will create an issue to investigate the root cause and the proper fix. This patch will get us to the editor startup and level load without crashing. 

Based on https://github.com/fabioanderegg/o3de/commit/6e701bba30a547911b5a297cb70609be81d32800 

Signed-off-by: spham-amzn <spham@amazon.com>