### PR TITLE
Add connection interface timeout config and remove Ctrl+G timer

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
@@ -104,8 +104,8 @@ namespace AzNetworking
         virtual bool Disconnect(ConnectionId connectionId, DisconnectReason reason) = 0;
 
         //! Sets whether this connection interface can disconnect by virtue of a timeout
-        //! @param doesTimeout If this connection interface will automatically disconnect due to a timeout
-        virtual void SetTimeoutEnabled(bool doesTimeout) = 0;
+        //! @param timeoutEnabled If this connection interface will automatically disconnect due to a timeout
+        virtual void SetTimeoutEnabled(bool timeoutEnabled) = 0;
 
         //! Whether this connection interface will disconnect by virtue of a time out (does not account for cvars affecting all connections)
         //! @return boolean true if this connection will not disconnect on timeout (does not account for cvars affecting all connections)

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
@@ -105,11 +105,11 @@ namespace AzNetworking
 
         //! Sets whether this connection interface can disconnect by virtue of a timeout
         //! @param doesTimeout If this connection interface will automatically disconnect due to a timeout
-        virtual void SetDoesTimeout(bool doesTimeout) = 0;
+        virtual void SetTimeoutEnabled(bool doesTimeout) = 0;
 
         //! Whether this connection interface will disconnect by virtue of a time out (does not account for cvars affecting all connections)
         //! @return boolean true if this connection will not disconnect on timeout (does not account for cvars affecting all connections)
-        virtual bool DoesTimeout() = 0;
+        virtual bool IsTimeoutEnabled() = 0;
 
         //! Const access to the metrics tracked by this network interface.
         //! @return const reference to the metrics tracked by this network interface

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
@@ -109,7 +109,7 @@ namespace AzNetworking
 
         //! Whether this connection interface will disconnect by virtue of a time out (does not account for cvars affecting all connections)
         //! @return boolean true if this connection will not disconnect on timeout (does not account for cvars affecting all connections)
-        virtual bool IsTimeoutEnabled() = 0;
+        virtual bool IsTimeoutEnabled() const = 0;
 
         //! Const access to the metrics tracked by this network interface.
         //! @return const reference to the metrics tracked by this network interface

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/INetworkInterface.h
@@ -103,6 +103,14 @@ namespace AzNetworking
         //! @return boolean true on success
         virtual bool Disconnect(ConnectionId connectionId, DisconnectReason reason) = 0;
 
+        //! Sets whether this connection interface can disconnect by virtue of a timeout
+        //! @param doesTimeout If this connection interface will automatically disconnect due to a timeout
+        virtual void SetDoesTimeout(bool doesTimeout) = 0;
+
+        //! Whether this connection interface will disconnect by virtue of a time out (does not account for cvars affecting all connections)
+        //! @return boolean true if this connection will not disconnect on timeout (does not account for cvars affecting all connections)
+        virtual bool DoesTimeout() = 0;
+
         //! Const access to the metrics tracked by this network interface.
         //! @return const reference to the metrics tracked by this network interface
         const NetworkInterfaceMetrics& GetMetrics() const;

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
@@ -179,7 +179,7 @@ namespace AzNetworking
         m_timeoutEnabled = timeoutEnabled;
     }
 
-    bool TcpNetworkInterface::IsTimeoutEnabled()
+    bool TcpNetworkInterface::IsTimeoutEnabled() const
     {
         return m_timeoutEnabled;
     }

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
@@ -174,14 +174,14 @@ namespace AzNetworking
         return connection->Disconnect(reason, TerminationEndpoint::Local);
     }
 
-    void TcpNetworkInterface::SetTimeoutEnabled(bool doesTimeout)
+    void TcpNetworkInterface::SetTimeoutEnabled(bool timeoutEnabled)
     {
-        m_doesTimeout = doesTimeout;
+        m_timeoutEnabled = timeoutEnabled;
     }
 
     bool TcpNetworkInterface::IsTimeoutEnabled()
     {
-        return m_doesTimeout;
+        return m_timeoutEnabled;
     }
 
     void TcpNetworkInterface::QueueNewConnection(const PendingConnection& pendingConnection)

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
@@ -174,6 +174,16 @@ namespace AzNetworking
         return connection->Disconnect(reason, TerminationEndpoint::Local);
     }
 
+    void TcpNetworkInterface::SetDoesTimeout(bool doesTimeout)
+    {
+        m_doesTimeout = doesTimeout;
+    }
+
+    bool TcpNetworkInterface::DoesTimeout()
+    {
+        return m_doesTimeout;
+    }
+
     void TcpNetworkInterface::QueueNewConnection(const PendingConnection& pendingConnection)
     {
         m_pendingConnections.PushBackItem(pendingConnection);
@@ -306,7 +316,7 @@ namespace AzNetworking
         {
             tcpConnection->SendReliablePacket(CorePackets::HeartbeatPacket());
         }
-        else if (net_TcpTimeoutConnections)
+        else if (net_TcpTimeoutConnections && m_networkInterface.DoesTimeout())
         {
             tcpConnection->Disconnect(DisconnectReason::Timeout, TerminationEndpoint::Local);
             return TimeoutResult::Delete;

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
@@ -174,12 +174,12 @@ namespace AzNetworking
         return connection->Disconnect(reason, TerminationEndpoint::Local);
     }
 
-    void TcpNetworkInterface::SetDoesTimeout(bool doesTimeout)
+    void TcpNetworkInterface::SetTimeoutEnabled(bool doesTimeout)
     {
         m_doesTimeout = doesTimeout;
     }
 
-    bool TcpNetworkInterface::DoesTimeout()
+    bool TcpNetworkInterface::IsTimeoutEnabled()
     {
         return m_doesTimeout;
     }
@@ -316,7 +316,7 @@ namespace AzNetworking
         {
             tcpConnection->SendReliablePacket(CorePackets::HeartbeatPacket());
         }
-        else if (net_TcpTimeoutConnections && m_networkInterface.DoesTimeout())
+        else if (net_TcpTimeoutConnections && m_networkInterface.IsTimeoutEnabled())
         {
             tcpConnection->Disconnect(DisconnectReason::Timeout, TerminationEndpoint::Local);
             return TimeoutResult::Delete;

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
@@ -100,7 +100,7 @@ namespace AzNetworking
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
         void SetTimeoutEnabled(bool timeoutEnabled) override;
-        bool IsTimeoutEnabled() override;
+        bool IsTimeoutEnabled() const override;
         //! @}
 
         //! Queues a new incoming connection for this network interface.

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
@@ -99,7 +99,7 @@ namespace AzNetworking
         bool WasPacketAcked(ConnectionId connectionId, PacketId packetId) override;
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
-        void SetTimeoutEnabled(bool doesTimeout) override;
+        void SetTimeoutEnabled(bool timeoutEnabled) override;
         bool IsTimeoutEnabled() override;
         //! @}
 
@@ -156,7 +156,7 @@ namespace AzNetworking
         AZ::Name m_name;
         TrustZone m_trustZone;
         uint16_t m_port = 0;
-        bool m_doesTimeout = true;
+        bool m_timeoutEnabled = true;
         IConnectionListener& m_connectionListener;
         TcpConnectionSet m_connectionSet;
         TcpSocketManager m_tcpSocketManager;

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
@@ -99,8 +99,8 @@ namespace AzNetworking
         bool WasPacketAcked(ConnectionId connectionId, PacketId packetId) override;
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
-        void SetDoesTimeout(bool doesTimeout) override;
-        bool DoesTimeout() override;
+        void SetTimeoutEnabled(bool doesTimeout) override;
+        bool IsTimeoutEnabled() override;
         //! @}
 
         //! Queues a new incoming connection for this network interface.

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
@@ -99,6 +99,8 @@ namespace AzNetworking
         bool WasPacketAcked(ConnectionId connectionId, PacketId packetId) override;
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
+        void SetDoesTimeout(bool doesTimeout) override;
+        bool DoesTimeout() override;
         //! @}
 
         //! Queues a new incoming connection for this network interface.
@@ -154,6 +156,7 @@ namespace AzNetworking
         AZ::Name m_name;
         TrustZone m_trustZone;
         uint16_t m_port = 0;
+        bool m_doesTimeout = true;
         IConnectionListener& m_connectionListener;
         TcpConnectionSet m_connectionSet;
         TcpSocketManager m_tcpSocketManager;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -402,7 +402,7 @@ namespace AzNetworking
         m_timeoutEnabled = timeoutEnabled;
     }
 
-    bool UdpNetworkInterface::IsTimeoutEnabled()
+    bool UdpNetworkInterface::IsTimeoutEnabled() const
     {
         return m_timeoutEnabled;
     }

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -397,6 +397,16 @@ namespace AzNetworking
         return connection->Disconnect(reason, TerminationEndpoint::Local);
     }
 
+    void UdpNetworkInterface::SetDoesTimeout(bool doesTimeout)
+    {
+        m_doesTimeout = doesTimeout;
+    }
+
+    bool UdpNetworkInterface::DoesTimeout()
+    {
+        return m_doesTimeout;
+    }
+
     bool UdpNetworkInterface::IsEncrypted() const
     {
         return m_socket->IsEncrypted();
@@ -729,7 +739,7 @@ namespace AzNetworking
         {
             udpConnection->SendUnreliablePacket(CorePackets::HeartbeatPacket());
         }
-        else if (net_UdpTimeoutConnections)
+        else if (net_UdpTimeoutConnections && m_networkInterface.DoesTimeout())
         {
             udpConnection->Disconnect(DisconnectReason::Timeout, TerminationEndpoint::Local);
             return TimeoutResult::Delete;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -397,14 +397,14 @@ namespace AzNetworking
         return connection->Disconnect(reason, TerminationEndpoint::Local);
     }
 
-    void UdpNetworkInterface::SetTimeoutEnabled(bool doesTimeout)
+    void UdpNetworkInterface::SetTimeoutEnabled(bool timeoutEnabled)
     {
-        m_doesTimeout = doesTimeout;
+        m_timeoutEnabled = timeoutEnabled;
     }
 
     bool UdpNetworkInterface::IsTimeoutEnabled()
     {
-        return m_doesTimeout;
+        return m_timeoutEnabled;
     }
 
     bool UdpNetworkInterface::IsEncrypted() const

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -397,12 +397,12 @@ namespace AzNetworking
         return connection->Disconnect(reason, TerminationEndpoint::Local);
     }
 
-    void UdpNetworkInterface::SetDoesTimeout(bool doesTimeout)
+    void UdpNetworkInterface::SetTimeoutEnabled(bool doesTimeout)
     {
         m_doesTimeout = doesTimeout;
     }
 
-    bool UdpNetworkInterface::DoesTimeout()
+    bool UdpNetworkInterface::IsTimeoutEnabled()
     {
         return m_doesTimeout;
     }
@@ -739,7 +739,7 @@ namespace AzNetworking
         {
             udpConnection->SendUnreliablePacket(CorePackets::HeartbeatPacket());
         }
-        else if (net_UdpTimeoutConnections && m_networkInterface.DoesTimeout())
+        else if (net_UdpTimeoutConnections && m_networkInterface.IsTimeoutEnabled())
         {
             udpConnection->Disconnect(DisconnectReason::Timeout, TerminationEndpoint::Local);
             return TimeoutResult::Delete;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
@@ -104,8 +104,8 @@ namespace AzNetworking
         bool WasPacketAcked(ConnectionId connectionId, PacketId packetId) override;
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
-        void SetDoesTimeout(bool doesTimeout) override;
-        bool DoesTimeout() override;
+        void SetTimeoutEnabled(bool doesTimeout) override;
+        bool IsTimeoutEnabled() override;
         //! @}
 
         //! Returns true if this is an encrypted socket, false if not.

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
@@ -104,6 +104,8 @@ namespace AzNetworking
         bool WasPacketAcked(ConnectionId connectionId, PacketId packetId) override;
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
+        void SetDoesTimeout(bool doesTimeout) override;
+        bool DoesTimeout() override;
         //! @}
 
         //! Returns true if this is an encrypted socket, false if not.
@@ -179,6 +181,7 @@ namespace AzNetworking
         TrustZone m_trustZone;
         uint16_t m_port = 0;
         bool m_allowIncomingConnections = false;
+        bool m_doesTimeout = true;
         IConnectionListener& m_connectionListener;
         UdpConnectionSet m_connectionSet;
         TimeoutQueue m_connectionTimeoutQueue;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
@@ -104,7 +104,7 @@ namespace AzNetworking
         bool WasPacketAcked(ConnectionId connectionId, PacketId packetId) override;
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
-        void SetTimeoutEnabled(bool doesTimeout) override;
+        void SetTimeoutEnabled(bool timeoutEnabled) override;
         bool IsTimeoutEnabled() override;
         //! @}
 
@@ -181,7 +181,7 @@ namespace AzNetworking
         TrustZone m_trustZone;
         uint16_t m_port = 0;
         bool m_allowIncomingConnections = false;
-        bool m_doesTimeout = true;
+        bool m_timeoutEnabled = true;
         IConnectionListener& m_connectionListener;
         UdpConnectionSet m_connectionSet;
         TimeoutQueue m_connectionTimeoutQueue;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
@@ -105,7 +105,7 @@ namespace AzNetworking
         bool StopListening() override;
         bool Disconnect(ConnectionId connectionId, DisconnectReason reason) override;
         void SetTimeoutEnabled(bool timeoutEnabled) override;
-        bool IsTimeoutEnabled() override;
+        bool IsTimeoutEnabled() const override;
         //! @}
 
         //! Returns true if this is an encrypted socket, false if not.

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -32,6 +32,7 @@ namespace Multiplayer
     {
         m_networkEditorInterface = AZ::Interface<INetworking>::Get()->CreateNetworkInterface(
             AZ::Name(MPEditorInterfaceName), ProtocolType::Tcp, TrustZone::ExternalClientToServer, *this);
+        m_networkEditorInterface->SetDoesTimeout(false);
         if (editorsv_isDedicated)
         {
             uint16_t editorServerPort = DefaultServerEditorPort;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -32,7 +32,7 @@ namespace Multiplayer
     {
         m_networkEditorInterface = AZ::Interface<INetworking>::Get()->CreateNetworkInterface(
             AZ::Name(MPEditorInterfaceName), ProtocolType::Tcp, TrustZone::ExternalClientToServer, *this);
-        m_networkEditorInterface->SetDoesTimeout(false);
+        m_networkEditorInterface->SetTimeoutEnabled(false);
         if (editorsv_isDedicated)
         {
             uint16_t editorServerPort = DefaultServerEditorPort;

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -147,13 +147,9 @@ namespace Multiplayer
         processLaunchInfo.m_showWindow = true;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;
 
-        // Launch the Server and give it a few seconds to boot up
+        // Launch the Server
         AzFramework::ProcessWatcher* outProcess = AzFramework::ProcessWatcher::LaunchProcess(
             processLaunchInfo, AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_NONE);
-        if (outProcess)
-        {
-            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(15000));
-        }
 
         return outProcess;
     }


### PR DESCRIPTION
This change adds per connection interface configuration of whether connection timeout should be enforced. Enforcement requires an opt-in from both the connection interface and the global cvars. The connection interface is opt-in by default.

Additionally, defaulting the Editor Connection Interface used to drive the Ctrl+G UX to not enforcing timeout which eliminates the need for the 15s timer. This connection cleans itself up once its job is done as well.

Signed-off-by: puvvadar <puvvadar@amazon.com>