### PR TITLE
[LYN-5268] Copy resource mapping tool to install target and add argument for log path

### DIFF
--- a/Gems/AWSCore/Code/CMakeLists.txt
+++ b/Gems/AWSCore/Code/CMakeLists.txt
@@ -166,3 +166,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         )
     endif()
 endif()
+
+install(DIRECTORY "Tools/ResourceMappingTool"
+    DESTINATION "Gems/AWSCore/Code/Tools"
+    PATTERN "__pycache__" EXCLUDE
+)

--- a/Gems/AWSCore/Code/CMakeLists.txt
+++ b/Gems/AWSCore/Code/CMakeLists.txt
@@ -169,5 +169,6 @@ endif()
 
 install(DIRECTORY "Tools/ResourceMappingTool"
     DESTINATION "Gems/AWSCore/Code/Tools"
+    COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     PATTERN "__pycache__" EXCLUDE
 )

--- a/Gems/AWSCore/Code/Include/Private/AWSCoreInternalBus.h
+++ b/Gems/AWSCore/Code/Include/Private/AWSCoreInternalBus.h
@@ -34,11 +34,6 @@ namespace AWSCore
         //! @return The path of AWS resource mapping config file
         virtual AZStd::string GetResourceMappingConfigFilePath() const = 0;
 
-        //! GetResourceMappingConfigFolderPath
-        //! Get the path of AWS resource mapping config folder
-        //! @return The path of AWS resource mapping config folder
-        virtual AZStd::string GetResourceMappingConfigFolderPath() const = 0;
-
         //! ReloadConfiguration
         //! Reload AWSCore configuration without restarting application
         virtual void ReloadConfiguration() = 0;

--- a/Gems/AWSCore/Code/Include/Private/Configuration/AWSCoreConfiguration.h
+++ b/Gems/AWSCore/Code/Include/Private/Configuration/AWSCoreConfiguration.h
@@ -50,7 +50,6 @@ namespace AWSCore
 
         // AWSCoreInternalRequestBus interface implementation
         AZStd::string GetResourceMappingConfigFilePath() const override;
-        AZStd::string GetResourceMappingConfigFolderPath() const override;
         AZStd::string GetProfileName() const override;
         void ReloadConfiguration() override;
 

--- a/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreResourceMappingToolAction.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreResourceMappingToolAction.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/std/string/string.h>
 
 #include <QAction>
@@ -33,12 +34,11 @@ namespace AWSCore
 
     private:
         bool m_isDebug;
-        AZStd::string m_enginePythonEntryPath;
-        AZStd::string m_toolScriptPath;
-        AZStd::string m_toolQtBinDirectoryPath;
-
-        AZStd::string m_toolLogDirectoryPath;
-        AZStd::string m_toolConfigDirectoryPath;
-        AZStd::string m_toolReadMePath;
+        AZ::IO::Path m_enginePythonEntryPath;
+        AZ::IO::Path m_toolScriptPath;
+        AZ::IO::Path m_toolQtBinDirectoryPath;
+        AZ::IO::Path m_toolLogDirectoryPath;
+        AZ::IO::Path m_toolConfigDirectoryPath;
+        AZ::IO::Path m_toolReadMePath;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreResourceMappingToolAction.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreResourceMappingToolAction.h
@@ -10,6 +10,7 @@
 #include <AzCore/std/string/string.h>
 
 #include <QAction>
+#include <QObject>
 
 namespace AWSCore
 {
@@ -17,13 +18,17 @@ namespace AWSCore
         : public QAction
     {
     public:
+        static constexpr const char AWSCoreResourceMappingToolActionName[] = "AWSCoreResourceMappingToolAction";
         static constexpr const char ResourceMappingToolDirectoryPath[] = "Gems/AWSCore/Code/Tools/ResourceMappingTool";
+        static constexpr const char ResourceMappingToolLogDirectoryPath[] = "user/log/";
         static constexpr const char EngineWindowsPythonEntryScriptPath[] = "python/python.cmd";
 
-        AWSCoreResourceMappingToolAction(const QString& text);
+        AWSCoreResourceMappingToolAction(const QString& text, QObject* parent = nullptr);
+
+        void InitAWSCoreResourceMappingToolAction();
 
         AZStd::string GetToolLaunchCommand() const;
-        AZStd::string GetToolLogPath() const;
+        AZStd::string GetToolLogFilePath() const;
         AZStd::string GetToolReadMePath() const;
 
     private:
@@ -32,7 +37,8 @@ namespace AWSCore
         AZStd::string m_toolScriptPath;
         AZStd::string m_toolQtBinDirectoryPath;
 
-        AZStd::string m_toolLogPath;
+        AZStd::string m_toolLogDirectoryPath;
+        AZStd::string m_toolConfigDirectoryPath;
         AZStd::string m_toolReadMePath;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
+++ b/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
@@ -56,19 +56,6 @@ namespace AWSCore
         return configFilePath;
     }
 
-    AZStd::string AWSCoreConfiguration::GetResourceMappingConfigFolderPath() const
-    {
-        if (m_sourceProjectFolder.empty())
-        {
-            AZ_Warning(AWSCoreConfigurationName, false, ProjectSourceFolderNotFoundErrorMessage);
-            return "";
-        }
-        AZStd::string configFolderPath = AZStd::string::format(
-            "%s/%s", m_sourceProjectFolder.c_str(), AWSCoreResourceMappingConfigFolderName);
-        AzFramework::StringFunc::Path::Normalize(configFolderPath);
-        return configFolderPath;
-    }
-
     void AWSCoreConfiguration::InitConfig()
     {
         InitSourceProjectFolderPath();

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
@@ -80,7 +80,7 @@ namespace AWSCore
     {
 #ifdef AWSCORE_EDITOR_RESOURCE_MAPPING_TOOL_ENABLED
         AWSCoreResourceMappingToolAction* resourceMappingTool =
-            new AWSCoreResourceMappingToolAction(QObject::tr(AWSResourceMappingToolActionText));
+            new AWSCoreResourceMappingToolAction(QObject::tr(AWSResourceMappingToolActionText), this);
         QObject::connect(resourceMappingTool, &QAction::triggered, this,
             [resourceMappingTool, this]() {
                 AZStd::string launchCommand = resourceMappingTool->GetToolLaunchCommand();
@@ -109,7 +109,7 @@ namespace AWSCore
 
                 if (!m_resourceMappingToolWatcher || !m_resourceMappingToolWatcher->IsProcessRunning())
                 {
-                    AZStd::string resourceMappingToolLogPath = resourceMappingTool->GetToolLogPath();
+                    AZStd::string resourceMappingToolLogPath = resourceMappingTool->GetToolLogFilePath();
                     AZStd::string message = AZStd::string::format(AWSResourceMappingToolLogWarningText, resourceMappingToolLogPath.c_str());
                     QMessageBox::warning(QApplication::activeWindow(), "Warning", message.c_str(), QMessageBox::Ok);
                 }

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreResourceMappingToolAction.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreResourceMappingToolAction.cpp
@@ -11,124 +11,141 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 
 #include <AWSCoreInternalBus.h>
+#include <Configuration/AWSCoreConfiguration.h>
 #include <Editor/UI/AWSCoreResourceMappingToolAction.h>
 
 namespace AWSCore
 {
-    AWSCoreResourceMappingToolAction::AWSCoreResourceMappingToolAction(const QString& text)
-        : QAction(text)
+    AWSCoreResourceMappingToolAction::AWSCoreResourceMappingToolAction(const QString& text, QObject* parent)
+        : QAction(text, parent)
         , m_isDebug(false)
         , m_enginePythonEntryPath("")
         , m_toolScriptPath("")
         , m_toolQtBinDirectoryPath("")
-        , m_toolLogPath("")
+        , m_toolLogDirectoryPath("")
+        , m_toolConfigDirectoryPath("")
         , m_toolReadMePath("")
     {
-        auto engineRootPath = AZ::IO::FileIOBase::GetInstance()->GetAlias("@engroot@");
-        if (!engineRootPath)
+        InitAWSCoreResourceMappingToolAction();
+    }
+
+    void AWSCoreResourceMappingToolAction::InitAWSCoreResourceMappingToolAction()
+    {
+        auto engineRootPath = AZ::Utils::GetEnginePath();
+
+        m_enginePythonEntryPath = AZStd::string::format("%s/%s", engineRootPath.c_str(), EngineWindowsPythonEntryScriptPath);
+        AzFramework::StringFunc::Path::Normalize(m_enginePythonEntryPath);
+        if (!AZ::IO::SystemFile::Exists(m_enginePythonEntryPath.c_str()))
         {
-            AZ_Error("AWSCoreEditor", false, "Failed to determine engine root path.");
+            AZ_Error(
+                AWSCoreResourceMappingToolActionName, false, "Failed to find engine python entry at %s.", m_enginePythonEntryPath.c_str());
+            m_enginePythonEntryPath.clear();
+        }
+
+        m_toolScriptPath =
+            AZStd::string::format("%s/%s/resource_mapping_tool.py", engineRootPath.c_str(), ResourceMappingToolDirectoryPath);
+        AzFramework::StringFunc::Path::Normalize(m_toolScriptPath);
+        if (!AZ::IO::SystemFile::Exists(m_toolScriptPath.c_str()))
+        {
+            AZ_Error(
+                AWSCoreResourceMappingToolActionName, false, "Failed to find ResourceMappingTool python script at %s.",
+                m_toolScriptPath.c_str());
+            m_toolScriptPath.clear();
+        }
+
+        auto projectPath = AZ::Utils::GetProjectPath();
+        m_toolLogDirectoryPath = AZStd::string::format("%s/%s", projectPath.c_str(), ResourceMappingToolLogDirectoryPath);
+        AzFramework::StringFunc::Path::Normalize(m_toolLogDirectoryPath);
+
+        m_toolConfigDirectoryPath =
+            AZStd::string::format("%s/%s", projectPath.c_str(), AWSCoreConfiguration::AWSCoreResourceMappingConfigFolderName);
+        AzFramework::StringFunc::Path::Normalize(m_toolConfigDirectoryPath);
+
+        m_toolReadMePath = AZStd::string::format("%s/%s/README.md", engineRootPath.c_str(), ResourceMappingToolDirectoryPath);
+        AzFramework::StringFunc::Path::Normalize(m_toolReadMePath);
+        if (!AZ::IO::SystemFile::Exists(m_toolReadMePath.c_str()))
+        {
+            AZ_Error(
+                AWSCoreResourceMappingToolActionName, false, "Failed to find ResourceMappingTool README file at %s.",
+                m_toolReadMePath.c_str());
+            m_toolReadMePath.clear();
+        }
+
+        char executablePath[AZ_MAX_PATH_LEN];
+        auto result = AZ::Utils::GetExecutablePath(executablePath, AZ_MAX_PATH_LEN);
+        if (result.m_pathStored != AZ::Utils::ExecutablePathResult::Success)
+        {
+            AZ_Error(AWSCoreResourceMappingToolActionName, false, "Failed to find engine executable path.");
         }
         else
         {
-            m_enginePythonEntryPath = AZStd::string::format("%s/%s", engineRootPath, EngineWindowsPythonEntryScriptPath);
-            AzFramework::StringFunc::Path::Normalize(m_enginePythonEntryPath);
-            if (!AZ::IO::SystemFile::Exists(m_enginePythonEntryPath.c_str()))
+            if (result.m_pathIncludesFilename)
             {
-                AZ_Error("AWSCoreEditor", false, "Failed to find engine python entry at %s.", m_enginePythonEntryPath.c_str());
-                m_enginePythonEntryPath.clear();
-            }
-
-            m_toolScriptPath = AZStd::string::format("%s/%s/resource_mapping_tool.py", engineRootPath, ResourceMappingToolDirectoryPath);
-            AzFramework::StringFunc::Path::Normalize(m_toolScriptPath);
-            if (!AZ::IO::SystemFile::Exists(m_toolScriptPath.c_str()))
-            {
-                AZ_Error("AWSCoreEditor", false, "Failed to find ResourceMappingTool python script at %s.", m_toolScriptPath.c_str());
-                m_toolScriptPath.clear();
-            }
-
-            m_toolLogPath = AZStd::string::format("%s/%s/resource_mapping_tool.log", engineRootPath, ResourceMappingToolDirectoryPath);
-            AzFramework::StringFunc::Path::Normalize(m_toolLogPath);
-            if (!AZ::IO::SystemFile::Exists(m_toolLogPath.c_str()))
-            {
-                AZ_Error("AWSCoreEditor", false, "Failed to find ResourceMappingTool log file at %s.", m_toolLogPath.c_str());
-                m_toolLogPath.clear();
-            }
-
-            m_toolReadMePath = AZStd::string::format("%s/%s/README.md", engineRootPath, ResourceMappingToolDirectoryPath);
-            AzFramework::StringFunc::Path::Normalize(m_toolReadMePath);
-            if (!AZ::IO::SystemFile::Exists(m_toolReadMePath.c_str()))
-            {
-                AZ_Error("AWSCoreEditor", false, "Failed to find ResourceMappingTool README file at %s.", m_toolReadMePath.c_str());
-                m_toolReadMePath.clear();
-            }
-
-            char executablePath[AZ_MAX_PATH_LEN];
-            auto result = AZ::Utils::GetExecutablePath(executablePath, AZ_MAX_PATH_LEN);
-            if (result.m_pathStored != AZ::Utils::ExecutablePathResult::Success)
-            {
-                AZ_Error("AWSCoreEditor", false, "Failed to find engine executable path.");
-            }
-            else
-            {
-                if (result.m_pathIncludesFilename)
+                // Remove the file name if it exists, and keep the parent folder only
+                char* lastSeparatorAddress = strrchr(executablePath, AZ_CORRECT_FILESYSTEM_SEPARATOR);
+                if (lastSeparatorAddress)
                 {
-                    // Remove the file name if it exists, and keep the parent folder only
-                    char* lastSeparatorAddress = strrchr(executablePath, AZ_CORRECT_FILESYSTEM_SEPARATOR);
-                    if (lastSeparatorAddress)
-                    {
-                        *lastSeparatorAddress = '\0';
-                    }
+                    *lastSeparatorAddress = '\0';
                 }
             }
+        }
 
-            AZStd::string binDirectoryPath(executablePath);
-            auto lastSeparator = binDirectoryPath.find_last_of(AZ_CORRECT_FILESYSTEM_SEPARATOR);
-            if (lastSeparator != AZStd::string::npos)
-            {
-                m_isDebug = binDirectoryPath.substr(lastSeparator).contains("debug");
-            }
+        AZStd::string binDirectoryPath(executablePath);
+        auto lastSeparator = binDirectoryPath.find_last_of(AZ_CORRECT_FILESYSTEM_SEPARATOR);
+        if (lastSeparator != AZStd::string::npos)
+        {
+            m_isDebug = binDirectoryPath.substr(lastSeparator).contains("debug");
+        }
 
-            m_toolQtBinDirectoryPath = AZStd::string::format("%s/%s", binDirectoryPath.c_str(), "AWSCoreEditorQtBin");
-            AzFramework::StringFunc::Path::Normalize(m_toolQtBinDirectoryPath);
-            if (!AZ::IO::SystemFile::Exists(m_toolQtBinDirectoryPath.c_str()))
-            {
-                AZ_Error("AWSCoreEditor", false, "Failed to find ResourceMappingTool Qt binaries at %s.", m_toolQtBinDirectoryPath.c_str());
-                m_toolQtBinDirectoryPath.clear();
-            }
+        m_toolQtBinDirectoryPath = AZStd::string::format("%s/%s", binDirectoryPath.c_str(), "AWSCoreEditorQtBin");
+        AzFramework::StringFunc::Path::Normalize(m_toolQtBinDirectoryPath);
+        if (!AZ::IO::SystemFile::Exists(m_toolQtBinDirectoryPath.c_str()))
+        {
+            AZ_Error(
+                AWSCoreResourceMappingToolActionName, false, "Failed to find ResourceMappingTool Qt binaries at %s.",
+                m_toolQtBinDirectoryPath.c_str());
+            m_toolQtBinDirectoryPath.clear();
         }
     }
 
     AZStd::string AWSCoreResourceMappingToolAction::GetToolLaunchCommand() const
     {
-        if (m_enginePythonEntryPath.empty() || m_toolScriptPath.empty() || m_toolQtBinDirectoryPath.empty())
+        if (m_enginePythonEntryPath.empty() ||
+            m_toolScriptPath.empty() ||
+            m_toolQtBinDirectoryPath.empty() ||
+            m_toolConfigDirectoryPath.empty() ||
+            m_toolLogDirectoryPath.empty())
         {
+            AZ_Error(AWSCoreResourceMappingToolActionName, false,
+                "Failed to get tool launch command, engine python path: %s, tool script path: %s, tool qt binaries path: %s, tool config path: %s, tool log path: %s",
+                m_enginePythonEntryPath.c_str(), m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(), m_toolConfigDirectoryPath.c_str(), m_toolLogDirectoryPath.c_str());
             return "";
         }
 
         AZStd::string profileName = "default";
         AWSCoreInternalRequestBus::BroadcastResult(profileName, &AWSCoreInternalRequests::GetProfileName);
 
-        AZStd::string configPath = "";
-        AWSCoreInternalRequestBus::BroadcastResult(configPath, &AWSCoreInternalRequests::GetResourceMappingConfigFolderPath);
-
         if (m_isDebug)
         {
             return AZStd::string::format(
-                "%s debug %s --binaries_path %s --debug --profile %s --config_path %s", m_enginePythonEntryPath.c_str(),
-                m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(), profileName.c_str(), configPath.c_str());
+                "%s debug -B %s --binaries_path %s --debug --profile %s --config_path %s --log_path %s",
+                m_enginePythonEntryPath.c_str(), m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(),
+                profileName.c_str(), m_toolConfigDirectoryPath.c_str(), m_toolLogDirectoryPath.c_str());
         }
         else
         {
             return AZStd::string::format(
-                "%s %s --binaries_path %s --profile %s --config_path %s", m_enginePythonEntryPath.c_str(),
-                m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(), profileName.c_str(), configPath.c_str());
+                "%s -B %s --binaries_path %s --profile %s --config_path %s --log_path %s",
+                m_enginePythonEntryPath.c_str(), m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(),
+                profileName.c_str(), m_toolConfigDirectoryPath.c_str(), m_toolLogDirectoryPath.c_str());
         }
     }
 
-    AZStd::string AWSCoreResourceMappingToolAction::GetToolLogPath() const
+    AZStd::string AWSCoreResourceMappingToolAction::GetToolLogFilePath() const
     {
-        return m_toolLogPath;
+        AZStd::string toolLogFilePath = AZStd::string::format("%s/resource_mapping_tool.log", m_toolLogDirectoryPath.c_str());
+        AzFramework::StringFunc::Path::Normalize(toolLogFilePath);
+        return toolLogFilePath;
     }
 
     AZStd::string AWSCoreResourceMappingToolAction::GetToolReadMePath() const

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreResourceMappingToolAction.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreResourceMappingToolAction.cpp
@@ -6,9 +6,7 @@
  *
  */
 
-#include <AzCore/IO/FileIO.h>
 #include <AzCore/Utils/Utils.h>
-#include <AzFramework/StringFunc/StringFunc.h>
 
 #include <AWSCoreInternalBus.h>
 #include <Configuration/AWSCoreConfiguration.h>
@@ -31,93 +29,31 @@ namespace AWSCore
 
     void AWSCoreResourceMappingToolAction::InitAWSCoreResourceMappingToolAction()
     {
-        auto engineRootPath = AZ::Utils::GetEnginePath();
+        AZ::IO::Path engineRootPath = AZ::IO::PathView(AZ::Utils::GetEnginePath());
+        m_enginePythonEntryPath = (engineRootPath / EngineWindowsPythonEntryScriptPath).LexicallyNormal();
+        m_toolScriptPath = (engineRootPath / ResourceMappingToolDirectoryPath / "resource_mapping_tool.py").LexicallyNormal();
+        m_toolReadMePath = (engineRootPath / ResourceMappingToolDirectoryPath / "README.md").LexicallyNormal();
 
-        m_enginePythonEntryPath = AZStd::string::format("%s/%s", engineRootPath.c_str(), EngineWindowsPythonEntryScriptPath);
-        AzFramework::StringFunc::Path::Normalize(m_enginePythonEntryPath);
-        if (!AZ::IO::SystemFile::Exists(m_enginePythonEntryPath.c_str()))
-        {
-            AZ_Error(
-                AWSCoreResourceMappingToolActionName, false, "Failed to find engine python entry at %s.", m_enginePythonEntryPath.c_str());
-            m_enginePythonEntryPath.clear();
-        }
+        AZ::IO::Path projectPath = AZ::IO::PathView(AZ::Utils::GetProjectPath());
+        m_toolLogDirectoryPath = (projectPath / ResourceMappingToolLogDirectoryPath).LexicallyNormal();
+        m_toolConfigDirectoryPath = (projectPath / AWSCoreConfiguration::AWSCoreResourceMappingConfigFolderName).LexicallyNormal();
 
-        m_toolScriptPath =
-            AZStd::string::format("%s/%s/resource_mapping_tool.py", engineRootPath.c_str(), ResourceMappingToolDirectoryPath);
-        AzFramework::StringFunc::Path::Normalize(m_toolScriptPath);
-        if (!AZ::IO::SystemFile::Exists(m_toolScriptPath.c_str()))
-        {
-            AZ_Error(
-                AWSCoreResourceMappingToolActionName, false, "Failed to find ResourceMappingTool python script at %s.",
-                m_toolScriptPath.c_str());
-            m_toolScriptPath.clear();
-        }
+        AZ::IO::Path executablePath = AZ::IO::PathView(AZ::Utils::GetExecutableDirectory());
+        m_toolQtBinDirectoryPath = (executablePath / "AWSCoreEditorQtBin").LexicallyNormal();
 
-        auto projectPath = AZ::Utils::GetProjectPath();
-        m_toolLogDirectoryPath = AZStd::string::format("%s/%s", projectPath.c_str(), ResourceMappingToolLogDirectoryPath);
-        AzFramework::StringFunc::Path::Normalize(m_toolLogDirectoryPath);
-
-        m_toolConfigDirectoryPath =
-            AZStd::string::format("%s/%s", projectPath.c_str(), AWSCoreConfiguration::AWSCoreResourceMappingConfigFolderName);
-        AzFramework::StringFunc::Path::Normalize(m_toolConfigDirectoryPath);
-
-        m_toolReadMePath = AZStd::string::format("%s/%s/README.md", engineRootPath.c_str(), ResourceMappingToolDirectoryPath);
-        AzFramework::StringFunc::Path::Normalize(m_toolReadMePath);
-        if (!AZ::IO::SystemFile::Exists(m_toolReadMePath.c_str()))
-        {
-            AZ_Error(
-                AWSCoreResourceMappingToolActionName, false, "Failed to find ResourceMappingTool README file at %s.",
-                m_toolReadMePath.c_str());
-            m_toolReadMePath.clear();
-        }
-
-        char executablePath[AZ_MAX_PATH_LEN];
-        auto result = AZ::Utils::GetExecutablePath(executablePath, AZ_MAX_PATH_LEN);
-        if (result.m_pathStored != AZ::Utils::ExecutablePathResult::Success)
-        {
-            AZ_Error(AWSCoreResourceMappingToolActionName, false, "Failed to find engine executable path.");
-        }
-        else
-        {
-            if (result.m_pathIncludesFilename)
-            {
-                // Remove the file name if it exists, and keep the parent folder only
-                char* lastSeparatorAddress = strrchr(executablePath, AZ_CORRECT_FILESYSTEM_SEPARATOR);
-                if (lastSeparatorAddress)
-                {
-                    *lastSeparatorAddress = '\0';
-                }
-            }
-        }
-
-        AZStd::string binDirectoryPath(executablePath);
-        auto lastSeparator = binDirectoryPath.find_last_of(AZ_CORRECT_FILESYSTEM_SEPARATOR);
-        if (lastSeparator != AZStd::string::npos)
-        {
-            m_isDebug = binDirectoryPath.substr(lastSeparator).contains("debug");
-        }
-
-        m_toolQtBinDirectoryPath = AZStd::string::format("%s/%s", binDirectoryPath.c_str(), "AWSCoreEditorQtBin");
-        AzFramework::StringFunc::Path::Normalize(m_toolQtBinDirectoryPath);
-        if (!AZ::IO::SystemFile::Exists(m_toolQtBinDirectoryPath.c_str()))
-        {
-            AZ_Error(
-                AWSCoreResourceMappingToolActionName, false, "Failed to find ResourceMappingTool Qt binaries at %s.",
-                m_toolQtBinDirectoryPath.c_str());
-            m_toolQtBinDirectoryPath.clear();
-        }
+        m_isDebug = AZStd::string_view(AZ_BUILD_CONFIGURATION_TYPE) == "debug";
     }
 
     AZStd::string AWSCoreResourceMappingToolAction::GetToolLaunchCommand() const
     {
-        if (m_enginePythonEntryPath.empty() ||
-            m_toolScriptPath.empty() ||
-            m_toolQtBinDirectoryPath.empty() ||
-            m_toolConfigDirectoryPath.empty() ||
-            m_toolLogDirectoryPath.empty())
+        if (!AZ::IO::SystemFile::Exists(m_enginePythonEntryPath.c_str()) ||
+            !AZ::IO::SystemFile::Exists(m_toolScriptPath.c_str()) ||
+            !AZ::IO::SystemFile::Exists(m_toolQtBinDirectoryPath.c_str()) ||
+            !AZ::IO::SystemFile::Exists(m_toolConfigDirectoryPath.c_str()) ||
+            !AZ::IO::SystemFile::Exists(m_toolLogDirectoryPath.c_str()))
         {
             AZ_Error(AWSCoreResourceMappingToolActionName, false,
-                "Failed to get tool launch command, engine python path: %s, tool script path: %s, tool qt binaries path: %s, tool config path: %s, tool log path: %s",
+                "Expected parameter for tool launch command is invalid, engine python path: %s, tool script path: %s, tool qt binaries path: %s, tool config path: %s, tool log path: %s",
                 m_enginePythonEntryPath.c_str(), m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(), m_toolConfigDirectoryPath.c_str(), m_toolLogDirectoryPath.c_str());
             return "";
         }
@@ -128,14 +64,14 @@ namespace AWSCore
         if (m_isDebug)
         {
             return AZStd::string::format(
-                "%s debug -B %s --binaries_path %s --debug --profile %s --config_path %s --log_path %s",
+                "\"%s\" debug -B \"%s\" --binaries-path \"%s\" --debug --profile \"%s\" --config-path \"%s\" --log-path \"%s\"",
                 m_enginePythonEntryPath.c_str(), m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(),
                 profileName.c_str(), m_toolConfigDirectoryPath.c_str(), m_toolLogDirectoryPath.c_str());
         }
         else
         {
             return AZStd::string::format(
-                "%s -B %s --binaries_path %s --profile %s --config_path %s --log_path %s",
+                "\"%s\" -B \"%s\" --binaries-path \"%s\" --profile \"%s\" --config-path \"%s\" --log-path \"%s\"",
                 m_enginePythonEntryPath.c_str(), m_toolScriptPath.c_str(), m_toolQtBinDirectoryPath.c_str(),
                 profileName.c_str(), m_toolConfigDirectoryPath.c_str(), m_toolLogDirectoryPath.c_str());
         }
@@ -143,13 +79,22 @@ namespace AWSCore
 
     AZStd::string AWSCoreResourceMappingToolAction::GetToolLogFilePath() const
     {
-        AZStd::string toolLogFilePath = AZStd::string::format("%s/resource_mapping_tool.log", m_toolLogDirectoryPath.c_str());
-        AzFramework::StringFunc::Path::Normalize(toolLogFilePath);
-        return toolLogFilePath;
+        AZ::IO::Path toolLogFilePath = (m_toolLogDirectoryPath / "resource_mapping_tool.log").LexicallyNormal();
+        if (!AZ::IO::SystemFile::Exists(toolLogFilePath.c_str()))
+        {
+            AZ_Error(AWSCoreResourceMappingToolActionName, false, "Invalid tool log file path: %s", toolLogFilePath.c_str());
+            return "";
+        }
+        return toolLogFilePath.c_str();
     }
 
     AZStd::string AWSCoreResourceMappingToolAction::GetToolReadMePath() const
     {
-        return m_toolReadMePath;
+        if (!AZ::IO::SystemFile::Exists(m_toolReadMePath.c_str()))
+        {
+            AZ_Error(AWSCoreResourceMappingToolActionName, false, "Invalid tool readme path: %s", m_toolReadMePath.c_str());
+            return "";
+        }
+        return m_toolReadMePath.c_str();
     }
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreResourceMappingToolAction.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreResourceMappingToolAction.cpp
@@ -17,12 +17,6 @@ namespace AWSCore
     AWSCoreResourceMappingToolAction::AWSCoreResourceMappingToolAction(const QString& text, QObject* parent)
         : QAction(text, parent)
         , m_isDebug(false)
-        , m_enginePythonEntryPath("")
-        , m_toolScriptPath("")
-        , m_toolQtBinDirectoryPath("")
-        , m_toolLogDirectoryPath("")
-        , m_toolConfigDirectoryPath("")
-        , m_toolReadMePath("")
     {
         InitAWSCoreResourceMappingToolAction();
     }
@@ -85,7 +79,7 @@ namespace AWSCore
             AZ_Error(AWSCoreResourceMappingToolActionName, false, "Invalid tool log file path: %s", toolLogFilePath.c_str());
             return "";
         }
-        return toolLogFilePath.c_str();
+        return toolLogFilePath.Native();
     }
 
     AZStd::string AWSCoreResourceMappingToolAction::GetToolReadMePath() const
@@ -95,6 +89,6 @@ namespace AWSCore
             AZ_Error(AWSCoreResourceMappingToolActionName, false, "Invalid tool readme path: %s", m_toolReadMePath.c_str());
             return "";
         }
-        return m_toolReadMePath.c_str();
+        return m_toolReadMePath.Native();
     }
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
@@ -73,7 +73,6 @@ public:
     // AWSCoreInternalRequestBus interface implementation
     AZStd::string GetProfileName() const override { return m_profileName; }
     AZStd::string GetResourceMappingConfigFilePath() const override { return ""; }
-    AZStd::string GetResourceMappingConfigFolderPath() const override { return ""; }
     void ReloadConfiguration() override {}
 
     std::shared_ptr<EnvironmentAWSCredentialsProviderMock> m_environmentCredentialsProviderMock;

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorManagerTest.cpp
@@ -36,6 +36,6 @@ TEST_F(AWSCoreEditorManagerTest, AWSCoreEditorManager_Constructor_HaveExpectedUI
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreEditorManager testManager;
-    AZ_TEST_STOP_TRACE_SUPPRESSION(1); // expect the above have thrown an AZ_Error
+    AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
     EXPECT_TRUE(testManager.GetAWSCoreEditorMenu());
 }

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorManagerTest.cpp
@@ -34,8 +34,6 @@ class AWSCoreEditorManagerTest
 
 TEST_F(AWSCoreEditorManagerTest, AWSCoreEditorManager_Constructor_HaveExpectedUIResourcesCreated)
 {
-    AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreEditorManager testManager;
-    AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
     EXPECT_TRUE(testManager.GetAWSCoreEditorMenu());
 }

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
@@ -41,9 +41,7 @@ class AWSCoreEditorSystemComponentTest
 
         m_entity = aznew AZ::Entity();
         m_coreEditorSystemsComponent.reset(m_entity->CreateComponent<AWSCoreEditorSystemComponent>());
-        AZ_TEST_START_TRACE_SUPPRESSION;
         m_entity->Init();
-        AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
         m_entity->Activate();
     }
 

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
@@ -43,7 +43,7 @@ class AWSCoreEditorSystemComponentTest
         m_coreEditorSystemsComponent.reset(m_entity->CreateComponent<AWSCoreEditorSystemComponent>());
         AZ_TEST_START_TRACE_SUPPRESSION;
         m_entity->Init();
-        AZ_TEST_STOP_TRACE_SUPPRESSION(1); // expect the above have thrown an AZ_Error
+        AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
         m_entity->Activate();
     }
 

--- a/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreEditorMenuTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreEditorMenuTest.cpp
@@ -44,9 +44,7 @@ class AWSCoreEditorMenuTest
 
 TEST_F(AWSCoreEditorMenuTest, AWSCoreEditorMenu_GetAllActions_GetExpectedNumberOfActions)
 {
-    AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreEditorMenu testMenu("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
 
     QList<QAction*> actualActions = testMenu.actions();
 #ifdef AWSCORE_EDITOR_RESOURCE_MAPPING_TOOL_ENABLED
@@ -58,9 +56,7 @@ TEST_F(AWSCoreEditorMenuTest, AWSCoreEditorMenu_GetAllActions_GetExpectedNumberO
 
 TEST_F(AWSCoreEditorMenuTest, AWSCoreEditorMenu_BroadcastFeatureGemsAreEnabled_CorrespondingActionsAreEnabled)
 {
-    AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreEditorMenu testMenu("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
 
     AWSCoreEditorRequestBus::Broadcast(&AWSCoreEditorRequests::SetAWSClientAuthEnabled);
     AWSCoreEditorRequestBus::Broadcast(&AWSCoreEditorRequests::SetAWSMetricsEnabled);

--- a/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreEditorMenuTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreEditorMenuTest.cpp
@@ -42,18 +42,11 @@ class AWSCoreEditorMenuTest
     }
 };
 
-TEST_F(AWSCoreEditorMenuTest, AWSCoreEditorMenu_NoEngineRootFolder_ExpectOneError)
-{
-    AZ_TEST_START_TRACE_SUPPRESSION;
-    AWSCoreEditorMenu testMenu("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(1); // expect the above have thrown an AZ_Error
-}
-
 TEST_F(AWSCoreEditorMenuTest, AWSCoreEditorMenu_GetAllActions_GetExpectedNumberOfActions)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreEditorMenu testMenu("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(1); // expect the above have thrown an AZ_Error
+    AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
 
     QList<QAction*> actualActions = testMenu.actions();
 #ifdef AWSCORE_EDITOR_RESOURCE_MAPPING_TOOL_ENABLED
@@ -67,7 +60,7 @@ TEST_F(AWSCoreEditorMenuTest, AWSCoreEditorMenu_BroadcastFeatureGemsAreEnabled_C
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreEditorMenu testMenu("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(1); // expect the above have thrown an AZ_Error
+    AZ_TEST_STOP_TRACE_SUPPRESSION(3); // expect the above have thrown an AZ_Error
 
     AWSCoreEditorRequestBus::Broadcast(&AWSCoreEditorRequests::SetAWSClientAuthEnabled);
     AWSCoreEditorRequestBus::Broadcast(&AWSCoreEditorRequests::SetAWSMetricsEnabled);

--- a/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreResourceMappingToolActionTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreResourceMappingToolActionTest.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzTest/AzTest.h>
+#include <AzFramework/StringFunc/StringFunc.h>
 
 #include <Editor/UI/AWSCoreResourceMappingToolAction.h>
 #include <Editor/UI/AWSCoreEditorUIFixture.h>
@@ -24,7 +25,6 @@ class AWSCoreResourceMappingToolActionTest
     {
         AWSCoreEditorUIFixture::SetUp();
         AWSCoreFixture::SetUp();
-        m_localFileIO->SetAlias("@engroot@", "dummy engine root");
     }
 
     void TearDown() override
@@ -34,20 +34,14 @@ class AWSCoreResourceMappingToolActionTest
     }
 };
 
-TEST_F(AWSCoreResourceMappingToolActionTest, AWSCoreResourceMappingToolAction_NoEngineRootFolder_ExpectOneError)
-{
-    m_localFileIO->ClearAlias("@engroot@");
-    AZ_TEST_START_TRACE_SUPPRESSION;
-    AWSCoreResourceMappingToolAction testAction("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(1); // expect the above have thrown an AZ_Error
-}
-
-TEST_F(AWSCoreResourceMappingToolActionTest, AWSCoreResourceMappingToolAction_UnableToFindExpectedFileOrFolder_ExpectFiveErrorsAndEmptyResult)
+TEST_F(AWSCoreResourceMappingToolActionTest, AWSCoreResourceMappingToolAction_NoEngineRootPath_ExpectErrorsAndResult)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreResourceMappingToolAction testAction("dummy title");
-    AZ_TEST_STOP_TRACE_SUPPRESSION_NO_COUNT;
     EXPECT_TRUE(testAction.GetToolLaunchCommand() == "");
-    EXPECT_TRUE(testAction.GetToolLogPath() == "");
+    AZ_TEST_STOP_TRACE_SUPPRESSION(4);
+    AZStd::string expectedLogPath = AZStd::string::format("/%s/resource_mapping_tool.log", AWSCoreResourceMappingToolAction::ResourceMappingToolLogDirectoryPath);
+    AzFramework::StringFunc::Path::Normalize(expectedLogPath);
+    EXPECT_TRUE(testAction.GetToolLogFilePath() == expectedLogPath);
     EXPECT_TRUE(testAction.GetToolReadMePath() == "");
 }

--- a/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreResourceMappingToolActionTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreResourceMappingToolActionTest.cpp
@@ -36,12 +36,10 @@ class AWSCoreResourceMappingToolActionTest
 
 TEST_F(AWSCoreResourceMappingToolActionTest, AWSCoreResourceMappingToolAction_NoEngineRootPath_ExpectErrorsAndResult)
 {
-    AZ_TEST_START_TRACE_SUPPRESSION;
     AWSCoreResourceMappingToolAction testAction("dummy title");
+    AZ_TEST_START_TRACE_SUPPRESSION;
     EXPECT_TRUE(testAction.GetToolLaunchCommand() == "");
-    AZ_TEST_STOP_TRACE_SUPPRESSION(4);
-    AZStd::string expectedLogPath = AZStd::string::format("/%s/resource_mapping_tool.log", AWSCoreResourceMappingToolAction::ResourceMappingToolLogDirectoryPath);
-    AzFramework::StringFunc::Path::Normalize(expectedLogPath);
-    EXPECT_TRUE(testAction.GetToolLogFilePath() == expectedLogPath);
+    EXPECT_TRUE(testAction.GetToolLogFilePath() == "");
     EXPECT_TRUE(testAction.GetToolReadMePath() == "");
+    AZ_TEST_STOP_TRACE_SUPPRESSION(3);
 }

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
@@ -115,7 +115,6 @@ public:
     // AWSCoreInternalRequestBus interface implementation
     AZStd::string GetProfileName() const override { return ""; }
     AZStd::string GetResourceMappingConfigFilePath() const override { return m_normalizedConfigFilePath; }
-    AZStd::string GetResourceMappingConfigFolderPath() const override { return m_normalizedConfigFolderPath; }
     void ReloadConfiguration() override { m_reloadConfigurationCounter++; }
 
     AZStd::unique_ptr<AWSCore::AWSResourceMappingManager> m_resourceMappingManager;

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/README.md
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/README.md
@@ -90,12 +90,12 @@ you can create the virtualenv manually.
    $ python3 resource_mapping_tool.py
    ```
 ## Tool Arguments
-* `--binaries_path` **[Optional]** Path to QT Binaries necessary for PySide,
+* `--binaries-path` **[Optional]** Path to QT Binaries necessary for PySide,
                     required if launching tool with engine python environment.
-* `--config_path`   **[Optional]** Path to resource mapping config directory,
+* `--config-path`   **[Optional]** Path to resource mapping config directory,
                     if not provided tool will use current directory.
 * `--debug`         **[Optional]** Execute on debug mode to enable DEBUG logging level.
-* `--log_path`      **[Optional]** Path to resource mapping tool logging directory,
+* `--log-path`      **[Optional]** Path to resource mapping tool logging directory,
                     if not provided tool will store logging under tool source code directory.
 * `--profile`       **[Optional]** Named AWS profile to use for querying AWS resources,
                     if not provided tool will use `default` aws profile.

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/README.md
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/README.md
@@ -89,3 +89,13 @@ you can create the virtualenv manually.
    ```
    $ python3 resource_mapping_tool.py
    ```
+## Tool Arguments
+* `--binaries_path` **[Optional]** Path to QT Binaries necessary for PySide,
+                    required if launching tool with engine python environment.
+* `--config_path`   **[Optional]** Path to resource mapping config directory,
+                    if not provided tool will use current directory.
+* `--debug`         **[Optional]** Execute on debug mode to enable DEBUG logging level.
+* `--log_path`      **[Optional]** Path to resource mapping tool logging directory,
+                    if not provided tool will store logging under tool source code directory.
+* `--profile`       **[Optional]** Named AWS profile to use for querying AWS resources,
+                    if not provided tool will use `default` aws profile.

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py
@@ -9,7 +9,6 @@ from argparse import (ArgumentParser, Namespace)
 import logging
 import sys
 
-from utils import aws_utils
 from utils import environment_utils
 from utils import file_utils
 
@@ -18,6 +17,7 @@ argument_parser: ArgumentParser = ArgumentParser()
 argument_parser.add_argument('--binaries_path', help='Path to QT Binaries necessary for PySide.')
 argument_parser.add_argument('--config_path', help='Path to resource mapping config directory.')
 argument_parser.add_argument('--debug', action='store_true', help='Execute on debug mode to enable DEBUG logging level')
+argument_parser.add_argument('--log_path', help='Path to resource mapping tool logging directory.')
 argument_parser.add_argument('--profile', default='default', help='Named AWS profile to use for querying AWS resources')
 arguments: Namespace = argument_parser.parse_args()
 
@@ -25,8 +25,11 @@ arguments: Namespace = argument_parser.parse_args()
 logging_level: int = logging.INFO
 if arguments.debug:
     logging_level = logging.DEBUG
-logging_path: str = file_utils.join_path(file_utils.get_parent_directory_path(__file__),
-                                         'resource_mapping_tool.log')
+logging_path: str = file_utils.join_path(file_utils.get_parent_directory_path(__file__), 'resource_mapping_tool.log')
+if arguments.log_path:
+    normalized_logging_path: str = file_utils.normalize_file_path(arguments.log_path, False)
+    if normalized_logging_path and file_utils.create_directory(normalized_logging_path):
+        logging_path = file_utils.join_path(normalized_logging_path, 'resource_mapping_tool.log')
 logging.basicConfig(filename=logging_path, filemode='w', level=logging_level,
                     format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s', datefmt='%H:%M:%S')
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
@@ -34,6 +37,7 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 logging.getLogger('s3transfer').setLevel(logging.CRITICAL)
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 logger = logging.getLogger(__name__)
+logger.info(f"Setting logging file at {logging_path}")
 
 if __name__ == "__main__":
     if arguments.binaries_path and not environment_utils.is_qt_linked():

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/resource_mapping_tool.py
@@ -14,10 +14,11 @@ from utils import file_utils
 
 # arguments setup
 argument_parser: ArgumentParser = ArgumentParser()
-argument_parser.add_argument('--binaries_path', help='Path to QT Binaries necessary for PySide.')
-argument_parser.add_argument('--config_path', help='Path to resource mapping config directory.')
+argument_parser.add_argument('--binaries-path', help='Path to QT Binaries necessary for PySide.')
+argument_parser.add_argument('--config-path', help='Path to resource mapping config directory.')
 argument_parser.add_argument('--debug', action='store_true', help='Execute on debug mode to enable DEBUG logging level')
-argument_parser.add_argument('--log_path', help='Path to resource mapping tool logging directory.')
+argument_parser.add_argument('--log-path', help='Path to resource mapping tool logging directory '
+                                                '(if not provided, logging file will be located at tool directory)')
 argument_parser.add_argument('--profile', default='default', help='Named AWS profile to use for querying AWS resources')
 arguments: Namespace = argument_parser.parse_args()
 
@@ -37,7 +38,7 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 logging.getLogger('s3transfer').setLevel(logging.CRITICAL)
 logging.getLogger('urllib3').setLevel(logging.CRITICAL)
 logger = logging.getLogger(__name__)
-logger.info(f"Setting logging file at {logging_path}")
+logger.info(f"Using {logging_path} for logging.")
 
 if __name__ == "__main__":
     if arguments.binaries_path and not environment_utils.is_qt_linked():

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_file_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_file_utils.py
@@ -44,6 +44,23 @@ class TestFileUtils(TestCase):
         mocked_path.exists.assert_called_once()
         assert not actual_result
 
+    def test_create_directory_return_true(self) -> None:
+        mocked_path: MagicMock = self._mock_path.return_value
+
+        actual_result: bool = file_utils.create_directory("dummy")
+        self._mock_path.assert_called_once()
+        mocked_path.mkdir.assert_called_once()
+        assert actual_result
+
+    def test_create_directory_return_false_when_exception_raised(self) -> None:
+        mocked_path: MagicMock = self._mock_path.return_value
+        mocked_path.mkdir.side_effect = FileExistsError()
+
+        actual_result: bool = file_utils.create_directory("dummy")
+        self._mock_path.assert_called_once()
+        mocked_path.mkdir.assert_called_once()
+        assert not actual_result
+
     def test_get_current_directory_path_return_expected_path_name(self) -> None:
         self._mock_path.cwd.return_value = TestFileUtils._expected_path_name
 

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/file_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/file_utils.py
@@ -20,6 +20,15 @@ def check_path_exists(file_path: str) -> bool:
     return pathlib.Path(file_path).exists()
 
 
+def create_directory(dir_path: str) -> bool:
+    try:
+        pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
+        return True
+    except FileExistsError:
+        logger.warning(f"Failed to create directory at {dir_path}")
+        return False
+
+
 def get_current_directory_path() -> str:
     return str(pathlib.Path.cwd())
 
@@ -40,10 +49,10 @@ def find_files_with_suffix_under_directory(dir_path: str, suffix: str) -> List[s
     return results
 
 
-def normalize_file_path(file_path: str) -> str:
+def normalize_file_path(file_path: str, strict: bool = True) -> str:
     if file_path:
         try:
-            return str(pathlib.Path(file_path).resolve(True))
+            return str(pathlib.Path(file_path).resolve(strict))
         except (FileNotFoundError, RuntimeError):
             logger.warning(f"Failed to normalize file path {file_path}, return empty string instead")
     return ""

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -493,7 +493,7 @@ endfunction()
 function(ly_setup_others)
 
     # List of directories we want to install relative to engine root
-    set(DIRECTORIES_TO_INSTALL Tools/LyTestTools Tools/RemoteConsole Gems/AWSCore/Code/Tools/ResourceMappingTool)
+    set(DIRECTORIES_TO_INSTALL Tools/LyTestTools Tools/RemoteConsole)
     foreach(dir ${DIRECTORIES_TO_INSTALL})
 
         get_filename_component(install_path ${dir} DIRECTORY)

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -493,7 +493,7 @@ endfunction()
 function(ly_setup_others)
 
     # List of directories we want to install relative to engine root
-    set(DIRECTORIES_TO_INSTALL Tools/LyTestTools Tools/RemoteConsole)
+    set(DIRECTORIES_TO_INSTALL Tools/LyTestTools Tools/RemoteConsole Gems/AWSCore/Code/Tools/ResourceMappingTool)
     foreach(dir ${DIRECTORIES_TO_INSTALL})
 
         get_filename_component(install_path ${dir} DIRECTORY)


### PR DESCRIPTION
## Details
1. Modify install_common.cmake so install target will include resource mapping tool python code
2. Add log path argument for resource mapping tool so logging file gets generated in project user/log directory while launching from Editor (as tool should not modify files where it is located)
3. Launch python tool with `-B` argument so no .pyc gets generated as install target is expected to run under read-only directory

## Testings
Manual testing through both general build target and install target, and verified that logging file is generated under project user/log directory
Unit test pass

Signed-off-by: onecent1101 <liug@amazon.com>