### PR TITLE
Update the cloth rule to look for optimized meshes

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -109,7 +109,7 @@ namespace AZ
             if (auto* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<ModelAssetBuilderComponent, SceneAPI::SceneCore::ExportingComponent>()
-                    ->Version(29);  // (updated to separate material slot ID from default material asset)
+                    ->Version(30);  // (updated to separate material slot ID from default material asset)
             }
         }
 

--- a/Gems/NvCloth/Code/Source/Pipeline/SceneAPIExt/ClothRule.cpp
+++ b/Gems/NvCloth/Code/Source/Pipeline/SceneAPIExt/ClothRule.cpp
@@ -37,7 +37,15 @@ namespace NvCloth
             const AZ::SceneAPI::Containers::SceneGraph& graph,
             const size_t numVertices) const
         {
-            const auto meshNodeIndex = graph.Find(GetMeshNodeName());
+            const AZ::SceneAPI::Containers::SceneGraph::NodeIndex meshNodeIndex = [this, &graph]()
+            {
+                if (const auto index = graph.Find(GetMeshNodeName() + AZStd::string(AZ::SceneAPI::Utilities::OptimizedMeshSuffix)); index.IsValid())
+                {
+                    return index;
+                }
+                return graph.Find(GetMeshNodeName());
+            }();
+
             if (!meshNodeIndex.IsValid())
             {
                 return {};


### PR DESCRIPTION
The cloth rule stores the name of a mesh node that is used to retrieve
cloth data from. However, at asset processing time, the model builder
switches things to look for the optimized version of a mesh. The cloth
rule was not doing this, so it would return the cloth data for the
unoptimized mesh. This resulted in the final mesh having some data from
the optimized mesh and cloth data from the non-optimized mesh.

This changes the cloth rule to use the optimized version of a mesh, if
it exists, and fall back to the unoptimized mesh when it does not exist.

This closes issue 2454.