### PR TITLE
Removed legacy ObjectIcons and shelve icons from Editor.

### DIFF
--- a/Assets/Editor/ObjectIcons/AreaTrigger.bmp
+++ b/Assets/Editor/ObjectIcons/AreaTrigger.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4cf08659d31a337ceb28de2765b0177abf404f3e671f5277dd7a280f2fd6c60d
-size 3128

--- a/Assets/Editor/ObjectIcons/AudioAreaAmbience.bmp
+++ b/Assets/Editor/ObjectIcons/AudioAreaAmbience.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:706b12b37518596b01fc6c5cdb3aadc5fdbe76b668e9989ba2bb03ee23376dbf
-size 3126

--- a/Assets/Editor/ObjectIcons/AudioAreaEntity.bmp
+++ b/Assets/Editor/ObjectIcons/AudioAreaEntity.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e67540926b2d55c70ac5867266ac9688437fc139b459f165f9d52d9b351851c
-size 3128

--- a/Assets/Editor/ObjectIcons/AudioAreaRandom.bmp
+++ b/Assets/Editor/ObjectIcons/AudioAreaRandom.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96ec04e8126bcffb7fe391dc55ea1aa6a82419825c8305117f9b0ae72b40e63e
-size 3126

--- a/Assets/Editor/ObjectIcons/Camera.bmp
+++ b/Assets/Editor/ObjectIcons/Camera.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4168676b803b7e3b03a90fb69502204a418b6598941c75f0c36e589a31455db5
-size 3128

--- a/Assets/Editor/ObjectIcons/Checkpoint.bmp
+++ b/Assets/Editor/ObjectIcons/Checkpoint.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b11c94da25b704a36f2b437dae98c04a5cea54f02022567306e2cf82837bf7a1
-size 3128

--- a/Assets/Editor/ObjectIcons/ClipVolume.bmp
+++ b/Assets/Editor/ObjectIcons/ClipVolume.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ca14c966de6d392beb4d154221b622a417163fcdf92eb049638bf8495c13774
-size 3128

--- a/Assets/Editor/ObjectIcons/Clock.bmp
+++ b/Assets/Editor/ObjectIcons/Clock.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d11fd9413f06706bc706a97f39cc72b1ae6ff7cb6c506cf2fcda98660e2a92f
-size 3128

--- a/Assets/Editor/ObjectIcons/Clouds.bmp
+++ b/Assets/Editor/ObjectIcons/Clouds.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1f5fd7032f82fbb7364cd0a96989918defd63f26a899836c61b039541cf3b3af
-size 3128

--- a/Assets/Editor/ObjectIcons/Comment.bmp
+++ b/Assets/Editor/ObjectIcons/Comment.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9201d97225c19b8fc2fc208ab913ab100a94328b64b026ab65be9c4cd9c4e28a
-size 3128

--- a/Assets/Editor/ObjectIcons/DeadBody.bmp
+++ b/Assets/Editor/ObjectIcons/DeadBody.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a2937837233d9f313b2500232c74952cee3f4e7497ee0e1099b301ef2fa49bf8
-size 3128

--- a/Assets/Editor/ObjectIcons/Decal.bmp
+++ b/Assets/Editor/ObjectIcons/Decal.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffbe8438c19ac2a9b6614beb78f0d651184dbe5cf2998063257dc7272c9c2c10
-size 3128

--- a/Assets/Editor/ObjectIcons/Dialog.bmp
+++ b/Assets/Editor/ObjectIcons/Dialog.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:63640478bd3258aa310dd639014cde714780ebaa168aa784093e74fc0da23a4c
-size 3126

--- a/Assets/Editor/ObjectIcons/Flash.bmp
+++ b/Assets/Editor/ObjectIcons/Flash.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b66daefbb3f11f527d9c10ff1dd54f87635e6561cc546a762ae2e72793ae6ef6
-size 3128

--- a/Assets/Editor/ObjectIcons/Fog.bmp
+++ b/Assets/Editor/ObjectIcons/Fog.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42e0c1dc60809958d74145ae14030c22e351ef3b72ed6d820fdb19632b691c89
-size 3128

--- a/Assets/Editor/ObjectIcons/FogVolume.bmp
+++ b/Assets/Editor/ObjectIcons/FogVolume.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cbb23fc09d47d16b2414d622fd16b330d9f684398dcfc44e0fb44378dfd3287
-size 3128

--- a/Assets/Editor/ObjectIcons/GravitySphere.bmp
+++ b/Assets/Editor/ObjectIcons/GravitySphere.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:26b6e2f28ed72b9cdb90410351e3a22fee3c0498ac315e71d966a1ffb77742fe
-size 3128

--- a/Assets/Editor/ObjectIcons/Item.bmp
+++ b/Assets/Editor/ObjectIcons/Item.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bd6f39152affb52a7b3c4361032d1d7d77e7e94841613a83d7e2cdea9eaab553
-size 3128

--- a/Assets/Editor/ObjectIcons/Ladder.bmp
+++ b/Assets/Editor/ObjectIcons/Ladder.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:077502953026981b6e8cc5e40ab58722fc514947f175021508e6af8058340f32
-size 3128

--- a/Assets/Editor/ObjectIcons/Light.bmp
+++ b/Assets/Editor/ObjectIcons/Light.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9ecfc056ab66b3221be3175889d182229c0e49bf9604abd7946fe58cc7d29a9
-size 3128

--- a/Assets/Editor/ObjectIcons/LightPropagationVolume.bmp
+++ b/Assets/Editor/ObjectIcons/LightPropagationVolume.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:206820d3bb5d6a4d26bf87fc0b91a36adcbd0f154149b7cb5f5ce067f5ee4d67
-size 3128

--- a/Assets/Editor/ObjectIcons/Lightning.bmp
+++ b/Assets/Editor/ObjectIcons/Lightning.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7c81a8000339695f73277bcebaedb0cfeacdff547f51c1ff7f4761c75927ca4
-size 3126

--- a/Assets/Editor/ObjectIcons/Magnet.bmp
+++ b/Assets/Editor/ObjectIcons/Magnet.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:560c3af6e8f2fb98ddc8638b0ea4786131e75b6fe0acece964bfdb28f8c3ec9f
-size 3128

--- a/Assets/Editor/ObjectIcons/MultiTrigger.bmp
+++ b/Assets/Editor/ObjectIcons/MultiTrigger.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a3a64d33b65c4cd5d666c11abf03b4148acadfe69e4c80e79382b56d2906ae6
-size 3128

--- a/Assets/Editor/ObjectIcons/ODD.bmp
+++ b/Assets/Editor/ObjectIcons/ODD.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:113d0a416da49ce24dae2c47514318b75e0ca4d7dc257a9927e0db4bdad35d91
-size 3128

--- a/Assets/Editor/ObjectIcons/Particles.bmp
+++ b/Assets/Editor/ObjectIcons/Particles.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ca81d96a5450660f7e17f75565595368fb7c0071df9589bcbfda2ba54d5c0ae
-size 3128

--- a/Assets/Editor/ObjectIcons/PrecacheCamera.bmp
+++ b/Assets/Editor/ObjectIcons/PrecacheCamera.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73629b1903365aa6acf35fd7846896c23c38401fac12bc23b23285e5ed9ae89d
-size 3126

--- a/Assets/Editor/ObjectIcons/Prefab.bmp
+++ b/Assets/Editor/ObjectIcons/Prefab.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6d7fbb76f67165492a51e6b8715ee3716040d44bd5419b12481e2c9cc627c291
-size 3128

--- a/Assets/Editor/ObjectIcons/Prompt.bmp
+++ b/Assets/Editor/ObjectIcons/Prompt.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2482da67fbf513a9597b3919562a65d361a4c8264fcc8510ef45321b4192ce4d
-size 3128

--- a/Assets/Editor/ObjectIcons/SavePoint.bmp
+++ b/Assets/Editor/ObjectIcons/SavePoint.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06f866e66e0458ccf3e014a30fef2dfaab832d9b4b1179f98b7cdd716b358b48
-size 3128

--- a/Assets/Editor/ObjectIcons/Seed.bmp
+++ b/Assets/Editor/ObjectIcons/Seed.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdcea1e14d3b01b1ed6ea123767343eddc646969ee447b4bf725c233fd7946f4
-size 3128

--- a/Assets/Editor/ObjectIcons/Sound.bmp
+++ b/Assets/Editor/ObjectIcons/Sound.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:14a4003a9faf9a2fb3a17d2f87825c8497aeaca364c592ab75970d00e77aa203
-size 3128

--- a/Assets/Editor/ObjectIcons/SpawnPoint.bmp
+++ b/Assets/Editor/ObjectIcons/SpawnPoint.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7e109f57e5e9bc6bcaee7176a479bb6434353bc49a8021ab96e016ce27f41a1
-size 3128

--- a/Assets/Editor/ObjectIcons/T.bmp
+++ b/Assets/Editor/ObjectIcons/T.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c2288c239604402f7e85d753141fbd8a82fde9f18e4f95006b039ceeec41d0c
-size 3128

--- a/Assets/Editor/ObjectIcons/TagPoint.bmp
+++ b/Assets/Editor/ObjectIcons/TagPoint.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f58cabe21df546914abc1e8f2604989d87b4a3471c1902956a4e1e1be9930b8
-size 3128

--- a/Assets/Editor/ObjectIcons/Trigger.bmp
+++ b/Assets/Editor/ObjectIcons/Trigger.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e9cfb325abea577e8737b837098ff3cecd564e302b2c30925b3d35a62fa6c7c3
-size 3128

--- a/Assets/Editor/ObjectIcons/UiCanvasRefEntity.bmp
+++ b/Assets/Editor/ObjectIcons/UiCanvasRefEntity.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcd9a1efaab42cdea4557265e544f2370565872115d21cc84af6e6998bb7ad01
-size 3128

--- a/Assets/Editor/ObjectIcons/User.bmp
+++ b/Assets/Editor/ObjectIcons/User.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:56a379a337a44617cb6ed5a20560286b8263c75871742ca04cc61cac49736a2a
-size 3128

--- a/Assets/Editor/ObjectIcons/VVVArea.bmp
+++ b/Assets/Editor/ObjectIcons/VVVArea.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cab80e4ce74155a3eaf771fa9b2464c1f3b36bce6de55d3f5aa180576cabec2
-size 3128

--- a/Assets/Editor/ObjectIcons/W.bmp
+++ b/Assets/Editor/ObjectIcons/W.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6ebc8eacd6695caafd131d5c8ca29b45fea16bc2147cdb169478e391d6f13b70
-size 3128

--- a/Assets/Editor/ObjectIcons/Water.bmp
+++ b/Assets/Editor/ObjectIcons/Water.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5d24ecf0878409dc3f7ed0f447734061bb9e313e4adb767580bd961b0038236
-size 3126

--- a/Assets/Editor/ObjectIcons/animobject.bmp
+++ b/Assets/Editor/ObjectIcons/animobject.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:514fb756bd23f0376a03ba7222a5a8479408eb68efbfcecac30957142580e494
-size 3128

--- a/Assets/Editor/ObjectIcons/bird.bmp
+++ b/Assets/Editor/ObjectIcons/bird.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7d72d46274c9c0863e7e34caccfdf78a7c8c77262caf1b7f4305a822ac0145c
-size 3128

--- a/Assets/Editor/ObjectIcons/bug.bmp
+++ b/Assets/Editor/ObjectIcons/bug.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d238a0d17e3469c499249bd907b5aba0b924fb8539259a1b92af64e39820b619
-size 3128

--- a/Assets/Editor/ObjectIcons/character.bmp
+++ b/Assets/Editor/ObjectIcons/character.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b7bd2ee00f000d13ef096bd4d430fbca5cd35f3d641d44f4698c1270423b484
-size 3128

--- a/Assets/Editor/ObjectIcons/death.bmp
+++ b/Assets/Editor/ObjectIcons/death.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d93aa4486316a2ba269f860d64f741da15359fec6111da1049331a5a75dee02
-size 3128

--- a/Assets/Editor/ObjectIcons/door.bmp
+++ b/Assets/Editor/ObjectIcons/door.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4be7c244d9350a46c18161222ace0eaea1213dd1e7ed5ba02fa94ee5a98dc728
-size 3128

--- a/Assets/Editor/ObjectIcons/elevator.bmp
+++ b/Assets/Editor/ObjectIcons/elevator.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c1cf46f0825ecf1d3331bdca3d5f6a0d348aa6346af9fb1fdb3b75cfc5564dd
-size 3128

--- a/Assets/Editor/ObjectIcons/environmentProbe.bmp
+++ b/Assets/Editor/ObjectIcons/environmentProbe.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:27c8ae2924af50058207e7a1e1f4e35799f27abd7cb2e0778b8903ce00e99732
-size 4152

--- a/Assets/Editor/ObjectIcons/explosion.bmp
+++ b/Assets/Editor/ObjectIcons/explosion.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a93e2e2164781ed0de1be34bbbd0c85d630a31efd3fe568ea7f3c026646209c8
-size 3128

--- a/Assets/Editor/ObjectIcons/fish.bmp
+++ b/Assets/Editor/ObjectIcons/fish.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:590e0458bbc0d528ba71cd048b6019ebb8d1764a55cc3b9b3e2b1446182cfaa9
-size 3128

--- a/Assets/Editor/ObjectIcons/forbiddenarea.bmp
+++ b/Assets/Editor/ObjectIcons/forbiddenarea.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a8eac076d5094c722513bcdb6b71def9116ae063d453017d7bb0b38068c3a7e
-size 3128

--- a/Assets/Editor/ObjectIcons/hazard.bmp
+++ b/Assets/Editor/ObjectIcons/hazard.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71c3e9e9ccf404c3c17f71f806cd6ee0e4b48f6f2e172b52aeca78cc28668ac3
-size 3128

--- a/Assets/Editor/ObjectIcons/health.bmp
+++ b/Assets/Editor/ObjectIcons/health.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ded11545905ac937fe6e28929e57c10abe55befa74b44260dee5b206cdf3d15
-size 3128

--- a/Assets/Editor/ObjectIcons/ledge.bmp
+++ b/Assets/Editor/ObjectIcons/ledge.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c43daede42eb72eca0f80454b0e70de1e03156b5f098bcc8dbc080117c34380a
-size 3128

--- a/Assets/Editor/ObjectIcons/mine.bmp
+++ b/Assets/Editor/ObjectIcons/mine.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da1bb03a55949c6dc80ac18e3cf87c962e30fe2eacfd4fac74cc93db58552ac5
-size 3128

--- a/Assets/Editor/ObjectIcons/physicsobject.bmp
+++ b/Assets/Editor/ObjectIcons/physicsobject.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74cdfbf6f61029fa6f1262f78c2787afb9dddc0218911b53349962c4ed548bbf
-size 3128

--- a/Assets/Editor/ObjectIcons/prefabbuilding.bmp
+++ b/Assets/Editor/ObjectIcons/prefabbuilding.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98aaf6d6e532f5a3f31cdc08676432e30b4e52fd4f376331f4610379f288a191
-size 3128

--- a/Assets/Editor/ObjectIcons/proceduralbuilding.bmp
+++ b/Assets/Editor/ObjectIcons/proceduralbuilding.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98aaf6d6e532f5a3f31cdc08676432e30b4e52fd4f376331f4610379f288a191
-size 3128

--- a/Assets/Editor/ObjectIcons/proceduralobject.bmp
+++ b/Assets/Editor/ObjectIcons/proceduralobject.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98aaf6d6e532f5a3f31cdc08676432e30b4e52fd4f376331f4610379f288a191
-size 3128

--- a/Assets/Editor/ObjectIcons/proximitytrigger.bmp
+++ b/Assets/Editor/ObjectIcons/proximitytrigger.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ac364f478ca4dfa0186069fb69d19b8005a8d1da74cff34ced76bb85cf4402e7
-size 3128

--- a/Assets/Editor/ObjectIcons/river.bmp
+++ b/Assets/Editor/ObjectIcons/river.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:910d8f788514dc2d66c58027cb841a16e7d5194ee1f1ff3ccfcf5badd86c768a
-size 3128

--- a/Assets/Editor/ObjectIcons/road.bmp
+++ b/Assets/Editor/ObjectIcons/road.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9e92c9792886fab49007891c38addf2f62719d6563a36cd81250de13c50fbf61
-size 3128

--- a/Assets/Editor/ObjectIcons/rope.bmp
+++ b/Assets/Editor/ObjectIcons/rope.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:738525640cf00402ebd807ce9a35d6d7ed67be39cde7def7930b136596977a2e
-size 3128

--- a/Assets/Editor/ObjectIcons/sequence.bmp
+++ b/Assets/Editor/ObjectIcons/sequence.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e339afca6ba8ffa2463bf6b367615e66bb953fced380d739996d52c2971feab5
-size 3128

--- a/Assets/Editor/ObjectIcons/shake.bmp
+++ b/Assets/Editor/ObjectIcons/shake.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f3130dcb95136d806aff1882d3933eb3f7ee88aaa9876423b53dbf73f02c8cd3
-size 3128

--- a/Assets/Editor/ObjectIcons/smartobject.bmp
+++ b/Assets/Editor/ObjectIcons/smartobject.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e908579e0a62d74a1402ee786876e88eadb0ef0de0542617d02291947504078b
-size 3128

--- a/Assets/Editor/ObjectIcons/spawngroup.bmp
+++ b/Assets/Editor/ObjectIcons/spawngroup.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28111b13e60816f31f3916131d4632ce2d0c48c1a7712421593f79dff79c99d0
-size 3128

--- a/Assets/Editor/ObjectIcons/spectator.bmp
+++ b/Assets/Editor/ObjectIcons/spectator.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9a2885b3eb0845b48571f1af08d9e685b52361c78c31485c64f8e1efb38e8cc4
-size 3128

--- a/Assets/Editor/ObjectIcons/switch.bmp
+++ b/Assets/Editor/ObjectIcons/switch.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9bdce356a35d214c4d806ba568d2de72af636410eb433be5c0390eae67d8478a
-size 3128

--- a/Assets/Editor/ObjectIcons/territory.bmp
+++ b/Assets/Editor/ObjectIcons/territory.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc350e4d3226531a35ac810fa5ebe1894bfdcafac605334afffcdd3a14416f94
-size 3128

--- a/Assets/Editor/ObjectIcons/tornado.bmp
+++ b/Assets/Editor/ObjectIcons/tornado.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c54df0fb1c9b8abeee30adc5e983bfd7dd524c551909b26466a9d8b6422a094a
-size 3128

--- a/Assets/Editor/ObjectIcons/vehicle.bmp
+++ b/Assets/Editor/ObjectIcons/vehicle.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e0b4d6a86953c33b0c3ace60bb53d119fa5acd193f4d9aa2c0934f3074cb19
-size 3128

--- a/Assets/Editor/ObjectIcons/voxel.bmp
+++ b/Assets/Editor/ObjectIcons/voxel.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8ca14c966de6d392beb4d154221b622a417163fcdf92eb049638bf8495c13774
-size 3128

--- a/Assets/Editor/ObjectIcons/wave.bmp
+++ b/Assets/Editor/ObjectIcons/wave.bmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:573d22719ad010351a58733b63315a9a0fc07545dde71f3931f37371dfe44ce3
-size 3128

--- a/Assets/Editor/Scripts/Shelves/icons/Albedo.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Albedo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a91ea78d1ffd91490f20efcf76ad8790e450836240b8a77dda719da963235c85
-size 2987

--- a/Assets/Editor/Scripts/Shelves/icons/Diffuse_Lighting.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Diffuse_Lighting.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d8eadc0bdc63391e88936b0acfd0616c2d7bce550ea82cee1f967f971ace8a6
-size 2905

--- a/Assets/Editor/Scripts/Shelves/icons/Diffuse_Texture_Res_360.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Diffuse_Texture_Res_360.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9cdb92de995635eadfbb6dceb25f44a737dde744e09f0fcfe7016de981dce786
-size 2975

--- a/Assets/Editor/Scripts/Shelves/icons/Empty_Wireframe.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Empty_Wireframe.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:268a5b239b9988be0ae13a2f42a99ac39ac2db9988f92604154630b661b89999
-size 2865

--- a/Assets/Editor/Scripts/Shelves/icons/Exit.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Exit.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:030f4dc71dac36f220cd7e7c07eb24bda2df3c1e14b054e48fc6274573734bdb
-size 2898

--- a/Assets/Editor/Scripts/Shelves/icons/Fuzziness.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Fuzziness.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0fa6d24bbb7f969a71b9e761f2dc4ec990a7e522201af9b13b2651d0565e1f0
-size 3607

--- a/Assets/Editor/Scripts/Shelves/icons/Gloss.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Gloss.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d5b949330e86f02662bb3b25db123fd77be31c910ad7e1e21223a543820ce46a
-size 2959

--- a/Assets/Editor/Scripts/Shelves/icons/Normal_Texture_Res_360.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Normal_Texture_Res_360.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49086e4fa1736415d79d7d1d5ed8484b49582db8c27957148ef2a6d7f5dec189
-size 3176

--- a/Assets/Editor/Scripts/Shelves/icons/PrefabAddLibrary.png
+++ b/Assets/Editor/Scripts/Shelves/icons/PrefabAddLibrary.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0d9c3f0be3c978deaa053d458a49908e99d8d0f7e87169b5b03b7f500e37f55
-size 3248

--- a/Assets/Editor/Scripts/Shelves/icons/PrefabAddSelection.png
+++ b/Assets/Editor/Scripts/Shelves/icons/PrefabAddSelection.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5d98fa218cf0c13100584611e1c4d536bdd9cf78a4a10dd1a0a49e4265b5292d
-size 503

--- a/Assets/Editor/Scripts/Shelves/icons/PrefabBreak.png
+++ b/Assets/Editor/Scripts/Shelves/icons/PrefabBreak.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e538188411092f7a172ef364035df77dc228bc91d43cfc35ffbbd824e716800e
-size 3231

--- a/Assets/Editor/Scripts/Shelves/icons/PrefabConvert.png
+++ b/Assets/Editor/Scripts/Shelves/icons/PrefabConvert.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52b2c98b0f50fcfdd8334bcde259aef0a0533055f6caa1a1606536f5d2eca23f
-size 3079

--- a/Assets/Editor/Scripts/Shelves/icons/PrefabCreate.png
+++ b/Assets/Editor/Scripts/Shelves/icons/PrefabCreate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40905f7865cd5a71bfdace3943ccdd8fe532ee111419fb023befac357256eb07
-size 490

--- a/Assets/Editor/Scripts/Shelves/icons/PrefabIsolate.png
+++ b/Assets/Editor/Scripts/Shelves/icons/PrefabIsolate.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:31f8f9a5ff20b33bdf86af8da579717cda40e097db6f893ec4e2fffab720f90e
-size 3211

--- a/Assets/Editor/Scripts/Shelves/icons/Scattering.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Scattering.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9ec02e421b4e832f73576d1f1bf2b6bc60879521f3a8abbb554925982574c374
-size 3146

--- a/Assets/Editor/Scripts/Shelves/icons/Solid_Wireframe.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Solid_Wireframe.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcc61dfe03d5bae6060c1fc6814b7be299705803fdb9058cabe6227f386ddeef
-size 2872

--- a/Assets/Editor/Scripts/Shelves/icons/Spec_Amount.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Spec_Amount.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a67c8e063331c5c6ce256892abdde113f405c60854115ba87f6798d06f57eb02
-size 2892

--- a/Assets/Editor/Scripts/Shelves/icons/Spec_Lighting.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Spec_Lighting.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:927d3b2f83e6e962a492ea625240bb5f336e30aa2052d1f8699b76a86a5e475d
-size 2897

--- a/Assets/Editor/Scripts/Shelves/icons/Texel_Per_Meter_1024.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Texel_Per_Meter_1024.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a3861aa38f3e521127a48f08e6c24e12e61c15450bb4d10ef27a0a95c2c420c0
-size 2889

--- a/Assets/Editor/Scripts/Shelves/icons/Texel_Per_Meter_256.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Texel_Per_Meter_256.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5ecc3596974c0c9f1703d51e60de2ca00a479012d98f11316966686cc891f982
-size 2922

--- a/Assets/Editor/Scripts/Shelves/icons/Texel_Per_Meter_512.png
+++ b/Assets/Editor/Scripts/Shelves/icons/Texel_Per_Meter_512.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce1ca5c1d89cd6d7a0cf35142be114904ec469afab2fa69a12afe6824055b67b
-size 2913

--- a/Assets/Editor/Scripts/Shelves/icons/all.png
+++ b/Assets/Editor/Scripts/Shelves/icons/all.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffcf54b92f48aa06f38e94826a76f350b425ad9d46c0e2170455730123a69a6d
-size 3693

--- a/Assets/Editor/Scripts/Shelves/icons/beams.png
+++ b/Assets/Editor/Scripts/Shelves/icons/beams.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:68c4333ba27b39baed2696fa90040cc4e669dbc5e9fab43b11abd854d5482474
-size 613

--- a/Assets/Editor/Scripts/Shelves/icons/blanker.png
+++ b/Assets/Editor/Scripts/Shelves/icons/blanker.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:adac9f1fc606475d1d86ca8f5b2376570ebc70161e4b5240ede3cb8f176b8f41
-size 2810

--- a/Assets/Editor/Scripts/Shelves/icons/bounding_box.png
+++ b/Assets/Editor/Scripts/Shelves/icons/bounding_box.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f00fa9904ce4687aaf21f1553d03bf1d47390d007fd38513ad959f324a4b6ebb
-size 3618

--- a/Assets/Editor/Scripts/Shelves/icons/brushes.png
+++ b/Assets/Editor/Scripts/Shelves/icons/brushes.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed21a97324849633d156ec03f949a3cf21b8b682a3a6ad1dcfac6eee9df7a497
-size 734

--- a/Assets/Editor/Scripts/Shelves/icons/cloud.png
+++ b/Assets/Editor/Scripts/Shelves/icons/cloud.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:11599538b6bc197e92f07db149ccdfee50ddea630f095865bac9782254a7c06f
-size 387

--- a/Assets/Editor/Scripts/Shelves/icons/cloud_dark.png
+++ b/Assets/Editor/Scripts/Shelves/icons/cloud_dark.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:559ec911f9cac84de411e92d746913c3828ebf1d1f8c7bab794fb9c768c1581d
-size 387

--- a/Assets/Editor/Scripts/Shelves/icons/cloud_dark_rain.png
+++ b/Assets/Editor/Scripts/Shelves/icons/cloud_dark_rain.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88d11b32db70a437fd8ff8c845b4ff26182d28f5b7a2f6b3de4fce61dffff98d
-size 489

--- a/Assets/Editor/Scripts/Shelves/icons/collisions.png
+++ b/Assets/Editor/Scripts/Shelves/icons/collisions.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0510fa11c090234a2008703917834ad0455bc6e5e9a2d2375ebd0fc279b41851
-size 3491

--- a/Assets/Editor/Scripts/Shelves/icons/create_ao_volume_box.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_ao_volume_box.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24fc2750f740f0b85ca720beedb564f2a01bbeed229cb89c6d8f395d5cf5d439
-size 844

--- a/Assets/Editor/Scripts/Shelves/icons/create_both_vis_box_envprobe.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_both_vis_box_envprobe.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:000effa8925a61313fdf420830857172bc69c38cb8a14737a389b9c9df1b36df
-size 745

--- a/Assets/Editor/Scripts/Shelves/icons/create_envprobe.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_envprobe.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d91f30f31576dc957f57d59e2b94d6e45c9aef28f321240c31639c148f62aea
-size 803

--- a/Assets/Editor/Scripts/Shelves/icons/create_portal_box.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_portal_box.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6452c7e2baef1d8d285a96e72d053a8af80430e52a149ce14795c946d55896fb
-size 807

--- a/Assets/Editor/Scripts/Shelves/icons/create_vis_box.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_vis_box.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e0d5e21ccaec784d3118a2609e5f26caca4a26901a92db0821e2e0f18e555534
-size 833

--- a/Assets/Editor/Scripts/Shelves/icons/create_vis_box_and_portal_box.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_vis_box_and_portal_box.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5717c6fde94577b831b8d83104733f86ed82f030664624d62cb4a6d26dd5646
-size 822

--- a/Assets/Editor/Scripts/Shelves/icons/create_vis_box_env_probe_and_portal.png
+++ b/Assets/Editor/Scripts/Shelves/icons/create_vis_box_env_probe_and_portal.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07e831e8cab5e1e222b4a4d6a64932bbb8a9a5fcb7cae020432905a7c1e53402
-size 782

--- a/Assets/Editor/Scripts/Shelves/icons/cubemap.png
+++ b/Assets/Editor/Scripts/Shelves/icons/cubemap.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9775b4823563dbff4c3410c1751f022e2985f91202e6d691f86172ef1f820f4b
-size 3353

--- a/Assets/Editor/Scripts/Shelves/icons/decals.png
+++ b/Assets/Editor/Scripts/Shelves/icons/decals.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c12d69b2d85c339bbff06011fff7c2468a2b2e6c67726ad7fb0ab82384eb39df
-size 918

--- a/Assets/Editor/Scripts/Shelves/icons/default_material.png
+++ b/Assets/Editor/Scripts/Shelves/icons/default_material.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:98146b9b75602ddc8a46529fe0427303491dfe4584cadb914d3774377593c7ef
-size 3809

--- a/Assets/Editor/Scripts/Shelves/icons/default_material_with_normals.png
+++ b/Assets/Editor/Scripts/Shelves/icons/default_material_with_normals.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a1c7e790dad53937ed0845cb89c5651c7932a696d7d34d85df6fc8c4b09c7245
-size 3106

--- a/Assets/Editor/Scripts/Shelves/icons/designer.png
+++ b/Assets/Editor/Scripts/Shelves/icons/designer.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e790bb52b7f7d52e79b2c5b84ee4a4587a721c7e3c70d2d7e0eb683b478b51f7
-size 1015

--- a/Assets/Editor/Scripts/Shelves/icons/diff_acc.png
+++ b/Assets/Editor/Scripts/Shelves/icons/diff_acc.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b341792fb1c13db8144f74c3895942251c07e67e87ac374c09df21e3459b3610
-size 3930

--- a/Assets/Editor/Scripts/Shelves/icons/display_info.png
+++ b/Assets/Editor/Scripts/Shelves/icons/display_info.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0fc2408c2f1801de3f625dcbdf960104195c1d47d7e240f4ec9391a7b645399c
-size 3623

--- a/Assets/Editor/Scripts/Shelves/icons/dual_layer_mask.png
+++ b/Assets/Editor/Scripts/Shelves/icons/dual_layer_mask.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80bca215bbcec9d9e1e33abfbf0b17d6032327a175d6f9d4d76bfefd5c7f2480
-size 3517

--- a/Assets/Editor/Scripts/Shelves/icons/dynamiclights.png
+++ b/Assets/Editor/Scripts/Shelves/icons/dynamiclights.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef3cae03d5f38bdf9e82ff29b1a77133a44e5e859cfdb063c449ee5609902367
-size 780

--- a/Assets/Editor/Scripts/Shelves/icons/entities.png
+++ b/Assets/Editor/Scripts/Shelves/icons/entities.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42de1878f5cef5c3f80dd56e042584eeb8759cacd58a0b22115644ed38800836
-size 870

--- a/Assets/Editor/Scripts/Shelves/icons/eye_adaptation_speed.png
+++ b/Assets/Editor/Scripts/Shelves/icons/eye_adaptation_speed.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f1b4a6d4cca72740f14e97239bf8490d23ccb3d9283d4ff558f0302d9fa773ad
-size 1017

--- a/Assets/Editor/Scripts/Shelves/icons/fog.png
+++ b/Assets/Editor/Scripts/Shelves/icons/fog.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4dea1c985077475184c32562609e27b7919cd1c08776174a83f38f095a11f3d4
-size 394

--- a/Assets/Editor/Scripts/Shelves/icons/fogvolumes.png
+++ b/Assets/Editor/Scripts/Shelves/icons/fogvolumes.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbf140c23e75f1c1035defd58ec8522230abdb5fc7538953ed88eb3bc06c9ca3
-size 349

--- a/Assets/Editor/Scripts/Shelves/icons/freeze_particles.png
+++ b/Assets/Editor/Scripts/Shelves/icons/freeze_particles.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:52986df9e8a866606cbfbe8a9702f15483a6f3bfa0b15563e64a5c6d208dab55
-size 4076

--- a/Assets/Editor/Scripts/Shelves/icons/full_shading.png
+++ b/Assets/Editor/Scripts/Shelves/icons/full_shading.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:339d6542b6a259feeb7dc8ebc536ca6fed44a91faaf021b1453a735b39d98450
-size 3021

--- a/Assets/Editor/Scripts/Shelves/icons/gamma.png
+++ b/Assets/Editor/Scripts/Shelves/icons/gamma.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b93bb51dd54685b9dd1a37b535c7cb456110b45c62ae64eaaceb61a58b99f254
-size 1418

--- a/Assets/Editor/Scripts/Shelves/icons/gi.png
+++ b/Assets/Editor/Scripts/Shelves/icons/gi.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbc47ed9888c792af55b4e0ab5d5c7a7b8a582fdb202fa035e21b974c7df1022
-size 885

--- a/Assets/Editor/Scripts/Shelves/icons/lens_flare.png
+++ b/Assets/Editor/Scripts/Shelves/icons/lens_flare.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2cbf9570c227884d49ac2a702377821891d06eaa91b6bf92861088508927796
-size 670

--- a/Assets/Editor/Scripts/Shelves/icons/lighting_only.png
+++ b/Assets/Editor/Scripts/Shelves/icons/lighting_only.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:695dcdc3004705d1489b5b2a0a750bf6d30940d343a62bc8ff06bc103d3ae6f7
-size 2870

--- a/Assets/Editor/Scripts/Shelves/icons/lods.png
+++ b/Assets/Editor/Scripts/Shelves/icons/lods.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:266450829046d2be9557c86f8061f1b50d8f55795436b608689d6c117c5b970d
-size 1156

--- a/Assets/Editor/Scripts/Shelves/icons/lsao.png
+++ b/Assets/Editor/Scripts/Shelves/icons/lsao.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7a253c696ce28fb7699b6879c35e874d906033b59e89224d307bf029dd9257e6
-size 3926

--- a/Assets/Editor/Scripts/Shelves/icons/lsao_toggle.png
+++ b/Assets/Editor/Scripts/Shelves/icons/lsao_toggle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:734ca55bc936d229c56abb4f141a746fe64affc570570d182308f6f0d8f21638
-size 3952

--- a/Assets/Editor/Scripts/Shelves/icons/lsro.png
+++ b/Assets/Editor/Scripts/Shelves/icons/lsro.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a100211ce724c005cd2fadecb4ca3c36feacad4f7cb4bbccd8761ae622d59aa3
-size 1153

--- a/Assets/Editor/Scripts/Shelves/icons/normals.png
+++ b/Assets/Editor/Scripts/Shelves/icons/normals.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:58e65981a6b66482ac3443f644fe210d9c90d01b4a5ab381796d37bf6d5be289
-size 3215

--- a/Assets/Editor/Scripts/Shelves/icons/normals_x.png
+++ b/Assets/Editor/Scripts/Shelves/icons/normals_x.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1be96cc2682443b03bfc4696403d5c3d98eec709878acac0b690dbb635d04ea9
-size 3227

--- a/Assets/Editor/Scripts/Shelves/icons/normals_y.png
+++ b/Assets/Editor/Scripts/Shelves/icons/normals_y.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2eaf04f15e42ac910dc7c29fb61034dc5126a80832b6a0bc0a842b549c23eaf7
-size 3118

--- a/Assets/Editor/Scripts/Shelves/icons/normals_z.png
+++ b/Assets/Editor/Scripts/Shelves/icons/normals_z.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0c8ec3131755522c3f1a4fc45cef0b9ace4641316d890d3f6f042557f220d6ba
-size 3152

--- a/Assets/Editor/Scripts/Shelves/icons/ocean.png
+++ b/Assets/Editor/Scripts/Shelves/icons/ocean.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1407119e10f378a6ae375f3951dbfe42505560f75a88687f4c03e0ac2e85a05e
-size 700

--- a/Assets/Editor/Scripts/Shelves/icons/particles.png
+++ b/Assets/Editor/Scripts/Shelves/icons/particles.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9875276bc1b8055f306d0bf95b0ba3f6c8f9a49447a68f75334e86b360f4359
-size 713

--- a/Assets/Editor/Scripts/Shelves/icons/particles_bounds.png
+++ b/Assets/Editor/Scripts/Shelves/icons/particles_bounds.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:231f6c7939361f71b9926f551bbf2eb93ca4ec8394318dcfed0fa413ccd58e66
-size 4073

--- a/Assets/Editor/Scripts/Shelves/icons/particles_off.png
+++ b/Assets/Editor/Scripts/Shelves/icons/particles_off.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6e656417153394c5466a207bd6ff21072c6ef82fe6972380ceda7fa6e60c478
-size 4053

--- a/Assets/Editor/Scripts/Shelves/icons/particles_overdraw.png
+++ b/Assets/Editor/Scripts/Shelves/icons/particles_overdraw.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f021d07012f712d8ab70af609974e1cb0933d571bbe0f184e0e7479ee172834
-size 3004

--- a/Assets/Editor/Scripts/Shelves/icons/particles_screen_coverage.png
+++ b/Assets/Editor/Scripts/Shelves/icons/particles_screen_coverage.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:387a799eeb739b6183f3d47186c122ea51c8998664bd0cff76e28f8de2cf49ee
-size 4024

--- a/Assets/Editor/Scripts/Shelves/icons/placeholder.png
+++ b/Assets/Editor/Scripts/Shelves/icons/placeholder.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a91ea78d1ffd91490f20efcf76ad8790e450836240b8a77dda719da963235c85
-size 2987

--- a/Assets/Editor/Scripts/Shelves/icons/prefab.png
+++ b/Assets/Editor/Scripts/Shelves/icons/prefab.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:332071c8b20030de53ec194dfe853b29f45a0de04d99dcd1b1c4b32dcf2946a5
-size 683

--- a/Assets/Editor/Scripts/Shelves/icons/reflections.png
+++ b/Assets/Editor/Scripts/Shelves/icons/reflections.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee9fdf1b6ab47cfc72c3794a46b6886b9993e691a7d097b3d109127ddcde46ac
-size 640

--- a/Assets/Editor/Scripts/Shelves/icons/reset.png
+++ b/Assets/Editor/Scripts/Shelves/icons/reset.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:120be39c58db0bab5450db22604f94cf31eb68a480f06daf3d4f76828461385b
-size 4076

--- a/Assets/Editor/Scripts/Shelves/icons/selfocc.png
+++ b/Assets/Editor/Scripts/Shelves/icons/selfocc.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:83e8233f9f0594151e734583f9fd3835250f370dac8b648554f1060d79efa43b
-size 2935

--- a/Assets/Editor/Scripts/Shelves/icons/shaded_wireframe.png
+++ b/Assets/Editor/Scripts/Shelves/icons/shaded_wireframe.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f514eebcdcd02d8195d8b51966ad84cfb8162c3811facc6da9fc0a71e10443bc
-size 3041

--- a/Assets/Editor/Scripts/Shelves/icons/shadows.png
+++ b/Assets/Editor/Scripts/Shelves/icons/shadows.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:281c6d85ab6d7e706f73865a7beb523bf64e505d8fd2b3c367f6ad56b008a77e
-size 818

--- a/Assets/Editor/Scripts/Shelves/icons/showlines.png
+++ b/Assets/Editor/Scripts/Shelves/icons/showlines.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:268a5b239b9988be0ae13a2f42a99ac39ac2db9988f92604154630b661b89999
-size 2865

--- a/Assets/Editor/Scripts/Shelves/icons/sky.png
+++ b/Assets/Editor/Scripts/Shelves/icons/sky.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3598e1bdc4c47d6be99ad6ff10e91b307bb4a94286fff57a0c339d6aaed2e0a3
-size 620

--- a/Assets/Editor/Scripts/Shelves/icons/spec_acc.png
+++ b/Assets/Editor/Scripts/Shelves/icons/spec_acc.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee2c46410495a75862d8f5d2e69cce11c94745680ef03b50ba7b17af9c137656
-size 3334

--- a/Assets/Editor/Scripts/Shelves/icons/spec_lum.png
+++ b/Assets/Editor/Scripts/Shelves/icons/spec_lum.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a67c8e063331c5c6ce256892abdde113f405c60854115ba87f6798d06f57eb02
-size 2892

--- a/Assets/Editor/Scripts/Shelves/icons/spec_occ.png
+++ b/Assets/Editor/Scripts/Shelves/icons/spec_occ.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23a7074e8ced66649cc8c2f69db33559bd600658709aaf287a9d9de9c98a05f6
-size 3182

--- a/Assets/Editor/Scripts/Shelves/icons/ssao.png
+++ b/Assets/Editor/Scripts/Shelves/icons/ssao.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:134cbfd478080236c3f5ea2ee32319e63ee21ff48f187b709ab9dc0f3688c2dd
-size 3932

--- a/Assets/Editor/Scripts/Shelves/icons/ssdo.png
+++ b/Assets/Editor/Scripts/Shelves/icons/ssdo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c200aad6ad59b7d466edc44026ffca2272ca3b20944070210db1108f21f1cb60
-size 3972

--- a/Assets/Editor/Scripts/Shelves/icons/ssdo_toggle.png
+++ b/Assets/Editor/Scripts/Shelves/icons/ssdo_toggle.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c897d61016bc32c7072273a081e624880b90beb89e90f20b25e689f5198d1f63
-size 3966

--- a/Assets/Editor/Scripts/Shelves/icons/sun.big.png
+++ b/Assets/Editor/Scripts/Shelves/icons/sun.big.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c49214e755a68e48bba8b8be9183777c24c3443aa734e4969e74bc42d5979cb7
-size 539

--- a/Assets/Editor/Scripts/Shelves/icons/tangents.png
+++ b/Assets/Editor/Scripts/Shelves/icons/tangents.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8a5f21232c186fed9bd9a0d62bd4023dca1d496e151ad0fee5b593fc67645bf
-size 1115

--- a/Assets/Editor/Scripts/Shelves/icons/terrain.png
+++ b/Assets/Editor/Scripts/Shelves/icons/terrain.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:821ef3daa0cdf246985c0bc1bd988edeceadb672dd81f4813320e8d50ca0e41c
-size 461

--- a/Assets/Editor/Scripts/Shelves/icons/time_scale_double.png
+++ b/Assets/Editor/Scripts/Shelves/icons/time_scale_double.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86ebd1c792b9024662a179995ba65d181157a9887112f12571fbfe05a3dc8a79
-size 3145

--- a/Assets/Editor/Scripts/Shelves/icons/time_scale_frozen.png
+++ b/Assets/Editor/Scripts/Shelves/icons/time_scale_frozen.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4fbe9783be75404b2364726b09f9013360522d2e71f479476a715b6577def003
-size 3386

--- a/Assets/Editor/Scripts/Shelves/icons/time_scale_half.png
+++ b/Assets/Editor/Scripts/Shelves/icons/time_scale_half.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a6740a0e38ea99c83c1460a33f62c3dead3ab85f05bf446426fb39a75aa76f8
-size 3137

--- a/Assets/Editor/Scripts/Shelves/icons/time_scale_quarter.png
+++ b/Assets/Editor/Scripts/Shelves/icons/time_scale_quarter.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4b0baf9f76bcc0bcd38fea907b79edde3bcb66e78b221094473a8abd0b222734
-size 3175

--- a/Assets/Editor/Scripts/Shelves/icons/time_scale_tenth.png
+++ b/Assets/Editor/Scripts/Shelves/icons/time_scale_tenth.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f71d44c06aa67ab94b190bd74516ce73c534a7d6421415437db262659b2ff32a
-size 3124

--- a/Assets/Editor/Scripts/Shelves/icons/tod.png
+++ b/Assets/Editor/Scripts/Shelves/icons/tod.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6028cef57651c79f5eb83c52eb0ab63eb42dbf4014dcb0f60c4c15ab8fe3cafd
-size 977

--- a/Assets/Editor/Scripts/Shelves/icons/translucency.png
+++ b/Assets/Editor/Scripts/Shelves/icons/translucency.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07457d1315f4cf1bd931187d849a1e842c931640edb53abb2a4f5b2d8d65716b
-size 3110

--- a/Assets/Editor/Scripts/Shelves/icons/transparency.png
+++ b/Assets/Editor/Scripts/Shelves/icons/transparency.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e59571a1490d7dd4696bc118bd4ccc8e08a663afac1ce3f2d88bb5d7d6fdb196
-size 558

--- a/Assets/Editor/Scripts/Shelves/icons/valid_albedo.png
+++ b/Assets/Editor/Scripts/Shelves/icons/valid_albedo.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ce233f32949099694d4294b95252068c4486edba163a466ebdb20a54a2338f0f
-size 3120

--- a/Assets/Editor/Scripts/Shelves/icons/valid_spec_lum.png
+++ b/Assets/Editor/Scripts/Shelves/icons/valid_spec_lum.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f5f365970f6f9138d6e78a2053338eb1275c562fb700670ab00e800e6a43280d
-size 3199

--- a/Assets/Editor/Scripts/Shelves/icons/vegetation.png
+++ b/Assets/Editor/Scripts/Shelves/icons/vegetation.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48a435a0632d7d0a8bdfee418423d8c411c4eab9b1da0fac257f32451a233d8f
-size 747

--- a/Assets/Editor/Scripts/Shelves/icons/vertex_normals.png
+++ b/Assets/Editor/Scripts/Shelves/icons/vertex_normals.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:101e61f7e5b40aaa48bed685f854fc01c58aec66ca8becc5386f6f0c22c020ad
-size 1114

--- a/Assets/Editor/Scripts/Shelves/icons/vis_area.png
+++ b/Assets/Editor/Scripts/Shelves/icons/vis_area.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae9997b5b999a6b66e56d6024617f718ea06fd389a98a97465a5d76780a1da75
-size 3915

--- a/Assets/Editor/Scripts/Shelves/icons/water_volume.png
+++ b/Assets/Editor/Scripts/Shelves/icons/water_volume.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e88a2a6e4d14bced3d3e48c25d4bfe075d8587898cd61fbd0e3ab99e4391e663
-size 602

--- a/Assets/Editor/Scripts/Shelves/icons/wind.png
+++ b/Assets/Editor/Scripts/Shelves/icons/wind.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:caa003d65336c2e2a8987122ace98e0300e5d8afe1864dffef0d1651b136ccc1
-size 720

--- a/Assets/Editor/Scripts/Shelves/icons/wireframe.png
+++ b/Assets/Editor/Scripts/Shelves/icons/wireframe.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd5356c97575c12fa7038443c0216a316c234e4e50e2e439ff8dde4504e56243
-size 2848

--- a/Code/Editor/ToolBox.cpp
+++ b/Code/Editor/ToolBox.cpp
@@ -321,42 +321,13 @@ bool CToolBoxManager::SetMacroTitle(int index, const QString& title, bool bToolb
 }
 
 //////////////////////////////////////////////////////////////////////////
-void CToolBoxManager::Load(ActionManager* actionManager)
+void CToolBoxManager::Load([[maybe_unused]] ActionManager* actionManager)
 {
     Clear();
 
     QString path;
     GetSaveFilePath(path);
     Load(path, nullptr, true, nullptr);
-
-    if (actionManager)
-    {
-        auto engineSourceAssetPath = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / "Assets";
-        LoadShelves((engineSourceAssetPath / "Editor" / "Scripts").c_str(),
-            (engineSourceAssetPath / "Editor" / "Scripts" / "Shelves").c_str(), actionManager);
-    }
-}
-
-void CToolBoxManager::LoadShelves(QString scriptPath, QString shelvesPath, ActionManager* actionManager)
-{
-    IFileUtil::FileArray files;
-    CFileUtil::ScanDirectory(shelvesPath, "*.xml", files);
-
-    const int shelfCount = files.size();
-    for (int idx = 0; idx < shelfCount; ++idx)
-    {
-        if (Path::GetExt(files[idx].filename) != "xml")
-        {
-            continue;
-        }
-
-        QString shelfName(PathUtil::GetFileName(files[idx].filename.toUtf8().data()));
-
-        AmazonToolbar toolbar(shelfName, shelfName);
-        Load(shelvesPath + QString("/") + files[idx].filename, &toolbar, false, actionManager);
-
-        m_toolbars.push_back(toolbar);
-    }
 }
 
 void CToolBoxManager::Load(QString xmlpath, AmazonToolbar* pToolbar, bool bToolbox, ActionManager* actionManager)

--- a/Code/Editor/ToolBox.h
+++ b/Code/Editor/ToolBox.h
@@ -129,7 +129,6 @@ public:
     void Save() const;
     // Load macros configuration from registry.
     void Load(ActionManager* actionManager = nullptr);
-    void LoadShelves(QString scriptPath, QString shelvesPath, ActionManager* actionManager);
 
     //! Get the number of managed macros.
     int GetMacroCount(bool bToolbox) const;


### PR DESCRIPTION
Fixes #2667 

Removed legacy ObjectIcons and shelve icons from the Editor. Also removed some now defunct code for import shelve xml files (which no longer exist).

Signed-off-by: Chris Galvan <chgalvan@amazon.com>