### PR TITLE
Editor code: tidy up BOOLs,NULLs and overrides pt2.

### DIFF
--- a/Code/Editor/Lib/Tests/test_EditorUtils.cpp
+++ b/Code/Editor/Lib/Tests/test_EditorUtils.cpp
@@ -23,12 +23,12 @@ namespace EditorUtilsTest
             BusConnect();
         }
 
-        ~WarningDetector()
+        ~WarningDetector() override
         {
             BusDisconnect();
         }
 
-        virtual bool OnWarning(const char* /*window*/, const char* /*message*/) override 
+        bool OnWarning(const char* /*window*/, const char* /*message*/) override 
         {
             m_gotWarning = true;
             return true;

--- a/Code/Editor/Lib/Tests/test_Main.cpp
+++ b/Code/Editor/Lib/Tests/test_Main.cpp
@@ -17,7 +17,7 @@ class EditorLibTestEnvironment
     : public AZ::Test::ITestEnvironment
 {
 public:
-    ~EditorLibTestEnvironment() override {}
+    ~EditorLibTestEnvironment() override = default;
 
 protected:
     void SetupEnvironment() override

--- a/Code/Editor/Lib/Tests/test_Main.cpp
+++ b/Code/Editor/Lib/Tests/test_Main.cpp
@@ -17,7 +17,7 @@ class EditorLibTestEnvironment
     : public AZ::Test::ITestEnvironment
 {
 public:
-    virtual ~EditorLibTestEnvironment() {}
+    ~EditorLibTestEnvironment() override {}
 
 protected:
     void SetupEnvironment() override

--- a/Code/Editor/Objects/BaseObject.cpp
+++ b/Code/Editor/Objects/BaseObject.cpp
@@ -57,12 +57,12 @@ public:
     CUndoBaseObject(CBaseObject* pObj, const char* undoDescription);
 
 protected:
-    virtual int GetSize() { return sizeof(*this);   }
-    virtual QString GetDescription() { return m_undoDescription; };
-    virtual QString GetObjectName();
+    int GetSize() override { return sizeof(*this);   }
+    QString GetDescription() override { return m_undoDescription; };
+    QString GetObjectName() override;
 
-    virtual void Undo(bool bUndo);
-    virtual void Redo();
+    void Undo(bool bUndo) override;
+    void Redo() override;
 
 protected:
     QString m_undoDescription;
@@ -81,12 +81,12 @@ public:
     CUndoBaseObjectMinimal(CBaseObject* obj, const char* undoDescription, int flags);
 
 protected:
-    virtual int GetSize() { return sizeof(*this); }
-    virtual QString GetDescription() { return m_undoDescription; };
-    virtual QString GetObjectName();
+    int GetSize() override { return sizeof(*this); }
+    QString GetDescription() override { return m_undoDescription; };
+    QString GetObjectName() override;
 
-    virtual void Undo(bool bUndo);
-    virtual void Redo();
+    void Undo(bool bUndo) override;
+    void Redo() override;
 
 private:
     struct StateStruct
@@ -119,7 +119,7 @@ public:
         , m_bKeepPos(bKeepPos)
         , m_bAttach(bAttach) {}
 
-    virtual void Undo([[maybe_unused]] bool bUndo) override
+    void Undo([[maybe_unused]] bool bUndo) override
     {
         if (m_bAttach)
         {
@@ -131,7 +131,7 @@ public:
         }
     }
 
-    virtual void Redo() override
+    void Redo() override
     {
         if (m_bAttach)
         {
@@ -167,8 +167,8 @@ private:
         }
     }
 
-    virtual int GetSize() { return sizeof(CUndoAttachBaseObject); }
-    virtual QString GetDescription() { return "Attachment Changed"; }
+    int GetSize() override { return sizeof(CUndoAttachBaseObject); }
+    QString GetDescription() override { return "Attachment Changed"; }
 
     GUID m_attachedObjectGUID;
     GUID m_parentObjectGUID;
@@ -184,7 +184,7 @@ CUndoBaseObject::CUndoBaseObject(CBaseObject* obj, const char* undoDescription)
     m_undoDescription = undoDescription;
     m_guid = obj->GetId();
 
-    m_redo = 0;
+    m_redo = nullptr;
     m_undo = XmlHelpers::CreateXmlNode("Undo");
     CObjectArchive ar(GetIEditor()->GetObjectManager(), m_undo, false);
     ar.bUndo = true;
@@ -355,7 +355,7 @@ void CObjectCloneContext::AddClone(CBaseObject* pFromObject, CBaseObject* pToObj
 //////////////////////////////////////////////////////////////////////////
 CBaseObject* CObjectCloneContext::FindClone(CBaseObject* pFromObject)
 {
-    CBaseObject* pTarget = stl::find_in_map(m_objectsMap, pFromObject, (CBaseObject*) NULL);
+    CBaseObject* pTarget = stl::find_in_map(m_objectsMap, pFromObject, (CBaseObject*) nullptr);
     return pTarget;
 }
 
@@ -426,7 +426,7 @@ bool CBaseObject::Init([[maybe_unused]] IEditor* ie, CBaseObject* prev, [[maybe_
 {
     SetFlags(m_flags & (~OBJFLAG_DELETED));
 
-    if (prev != 0)
+    if (prev != nullptr)
     {
         SetUniqueName(prev->GetName());
         SetLocalTM(prev->GetPos(), prev->GetRotation(), prev->GetScale());
@@ -457,7 +457,7 @@ CBaseObject::~CBaseObject()
     for (Childs::iterator c = m_childs.begin(); c != m_childs.end(); c++)
     {
         CBaseObject* child = *c;
-        child->m_parent = 0;
+        child->m_parent = nullptr;
     }
     m_childs.clear();
 }
@@ -470,10 +470,10 @@ void CBaseObject::Done()
     // From children
     DetachAll();
 
-    SetLookAt(0);
+    SetLookAt(nullptr);
     if (m_lookatSource)
     {
-        m_lookatSource->SetLookAt(0);
+        m_lookatSource->SetLookAt(nullptr);
     }
     SetFlags(m_flags | OBJFLAG_DELETED);
 
@@ -1730,7 +1730,7 @@ bool CBaseObject::IntersectRayBounds(const Ray& ray)
 //////////////////////////////////////////////////////////////////////////
 namespace
 {
-    typedef std::pair<Vec2, Vec2> Edge2D;
+    using Edge2D = std::pair<Vec2, Vec2>;
 }
 bool IsIncludePointsInConvexHull(Edge2D* pEdgeArray0, int nEdgeArray0Size, Edge2D* pEdgeArray1, int nEdgeArray1Size)
 {
@@ -2065,7 +2065,7 @@ void CBaseObject::GetAllChildren(TBaseObjects& outAllChildren, CBaseObject* pObj
     for (int i = 0, iChildCount(pBaseObj->GetChildCount()); i < iChildCount; ++i)
     {
         CBaseObject* pChild = pBaseObj->GetChild(i);
-        if (pChild == NULL)
+        if (pChild == nullptr)
         {
             continue;
         }
@@ -2081,7 +2081,7 @@ void CBaseObject::GetAllChildren(DynArray< _smart_ptr<CBaseObject> >& outAllChil
     for (int i = 0, iChildCount(pBaseObj->GetChildCount()); i < iChildCount; ++i)
     {
         CBaseObject* pChild = pBaseObj->GetChild(i);
-        if (pChild == NULL)
+        if (pChild == nullptr)
         {
             continue;
         }
@@ -2097,7 +2097,7 @@ void CBaseObject::GetAllChildren(CSelectionGroup& outAllChildren, CBaseObject* p
     for (int i = 0, iChildCount(pBaseObj->GetChildCount()); i < iChildCount; ++i)
     {
         CBaseObject* pChild = pBaseObj->GetChild(i);
-        if (pChild == NULL)
+        if (pChild == nullptr)
         {
             continue;
         }
@@ -2109,7 +2109,7 @@ void CBaseObject::GetAllChildren(CSelectionGroup& outAllChildren, CBaseObject* p
 //////////////////////////////////////////////////////////////////////////
 void CBaseObject::CloneChildren(CBaseObject* pFromObject)
 {
-    if (pFromObject == NULL)
+    if (pFromObject == nullptr)
     {
         return;
     }
@@ -2119,7 +2119,7 @@ void CBaseObject::CloneChildren(CBaseObject* pFromObject)
         CBaseObject* pFromChildObject = pFromObject->GetChild(i);
 
         CBaseObject* pChildClone = GetObjectManager()->CloneObject(pFromChildObject);
-        if (pChildClone == NULL)
+        if (pChildClone == nullptr)
         {
             continue;
         }
@@ -2248,7 +2248,7 @@ void CBaseObject::DetachThis(bool bKeepPos)
 
             // Copy parent to temp var, erasing child from parent may delete this node if child referenced only from parent.
             CBaseObject* parent = m_parent;
-            m_parent = 0;
+            m_parent = nullptr;
             parent->RemoveChild(this);
 
             if (bKeepPos)
@@ -2389,7 +2389,7 @@ void CBaseObject::InvalidateTM([[maybe_unused]] int flags)
         // Invalidate matrices off all child objects.
         for (int i = 0; i < m_childs.size(); i++)
         {
-            if (m_childs[i] != 0 && m_childs[i]->m_bMatrixValid)
+            if (m_childs[i] != nullptr && m_childs[i]->m_bMatrixValid)
             {
                 m_childs[i]->InvalidateTM(eObjectUpdateFlags_ParentChanged);
             }
@@ -2538,7 +2538,7 @@ void CBaseObject::SetLookAt(CBaseObject* target)
 //////////////////////////////////////////////////////////////////////////
 bool CBaseObject::IsLookAtTarget() const
 {
-    return m_lookatSource != 0;
+    return m_lookatSource != nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -2806,7 +2806,7 @@ bool CBaseObject::IntersectRayMesh(const Vec3& raySrc, const Vec3& rayDir, SRayH
     outHitInfo.bInFirstHit = false;
     outHitInfo.bUseCache = false;
 
-    return pStatObj->RayIntersection(outHitInfo, 0);
+    return pStatObj->RayIntersection(outHitInfo, nullptr);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Objects/BaseObject.h
+++ b/Code/Editor/Objects/BaseObject.h
@@ -321,7 +321,7 @@ public:
     //! Set object selected status.
     virtual void SetSelected(bool bSelect);
     //! Return associated 3DEngine render node
-    virtual IRenderNode* GetEngineNode() const { return NULL; };
+    virtual IRenderNode* GetEngineNode() const { return nullptr; };
     //! Set object highlighted (Note: not selected)
     virtual void SetHighlight(bool bHighlight);
     //! Check if object is highlighted.
@@ -410,9 +410,9 @@ public:
     //! Scans hierarchy up to determine if we child of specified node.
     virtual bool IsChildOf(CBaseObject* node);
     //! Get all child objects
-    void GetAllChildren(TBaseObjects& outAllChildren, CBaseObject* pObj = NULL) const;
-    void GetAllChildren(DynArray< _smart_ptr<CBaseObject> >& outAllChildren, CBaseObject* pObj = NULL) const;
-    void GetAllChildren(CSelectionGroup& outAllChildren, CBaseObject* pObj = NULL) const;
+    void GetAllChildren(TBaseObjects& outAllChildren, CBaseObject* pObj = nullptr) const;
+    void GetAllChildren(DynArray< _smart_ptr<CBaseObject> >& outAllChildren, CBaseObject* pObj = nullptr) const;
+    void GetAllChildren(CSelectionGroup& outAllChildren, CBaseObject* pObj = nullptr) const;
     //! Clone Children
     void CloneChildren(CBaseObject* pFromObject);
     //! Attach new child node.
@@ -468,8 +468,8 @@ public:
     //! Called when object is being created (use GetMouseCreateCallback for more advanced mouse creation callback).
     virtual int MouseCreateCallback(CViewport* view, EMouseEvent event, QPoint& point, int flags);
     // Return pointer to the callback object used when creating object by the mouse.
-    // If this function return NULL MouseCreateCallback method will be used instead.
-    virtual IMouseCreateCallback* GetMouseCreateCallback() { return 0; };
+    // If this function return nullptr MouseCreateCallback method will be used instead.
+    virtual IMouseCreateCallback* GetMouseCreateCallback() { return nullptr; };
 
     //! Draw object to specified viewport.
     virtual void Display([[maybe_unused]] DisplayContext& disp) {}
@@ -598,7 +598,7 @@ public:
     bool CanBeHightlighted() const;
     bool IsSkipSelectionHelper() const;
 
-    virtual IStatObj* GetIStatObj() {   return NULL; }
+    virtual IStatObj* GetIStatObj() {   return nullptr; }
 
     // Invalidates cached transformation matrix.
     // nWhyFlags - Flags that indicate the reason for matrix invalidation.
@@ -672,7 +672,7 @@ protected:
     //! Draw warning icons
     virtual void DrawWarningIcons(DisplayContext& dc, const Vec3& pos);
     //! Check if dimension's figures can be displayed before draw them.
-    virtual void DrawDimensions(DisplayContext& dc, AABB* pMergedBoundBox = NULL);
+    virtual void DrawDimensions(DisplayContext& dc, AABB* pMergedBoundBox = nullptr);
 
     //! Draw highlight.
     virtual void DrawHighlight(DisplayContext& dc);

--- a/Code/Editor/Objects/EntityObject.cpp
+++ b/Code/Editor/Objects/EntityObject.cpp
@@ -56,18 +56,18 @@ public:
     }
 
 protected:
-    virtual void Release() { delete this; };
-    virtual int GetSize() { return sizeof(*this); }; // Return size of xml state.
-    virtual QString GetDescription() { return "Entity Link"; };
-    virtual QString GetObjectName(){ return ""; };
+    void Release() override { delete this; };
+    int GetSize() override { return sizeof(*this); }; // Return size of xml state.
+    QString GetDescription() override { return "Entity Link"; };
+    QString GetObjectName() override{ return ""; };
 
-    virtual void Undo([[maybe_unused]] bool bUndo)
+    void Undo([[maybe_unused]] bool bUndo) override
     {
         for (int i = 0, iLinkSize(m_Links.size()); i < iLinkSize; ++i)
         {
             SLink& link = m_Links[i];
             CBaseObject* pObj = GetIEditor()->GetObjectManager()->FindObject(link.entityID);
-            if (pObj == NULL)
+            if (pObj == nullptr)
             {
                 continue;
             }
@@ -83,7 +83,7 @@ protected:
             pEntity->LoadLink(link.linkXmlNode->getChild(0));
         }
     }
-    virtual void Redo(){}
+    void Redo() override{}
 
 private:
 
@@ -109,7 +109,7 @@ public:
         , m_bAttach(bAttach)
     {}
 
-    virtual void Undo([[maybe_unused]] bool bUndo) override
+    void Undo([[maybe_unused]] bool bUndo) override
     {
         if (!m_bAttach)
         {
@@ -117,7 +117,7 @@ public:
         }
     }
 
-    virtual void Redo() override
+    void Redo() override
     {
         if (m_bAttach)
         {
@@ -138,8 +138,8 @@ private:
         }
     }
 
-    virtual int GetSize() { return sizeof(CUndoAttachEntity); }
-    virtual QString GetDescription() { return "Attachment Changed"; }
+    int GetSize() override { return sizeof(CUndoAttachEntity); }
+    QString GetDescription() override { return "Attachment Changed"; }
 
     GUID m_attachedEntityGUID;
     CEntityObject::EAttachmentType m_attachmentType;
@@ -167,7 +167,7 @@ CEntityObject::CEntityObject()
 {
     m_bLoadFailed = false;
 
-    m_visualObject = 0;
+    m_visualObject = nullptr;
 
     m_box.min.Set(0, 0, 0);
     m_box.max.Set(0, 0, 0);
@@ -225,7 +225,7 @@ CEntityObject::CEntityObject()
     mv_ratioLOD.SetLimits(0, 255);
     mv_viewDistanceMultiplier.SetLimits(0.0f, IRenderNode::VIEW_DISTANCE_MULTIPLIER_MAX);
 
-    m_physicsState = 0;
+    m_physicsState = nullptr;
 
     m_attachmentType = eAT_Pivot;
 
@@ -540,7 +540,7 @@ IVariable* CEntityObject::FindVariableInSubBlock(CVarBlockPtr& properties, IVari
 //////////////////////////////////////////////////////////////////////////
 void CEntityObject::AdjustLightProperties(CVarBlockPtr& properties, const char* pSubBlock)
 {
-    IVariable* pSubBlockVar = pSubBlock ? properties->FindVariable(pSubBlock) : NULL;
+    IVariable* pSubBlockVar = pSubBlock ? properties->FindVariable(pSubBlock) : nullptr;
 
     if (IVariable* pRadius = FindVariableInSubBlock(properties, pSubBlockVar, "Radius"))
     {
@@ -933,7 +933,7 @@ void CEntityObject::Serialize(CObjectArchive& ar)
             {
                 XmlNodeRef eventTarget = eventTargets->getChild(i);
                 CEntityEventTarget et;
-                et.target = 0;
+                et.target = nullptr;
                 GUID targetId = GUID_NULL;
                 eventTarget->getAttr("TargetId", targetId);
                 eventTarget->getAttr("Event", et.event);
@@ -1029,7 +1029,7 @@ void CEntityObject::Serialize(CObjectArchive& ar)
             {
                 CEntityEventTarget& et = m_eventTargets[i];
                 GUID targetId = GUID_NULL;
-                if (et.target != 0)
+                if (et.target != nullptr)
                 {
                     targetId = et.target->GetId();
                 }
@@ -1060,7 +1060,7 @@ XmlNodeRef CEntityObject::Export([[maybe_unused]] const QString& levelPath, XmlN
 {
     if (m_bLoadFailed)
     {
-        return 0;
+        return nullptr;
     }
 
     // Do not export entity with bad id.
@@ -1268,7 +1268,7 @@ void CEntityObject::OnEvent(ObjectEvent event)
         IObjectManager* objMan = GetIEditor()->GetObjectManager();
         if (objMan && objMan->IsLightClass(this))
         {
-            OnPropertyChange(NULL);
+            OnPropertyChange(nullptr);
         }
         break;
     }
@@ -1314,7 +1314,7 @@ IVariable* CEntityObject::GetLightVariable(const char* name0) const
             {
                 IVariable* pChild = pLightProperties->GetVariable(i);
 
-                if (pChild == NULL)
+                if (pChild == nullptr)
                 {
                     continue;
                 }
@@ -1341,7 +1341,7 @@ QString CEntityObject::GetLightAnimation() const
         {
             IVariable* pChild = pStyleGroup->GetVariable(i);
 
-            if (pChild == NULL)
+            if (pChild == nullptr)
             {
                 continue;
             }
@@ -1617,7 +1617,7 @@ void CEntityObject::RemoveEventTarget(int index, [[maybe_unused]] bool bUpdateSc
 //////////////////////////////////////////////////////////////////////////
 int CEntityObject::AddEntityLink(const QString& name, GUID targetEntityId)
 {
-    CEntityObject* target = 0;
+    CEntityObject* target = nullptr;
     if (targetEntityId != GUID_NULL)
     {
         CBaseObject* pObject = FindObject(targetEntityId);
@@ -1635,7 +1635,7 @@ int CEntityObject::AddEntityLink(const QString& name, GUID targetEntityId)
 
     StoreUndo("Add EntityLink");
 
-    CLineGizmo* pLineGizmo = 0;
+    CLineGizmo* pLineGizmo = nullptr;
 
     // Assign event target.
     if (target)
@@ -1968,7 +1968,7 @@ void CEntityObject::ResetCallbacks()
 
         //@FIXME Hack to display radii of properties.
         // wires properties from param block, to this entity internal variables.
-        IVariable* var = 0;
+        IVariable* var = nullptr;
         var = pProperties->FindVariable("Radius", false);
         if (var && (var->GetType() == IVariable::FLOAT || var->GetType() == IVariable::INT))
         {
@@ -2194,7 +2194,7 @@ template <typename T>
 T CEntityObject::GetEntityProperty(const char* pName, T defaultvalue) const
 {
     CVarBlock* pProperties = GetProperties2();
-    IVariable* pVariable = NULL;
+    IVariable* pVariable = nullptr;
     if (pProperties)
     {
         pVariable = pProperties->FindVariable(pName);
@@ -2228,7 +2228,7 @@ template <typename T>
 void CEntityObject::SetEntityProperty(const char* pName, T value)
 {
     CVarBlock* pProperties = GetProperties2();
-    IVariable* pVariable = NULL;
+    IVariable* pVariable = nullptr;
     if (pProperties)
     {
         pVariable = pProperties->FindVariable(pName);

--- a/Code/Editor/Objects/EntityObject.h
+++ b/Code/Editor/Objects/EntityObject.h
@@ -185,7 +185,7 @@ public:
     void RemoveAllEntityLinks();
     virtual void EntityLinked([[maybe_unused]] const QString& name, [[maybe_unused]] GUID targetEntityId){}
     virtual void EntityUnlinked([[maybe_unused]] const QString& name, [[maybe_unused]] GUID targetEntityId) {}
-    void LoadLink(XmlNodeRef xmlNode, CObjectArchive* pArchive = NULL);
+    void LoadLink(XmlNodeRef xmlNode, CObjectArchive* pArchive = nullptr);
     void SaveLink(XmlNodeRef xmlNode);
     //////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Objects/Gizmo.h
+++ b/Code/Editor/Objects/Gizmo.h
@@ -67,7 +67,7 @@ public:
     //! Set this gizmo to be deleted.
     void DeleteThis();
 
-    virtual CBaseObjectPtr GetBaseObject() const {  return NULL; }
+    virtual CBaseObjectPtr GetBaseObject() const {  return nullptr; }
 
 
 protected:

--- a/Code/Editor/Objects/GizmoManager.cpp
+++ b/Code/Editor/Objects/GizmoManager.cpp
@@ -79,7 +79,7 @@ CGizmo* CGizmoManager::GetGizmoByIndex(int nIndex) const
             return *ii;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Objects/LineGizmo.cpp
+++ b/Code/Editor/Objects/LineGizmo.cpp
@@ -37,8 +37,8 @@ CLineGizmo::~CLineGizmo()
     {
         m_object[1]->RemoveEventListener(this);
     }
-    m_object[0] = 0;
-    m_object[1] = 0;
+    m_object[0] = nullptr;
+    m_object[1] = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -164,7 +164,7 @@ void CLineGizmo::SetName(const char* sName)
 //////////////////////////////////////////////////////////////////////////
 bool CLineGizmo::HitTest([[maybe_unused]] HitContext& hc)
 {
-    return 0;
+    return false;
     /*
     if (hc.distanceTollerance != 0)
         return 0;

--- a/Code/Editor/Objects/ObjectLoader.cpp
+++ b/Code/Editor/Objects/ObjectLoader.cpp
@@ -28,8 +28,8 @@ CObjectArchive::CObjectArchive(IObjectManager* objMan, XmlNodeRef xmlRoot, bool 
     m_nFlags = 0;
     node = xmlRoot;
     m_pCurrentErrorReport = GetIEditor()->GetErrorReport();
-    m_pGeometryPak = NULL;
-    m_pCurrentObject = NULL;
+    m_pGeometryPak = nullptr;
+    m_pCurrentObject = nullptr;
     m_bNeedResolveObjects = false;
     m_bProgressBarEnabled = true;
 }
@@ -145,7 +145,7 @@ void CObjectArchive::ResolveObjects()
             // Objects can be added to the list here (from Groups).
             numObj = m_loadedObjects.size();
         }
-        m_pCurrentErrorReport->SetCurrentValidatorObject(NULL);
+        m_pCurrentErrorReport->SetCurrentValidatorObject(nullptr);
         //////////////////////////////////////////////////////////////////////////
         GetIEditor()->ResumeUndo();
     }
@@ -238,7 +238,7 @@ void CObjectArchive::ResolveObjects()
             // might generate unrelated errors
             m_pCurrentErrorReport->SetCurrentValidatorObject(nullptr);
         }
-        m_pCurrentErrorReport->SetCurrentValidatorObject(NULL);
+        m_pCurrentErrorReport->SetCurrentValidatorObject(nullptr);
         //////////////////////////////////////////////////////////////////////////
     }
 
@@ -257,7 +257,7 @@ void CObjectArchive::ResolveObjects()
     }
 
     m_bNeedResolveObjects = false;
-    m_pCurrentErrorReport->SetCurrentValidatorObject(NULL);
+    m_pCurrentErrorReport->SetCurrentValidatorObject(nullptr);
     m_sequenceIdRemap.clear();
     m_pendingIds.clear();
 }
@@ -314,7 +314,7 @@ void CObjectArchive::LoadObjects(XmlNodeRef& rootObjectsNode)
     for (int i = 0; i < numObjects; i++)
     {
         XmlNodeRef objNode = rootObjectsNode->getChild(i);
-        LoadObject(objNode, NULL);
+        LoadObject(objNode, nullptr);
     }
 }
 
@@ -401,7 +401,7 @@ void CObjectArchive::AddSequenceIdMapping(uint32 oldId, uint32 newId)
 {
     assert(oldId != newId);
     assert(GetIEditor()->GetMovieSystem()->FindSequenceById(oldId) || stl::find(m_pendingIds, oldId));
-    assert(GetIEditor()->GetMovieSystem()->FindSequenceById(newId) == NULL);
+    assert(GetIEditor()->GetMovieSystem()->FindSequenceById(newId) == nullptr);
     assert(stl::find(m_pendingIds, newId) == false);
     m_sequenceIdRemap[oldId] = newId;
     m_pendingIds.push_back(newId);

--- a/Code/Editor/Objects/ObjectLoader.h
+++ b/Code/Editor/Objects/ObjectLoader.h
@@ -67,7 +67,7 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     void LoadObjects(XmlNodeRef& rootObjectsNode);
 
     //! Load one object from archive.
-    CBaseObject* LoadObject(const XmlNodeRef& objNode, CBaseObject* pPrevObject = NULL);
+    CBaseObject* LoadObject(const XmlNodeRef& objNode, CBaseObject* pPrevObject = nullptr);
 
     //////////////////////////////////////////////////////////////////////////
     int GetLoadedObjectsCount() { return m_loadedObjects.size(); }

--- a/Code/Editor/Objects/ObjectManager.cpp
+++ b/Code/Editor/Objects/ObjectManager.cpp
@@ -49,16 +49,16 @@ public:
     GUID guid;
 
 public:
-    REFGUID ClassID()
+    REFGUID ClassID() override
     {
         return guid;
     }
-    ObjectType GetObjectType() { return superType->GetObjectType(); };
-    QString ClassName() { return type; };
-    QString Category() { return category; };
+    ObjectType GetObjectType() override { return superType->GetObjectType(); };
+    QString ClassName() override { return type; };
+    QString Category() override { return category; };
     QObject* CreateQObject() const override { return superType->CreateQObject(); }
-    QString GetTextureIcon() { return superType->GetTextureIcon(); };
-    QString GetFileSpec()
+    QString GetTextureIcon() override { return superType->GetTextureIcon(); };
+    QString GetFileSpec() override
     {
         if (!fileSpec.isEmpty())
         {
@@ -69,7 +69,7 @@ public:
             return superType->GetFileSpec();
         }
     };
-    virtual int GameCreationOrder() { return superType->GameCreationOrder(); };
+    int GameCreationOrder() override { return superType->GameCreationOrder(); };
 };
 
 void CBaseObjectsCache::AddObject(CBaseObject* object)
@@ -86,7 +86,7 @@ void CBaseObjectsCache::AddObject(CBaseObject* object)
 //////////////////////////////////////////////////////////////////////////
 // CObjectManager implementation.
 //////////////////////////////////////////////////////////////////////////
-CObjectManager* g_pObjectManager = 0;
+CObjectManager* g_pObjectManager = nullptr;
 
 //////////////////////////////////////////////////////////////////////////
 CObjectManager::CObjectManager()
@@ -182,19 +182,19 @@ CBaseObject* CObjectManager::NewObject(CObjectClassDesc* cls, CBaseObject* prev,
 
             if (!AddObject(obj))
             {
-                obj = 0;
+                obj = nullptr;
             }
         }
         else
         {
-            obj = 0;
+            obj = nullptr;
         }
-        GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(NULL);
+        GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(nullptr);
     }
 
     GetIEditor()->ResumeUndo();
 
-    if (obj != 0 && GetIEditor()->IsUndoRecording())
+    if (obj != nullptr && GetIEditor()->IsUndoRecording())
     {
         // AZ entity creations are handled through the AZ undo system.
         if (obj->GetType() != OBJTYPE_AZENTITY)
@@ -228,7 +228,7 @@ CBaseObject* CObjectManager::NewObject(CObjectArchive& ar, CBaseObject* pUndoObj
 
     if (!objNode->getAttr("Type", typeName))
     {
-        return 0;
+        return nullptr;
     }
 
     if (!objNode->getAttr("Id", id))
@@ -268,7 +268,7 @@ CBaseObject* CObjectManager::NewObject(CObjectArchive& ar, CBaseObject* pUndoObj
         if (!cls)
         {
             CryWarning(VALIDATOR_MODULE_EDITOR, VALIDATOR_ERROR, "RuntimeClass %s not registered", typeName.toUtf8().data());
-            return 0;
+            return nullptr;
         }
 
         pObject = qobject_cast<CBaseObject*>(cls->CreateQObject());
@@ -301,29 +301,29 @@ CBaseObject* CObjectManager::NewObject(CObjectArchive& ar, CBaseObject* pUndoObj
                 GetIEditor()->GetErrorReport()->ReportError(errorRecord);
             }
 
-            return 0;
+            return nullptr;
             //CoCreateGuid( &pObject->m_guid ); // generate uniq GUID for this object.
         }
     }
 
     GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(pObject);
-    if (!pObject->Init(GetIEditor(), 0, ""))
+    if (!pObject->Init(GetIEditor(), nullptr, ""))
     {
-        GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(NULL);
-        return 0;
+        GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(nullptr);
+        return nullptr;
     }
 
     if (!AddObject(pObject))
     {
-        GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(NULL);
-        return 0;
+        GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(nullptr);
+        return nullptr;
     }
 
     //pObject->Serialize( ar );
 
-    GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(NULL);
+    GetIEditor()->GetErrorReport()->SetCurrentValidatorObject(nullptr);
 
-    if (pObject != 0 && pUndoObject == 0)
+    if (pObject != nullptr && pUndoObject == nullptr)
     {
         // If new object with no undo, record it.
         if (CUndo::IsRecording())
@@ -355,7 +355,7 @@ CBaseObject* CObjectManager::NewObject(const QString& typeName, CBaseObject* pre
     if (!cls)
     {
         GetIEditor()->GetSystem()->GetILog()->Log("Warning: RuntimeClass %s (as well as %s) not registered", typeName.toUtf8().data(), fullName.toUtf8().data());
-        return 0;
+        return nullptr;
     }
     CBaseObject* pObject = NewObject(cls, prev, file, newObjectName);
     return pObject;
@@ -411,7 +411,7 @@ void    CObjectManager::DeleteObject(CBaseObject* obj)
 void CObjectManager::DeleteSelection(CSelectionGroup* pSelection)
 {
     AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::Editor);
-    if (pSelection == NULL)
+    if (pSelection == nullptr)
     {
         return;
     }
@@ -527,7 +527,7 @@ CBaseObject* CObjectManager::CloneObject(CBaseObject* obj)
 //////////////////////////////////////////////////////////////////////////
 CBaseObject* CObjectManager::FindObject(REFGUID guid) const
 {
-    CBaseObject* result = stl::find_in_map(m_objects, guid, (CBaseObject*)0);
+    CBaseObject* result = stl::find_in_map(m_objects, guid, (CBaseObject*)nullptr);
     return result;
 }
 
@@ -603,7 +603,7 @@ void CObjectManager::FindObjectsInAABB(const AABB& aabb, std::vector<CBaseObject
 //////////////////////////////////////////////////////////////////////////
 bool CObjectManager::AddObject(CBaseObject* obj)
 {
-    CBaseObjectPtr p = stl::find_in_map(m_objects, obj->GetId(), 0);
+    CBaseObjectPtr p = stl::find_in_map(m_objects, obj->GetId(), nullptr);
     if (p)
     {
         CErrorRecord err;
@@ -908,7 +908,7 @@ void CObjectManager::UnfreezeAll()
 bool CObjectManager::SelectObject(CBaseObject* obj, bool bUseMask)
 {
     assert(obj);
-    if (obj == NULL)
+    if (obj == nullptr)
     {
         return false;
     }
@@ -974,7 +974,7 @@ void CObjectManager::UnselectObject(CBaseObject* obj)
 
 CSelectionGroup* CObjectManager::GetSelection(const QString& name) const
 {
-    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)0);
+    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)nullptr);
     return selection;
 }
 
@@ -993,7 +993,7 @@ void CObjectManager::NameSelection(const QString& name)
         return;
     }
 
-    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)0);
+    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)nullptr);
     if (selection)
     {
         assert(selection != 0);
@@ -1020,7 +1020,7 @@ void CObjectManager::SerializeNameSelection(XmlNodeRef& rootNode, bool bLoading)
         return;
     }
 
-    _smart_ptr<CSelectionGroup> tmpGroup(0);
+    _smart_ptr<CSelectionGroup> tmpGroup(nullptr);
 
     QString selRootStr("NameSelection");
     QString selNodeStr("NameSelectionNode");
@@ -1075,7 +1075,7 @@ void CObjectManager::SerializeNameSelection(XmlNodeRef& rootNode, bool bLoading)
     else
     {
         startNode = rootNode->newChild(selRootStr.toUtf8().data());
-        CSelectionGroup* objSelection = 0;
+        CSelectionGroup* objSelection = nullptr;
 
         for (TNameSelectionMap::iterator it = m_selections.begin(); it != m_selections.end(); ++it)
         {
@@ -1186,7 +1186,7 @@ int CObjectManager::InvertSelection()
 void CObjectManager::SetSelection(const QString& name)
 {
     AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::Editor);
-    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)0);
+    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)nullptr);
     if (selection)
     {
         UnselectCurrent();
@@ -1201,7 +1201,7 @@ void CObjectManager::RemoveSelection(const QString& name)
     AZ_PROFILE_FUNCTION(AZ::Debug::ProfileCategory::Editor);
 
     QString selName = name;
-    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)0);
+    CSelectionGroup* selection = stl::find_in_map(m_selections, name, (CSelectionGroup*)nullptr);
     if (selection)
     {
         if (selection == m_currSelection)
@@ -1359,7 +1359,7 @@ void CObjectManager::FindDisplayableObjects(DisplayContext& dc, [[maybe_unused]]
             for (int i = 0, iCount(pSelection->GetCount()); i < iCount; ++i)
             {
                 CBaseObject* pObj(pSelection->GetObject(i));
-                if (pObj == NULL)
+                if (pObj == nullptr)
                 {
                     continue;
                 }
@@ -1443,7 +1443,7 @@ void CObjectManager::BeginEditParams(CBaseObject* obj, int flags)
 void CObjectManager::EndEditParams([[maybe_unused]] int flags)
 {
     m_bSingleSelection = false;
-    m_currEditObject = 0;
+    m_currEditObject = nullptr;
     //m_bSelectionChanged = false; // don't need to clear for ungroup
 }
 
@@ -1657,7 +1657,7 @@ bool CObjectManager::HitTest(HitContext& hitInfo)
     HitContext hcOrg = hitInfo;
     if (hcOrg.view)
     {
-        hcOrg.view->GetPerpendicularAxis(0, &hcOrg.b2DViewport);
+        hcOrg.view->GetPerpendicularAxis(nullptr, &hcOrg.b2DViewport);
     }
     hcOrg.rayDir = hcOrg.rayDir.GetNormalized();
 
@@ -1692,7 +1692,7 @@ bool CObjectManager::HitTest(HitContext& hitInfo)
 
     const bool iconsPrioritized = true; // Force icons to always be prioritized over other things you hit. Can change to be a configurable option in the future.
 
-    CBaseObject* selected = 0;
+    CBaseObject* selected = nullptr;
     const char* name = nullptr;
     bool iconHit = false;
     int numVis = pDispayedViewObjects->GetObjectCount();
@@ -1993,11 +1993,11 @@ bool CObjectManager::EnableUniqObjectNames(bool bEnable)
 CObjectClassDesc* CObjectManager::FindClass(const QString& className)
 {
     IClassDesc* cls = CClassFactory::Instance()->FindClass(className.toUtf8().data());
-    if (cls != NULL && cls->SystemClassID() == ESYSTEM_CLASS_OBJECT)
+    if (cls != nullptr && cls->SystemClassID() == ESYSTEM_CLASS_OBJECT)
     {
         return (CObjectClassDesc*)cls;
     }
-    return 0;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -2101,7 +2101,7 @@ void CObjectManager::LoadClassTemplates(const QString& path)
     {
         // Construct the full filepath of the current file
         XmlNodeRef node = XmlHelpers::LoadXmlFromFile((dir + files[k].filename).toUtf8().data());
-        if (node != 0 && node->isTag("ObjectTemplates"))
+        if (node != nullptr && node->isTag("ObjectTemplates"))
         {
             QString name;
             for (int i = 0; i < node->getChildCount(); i++)
@@ -2449,7 +2449,7 @@ void CObjectManager::EndObjectsLoading()
     {
         delete m_pLoadProgress;
     }
-    m_pLoadProgress = 0;
+    m_pLoadProgress = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -2481,20 +2481,20 @@ bool CObjectManager::IsLightClass(CBaseObject* pObject)
         {
             if (pEntity->GetEntityClass().compare(CLASS_LIGHT) == 0)
             {
-                return TRUE;
+                return true;
             }
             if (pEntity->GetEntityClass().compare(CLASS_RIGIDBODY_LIGHT) == 0)
             {
-                return TRUE;
+                return true;
             }
             if (pEntity->GetEntityClass().compare(CLASS_DESTROYABLE_LIGHT) == 0)
             {
-                return TRUE;
+                return true;
             }
         }
     }
 
-    return FALSE;
+    return false;
 }
 
 void CObjectManager::FindAndRenameProperty2(const char* property2Name, const QString& oldValue, const QString& newValue)

--- a/Code/Editor/Objects/SelectionGroup.cpp
+++ b/Code/Editor/Objects/SelectionGroup.cpp
@@ -636,7 +636,7 @@ void CSelectionGroup::FinishChanges()
     for (int i = 0; i < iObjectSize; ++i)
     {
         CBaseObject* pObject = selectedObjects[i];
-        if (pObject == NULL)
+        if (pObject == nullptr)
         {
             continue;
         }

--- a/Code/Editor/Objects/TrackGizmo.cpp
+++ b/Code/Editor/Objects/TrackGizmo.cpp
@@ -34,7 +34,7 @@ namespace {
 //////////////////////////////////////////////////////////////////////////
 CTrackGizmo::CTrackGizmo()
 {
-    m_pAnimNode = 0;
+    m_pAnimNode = nullptr;
 
     m_worldBbox.min = Vec3(-10000, -10000, -10000);
     m_worldBbox.max = Vec3(10000, 10000, 10000);

--- a/Code/Editor/Platform/Windows/Util/Mailer_Windows.cpp
+++ b/Code/Editor/Platform/Windows/Util/Mailer_Windows.cpp
@@ -51,8 +51,8 @@ bool CMailer::SendMail(const char* subject,
         attachments[i].flFlags      = 0;
         attachments[i].nPosition    = (ULONG)-1;
         attachments[i].lpszPathName = (char*)(const char*)_attachments[k];
-        attachments[i].lpszFileName = NULL;
-        attachments[i].lpFileType   = NULL;
+        attachments[i].lpszFileName = nullptr;
+        attachments[i].lpFileType   = nullptr;
         i++;
     }
     int numAttachments = i;
@@ -74,14 +74,14 @@ bool CMailer::SendMail(const char* subject,
         recipients[i].lpszName     = (char*)(const char*)_recipients[i];
         recipients[i].lpszAddress  = (char*)addresses[i].c_str();
         recipients[i].ulEIDSize    = 0;
-        recipients[i].lpEntryID    = NULL;
+        recipients[i].lpEntryID    = nullptr;
     }
 
     MapiMessage message;
     memset(&message, 0, sizeof(message));
     message.lpszSubject = (char*)(const char*)subject;
     message.lpszNoteText = (char*)(const char*)messageBody;
-    message.lpszMessageType = NULL;
+    message.lpszMessageType = nullptr;
 
     message.nRecipCount = numRecipients;
     message.lpRecips = recipients;

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1815,7 +1815,7 @@ void SandboxIntegrationManager::ContextMenu_PushEntitiesToSlice(AzToolsFramework
     (void)targetAncestorId;
     (void)affectEntireHierarchy;
 
-    AZ::SerializeContext* serializeContext = NULL;
+    AZ::SerializeContext* serializeContext = nullptr;
     EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
     AZ_Assert(serializeContext, "No serialize context");
 

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/ComponentPalette/ComponentPaletteWindow.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/ComponentPalette/ComponentPaletteWindow.cpp
@@ -42,7 +42,7 @@ void ComponentPaletteWindow::Init()
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
-    QHBoxLayout* gridLayout = new QHBoxLayout(NULL);
+    QHBoxLayout* gridLayout = new QHBoxLayout(nullptr);
     gridLayout->setSizeConstraint(QLayout::SetMaximumSize);
     gridLayout->setContentsMargins(0, 0, 0, 0);
     gridLayout->setSpacing(0);

--- a/Code/Editor/Plugins/EditorCommon/DockTitleBarWidget.cpp
+++ b/Code/Editor/Plugins/EditorCommon/DockTitleBarWidget.cpp
@@ -30,13 +30,13 @@ class CDockWidgetTitleButton
 public:
     CDockWidgetTitleButton(QWidget* parent);
 
-    QSize sizeHint() const;
-    QSize minimumSizeHint() const { return sizeHint(); }
+    QSize sizeHint() const override;
+    QSize minimumSizeHint() const override { return sizeHint(); }
 
 protected:
-    void enterEvent(QEvent* ev);
-    void leaveEvent(QEvent* ev);
-    void paintEvent(QPaintEvent* ev);
+    void enterEvent(QEvent* ev) override;
+    void leaveEvent(QEvent* ev) override;
+    void paintEvent(QPaintEvent* ev) override;
 };
 
 class CTitleBarText
@@ -85,10 +85,10 @@ QSize CDockWidgetTitleButton::sizeHint() const
 {
     ensurePolished();
 
-    int size = 2 * style()->pixelMetric(QStyle::PM_DockWidgetTitleBarButtonMargin, 0, this);
+    int size = 2 * style()->pixelMetric(QStyle::PM_DockWidgetTitleBarButtonMargin, nullptr, this);
     if (!icon().isNull())
     {
-        int iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize, 0, this);
+        int iconSize = style()->pixelMetric(QStyle::PM_SmallIconSize, nullptr, this);
         QSize sz = icon().actualSize(QSize(iconSize, iconSize));
         size += qMax(sz.width(), sz.height());
     }
@@ -145,7 +145,7 @@ void CDockWidgetTitleButton::paintEvent([[maybe_unused]] QPaintEvent* ev)
     opt.activeSubControls = QStyle::SubControls();
     opt.features = QStyleOptionToolButton::None;
     opt.arrowType = Qt::NoArrow;
-    int size = style()->pixelMetric(QStyle::PM_SmallIconSize, 0, this);
+    int size = style()->pixelMetric(QStyle::PM_SmallIconSize, nullptr, this);
     opt.iconSize = QSize(size, size);
     style()->drawComplexControl(QStyle::CC_ToolButton, &opt, &painter, this);
 }

--- a/Code/Editor/Plugins/FFMPEGPlugin/main.cpp
+++ b/Code/Editor/Plugins/FFMPEGPlugin/main.cpp
@@ -15,7 +15,7 @@ PLUGIN_API IPlugin* CreatePluginInstance(PLUGIN_INIT_PARAM* pInitParam)
     if (pInitParam->pluginVersion != SANDBOX_PLUGIN_SYSTEM_VERSION)
     {
         pInitParam->outErrorCode = IPlugin::eError_VersionMismatch;
-        return 0;
+        return nullptr;
     }
 
     ModuleInitISystem(GetIEditor()->GetSystem(), "FFMPEGPlugin");

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Android.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Android.cpp
@@ -165,8 +165,8 @@ namespace ProjectSettingsTool
             if (editContext)
             {
                 editContext->Class<AndroidSplashscreens>("Splashscreens", "All splashscreen overrides for Android.")
-                    ->DataElement(nullptr, &AndroidSplashscreens::m_landscapeSplashscreens)
-                    ->DataElement(nullptr, &AndroidSplashscreens::m_portraitSplashscreens)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSplashscreens::m_landscapeSplashscreens)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &AndroidSplashscreens::m_portraitSplashscreens)
                 ;
             }
         }

--- a/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Android.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/PlatformSettings_Android.cpp
@@ -165,8 +165,8 @@ namespace ProjectSettingsTool
             if (editContext)
             {
                 editContext->Class<AndroidSplashscreens>("Splashscreens", "All splashscreen overrides for Android.")
-                    ->DataElement(0, &AndroidSplashscreens::m_landscapeSplashscreens)
-                    ->DataElement(0, &AndroidSplashscreens::m_portraitSplashscreens)
+                    ->DataElement(nullptr, &AndroidSplashscreens::m_landscapeSplashscreens)
+                    ->DataElement(nullptr, &AndroidSplashscreens::m_portraitSplashscreens)
                 ;
             }
         }

--- a/Code/Editor/Plugins/ProjectSettingsTool/Validators.cpp
+++ b/Code/Editor/Plugins/ProjectSettingsTool/Validators.cpp
@@ -16,7 +16,7 @@
 
 namespace 
 {
-    typedef ProjectSettingsTool::FunctorValidator::ReturnType RetType;
+    using RetType = ProjectSettingsTool::FunctorValidator::ReturnType;
 
     static const int noMaxLength = -1;
     static const int maxIosVersionLength = 18;


### PR DESCRIPTION
A few 'typedefs' replaced by 'using's
This shouldn't have any functional changes at all, just c++17 modernization
It's a part 2 of a split #2847

*Note to reviewers this is a split PR meant to ease reviewing, but sadly I cannot say if this or any other part will compile correctly in isolation.*

Signed-off-by: Nemerle <nemerle5+git@gmail.com>