### PR TITLE
Fix logic in ReadConnectionSettingsFromSettingsRegistry

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponentHelper.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponentHelper.cpp
@@ -163,7 +163,11 @@ namespace AzFramework
                     AZ_TracePrintfOnce("AssetSystemComponent", "Failed to find asset platform, setting 'pc'\n");
                     outputConnectionSettings.m_assetPlatform = "pc";
                 }
-                outputConnectionSettings.m_assetPlatform = assetsPlatform;
+                else
+                {
+                    outputConnectionSettings.m_assetPlatform = assetsPlatform;
+                }
+
                 if (outputConnectionSettings.m_assetPlatform.empty())
                 {
                     assetsPlatform = AzFramework::OSPlatformToDefaultAssetPlatform(AZ_TRAIT_OS_PLATFORM_CODENAME);


### PR DESCRIPTION
In case an asset platform setting is missing it was supposed to be set to a 'pc' value.
Instead it was set to an empty string.

Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>