### PR TITLE
Visualizer: switch to erase_if to improve performance

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.inl
@@ -520,13 +520,14 @@ namespace AZ
             {
                 AZStd::size_t sizeBeforeRemove = savedRegions.size();
 
-                auto firstRegionToKeep = AZStd::lower_bound(
-                    savedRegions.begin(), savedRegions.end(), deleteBeforeTick,
-                    [](const TimeRegion& region, AZStd::sys_time_t target)
+                // Use erase_if over plain upper_bound + erase to avoid repeated shifts. erase requires a shift of all elements to the right
+                // for each element that is erased, while erase_if squashes all removes into a single shift which significantly improves perf.
+                AZStd::erase_if(
+                    savedRegions,
+                    [deleteBeforeTick](const TimeRegion& region)
                     {
-                        return region.m_startTick < target;
+                        return region.m_startTick < deleteBeforeTick;
                     });
-                savedRegions.erase(savedRegions.begin(), firstRegionToKeep);
 
                 m_savedRegionCount -= sizeBeforeRemove - savedRegions.size();
             }


### PR DESCRIPTION
## Please start a [build](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-2779/) and request @o3de/sig-presentation 

The main performance impact of the CPU visualizer widget was caused by calling `vec.erase()` on the front of a large vector (500k+ entries). We can switch to using `erase_if` (which calls `erase` + `remove_if` internally) to improve performance by avoiding repeated shifts of elements in the vector. 

### Profiling (tested in ShadowedSponza sample at default settings)
Erase + lower_bound:
- 250k: 0.57 ms avg / call  
- 500k: 1.09 ms avg / call   
- 1mil: 2.19 ms avg / call   
- 1.5mil: 3.25 ms avg / call  


Erase_if:
- 250k: 0.34 ms avg / call   
- 500k: 0.61 ms avg / call   
- 1mil: 1.31 ms avg / call   
- 1.5mil: 1.87 ms avg / call   



