### PR TITLE
Fixed bug in hash_table that made rehash() function run forever

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/hash.cpp
+++ b/Code/Framework/AzCore/AzCore/std/hash.cpp
@@ -21,6 +21,7 @@ namespace AZStd
         1610612741ul, 3221225473ul, 4294967291ul
     };
 
+    // Bucket size suitable to hold n elements.
     AZStd::size_t hash_next_bucket_size(AZStd::size_t n)
     {
         const AZStd::size_t* first = prime_list;

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -201,8 +201,6 @@ namespace AZStd
                             // which is undefined behavior for a hash table
                             AZ_Assert(false, "Found a duplicate element when rehashing. "
                                 "Review the hashing function for type '%s' and make sure two equal elements always have the same hash", typeid(Traits::value_type).name());
-                            m_list.erase(cur, curEnd);
-                            continue;
                         }
 
                         newList.splice(insertIter, m_list, cur, curEnd);

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -269,7 +269,7 @@ namespace AZStd
         private:
             vector_value_type* m_buckets;       ///< Current buckets array. (can point to the m_vector or m_startBucket).
             size_type           m_numBuckets;   ///< Current number of buckets.
-            float               m_max_load_factor; ///< Maximum element load(elements/buckets) for a bucket before rehashing
+            float               m_max_load_factor; ///< Maximum load(elements/buckets) before rehashing
             vector_value_type   m_startBucket;  ///< Start bucket used for before we start dynamically allocate memory from m_vector.
         };
 

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -199,7 +199,7 @@ namespace AZStd
                             // This happens when there was an insertion of two elements that are equal but have different hashes,
                             // which is undefined behavior for a hash table: ISO C++ N4713, section 23.14.15 - 5.3
                             AZ_Assert(false, "Found a duplicate element when rehashing. "
-                                "Review the hashing function for type '%s' and make sure two equal elements always have the same hash", typeid(Traits::value_type).name());
+                                "Review the hashing function for type '%s' and make sure two equal elements always have the same hash", typeid(typename Traits::value_type).name());
                         }
 
                         newList.splice(insertIter, m_list, cur, curEnd);

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -269,7 +269,7 @@ namespace AZStd
         private:
             vector_value_type* m_buckets;       ///< Current buckets array. (can point to the m_vector or m_startBucket).
             size_type           m_numBuckets;   ///< Current number of buckets.
-            float               m_max_load_factor; ///< Maximum element load for a bucket before rehashing (elements/buckets)
+            float               m_max_load_factor; ///< Maximum element load(elements/buckets) for a bucket before rehashing
             vector_value_type   m_startBucket;  ///< Start bucket used for before we start dynamically allocate memory from m_vector.
         };
 

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -196,7 +196,11 @@ namespace AZStd
                         // Since they are elements already in the bucket, update `insertIter` to where the elements will need to be inserted.
                         if (!table->find_insert_position(valueKey, table->m_keyEqual, insertIter, numElements, integral_constant<bool, Traits::has_multi_elements>()))
                         {
-                            // The elements shouldn't be inserted, remove them from the list and keep processing
+                            // An element was found but we don't allow for duplicate elements in this table.
+                            // This happens when there was an insertion of two elements that are equal but have different hash,
+                            // which is undefined behavior for a hash table
+                            AZ_Assert(false, "Found a duplicate element when rehashing. "
+                                "Review the hashing function for type '%s' and make sure two equal elements always have the same hash", typeid(Traits::value_type).name());
                             m_list.erase(cur, curEnd);
                             continue;
                         }

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -197,7 +197,7 @@ namespace AZStd
                         if (!table->find_insert_position(valueKey, table->m_keyEqual, insertIter, numElements, integral_constant<bool, Traits::has_multi_elements>()))
                         {
                             // The elements shouldn't be inserted, remove them from the list and keep processing
-                            newList.erase(cur, curEnd);
+                            m_list.erase(cur, curEnd);
                             continue;
                         }
 

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -134,6 +134,7 @@ namespace AZStd
             void        rehash(HashTable* table, size_type numBucketsMin)
             {
                 size_type num_buckets = 0;
+
                 numBucketsMin = (AZStd::max)(numBucketsMin, (size_type)ceilf((float)m_list.size() / m_max_load_factor));
 
                 if (numBucketsMin != 0)
@@ -143,7 +144,7 @@ namespace AZStd
 
                 if (num_buckets == m_numBuckets)
                 {
-                    return; // no point
+                    return; // no need yet to rehash
                 }
                 m_numBuckets = num_buckets;
 
@@ -165,32 +166,42 @@ namespace AZStd
                 while (!m_list.empty())
                 {
                     cur = m_list.begin();
+                    typename list_type::iterator insertIter, curEnd(cur);
+                    const typename HashTable::key_type& valueKey = Traits::key_from_value(*cur);
 
-                    typename list_type::iterator newIter, iter(cur);
                     size_type numValues = 1;
-                    for (++iter; iter != last && table->m_keyEqual(Traits::key_from_value(*cur), Traits::key_from_value(*iter)); ++iter, ++numValues)
+                    // Get the number of same consecutive elements in the table with same key,
+                    // this allows range insertion of elements at once
+                    for (++curEnd; curEnd != last && table->m_keyEqual(valueKey, Traits::key_from_value(*curEnd)); ++curEnd, ++numValues)
                     {
                     }
                     ;
 
-                    const typename HashTable::key_type& valueKey = Traits::key_from_value(*cur);
                     size_type newBucketIndex = table->bucket_from_hash(table->m_hasher(valueKey));
+
+                    // newBucket.first holds the total number of elements in the bucket
+                    // newBucket.second contains the pointer to the first element of the bucket
                     vector_value_type& newBucket = newBuckets[newBucketIndex];
                     size_type numElements = newBucket.first;
-                    newIter = newBucket.second;
+                    insertIter = newBucket.second;
+
+                    // If we don't have elements in the bucket yet, transfer the elements directly
                     if (numElements == 0)
                     {
-                        newList.splice(newList.begin(), m_list, cur, iter);
+                        newList.splice(newList.begin(), m_list, cur, curEnd);
                         newBucket.second = newList.begin();
                     }
                     else
                     {
-                        if (!table->find_insert_position(valueKey, table->m_keyEqual, newIter, numElements, integral_constant<bool, Traits::has_multi_elements>()))
+                        // Since they are elements already in the bucket, update `insertIter` to where the elements will need to be inserted.
+                        if (!table->find_insert_position(valueKey, table->m_keyEqual, insertIter, numElements, integral_constant<bool, Traits::has_multi_elements>()))
                         {
+                            // The elements shouldn't be inserted, remove them from the list and keep processing
+                            newList.erase(cur, curEnd);
                             continue;
                         }
 
-                        newList.splice(newIter, m_list, cur, iter);
+                        newList.splice(insertIter, m_list, cur, curEnd);
                     }
 
                     newBucket.first += numValues;
@@ -258,7 +269,7 @@ namespace AZStd
         private:
             vector_value_type* m_buckets;       ///< Current buckets array. (can point to the m_vector or m_startBucket).
             size_type           m_numBuckets;   ///< Current number of buckets.
-            float               m_max_load_factor;
+            float               m_max_load_factor; ///< Maximum element load for a bucket before rehashing (elements/buckets)
             vector_value_type   m_startBucket;  ///< Start bucket used for before we start dynamically allocate memory from m_vector.
         };
 
@@ -972,28 +983,32 @@ namespace AZStd
             rhs.clear();
         }
 
+        // find_insert_position sets `insertIter` to where the element should be inserted
+        // and returns true if the element should be inserted, otherwise false
         template<class ComparableToKey, class KeyEq>
-        bool find_insert_position(const ComparableToKey& keyCmp, const KeyEq& keyEq, iterator& iter, size_type numElements, const true_type& /* is multi elements */)
+        bool find_insert_position(const ComparableToKey& keyCmp, const KeyEq& keyEq, iterator& insertIter, size_type numElements, const true_type& /* is multi elements */)
         {
-            for (size_type i = 0; i < numElements; ++i, ++iter)
+            for (size_type i = 0; i < numElements; ++i, ++insertIter)
             {
-                if (keyEq(keyCmp, Traits::key_from_value(*iter)))
+                if (keyEq(keyCmp, Traits::key_from_value(*insertIter)))
                 {
-                    ++iter;
+                    ++insertIter;
                     break;
                 }
             }
 
+            // we always return true since multi elements (like multiset) allow to have repeated elements
             return true;
         }
 
         template<class ComparableToKey, class KeyEq>
-        bool find_insert_position(const ComparableToKey& keyCmp, const KeyEq& keyEq, iterator& iter, size_type numElements, const false_type& /* !is multi elements */)
+        bool find_insert_position(const ComparableToKey& keyCmp, const KeyEq& keyEq, iterator& insertIter, size_type numElements, const false_type& /* !is multi elements */)
         {
-            for (size_type i = 0; i < numElements; ++i, ++iter)
+            for (size_type i = 0; i < numElements; ++i, ++insertIter)
             {
-                if (keyEq(keyCmp, Traits::key_from_value(*iter)))
+                if (keyEq(keyCmp, Traits::key_from_value(*insertIter)))
                 {
+                    // Element already exists, it shouldn't be inserted as we don't allow more than one element for this specialization
                     return false;
                 }
             }

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -175,12 +175,11 @@ namespace AZStd
                     for (++curEnd; curEnd != last && table->m_keyEqual(valueKey, Traits::key_from_value(*curEnd)); ++curEnd, ++numValues)
                     {
                     }
-                    ;
 
                     size_type newBucketIndex = table->bucket_from_hash(table->m_hasher(valueKey));
 
                     // newBucket.first holds the total number of elements in the bucket
-                    // newBucket.second contains the pointer to the first element of the bucket
+                    // newBucket.second contains the pointer to the first element in the bucket
                     vector_value_type& newBucket = newBuckets[newBucketIndex];
                     size_type numElements = newBucket.first;
                     insertIter = newBucket.second;
@@ -193,12 +192,12 @@ namespace AZStd
                     }
                     else
                     {
-                        // Since they are elements already in the bucket, update `insertIter` to where the elements will need to be inserted.
+                        // Since there are elements already in the bucket, update `insertIter` to where the elements will need to be inserted.
                         if (!table->find_insert_position(valueKey, table->m_keyEqual, insertIter, numElements, integral_constant<bool, Traits::has_multi_elements>()))
                         {
                             // An element was found but we don't allow for duplicate elements in this table.
-                            // This happens when there was an insertion of two elements that are equal but have different hash,
-                            // which is undefined behavior for a hash table
+                            // This happens when there was an insertion of two elements that are equal but have different hashes,
+                            // which is undefined behavior for a hash table: ISO C++ N4713, section 23.14.15 - 5.3
                             AZ_Assert(false, "Found a duplicate element when rehashing. "
                                 "Review the hashing function for type '%s' and make sure two equal elements always have the same hash", typeid(Traits::value_type).name());
                         }
@@ -264,15 +263,15 @@ namespace AZStd
                 m_vector.set_allocator(typename vector_type::allocator_type(&m_allocator));
             }
 
-            allocator_type  m_allocator;    ///< The single instance of the allocator shared between list and vector containers.
-            list_type       m_list;         ///< List with elements.
-            vector_type     m_vector;       ///< Buckets with list iterators.
+            allocator_type  m_allocator;    //!< The single instance of the allocator shared between list and vector containers.
+            list_type       m_list;         //!< List with elements.
+            vector_type     m_vector;       //!< Buckets with list iterators.
 
         private:
-            vector_value_type* m_buckets;       ///< Current buckets array. (can point to the m_vector or m_startBucket).
-            size_type           m_numBuckets;   ///< Current number of buckets.
-            float               m_max_load_factor; ///< Maximum load(elements/buckets) before rehashing
-            vector_value_type   m_startBucket;  ///< Start bucket used for before we start dynamically allocate memory from m_vector.
+            vector_value_type* m_buckets;       //!< Current buckets array. (can point to the m_vector or m_startBucket).
+            size_type           m_numBuckets;   //!< Current number of buckets.
+            float               m_max_load_factor; //!< Maximum load (elements/buckets) before rehashing.
+            vector_value_type   m_startBucket;  //!< Start bucket used for before we start dynamically allocate memory from m_vector.
         };
 
         /**
@@ -334,8 +333,8 @@ namespace AZStd
             template<class HashTable>
             AZ_FORCE_INLINE void    rehash(HashTable*, size_type) {}
 
-            vector_type     m_vector;       ///< Buckets with list iterators.
-            list_type       m_list;         ///< List with elements.
+            vector_type     m_vector;       //!< Buckets with list iterators.
+            list_type       m_list;         //!< List with elements.
         };
     }
 
@@ -985,7 +984,7 @@ namespace AZStd
             rhs.clear();
         }
 
-        // find_insert_position sets `insertIter` to where the element should be inserted
+        // find_insert_position sets insertIter to where the element should be inserted
         // and returns true if the element should be inserted, otherwise false
         template<class ComparableToKey, class KeyEq>
         bool find_insert_position(const ComparableToKey& keyCmp, const KeyEq& keyEq, iterator& insertIter, size_type numElements, const true_type& /* is multi elements */)
@@ -999,7 +998,7 @@ namespace AZStd
                 }
             }
 
-            // we always return true since multi elements (like multiset) allow to have repeated elements
+            // always return true since multi elements (like multiset) allow repeated elements
             return true;
         }
 

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -1008,7 +1008,7 @@ namespace AZStd
             {
                 if (keyEq(keyCmp, Traits::key_from_value(*insertIter)))
                 {
-                    // Element already exists, it shouldn't be inserted as we don't allow more than one element for this specialization
+                    // Element already exists, it shouldn't be inserted as we don't allow more than one repeated element for this specialization
                     return false;
                 }
             }

--- a/Code/Framework/AzCore/AzCore/std/hash_table.h
+++ b/Code/Framework/AzCore/AzCore/std/hash_table.h
@@ -199,7 +199,7 @@ namespace AZStd
                             // This happens when there was an insertion of two elements that are equal but have different hashes,
                             // which is undefined behavior for a hash table: ISO C++ N4713, section 23.14.15 - 5.3
                             AZ_Assert(false, "Found a duplicate element when rehashing. "
-                                "Review the hashing function for type '%s' and make sure two equal elements always have the same hash", typeid(typename Traits::value_type).name());
+                                "Review the hashing function for this type and make sure two equal elements always have the same hash");
                         }
 
                         newList.splice(insertIter, m_list, cur, curEnd);

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -308,6 +308,9 @@ namespace UnitTest
             }
         };
 
+        // This hashing function produces different hashes for two equal values,
+        // which violates the requirement for hashing functions.
+        // The test makes sure that this does not reproduce an issue that caused the insert() function to loop infinitely.
         struct TwoPtrsHasher
         {
             size_t operator()(const TwoPtrs& p) const
@@ -319,36 +322,15 @@ namespace UnitTest
         };
         using PairSet = AZStd::unordered_set<TwoPtrs, TwoPtrsHasher>;
         PairSet set;
-        set.insert({ (void*)0x000001ceddd942a0, (void*)0x000001ceddd94720 });
-        set.insert({ (void*)0x000001ceddd94420, (void*)0x000001ceddd94a20 });
-        set.insert({ (void*)0x000001ceddd94720, (void*)0x000001ceddd94420 });
-        set.insert({ (void*)0x000001ceddd948a0, (void*)0x000001ceddd945a0 });
-        set.insert({ (void*)0x000001ceddd94a20, (void*)0x000001ceddd9c420 });
-        set.insert({ (void*)0x000001ceddd94ba0, (void*)0x000001ceddd94d20 });
-        set.insert({ (void*)0x000001ceddd94d20, (void*)0x000001ceddd948a0 });
-        set.insert({ (void*)0x000001ceddd9c2a0, (void*)0x000001ceddd942a0 });
-        set.insert({ (void*)0x000001ceddd9c420, (void*)0x000001ceddd94ba0 });
-        set.insert({ (void*)0x000001ceddd9c5a0, (void*)0x000001ceddd9c720 });
-        set.insert({ (void*)0x000001ceddd9c720, (void*)0x000001ceddd9c8a0 });
-        set.insert({ (void*)0x000001ceddd9c8a0, (void*)0x000001ceddd94a20 });
-        set.insert({ (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cba0 });
-        set.insert({ (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9cd20 });
-        set.insert({ (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9cea0 });
-        set.insert({ (void*)0x000001ceddd9cea0, (void*)0x000001ceddd94a20 });
-        set.insert({ (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e2c0 });
-        set.insert({ (void*)0x000001ceddd9e2c0, (void*)0x000001ceddd9e440 });
-        set.insert({ (void*)0x000001ceddd9e440, (void*)0x000001ceddd948a0 });
-        set.insert({ (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9e740 });
-        set.insert({ (void*)0x000001ceddd9e740, (void*)0x000001ceddd9e8c0 });
-        set.insert({ (void*)0x000001ceddd9e8c0, (void*)0x000001ceddd948a0 });
-        set.insert({ (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9d020 });
-        set.insert({ (void*)0x000001ceddd9e440, (void*)0x000001ceddd9cd20 });
-        set.insert({ (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e440 });
-        set.insert({ (void*)0x000001ceddd9cea0, (void*)0x000001ceddd9e2c0 });
-        set.insert({ (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9c720 });
-        set.insert({ (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9ca20 });
+        set.insert({ (void*)1, (void*)2 });
+        set.insert({ (void*)3, (void*)4 });
+        set.insert({ (void*)5, (void*)6 });
+        set.insert({ (void*)7, (void*)8 });
+        // Elements with different hashes, but equal
+        set.insert({ (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cba0 }); // hash(148335135725641)
+        set.insert({ (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9ca20 }); // hash(148335135764189)
         AZ_TEST_START_TRACE_SUPPRESSION;
-        // This will trigger the rehashing and the assertion of duplicated elements found
+        // This will trigger the assertion of duplicated elements found
         set.rehash(23);
         AZ_TEST_STOP_TRACE_SUPPRESSION(1); // 1 assertion
     }

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -287,6 +287,77 @@ namespace UnitTest
         }
     }
 
+    TEST_F(HashedContainers, HashTable_InsertionDuplicateOnRehash)
+    {
+        struct TwoPtrs
+        {
+            void* m_ptr1;
+            void* m_ptr2;
+
+            bool operator==(const TwoPtrs& other) const
+            {
+                if (m_ptr1 == other.m_ptr1)
+                {
+                    return m_ptr2 == other.m_ptr2;
+                }
+                else if (m_ptr1 == other.m_ptr2)
+                {
+                    return m_ptr2 == other.m_ptr1;
+                }
+                return false;
+            }
+        };
+
+        struct TwoPtrsHasher
+        {
+            size_t operator()(const TwoPtrs& p) const
+            {
+                size_t hash{ 0 };
+                AZStd::hash_combine(hash, p.m_ptr1, p.m_ptr2);
+                return hash;
+            }
+        };
+        using PairSet = AZStd::unordered_set<TwoPtrs, TwoPtrsHasher>;
+        PairSet set;
+        TwoPtrs data[] =
+        {
+            { (void*)0x000001ceddd942a0, (void*)0x000001ceddd94720 },
+            { (void*)0x000001ceddd94420, (void*)0x000001ceddd94a20 },
+            { (void*)0x000001ceddd94720, (void*)0x000001ceddd94420 },
+            { (void*)0x000001ceddd948a0, (void*)0x000001ceddd945a0 },
+            { (void*)0x000001ceddd94a20, (void*)0x000001ceddd9c420 },
+            { (void*)0x000001ceddd94ba0, (void*)0x000001ceddd94d20 },
+            { (void*)0x000001ceddd94d20, (void*)0x000001ceddd948a0 },
+            { (void*)0x000001ceddd9c2a0, (void*)0x000001ceddd942a0 },
+            { (void*)0x000001ceddd9c420, (void*)0x000001ceddd94ba0 },
+            { (void*)0x000001ceddd9c5a0, (void*)0x000001ceddd9c720 },
+            { (void*)0x000001ceddd9c720, (void*)0x000001ceddd9c8a0 },
+            { (void*)0x000001ceddd9c8a0, (void*)0x000001ceddd94a20 },
+            { (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cba0 },
+            { (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9cd20 },
+            { (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9cea0 },
+            { (void*)0x000001ceddd9cea0, (void*)0x000001ceddd94a20 },
+            { (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e2c0 },
+            { (void*)0x000001ceddd9e2c0, (void*)0x000001ceddd9e440 },
+            { (void*)0x000001ceddd9e440, (void*)0x000001ceddd948a0 },
+            { (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9e740 },
+            { (void*)0x000001ceddd9e740, (void*)0x000001ceddd9e8c0 },
+            { (void*)0x000001ceddd9e8c0, (void*)0x000001ceddd948a0 },
+            { (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9d020 },
+            { (void*)0x000001ceddd9e440, (void*)0x000001ceddd9cd20 },
+            { (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e440 },
+            { (void*)0x000001ceddd9cea0, (void*)0x000001ceddd9e2c0 },
+            { (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9c720 },
+            { (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9ca20 },
+            { (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cea0 }
+        };
+
+        for (auto& e : data)
+        {
+            set.insert(e);
+        }
+    }
+
     TEST_F(HashedContainers, HashTable_Fixed)
     {
         array<int, 5> elements = {

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -287,73 +287,70 @@ namespace UnitTest
         }
     }
 
-    TEST_F(HashedContainers, HashTable_Insertion_Duplicate_WithEqualNotEqualHashes)
+    TEST_F(HashedContainers, HashTable_InsertionDuplicateOnRehash)
     {
-        struct TwoInts
+        struct TwoPtrs
         {
-            uint64_t m_a;
-            uint64_t m_b;
+            void* m_ptr1;
+            void* m_ptr2;
 
-            bool operator==(const TwoInts& other) const
+            bool operator==(const TwoPtrs& other) const
             {
-                if (m_a == other.m_a)
+                if (m_ptr1 == other.m_ptr1)
                 {
-                    return m_b == other.m_b;
+                    return m_ptr2 == other.m_ptr2;
                 }
-                else if (m_a == other.m_b)
+                else if (m_ptr1 == other.m_ptr2)
                 {
-                    return m_b == other.m_a;
+                    return m_ptr2 == other.m_ptr1;
                 }
                 return false;
             }
         };
 
-        // This hashing function produces different hashes for two equal values,
-        // which violates the requirement for hashing functions.
-        // The test would only make sure that this does not reproduce a bug that happened in the past in this case,
-        // where it would make the insert() to loop infinitely.
         struct TwoPtrsHasher
         {
-            size_t operator()(const TwoInts& p) const
+            size_t operator()(const TwoPtrs& p) const
             {
                 size_t hash{ 0 };
-                AZStd::hash_combine(hash, p.m_a, p.m_b);
+                AZStd::hash_combine(hash, p.m_ptr1, p.m_ptr2);
                 return hash;
             }
         };
-        using PairSet = AZStd::unordered_set<TwoInts, TwoPtrsHasher>;
+        using PairSet = AZStd::unordered_set<TwoPtrs, TwoPtrsHasher>;
         PairSet set;
-        
-        set.insert({ 0x000001ceddd942a0, 0x000001ceddd94720 });
-        set.insert({ 0x000001ceddd94420, 0x000001ceddd94a20 });
-        set.insert({ 0x000001ceddd94720, 0x000001ceddd94420 });
-        set.insert({ 0x000001ceddd948a0, 0x000001ceddd945a0 });
-        set.insert({ 0x000001ceddd94a20, 0x000001ceddd9c420 });
-        set.insert({ 0x000001ceddd94ba0, 0x000001ceddd94d20 });
-        set.insert({ 0x000001ceddd94d20, 0x000001ceddd948a0 });
-        set.insert({ 0x000001ceddd9c2a0, 0x000001ceddd942a0 });
-        set.insert({ 0x000001ceddd9c420, 0x000001ceddd94ba0 });
-        set.insert({ 0x000001ceddd9c5a0, 0x000001ceddd9c720 });
-        set.insert({ 0x000001ceddd9c720, 0x000001ceddd9c8a0 });
-        set.insert({ 0x000001ceddd9c8a0, 0x000001ceddd94a20 });
-        set.insert({ 0x000001ceddd9ca20, 0x000001ceddd9cba0 });
-        set.insert({ 0x000001ceddd9cba0, 0x000001ceddd9cd20 });
-        set.insert({ 0x000001ceddd9cd20, 0x000001ceddd9cea0 });
-        set.insert({ 0x000001ceddd9cea0, 0x000001ceddd94a20 });
-        set.insert({ 0x000001ceddd9d020, 0x000001ceddd9e2c0 });
-        set.insert({ 0x000001ceddd9e2c0, 0x000001ceddd9e440 });
-        set.insert({ 0x000001ceddd9e440, 0x000001ceddd948a0 });
-        set.insert({ 0x000001ceddd9e5c0, 0x000001ceddd9e740 });
-        set.insert({ 0x000001ceddd9e740, 0x000001ceddd9e8c0 });
-        set.insert({ 0x000001ceddd9e8c0, 0x000001ceddd948a0 });
-        set.insert({ 0x000001ceddd9e5c0, 0x000001ceddd9d020 });
-        set.insert({ 0x000001ceddd9e440, 0x000001ceddd9cd20 });
-        set.insert({ 0x000001ceddd9d020, 0x000001ceddd9e440 });
-        set.insert({ 0x000001ceddd9cea0, 0x000001ceddd9e2c0 });
-        set.insert({ 0x000001ceddd9cd20, 0x000001ceddd9c720 });
-        set.insert({ 0x000001ceddd9cba0, 0x000001ceddd9ca20 });
-        // This line will toggle a rehash
-        set.insert({ 0x000001ceddd9ca20, 0x000001ceddd9cea0 });
+        set.insert({ (void*)0x000001ceddd942a0, (void*)0x000001ceddd94720 });
+        set.insert({ (void*)0x000001ceddd94420, (void*)0x000001ceddd94a20 });
+        set.insert({ (void*)0x000001ceddd94720, (void*)0x000001ceddd94420 });
+        set.insert({ (void*)0x000001ceddd948a0, (void*)0x000001ceddd945a0 });
+        set.insert({ (void*)0x000001ceddd94a20, (void*)0x000001ceddd9c420 });
+        set.insert({ (void*)0x000001ceddd94ba0, (void*)0x000001ceddd94d20 });
+        set.insert({ (void*)0x000001ceddd94d20, (void*)0x000001ceddd948a0 });
+        set.insert({ (void*)0x000001ceddd9c2a0, (void*)0x000001ceddd942a0 });
+        set.insert({ (void*)0x000001ceddd9c420, (void*)0x000001ceddd94ba0 });
+        set.insert({ (void*)0x000001ceddd9c5a0, (void*)0x000001ceddd9c720 });
+        set.insert({ (void*)0x000001ceddd9c720, (void*)0x000001ceddd9c8a0 });
+        set.insert({ (void*)0x000001ceddd9c8a0, (void*)0x000001ceddd94a20 });
+        set.insert({ (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cba0 });
+        set.insert({ (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9cd20 });
+        set.insert({ (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9cea0 });
+        set.insert({ (void*)0x000001ceddd9cea0, (void*)0x000001ceddd94a20 });
+        set.insert({ (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e2c0 });
+        set.insert({ (void*)0x000001ceddd9e2c0, (void*)0x000001ceddd9e440 });
+        set.insert({ (void*)0x000001ceddd9e440, (void*)0x000001ceddd948a0 });
+        set.insert({ (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9e740 });
+        set.insert({ (void*)0x000001ceddd9e740, (void*)0x000001ceddd9e8c0 });
+        set.insert({ (void*)0x000001ceddd9e8c0, (void*)0x000001ceddd948a0 });
+        set.insert({ (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9d020 });
+        set.insert({ (void*)0x000001ceddd9e440, (void*)0x000001ceddd9cd20 });
+        set.insert({ (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e440 });
+        set.insert({ (void*)0x000001ceddd9cea0, (void*)0x000001ceddd9e2c0 });
+        set.insert({ (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9c720 });
+        set.insert({ (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9ca20 });
+        AZ_TEST_START_TRACE_SUPPRESSION;
+        // This will trigger the rehashing and the assertion of duplicated elements found
+        set.rehash(23);
+        AZ_TEST_STOP_TRACE_SUPPRESSION(1); // 1 assertion
     }
 
     TEST_F(HashedContainers, HashTable_Fixed)

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -287,75 +287,73 @@ namespace UnitTest
         }
     }
 
-    TEST_F(HashedContainers, HashTable_InsertionDuplicateOnRehash)
+    TEST_F(HashedContainers, HashTable_Insertion_Duplicate_WithEqualNotEqualHashes)
     {
-        struct TwoPtrs
+        struct TwoInts
         {
-            void* m_ptr1;
-            void* m_ptr2;
+            uint64_t m_a;
+            uint64_t m_b;
 
-            bool operator==(const TwoPtrs& other) const
+            bool operator==(const TwoInts& other) const
             {
-                if (m_ptr1 == other.m_ptr1)
+                if (m_a == other.m_a)
                 {
-                    return m_ptr2 == other.m_ptr2;
+                    return m_b == other.m_b;
                 }
-                else if (m_ptr1 == other.m_ptr2)
+                else if (m_a == other.m_b)
                 {
-                    return m_ptr2 == other.m_ptr1;
+                    return m_b == other.m_a;
                 }
                 return false;
             }
         };
 
+        // This hashing function produces different hashes for two equal values,
+        // which violates the requirement for hashing functions.
+        // The test would only make sure that this does not reproduce a bug that happened in the past in this case,
+        // where it would make the insert() to loop infinitely.
         struct TwoPtrsHasher
         {
-            size_t operator()(const TwoPtrs& p) const
+            size_t operator()(const TwoInts& p) const
             {
                 size_t hash{ 0 };
-                AZStd::hash_combine(hash, p.m_ptr1, p.m_ptr2);
+                AZStd::hash_combine(hash, p.m_a, p.m_b);
                 return hash;
             }
         };
-        using PairSet = AZStd::unordered_set<TwoPtrs, TwoPtrsHasher>;
+        using PairSet = AZStd::unordered_set<TwoInts, TwoPtrsHasher>;
         PairSet set;
-        TwoPtrs data[] =
-        {
-            { (void*)0x000001ceddd942a0, (void*)0x000001ceddd94720 },
-            { (void*)0x000001ceddd94420, (void*)0x000001ceddd94a20 },
-            { (void*)0x000001ceddd94720, (void*)0x000001ceddd94420 },
-            { (void*)0x000001ceddd948a0, (void*)0x000001ceddd945a0 },
-            { (void*)0x000001ceddd94a20, (void*)0x000001ceddd9c420 },
-            { (void*)0x000001ceddd94ba0, (void*)0x000001ceddd94d20 },
-            { (void*)0x000001ceddd94d20, (void*)0x000001ceddd948a0 },
-            { (void*)0x000001ceddd9c2a0, (void*)0x000001ceddd942a0 },
-            { (void*)0x000001ceddd9c420, (void*)0x000001ceddd94ba0 },
-            { (void*)0x000001ceddd9c5a0, (void*)0x000001ceddd9c720 },
-            { (void*)0x000001ceddd9c720, (void*)0x000001ceddd9c8a0 },
-            { (void*)0x000001ceddd9c8a0, (void*)0x000001ceddd94a20 },
-            { (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cba0 },
-            { (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9cd20 },
-            { (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9cea0 },
-            { (void*)0x000001ceddd9cea0, (void*)0x000001ceddd94a20 },
-            { (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e2c0 },
-            { (void*)0x000001ceddd9e2c0, (void*)0x000001ceddd9e440 },
-            { (void*)0x000001ceddd9e440, (void*)0x000001ceddd948a0 },
-            { (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9e740 },
-            { (void*)0x000001ceddd9e740, (void*)0x000001ceddd9e8c0 },
-            { (void*)0x000001ceddd9e8c0, (void*)0x000001ceddd948a0 },
-            { (void*)0x000001ceddd9e5c0, (void*)0x000001ceddd9d020 },
-            { (void*)0x000001ceddd9e440, (void*)0x000001ceddd9cd20 },
-            { (void*)0x000001ceddd9d020, (void*)0x000001ceddd9e440 },
-            { (void*)0x000001ceddd9cea0, (void*)0x000001ceddd9e2c0 },
-            { (void*)0x000001ceddd9cd20, (void*)0x000001ceddd9c720 },
-            { (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9ca20 },
-            { (void*)0x000001ceddd9ca20, (void*)0x000001ceddd9cea0 }
-        };
-
-        for (auto& e : data)
-        {
-            set.insert(e);
-        }
+        
+        set.insert({ 0x000001ceddd942a0, 0x000001ceddd94720 });
+        set.insert({ 0x000001ceddd94420, 0x000001ceddd94a20 });
+        set.insert({ 0x000001ceddd94720, 0x000001ceddd94420 });
+        set.insert({ 0x000001ceddd948a0, 0x000001ceddd945a0 });
+        set.insert({ 0x000001ceddd94a20, 0x000001ceddd9c420 });
+        set.insert({ 0x000001ceddd94ba0, 0x000001ceddd94d20 });
+        set.insert({ 0x000001ceddd94d20, 0x000001ceddd948a0 });
+        set.insert({ 0x000001ceddd9c2a0, 0x000001ceddd942a0 });
+        set.insert({ 0x000001ceddd9c420, 0x000001ceddd94ba0 });
+        set.insert({ 0x000001ceddd9c5a0, 0x000001ceddd9c720 });
+        set.insert({ 0x000001ceddd9c720, 0x000001ceddd9c8a0 });
+        set.insert({ 0x000001ceddd9c8a0, 0x000001ceddd94a20 });
+        set.insert({ 0x000001ceddd9ca20, 0x000001ceddd9cba0 });
+        set.insert({ 0x000001ceddd9cba0, 0x000001ceddd9cd20 });
+        set.insert({ 0x000001ceddd9cd20, 0x000001ceddd9cea0 });
+        set.insert({ 0x000001ceddd9cea0, 0x000001ceddd94a20 });
+        set.insert({ 0x000001ceddd9d020, 0x000001ceddd9e2c0 });
+        set.insert({ 0x000001ceddd9e2c0, 0x000001ceddd9e440 });
+        set.insert({ 0x000001ceddd9e440, 0x000001ceddd948a0 });
+        set.insert({ 0x000001ceddd9e5c0, 0x000001ceddd9e740 });
+        set.insert({ 0x000001ceddd9e740, 0x000001ceddd9e8c0 });
+        set.insert({ 0x000001ceddd9e8c0, 0x000001ceddd948a0 });
+        set.insert({ 0x000001ceddd9e5c0, 0x000001ceddd9d020 });
+        set.insert({ 0x000001ceddd9e440, 0x000001ceddd9cd20 });
+        set.insert({ 0x000001ceddd9d020, 0x000001ceddd9e440 });
+        set.insert({ 0x000001ceddd9cea0, 0x000001ceddd9e2c0 });
+        set.insert({ 0x000001ceddd9cd20, 0x000001ceddd9c720 });
+        set.insert({ 0x000001ceddd9cba0, 0x000001ceddd9ca20 });
+        // This line will toggle a rehash
+        set.insert({ 0x000001ceddd9ca20, 0x000001ceddd9cea0 });
     }
 
     TEST_F(HashedContainers, HashTable_Fixed)

--- a/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
+++ b/Code/Framework/AzCore/Tests/AZStd/Hashed.cpp
@@ -331,6 +331,7 @@ namespace UnitTest
         set.insert({ (void*)0x000001ceddd9cba0, (void*)0x000001ceddd9ca20 }); // hash(148335135764189)
         AZ_TEST_START_TRACE_SUPPRESSION;
         // This will trigger the assertion of duplicated elements found
+        // A bucket size of 23 since is where the collision between different hashes happens
         set.rehash(23);
         AZ_TEST_STOP_TRACE_SUPPRESSION(1); // 1 assertion
     }

--- a/Gems/PhysX/Code/Source/Scene/PhysXSceneSimulationFilterCallback.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXSceneSimulationFilterCallback.cpp
@@ -55,7 +55,10 @@ namespace PhysX
     size_t SceneSimulationFilterCallback::CollisionPairHasher::operator()(const CollisionActorPair& collisionPair) const
     {
         size_t hash{ 0 };
-        AZStd::hash_combine(hash, collisionPair.m_actorA, collisionPair.m_actorB);
+        // Order elements so {1,2} and {2,1} would generate the same hash
+        const physx::PxActor* smallerVal = AZStd::min(collisionPair.m_actorA, collisionPair.m_actorB);
+        const physx::PxActor* biggerVal = AZStd::max(collisionPair.m_actorA, collisionPair.m_actorB);
+        AZStd::hash_combine(hash, smallerVal, biggerVal);
         return hash;
     }
 

--- a/Gems/PhysX/Code/Source/Scene/PhysXSceneSimulationFilterCallback.cpp
+++ b/Gems/PhysX/Code/Source/Scene/PhysXSceneSimulationFilterCallback.cpp
@@ -56,8 +56,7 @@ namespace PhysX
     {
         size_t hash{ 0 };
         // Order elements so {1,2} and {2,1} would generate the same hash
-        const physx::PxActor* smallerVal = AZStd::min(collisionPair.m_actorA, collisionPair.m_actorB);
-        const physx::PxActor* biggerVal = AZStd::max(collisionPair.m_actorA, collisionPair.m_actorB);
+        auto [smallerVal, biggerVal] = AZStd::minmax(collisionPair.m_actorA, collisionPair.m_actorB);
         AZStd::hash_combine(hash, smallerVal, biggerVal);
         return hash;
     }


### PR DESCRIPTION
The `hash_table::rehash()` function would run forever for non-multi versions in very specific cases when providing a hashing function that generated different hashes for two equal elements (invoking undefined behavior).

### Brief hash_table explanation

`hash_table` (an implementation of `unordered_set`/`unordered_map` etc.) contains buckets which are vectors of pointers. Each bucket will contain the element that matches (`hash % number_of_buckets`). This means that elements with the same hash will go into the same bucket and in some rare cases elements with different hashes could also happen to share the same bucket. The likelihood of this happening depends on the hashing function and number of buckets. In order to tell if an item exists in the table it picks the bucket it belongs to and does a linear search over it. The `insert()` function may also call `rehash()`, which increases the buckets and moves the elements to these new buckets.

### The problem

If we provide an invalid hashing and equality function that generate different hashes for two equal elements, it means that these two elements, even being equal, would end up in two different buckets. This will cause the container to have duplicate elements.
However, there is a small chance that when rehashing, these duplicate elements (that were already in different buckets) would then end up in the same bucket. This code path is unlikely but has happened. The code that we had before in that case would not process or skip the element, looping infinitely.

### The solution

Now if we find a duplicate element when rehashing, we *assert* and alert the user of a possibly incorrect hashing function and then continue even with the duplicated elements (this is what MSVC and other compilers seem to do). This may not happen very often, but detecting a wrong hashing function is very difficult to do without significantly slowing down the `hash_table` implementation. So for this PR, I believe it is the right approach for now.

This PR also adds a unit test that reproduces the issue (from observed halts) 100% of the times without the fix. Some comments and naming improvements have also been made to make `hash_table` code more understandable.

It also fixes an incorrect hashing use case where the original issue was discovered.