### PR TITLE
Fix release build error.

### DIFF
--- a/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
@@ -235,7 +235,7 @@ namespace AZ
             UpdateViewToClipMatrix();
         }
 
-        void CameraComponent::SetOrthographic(bool orthographic)
+        void CameraComponent::SetOrthographic([[maybe_unused]] bool orthographic)
         {
             AZ_Assert(!orthographic, "DebugCamera does not support orthographic projection");
         }


### PR DESCRIPTION
Atom's DebugCamera SetOrthographic was only using a parameter during an assert, leading to a release compile error, this fixes that

Signed-off-by: nvsickle <nvsickle@amazon.com>