### PR TITLE
Material Component: Add functions to lookup material ids by name

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
@@ -1,0 +1,160 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+local FindMaterialAssignmentTest = 
+{
+    Properties = 
+    {
+        Textures = 
+        {
+            "materials/presets/macbeth/05_blue_flower_srgb.tif.streamingimage",
+            "materials/presets/macbeth/06_bluish_green_srgb.tif.streamingimage",
+            "materials/presets/macbeth/09_moderate_red_srgb.tif.streamingimage",
+            "materials/presets/macbeth/11_yellow_green_srgb.tif.streamingimage",
+            "materials/presets/macbeth/12_orange_yellow_srgb.tif.streamingimage",
+            "materials/presets/macbeth/17_magenta_srgb.tif.streamingimage"
+        }, 
+    }, 
+}
+
+function randomColor()
+    return Color(math.random(), math.random(), math.random(), 1.0)
+end
+
+function randomDir()
+    dir = {}
+    for i = 1, 3 do
+        lerpDir = math.random()
+        if lerpDir < 0.5 then
+            table.insert(dir, -1.0)
+        else
+            table.insert(dir, 1.0)
+        end
+    end
+    return dir
+end
+
+function FindMaterialAssignmentTest:OnActivate()
+    self.timer = 0.0
+    self.totalTime = 0.0
+    self.totalTimeMax = 200.0
+    self.timeUpdate = 2.0
+    self.colors = {}
+    self.lerpDirs = {}
+
+    self.assignmentIds =
+    {
+        MaterialComponentRequestBus.Event.FindMaterialAssignmentId(self.entityId, -1, "lambert"),
+    }
+
+    for index = 1, #self.assignmentIds do
+        local id = self.assignmentIds[index]
+        if (id ~= nil) then
+            self.colors[index] = randomColor()
+            self.lerpDirs[index] = randomDir()
+        end
+    end
+    self.tickBusHandler = TickBus.Connect(self);
+end
+
+function FindMaterialAssignmentTest:UpdateFactor(assignmentId)
+    local propertyName = Name("baseColor.factor")
+    local propertyValue = math.random()
+    MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
+end
+
+function FindMaterialAssignmentTest:UpdateColor(assignmentId, color)
+    local propertyName = Name("baseColor.color")
+    local propertyValue = color
+    MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
+end
+
+function FindMaterialAssignmentTest:UpdateTexture(assignmentId)
+    if (#self.Properties.Textures > 0) then
+        local propertyName = Name("baseColor.textureMap")
+        local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
+        Debug.Log(textureName)
+        local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)
+        MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, textureAssetId);
+    end
+end
+
+function FindMaterialAssignmentTest:UpdateProperties()
+    Debug.Log("Overriding properties...")
+    for index = 1, #self.assignmentIds do
+        local id = self.assignmentIds[index]
+        if (id ~= nil) then
+            self:UpdateFactor(id)
+            self:UpdateTexture(id)
+        end
+    end
+end
+
+function FindMaterialAssignmentTest:ClearProperties()
+    Debug.Log("Clearing properties...")
+    MaterialComponentRequestBus.Event.ClearAllPropertyOverrides(self.entityId);
+end
+
+function lerpColor(color, lerpDir, deltaTime)
+    local lerpSpeed = 0.5
+    color.r = color.r + deltaTime * lerpDir[1] * lerpSpeed
+    if color.r > 1.0 then
+        color.r = 1.0
+        lerpDir[1] = -1.0
+    elseif color.r < 0 then
+        color.r = 0
+        lerpDir[1] = 1.0
+    end
+
+    color.g = color.g + deltaTime * lerpDir[2] * lerpSpeed
+    if color.g > 1.0 then
+        color.g = 1.0
+        lerpDir[2] = -1.0
+    elseif color.g < 0 then
+        color.g = 0
+        lerpDir[2] = 1.0
+    end
+
+    color.b = color.b + deltaTime * lerpDir[3] * lerpSpeed
+    if color.b > 1.0 then
+        color.b = 1.0
+        lerpDir[3] = -1.0
+    elseif color.b < 0 then
+        color.b = 0
+        lerpDir[3] = 1.0
+    end
+end
+
+function FindMaterialAssignmentTest:lerpColors(deltaTime)
+    for index = 1, #self.assignmentIds do
+        local id = self.assignmentIds[index]
+        if (id ~= nil) then
+            lerpColor(self.colors[index], self.lerpDirs[index], deltaTime)
+            self:UpdateColor(id, self.colors[index])
+        end
+    end
+end
+
+function FindMaterialAssignmentTest:OnTick(deltaTime, timePoint)
+    self.timer = self.timer + deltaTime
+    self.totalTime = self.totalTime + deltaTime
+    self:lerpColors(deltaTime)
+
+    if (self.timer > self.timeUpdate and self.totalTime < self.totalTimeMax) then
+        self.timer = self.timer - self.timeUpdate
+        self:UpdateProperties()
+    elseif self.totalTime > self.totalTimeMax then
+        self:ClearProperties()
+        self.tickBusHandler:Disconnect(self);
+    end
+end
+
+return FindMaterialAssignmentTest

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
@@ -63,5 +63,8 @@ namespace AZ
         //! Utility function for generating a set of available material assignments in a model
         MaterialAssignmentMap GetMaterialAssignmentsFromModel(Data::Instance<AZ::RPI::Model> model);
 
-    } // namespace Render
-} // namespace AZ
+        //! Find an assignment id corresponding to the lod and label substring filters
+        MaterialAssignmentId FindMaterialAssignmentIdInModel(
+            const Data::Instance<AZ::RPI::Model> model, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter);
+    } // namespace R    ender
+    } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Material/MaterialAssignment.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
 
 #include <Atom/Feature/Material/MaterialAssignmentId.h>
@@ -66,5 +67,5 @@ namespace AZ
         //! Find an assignment id corresponding to the lod and label substring filters
         MaterialAssignmentId FindMaterialAssignmentIdInModel(
             const Data::Instance<AZ::RPI::Model> model, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter);
-    } // namespace R    ender
-    } // namespace AZ
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Material/MaterialAssignment.cpp
@@ -166,5 +166,48 @@ namespace AZ
 
             return materials;
         }
+
+        MaterialAssignmentId FindMaterialAssignmentIdInLod(
+            const Data::Instance<AZ::RPI::ModelLod>& lod, const MaterialAssignmentLodIndex lodIndex, const AZStd::string& labelFilter)
+        {
+            for (const AZ::RPI::ModelLod::Mesh& mesh : lod->GetMeshes())
+            {
+                if (mesh.m_material && mesh.m_material->GetAssetId().IsValid())
+                {
+                    AZ::Data::AssetInfo assetInfo;
+                    AZ::Data::AssetCatalogRequestBus::BroadcastResult(
+                        assetInfo, &AZ::Data::AssetCatalogRequests::GetAssetInfoById, mesh.m_material->GetAssetId());
+                    if (assetInfo.m_assetId.IsValid() && AZ::StringFunc::Contains(assetInfo.m_relativePath, labelFilter, true))
+                    {
+                        return MaterialAssignmentId::CreateFromLodAndAsset(lodIndex, mesh.m_material->GetAssetId());
+                    }
+                }
+            }
+            return MaterialAssignmentId();
+        }
+
+        MaterialAssignmentId FindMaterialAssignmentIdInModel(
+            const Data::Instance<AZ::RPI::Model> model, const MaterialAssignmentLodIndex lodFilter, const AZStd::string& labelFilter)
+        {
+            if (model && !labelFilter.empty())
+            {
+                if (lodFilter < model->GetLodCount())
+                {
+                    return FindMaterialAssignmentIdInLod(model->GetLods()[lodFilter], lodFilter, labelFilter);
+                }
+
+                for (size_t lodIndex = 0; lodIndex < model->GetLodCount(); ++lodIndex)
+                {
+                    const MaterialAssignmentId result =
+                        FindMaterialAssignmentIdInLod(model->GetLods()[lodIndex], MaterialAssignmentId::NonLodIndex, labelFilter);
+                    if (!result.IsDefault())
+                    {
+                        return result;
+                    }
+                }
+            }
+
+            return MaterialAssignmentId();
+        }
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -21,6 +21,8 @@ namespace AZ
         public:
             //! Get all material assignments that can be overridden
             virtual MaterialAssignmentMap GetOriginalMaterialAssignments() const = 0;
+            //! Get material assignment id matching lod and label substring
+            virtual MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
             //! Set material overrides
             virtual void SetMaterialOverrides(const MaterialAssignmentMap& materials) = 0;
             //! Get material overrides
@@ -69,6 +71,9 @@ namespace AZ
             : public ComponentBus
         {
         public:
+            //! Get material assignment id matching lod and label substring
+            virtual MaterialAssignmentId FindMaterialAssignmentId(
+                const MaterialAssignmentLodIndex lod, const AZStd::string& label) const = 0;
             virtual MaterialAssignmentMap GetMaterialAssignments() const = 0;
             virtual AZStd::unordered_set<AZ::Name> GetModelUvNames() const = 0;
         };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -33,6 +33,7 @@ namespace AZ
                     ->Attribute(AZ::Script::Attributes::Category, "render")
                     ->Attribute(AZ::Script::Attributes::Module, "render")
                     ->Event("GetOriginalMaterialAssignments", &MaterialComponentRequestBus::Events::GetOriginalMaterialAssignments)
+                    ->Event("FindMaterialAssignmentId", &MaterialComponentRequestBus::Events::FindMaterialAssignmentId)
                     ->Event("SetMaterialOverrides", &MaterialComponentRequestBus::Events::SetMaterialOverrides)
                     ->Event("GetMaterialOverrides", &MaterialComponentRequestBus::Events::GetMaterialOverrides)
                     ->Event("ClearAllMaterialOverrides", &MaterialComponentRequestBus::Events::ClearAllMaterialOverrides)
@@ -249,8 +250,18 @@ namespace AZ
         MaterialAssignmentMap MaterialComponentController::GetOriginalMaterialAssignments() const
         {
             MaterialAssignmentMap materialAssignmentMap;
-            MaterialReceiverRequestBus::EventResult(materialAssignmentMap, m_entityId, &MaterialReceiverRequestBus::Events::GetMaterialAssignments);
+            MaterialReceiverRequestBus::EventResult(
+                materialAssignmentMap, m_entityId, &MaterialReceiverRequestBus::Events::GetMaterialAssignments);
             return materialAssignmentMap;
+        }
+
+        MaterialAssignmentId MaterialComponentController::FindMaterialAssignmentId(
+            const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
+        {
+            MaterialAssignmentId materialAssignmentId;
+            MaterialReceiverRequestBus::EventResult(
+                materialAssignmentId, m_entityId, &MaterialReceiverRequestBus::Events::FindMaterialAssignmentId, lod, label);
+            return materialAssignmentId;
         }
 
         void MaterialComponentController::SetMaterialOverrides(const MaterialAssignmentMap& materials)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -46,6 +46,7 @@ namespace AZ
 
             //! MaterialComponentRequestBus overrides...
             MaterialAssignmentMap GetOriginalMaterialAssignments() const override;
+            MaterialAssignmentId FindMaterialAssignmentId(const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             void SetMaterialOverrides(const MaterialAssignmentMap& materials) override;
             const MaterialAssignmentMap& GetMaterialOverrides() const override;
             void ClearAllMaterialOverrides() override;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -252,6 +252,12 @@ namespace AZ
             }
         }
 
+        MaterialAssignmentId MeshComponentController::FindMaterialAssignmentId(
+            const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
+        {
+            return FindMaterialAssignmentIdInModel(GetModel(), lod, label);
+        }
+
         MaterialAssignmentMap MeshComponentController::GetMaterialAssignments() const
         {
             return GetMaterialAssignmentsFromModel(GetModel());

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.h
@@ -111,6 +111,8 @@ namespace AZ
             void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
             // MaterialReceiverRequestBus::Handler overrides ...
+            virtual MaterialAssignmentId FindMaterialAssignmentId(
+                const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             MaterialAssignmentMap GetMaterialAssignments() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -308,6 +308,17 @@ namespace AZ
             m_skinnedMeshFeatureProcessor = nullptr;
         }
 
+        MaterialAssignmentId AtomActorInstance::FindMaterialAssignmentId(
+            const MaterialAssignmentLodIndex lod, const AZStd::string& label) const
+        {
+            if (m_skinnedMeshInstance && m_skinnedMeshInstance->m_model)
+            {
+                return FindMaterialAssignmentIdInModel(m_skinnedMeshInstance->m_model, lod, label);
+            }
+
+            return MaterialAssignmentId();
+        }
+
         MaterialAssignmentMap AtomActorInstance::GetMaterialAssignments() const
         {
             if (m_skinnedMeshInstance && m_skinnedMeshInstance->m_model)

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.h
@@ -120,6 +120,8 @@ namespace AZ
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // MaterialReceiverRequestBus::Handler overrides...
+            virtual MaterialAssignmentId FindMaterialAssignmentId(
+                const MaterialAssignmentLodIndex lod, const AZStd::string& label) const override;
             MaterialAssignmentMap GetMaterialAssignments() const override;
             AZStd::unordered_set<AZ::Name> GetModelUvNames() const override;
 


### PR DESCRIPTION
- Added utility functions to search a model hierarchy for material assignment slots matching an LOD and substring
- Extending material receiver request bus with an interface function to look up material assignment IDs
- Extending material component request bus with a corresponding function
- Implemented new functions on mesh and actor components
- Modified lua test script to demonstrate new functionality
- The new function should make working with materials in script much easier because they allow directly targeting a specific material slot by name
- This will be optimized after pending changes for storing material slot labels in the model asset are checked in