### PR TITLE
[development] installer work - added 'files in use' page and fixed toolset path propagation

### DIFF
--- a/cmake/Platform/Windows/Packaging/Bootstrapper.wxs
+++ b/cmake/Platform/Windows/Packaging/Bootstrapper.wxs
@@ -33,6 +33,7 @@
                     LogoFile="$(var.CPACK_WIX_PRODUCT_LOGO)"
                     ThemeFile="$(var.CPACK_BOOTSTRAP_THEME_FILE).xml"
                     LocalizationFile="$(var.CPACK_BOOTSTRAP_THEME_FILE).wxl"
+                    ShowFilesInUse="yes"
                     ShowVersion="yes" />
 
                 <PayloadGroupRef Id="Images"/>
@@ -44,6 +45,7 @@
                     LogoFile="$(var.CPACK_WIX_PRODUCT_LOGO)"
                     ThemeFile="$(var.CPACK_BOOTSTRAP_THEME_FILE).xml"
                     LocalizationFile="$(var.CPACK_BOOTSTRAP_THEME_FILE).wxl"
+                    ShowFilesInUse="yes"
                     ShowVersion="yes" />
 
                 <PayloadGroupRef Id="Images"/>

--- a/cmake/Platform/Windows/Packaging/BootstrapperTheme.wxl.in
+++ b/cmake/Platform/Windows/Packaging/BootstrapperTheme.wxl.in
@@ -39,6 +39,14 @@ Setup will install [WixBundleName] on your computer. Click install to continue, 
     <String Id="ExecuteProgressLabel">Execution Progress</String>
     <String Id="ProgressCancelButton">&amp;Cancel</String>
 
+    <!-- files in use page (action blocking) -->
+    <String Id="FilesInUseHeader">Files In Use</String>
+    <String Id="FilesInUseLabel">The following applications are using files that need to be modified:</String>
+    <String Id="FilesInUseCloseRadioButton">Close the &amp;applications</String>
+    <String Id="FilesInUseDontCloseRadioButton">&amp;Do not close applications, may cause unexpected side effects</String>
+    <String Id="FilesInUseOkButton">&amp;OK</String>
+    <String Id="FilesInUseCancelButton">&amp;Cancel</String>
+
     <!-- final page (success state) -->
     <String Id="SuccessHeader">Setup Successful</String>
     <String Id="SuccessInstallHeader">Installation Successfully Completed</String>

--- a/cmake/Platform/Windows/Packaging/BootstrapperTheme.xml.in
+++ b/cmake/Platform/Windows/Packaging/BootstrapperTheme.xml.in
@@ -70,6 +70,21 @@
         <Button Name="ProgressCancelButton" X="-22" Y="-10" Width="80" Height="24" TabStop="yes" FontId="2">#(loc.ProgressCancelButton)</Button>
     </Page>
 
+    <!-- files in use page (action blocking) -->
+    <Page Name="FilesInUse">
+      <Text X="38" Y="142" Width="-42" Height="34" FontId="0" DisablePrefix="yes">#(loc.FilesInUseHeader)</Text>
+
+      <Text X="42" Y="202" Width="-42" Height="18" FontId="1" DisablePrefix="yes">#(loc.FilesInUseLabel)</Text>
+      <Richedit Name="FilesInUseText" X="42" Y="230" Width="-42" Height="-104" FontId="1" DisablePrefix="yes" HexStyle="0x800000" />
+
+      <Button Name="FilesInUseCloseRadioButton" X="42" Y="-76" Width="-42" Height="18" TabStop="yes" FontId="2" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseCloseRadioButton)</Button>
+      <Button Name="FilesInUseDontCloseRadioButton" X="42" Y="-56" Width="-42" Height="18" TabStop="yes" FontId="2" HideWhenDisabled="yes" HexStyle="0x000009">#(loc.FilesInUseDontCloseRadioButton)</Button>
+
+      <Text X="0" Y="426" Width="672" Height="46" FontId="3" HideWhenDisabled="yes" />
+      <Button Name="FilesInUseOkButton" X="-106" Y="-10" Width="80" Height="24" TabStop="yes" FontId="2" HideWhenDisabled="yes">#(loc.FilesInUseOkButton)</Button>
+      <Button Name="FilesInUseCancelButton" X="-22" Y="-10" Width="80" Height="24" TabStop="yes" FontId="2">#(loc.FilesInUseCancelButton)</Button>
+    </Page>
+
     <!-- final page (success state) -->
     <Page Name="Success">
         <Text Name="SuccessHeader" X="38" Y="142" Width="-42" Height="34" FontId="0" HideWhenDisabled="yes" DisablePrefix="yes">#(loc.SuccessHeader)</Text>

--- a/cmake/Platform/Windows/Packaging_windows.cmake
+++ b/cmake/Platform/Windows/Packaging_windows.cmake
@@ -17,6 +17,10 @@ else()
     return()
 endif()
 
+# IMPORTANT: CPACK_WIX_ROOT is a built-in variable that is required to propagate the path supplied
+# via command line down to the cpack internals
+set(CPACK_WIX_ROOT ${LY_INSTALLER_WIX_ROOT})
+
 set(CPACK_GENERATOR WIX)
 
 set(_cmake_package_name "cmake-${CPACK_DESIRED_CMAKE_VERSION}-windows-x86_64")


### PR DESCRIPTION
- Enable files in use dialog in bootstrap installer to close running o3de tools during uninstall or repair
![image](https://user-images.githubusercontent.com/24445312/128256312-9d3027c7-896f-430d-ba6e-91cb90750fdc.png)
- Fixed installer toolset path propagation after variable name change

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>