### PR TITLE
Ensure Editor FOV corrects on viewport resize

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -472,6 +472,12 @@ void EditorViewportWidget::Update()
         m_Camera.SetZRange(cameraState.m_nearClip, cameraState.m_farClip);
     }
 
+    // Ensure the FOV matches our internally stored setting if we're using the Editor camera
+    if (!m_viewEntityId.IsValid() && !GetIEditor()->IsInGameMode())
+    {
+        SetFOV(GetFOV());
+    }
+
     // Reset the camera update flag now that we're finished updating our viewport context
     m_updateCameraPositionNextTick = false;
 
@@ -2624,8 +2630,6 @@ void EditorViewportWidget::DestroyRenderContext()
 //////////////////////////////////////////////////////////////////////////
 void EditorViewportWidget::SetDefaultCamera()
 {
-    // Ensure the FOV matches our internally stored setting
-    SetFOV(GetFOV());
     if (IsDefaultCamera())
     {
         return;


### PR DESCRIPTION
EditorViewportWidget should authoritatively own the FOV when a Camera component isn't activate. This wasn't updating on tick any more, preventing FOV from being recalculated on viewport resize. This ensures FOV gets recalculated on render when the Editor camera is active.

Fixes https://github.com/o3de/o3de/issues/2456