### PR TITLE
Adds Light component tests (non-GPU portion) to AutomatedTesting from AtomTest

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
@@ -17,7 +17,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
         TEST_SUITE main
         PATH ${CMAKE_CURRENT_LIST_DIR}/test_Atom_MainSuite.py
         TEST_SERIAL
-        TIMEOUT 400
+        TIMEOUT 600
         RUNTIME_DEPENDENCIES
             AssetProcessor
             AutomatedTesting.Assets

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomEditorComponents_LightComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomEditorComponents_LightComponent.py
@@ -1,0 +1,85 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+Hydra script that creates an entity, attaches the Light component to it for test verifications.
+The test verifies that each light type option is available and can be selected without errors.
+"""
+
+import os
+import sys
+
+import azlmbr.bus as bus
+import azlmbr.editor as editor
+import azlmbr.math as math
+import azlmbr.paths
+import azlmbr.legacy.general as general
+
+sys.path.append(os.path.join(azlmbr.paths.devassets, "Gem", "PythonTests"))
+
+import editor_python_test_tools.hydra_editor_utils as hydra
+from atom_renderer.atom_utils.atom_component_helper import LIGHT_TYPES
+
+
+def run():
+    """
+    Test Case - Light Component
+    1. Creates a "light_entity" Entity and attaches a "Light" component to it.
+    2. Updates the Light component to each light type option from the LIGHT_TYPES constant.
+    3. The test will check the Editor log to ensure each light type was selected.
+    4. Prints the string "Light component test (non-GPU) completed" after completion.
+
+    Tests will fail immediately if any of these log lines are found:
+    1. Trace::Assert
+    2. Trace::Error
+    3. Traceback (most recent call last):
+
+    :return: None
+    """
+    # Create a "light_entity" entity with "Light" component.
+    light_entity_name = "light_entity"
+    light_component = "Light"
+    light_entity = hydra.Entity(f"{light_entity_name}")
+    light_entity.create_entity(math.Vector3(-1.0, -2.0, 3.0), [light_component])
+    general.log(
+        f"{light_entity_name}_test: Component added to the entity: "
+        f"{hydra.has_components(light_entity.id, [light_component])}")
+
+    # Populate the light_component_id_pair value so that it can be used to select all Light component options.
+    light_component_id_pair = None
+    component_type_id_list = azlmbr.editor.EditorComponentAPIBus(
+        azlmbr.bus.Broadcast, 'FindComponentTypeIdsByEntityType', [light_component], 0)
+    general.log(f"Components found = {len(component_type_id_list)}")
+    if len(component_type_id_list) < 1:
+        general.log(f"ERROR: A component class with name {light_component} doesn't exist")
+        light_component_id_pair = None
+    elif len(component_type_id_list) > 1:
+        general.log(f"ERROR: Found more than one component classes with same name: {light_component}")
+        light_component_id_pair = None
+    entity_component_id_pair = azlmbr.editor.EditorComponentAPIBus(
+        azlmbr.bus.Broadcast, 'GetComponentOfType', light_entity.id, component_type_id_list[0])
+    if entity_component_id_pair.IsSuccess():
+        light_component_id_pair = entity_component_id_pair.GetValue()
+
+    # Test each Light component option can be selected.
+    light_type_property = 'Controller|Configuration|Light type'
+    for light_type in LIGHT_TYPES:
+        current_light_type = light_type
+        azlmbr.editor.EditorComponentAPIBus(
+            azlmbr.bus.Broadcast,
+            'SetComponentProperty',
+            light_component_id_pair,
+            light_type_property,
+            current_light_type
+        )
+
+        property_value = editor.EditorComponentAPIBus(
+            bus.Broadcast, "GetComponentProperty", light_entity.components[0], light_type_property).GetValue()
+        general.log(f"{light_entity_name}_test: Property value is {property_value} which matches {current_light_type}")
+
+    general.log("Light component test (non-GPU) completed.")
+
+
+if __name__ == "__main__":
+    run()

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomEditorComponents_LightComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomEditorComponents_LightComponent.py
@@ -85,7 +85,7 @@ def run():
     # Create a "light_entity" entity with "Light" component.
     light_entity_name = "light_entity"
     light_component = "Light"
-    light_entity = hydra.Entity(f"{light_entity_name}")
+    light_entity = hydra.Entity(light_entity_name)
     light_entity.create_entity(math.Vector3(-1.0, -2.0, 3.0), [light_component])
     general.log(
         f"{light_entity_name}_test: Component added to the entity: "
@@ -95,7 +95,6 @@ def run():
     light_component_id_pair = None
     component_type_id_list = azlmbr.editor.EditorComponentAPIBus(
         azlmbr.bus.Broadcast, 'FindComponentTypeIdsByEntityType', [light_component], 0)
-    general.log(f"Components found = {len(component_type_id_list)}")
     if len(component_type_id_list) < 1:
         general.log(f"ERROR: A component class with name {light_component} doesn't exist")
         light_component_id_pair = None
@@ -109,9 +108,8 @@ def run():
 
     # Test each Light component option can be selected and it's properties updated.
     # Point (sphere) light type checks.
-    sphere_light_type = LIGHT_TYPES[1]
     light_type_property_test(
-        light_type=sphere_light_type,
+        light_type=LIGHT_TYPES['sphere'],
         light_properties=SPHERE_AND_SPOT_DISK_LIGHT_PROPERTIES,
         light_component_id_pair=light_component_id_pair,
         light_entity_name=light_entity_name,
@@ -119,9 +117,8 @@ def run():
     )
 
     # Spot (disk) light type checks.
-    spot_disk_light_type = LIGHT_TYPES[2]
     light_type_property_test(
-        light_type=spot_disk_light_type,
+        light_type=LIGHT_TYPES['spot_disk'],
         light_properties=SPHERE_AND_SPOT_DISK_LIGHT_PROPERTIES,
         light_component_id_pair=light_component_id_pair,
         light_entity_name=light_entity_name,
@@ -129,25 +126,23 @@ def run():
     )
 
     # Capsule light type checks.
-    capsule_light_type = LIGHT_TYPES[3]
     azlmbr.editor.EditorComponentAPIBus(
         azlmbr.bus.Broadcast,
         'SetComponentProperty',
         light_component_id_pair,
         LIGHT_TYPE_PROPERTY,
-        capsule_light_type
+        LIGHT_TYPES['capsule']
     )
     verify_required_component_property_value(
         entity_name=light_entity_name,
         component=light_entity.components[0],
         property_path=LIGHT_TYPE_PROPERTY,
-        expected_property_value=capsule_light_type
+        expected_property_value=LIGHT_TYPES['capsule']
     )
 
     # Quad light type checks.
-    quad_light_type = LIGHT_TYPES[4]
     light_type_property_test(
-        light_type=quad_light_type,
+        light_type=LIGHT_TYPES['quad'],
         light_properties=QUAD_LIGHT_PROPERTIES,
         light_component_id_pair=light_component_id_pair,
         light_entity_name=light_entity_name,
@@ -155,25 +150,23 @@ def run():
     )
 
     # Polygon light type checks.
-    polygon_light_type = LIGHT_TYPES[5]
     azlmbr.editor.EditorComponentAPIBus(
         azlmbr.bus.Broadcast,
         'SetComponentProperty',
         light_component_id_pair,
         LIGHT_TYPE_PROPERTY,
-        polygon_light_type
+        LIGHT_TYPES['polygon']
     )
     verify_required_component_property_value(
         entity_name=light_entity_name,
         component=light_entity.components[0],
         property_path=LIGHT_TYPE_PROPERTY,
-        expected_property_value=polygon_light_type
+        expected_property_value=LIGHT_TYPES['polygon']
     )
 
     # Point (simple punctual) light type checks.
-    simple_point_light = LIGHT_TYPES[6]
     light_type_property_test(
-        light_type=simple_point_light,
+        light_type=LIGHT_TYPES['simple_point'],
         light_properties=SIMPLE_POINT_LIGHT_PROPERTIES,
         light_component_id_pair=light_component_id_pair,
         light_entity_name=light_entity_name,
@@ -181,9 +174,8 @@ def run():
     )
 
     # Spot (simple punctual) light type checks.
-    simple_spot_light = LIGHT_TYPES[7]
     light_type_property_test(
-        light_type=simple_spot_light,
+        light_type=LIGHT_TYPES['simple_spot'],
         light_properties=SIMPLE_SPOT_LIGHT_PROPERTIES,
         light_component_id_pair=light_component_id_pair,
         light_entity_name=light_entity_name,

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_utils/atom_component_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_utils/atom_component_helper.py
@@ -7,13 +7,13 @@ File to assist with common hydra component functions or constants used across va
 """
 
 # Light type options for the Light component.
-LIGHT_TYPES = [
-    0,  # UNKNOWN
-    1,  # SPHERE
-    2,  # SPOTDISK
-    3,  # CAPSULE
-    4,  # QUAD
-    5,  # POLYGON
-    6,  # SIMPLEPOINT
-    7,  # SIMPLESPOT
-]
+LIGHT_TYPES = {
+    'unknown': 0,
+    'sphere': 1,
+    'spot_disk': 2,
+    'capsule': 3,
+    'quad': 4,
+    'polygon': 5,
+    'simple_point': 6,
+    'simple_spot': 7,
+}

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_utils/atom_component_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_utils/atom_component_helper.py
@@ -1,0 +1,19 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+File to assist with common hydra component functions or constants used across various Atom tests.
+"""
+
+# Light type options for the Light component.
+LIGHT_TYPES = [
+    0,  # UNKNOWN
+    1,  # SPHERE
+    2,  # SPOTDISK
+    3,  # CAPSULE
+    4,  # QUAD
+    5,  # POLYGON
+    6,  # SIMPLEPOINT
+    7,  # SIMPLESPOT
+]

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -12,9 +12,10 @@ import os
 import pytest
 
 import editor_python_test_tools.hydra_test_utils as hydra
+from atom_renderer.atom_utils.atom_component_helper import LIGHT_TYPES
 
 logger = logging.getLogger(__name__)
-EDITOR_TIMEOUT = 300
+EDITOR_TIMEOUT = 120
 TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "atom_hydra_scripts")
 
 
@@ -173,6 +174,55 @@ class TestAtomEditorComponentsMain(object):
             TEST_DIRECTORY,
             editor,
             "hydra_AtomEditorComponents_AddedToEntity.py",
+            timeout=EDITOR_TIMEOUT,
+            expected_lines=expected_lines,
+            unexpected_lines=unexpected_lines,
+            halt_on_unexpected=True,
+            null_renderer=True,
+            cfg_args=cfg_args,
+        )
+
+    def test_AtomEditorComponents_LightComponent(
+            self, request, editor, workspace, project, launcher_platform, level):
+        """
+        Please review the hydra script run by this test for more specific test info.
+        Tests that the Light component has the expected property options available to it.
+        """
+        cfg_args = [level]
+
+        sphere_light_type = LIGHT_TYPES[1]
+        spot_disk_light_type = LIGHT_TYPES[2]
+        capsule_light_type = LIGHT_TYPES[3]
+        quad_light_type = LIGHT_TYPES[4]
+        polygon_light_type = LIGHT_TYPES[5]
+        simple_point_light = LIGHT_TYPES[6]
+        simple_spot_light = LIGHT_TYPES[7]
+
+        expected_lines = [
+            "light_entity Entity successfully created",
+            "light_entity_test: Component added to the entity: True",
+            f"light_entity_test: Property value is {capsule_light_type} which matches {capsule_light_type}",
+            f"light_entity_test: Property value is {spot_disk_light_type} which matches {spot_disk_light_type}",
+            f"light_entity_test: Property value is {sphere_light_type} which matches {sphere_light_type}",
+            f"light_entity_test: Property value is {quad_light_type} which matches {quad_light_type}",
+            f"light_entity_test: Property value is {polygon_light_type} which matches {polygon_light_type}",
+            f"light_entity_test: Property value is {simple_point_light} which matches {simple_point_light}",
+            f"light_entity_test: Property value is {simple_spot_light} which matches {simple_spot_light}",
+            "light_entity_test: Component added to the entity: True",
+            "Light component test (non-GPU) completed.",
+        ]
+
+        unexpected_lines = [
+            "Trace::Assert",
+            "Trace::Error",
+            "Traceback (most recent call last):",
+        ]
+
+        hydra.launch_and_validate_results(
+            request,
+            TEST_DIRECTORY,
+            editor,
+            "hydra_AtomEditorComponents_LightComponent.py",
             timeout=EDITOR_TIMEOUT,
             expected_lines=expected_lines,
             unexpected_lines=unexpected_lines,

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -190,19 +190,11 @@ class TestAtomEditorComponentsMain(object):
         """
         cfg_args = [level]
 
-        sphere_light_type = LIGHT_TYPES[1]
-        spot_disk_light_type = LIGHT_TYPES[2]
-        capsule_light_type = LIGHT_TYPES[3]
-        quad_light_type = LIGHT_TYPES[4]
-        polygon_light_type = LIGHT_TYPES[5]
-        simple_point_light = LIGHT_TYPES[6]
-        simple_spot_light = LIGHT_TYPES[7]
-
         expected_lines = [
             "light_entity Entity successfully created",
             "Entity has a Light component",
             "light_entity_test: Component added to the entity: True",
-            f"light_entity_test: Property value is {sphere_light_type} which matches {sphere_light_type}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['sphere']} which matches {LIGHT_TYPES['sphere']}",
             "Controller|Configuration|Shadows|Enable shadow set to True",
             "light_entity Controller|Configuration|Shadows|Shadowmap size: SUCCESS",
             "Controller|Configuration|Shadows|Shadow filter method set to 1",  # PCF
@@ -214,16 +206,18 @@ class TestAtomEditorComponentsMain(object):
             "Controller|Configuration|Shadows|ESM exponent set to 50.0",
             "Controller|Configuration|Shadows|ESM exponent set to 5000.0",
             "Controller|Configuration|Shadows|Shadow filter method set to 3",  # ESM+PCF
-            f"light_entity_test: Property value is {spot_disk_light_type} which matches {spot_disk_light_type}",
-            f"light_entity_test: Property value is {capsule_light_type} which matches {capsule_light_type}",
-            f"light_entity_test: Property value is {quad_light_type} which matches {quad_light_type}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['spot_disk']} which matches {LIGHT_TYPES['spot_disk']}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['capsule']} which matches {LIGHT_TYPES['capsule']}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['quad']} which matches {LIGHT_TYPES['quad']}",
             "light_entity Controller|Configuration|Fast approximation: SUCCESS",
             "light_entity Controller|Configuration|Both directions: SUCCESS",
-            f"light_entity_test: Property value is {polygon_light_type} which matches {polygon_light_type}",
-            f"light_entity_test: Property value is {simple_point_light} which matches {simple_point_light}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['polygon']} which matches {LIGHT_TYPES['polygon']}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['simple_point']} "
+            f"which matches {LIGHT_TYPES['simple_point']}",
             "Controller|Configuration|Attenuation radius|Mode set to 0",
             "Controller|Configuration|Attenuation radius|Radius set to 100.0",
-            f"light_entity_test: Property value is {simple_spot_light} which matches {simple_spot_light}",
+            f"light_entity_test: Property value is {LIGHT_TYPES['simple_spot']} "
+            f"which matches {LIGHT_TYPES['simple_spot']}",
             "Controller|Configuration|Shutters|Outer angle set to 45.0",
             "Controller|Configuration|Shutters|Outer angle set to 90.0",
             "light_entity_test: Component added to the entity: True",

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -200,14 +200,32 @@ class TestAtomEditorComponentsMain(object):
 
         expected_lines = [
             "light_entity Entity successfully created",
+            "Entity has a Light component",
             "light_entity_test: Component added to the entity: True",
-            f"light_entity_test: Property value is {capsule_light_type} which matches {capsule_light_type}",
-            f"light_entity_test: Property value is {spot_disk_light_type} which matches {spot_disk_light_type}",
             f"light_entity_test: Property value is {sphere_light_type} which matches {sphere_light_type}",
+            "Controller|Configuration|Shadows|Enable shadow set to True",
+            "light_entity Controller|Configuration|Shadows|Shadowmap size: SUCCESS",
+            "Controller|Configuration|Shadows|Shadow filter method set to 1",  # PCF
+            "Controller|Configuration|Shadows|Filtering sample count set to 4",
+            "Controller|Configuration|Shadows|Filtering sample count set to 64",
+            "Controller|Configuration|Shadows|PCF method set to 0",
+            "Controller|Configuration|Shadows|PCF method set to 1",
+            "Controller|Configuration|Shadows|Shadow filter method set to 2",  # ESM
+            "Controller|Configuration|Shadows|ESM exponent set to 50.0",
+            "Controller|Configuration|Shadows|ESM exponent set to 5000.0",
+            "Controller|Configuration|Shadows|Shadow filter method set to 3",  # ESM+PCF
+            f"light_entity_test: Property value is {spot_disk_light_type} which matches {spot_disk_light_type}",
+            f"light_entity_test: Property value is {capsule_light_type} which matches {capsule_light_type}",
             f"light_entity_test: Property value is {quad_light_type} which matches {quad_light_type}",
+            "light_entity Controller|Configuration|Fast approximation: SUCCESS",
+            "light_entity Controller|Configuration|Both directions: SUCCESS",
             f"light_entity_test: Property value is {polygon_light_type} which matches {polygon_light_type}",
             f"light_entity_test: Property value is {simple_point_light} which matches {simple_point_light}",
+            "Controller|Configuration|Attenuation radius|Mode set to 0",
+            "Controller|Configuration|Attenuation radius|Radius set to 100.0",
             f"light_entity_test: Property value is {simple_spot_light} which matches {simple_spot_light}",
+            "Controller|Configuration|Shutters|Outer angle set to 45.0",
+            "Controller|Configuration|Shutters|Outer angle set to 90.0",
             "light_entity_test: Component added to the entity: True",
             "Light component test (non-GPU) completed.",
         ]

--- a/Gems/Vegetation/Code/Source/Editor/EditorSpawnerComponent.h
+++ b/Gems/Vegetation/Code/Source/Editor/EditorSpawnerComponent.h
@@ -29,6 +29,6 @@ namespace Vegetation
         static constexpr const char* const s_componentDescription = "Creates dynamic vegetation in a specified area";
         static constexpr const char* const s_icon = "Editor/Icons/Components/Vegetation.svg";
         static constexpr const char* const s_viewportIcon = "Editor/Icons/Components/Viewport/Vegetation.svg";
-        static constexpr const char* const s_helpUrl = "https://o3de.org/docs/user-guide/components/reference/vegetation-layer-spawner/";
+        static constexpr const char* const s_helpUrl = "https://o3de.org/docs/user-guide/components/reference/vegetation/layer-spawner/";
     };
 }


### PR DESCRIPTION
- Work is ongoing to move the tests over.
- The GPU and non-GPU portions of this test are being split up. This PR is for the non-GPU portion.
- Sample test pass output:
```
31878.682851791382 - INFO - [MainThread] - ly_test_tools.log.log_monitor - Finished log monitoring for '120' seconds, validating results.
expected_lines_not_found: []
 unexpected_lines_found: []
31882.710695266724 - INFO - [MainThread] - ly_test_tools.log.log_monitor - LogMonitor Result:
--- Expected lines ---
[ FOUND ] light_entity Entity successfully created
[ FOUND ] Entity has a Light component
[ FOUND ] light_entity_test: Component added to the entity: True
[ FOUND ] light_entity_test: Property value is 1 which matches 1
[ FOUND ] Controller|Configuration|Shadows|Enable shadow set to True
[ FOUND ] light_entity Controller|Configuration|Shadows|Shadowmap size: SUCCESS
[ FOUND ] Controller|Configuration|Shadows|Shadow filter method set to 1
[ FOUND ] Controller|Configuration|Shadows|Filtering sample count set to 4
[ FOUND ] Controller|Configuration|Shadows|Filtering sample count set to 64
[ FOUND ] Controller|Configuration|Shadows|PCF method set to 0
[ FOUND ] Controller|Configuration|Shadows|PCF method set to 1
[ FOUND ] Controller|Configuration|Shadows|Shadow filter method set to 2
[ FOUND ] Controller|Configuration|Shadows|ESM exponent set to 50.0
[ FOUND ] Controller|Configuration|Shadows|ESM exponent set to 5000.0
[ FOUND ] Controller|Configuration|Shadows|Shadow filter method set to 3
[ FOUND ] light_entity_test: Property value is 2 which matches 2
[ FOUND ] light_entity_test: Property value is 3 which matches 3
[ FOUND ] light_entity_test: Property value is 4 which matches 4
[ FOUND ] light_entity Controller|Configuration|Fast approximation: SUCCESS
[ FOUND ] light_entity Controller|Configuration|Both directions: SUCCESS
[ FOUND ] light_entity_test: Property value is 5 which matches 5
[ FOUND ] light_entity_test: Property value is 6 which matches 6
[ FOUND ] Controller|Configuration|Attenuation radius|Mode set to 0
[ FOUND ] Controller|Configuration|Attenuation radius|Radius set to 100.0
[ FOUND ] light_entity_test: Property value is 7 which matches 7
[ FOUND ] Controller|Configuration|Shutters|Outer angle set to 45.0
[ FOUND ] Controller|Configuration|Shutters|Outer angle set to 90.0
[ FOUND ] light_entity_test: Component added to the entity: True
[ FOUND ] Light component test (non-GPU) completed.
Found 29/29 expected lines
== 1 passed, 1 deselected in 33.14s ==
```