### PR TITLE
EnvironmentVariableHolder: reduce the size of template instantiation.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Module/Environment.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.cpp
@@ -87,7 +87,7 @@ namespace AZ
                 {
                     releaseByModule = true;
                 }
-                if (!moduleRelease && !releaseByUseCount)
+                if (!releaseByModule && !releaseByUseCount)
                 {
                     return;
                 }

--- a/Code/Framework/AzCore/AzCore/Module/Environment.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.cpp
@@ -80,7 +80,7 @@ namespace AZ
         {
             bool releaseByModule = false;
             const bool releaseByUseCount = (--m_useCount == 0);
-            // We take over the lock, and release it before potentially destructin/freeing ourselves
+            // We take over the lock, and release it before potentially destroying/freeing ourselves
             {
                 AZStd::scoped_lock envLockHolder(AZStd::adopt_lock, m_mutex);
                 if (moduleRelease && !m_canTransferOwnership && m_moduleOwner == AZ::Environment::GetModuleId())

--- a/Code/Framework/AzCore/AzCore/Module/Environment.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.cpp
@@ -75,15 +75,15 @@ namespace AZ
         bool operator==(const OSStdAllocator& a, const OSStdAllocator& b) { (void)a; (void)b; return true; }
         bool operator!=(const OSStdAllocator& a, const OSStdAllocator& b) { (void)a; (void)b; return false; }
 
-        void EnvironmentVariableHolderBase::UnregisterAndDestroy(void (*destruct)(EnvironmentVariableHolderBase *, DestroyTarget), bool module_release)
+        void EnvironmentVariableHolderBase::UnregisterAndDestroy(DestructFunc destruct, bool moduleRelease)
         {
             bool release_by_module = false;
             const bool release_by_use_count = (--m_useCount == 0);
-            if (module_release && !m_canTransferOwnership && m_moduleOwner == AZ::Environment::GetModuleId())
+            if (moduleRelease && !m_canTransferOwnership && m_moduleOwner == AZ::Environment::GetModuleId())
             {
                 release_by_module = true;
             }
-            if (!module_release && !release_by_use_count)
+            if (!moduleRelease && !release_by_use_count)
             {
                 m_mutex.unlock();
                 return;

--- a/Code/Framework/AzCore/AzCore/Module/Environment.cpp
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.cpp
@@ -78,15 +78,12 @@ namespace AZ
 
         void EnvironmentVariableHolderBase::UnregisterAndDestroy(DestructFunc destruct, bool moduleRelease)
         {
-            bool releaseByModule = false;
             const bool releaseByUseCount = (--m_useCount == 0);
             // We take over the lock, and release it before potentially destroying/freeing ourselves
             {
                 AZStd::scoped_lock envLockHolder(AZStd::adopt_lock, m_mutex);
-                if (moduleRelease && !m_canTransferOwnership && m_moduleOwner == AZ::Environment::GetModuleId())
-                {
-                    releaseByModule = true;
-                }
+                const bool releaseByModule = (moduleRelease && !m_canTransferOwnership && m_moduleOwner == AZ::Environment::GetModuleId());
+
                 if (!releaseByModule && !releaseByUseCount)
                 {
                     return;

--- a/Code/Framework/AzCore/AzCore/Module/Environment.h
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.h
@@ -233,8 +233,8 @@ namespace AZ
             }
         protected:
             using DestructFunc = void (*)(EnvironmentVariableHolderBase *, DestroyTarget);
-            // Assumes the lock is already held
-            // The lock is no longer held after return from this function.
+            // Assumes the m_mutex is already locked.
+            // On return m_mutex is in an unlocked state.
             void UnregisterAndDestroy(DestructFunc destruct, bool moduleRelease);
 
             AZ::Internal::EnvironmentInterface* m_environmentOwner; ///< Used to know which environment we should use to free the variable if we can't transfer ownership

--- a/Code/Framework/AzCore/AzCore/Module/Environment.h
+++ b/Code/Framework/AzCore/AzCore/Module/Environment.h
@@ -274,7 +274,7 @@ namespace AZ
                 AZ_Assert(self->m_isConstructed, "Variable is not constructed. Please check your logic and guard if needed!");
                 self->m_isConstructed = false;
                 self->m_moduleOwner = nullptr;
-                if constexpr(AZStd::is_trivially_destructible_v<T>)
+                if constexpr(!AZStd::is_trivially_destructible_v<T>)
                 {
                     reinterpret_cast<T*>(&self->m_value)->~T();
                 }


### PR DESCRIPTION
Move almost all destruction logic to EnvironmentVariableHolderBase::UnregisterAndDestroy.
Specialized templates have DestructDispatchNoLock instead that can either destroy the held value,
or the holder itself.

UnregisterAndDestroy has been moved to the cpp file.

All of these changes reduce the profile build time and size on linux
Here, the size of `bin/profile` goes down by ~200MB.

Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>