### PR TITLE
Editor code: tidy up BOOLs,NULLs and overrides pt3.

### DIFF
--- a/Code/Editor/QtUI/QCollapsibleGroupBox.cpp
+++ b/Code/Editor/QtUI/QCollapsibleGroupBox.cpp
@@ -13,7 +13,7 @@
 QCollapsibleGroupBox::QCollapsibleGroupBox(QWidget* parent)
     : QGroupBox(parent)
     , m_collapsed(false)
-    , m_toggleButton(0)
+    , m_toggleButton(nullptr)
 {
     m_toggleButton = new QToolButton(this);
     m_toggleButton->setFixedSize(16, 16);

--- a/Code/Editor/RenderHelpers/AxisHelper.h
+++ b/Code/Editor/RenderHelpers/AxisHelper.h
@@ -60,7 +60,7 @@ public:
     void DrawDome(const Matrix34& worldTM, const SGizmoParameters& setup, DisplayContext& dc, AABB& objectBox);
     bool HitTest(const Matrix34& worldTM, const SGizmoParameters& setup, HitContext& hc);
 
-    bool HitTestForRotationCircle(const Matrix34& worldTM, IDisplayViewport* view, const QPoint& pos, float fHitWidth, Vec3* pOutHitPos = NULL, Vec3* pOutHitNormal = NULL);
+    bool HitTestForRotationCircle(const Matrix34& worldTM, IDisplayViewport* view, const QPoint& pos, float fHitWidth, Vec3* pOutHitPos = nullptr, Vec3* pOutHitNormal = nullptr);
 
     void SetHighlightAxis(int axis) { m_highlightAxis = axis; };
     int  GetHighlightAxis() const { return m_highlightAxis; };

--- a/Code/Editor/TrackView/2DBezierKeyUIControls.cpp
+++ b/Code/Editor/TrackView/2DBezierKeyUIControls.cpp
@@ -26,19 +26,19 @@ public:
     CSmartVariableArray mv_table;
     CSmartVariable<float> mv_value;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_value, "Value");
     }
-    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return trackType == eAnimCurveType_BezierFloat;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 0; }
+    unsigned int GetPriority() const override { return 0; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
+++ b/Code/Editor/TrackView/AssetBlendKeyUIControls.cpp
@@ -41,7 +41,7 @@ public:
     CSmartVariable<float> mv_blendInTime;
     CSmartVariable<float> mv_blendOutTime;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         // Init to an invalid id
         AZ::Data::AssetId assetId;
@@ -62,15 +62,15 @@ public:
         mv_timeScale->SetLimits(0.001f, 100.f);
     }
 
-    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
     {
         return valueType == AnimValueType::AssetBlend;
     }
 
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/CaptureKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CaptureKeyUIControls.cpp
@@ -27,7 +27,7 @@ public:
     CSmartVariable<QString> mv_folder;
     CSmartVariable<bool> mv_once;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         mv_duration.GetVar()->SetLimits(0, 100000.0f);
         mv_timeStep.GetVar()->SetLimits(0.001f, 1.0f);
@@ -39,14 +39,14 @@ public:
         AddVariable(mv_table, mv_folder, "Output Folder");
         AddVariable(mv_table, mv_once, "Just one frame?");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::Capture;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/CharacterKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CharacterKeyUIControls.cpp
@@ -33,7 +33,7 @@ public:
     CSmartVariable<float> mv_endTime;
     CSmartVariable<float> mv_timeScale;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_animation, "Animation", IVariable::DT_ANIMATION);
@@ -45,14 +45,14 @@ public:
         AddVariable(mv_table, mv_timeScale, "Time Scale");
         mv_timeScale->SetLimits(0.001f, 100.f);
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
     {
         return paramType == AnimParamType::Animation || valueType == AnimValueType::CharacterAnim;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/CommentKeyUIControls.cpp
+++ b/Code/Editor/TrackView/CommentKeyUIControls.cpp
@@ -30,7 +30,7 @@ public:
     CSmartVariableEnum<QString> mv_font;
 
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_comment, "Comment");
@@ -41,13 +41,13 @@ public:
 
         AddVariable(mv_table, mv_color, "Color", IVariable::DT_COLOR);
 
-        mv_align->SetEnumList(NULL);
+        mv_align->SetEnumList(nullptr);
         mv_align->AddEnumItem("Left", ICommentKey::eTA_Left);
         mv_align->AddEnumItem("Center", ICommentKey::eTA_Center);
         mv_align->AddEnumItem("Right", ICommentKey::eTA_Right);
         AddVariable(mv_table, mv_align, "Align");
 
-        mv_font->SetEnumList(NULL);
+        mv_font->SetEnumList(nullptr);
         IFileUtil::FileArray fa;
         CFileUtil::ScanDirectory((Path::GetEditingGameDataFolder() + "/Fonts/").c_str(), "*.xml", fa, true);
         for (size_t i = 0; i < fa.size(); ++i)
@@ -58,14 +58,14 @@ public:
         }
         AddVariable(mv_table, mv_font, "Font");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::CommentText;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/CommentNodeAnimator.cpp
+++ b/Code/Editor/TrackView/CommentNodeAnimator.cpp
@@ -26,7 +26,7 @@ CCommentNodeAnimator::CCommentNodeAnimator(CTrackViewAnimNode* pCommentNode)
 
 CCommentNodeAnimator::~CCommentNodeAnimator()
 {
-    m_pCommentNode = 0;
+    m_pCommentNode = nullptr;
 }
 
 void CCommentNodeAnimator::Animate(CTrackViewAnimNode* pNode, const SAnimContext& ac)

--- a/Code/Editor/TrackView/ConsoleKeyUIControls.cpp
+++ b/Code/Editor/TrackView/ConsoleKeyUIControls.cpp
@@ -24,19 +24,19 @@ public:
     CSmartVariableArray mv_table;
     CSmartVariable<QString> mv_command;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_command, "Command");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::Console;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/EventKeyUIControls.cpp
+++ b/Code/Editor/TrackView/EventKeyUIControls.cpp
@@ -26,7 +26,7 @@ public:
     CSmartVariable<QString> mv_value;
     CSmartVariable<bool> mv_notrigger_in_scrubbing;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_event, "Event");
@@ -35,14 +35,14 @@ public:
         AddVariable(mv_deprecated, "Deprecated");
         AddVariable(mv_deprecated, mv_animation, "Animation");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::Event;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {
@@ -73,8 +73,8 @@ bool CEventKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys
         CAnimParamType paramType = keyHandle.GetTrack()->GetParameterType();
         if (paramType == AnimParamType::Event)
         {
-            mv_event.SetEnumList(NULL);
-            mv_animation.SetEnumList(NULL);
+            mv_event.SetEnumList(nullptr);
+            mv_animation.SetEnumList(nullptr);
 
             // Add <None> for empty, unset event
             mv_event->AddEnumItem(QObject::tr("<None>"), "");

--- a/Code/Editor/TrackView/GotoKeyUIControls.cpp
+++ b/Code/Editor/TrackView/GotoKeyUIControls.cpp
@@ -24,12 +24,12 @@ public:
     CSmartVariableArray mv_table;
     CSmartVariable<float> mv_command;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_command, "Goto Time");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         if (paramType == AnimParamType::Goto)
         {
@@ -40,10 +40,10 @@ public:
             return false;
         }
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/ScreenFaderKeyUIControls.cpp
+++ b/Code/Editor/TrackView/ScreenFaderKeyUIControls.cpp
@@ -33,23 +33,23 @@ class CScreenFaderKeyUIControls
 public:
     //-----------------------------------------------------------------------------
     //!
-    virtual bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::ScreenFader;
     }
 
     //-----------------------------------------------------------------------------
     //!
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
 
-        mv_fadeType->SetEnumList(NULL);
+        mv_fadeType->SetEnumList(nullptr);
         mv_fadeType->AddEnumItem("FadeIn", IScreenFaderKey::eFT_FadeIn);
         mv_fadeType->AddEnumItem("FadeOut", IScreenFaderKey::eFT_FadeOut);
         AddVariable(mv_table, mv_fadeType, "Type");
 
-        mv_fadechangeType->SetEnumList(NULL);
+        mv_fadechangeType->SetEnumList(nullptr);
         mv_fadechangeType->AddEnumItem("Linear", IScreenFaderKey::eFCT_Linear);
         mv_fadechangeType->AddEnumItem("Square", IScreenFaderKey::eFCT_Square);
         mv_fadechangeType->AddEnumItem("Cubic Square", IScreenFaderKey::eFCT_CubicSquare);
@@ -67,13 +67,13 @@ public:
 
     //-----------------------------------------------------------------------------
     //!
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& keys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& keys) override;
 
     //-----------------------------------------------------------------------------
     //!
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& keys);
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& keys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/SelectKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SelectKeyUIControls.cpp
@@ -22,7 +22,7 @@ class CSelectKeyUIControls
     , protected AZ::EntitySystemBus::Handler
 {
 public:
-    CSelectKeyUIControls() {}
+    CSelectKeyUIControls() = default;
 
     ~CSelectKeyUIControls() override;
 
@@ -30,7 +30,7 @@ public:
     CSmartVariableEnum<QString> mv_camera;
     CSmartVariable<float> mv_BlendTime;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_camera, "Camera");
@@ -39,14 +39,14 @@ public:
         Camera::CameraNotificationBus::Handler::BusConnect();
         AZ::EntitySystemBus::Handler::BusConnect();
     }
-    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const
+    bool SupportTrackType([[maybe_unused]] const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, AnimValueType valueType) const override
     {
         return valueType == AnimValueType::Select;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {
@@ -98,7 +98,7 @@ bool CSelectKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedKey
             ResetCameraEntries();
 
             // Get All cameras.
-            mv_camera.SetEnumList(NULL);
+            mv_camera.SetEnumList(nullptr);
 
             mv_camera->AddEnumItem(QObject::tr("<None>"), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
@@ -217,7 +217,7 @@ void CSelectKeyUIControls::OnCameraRemoved(const AZ::EntityId & cameraId)
     // We can't iterate or remove an item from the enum list, and Camera::CameraRequests::GetCameras
     // still includes the deleted camera at this point. Reset the list anyway and filter out the
     // deleted camera.
-    mv_camera->SetEnumList(NULL);
+    mv_camera->SetEnumList(nullptr);
     mv_camera->AddEnumItem(QObject::tr("<None>"), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
     AZ::EBusAggregateResults<AZ::EntityId> cameraComponentEntities;
@@ -256,7 +256,7 @@ void CSelectKeyUIControls::OnEntityNameChanged(const AZ::EntityId & entityId, [[
 
 void CSelectKeyUIControls::ResetCameraEntries()
 {
-    mv_camera.SetEnumList(NULL);
+    mv_camera.SetEnumList(nullptr);
     mv_camera->AddEnumItem(QObject::tr("<None>"), QString::number(static_cast<AZ::u64>(AZ::EntityId::InvalidEntityId)));
 
     // Find all Component Entity Cameras

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -117,8 +117,7 @@ CSequenceBatchRenderDialog::CSequenceBatchRenderDialog(float fps, QWidget* pPare
 }
 
 CSequenceBatchRenderDialog::~CSequenceBatchRenderDialog()
-{
-}
+= default;
 
 void CSequenceBatchRenderDialog::reject()
 {
@@ -519,7 +518,7 @@ void CSequenceBatchRenderDialog::OnGo()
         InitializeContext();
 
         // Trigger the first item.
-        OnMovieEvent(IMovieListener::eMovieEvent_Stopped, NULL);
+        OnMovieEvent(IMovieListener::eMovieEvent_Stopped, nullptr);
     }
 }
 
@@ -728,7 +727,7 @@ bool CSequenceBatchRenderDialog::GetResolutionFromCustomResText(const char* cust
 bool CSequenceBatchRenderDialog::LoadOutputOptions(const QString& pathname)
 {
     XmlNodeRef batchRenderOptionsNode = XmlHelpers::LoadXmlFromFile(pathname.toStdString().c_str());
-    if (batchRenderOptionsNode == NULL)
+    if (batchRenderOptionsNode == nullptr)
     {
         return true;
     }
@@ -1391,7 +1390,7 @@ void CSequenceBatchRenderDialog::OnLoadBatch()
             Path::GetUserSandboxFolder(), loadPath))
     {
         XmlNodeRef batchRenderListNode = XmlHelpers::LoadXmlFromFile(loadPath.toStdString().c_str());
-        if (batchRenderListNode == NULL)
+        if (batchRenderListNode == nullptr)
         {
             return;
         }
@@ -1414,7 +1413,7 @@ void CSequenceBatchRenderDialog::OnLoadBatch()
             // sequence
             const QString seqName = itemNode->getAttr("sequence");
             item.pSequence = GetIEditor()->GetMovieSystem()->FindLegacySequenceByName(seqName.toUtf8().data());
-            if (item.pSequence == NULL)
+            if (item.pSequence == nullptr)
             {
                 QMessageBox::warning(this, tr("Sequence not found"), tr("A sequence of '%1' not found! This'll be skipped.").arg(seqName));
                 continue;
@@ -1431,7 +1430,7 @@ void CSequenceBatchRenderDialog::OnLoadBatch()
                     break;
                 }
             }
-            if (item.pDirectorNode == NULL)
+            if (item.pDirectorNode == nullptr)
             {
                 QMessageBox::warning(this, tr("Director node not found"), tr("A director node of '%1' not found in the sequence of '%2'! This'll be skipped.").arg(directorName).arg(seqName));
                 continue;
@@ -1544,7 +1543,7 @@ bool CSequenceBatchRenderDialog::SetUpNewRenderItem(SRenderItem& item)
             break;
         }
     }
-    if (item.pDirectorNode == NULL)
+    if (item.pDirectorNode == nullptr)
     {
         return false;
     }

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.h
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.h
@@ -81,8 +81,8 @@ protected:
         bool disableDebugInfo;
         bool bCreateVideo;
         SRenderItem()
-            : pSequence(NULL)
-            , pDirectorNode(NULL)
+            : pSequence(nullptr)
+            , pDirectorNode(nullptr)
             , disableDebugInfo(false)
             , bCreateVideo(false) {}
         bool operator==(const SRenderItem& item)
@@ -155,7 +155,7 @@ protected:
             , expectedTotalTime(0)
             , spentTime(0)
             , flagBU(0)
-            , pActiveDirectorBU(NULL)
+            , pActiveDirectorBU(nullptr)
             , cvarCustomResWidthBU(0)
             , cvarCustomResHeightBU(0)
             , cvarDisplayInfoBU(0)

--- a/Code/Editor/TrackView/SequenceKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SequenceKeyUIControls.cpp
@@ -27,7 +27,7 @@ public:
     CSmartVariable<float> mv_startTime;
     CSmartVariable<float> mv_endTime;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_sequence, "Sequence");
@@ -35,14 +35,14 @@ public:
         AddVariable(mv_table, mv_startTime, "Start Time");
         AddVariable(mv_table, mv_endTime, "End Time");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::Sequence;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {
@@ -78,7 +78,7 @@ bool CSequenceKeyUIControls::OnKeySelectionChange(CTrackViewKeyBundle& selectedK
 
             /////////////////////////////////////////////////////////////////////////////////
             // fill sequence comboBox with available sequences
-            mv_sequence.SetEnumList(NULL);
+            mv_sequence.SetEnumList(nullptr);
 
             // Insert '<None>' empty enum
             mv_sequence->AddEnumItem(QObject::tr("<None>"), CTrackViewDialog::GetEntityIdAsString(AZ::EntityId(AZ::EntityId::InvalidEntityId)));
@@ -193,7 +193,7 @@ void CSequenceKeyUIControls::OnUIChange(IVariable* pVar, CTrackViewKeyBundle& se
 
             IMovieSystem* pMovieSystem = GetIEditor()->GetSystem()->GetIMovieSystem();
 
-            if (pMovieSystem != NULL)
+            if (pMovieSystem != nullptr)
             {
                 pMovieSystem->SetStartEndTime(pSequence, sequenceKey.fStartTime, sequenceKey.fEndTime);
             }

--- a/Code/Editor/TrackView/SoundKeyUIControls.cpp
+++ b/Code/Editor/TrackView/SoundKeyUIControls.cpp
@@ -29,7 +29,7 @@ public:
     CSmartVariable<float> mv_duration;
     CSmartVariable<Vec3> mv_customColor;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_startTrigger, "StartTrigger", IVariable::DT_AUDIO_TRIGGER);
@@ -38,14 +38,14 @@ public:
         AddVariable(mv_options, "Options");
         AddVariable(mv_options, mv_customColor, "Custom Color", IVariable::DT_COLOR);
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::Sound;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
+++ b/Code/Editor/TrackView/TVCustomizeTrackColorsDlg.cpp
@@ -344,7 +344,7 @@ void CTVCustomizeTrackColorsDlg::Export(const QString& fullPath) const
 bool CTVCustomizeTrackColorsDlg::Import(const QString& fullPath)
 {
     XmlNodeRef customTrackColorsNode = XmlHelpers::LoadXmlFromFile(fullPath.toStdString().c_str());
-    if (customTrackColorsNode == NULL)
+    if (customTrackColorsNode == nullptr)
     {
         return false;
     }

--- a/Code/Editor/TrackView/TVEventsDialog.cpp
+++ b/Code/Editor/TrackView/TVEventsDialog.cpp
@@ -211,7 +211,7 @@ public:
     int GetNumberOfUsageAndFirstTimeUsed(const char* eventName, float& timeFirstUsed) const;
 };
 
-CTVEventsDialog::CTVEventsDialog(QWidget* pParent /*=NULL*/)
+CTVEventsDialog::CTVEventsDialog(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_ui(new Ui::TVEventsDialog)
 {

--- a/Code/Editor/TrackView/TVSequenceProps.cpp
+++ b/Code/Editor/TrackView/TVSequenceProps.cpp
@@ -51,7 +51,7 @@ CTVSequenceProps::~CTVSequenceProps()
 }
 
 // CTVSequenceProps message handlers
-BOOL CTVSequenceProps::OnInitDialog()
+bool CTVSequenceProps::OnInitDialog()
 {
     ui->NAME->setText(m_pSequence->GetName());
     int seqFlags = m_pSequence->GetFlags();
@@ -97,7 +97,7 @@ BOOL CTVSequenceProps::OnInitDialog()
         ui->ORT_ONCE->setChecked(true);
     }
 
-    return TRUE;  // return TRUE unless you set the focus to a control
+    return true;  // return true unless you set the focus to a control
     // EXCEPTION: OCX Property Pages should return FALSE
 }
 
@@ -259,7 +259,7 @@ void CTVSequenceProps::OnOK()
 
 void CTVSequenceProps::ToggleCutsceneOptions(bool bActivated)
 {
-    if (bActivated == FALSE)
+    if (bActivated == false)
     {
         ui->NOABORT->setChecked(false);
         ui->DISABLEPLAYER->setChecked(false);

--- a/Code/Editor/TrackView/TVSequenceProps.h
+++ b/Code/Editor/TrackView/TVSequenceProps.h
@@ -28,7 +28,7 @@ class CTVSequenceProps
 {
     Q_OBJECT
 public:
-    CTVSequenceProps(CTrackViewSequence* pSequence, float fps, QWidget* pParent = NULL);    // standard constructor
+    CTVSequenceProps(CTrackViewSequence* pSequence, float fps, QWidget* pParent = nullptr);    // standard constructor
     ~CTVSequenceProps();
 
 private:
@@ -39,7 +39,7 @@ private:
     };
     CTrackViewSequence* m_pSequence;
 
-    virtual BOOL OnInitDialog();
+    virtual bool OnInitDialog();
     virtual void OnOK();
 
     void MoveScaleKeys();

--- a/Code/Editor/TrackView/TimeRangeKeyUIControls.cpp
+++ b/Code/Editor/TrackView/TimeRangeKeyUIControls.cpp
@@ -27,7 +27,7 @@ public:
     CSmartVariable<float> mv_timeScale;
     CSmartVariable<bool> mv_bLoop;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_startTime, "Start Time");
@@ -36,14 +36,14 @@ public:
         AddVariable(mv_table, mv_bLoop, "Loop");
         mv_timeScale->SetLimits(0.001f, 100.f);
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::TimeRanges;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {

--- a/Code/Editor/TrackView/TrackEventKeyUIControls.cpp
+++ b/Code/Editor/TrackView/TrackEventKeyUIControls.cpp
@@ -26,21 +26,21 @@ public:
     CSmartVariableEnum<QString> mv_event;
     CSmartVariable<QString> mv_value;
 
-    virtual void OnCreateVars()
+    void OnCreateVars() override
     {
         AddVariable(mv_table, "Key Properties");
         AddVariable(mv_table, mv_event, "Track Event");
         mv_event->SetFlags(mv_event->GetFlags() | IVariable::UI_UNSORTED);
         AddVariable(mv_table, mv_value, "Value");
     }
-    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const
+    bool SupportTrackType(const CAnimParamType& paramType, [[maybe_unused]] EAnimCurveType trackType, [[maybe_unused]] AnimValueType valueType) const override
     {
         return paramType == AnimParamType::TrackEvent;
     }
-    virtual bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys);
-    virtual void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys);
+    bool OnKeySelectionChange(CTrackViewKeyBundle& selectedKeys) override;
+    void OnUIChange(IVariable* pVar, CTrackViewKeyBundle& selectedKeys) override;
 
-    virtual unsigned int GetPriority() const { return 1; }
+    unsigned int GetPriority() const override { return 1; }
 
     static const GUID& GetClassID()
     {
@@ -182,7 +182,7 @@ void CTrackEventKeyUIControls::BuildEventDropDown(QString& curEvent, const QStri
         {
             bool curEventExists = false;
             bool addedEventExists = false;
-            mv_event.SetEnumList(NULL);
+            mv_event.SetEnumList(nullptr);
             const int eventCount = sequence->GetTrackEventsCount();
 
             // Need to check if event exists before adding all events

--- a/Code/Editor/TrackView/TrackViewAnimNode.cpp
+++ b/Code/Editor/TrackView/TrackViewAnimNode.cpp
@@ -370,7 +370,7 @@ bool CTrackViewAnimNode::IsBoundToEditorObjects() const
         else
         {
             // check if bound to legacy entity
-            return (m_animNode->GetNodeOwner() != NULL);
+            return (m_animNode->GetNodeOwner() != nullptr);
         }
     }
 
@@ -1468,7 +1468,7 @@ bool CTrackViewAnimNode::PasteNodesFromClipboard(QWidget* context)
     }
 
     XmlNodeRef animNodesRoot = clipboard.Get();
-    if (animNodesRoot == NULL || strcmp(animNodesRoot->getTag(), "CopyAnimNodesRoot") != 0)
+    if (animNodesRoot == nullptr || strcmp(animNodesRoot->getTag(), "CopyAnimNodesRoot") != 0)
     {
         return false;
     }

--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -130,10 +130,10 @@ const GUID& CTrackViewDialog::GetClassID()
 
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewDialog* CTrackViewDialog::s_pTrackViewDialog = NULL;
+CTrackViewDialog* CTrackViewDialog::s_pTrackViewDialog = nullptr;
 
 //////////////////////////////////////////////////////////////////////////
-CTrackViewDialog::CTrackViewDialog(QWidget* pParent /*=NULL*/)
+CTrackViewDialog::CTrackViewDialog(QWidget* pParent /*=nullptr*/)
     : QMainWindow(pParent)
 {
     s_pTrackViewDialog = this;
@@ -152,7 +152,7 @@ CTrackViewDialog::CTrackViewDialog(QWidget* pParent /*=NULL*/)
     m_lazyInitDone = false;
     m_bEditLock = false;
 
-    m_pNodeForTracksToolBar = NULL;
+    m_pNodeForTracksToolBar = nullptr;
 
     m_currentToolBarParamTypeId = 0;
 
@@ -181,7 +181,7 @@ CTrackViewDialog::~CTrackViewDialog()
         m_findDlg->deleteLater();
         m_findDlg = nullptr;
     }
-    s_pTrackViewDialog = 0;
+    s_pTrackViewDialog = nullptr;
 
     const CTrackViewSequenceManager* pSequenceManager = GetIEditor()->GetSequenceManager();
     CTrackViewSequence* sequence = pSequenceManager->GetSequenceByEntityId(m_currentSequenceEntityId);
@@ -210,7 +210,7 @@ void CTrackViewDialog::OnAddEntityNodeMenu()
 }
 
 //////////////////////////////////////////////////////////////////////////
-BOOL CTrackViewDialog::OnInitDialog()
+bool CTrackViewDialog::OnInitDialog()
 {
     InitToolbar();
     InitMenu();
@@ -270,7 +270,7 @@ BOOL CTrackViewDialog::OnInitDialog()
     QString cursorPosText = QString("0.000(%1fps)").arg(FloatToIntRet(m_wndCurveEditor->GetFPS()));
     m_cursorPos->setText(cursorPosText);
 
-    return TRUE;  // return TRUE unless you set the focus to a control
+    return true;  // return true unless you set the focus to a control
     // EXCEPTION: OCX Property Pages should return FALSE
 }
 
@@ -621,7 +621,7 @@ void CTrackViewDialog::InitToolbar()
     {
         qaction2->setCheckable(true);
     }
-    
+
     m_actions[ID_TV_SNAP_NONE]->setChecked(true);
 
     m_tracksToolBar = addToolBar("Tracks Toolbar");
@@ -883,7 +883,7 @@ void CTrackViewDialog::Update()
     // The active camera node means two conditions:
     // 1. Sequence camera is currently active.
     // 2. The camera which owns this node has been set as the current camera by the director node.
-    bool bSequenceCamInUse = gEnv->pMovieSystem->GetCallback() == NULL ||
+    bool bSequenceCamInUse = gEnv->pMovieSystem->GetCallback() == nullptr ||
         gEnv->pMovieSystem->GetCallback()->IsSequenceCamUsed();
     AZ::EntityId camId = gEnv->pMovieSystem->GetCameraParams().cameraEntityId;
     if (camId.IsValid() && bSequenceCamInUse)
@@ -2049,7 +2049,7 @@ void CTrackViewDialog::ClearTracksToolBar()
     m_tracksToolBar->clear();
     m_tracksToolBar->addWidget(new QLabel("Tracks:"));
 
-    m_pNodeForTracksToolBar = NULL;
+    m_pNodeForTracksToolBar = nullptr;
     m_toolBarParamTypes.clear();
     m_currentToolBarParamTypeId = 0;
 }

--- a/Code/Editor/TrackView/TrackViewDialog.h
+++ b/Code/Editor/TrackView/TrackViewDialog.h
@@ -52,7 +52,7 @@ class CTrackViewDialog
 public:
     friend CMovieCallback;
 
-    CTrackViewDialog(QWidget* pParent = NULL);
+    CTrackViewDialog(QWidget* pParent = nullptr);
     ~CTrackViewDialog();
 
     static void RegisterViewClass();
@@ -183,7 +183,7 @@ private:
     void OnAddEntityNodeMenu();
 
     void OnEditorNotifyEvent(EEditorNotifyEvent event) override;
-    BOOL OnInitDialog();
+    bool OnInitDialog();
 
     void SaveLayouts();
     void SaveMiscSettings() const;

--- a/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
+++ b/Code/Editor/TrackView/TrackViewDopeSheetBase.cpp
@@ -88,7 +88,7 @@ CTrackViewDopeSheetBase::CTrackViewDopeSheetBase(QWidget* parent)
     m_currentTime = 0.0f;
     m_storedTime = m_currentTime;
     m_rcSelect = QRect(0, 0, 0, 0);
-    m_rubberBand = 0;
+    m_rubberBand = nullptr;
     m_scrollBar = new QScrollBar(Qt::Horizontal, this);
     connect(m_scrollBar, &QScrollBar::valueChanged, this, &CTrackViewDopeSheetBase::OnHScroll);
     m_keyTimeOffset = 0;
@@ -113,7 +113,7 @@ CTrackViewDopeSheetBase::CTrackViewDopeSheetBase(QWidget* parent)
 
     m_bFastRedraw = false;
 
-    m_pLastTrackSelectedOnSpot = NULL;
+    m_pLastTrackSelectedOnSpot = nullptr;
 
     m_wndPropsOnSpot = nullptr;
 
@@ -544,7 +544,7 @@ void CTrackViewDopeSheetBase::OnLButtonUp(Qt::KeyboardModifiers modifiers, const
         SelectKeys(m_rcSelect, modifiers & Qt::ControlModifier);
         m_rcSelect = QRect();
         m_rubberBand->deleteLater();
-        m_rubberBand = 0;
+        m_rubberBand = nullptr;
     }
     else if (m_mouseMode == eTVMouseMode_SelectWithinTime)
     {
@@ -552,7 +552,7 @@ void CTrackViewDopeSheetBase::OnLButtonUp(Qt::KeyboardModifiers modifiers, const
         SelectAllKeysWithinTimeFrame(m_rcSelect, modifiers & Qt::ControlModifier);
         m_rcSelect = QRect();
         m_rubberBand->deleteLater();
-        m_rubberBand = 0;
+        m_rubberBand = nullptr;
     }
     else if (m_mouseMode == eTVMouseMode_DragTime)
     {
@@ -744,7 +744,7 @@ void CTrackViewDopeSheetBase::OnRButtonDown(Qt::KeyboardModifiers modifiers, con
             }
             else
             {
-                m_pLastTrackSelectedOnSpot = NULL;
+                m_pLastTrackSelectedOnSpot = nullptr;
             }
 
             ShowKeyPropertyCtrlOnSpot(p.x(), p.y(), selectedKeys.GetKeyCount() > 1, bKeyChangeInSameTrack);
@@ -783,7 +783,7 @@ void CTrackViewDopeSheetBase::OnRButtonUp([[maybe_unused]] Qt::KeyboardModifiers
 
     if (!m_bCursorWasInKey)
     {
-        const bool bHasCopiedKey = (GetKeysInClickboard() != NULL);
+        const bool bHasCopiedKey = (GetKeysInClickboard() != nullptr);
 
         if (bHasCopiedKey && m_bMouseMovedAfterRButtonDown == false)    // Once moved, it means the user wanted to scroll, so no paste pop-up.
         {
@@ -1230,24 +1230,24 @@ XmlNodeRef CTrackViewDopeSheetBase::GetKeysInClickboard()
     CClipboard clip(this);
     if (clip.IsEmpty())
     {
-        return NULL;
+        return nullptr;
     }
 
     if (clip.GetTitle() != "Track view keys")
     {
-        return NULL;
+        return nullptr;
     }
 
     XmlNodeRef copyNode = clip.Get();
-    if (copyNode == NULL || strcmp(copyNode->getTag(), "CopyKeysNode"))
+    if (copyNode == nullptr || strcmp(copyNode->getTag(), "CopyKeysNode"))
     {
-        return NULL;
+        return nullptr;
     }
 
     int nNumTracksToPaste = copyNode->getChildCount();
     if (nNumTracksToPaste == 0)
     {
-        return NULL;
+        return nullptr;
     }
 
     return copyNode;
@@ -1789,7 +1789,7 @@ float CTrackViewDopeSheetBase::FrameSnap(float time) const
 //////////////////////////////////////////////////////////////////////////
 void CTrackViewDopeSheetBase::ShowKeyPropertyCtrlOnSpot(int x, int y, [[maybe_unused]] bool bMultipleKeysSelected, bool bKeyChangeInSameTrack)
 {
-    if (m_keyPropertiesDlg == NULL)
+    if (m_keyPropertiesDlg == nullptr)
     {
         return;
     }

--- a/Code/Editor/TrackView/TrackViewFindDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewFindDlg.cpp
@@ -24,13 +24,13 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 // CTrackViewFindDlg dialog
 
 
-CTrackViewFindDlg::CTrackViewFindDlg(const char* title, QWidget* pParent /*=NULL*/)
+CTrackViewFindDlg::CTrackViewFindDlg(const char* title, QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , ui(new Ui::TrackViewFindDlg)
 {
     setWindowTitle(title);
 
-    m_tvDlg = 0;
+    m_tvDlg = nullptr;
     m_numSeqs = 0;
 
     ui->setupUi(this);

--- a/Code/Editor/TrackView/TrackViewFindDlg.h
+++ b/Code/Editor/TrackView/TrackViewFindDlg.h
@@ -32,7 +32,7 @@ class CTrackViewFindDlg
     Q_OBJECT
     // Construction
 public:
-    CTrackViewFindDlg(const char* title = NULL, QWidget* pParent = NULL);   // standard constructor
+    CTrackViewFindDlg(const char* title = nullptr, QWidget* pParent = nullptr);   // standard constructor
     ~CTrackViewFindDlg();
 
     //Functions

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.cpp
@@ -328,8 +328,8 @@ bool CTrackViewTrackPropsDlg::OnKeySelectionChange(CTrackViewKeyBundle& selected
     }
     else
     {
-        ui->PREVNEXT->setEnabled(FALSE);
-        ui->TIME->setEnabled(FALSE);
+        ui->PREVNEXT->setEnabled(false);
+        ui->TIME->setEnabled(false);
     }
     return true;
 }

--- a/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.h
+++ b/Code/Editor/TrackView/TrackViewKeyPropertiesDlg.h
@@ -74,7 +74,7 @@ protected:
     // Helper functions.
     //////////////////////////////////////////////////////////////////////////
     template <class T>
-    void SyncValue(CSmartVariable<T>& var, T& value, bool bCopyToUI, IVariable* pSrcVar = NULL)
+    void SyncValue(CSmartVariable<T>& var, T& value, bool bCopyToUI, IVariable* pSrcVar = nullptr)
     {
         if (bCopyToUI)
         {

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -69,7 +69,7 @@ public:
         : QStyledItemDelegate(parent)
     {}
 
-    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
     {
         bool enabled = index.data(CTrackViewNodesCtrl::CRecord::EnableRole).toBool();
         QStyleOptionViewItem opt = option;
@@ -106,7 +106,7 @@ protected:
         return Qt::CopyAction | Qt::MoveAction;
     }
 
-    void dragMoveEvent(QDragMoveEvent* event)
+    void dragMoveEvent(QDragMoveEvent* event) override
     {
         CTrackViewNodesCtrl::CRecord* record = (CTrackViewNodesCtrl::CRecord*) itemAt(event->pos());
         if (!record)
@@ -144,7 +144,7 @@ protected:
         }
     }
 
-    void dropEvent(QDropEvent* event)
+    void dropEvent(QDropEvent* event) override
     {
         CTrackViewNodesCtrl::CRecord* record = (CTrackViewNodesCtrl::CRecord*) itemAt(event->pos());
         if (!record)
@@ -200,7 +200,7 @@ protected:
         }
     }
 
-    void keyPressEvent(QKeyEvent* event)
+    void keyPressEvent(QKeyEvent* event) override
     {
         // HAVE TO INCLUDE CASES FOR THESE IN THE ShortcutOverride handler in ::event() below
         switch (event->key())
@@ -242,7 +242,7 @@ protected:
     }
 
 
-    bool focusNextPrevChild([[maybe_unused]] bool next)
+    bool focusNextPrevChild([[maybe_unused]] bool next) override
     {
         return false;   // so we get the tab key
     }
@@ -361,7 +361,7 @@ CTrackViewNodesCtrl::CTrackViewNodesCtrl(QWidget* hParentWnd, CTrackViewDialog* 
     , m_pTrackViewDialog(parent)
 {
     ui->setupUi(this);
-    m_pDopeSheet = 0;
+    m_pDopeSheet = nullptr;
     m_currentMatchIndex = 0;
     m_matchCount = 0;
 
@@ -954,7 +954,7 @@ void CTrackViewNodesCtrl::OnSelectionChanged()
 //////////////////////////////////////////////////////////////////////////
 void CTrackViewNodesCtrl::OnNMRclick(QPoint point)
 {
-    CRecord* record = 0;
+    CRecord* record = nullptr;
     bool isOnAzEntity = false;
     CTrackViewSequence* sequence = GetIEditor()->GetAnimation()->GetSequence();
     if (!sequence)
@@ -1605,7 +1605,7 @@ CTrackViewTrack* CTrackViewNodesCtrl::GetTrackViewTrack(const Export::EntityAnim
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/TrackView/TrackViewSplineCtrl.cpp
+++ b/Code/Editor/TrackView/TrackViewSplineCtrl.cpp
@@ -56,10 +56,10 @@ protected:
         }
     }
 
-    virtual int GetSize() { return sizeof(*this); }
-    virtual QString GetDescription() { return "UndoTrackViewSplineCtrl"; };
+    int GetSize() override { return sizeof(*this); }
+    QString GetDescription() override { return "UndoTrackViewSplineCtrl"; };
 
-    virtual void Undo(bool bUndo)
+    void Undo(bool bUndo) override
     {
         CTrackViewSplineCtrl* pCtrl = FindControl(m_pCtrl);
         if (pCtrl)
@@ -103,7 +103,7 @@ protected:
         }
     }
 
-    virtual void Redo()
+    void Redo() override
     {
         const CTrackViewSequenceManager* pSequenceManager = GetIEditor()->GetSequenceManager();
         CTrackViewSequence* sequence = pSequenceManager->GetSequenceByEntityId(m_sequenceEntityId);
@@ -136,7 +136,7 @@ protected:
         sequence->OnKeySelectionChanged();
     }
 
-    virtual bool IsSelectionChanged() const
+    bool IsSelectionChanged() const override
     {
         const CTrackViewSequenceManager* sequenceManager = GetIEditor()->GetSequenceManager();
         CTrackViewSequence* sequence = sequenceManager->GetSequenceByEntityId(m_sequenceEntityId);
@@ -151,19 +151,19 @@ protected:
     }
 
 public:
-    typedef std::list<CTrackViewSplineCtrl*> CTrackViewSplineCtrls;
+    using CTrackViewSplineCtrls = std::list<CTrackViewSplineCtrl*>;
 
     static CTrackViewSplineCtrl* FindControl(CTrackViewSplineCtrl* pCtrl)
     {
         if (!pCtrl)
         {
-            return 0;
+            return nullptr;
         }
 
         auto iter = std::find(s_activeCtrls.begin(), s_activeCtrls.end(), pCtrl);
         if (iter == s_activeCtrls.end())
         {
-            return 0;
+            return nullptr;
         }
 
         return *iter;
@@ -449,7 +449,7 @@ void CTrackViewSplineCtrl::AddSpline(ISplineInterpolator* pSpline, CTrackViewTra
     }
 
     si.pSpline = pSpline;
-    si.pDetailSpline = NULL;
+    si.pDetailSpline = nullptr;
     m_splines.push_back(si);
     m_tracks.push_back(pTrack);
     m_bKeyTimesDirty = true;
@@ -896,7 +896,7 @@ bool CTrackViewSplineCtrl::IsUnifiedKeyCurrentlySelected() const
     {
         ISplineInterpolator* pSpline = m_splines[splineIndex].pSpline;
 
-        if (pSpline == NULL)
+        if (pSpline == nullptr)
         {
             continue;
         }
@@ -960,7 +960,7 @@ void CTrackViewSplineCtrl::mouseReleaseEvent(QMouseEvent* event)
     if (GetIEditor()->GetAnimation()->GetSequence())
     {
         bool restoreRecordModeToTrue = (m_editMode == TimeMarkerMode && m_stashedRecordModeWhenDraggingTime);
-        
+
         SplineWidget::mouseReleaseEvent(event);
 
         if (restoreRecordModeToTrue)


### PR DESCRIPTION
A few 'typedefs' replaced by 'using's
This shouldn't have any functional changes at all, just c++17 modernization
It's a part 3 of a split #2847

*Note to reviewers this is a split PR meant to ease reviewing, but sadly I cannot say if this or any other part will compile correctly in isolation.*

Signed-off-by: Nemerle <nemerle5+git@gmail.com>