### PR TITLE
Make camera controller priority customizable

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1240,6 +1240,13 @@ AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateMod
     AzFramework::ViewportId viewportId)
 {
     auto controller = AZStd::make_shared<AtomToolsFramework::ModularViewportCameraController>();
+
+    controller->SetCameraInputHandlerCallback(
+        [](AtomToolsFramework::CameraInputHandler& cameraInputHander)
+        {
+            cameraInputHander = AtomToolsFramework::DefaultCameraInputHandler;
+        });
+
     controller->SetCameraPropsBuilderCallback(
         [](AzFramework::CameraProps& cameraProps)
         {

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1241,10 +1241,10 @@ AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateMod
 {
     auto controller = AZStd::make_shared<AtomToolsFramework::ModularViewportCameraController>();
 
-    controller->SetCameraInputHandlerCallback(
-        [](AtomToolsFramework::CameraInputHandler& cameraInputHander)
+    controller->SetCameraPriorityBuilderCallback(
+        [](AtomToolsFramework::CameraControllerPriorityFn& cameraControllerPriorityFn)
         {
-            cameraInputHander = AtomToolsFramework::DefaultCameraInputHandler;
+            cameraControllerPriorityFn = AtomToolsFramework::DefaultCameraControllerPriority;
         });
 
     controller->SetCameraPropsBuilderCallback(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -18,6 +18,13 @@ namespace AtomToolsFramework
 {
     class ModularViewportCameraControllerInstance;
 
+    //! Function object to represent configuring a camera input handler.
+    using CameraInputHandler =
+        AZStd::function<bool(AzFramework::ViewportControllerPriority priority, const AzFramework::CameraSystem& cameraSystem)>;
+
+    //! The default behavior for how the ModularViewportCameraControllerInstance should intercept and handle events.
+    bool DefaultCameraInputHandler(AzFramework::ViewportControllerPriority priority, const AzFramework::CameraSystem& cameraSystem);
+
     //! Builder class to create and configure a ModularViewportCameraControllerInstance.
     class ModularViewportCameraController
         : public AzFramework::MultiViewportController<
@@ -25,23 +32,33 @@ namespace AtomToolsFramework
               AzFramework::ViewportControllerPriority::DispatchToAllPriorities>
     {
     public:
+        friend ModularViewportCameraControllerInstance;
+
         using CameraListBuilder = AZStd::function<void(AzFramework::Cameras&)>;
         using CameraPropsBuilder = AZStd::function<void(AzFramework::CameraProps&)>;
+        using CameraInputHandlerBuilder = AZStd::function<void(CameraInputHandler&)>;
 
-        //! Sets the camera list builder callback used to populate new ModularViewportCameraControllerInstances
+        //! Sets the camera list builder callback used to populate new ModularViewportCameraControllerInstances.
         void SetCameraListBuilderCallback(const CameraListBuilder& builder);
-        //! Sets the camera props builder callback used to populate new ModularViewportCameraControllerInstances
+        //! Sets the camera props builder callback used to populate new ModularViewportCameraControllerInstances.
         void SetCameraPropsBuilderCallback(const CameraPropsBuilder& builder);
-        //! Sets up a camera list based on this controller's CameraListBuilderCallback
-        void SetupCameras(AzFramework::Cameras& cameras);
-        //! Sets up properties shared across all cameras
-        void SetupCameraProperies(AzFramework::CameraProps& cameraProps);
+        //! Sets the camera input handler builder callback used to populate new ModularViewportCameraControllerInstances.
+        void SetCameraInputHandlerCallback(const CameraInputHandlerBuilder& builder);
 
     private:
+        //! Sets up a camera list based on this controller's CameraListBuilderCallback.
+        void SetupCameras(AzFramework::Cameras& cameras);
+        //! Sets up properties shared across all cameras.
+        void SetupCameraProperies(AzFramework::CameraProps& cameraProps);
+        //! Sets up how the camera input handler should respond.
+        void SetupCameraInputHandler(CameraInputHandler& cameraInputHandler);
+
         //! Builder to generate a list of CameraInputs to run in the ModularViewportCameraControllerInstance.
         CameraListBuilder m_cameraListBuilder;
         CameraPropsBuilder m_cameraPropsBuilder; //!< Builder to define custom camera properties to use for things such as rotate and
                                                  //!< translate interpolation.
+        CameraInputHandlerBuilder m_cameraInputHandlerBuilder; //!< Builder to define custom rules for how a
+                                                               //!< ModularViewportCameraControllerInstance should respond to input events.
     };
 
     //! A customizable camera controller that can be configured to run a varying set of CameraInput instances.
@@ -87,6 +104,7 @@ namespace AtomToolsFramework
         AzFramework::Camera m_targetCamera; //!< The target (next) camera state that m_camera is catching up to.
         AzFramework::CameraSystem m_cameraSystem; //!< The camera system responsible for managing all CameraInputs.
         AzFramework::CameraProps m_cameraProps; //!< Camera properties to control rotate and translate smoothness.
+        CameraInputHandler m_cameraInputHandler; //!< Controls when and how the camera controller should respond to input events.
 
         CameraAnimation m_cameraAnimation; //!< Camera animation state (used during CameraMode::Animation).
         CameraMode m_cameraMode = CameraMode::Control; //!< The current mode the camera is operating in.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -22,7 +22,7 @@ namespace AtomToolsFramework
     using CameraControllerPriorityFn =
         AZStd::function<AzFramework::ViewportControllerPriority(const AzFramework::CameraSystem& cameraSystem)>;
 
-    //! The default behavior for what priority the ModularViewportCameraControllerInstance should respond to events.
+    //! The default behavior for what priority the camera controller should respond to events at.
     //! @note This can change based on the state of the camera controller/system.
     AzFramework::ViewportControllerPriority DefaultCameraControllerPriority(const AzFramework::CameraSystem& cameraSystem);
 


### PR DESCRIPTION
This is one more follow-on change from both https://github.com/o3de/o3de/pull/2346 and https://github.com/o3de/o3de/pull/2769 (got delayed with the Game Jam so just getting back to them).

We have the means to control at what priority the camera controller responds to events (as all priority events are dispatched to it). Right now that logic is quite specific to handle cases in the Editor Viewport, but as we're hoping to in future use the `ModularViewportCameraController` in other tools/viewports this logic should really be moved outside.

This change makes this possible so in other situations a much simpler priority determination could be used (e.g. Only responding to events that are at Normal priority for example). We still make `DefaultCameraControllerPriority` available for use as it likely will work fine in most cases, but users aren't tied to using this now.