### PR TITLE
Updated new project template .gitignore files so that temporary level saves in _savebackup files will be ignored as untracked files.

### DIFF
--- a/Templates/DefaultProject/Template/.gitignore
+++ b/Templates/DefaultProject/Template/.gitignore
@@ -2,3 +2,4 @@
 [Cc]ache/
 [Uu]ser/
 [Uu]ser_test*/
+_savebackup/

--- a/Templates/MinimalProject/Template/.gitignore
+++ b/Templates/MinimalProject/Template/.gitignore
@@ -1,3 +1,4 @@
 [Bb]uild/
 [Cc]ache/
 [Uu]ser/
+_savebackup/


### PR DESCRIPTION
Fixes #2489 

Created new projects with both templates and verified new levels that are created no longer have their temporary level save files (_savebackup**) show up as untracked files.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>