### PR TITLE
[ATOM-15976] Add more instrumentation

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -126,6 +126,7 @@ namespace AZ
 
         ResultCode FrameGraph::End()
         {
+            AZ_ATOM_PROFILE_FUNCTION("RHI", "FrameGraph: End");
             ResultCode resultCode = ValidateEnd();
             if (resultCode != ResultCode::Success)
             {

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -72,6 +72,7 @@ namespace AZ
         void FrameGraphExecuter::Begin(const FrameGraph& frameGraph)
         {
             AZ_TRACE_METHOD();
+            AZ_ATOM_PROFILE_FUNCTION("RHI", "FrameGraphExecuter: Begin");
             BeginInternal(frameGraph);
         }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/PipelineStateCache.h>
 #include <Atom/RHI/Factory.h>
 #include <AzCore/std/sort.h>
@@ -205,6 +206,7 @@ namespace AZ
 
         void PipelineStateCache::Compact()
         {
+            AZ_ATOM_PROFILE_FUNCTION("RHI", "PipelineStateCache: Compact");
             AZStd::unique_lock<AZStd::shared_mutex> lock(m_mutex);
 
             // Merge the pending cache into the read-only cache.

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -223,7 +223,7 @@ namespace AZ
                  * own RHI scopes to the frame scheduler. This happens prior to the RPI pass graph registration.
                  */
                 {
-                    AZ_ATOM_PROFILE_TIME_GROUP_REGION("RHI", "RHISystem :FrameUpdate: OnFramePrepare");
+                    AZ_ATOM_PROFILE_TIME_GROUP_REGION("RHI", "RHISystem: FrameUpdate: OnFramePrepare");
                     RHISystemNotificationBus::Broadcast(&RHISystemNotificationBus::Events::OnFramePrepare, m_frameScheduler);
                 }
 

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -469,6 +469,8 @@ namespace AZ
             ResourceTransitionLoggerNull logger(imageFrameAttachment.GetId());
 #endif
 
+            AZ_ATOM_PROFILE_FUNCTION("RHI", "FrameGraphCompiler: CompileImageBarriers (DX12)");
+
             Image& image = static_cast<Image&>(*imageFrameAttachment.GetImage());
             RHI::ImageScopeAttachment* scopeAttachment = imageFrameAttachment.GetFirstScopeAttachment();
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -720,6 +720,7 @@ namespace AZ
 
         void CullingScene::BeginCulling(const AZStd::vector<ViewPtr>& views)
         {
+            AZ_ATOM_PROFILE_FUNCTION("RPI", "CullingScene: BeginCulling");
             m_cullDataConcurrencyCheck.soft_lock();
 
             m_debugCtx.ResetCullStats();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -298,6 +298,7 @@ namespace AZ
 
         void PassSystem::ProcessQueuedChanges()
         {
+            AZ_ATOM_PROFILE_FUNCTION("RPI", "PassSystem: ProcessQueuedChanges");
             RemovePasses();
             BuildPasses();
             InitializePasses();
@@ -313,7 +314,11 @@ namespace AZ
 
             m_state = PassSystemState::Rendering;
             Pass::FramePrepareParams params{ &frameGraphBuilder };
-            m_rootPass->FrameBegin(params);
+
+            {
+                AZ_ATOM_PROFILE_TIME_GROUP_REGION("RPI", "Pass: FrameBegin");
+                m_rootPass->FrameBegin(params);
+            }
         }
 
         void PassSystem::FrameEnd()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -408,6 +408,7 @@ namespace AZ
 
             {
                 AZ_PROFILE_SCOPE(Debug::ProfileCategory::AzRender, "m_srgCallback");
+                AZ_ATOM_PROFILE_TIME_GROUP_REGION("RPI", "ShaderResourceGroupCallback: SrgCallback");
                 // Set values for scene srg
                 if (m_srg && m_srgCallback)
                 {
@@ -418,7 +419,7 @@ namespace AZ
             // Get active pipelines which need to be rendered and notify them frame started
             AZStd::vector<RenderPipelinePtr> activePipelines;
             {
-                AZ_ATOM_PROFILE_TIME_GROUP_REGION("RPI", "OnStartFrame");
+                AZ_ATOM_PROFILE_TIME_GROUP_REGION("RPI", "Scene: OnStartFrame");
                 for (auto& pipeline : m_pipelines)
                 {
                     if (pipeline->NeedsRender())
@@ -483,6 +484,7 @@ namespace AZ
 
             {
                 AZ_PROFILE_SCOPE(Debug::ProfileCategory::AzRender, "CollectDrawPackets");                
+                AZ_ATOM_PROFILE_TIME_GROUP_REGION("RPI", "CollectDrawPackets");
                 AZ::JobCompletion* collectDrawPacketsCompletion = aznew AZ::JobCompletion();
 
                 // Launch FeatureProcessor::Render() jobs


### PR DESCRIPTION
## Please [start a build](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-2636/) and request @o3de/sig-presentation 

Adds some new instrumentation macros throughout RPI & RHI, using the visualizer to find where current instrumentation is lacking running shadowed sponza sample + editor. Some notes:

- CullingScene: BeginCulling is very expensive in ShadowedSponza at 50 lights (~5ms)
- PipelineStateCache: Compact is also expensive, ~1ms average