### PR TITLE
AZStd::ref prevented compiler from using RVO

### DIFF
--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/VersionedProperty.h
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/Internal/VersionedProperty.h
@@ -109,7 +109,7 @@ namespace ScriptEventData
         {
             VersionedProperty property = VersionedProperty("Void");
             property.Set<const VoidType>(VoidType {});
-            return AZStd::ref(property);
+            return property;
         }
 
         template <typename T>


### PR DESCRIPTION
VersionedProperty::MakeVoid was using  `return AZStd::ref(property);` which caused the compiler to use copy-constructor when returning the value.

I suspect that the code here was once something like:
 ```cpp
        static VersionedProperty MakeVoid()
        {
            static VersionedProperty property = VersionedProperty("Void");
            property.Set<const VoidType>(VoidType {});
            return AZStd::ref(property);
        }
```
