### PR TITLE
Editor code: tidy up BOOLs,NULLs and overrides pt4.

### DIFF
--- a/Code/Editor/Undo/Undo.cpp
+++ b/Code/Editor/Undo/Undo.cpp
@@ -34,7 +34,7 @@ public:
     {
         m_undoSteps.push_back(step);
     }
-    virtual int GetSize() const
+    int GetSize() const override
     {
         int size = 0;
         for (int i = 0; i < m_undoSteps.size(); i++)
@@ -43,18 +43,18 @@ public:
         }
         return size;
     }
-    virtual bool IsEmpty() const
+    bool IsEmpty() const override
     {
         return m_undoSteps.empty();
     }
-    virtual void Undo(bool bUndo)
+    void Undo(bool bUndo) override
     {
         for (int i = m_undoSteps.size() - 1; i >= 0; i--)
         {
             m_undoSteps[i]->Undo(bUndo);
         }
     }
-    virtual void Redo()
+    void Redo() override
     {
         for (int i = 0; i < m_undoSteps.size(); i++)
         {
@@ -113,8 +113,8 @@ CUndoManager::CUndoManager()
     m_bRecording = false;
     m_bSuperRecording = false;
 
-    m_currentUndo = 0;
-    m_superUndo = 0;
+    m_currentUndo = nullptr;
+    m_superUndo = nullptr;
     m_assetManagerUndoInterruptor = new AssetManagerUndoInterruptor();
 
     m_suspendCount = 0;
@@ -270,7 +270,7 @@ void CUndoManager::Accept(const QString& name)
     }
 
     m_bRecording = false;
-    m_currentUndo = 0;
+    m_currentUndo = nullptr;
 
     SignalNumUndoRedoToListeners();
 
@@ -303,7 +303,7 @@ void CUndoManager::Cancel()
     }
 
     delete m_currentUndo;
-    m_currentUndo = 0;
+    m_currentUndo = nullptr;
     //CLogFile::WriteLine( "<Undo> Cancel OK" );
 }
 
@@ -582,7 +582,7 @@ void CUndoManager::SuperAccept(const QString& name)
 
     //CLogFile::FormatLine( "Undo Object Accepted (Undo:%d,Redo:%d)",m_undoStack.size(),m_redoStack.size() );
     m_bSuperRecording = false;
-    m_superUndo = 0;
+    m_superUndo = nullptr;
     //CLogFile::WriteLine( "<Undo> SupperAccept OK" );
 
     SignalNumUndoRedoToListeners();
@@ -616,7 +616,7 @@ void CUndoManager::SuperCancel()
 
     m_bSuperRecording = false;
     delete m_superUndo;
-    m_superUndo = 0;
+    m_superUndo = nullptr;
     //CLogFile::WriteLine( "<Undo> SuperCancel OK" );
 }
 
@@ -708,8 +708,8 @@ void CUndoManager::Flush()
 
     delete m_superUndo;
     delete m_currentUndo;
-    m_superUndo = 0;
-    m_currentUndo = 0;
+    m_superUndo = nullptr;
+    m_currentUndo = nullptr;
 
     SignalUndoFlushedToListeners();
 }

--- a/Code/Editor/Undo/Undo.h
+++ b/Code/Editor/Undo/Undo.h
@@ -116,7 +116,7 @@ public:
                 continue;
             }
 
-            if (m_undoObjects[i]->GetObjectName() == NULL)
+            if (m_undoObjects[i]->GetObjectName() == nullptr)
             {
                 continue;
             }
@@ -209,7 +209,7 @@ public:
 
     bool IsHaveUndo() const;
     bool IsHaveRedo() const;
-    
+
     void SetMaxUndoStep(int steps);
     int GetMaxUndoStep() const;
 

--- a/Code/Editor/Util/3DConnexionDriver.cpp
+++ b/Code/Editor/Util/3DConnexionDriver.cpp
@@ -34,12 +34,12 @@ bool C3DConnexionDriver::InitDevice()
     // Find the Raw Devices
     UINT nDevices;
     // Get Number of devices attached
-    if (GetRawInputDeviceList(NULL, &nDevices, sizeof(RAWINPUTDEVICELIST)) != 0)
+    if (GetRawInputDeviceList(nullptr, &nDevices, sizeof(RAWINPUTDEVICELIST)) != 0)
     {
         return false;
     }
     // Create list large enough to hold all RAWINPUTDEVICE structs
-    if ((m_pRawInputDeviceList = (PRAWINPUTDEVICELIST)malloc(sizeof(RAWINPUTDEVICELIST) * nDevices)) == NULL)
+    if ((m_pRawInputDeviceList = (PRAWINPUTDEVICELIST)malloc(sizeof(RAWINPUTDEVICELIST) * nDevices)) == nullptr)
     {
         return false;
     }
@@ -85,7 +85,7 @@ bool C3DConnexionDriver::InitDevice()
                         m_pRawInputDevices[m_nUsagePage1Usage8Devices].usUsagePage = phidInfo->usUsagePage;
                         m_pRawInputDevices[m_nUsagePage1Usage8Devices].usUsage     = phidInfo->usUsage;
                         m_pRawInputDevices[m_nUsagePage1Usage8Devices].dwFlags     = 0;
-                        m_pRawInputDevices[m_nUsagePage1Usage8Devices].hwndTarget  = NULL;
+                        m_pRawInputDevices[m_nUsagePage1Usage8Devices].hwndTarget  = nullptr;
                         m_nUsagePage1Usage8Devices++;
                     }
                 }
@@ -126,8 +126,8 @@ bool C3DConnexionDriver::GetInputMessageData(LPARAM lParam, S3DConnexionMessage&
     {
         if (event->header.dwType == RIM_TYPEHID)
         {
-            static BOOL bGotTranslation = FALSE,
-                        bGotRotation    = FALSE;
+            static bool bGotTranslation = false,
+                        bGotRotation    = false;
             static int all6DOFs[6] = {0};
             LPRAWHID pRawHid = &event->data.hid;
 

--- a/Code/Editor/Util/DynamicArray2D.cpp
+++ b/Code/Editor/Util/DynamicArray2D.cpp
@@ -58,7 +58,7 @@ CDynamicArray2D::~CDynamicArray2D()
     }
 
     delete [] m_Array;
-    m_Array = 0;
+    m_Array = nullptr;
 }
 
 

--- a/Code/Editor/Util/EditorUtils.cpp
+++ b/Code/Editor/Util/EditorUtils.cpp
@@ -42,14 +42,14 @@ void HeapCheck::Check([[maybe_unused]] const char* file, [[maybe_unused]] int li
             {
                 CString str;
                 str.Format( "Bad Start of Heap, at file %s line:%d",file,line );
-                MessageBox( NULL,str,"Heap Check",MB_OK );
+                MessageBox( nullptr,str,"Heap Check",MB_OK );
             }
       break;
    case _HEAPBADNODE:
             {
                 CString str;
                 str.Format( "Bad Node in Heap, at file %s line:%d",file,line );
-                MessageBox( NULL,str,"Heap Check",MB_OK );
+                MessageBox( nullptr,str,"Heap Check",MB_OK );
             }
       break;
    }
@@ -258,7 +258,7 @@ namespace EditorUtils
     AzWarningAbsorber::AzWarningAbsorber(const char* window)
         : m_window(window)
     AZ_POP_DISABLE_WARNING
-    { 
+    {
         BusConnect();
     }
 

--- a/Code/Editor/Util/EditorUtils.h
+++ b/Code/Editor/Util/EditorUtils.h
@@ -359,7 +359,7 @@ inline QString TokenizeString(const QString& s, LPCSTR pszTokens, int& iStart)
 
     QByteArray str = s.toUtf8();
 
-    if (pszTokens == NULL)
+    if (pszTokens == nullptr)
     {
         return str;
     }
@@ -472,7 +472,7 @@ inline const char* strstri(const char* pString, const char* pSubstring)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 
@@ -542,7 +542,7 @@ public:
         // There is a bug in QT with writing files larger than 32MB. It separates
         // the write into 32MB blocks, but doesn't write the last block correctly.
         // To deal with this, we'll separate into blocks here so QT doesn't have to.
-        
+
         // QT bug in qfileengine_win.cpp line 434. Block size is calculated once and always
         // used as the amount of data to write, but for the last block, unless there is exactly
         // block size left to write, the actual remaining amount needs to be written, not the
@@ -658,14 +658,14 @@ inline CArchive& operator>>(CArchive& ar, QString& str)
             str = QString::fromUtf16(reinterpret_cast<ushort*>(raw), aznumeric_cast<int>(length));
         }
     }
-    
+
     return ar;
 }
 
 inline CArchive& operator<<(CArchive& ar, const QString& str)
 {
     // This is written to mimic how MFC archiving worked, which was to
-    // write markers to indicate the size of the length - 
+    // write markers to indicate the size of the length -
     // so a length that will fit into 8 bits takes 8 bits.
     // A length that requires more than 8 bits, puts an 8 bit marker (0xff)
     // to indicate that the length is greater, then 16 bits for the length.
@@ -693,7 +693,7 @@ inline CArchive& operator<<(CArchive& ar, const QString& str)
         ar << static_cast<quint16>(0xffff);
         ar << static_cast<quint32>(length);
     }
-   
+
     ar.device()->write(data);
 
     return ar;

--- a/Code/Editor/Util/FileChangeMonitor.cpp
+++ b/Code/Editor/Util/FileChangeMonitor.cpp
@@ -16,7 +16,7 @@
 #include <QTimer>
 
 
-CFileChangeMonitor* CFileChangeMonitor::s_pFileMonitorInstance = NULL;
+CFileChangeMonitor* CFileChangeMonitor::s_pFileMonitorInstance = nullptr;
 
 //////////////////////////////////////////////////////////////////////////
 CFileChangeMonitor::CFileChangeMonitor(QObject* parent)
@@ -34,7 +34,7 @@ CFileChangeMonitor::~CFileChangeMonitor()
 
         if (pListener)
         {
-            pListener->SetMonitor(NULL);
+            pListener->SetMonitor(nullptr);
         }
     }
 
@@ -143,7 +143,7 @@ void CFileChangeMonitor::Unsubscribe(CFileChangeMonitorListener* pListener)
 {
     assert(pListener);
     m_listeners.erase(pListener);
-    pListener->SetMonitor(NULL);
+    pListener->SetMonitor(nullptr);
 }
 
 void CFileChangeMonitor::OnDirectoryChange(const QString &path)

--- a/Code/Editor/Util/FileChangeMonitor.h
+++ b/Code/Editor/Util/FileChangeMonitor.h
@@ -111,7 +111,7 @@ class CFileChangeMonitorListener
 {
 public:
     CFileChangeMonitorListener()
-        : m_pMonitor(NULL)
+        : m_pMonitor(nullptr)
     {
     }
 

--- a/Code/Editor/Util/FileEnum.cpp
+++ b/Code/Editor/Util/FileEnum.cpp
@@ -12,7 +12,7 @@
 #include "FileEnum.h"
 
 CFileEnum::CFileEnum()
-    : m_hEnumFile(0)
+    : m_hEnumFile(nullptr)
 {
 }
 
@@ -21,7 +21,7 @@ CFileEnum::~CFileEnum()
     if (m_hEnumFile)
     {
         delete m_hEnumFile;
-        m_hEnumFile = 0;
+        m_hEnumFile = nullptr;
     }
 }
 
@@ -53,7 +53,7 @@ bool CFileEnum::StartEnumeration(const QString& szEnumPathAndPattern, QFileInfo*
     if (m_hEnumFile)
     {
         delete m_hEnumFile;
-        m_hEnumFile = 0;
+        m_hEnumFile = nullptr;
     }
 
     QStringList parts = szEnumPathAndPattern.split(QRegularExpression(R"([\\/])"));
@@ -66,7 +66,7 @@ bool CFileEnum::StartEnumeration(const QString& szEnumPathAndPattern, QFileInfo*
     {
         // No files found
         delete m_hEnumFile;
-        m_hEnumFile = 0;
+        m_hEnumFile = nullptr;
 
         return false;
     }
@@ -84,7 +84,7 @@ bool CFileEnum::GetNextFile(QFileInfo* pFile)
     {
         // No more files left
         delete m_hEnumFile;
-        m_hEnumFile = 0;
+        m_hEnumFile = nullptr;
 
         return false;
     }

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -279,7 +279,7 @@ void CFileUtil::EditTextureFile(const char* textureFile, [[maybe_unused]] bool b
     // Qt does.
     QString fullTexturePathFixedForWindows = QString(fullTexturePath.data()).replace('/', '\\');
     QByteArray fullTexturePathFixedForWindowsUtf8 = fullTexturePathFixedForWindows.toUtf8();
-    HINSTANCE hInst = ShellExecute(NULL, "open", textureEditorPath.data(), fullTexturePathFixedForWindowsUtf8.data(), NULL, SW_SHOWNORMAL);
+    HINSTANCE hInst = ShellExecute(nullptr, "open", textureEditorPath.data(), fullTexturePathFixedForWindowsUtf8.data(), nullptr, SW_SHOWNORMAL);
     failedToLaunch = ((DWORD_PTR)hInst <= 32);
 #elif defined(AZ_PLATFORM_MAC)
     failedToLaunch = QProcess::execute(QString("/usr/bin/open"), {"-a", gSettings.textureEditor, QString(fullTexturePath.data()) }) != 0;
@@ -332,7 +332,7 @@ bool CFileUtil::EditMayaFile(const char* filepath, const bool bExtractFromPak, c
             CryMessageBox("Can't open the file. You can specify a source editor in Sandbox Preferences or create an association in Windows.", "Cannot open file!", MB_OK | MB_ICONERROR);
         }
     }
-    return TRUE;
+    return true;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -348,10 +348,10 @@ bool CFileUtil::EditFile(const char* filePath, const bool bExtrackFromPak, const
     else if ((extension.compare(".bspace") == 0) || (extension.compare(".comb") == 0))
     {
         EditTextFile(filePath, 0, IFileUtil::FILE_TYPE_BSPACE);
-        return TRUE;
+        return true;
     }
 
-    return FALSE;
+    return false;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -374,7 +374,7 @@ bool CFileUtil::CalculateDccFilename(const QString& assetFilename, QString& dccF
 //////////////////////////////////////////////////////////////////////////
 bool CFileUtil::ExtractDccFilenameFromAssetDatabase(const QString& assetFilename, QString& dccFilename)
 {
-    IAssetItemDatabase* pCurrentDatabaseInterface = NULL;
+    IAssetItemDatabase* pCurrentDatabaseInterface = nullptr;
     std::vector<IClassDesc*> assetDatabasePlugins;
     IEditorClassFactory* pClassFactory = GetIEditor()->GetClassFactory();
     pClassFactory->GetClassesByCategory("Asset Item DB", assetDatabasePlugins);
@@ -592,7 +592,7 @@ inline bool ScanDirectoryFiles(const QString& root, const QString& path, const Q
 
     /*
     CFileFind finder;
-    BOOL bWorking = finder.FindFile( Path::Make(dir,fileSpec) );
+    bool bWorking = finder.FindFile( Path::Make(dir,fileSpec) );
     while (bWorking)
     {
         bWorking = finder.FindNextFile();
@@ -663,7 +663,7 @@ inline int ScanDirectoryRecursive(const QString& root, const QString& path, cons
     {
         /*
         CFileFind finder;
-        BOOL bWorking = finder.FindFile( Path::Make(dir,"*.*") );
+        bool bWorking = finder.FindFile( Path::Make(dir,"*.*") );
         while (bWorking)
         {
             bWorking = finder.FindNextFile();
@@ -847,12 +847,12 @@ void BlockAndWait(const bool& opComplete, QWidget* parent, const char* message)
             {
                 // note that 16ms below is not the amount of time to wait, its the maximum time that
                 // processEvents is allowed to keep processing them if they just keep being emitted.
-                // adding a maximum time here means that we get an opportunity to pump the TickBus 
+                // adding a maximum time here means that we get an opportunity to pump the TickBus
                 // periodically even during a flood of events.
                 QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 16);
                 AZ::TickBus::ExecuteQueuedEvents();
             }
-            
+
             // if we are not the main thread then the above will be done by the main thread, and we can just wait for it to happen.
             // its fairly important we don't sleep for really long because this legacy code is often invoked in a blocking loop
             // for many items, and in the worst case, any time we spend sleeping here will be added to each item.
@@ -1206,10 +1206,10 @@ bool   CFileUtil::CreatePath(const QString& strPath)
     QString                                 strFilename;
     QString                                 strExtension;
     QString                                 strCurrentDirectoryPath;
-    QStringList        cstrDirectoryQueue;
+    QStringList                             cstrDirectoryQueue;
     size_t                                  nCurrentPathQueue(0);
     size_t                                  nTotalPathQueueElements(0);
-    BOOL                                        bnLastDirectoryWasCreated(FALSE);
+    bool                                    bnLastDirectoryWasCreated(false);
 
     if (PathExists(strPath))
     {
@@ -1361,7 +1361,7 @@ IFileUtil::ECopyTreeResult CFileUtil::CopyTree(const QString& strSourceDirectory
     nTotal = cFiles.size();
     for (nCurrent = 0; nCurrent < nTotal; ++nCurrent)
     {
-        BOOL        bnLastFileWasCopied(FALSE);
+        bool        bnLastFileWasCopied(false);
 
 
         if (eCopyResult == IFileUtil::ETREECOPYUSERCANCELED)
@@ -1447,7 +1447,7 @@ IFileUtil::ECopyTreeResult CFileUtil::CopyTree(const QString& strSourceDirectory
             return eCopyResult;
         }
 
-        BOOL        bnLastDirectoryWasCreated(FALSE);
+        bool        bnLastDirectoryWasCreated(false);
 
         QString sourceName = sourceDir.absoluteFilePath(cDirectories[nCurrent]);
         QString targetName = targetDir.absoluteFilePath(cDirectories[nCurrent]);
@@ -1529,7 +1529,7 @@ IFileUtil::ECopyTreeResult   CFileUtil::CopyFile(const QString& strSourceFile, c
     CUserOptions                            oFileOptions;
     IFileUtil::ECopyTreeResult                      eCopyResult(IFileUtil::ETREECOPYOK);
 
-    BOOL                                            bnLastFileWasCopied(FALSE);
+    bool                                        bnLastFileWasCopied(false);
     QString                                     name(strSourceFile);
     QString                                     strQueryFilename;
     QString                                     strFullStargetName;
@@ -1658,7 +1658,7 @@ IFileUtil::ECopyTreeResult   CFileUtil::CopyFile(const QString& strSourceFile, c
                 }
                 if (pfnProgress)
                 {
-                    pfnProgress(source.size(), totalRead, 0, 0, 0, 0, 0, 0, 0);
+                    pfnProgress(source.size(), totalRead, 0, 0, 0, 0, nullptr, nullptr, nullptr);
                 }
             }
             if (totalRead != source.size())
@@ -1742,7 +1742,7 @@ IFileUtil::ECopyTreeResult   CFileUtil::MoveTree(const QString& strSourceDirecto
             return eCopyResult;
         }
 
-        BOOL        bnLastFileWasCopied(FALSE);
+        bool    bnLastFileWasCopied(false);
         QString sourceName(sourceDir.absoluteFilePath(cFiles[nCurrent]));
         QString targetName(targetDir.absoluteFilePath(cFiles[nCurrent]));
 
@@ -1816,7 +1816,7 @@ IFileUtil::ECopyTreeResult   CFileUtil::MoveTree(const QString& strSourceDirecto
     nTotal = cDirectories.size();
     for (nCurrent = 0; nCurrent < nTotal; ++nCurrent)
     {
-        BOOL        bnLastDirectoryWasCreated(FALSE);
+        bool        bnLastDirectoryWasCreated(false);
 
         if (eCopyResult == IFileUtil::ETREECOPYUSERCANCELED)
         {

--- a/Code/Editor/Util/FileUtil.h
+++ b/Code/Editor/Util/FileUtil.h
@@ -123,7 +123,7 @@ public:
 
     //////////////////////////////////////////////////////////////////////////
     // @param LPPROGRESS_ROUTINE pfnProgress - called by the system to notify of file copy progress
-    // @param LPBOOL pbCancel - when the contents of this BOOL are set to TRUE, the system cancels the copy operation
+    // @param LPBOOL pbCancel - when the contents of this BOOL are set to true, the system cancels the copy operation
     static IFileUtil::ECopyTreeResult   CopyFile(const QString& strSourceFile, const QString& strTargetFile, bool boConfirmOverwrite = false, ProgressRoutine pfnProgress = nullptr, bool* pbCancel = nullptr);
 
 

--- a/Code/Editor/Util/FileUtil_impl.h
+++ b/Code/Editor/Util/FileUtil_impl.h
@@ -110,8 +110,8 @@ public:
 
     //////////////////////////////////////////////////////////////////////////
     // @param LPPROGRESS_ROUTINE pfnProgress - called by the system to notify of file copy progress
-    // @param LPBOOL pbCancel - when the contents of this BOOL are set to TRUE, the system cancels the copy operation
-    ECopyTreeResult CopyFile(const QString& strSourceFile, const QString& strTargetFile, bool boConfirmOverwrite = false, ProgressRoutine pfnProgress = NULL, bool* pbCancel = NULL) override;
+    // @param LPBOOL pbCancel - when the contents of this BOOL are set to true, the system cancels the copy operation
+    ECopyTreeResult CopyFile(const QString& strSourceFile, const QString& strTargetFile, bool boConfirmOverwrite = false, ProgressRoutine pfnProgress = nullptr, bool* pbCancel = nullptr) override;
 
     // As we don't have a FileUtil interface here, we have to duplicate some code :-( in order to keep
     // function calls clean.

--- a/Code/Editor/Util/GdiUtil.h
+++ b/Code/Editor/Util/GdiUtil.h
@@ -35,7 +35,7 @@ public:
     ~CAlphaBitmap();
 
     //! creates the bitmap from raw 32bpp data
-    //! \param pData the 32bpp raw image data, RGBA, can be NULL and it would create just an empty bitmap
+    //! \param pData the 32bpp raw image data, RGBA, can be nullptr and it would create just an empty bitmap
     //! \param aWidth the bitmap width
     //! \param aHeight the bitmap height
     bool            Create(void* pData, UINT aWidth, UINT aHeight, bool bVerticalFlip = false, bool bPremultiplyAlpha = false);

--- a/Code/Editor/Util/IXmlHistoryManager.h
+++ b/Code/Editor/Util/IXmlHistoryManager.h
@@ -37,7 +37,7 @@ struct IXmlHistoryEventListener
         eHET_HistoryGroupAdded,
         eHET_HistoryGroupRemoved,
     };
-    virtual void OnEvent(EHistoryEventType event, void* pData = NULL) = 0;
+    virtual void OnEvent(EHistoryEventType event, void* pData = nullptr) = 0;
 };
 
 struct IXmlHistoryView

--- a/Code/Editor/Util/ImageASC.cpp
+++ b/Code/Editor/Util/ImageASC.cpp
@@ -105,34 +105,34 @@ bool CImageASC::Load(const QString& fileName, CFloatImage& image)
 
     // ncols = grid width
     validData = validData && (azstricmp(token, "ncols") == 0);
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     width = atoi(token);
 
     // nrows = grid height
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     validData = validData && (azstricmp(token, "nrows") == 0);
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     height = atoi(token);
 
     // xllcorner = leftmost coordinate.  (Skip, we don't care about it)
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     validData = validData && (azstricmp(token, "xllcorner") == 0);
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
 
     // yllcorner = bottommost coordinate.  (Skip, we don't care about it)
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     validData = validData && (azstricmp(token, "yllcorner") == 0);
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
 
     // cellsize = size of each grid cell.  (Skip, we don't care about it)
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     validData = validData && (azstricmp(token, "cellsize") == 0);
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
 
     // nodata_value = the value used for missing data.  We'll replace these with 0 height.
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     validData = validData && (azstricmp(token, "nodata_value") == 0);
-    token = azstrtok(NULL, 0, seps, &nextToken);
+    token = azstrtok(nullptr, 0, seps, &nextToken);
     nodataValue = atof(token);
 
     if (!validData)
@@ -152,10 +152,10 @@ bool CImageASC::Load(const QString& fileName, CFloatImage& image)
     int i = 0;
     float pixelValue;
     float maxPixel = 0.0f;
-    while (token != NULL && i < size)
+    while (token != nullptr && i < size)
     {
-        token = azstrtok(NULL, 0, seps, &nextToken);
-        if (token != NULL)
+        token = azstrtok(nullptr, 0, seps, &nextToken);
+        if (token != nullptr)
         {
             // Negative heights aren't supported, clamp to 0.
             pixelValue = max(0.0, atof(token));

--- a/Code/Editor/Util/ImageGif.cpp
+++ b/Code/Editor/Util/ImageGif.cpp
@@ -223,7 +223,7 @@ bool CImageGif::Load(const QString& fileName, CImageEx& outImage)
     Pass = 0;
     OutCount = 0;
 
-    Palette = NULL;
+    Palette = nullptr;
     CHK (Raster = new uint8 [filesize]);
 
     if (strncmp((char*) ptr, id87, 6))

--- a/Code/Editor/Util/ImageTIF.cpp
+++ b/Code/Editor/Util/ImageTIF.cpp
@@ -142,7 +142,7 @@ bool CImageTIF::Load(const QString& fileName, CImageEx& outImage)
         uint32 dwWidth, dwHeight;
         size_t npixels;
         uint32* raster;
-        char* dccfilename = NULL;
+        char* dccfilename = nullptr;
 
         TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &dwWidth);
         TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &dwHeight);
@@ -232,7 +232,7 @@ bool CImageTIF::Load(const QString& fileName, CFloatImage& outImage)
     {
         uint32 width = 0, height = 0;
         uint16 spp = 0, bpp = 0, format = 0;
-        char* dccfilename = NULL;
+        char* dccfilename = nullptr;
 
         TIFFGetField(tif, TIFFTAG_IMAGEDESCRIPTION, &dccfilename);
 
@@ -252,11 +252,11 @@ bool CImageTIF::Load(const QString& fileName, CFloatImage& outImage)
 
         // Check to see if it's a GeoTIFF, and if so, whether or not it has the ZScale parameter.
         uint32 tagCount = 0;
-        double *pixelScales = NULL;
+        double *pixelScales = nullptr;
         if (TIFFGetField(tif, GEOTIFF_MODELPIXELSCALE_TAG, &tagCount, &pixelScales) == 1)
         {
             // if there's an xyz scale, and the Z scale isn't 0, let's use it.
-            if ((tagCount == 3) && (pixelScales != NULL) && (pixelScales[2] != 0.0f))
+            if ((tagCount == 3) && (pixelScales != nullptr) && (pixelScales[2] != 0.0f))
             {
                 pixelValueScale = static_cast<float>(pixelScales[2]);
             }
@@ -455,7 +455,7 @@ const char* CImageTIF::GetPreset(const QString& fileName)
     if (!file.Open(fileName.toUtf8().data(), "rb"))
     {
         CLogFile::FormatLine("File not found %s", fileName.toUtf8().data());
-        return NULL;
+        return nullptr;
     }
 
     MemImage memImage;
@@ -473,7 +473,7 @@ const char* CImageTIF::GetPreset(const QString& fileName)
             libtiffDummyCloseProc, libtiffDummySizeProc, libtiffDummyMapFileProc, libtiffDummyUnmapFileProc);
 
     string strReturn;
-    char* preset = NULL;
+    char* preset = nullptr;
     int size;
     if (tif)
     {

--- a/Code/Editor/Util/ImageUtil.cpp
+++ b/Code/Editor/Util/ImageUtil.cpp
@@ -149,13 +149,13 @@ bool CImageUtil::LoadPGM(const QString& fileName, CImageEx& image)
     char* nextToken = nullptr;
     token = azstrtok(str, 0, seps, &nextToken);
 
-    while (token != NULL && token[0] == '#')
+    while (token != nullptr && token[0] == '#')
     {
-        if (token != NULL && token[0] == '#')
+        if (token != nullptr && token[0] == '#')
         {
-            azstrtok(NULL, 0, "\n", &nextToken);
+            azstrtok(nullptr, 0, "\n", &nextToken);
         }
-        token = azstrtok(NULL, 0, seps, &nextToken);
+        token = azstrtok(nullptr, 0, seps, &nextToken);
     }
     if (azstricmp(token, "P2") != 0)
     {
@@ -167,32 +167,32 @@ bool CImageUtil::LoadPGM(const QString& fileName, CImageEx& image)
 
     do
     {
-        token = azstrtok(NULL, 0, seps, &nextToken);
-        if (token != NULL && token[0] == '#')
+        token = azstrtok(nullptr, 0, seps, &nextToken);
+        if (token != nullptr && token[0] == '#')
         {
-            azstrtok(NULL, 0, "\n", &nextToken);
+            azstrtok(nullptr, 0, "\n", &nextToken);
         }
-    } while (token != NULL && token[0] == '#');
+    } while (token != nullptr && token[0] == '#');
     width = atoi(token);
 
     do
     {
-        token = azstrtok(NULL, 0, seps, &nextToken);
-        if (token != NULL && token[0] == '#')
+        token = azstrtok(nullptr, 0, seps, &nextToken);
+        if (token != nullptr && token[0] == '#')
         {
-            azstrtok(NULL, 0, "\n", &nextToken);
+            azstrtok(nullptr, 0, "\n", &nextToken);
         }
-    } while (token != NULL && token[0] == '#');
+    } while (token != nullptr && token[0] == '#');
     height = atoi(token);
 
     do
     {
-        token = azstrtok(NULL, 0, seps, &nextToken);
-        if (token != NULL && token[0] == '#')
+        token = azstrtok(nullptr, 0, seps, &nextToken);
+        if (token != nullptr && token[0] == '#')
         {
-            azstrtok(NULL, 0, "\n", &nextToken);
+            azstrtok(nullptr, 0, "\n", &nextToken);
         }
-    } while (token != NULL && token[0] == '#');
+    } while (token != nullptr && token[0] == '#');
     numColors = atoi(token);
 
     image.Allocate(width, height);
@@ -200,12 +200,12 @@ bool CImageUtil::LoadPGM(const QString& fileName, CImageEx& image)
     uint32* p = image.GetData();
     int size = width * height;
     int i = 0;
-    while (token != NULL && i < size)
+    while (token != nullptr && i < size)
     {
         do
         {
-            token = azstrtok(NULL, 0, seps, &nextToken);
-        } while (token != NULL && token[0] == '#');
+            token = azstrtok(nullptr, 0, seps, &nextToken);
+        } while (token != nullptr && token[0] == '#');
         *p++ = atoi(token);
         i++;
     }

--- a/Code/Editor/Util/IndexedFiles.cpp
+++ b/Code/Editor/Util/IndexedFiles.cpp
@@ -14,7 +14,7 @@
 #include "IndexedFiles.h"
 
 volatile TIntAtomic CIndexedFiles::s_bIndexingDone;
-CIndexedFiles* CIndexedFiles::s_pIndexedFiles = NULL;
+CIndexedFiles* CIndexedFiles::s_pIndexedFiles = nullptr;
 
 bool CIndexedFiles::m_startedFileIndexing = false;
 

--- a/Code/Editor/Util/IndexedFiles.h
+++ b/Code/Editor/Util/IndexedFiles.h
@@ -88,7 +88,7 @@ public:
     }
 
 public:
-    void Initialize(const QString& path, IFileUtil::ScanDirectoryUpdateCallBack updateCB = NULL);
+    void Initialize(const QString& path, IFileUtil::ScanDirectoryUpdateCallBack updateCB = nullptr);
 
     // Adds a new file to the database.
     void AddFile(const IFileUtil::FileDesc& path);

--- a/Code/Editor/Util/KDTree.cpp
+++ b/Code/Editor/Util/KDTree.cpp
@@ -17,9 +17,9 @@ class KDTreeNode
 public:
     KDTreeNode()
     {
-        pChildren[0] = NULL;
-        pChildren[1] = NULL;
-        pVertexIndices = NULL;
+        pChildren[0] = nullptr;
+        pChildren[1] = nullptr;
+        pVertexIndices = nullptr;
     }
     ~KDTreeNode()
     {
@@ -76,13 +76,13 @@ public:
     }
     bool IsLeaf() const
     {
-        return pChildren[0] == NULL && pChildren[1] == NULL;
+        return pChildren[0] == nullptr && pChildren[1] == nullptr;
     }
     KDTreeNode* GetChild(uint32 nIndex) const
     {
         if (nIndex > 1)
         {
-            return NULL;
+            return nullptr;
         }
         return pChildren[nIndex];
     }
@@ -200,7 +200,7 @@ bool SearchForBestSplitPos(CKDTree::ESplitAxis axis, const std::vector<CKDTree::
         const CKDTree::SStatObj* pObj = &statObjList[nObjIndex];
 
         const IIndexedMesh* pMesh = pObj->pStatObj->GetIndexedMesh();
-        if (pMesh == NULL)
+        if (pMesh == nullptr)
         {
             continue;
         }
@@ -256,7 +256,7 @@ bool SplitNode(const std::vector<CKDTree::SStatObj>& statObjList, const AABB& bo
         const CKDTree::SStatObj* pObj = &statObjList[nObjIndex];
 
         const IIndexedMesh* pMesh = pObj->pStatObj->GetIndexedMesh();
-        if (pMesh == NULL)
+        if (pMesh == nullptr)
         {
             return false;
         }
@@ -295,7 +295,7 @@ bool SplitNode(const std::vector<CKDTree::SStatObj>& statObjList, const AABB& bo
 
 CKDTree::CKDTree()
 {
-    m_pRootNode = NULL;
+    m_pRootNode = nullptr;
 }
 
 CKDTree::~CKDTree()
@@ -308,7 +308,7 @@ CKDTree::~CKDTree()
 
 bool CKDTree::Build(IStatObj* pStatObj)
 {
-    if (pStatObj == NULL)
+    if (pStatObj == nullptr)
     {
         return false;
     }
@@ -332,7 +332,7 @@ bool CKDTree::Build(IStatObj* pStatObj)
     for (int i = 0, iStatObjSize(m_StatObjectList.size()); i < iStatObjSize; ++i)
     {
         IIndexedMesh* pMesh = m_StatObjectList[i].pStatObj->GetIndexedMesh(true);
-        if (pMesh == NULL)
+        if (pMesh == nullptr)
         {
             continue;
         }
@@ -398,7 +398,7 @@ void CKDTree::BuildRecursively(KDTreeNode* pNode, const AABB& boundbox, std::vec
 
 void CKDTree::ConstructStatObjList(IStatObj* pStatObj, const Matrix34& matParent)
 {
-    if (pStatObj == NULL)
+    if (pStatObj == nullptr)
     {
         return;
     }
@@ -472,7 +472,7 @@ bool CKDTree::FindNearestVertexRecursively(KDTreeNode* pNode, const Vec3& raySrc
             const SStatObj* pStatObjInfo = &(m_StatObjectList[nObjIndex]);
 
             IIndexedMesh* pMesh = m_StatObjectList[nObjIndex].pStatObj->GetIndexedMesh();
-            if (pMesh == NULL)
+            if (pMesh == nullptr)
             {
                 continue;
             }

--- a/Code/Editor/Util/Math.h
+++ b/Code/Editor/Util/Math.h
@@ -128,7 +128,7 @@ inline float PointToLineDistance(const Vec3& p1, const Vec3& p2, const Vec3& p3,
     @param p2 Target point of first line.
     @param p3 Source point of second line.
     @param p4 Target point of second line.
-    @return FALSE if no solution exists.
+    @return false if no solution exists.
 */
 inline bool LineLineIntersect(const Vec3& p1, const Vec3& p2, const Vec3& p3, const Vec3& p4,
     Vec3& pa, Vec3& pb, float& mua, float& mub)

--- a/Code/Editor/Util/MemoryBlock.cpp
+++ b/Code/Editor/Util/MemoryBlock.cpp
@@ -18,7 +18,7 @@
 
 //////////////////////////////////////////////////////////////////////////
 CMemoryBlock::CMemoryBlock()
-    : m_buffer(0)
+    : m_buffer(nullptr)
     , m_size(0)
     , m_uncompressedSize(0)
     , m_owns(false)
@@ -54,7 +54,7 @@ CMemoryBlock& CMemoryBlock::operator=(const CMemoryBlock& mem)
     }
     else
     {
-        m_buffer = 0;
+        m_buffer = nullptr;
         m_size = 0;
         m_owns = false;
     }
@@ -104,7 +104,7 @@ bool CMemoryBlock::Allocate(int size, int uncompressedSize)
     m_size = size;
     m_uncompressedSize = uncompressedSize;
     // Check if allocation failed.
-    if (m_buffer == 0)
+    if (m_buffer == nullptr)
     {
         return false;
     }
@@ -118,7 +118,7 @@ void CMemoryBlock::Free()
     {
         free(m_buffer);
     }
-    m_buffer = 0;
+    m_buffer = nullptr;
     m_owns = false;
     m_size = 0;
     m_uncompressedSize = 0;

--- a/Code/Editor/Util/NamedData.cpp
+++ b/Code/Editor/Util/NamedData.cpp
@@ -36,7 +36,7 @@ void CNamedData::AddDataBlock(const QString& blockName, void*   pData, int nSize
     assert(pData);
     assert(nSize > 0);
 
-    DataBlock* pBlock = stl::find_in_map(m_blocks, blockName, (DataBlock*)0);
+    DataBlock* pBlock = stl::find_in_map(m_blocks, blockName, (DataBlock*)nullptr);
     if (pBlock)
     {
         delete pBlock;
@@ -66,7 +66,7 @@ void CNamedData::AddDataBlock(const QString& blockName, void*   pData, int nSize
 
 void CNamedData::AddDataBlock(const QString& blockName, CMemoryBlock& mem)
 {
-    DataBlock* pBlock = stl::find_in_map(m_blocks, blockName, (DataBlock*)0);
+    DataBlock* pBlock = stl::find_in_map(m_blocks, blockName, (DataBlock*)nullptr);
     if (pBlock)
     {
         delete pBlock;
@@ -102,7 +102,7 @@ void CNamedData::Clear()
 //////////////////////////////////////////////////////////////////////////
 bool CNamedData::GetDataBlock(const QString& blockName, void*& pData, int& nSize)
 {
-    pData = 0;
+    pData = nullptr;
     nSize = 0;
 
     bool bUncompressed = false;
@@ -119,10 +119,10 @@ bool CNamedData::GetDataBlock(const QString& blockName, void*& pData, int& nSize
 //////////////////////////////////////////////////////////////////////////
 CMemoryBlock* CNamedData::GetDataBlock(const QString& blockName, bool& bCompressed)
 {
-    DataBlock* pBlock = stl::find_in_map(m_blocks, blockName, (DataBlock*)0);
+    DataBlock* pBlock = stl::find_in_map(m_blocks, blockName, (DataBlock*)nullptr);
     if (!pBlock)
     {
-        return 0;
+        return nullptr;
     }
 
     if (bCompressed)
@@ -150,7 +150,7 @@ CMemoryBlock* CNamedData::GetDataBlock(const QString& blockName, bool& bCompress
             }
         }
     }
-    return 0;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Util/PakFile.cpp
+++ b/Code/Editor/Util/PakFile.cpp
@@ -21,14 +21,14 @@
 
 //////////////////////////////////////////////////////////////////////////
 CPakFile::CPakFile()
-    : m_pArchive(NULL)
-    , m_pCryPak(NULL)
+    : m_pArchive(nullptr)
+    , m_pCryPak(nullptr)
 {
 }
 
 //////////////////////////////////////////////////////////////////////////
 CPakFile::CPakFile(AZ::IO::IArchive* pCryPak)
-    : m_pArchive(NULL)
+    : m_pArchive(nullptr)
     , m_pCryPak(pCryPak)
 {
 }
@@ -42,14 +42,14 @@ CPakFile::~CPakFile()
 //////////////////////////////////////////////////////////////////////////
 CPakFile::CPakFile(const char* filename)
 {
-    m_pArchive = NULL;
+    m_pArchive = nullptr;
     Open(filename);
 }
 
 //////////////////////////////////////////////////////////////////////////
 void CPakFile::Close()
 {
-    m_pArchive = NULL;
+    m_pArchive = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -61,7 +61,7 @@ bool CPakFile::Open(const char* filename, bool bAbsolutePath)
     }
 
     auto pCryPak = m_pCryPak ? m_pCryPak : GetIEditor()->GetSystem()->GetIPak();
-    if (pCryPak == NULL)
+    if (pCryPak == nullptr)
     {
         return false;
     }
@@ -89,7 +89,7 @@ bool CPakFile::OpenForRead(const char* filename)
         Close();
     }
     auto pCryPak = m_pCryPak ? m_pCryPak : GetIEditor()->GetSystem()->GetIPak();
-    if (pCryPak == NULL)
+    if (pCryPak == nullptr)
     {
         return false;
     }

--- a/Code/Editor/Util/PathUtil.cpp
+++ b/Code/Editor/Util/PathUtil.cpp
@@ -42,7 +42,7 @@ namespace Path
         // Directory named filenames containing ":" are invalid, so we can assume if there is a :
         // it will be the drive name.
         pchCurrentPosition = strchr(pchLastPosition, ':');
-        if (pchCurrentPosition == NULL)
+        if (pchCurrentPosition == nullptr)
         {
             rstrDriveLetter = "";
         }
@@ -54,7 +54,7 @@ namespace Path
 
         pchCurrentPosition = strrchr(pchLastPosition, '\\');
         pchAuxPosition = strrchr(pchLastPosition, '/');
-        if ((pchCurrentPosition == NULL) && (pchAuxPosition == NULL))
+        if ((pchCurrentPosition == nullptr) && (pchAuxPosition == nullptr))
         {
             rstrDirectory = "";
         }
@@ -70,7 +70,7 @@ namespace Path
         }
 
         pchCurrentPosition = strrchr(pchLastPosition, '.');
-        if (pchCurrentPosition == NULL)
+        if (pchCurrentPosition == nullptr)
         {
             rstrExtension = "";
             strFilename.assign(pchLastPosition);
@@ -114,7 +114,7 @@ namespace Path
         do
         {
             pchCurrentPosition = strpbrk(pchLastPosition, "\\/");
-            if (pchCurrentPosition == NULL)
+            if (pchCurrentPosition == nullptr)
             {
                 break;
             }

--- a/Code/Editor/Util/PathUtil.h
+++ b/Code/Editor/Util/PathUtil.h
@@ -228,7 +228,7 @@ namespace Path
     {
         return (path.endsWith(QStringLiteral("\\")) || path.endsWith(QStringLiteral("/")));
     }
-    
+
     template<size_t size>
     inline bool EndsWithSlash(CryStackStringT<char, size>* path)
     {
@@ -236,15 +236,15 @@ namespace Path
         {
             return false;
         }
-        
+
         if (
             ((*path)[path->size() - 1] != '\\') ||
-            ((*path)[path->size() - 1] != '/') 
+            ((*path)[path->size() - 1] != '/')
             )
         {
             return true;
         }
-        
+
         return false;
     }
 
@@ -336,9 +336,9 @@ namespace Path
     {
         char path_buffer[_MAX_PATH];
 #ifdef AZ_COMPILER_MSVC
-        _makepath_s(path_buffer, AZ_ARRAY_SIZE(path_buffer), NULL, dir.toUtf8().data(), filename.toUtf8().data(), ext.toUtf8().data());
+        _makepath_s(path_buffer, AZ_ARRAY_SIZE(path_buffer), nullptr, dir.toUtf8().data(), filename.toUtf8().data(), ext.toUtf8().data());
 #else
-        _makepath(path_buffer, NULL, dir.toUtf8().data(), filename.toUtf8().data(), ext.toUtf8().data());
+        _makepath(path_buffer, nullptr, dir.toUtf8().data(), filename.toUtf8().data(), ext.toUtf8().data());
 #endif
         return CaselessPaths(path_buffer);
     }

--- a/Code/Editor/Util/StringHelpers.cpp
+++ b/Code/Editor/Util/StringHelpers.cpp
@@ -48,7 +48,7 @@ static inline int Vscprintf(const char* format, va_list argList)
     int retval;
     va_list argcopy;
     va_copy(argcopy, argList);
-    retval = azvsnprintf(NULL, 0, format, argcopy);
+    retval = azvsnprintf(nullptr, 0, format, argcopy);
     va_end(argcopy);
     return retval;
 #else
@@ -64,7 +64,7 @@ static inline int Vscprintf(const wchar_t* format, va_list argList)
     int retval;
     va_list argcopy;
     va_copy(argcopy, argList);
-    retval = azvsnwprintf(NULL, 0, format, argcopy);
+    retval = azvsnwprintf(nullptr, 0, format, argcopy);
     va_end(argcopy);
     return retval;
 #else
@@ -408,9 +408,9 @@ bool StringHelpers::MatchesWildcardsIgnoreCase(const wstring& str, const wstring
 template <class TS>
 static inline bool MatchesWildcardsIgnoreCaseExt_Tpl(const TS& str, const TS& wildcards, std::vector<TS>& wildcardMatches)
 {
-    const typename TS::value_type* savedStrBegin = 0;
-    const typename TS::value_type* savedStrEnd = 0;
-    const typename TS::value_type* savedWild = 0;
+    const typename TS::value_type* savedStrBegin = nullptr;
+    const typename TS::value_type* savedStrEnd = nullptr;
+    const typename TS::value_type* savedWild = nullptr;
     size_t savedWildCount = 0;
 
     const typename TS::value_type* pStr = str.c_str();
@@ -775,7 +775,7 @@ void StringHelpers::SplitByAnyOf(const wstring& str, const wstring& separators, 
 template <class TS>
 static inline TS FormatVA_Tpl(const typename TS::value_type* const format, va_list parg)
 {
-    if ((format == 0) || (format[0] == 0))
+    if ((format == nullptr) || (format[0] == 0))
     {
         return TS();
     }
@@ -935,8 +935,8 @@ static string ConvertUtf16ToMultibyte(const wchar_t* wstr, uint codePage, char b
             len,
             0,
             0,
-            ((badChar && codePage != CP_UTF8) ? &badChar : NULL),
-            NULL);
+            ((badChar && codePage != CP_UTF8) ? &badChar : nullptr),
+            nullptr);
     if (neededByteCount <= 0)
     {
         return string();
@@ -952,8 +952,8 @@ static string ConvertUtf16ToMultibyte(const wchar_t* wstr, uint codePage, char b
             len,
             &buffer[0], // output buffer
             neededByteCount - 1, // size of the output buffer in bytes
-            ((badChar && codePage != CP_UTF8) ? &badChar : NULL),
-            NULL);
+            ((badChar && codePage != CP_UTF8) ? &badChar : nullptr),
+            nullptr);
     if (byteCount != neededByteCount - 1)
     {
         return string();

--- a/Code/Editor/Util/UIEnumerations.cpp
+++ b/Code/Editor/Util/UIEnumerations.cpp
@@ -55,15 +55,15 @@ CUIEnumerations::TDValuesContainer& CUIEnumerations::GetStandardNameContainer()
             {
                 oEnumerationItem = oEnumaration->getChild(nCurrentEnumarationItem);
 
-                const char* szKey(NULL);
-                const char* szValue(NULL);
+                const char* szKey(nullptr);
+                const char* szValue(nullptr);
                 oEnumerationItem->getAttributeByIndex(0, &szKey, &szValue);
 
                 cValues.push_back(szValue);
             }
 
-            const char* szKey(NULL);
-            const char* szValue(NULL);
+            const char* szKey(nullptr);
+            const char* szValue(nullptr);
             oEnumaration->getAttributeByIndex(0, &szKey, &szValue);
 
             cValuesContainer.insert(TDValuesContainer::value_type(szValue, cValues));

--- a/Code/Editor/Util/Variable.cpp
+++ b/Code/Editor/Util/Variable.cpp
@@ -447,7 +447,7 @@ void CVarObject::AddVariable(CVariableArray& table, CVariableBase& var, const QS
 //////////////////////////////////////////////////////////////////////////
 void CVarObject::RemoveVariable(IVariable* var)
 {
-    if (m_vars != NULL)
+    if (m_vars != nullptr)
     {
         m_vars->DeleteVariable(var);
     }
@@ -455,7 +455,7 @@ void CVarObject::RemoveVariable(IVariable* var)
 //////////////////////////////////////////////////////////////////////////
 void CVarObject::EnableUpdateCallbacks(bool boEnable)
 {
-    if (m_vars != NULL)
+    if (m_vars != nullptr)
     {
         m_vars->EnableUpdateCallbacks(boEnable);
     }
@@ -463,7 +463,7 @@ void CVarObject::EnableUpdateCallbacks(bool boEnable)
 //////////////////////////////////////////////////////////////////////////
 void CVarObject::OnSetValues()
 {
-    if (m_vars != NULL)
+    if (m_vars != nullptr)
     {
         m_vars->OnSetValues();
     }
@@ -471,7 +471,7 @@ void CVarObject::OnSetValues()
 //////////////////////////////////////////////////////////////////////////
 void CVarObject::ReserveNumVariables(int numVars)
 {
-    if (m_vars != NULL)
+    if (m_vars != nullptr)
     {
         m_vars->ReserveNumVariables(numVars);
     }
@@ -482,7 +482,7 @@ void CVarObject::CopyVariableValues(CVarObject* sourceObject)
 {
     // Check if compatible types.
     assert(metaObject() == sourceObject->metaObject());
-    if (m_vars != NULL && sourceObject->m_vars != NULL)
+    if (m_vars != nullptr && sourceObject->m_vars != nullptr)
     {
         m_vars->CopyValues(sourceObject->m_vars);
     }

--- a/Code/Editor/Util/Variable.h
+++ b/Code/Editor/Util/Variable.h
@@ -1411,7 +1411,7 @@ protected:
 struct IVarEnumList
     : public CRefCountBase
 {
-    //! Get the name of specified value in enumeration, or NULL if out of range.
+    //! Get the name of specified value in enumeration, or empty string if out of range.
     virtual QString GetItemName(uint index) = 0;
 };
 typedef _smart_ptr<IVarEnumList> IVarEnumListPtr;
@@ -1498,7 +1498,7 @@ public:
     {
         if (index >= m_items.size())
         {
-            return NULL;
+            return QString();
         }
         return m_items[index].name;
     };
@@ -1869,9 +1869,9 @@ public:
     void Serialize(XmlNodeRef node, bool load);
     CVarBlock* GetVarBlock() const { return m_vars; };
 
-    void AddVariable(CVariableBase& var, const QString& varName, VarOnSetCallback* cb = NULL, unsigned char dataType = IVariable::DT_SIMPLE);
-    void AddVariable(CVariableBase& var, const QString& varName, const QString& varHumanName, VarOnSetCallback* cb = NULL, unsigned char dataType = IVariable::DT_SIMPLE);
-    void AddVariable(CVariableArray& table, CVariableBase& var, const QString& varName, const QString& varHumanName, VarOnSetCallback* cb = NULL, unsigned char dataType = IVariable::DT_SIMPLE);
+    void AddVariable(CVariableBase& var, const QString& varName, VarOnSetCallback* cb = nullptr, unsigned char dataType = IVariable::DT_SIMPLE);
+    void AddVariable(CVariableBase& var, const QString& varName, const QString& varHumanName, VarOnSetCallback* cb = nullptr, unsigned char dataType = IVariable::DT_SIMPLE);
+    void AddVariable(CVariableArray& table, CVariableBase& var, const QString& varName, const QString& varHumanName, VarOnSetCallback* cb = nullptr, unsigned char dataType = IVariable::DT_SIMPLE);
     void ReserveNumVariables(int numVars);
     void RemoveVariable(IVariable* var);
 

--- a/Code/Editor/Util/VariablePropertyType.cpp
+++ b/Code/Editor/Util/VariablePropertyType.cpp
@@ -71,28 +71,28 @@ namespace Prop
     Description::Description()
         : m_type(ePropertyInvalid)
         , m_numImages(-1)
-        , m_enumList(NULL)
+        , m_enumList(nullptr)
         , m_rangeMin(0)
         , m_rangeMax(100)
         , m_step(0)
         , m_bHardMin(false)
         , m_bHardMax(false)
         , m_valueMultiplier(1)
-        , m_pEnumDBItem(NULL)
+        , m_pEnumDBItem(nullptr)
     {
     }
 
     Description::Description(IVariable* pVar)
         : m_type(ePropertyInvalid)
         , m_numImages(-1)
-        , m_enumList(NULL)
+        , m_enumList(nullptr)
         , m_rangeMin(0)
         , m_rangeMax(100)
         , m_step(0)
         , m_bHardMin(false)
         , m_bHardMax(false)
         , m_valueMultiplier(1)
-        , m_pEnumDBItem(NULL)
+        , m_pEnumDBItem(nullptr)
     {
         if (!pVar)
         {
@@ -110,7 +110,7 @@ namespace Prop
         m_name = pVar->GetHumanName();
         m_enumList = pVar->GetEnumList();
 
-        if (m_enumList != NULL)
+        if (m_enumList != nullptr)
         {
             m_type = ePropertySelection;
         }
@@ -325,7 +325,7 @@ namespace Prop
         case ePropertyAudioPreloadRequest:
             return "AudioPreloadRequest";
         default:
-            return 0;
+            return nullptr;
         }
     }
 }

--- a/Code/Editor/Util/XmlHistoryManager.cpp
+++ b/Code/Editor/Util/XmlHistoryManager.cpp
@@ -76,7 +76,7 @@ const XmlNodeRef& SXmlHistory::GetCurrentVersion(bool* bVersionExist, int* iVers
 bool SXmlHistory::IsModified() const
 {
     int currVersion;
-    GetCurrentVersion(NULL, &currVersion);
+    GetCurrentVersion(nullptr, &currVersion);
     return m_SavedVersion != currVersion;
 }
 
@@ -94,7 +94,7 @@ void SXmlHistory::FlagAsSaved()
     if (Exist())
     {
         int currVersion;
-        GetCurrentVersion(NULL, &currVersion);
+        GetCurrentVersion(nullptr, &currVersion);
         m_SavedVersion = currVersion;
     }
 }
@@ -167,7 +167,7 @@ SXmlHistory* SXmlHistoryGroup::GetHistory(int index) const
             --index;
         }
     }
-    return it != m_List.end() ? *it : NULL;
+    return it != m_List.end() ? *it : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -199,7 +199,7 @@ SXmlHistory* SXmlHistoryGroup::GetHistoryByTypeId(uint32 typeId, int index /*= 0
             return pHistory;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////
@@ -246,9 +246,9 @@ int SXmlHistoryGroup::GetHistoryIndex(const SXmlHistory* pHistory) const
 CXmlHistoryManager::CXmlHistoryManager()
     : m_CurrentVersion(0)
     , m_LatestVersion(0)
-    , m_pExclusiveListener(NULL)
+    , m_pExclusiveListener(nullptr)
     , m_RecordNextVersion(false)
-    , m_pExActiveGroup(NULL)
+    , m_pExActiveGroup(nullptr)
     , m_bIsActiveGroupEx(false)
 {
     m_pNullGroup = new SXmlHistoryGroup(this, (uint32) - 1);
@@ -376,7 +376,7 @@ void CXmlHistoryManager::PrepareForNextVersion()
 }
 
 /////////////////////////////////////////////////////////////////////////////
-void CXmlHistoryManager::RecordNextVersion(SXmlHistory* pHistory, XmlNodeRef newData, const char* undoDesc /*= NULL*/)
+void CXmlHistoryManager::RecordNextVersion(SXmlHistory* pHistory, XmlNodeRef newData, const char* undoDesc /*= nullptr*/)
 {
     assert(m_RecordNextVersion);
     RegisterUndoEventHandler(this, pHistory);
@@ -405,7 +405,7 @@ void CXmlHistoryManager::ClearHistory(bool flagAsSaved)
         it->ClearHistory(flagAsSaved);
     }
 
-    SetActiveGroup(NULL);
+    SetActiveGroup(nullptr);
 
     m_CurrentVersion = 0;
     m_LatestVersion = 0;
@@ -451,14 +451,14 @@ SXmlHistoryGroup* CXmlHistoryManager::CreateXmlGroup(uint32 typeId)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-void CXmlHistoryManager::AddXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc /*= NULL*/)
+void CXmlHistoryManager::AddXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc /*= nullptr*/)
 {
     RecordUndoInternal(undoDesc ? undoDesc : "New XML Group added");
     m_HistoryInfoMap[ m_CurrentVersion ].ActiveGroups.push_back(pGroup);
     NotifyUndoEventListener(IXmlHistoryEventListener::eHET_HistoryGroupAdded, (void*)pGroup);
 }
 /////////////////////////////////////////////////////////////////////////////
-void CXmlHistoryManager::RemoveXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc /*= NULL*/)
+void CXmlHistoryManager::RemoveXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc /*= nullptr*/)
 {
     bool unload = m_HistoryInfoMap[ m_CurrentVersion ].CurrGroup == pGroup;
     RecordUndoInternal(undoDesc ? undoDesc : "XML Group deleted");
@@ -466,14 +466,14 @@ void CXmlHistoryManager::RemoveXmlGroup(const SXmlHistoryGroup* pGroup, const ch
     stl::find_and_erase(list, pGroup);
     if (unload)
     {
-        SetActiveGroupInt(NULL);
+        SetActiveGroupInt(nullptr);
     }
     m_HistoryInfoMap[ m_CurrentVersion ].CurrGroup = m_pNullGroup;
     NotifyUndoEventListener(IXmlHistoryEventListener::eHET_HistoryGroupRemoved, (void*)pGroup);
 }
 
 /////////////////////////////////////////////////////////////////////////////
-void CXmlHistoryManager::SetActiveGroup(const SXmlHistoryGroup* pGroup, const char* displayName /*= NULL*/, const TGroupIndexMap& groupIndex /*= TGroupIndexMap()*/, bool setExternal /*= false*/)
+void CXmlHistoryManager::SetActiveGroup(const SXmlHistoryGroup* pGroup, const char* displayName /*= nullptr*/, const TGroupIndexMap& groupIndex /*= TGroupIndexMap()*/, bool setExternal /*= false*/)
 {
     TGroupIndexMap userIndex;
     const SXmlHistoryGroup* pActiveGroup = GetActiveGroup(userIndex);
@@ -488,7 +488,7 @@ void CXmlHistoryManager::SetActiveGroup(const SXmlHistoryGroup* pGroup, const ch
     }
 }
 
-void CXmlHistoryManager::SetActiveGroupInt(const SXmlHistoryGroup* pGroup, const char* displayName /*= NULL*/, bool bRecordNullUndo /*= false*/, const TGroupIndexMap& groupIndex /*= TGroupIndexMap()*/)
+void CXmlHistoryManager::SetActiveGroupInt(const SXmlHistoryGroup* pGroup, const char* displayName /*= nullptr*/, bool bRecordNullUndo /*= false*/, const TGroupIndexMap& groupIndex /*= TGroupIndexMap()*/)
 {
     UnloadInt();
 
@@ -511,7 +511,7 @@ void CXmlHistoryManager::SetActiveGroupInt(const SXmlHistoryGroup* pGroup, const
                     userIndexCount[ (*history)->GetTypeId() ] = 0;
                 }
                 uint32 userindex = userIndexCount[ (*history)->GetTypeId() ];
-                IXmlUndoEventHandler* pEventHandler = NULL;
+                IXmlUndoEventHandler* pEventHandler = nullptr;
                 TGroupIndexMap::const_iterator indexIter = groupIndex.find((*history)->GetTypeId());
                 if (indexIter == groupIndex.end() || indexIter->second == userindex)
                 {
@@ -581,12 +581,12 @@ const SXmlHistoryGroup* CXmlHistoryManager::GetActiveGroup(TGroupIndexMap& currU
             if (it != m_HistoryInfoMap.end() && pGroup)
             {
                 currUserIndex = it->second.CurrUserIndex;
-                return pGroup == m_pNullGroup ? NULL : pGroup;
+                return pGroup == m_pNullGroup ? nullptr : pGroup;
             }
         }
         currVersion--;
     } while (currVersion >= 0);
-    return NULL;
+    return nullptr;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -796,7 +796,7 @@ SXmlHistory* CXmlHistoryManager::GetLatestHistory(SUndoEventHandlerData& eventHa
         }
         currVersion--;
     } while (currVersion >= 0);
-    return NULL;
+    return nullptr;
 }
 
 

--- a/Code/Editor/Util/XmlHistoryManager.h
+++ b/Code/Editor/Util/XmlHistoryManager.h
@@ -23,9 +23,9 @@ public:
 
     void AddToHistory(const XmlNodeRef& newXmlVersion);
 
-    const XmlNodeRef& Undo(bool* bVersionExist = NULL);
+    const XmlNodeRef& Undo(bool* bVersionExist = nullptr);
     const XmlNodeRef& Redo();
-    const XmlNodeRef& GetCurrentVersion(bool* bVersionExist = NULL, int* iVersionNumber = NULL) const;
+    const XmlNodeRef& GetCurrentVersion(bool* bVersionExist = nullptr, int* iVersionNumber = nullptr) const;
     bool IsModified() const;
     uint32 GetTypeId() const {return m_typeId; }
     void FlagAsDeleted();
@@ -93,7 +93,7 @@ public:
     void RestoreUndoEventHandler(IXmlUndoEventHandler* pEventHandler, uint32 typeId);
 
     void PrepareForNextVersion();
-    void RecordNextVersion(SXmlHistory* pHistory, XmlNodeRef newData, const char* undoDesc = NULL);
+    void RecordNextVersion(SXmlHistory* pHistory, XmlNodeRef newData, const char* undoDesc = nullptr);
     bool IsPreparedForNextVersion() const {return m_RecordNextVersion; }
 
     void RegisterEventListener(IXmlHistoryEventListener* pEventListener);
@@ -112,11 +112,11 @@ public:
 
     // Xml History Groups
     SXmlHistoryGroup* CreateXmlGroup(uint32 typeId);
-    void SetActiveGroup(const SXmlHistoryGroup* pGroup, const char* displayName = NULL, const TGroupIndexMap& groupIndex = TGroupIndexMap(), bool setExternal = false);
+    void SetActiveGroup(const SXmlHistoryGroup* pGroup, const char* displayName = nullptr, const TGroupIndexMap& groupIndex = TGroupIndexMap(), bool setExternal = false);
     const SXmlHistoryGroup* GetActiveGroup() const;
     const SXmlHistoryGroup* GetActiveGroup(TGroupIndexMap& currUserIndex /*out*/) const;
-    void AddXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc = NULL);
-    void RemoveXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc = NULL);
+    void AddXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc = nullptr);
+    void RemoveXmlGroup(const SXmlHistoryGroup* pGroup, const char* undoDesc = nullptr);
 
     void DeleteAll();
 
@@ -156,7 +156,7 @@ private:
     {
         SHistoryInfo()
             : IsNullUndo(false)
-            , CurrGroup(NULL)
+            , CurrGroup(nullptr)
             , HistoryInvalidated(false) {}
 
         const SXmlHistoryGroup* CurrGroup;
@@ -174,7 +174,7 @@ private:
     struct SUndoEventHandlerData
     {
         SUndoEventHandlerData()
-            : CurrentData(NULL) {}
+            : CurrentData(nullptr) {}
 
         SXmlHistory* CurrentData;
         THistoryVersionMap HistoryData;
@@ -203,9 +203,9 @@ private:
     void RecordNullUndo(const TEventHandlerList& eventHandler, const char* desc, bool isNull = true);
     void ReloadCurrentVersion(const SXmlHistoryGroup* pPrevGroup, int prevVersion);
     SXmlHistory* GetLatestHistory(SUndoEventHandlerData& eventHandlerData);
-    void NotifyUndoEventListener(IXmlHistoryEventListener::EHistoryEventType event, void* pData = NULL);
+    void NotifyUndoEventListener(IXmlHistoryEventListener::EHistoryEventType event, void* pData = nullptr);
 
-    void SetActiveGroupInt(const SXmlHistoryGroup* pGroup, const char* displayName = NULL, bool bRecordNullUndo = false, const TGroupIndexMap& groupIndex = TGroupIndexMap());
+    void SetActiveGroupInt(const SXmlHistoryGroup* pGroup, const char* displayName = nullptr, bool bRecordNullUndo = false, const TGroupIndexMap& groupIndex = TGroupIndexMap());
     void UnloadInt();
     void ClearRedo();
 

--- a/Code/Editor/Util/XmlTemplate.cpp
+++ b/Code/Editor/Util/XmlTemplate.cpp
@@ -89,7 +89,7 @@ void CXmlTemplate::SetValues(const XmlNodeRef& node, XmlNodeRef& toNode)
         }
         else
         {
-            assert(!"NULL returned from node->GetChild()");
+            assert(!"nullptr returned from node->GetChild()");
         }
     }
 }
@@ -125,7 +125,7 @@ bool CXmlTemplate::SetValues(const XmlNodeRef& node, XmlNodeRef& toNode, const X
         }
         else
         {
-            assert(!"NULL returned from node->GetChild()");
+            assert(!"nullptr returned from node->GetChild()");
         }
     }
     return false;
@@ -193,7 +193,7 @@ void CXmlTemplateRegistry::LoadTemplates(const QString& path)
         XmlNodeRef child;
         // Construct the full filepath of the current file
         XmlNodeRef node = XmlHelpers::LoadXmlFromFile((dir + files[k].filename).toUtf8().data());
-        if (node != 0 && node->isTag("Templates"))
+        if (node != nullptr && node->isTag("Templates"))
         {
             QString name;
             for (int i = 0; i < node->getChildCount(); i++)
@@ -220,5 +220,5 @@ XmlNodeRef CXmlTemplateRegistry::FindTemplate(const QString& name)
     {
         return node;
     }
-    return 0;
+    return nullptr;
 }

--- a/Code/Editor/Util/bitarray.h
+++ b/Code/Editor/Util/bitarray.h
@@ -74,7 +74,7 @@ public:
         void flip() {* p ^= mask; }
     };
 
-    CBitArray() { m_base = NULL; m_bits = NULL; m_size = 0; m_numBits = 0; };
+    CBitArray() { m_base = nullptr; m_bits = nullptr; m_size = 0; m_numBits = 0; };
     CBitArray(int numBits)    { resize(numBits); };
     ~CBitArray()
     {


### PR DESCRIPTION
A few 'typedefs' replaced by 'using's
This shouldn't have any functional changes at all, just c++17 modernization
It's a part 4 of a split #2847

*Note to reviewers this is a split PR meant to ease reviewing, but sadly I cannot say if this or any other part will compile correctly in isolation.*

Signed-off-by: Nemerle <nemerle5+git@gmail.com>