### PR TITLE
Added .gitignore so that Script Canvas debug logs don't get picked up as untracked files.

### DIFF
--- a/Gems/ScriptCanvas/.gitignore
+++ b/Gems/ScriptCanvas/.gitignore
@@ -1,0 +1,1 @@
+Assets/Logs/


### PR DESCRIPTION
Fixes #2720 

Performed several debug sessions in Script Canvas and verified the Script Canvas log files no longer show up as untracked files in git.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>