### PR TITLE
Ensure network autonomy gets set before entity activation

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/INetworkEntityManager.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/INetworkEntityManager.h
@@ -59,7 +59,8 @@ namespace Multiplayer
         (
             const PrefabEntityId& prefabEntryId,
             NetEntityRole netEntityRole,
-            const AZ::Transform& transform
+            const AZ::Transform& transform,
+            AutoActivate autoActivate = AutoActivate::Activate
         ) = 0;
 
         //! Creates new entities of the given archetype

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -643,6 +643,7 @@ namespace Multiplayer
             {
                 controlledEntity.GetNetBindComponent()->SetOwningConnectionId(connection->GetConnectionId());
             }
+            controlledEntity.Activate();
             
             if (connection->GetUserData() == nullptr) // Only add user data if the connect event handler has not already done so
             {
@@ -763,6 +764,7 @@ namespace Multiplayer
             {
                 controlledEntityNetBindComponent->SetAllowAutonomy(true);
             }
+            controlledEntity.Activate();
         }
         
         AZLOG_INFO("Multiplayer operating in %s mode", GetEnumString(m_agentType));
@@ -964,7 +966,7 @@ namespace Multiplayer
     NetworkEntityHandle MultiplayerSystemComponent::SpawnDefaultPlayerPrefab()
     {
         PrefabEntityId playerPrefabEntityId(AZ::Name(static_cast<AZ::CVarFixedString>(sv_defaultPlayerSpawnAsset).c_str()));
-        INetworkEntityManager::EntityList entityList = m_networkEntityManager.CreateEntitiesImmediate(playerPrefabEntityId, NetEntityRole::Authority, AZ::Transform::CreateIdentity());
+        INetworkEntityManager::EntityList entityList = m_networkEntityManager.CreateEntitiesImmediate(playerPrefabEntityId, NetEntityRole::Authority, AZ::Transform::CreateIdentity(), Multiplayer::AutoActivate::DoNotActivate);
 
         NetworkEntityHandle controlledEntity;
         if (entityList.size() > 0)

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -304,7 +304,7 @@ namespace Multiplayer
     }
     
     INetworkEntityManager::EntityList NetworkEntityManager::CreateEntitiesImmediate(
-        const AzFramework::Spawnable& spawnable, NetEntityRole netEntityRole)
+        const AzFramework::Spawnable& spawnable, NetEntityRole netEntityRole, AutoActivate autoActivate)
     {
         INetworkEntityManager::EntityList returnList;
 
@@ -354,6 +354,11 @@ namespace Multiplayer
                 const NetEntityId netEntityId = NextId();
                 netBindComponent->PreInit(clone, prefabEntityId, netEntityId, netEntityRole);
 
+                if (autoActivate == AutoActivate::DoNotActivate)
+                {
+                    clone->SetRuntimeActiveByDefault(false);
+                }
+
                 AzFramework::GameEntityContextRequestBus::Broadcast(
                     &AzFramework::GameEntityContextRequestBus::Events::AddGameEntity, clone);
 
@@ -373,10 +378,11 @@ namespace Multiplayer
     (
         const PrefabEntityId& prefabEntryId,
         NetEntityRole netEntityRole,
-        const AZ::Transform& transform
+        const AZ::Transform& transform,
+        AutoActivate autoActivate
     )
     {
-        return CreateEntitiesImmediate(prefabEntryId, NextId(), netEntityRole, AutoActivate::Activate, transform);
+        return CreateEntitiesImmediate(prefabEntryId, NextId(), netEntityRole, autoActivate, transform);
     }
 
     INetworkEntityManager::EntityList NetworkEntityManager::CreateEntitiesImmediate
@@ -409,7 +415,7 @@ namespace Multiplayer
 
         if (entityIndex == PrefabEntityId::AllIndices)
         {
-            return CreateEntitiesImmediate(*netSpawnable, netEntityRole);
+            return CreateEntitiesImmediate(*netSpawnable, netEntityRole, autoActivate);
         }
 
         const AzFramework::Spawnable::EntityList& entities = netSpawnable->GetEntities();

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.h
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.h
@@ -42,12 +42,13 @@ namespace Multiplayer
         HostId GetHostId() const override;
         ConstNetworkEntityHandle GetEntity(NetEntityId netEntityId) const override;
 
-        EntityList CreateEntitiesImmediate(const AzFramework::Spawnable& spawnable, NetEntityRole netEntityRole);
+        EntityList CreateEntitiesImmediate(const AzFramework::Spawnable& spawnable, NetEntityRole netEntityRole, AutoActivate autoActivate);
         EntityList CreateEntitiesImmediate
         (
             const PrefabEntityId& prefabEntryId,
             NetEntityRole netEntityRole,
-            const AZ::Transform& transform
+            const AZ::Transform& transform,
+            AutoActivate autoActivate = AutoActivate::Activate
         ) override;
         EntityList CreateEntitiesImmediate
         (


### PR DESCRIPTION
(on non-dedicated servers)

-Exposes an AutoActivate flag to INetworkEntityManager and ensured it got respected for all paths
-Tweak SpawnDefaultPlayerPrefab to not immediately activate its spawned entity to allow SetAllowAutonomy to be picked up from the net bind component during component activation