### PR TITLE
CCryEditDoc: fix a few bugs 

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -108,21 +108,12 @@ namespace Internal
 // CCryEditDoc construction/destruction
 
 CCryEditDoc::CCryEditDoc()
-    : doc_validate_surface_types(0)
+    : doc_validate_surface_types(nullptr)
     , m_modifiedModuleFlags(eModifiedNothing)
-    // It assumes loaded levels have already been exported. Can be a big fat lie, though.
-    // The right way would require us to save to the level folder the export status of the
-    // level.
-    , m_boLevelExported(true)
-    , m_modified(false)
-    , m_envProbeHeight(200.0f)
-    , m_envProbeSliceRelativePath("EngineAssets/Slices/DefaultLevelSetup.slice")
 {
     ////////////////////////////////////////////////////////////////////////
     // Set member variables to initial values
     ////////////////////////////////////////////////////////////////////////
-    m_bLoadFailed = false;
-    m_waterColor = QColor(0, 0, 255);
 
     m_fogTemplate = GetIEditor()->FindTemplate("Fog");
     m_environmentTemplate = GetIEditor()->FindTemplate("Environment");
@@ -136,7 +127,6 @@ CCryEditDoc::CCryEditDoc()
         m_environmentTemplate = XmlHelpers::CreateXmlNode("Environment");
     }
 
-    m_bDocumentReady = false;
     GetIEditor()->SetDocument(this);
     CLogFile::WriteLine("Document created");
     RegisterConsoleVariables();
@@ -195,7 +185,7 @@ CCryEditDoc::DocumentEditingMode CCryEditDoc::GetEditMode() const
 
 QString CCryEditDoc::GetActivePathName() const
 {
-    return DocumentEditingMode() == CCryEditDoc::DocumentEditingMode::SliceEdit ? GetSlicePathName() : GetLevelPathName();
+    return GetEditMode() == CCryEditDoc::DocumentEditingMode::SliceEdit ? GetSlicePathName() : GetLevelPathName();
 }
 
 QString CCryEditDoc::GetTitle() const
@@ -260,9 +250,9 @@ void CCryEditDoc::DeleteContents()
     GetIEditor()->FlushUndo();
 
     // Notify listeners.
-    for (std::list<IDocListener*>::iterator it = m_listeners.begin(); it != m_listeners.end(); ++it)
+    for (IDocListener* listener : m_listeners)
     {
-        (*it)->OnCloseDocument();
+        listener->OnCloseDocument();
     }
 
     GetIEditor()->ResetViews();
@@ -458,7 +448,7 @@ void CCryEditDoc::Load(TDocMultiArchive& arrXmlAr, const QString& szFilename)
             //////////////////////////////////////////////////////////////////////////
             // Load water color.
             //////////////////////////////////////////////////////////////////////////
-                (*arrXmlAr[DMAS_GENERAL]).root->getAttr("WaterColor", m_waterColor);
+            (*arrXmlAr[DMAS_GENERAL]).root->getAttr("WaterColor", m_waterColor);
 
             //////////////////////////////////////////////////////////////////////////
             // Load View Settings
@@ -507,9 +497,9 @@ void CCryEditDoc::Load(TDocMultiArchive& arrXmlAr, const QString& szFilename)
             CAutoLogTime logtime("Post Load");
 
             // Notify listeners.
-            for (std::list<IDocListener*>::iterator it = m_listeners.begin(); it != m_listeners.end(); ++it)
+            for (IDocListener* listener : m_listeners)
             {
-                (*it)->OnLoadDocument();
+                listener->OnLoadDocument();
             }
         }
 
@@ -708,7 +698,8 @@ bool CCryEditDoc::SaveModified()
         return true;
     }
 
-    auto button = QMessageBox::question(AzToolsFramework::GetActiveWindow(), QString(), tr("Save changes to %1?").arg(GetTitle()), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+    auto button = QMessageBox::question(AzToolsFramework::GetActiveWindow(), QString(), tr("Save changes to %1?").arg(GetTitle()),
+        QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
     switch (button)
     {
     case QMessageBox::Cancel:
@@ -933,8 +924,7 @@ bool CCryEditDoc::OnSaveDocument(const QString& lpszPathName)
         }
 
         TSaveDocContext context;
-        if (shouldSaveLevel &&
-            BeforeSaveDocument(lpszPathName, context))
+        if (shouldSaveLevel && BeforeSaveDocument(lpszPathName, context))
         {
             DoSaveDocument(lpszPathName, context);
             saveSuccess = AfterSaveDocument(lpszPathName, context);
@@ -972,7 +962,7 @@ bool CCryEditDoc::BeforeSaveDocument(const QString& lpszPathName, TSaveDocContex
     return TRUE;
 }
 
-bool CCryEditDoc::HasLayerNameConflicts()
+bool CCryEditDoc::HasLayerNameConflicts() const
 {
     AZStd::vector<AZ::Entity*> editorEntities;
     AzToolsFramework::EditorEntityContextRequestBus::Broadcast(
@@ -1004,43 +994,42 @@ bool CCryEditDoc::HasLayerNameConflicts()
 bool CCryEditDoc::DoSaveDocument(const QString& filename, TSaveDocContext& context)
 {
     bool& bSaved = context.bSaved;
-    if (bSaved)
+    if (!bSaved)
     {
-        // Paranoia - we shouldn't get this far into the save routine without a level loaded (empty levelPath)
-        // If nothing is loaded, we don't need to save anything
-        if (filename.isEmpty())
-        {
-            bSaved = false;
-        }
-        else
-        {
-            // Save Tag Point locations to file if auto save of tag points disabled
-            if (!gSettings.bAutoSaveTagPoints)
-            {
-                CCryEditApp::instance()->SaveTagLocations();
-            }
-
-            QString normalizedPath = Path::ToUnixPath(filename);
-            if (IsSliceFile(normalizedPath))
-            {
-                bSaved = SaveSlice(normalizedPath);
-            }
-            else
-            {
-                bSaved = SaveLevel(normalizedPath);
-            }
-
-            // Changes filename for this document.
-            SetPathName(normalizedPath);
-        }
+        return false;
+    }
+    // Paranoia - we shouldn't get this far into the save routine without a level loaded (empty levelPath)
+    // If nothing is loaded, we don't need to save anything
+    if (filename.isEmpty())
+    {
+        bSaved = false;
+        return false;
     }
 
+    // Save Tag Point locations to file if auto save of tag points disabled
+    if (!gSettings.bAutoSaveTagPoints)
+    {
+        CCryEditApp::instance()->SaveTagLocations();
+    }
+
+    QString normalizedPath = Path::ToUnixPath(filename);
+    if (IsSliceFile(normalizedPath))
+    {
+        bSaved = SaveSlice(normalizedPath);
+    }
+    else
+    {
+        bSaved = SaveLevel(normalizedPath);
+    }
+
+    // Changes filename for this document.
+    SetPathName(normalizedPath);
     return bSaved;
 }
 
 bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName, TSaveDocContext& context, bool bShowPrompt)
 {
-    bool& bSaved = context.bSaved;
+    bool bSaved = context.bSaved;
 
     GetIEditor()->Notify(eNotify_OnEndSceneSave);
 
@@ -1067,8 +1056,7 @@ bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName
 static void GetUserSettingsFile(const QString& levelFolder, QString& userSettings)
 {
     const char* pUserName = GetISystem()->GetUserName();
-    QString fileName;
-    fileName = QStringLiteral("%1_usersettings.editor_xml").arg(pUserName);
+    QString fileName = QStringLiteral("%1_usersettings.editor_xml").arg(pUserName);
     userSettings = Path::Make(levelFolder, fileName);
 }
 
@@ -1182,9 +1170,9 @@ bool CCryEditDoc::SaveLevel(const QString& filename)
                 }
 
                 QString oldFilePath = QDir(oldLevelFolder).absoluteFilePath(sourceName);
-                QString newFilePath = QDir(newLevelFolder).absoluteFilePath(sourceName);
+                QString newFilePath = QDir(newLevelFolder).absoluteFilePath(destName);
                 CFileUtil::CopyFile(oldFilePath, newFilePath);
-            } while (findHandle = pIPak->FindNext(findHandle));
+            } while ((findHandle = pIPak->FindNext(findHandle)));
             pIPak->FindClose(findHandle);
         }
 
@@ -1506,7 +1494,7 @@ bool CCryEditDoc::LoadEntitiesFromLevel(const QString& levelPakFile)
             {
                 AZStd::vector<char> fileBuffer;
                 fileBuffer.resize(entitiesFile.GetLength());
-                if (fileBuffer.size() > 0)
+                if (!fileBuffer.empty())
                 {
                     if (fileBuffer.size() == entitiesFile.ReadRaw(fileBuffer.begin(), fileBuffer.size()))
                     {
@@ -1910,7 +1898,7 @@ void CCryEditDoc::UnregisterListener(IDocListener* listener)
     m_listeners.remove(listener);
 }
 
-void CCryEditDoc::LogLoadTime(int time)
+void CCryEditDoc::LogLoadTime(int time) const
 {
     QString appFilePath = QDir::toNativeSeparators(QCoreApplication::applicationFilePath());
     QString exePath = Path::GetPath(appFilePath);
@@ -1922,21 +1910,18 @@ void CCryEditDoc::LogLoadTime(int time)
     SetFileAttributes(filename.toUtf8().data(), FILE_ATTRIBUTE_ARCHIVE);
 #endif
 
-    FILE* file = nullptr;
-    azfopen(&file, filename.toUtf8().data(), "at");
-
-    if (file)
+    QFile file(filename);
+    if (!file.open(QFile::Append | QFile::Text))
     {
-        char version[50];
-        GetIEditor()->GetFileVersion().ToShortString(version, AZ_ARRAY_SIZE(version));
-
-        QString text;
-
-        time = time / 1000;
-        text = QStringLiteral("\n[%1] Level %2 loaded in %3 seconds").arg(version, level).arg(time);
-        fwrite(text.toUtf8().data(), text.toUtf8().length(), 1, file);
-        fclose(file);
+        return;
     }
+
+    char version[50];
+    GetIEditor()->GetFileVersion().ToShortString(version, AZ_ARRAY_SIZE(version));
+
+    time = time / 1000;
+    QString text = QStringLiteral("\n[%1] Level %2 loaded in %3 seconds").arg(version, level).arg(time);
+    file.write(text.toUtf8());
 }
 
 void CCryEditDoc::SetDocumentReady(bool bReady)
@@ -1944,7 +1929,7 @@ void CCryEditDoc::SetDocumentReady(bool bReady)
     m_bDocumentReady = bReady;
 }
 
-void CCryEditDoc::GetMemoryUsage(ICrySizer* pSizer)
+void CCryEditDoc::GetMemoryUsage(ICrySizer* pSizer) const
 {
     {
         SIZER_COMPONENT_NAME(pSizer, "UndoManager(estimate)");
@@ -2068,12 +2053,9 @@ void CCryEditDoc::InitEmptyLevel(int /*resolution*/, int /*unitSize*/, bool /*bU
     {
         // Notify listeners.
         std::list<IDocListener*> listeners = m_listeners;
-        std::list<IDocListener*>::iterator it, next;
-        for (it = listeners.begin(); it != listeners.end(); it = next)
+        for (IDocListener* listener : listeners)
         {
-            next = it;
-            next++;
-            (*it)->OnNewDocument();
+            listener->OnNewDocument();
         }
     }
 
@@ -2134,25 +2116,23 @@ void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
     {
         return;
     }
+    QString childValue;
 
     if (pVar->GetDataType() == IVariable::DT_COLOR)
     {
         Vec3 value;
         pVar->Get(value);
-        QString buff;
         QColor gammaColor = ColorLinearToGamma(ColorF(value.x, value.y, value.z));
-        buff = QStringLiteral("%1,%2,%3").arg(gammaColor.red()).arg(gammaColor.green()).arg(gammaColor.blue());
-        childNode->setAttr("value", buff.toUtf8().data());
+        childValue = QStringLiteral("%1,%2,%3").arg(gammaColor.red()).arg(gammaColor.green()).arg(gammaColor.blue());
     }
     else
     {
-        QString value;
-        pVar->Get(value);
-        childNode->setAttr("value", value.toUtf8().data());
+        pVar->Get(childValue);
     }
+    childNode->setAttr("value", childValue.toUtf8().data());
 }
 
-QString CCryEditDoc::GetCryIndexPath(const LPCTSTR levelFilePath)
+QString CCryEditDoc::GetCryIndexPath(const LPCTSTR levelFilePath) const
 {
     QString levelPath = Path::GetPath(levelFilePath);
     QString levelName = Path::GetFileName(levelFilePath);
@@ -2183,8 +2163,7 @@ BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString&
         }
 
         CPakFile pakFile;
-        bool loadFromPakSuccess;
-        loadFromPakSuccess = xmlAr.LoadFromPak(levelPath, pakFile);
+        bool loadFromPakSuccess = xmlAr.LoadFromPak(levelPath, pakFile);
         pIPak->ClosePack(absoluteLevelPath.toUtf8().data());
         if (!loadFromPakSuccess)
         {

--- a/Code/Editor/CryEditDoc.h
+++ b/Code/Editor/CryEditDoc.h
@@ -91,7 +91,7 @@ public: // Create from serialization only
     // ClassWizard generated virtual function overrides
     virtual bool OnOpenDocument(const QString& lpszPathName);
 
-    const bool IsLevelLoadFailed() const { return m_bLoadFailed; }
+    bool IsLevelLoadFailed() const { return m_bLoadFailed; }
 
     //! Marks this document as having errors.
     void SetHasErrors() { m_hasErrors = true; }
@@ -121,7 +121,7 @@ public: // Create from serialization only
 
     CClouds* GetClouds() { return m_pClouds; }
     void SetWaterColor(const QColor& col) { m_waterColor = col; }
-    QColor GetWaterColor() { return m_waterColor; }
+    QColor GetWaterColor() const { return m_waterColor; }
     XmlNodeRef& GetFogTemplate() { return m_fogTemplate; }
     XmlNodeRef& GetEnvironmentTemplate() { return m_environmentTemplate; }
     void OnEnvironmentPropertyChanged(IVariable* pVar);
@@ -129,7 +129,7 @@ public: // Create from serialization only
     void RegisterListener(IDocListener* listener);
     void UnregisterListener(IDocListener* listener);
 
-    void GetMemoryUsage(ICrySizer* pSizer);
+    void GetMemoryUsage(ICrySizer* pSizer) const;
 
     static bool IsBackupOrTempLevelSubdirectory(const QString& folderName);
 protected:
@@ -161,14 +161,14 @@ protected:
     void SerializeFogSettings(CXmlArchive& xmlAr);
     virtual void SerializeViewSettings(CXmlArchive& xmlAr);
     void SerializeNameSelection(CXmlArchive& xmlAr);
-    void LogLoadTime(int time);
+    void LogLoadTime(int time) const;
 
     struct TSaveDocContext
     {
         bool bSaved;
     };
     bool BeforeSaveDocument(const QString& lpszPathName, TSaveDocContext& context);
-    bool HasLayerNameConflicts();
+    bool HasLayerNameConflicts() const;
     bool DoSaveDocument(const QString& lpszPathName, TSaveDocContext& context);
     bool AfterSaveDocument(const QString& lpszPathName, TSaveDocContext& context, bool bShowPrompt = true);
 
@@ -180,7 +180,7 @@ protected:
     void OnStartLevelResourceList();
     static void OnValidateSurfaceTypesChanged(ICVar*);
 
-    QString GetCryIndexPath(const LPCTSTR levelFilePath);
+    QString GetCryIndexPath(const LPCTSTR levelFilePath) const;
 
     //////////////////////////////////////////////////////////////////////////
     // SliceEditorEntityOwnershipServiceNotificationBus::Handler
@@ -188,24 +188,26 @@ protected:
     void OnSliceInstantiationFailed(const AZ::Data::AssetId& sliceAssetId, const AzFramework::SliceInstantiationTicket& /*ticket*/) override;
     //////////////////////////////////////////////////////////////////////////
 
-    bool m_bLoadFailed;
-    QColor m_waterColor;
+    bool m_bLoadFailed = false;
+    QColor m_waterColor = QColor(0, 0, 255);
     XmlNodeRef m_fogTemplate;
     XmlNodeRef m_environmentTemplate;
     CClouds* m_pClouds;
     std::list<IDocListener*> m_listeners;
-    bool m_bDocumentReady;
-    ICVar* doc_validate_surface_types;
+    bool m_bDocumentReady = false;
+    ICVar* doc_validate_surface_types = nullptr;
     int m_modifiedModuleFlags;
-    bool m_boLevelExported;
-    bool m_modified;
+    // On construction, it assumes loaded levels have already been exported. Can be a big fat lie, though.
+    // The right way would require us to save to the level folder the export status of the level.
+    bool m_boLevelExported = true;
+    bool m_modified = false;
     QString m_pathName;
     QString m_slicePathName;
     QString m_title;
     AZ::Data::AssetId m_envProbeSliceAssetId;
     float m_terrainSize;
-    const char* m_envProbeSliceRelativePath;
-    const float m_envProbeHeight;
+    const char* m_envProbeSliceRelativePath = "EngineAssets/Slices/DefaultLevelSetup.slice";
+    const float m_envProbeHeight = 200.0f;
     bool m_hasErrors = false; ///< This is used to warn the user that they may lose work when they go to save.
 };
 


### PR DESCRIPTION
GetActivePathName was using default - constructed enum DocumentEditingMode()
SaveLevel was not using destName when constructing newFilePath

Other code changes:

* LogLoadTime is simplified by using QFile
* reduce nesting in DoSaveDocument by using early return.
* marked a few eligible methods as const
* Simplified OnEnvironmentPropertyChanged a bit

this is a split version of #2252 
Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>