### PR TITLE
performance metrics: Upload benchmark results to local index for locally-run builds.

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/benchmark/data_aggregator.py
+++ b/Tools/LyTestTools/ly_test_tools/benchmark/data_aggregator.py
@@ -10,6 +10,7 @@ import json
 from pathlib import Path
 import time
 import subprocess
+import os
 
 from ly_test_tools.mars.filebeat_client import FilebeatClient
 
@@ -21,7 +22,7 @@ class BenchmarkDataAggregator(object):
     def __init__(self, workspace, logger, test_suite):
         self.build_dir = workspace.paths.build_directory()
         self.results_dir = Path(workspace.paths.project(), 'user/Scripts/PerformanceBenchmarks')
-        self.test_suite = test_suite
+        self.test_suite = test_suite if os.environ.get('CI') else 'local'
         self.filebeat_client = FilebeatClient(logger)
 
     def _update_pass(self, pass_stats, entry):


### PR DESCRIPTION
`CI` should be set to true in Jenkins-based builds, and false if run locally, according to https://jenkins.build.o3de.org/env-vars.html/

Should consider if we want some other identifier in the Elasticsearch index so different developers don't conflate their build results with others run on the same day.