### PR TITLE
Fixed Vegetation Layer Spawner documentation link.

### DIFF
--- a/Gems/Vegetation/Code/Source/Editor/EditorSpawnerComponent.h
+++ b/Gems/Vegetation/Code/Source/Editor/EditorSpawnerComponent.h
@@ -29,6 +29,6 @@ namespace Vegetation
         static constexpr const char* const s_componentDescription = "Creates dynamic vegetation in a specified area";
         static constexpr const char* const s_icon = "Editor/Icons/Components/Vegetation.svg";
         static constexpr const char* const s_viewportIcon = "Editor/Icons/Components/Viewport/Vegetation.svg";
-        static constexpr const char* const s_helpUrl = "https://o3de.org/docs/user-guide/components/reference/vegetation-layer-spawner/";
+        static constexpr const char* const s_helpUrl = "https://o3de.org/docs/user-guide/components/reference/vegetation/layer-spawner/";
     };
 }


### PR DESCRIPTION
Fixes #2450 

Verified that the help button for the Vegetation Layer Spawner now goes to the correct URL.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>