### PR TITLE
Editor code: tidy up BOOLs,NULLs and overrides pt5.

### DIFF
--- a/Code/Editor/AboutDialog.cpp
+++ b/Code/Editor/AboutDialog.cpp
@@ -25,7 +25,7 @@ AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_AboutDialog.h>
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
-CAboutDialog::CAboutDialog(QString versionText, QString richTextCopyrightNotice, QWidget* pParent /*=NULL*/)
+CAboutDialog::CAboutDialog(QString versionText, QString richTextCopyrightNotice, QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_ui(new Ui::CAboutDialog)
 {

--- a/Code/Editor/AnimationContext.cpp
+++ b/Code/Editor/AnimationContext.cpp
@@ -29,7 +29,7 @@ class CMovieCallback
     : public IMovieCallback
 {
 protected:
-    virtual void OnMovieCallback(ECallbackReason reason, [[maybe_unused]] IAnimNode* pNode)
+    void OnMovieCallback(ECallbackReason reason, [[maybe_unused]] IAnimNode* pNode) override
     {
         switch (reason)
         {
@@ -49,7 +49,7 @@ protected:
         }
     }
 
-    void OnSetCamera(const SCameraParams& Params)
+    void OnSetCamera(const SCameraParams& Params) override
     {
         // Only switch camera when in Play mode.
         GUID camObjId = GUID_NULL;
@@ -79,14 +79,14 @@ protected:
         }
     };
 
-    bool IsSequenceCamUsed() const
+    bool IsSequenceCamUsed() const override
     {
         if (gEnv->IsEditorGameMode() == true)
         {
             return true;
         }
 
-        if (GetIEditor()->GetViewManager() == NULL)
+        if (GetIEditor()->GetViewManager() == nullptr)
         {
             return false;
         }
@@ -113,7 +113,7 @@ public:
     CAnimationContextPostRender(CAnimationContext* pAC)
         : m_pAC(pAC){}
 
-    void OnPostRender() const { assert(m_pAC); m_pAC->OnPostRender(); }
+    void OnPostRender() const override { assert(m_pAC); m_pAC->OnPostRender(); }
 
 protected:
     CAnimationContext* m_pAC;
@@ -231,7 +231,7 @@ void CAnimationContext::SetSequence(CTrackViewSequence* sequence, bool force, bo
         m_pSequence->UnBindFromEditorObjects();
     }
     m_pSequence = sequence;
-    
+
     // Notify a new sequence was just selected.
     Maestro::EditorSequenceNotificationBus::Broadcast(&Maestro::EditorSequenceNotificationBus::Events::OnSequenceSelected, m_pSequence ? m_pSequence->GetSequenceComponentEntityId() : AZ::EntityId());
 
@@ -347,7 +347,7 @@ void CAnimationContext::OnSequenceActivated(AZ::EntityId entityId)
                     {
                         // Hang onto this because SetSequence() will reset it.
                         float lastTime = m_mostRecentSequenceTime;
-                        
+
                         SetSequence(sequence, false, false);
 
                         // Restore the current time.

--- a/Code/Editor/BaseLibrary.cpp
+++ b/Code/Editor/BaseLibrary.cpp
@@ -24,10 +24,10 @@ class CUndoBaseLibrary
     : public IUndoObject
 {
 public:
-    CUndoBaseLibrary(CBaseLibrary* pLib, const QString& description, const QString& selectedItem = 0)
+    CUndoBaseLibrary(CBaseLibrary* pLib, const QString& description, const QString& selectedItem = QString())
         : m_pLib(pLib)
         , m_description(description)
-        , m_redo(0)
+        , m_redo(nullptr)
         , m_selectedItem(selectedItem)
     {
         assert(m_pLib);
@@ -36,16 +36,16 @@ public:
         m_pLib->Serialize(m_undo, false);
     }
 
-    virtual QString GetEditorObjectName()
+    QString GetEditorObjectName() override
     {
         return m_selectedItem;
     }
 
 protected:
-    virtual int GetSize() { return sizeof(CUndoBaseLibrary); }
-    virtual QString GetDescription() { return m_description; };
+    int GetSize() override { return sizeof(CUndoBaseLibrary); }
+    QString GetDescription() override { return m_description; };
 
-    virtual void Undo(bool bUndo)
+    void Undo(bool bUndo) override
     {
         if (bUndo)
         {
@@ -57,7 +57,7 @@ protected:
         GetIEditor()->Notify(eNotify_OnDataBaseUpdate);
     }
 
-    virtual void Redo()
+    void Redo() override
     {
         m_pLib->Serialize(m_redo, true);
         m_pLib->SetModified();
@@ -107,7 +107,7 @@ void CBaseLibrary::RemoveAllItems()
         // Unregister item in case it was registered.  It is ok if it wasn't.  This is still safe to call.
         m_pManager->UnregisterItem(m_items[i]);
         // Clear library item.
-        m_items[i]->m_library = NULL;
+        m_items[i]->m_library = nullptr;
     }
     m_items.clear();
     Release();
@@ -216,7 +216,7 @@ IDataBaseItem* CBaseLibrary::FindItem(const QString& name)
             return m_items[i];
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 bool CBaseLibrary::AddLibraryToSourceControl(const QString& fullPathName) const
@@ -233,8 +233,8 @@ bool CBaseLibrary::AddLibraryToSourceControl(const QString& fullPathName) const
 
 bool CBaseLibrary::SaveLibrary(const char* name, bool saveEmptyLibrary)
 {
-    assert(name != NULL);
-    if (name == NULL)
+    assert(name != nullptr);
+    if (name == nullptr)
     {
         CryFatalError("The library you are attempting to save has no name specified.");
         return false;

--- a/Code/Editor/BaseLibraryItem.cpp
+++ b/Code/Editor/BaseLibraryItem.cpp
@@ -16,7 +16,7 @@
 
 #include <AzCore/Math/Uuid.h>
 
-//undo object for multi-changes inside library item. such as set all variables to default values. 
+//undo object for multi-changes inside library item. such as set all variables to default values.
 //For example: change particle emitter shape will lead to multiple variable changes
 class CUndoBaseLibraryItem
     : public IUndoObject
@@ -54,24 +54,24 @@ public:
     }
 
 protected:
-    virtual int GetSize() 
-    { 
+    int GetSize() override
+    {
         return m_size;
     }
 
     QString GetDescription() override
-    { 
-        return m_description; 
+    {
+        return m_description;
     }
 
-    virtual void Undo(bool bUndo)
+    void Undo(bool bUndo) override
     {
         //find the libItem
         IDataBaseItem *libItem = m_libMgr->FindItemByName(m_itemPath);
         if (libItem == nullptr)
         {
             //the undo stack is not reliable any more..
-            assert(false);  
+            assert(false);
             return;
         }
 
@@ -95,7 +95,7 @@ protected:
         libItem->Serialize(m_undoCtx);
     }
 
-    virtual void Redo()
+    void Redo() override
     {
         //find the libItem
         IDataBaseItem *libItem = m_libMgr->FindItemByName(m_itemPath);
@@ -124,7 +124,7 @@ private:
 //////////////////////////////////////////////////////////////////////////
 CBaseLibraryItem::CBaseLibraryItem()
 {
-    m_library = 0;
+    m_library = nullptr;
     GenerateId();
     m_bModified = false;
 }
@@ -266,7 +266,7 @@ void CBaseLibraryItem::SetLibrary(CBaseLibrary* pLibrary)
 void CBaseLibraryItem::SetModified(bool bModified)
 {
     m_bModified = bModified;
-    if (m_bModified && m_library != NULL)
+    if (m_bModified && m_library != nullptr)
     {
         m_library->SetModified(bModified);
     }

--- a/Code/Editor/BaseLibraryManager.cpp
+++ b/Code/Editor/BaseLibraryManager.cpp
@@ -26,7 +26,7 @@ class CUndoBaseLibraryManager
     : public IUndoObject
 {
 public:
-    CUndoBaseLibraryManager(CBaseLibraryManager* pMngr, const QString& description, const QString& modifiedManager = 0)
+    CUndoBaseLibraryManager(CBaseLibraryManager* pMngr, const QString& description, const QString& modifiedManager = nullptr)
         : m_pMngr(pMngr)
         , m_description(description)
         , m_editorObject(modifiedManager)
@@ -35,16 +35,16 @@ public:
         SerializeTo(m_undos);
     }
 
-    virtual QString GetEditorObjectName()
+    QString GetEditorObjectName() override
     {
         return m_editorObject;
     }
 
 protected:
-    virtual int GetSize() { return sizeof(CUndoBaseLibraryManager); }
-    virtual QString GetDescription() { return m_description; };
+    int GetSize() override { return sizeof(CUndoBaseLibraryManager); }
+    QString GetDescription() override { return m_description; };
 
-    virtual void Undo(bool bUndo)
+    void Undo(bool bUndo) override
     {
         if (bUndo)
         {
@@ -55,7 +55,7 @@ protected:
         GetIEditor()->Notify(eNotify_OnDataBaseUpdate);
     }
 
-    virtual void Redo()
+    void Redo() override
     {
         m_pMngr->ClearAll();
         UnserializeFrom(m_redos);
@@ -84,7 +84,7 @@ private:
         for (int i = 0; i < m_pMngr->GetLibraryCount(); i++)
         {
             IDataBaseLibrary* library = m_pMngr->GetLibrary(i);
-            
+
             const char* tag = library->IsLevelLibrary() ? LEVEL_LIBRARY_TAG : LIBRARY_TAG;
             XmlNodeRef node = GetIEditor()->GetSystem()->CreateXmlNode(tag);
             QString file = library->GetFilename().isEmpty() ? library->GetFilename() : library->GetName();
@@ -203,7 +203,7 @@ int CBaseLibraryManager::FindLibraryIndex(const QString& library)
 //////////////////////////////////////////////////////////////////////////
 IDataBaseItem* CBaseLibraryManager::FindItem(REFGUID guid) const
 {
-    CBaseLibraryItem* pMtl = stl::find_in_map(m_itemsGuidMap, guid, (CBaseLibraryItem*)0);
+    CBaseLibraryItem* pMtl = stl::find_in_map(m_itemsGuidMap, guid, nullptr);
     return pMtl;
 }
 
@@ -226,7 +226,7 @@ void CBaseLibraryManager::SplitFullItemName(const QString& fullItemName, QString
 IDataBaseItem* CBaseLibraryManager::FindItemByName(const QString& fullItemName)
 {
     AZStd::lock_guard<AZStd::mutex> lock(m_itemsNameMapMutex);
-    return stl::find_in_map(m_itemsNameMap, fullItemName, 0);
+    return stl::find_in_map(m_itemsNameMap, fullItemName, nullptr);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -398,7 +398,7 @@ void CBaseLibraryManager::DeleteLibrary(const QString& library, bool forceDelete
                     UnregisterItem((CBaseLibraryItem*)pLibrary->GetItem(j));
                 }
                 pLibrary->RemoveAllItems();
-                
+
                 if (pLibrary->IsLevelLibrary())
                 {
                     m_pLevelLibrary = nullptr;
@@ -420,7 +420,7 @@ IDataBaseLibrary* CBaseLibraryManager::GetLibrary(int index) const
 //////////////////////////////////////////////////////////////////////////
 IDataBaseLibrary* CBaseLibraryManager::GetLevelLibrary() const
 {
-    IDataBaseLibrary* pLevelLib = NULL;
+    IDataBaseLibrary* pLevelLib = nullptr;
 
     for (int i = 0; i < GetLibraryCount(); i++)
     {
@@ -531,9 +531,9 @@ QString CBaseLibraryManager::MakeUniqueItemName(const QString& srcName, const QS
 
     // search for strings in the database that might have a similar name (ignore case)
     IDataBaseItemEnumerator* pEnum = GetItemEnumerator();
-    for (IDataBaseItem* pItem = pEnum->GetFirst(); pItem != NULL; pItem = pEnum->GetNext())
+    for (IDataBaseItem* pItem = pEnum->GetFirst(); pItem != nullptr; pItem = pEnum->GetNext())
     {
-        //Check if the item is in the target library first. 
+        //Check if the item is in the target library first.
         IDataBaseLibrary* itemLibrary = pItem->GetLibrary();
         QString itemLibraryName;
         if (itemLibrary)
@@ -590,7 +590,7 @@ QString CBaseLibraryManager::MakeUniqueItemName(const QString& srcName, const QS
 void CBaseLibraryManager::Validate()
 {
     IDataBaseItemEnumerator* pEnum = GetItemEnumerator();
-    for (IDataBaseItem* pItem = pEnum->GetFirst(); pItem != NULL; pItem = pEnum->GetNext())
+    for (IDataBaseItem* pItem = pEnum->GetFirst(); pItem != nullptr; pItem = pEnum->GetNext())
     {
         pItem->Validate();
     }
@@ -617,7 +617,7 @@ void CBaseLibraryManager::RegisterItem(CBaseLibraryItem* pItem, REFGUID newGuid)
         {
             return;
         }
-        CBaseLibraryItem* pOldItem = stl::find_in_map(m_itemsGuidMap, newGuid, (CBaseLibraryItem*)0);
+        CBaseLibraryItem* pOldItem = stl::find_in_map(m_itemsGuidMap, newGuid, nullptr);
         if (!pOldItem)
         {
             pItem->m_guid = newGuid;
@@ -677,7 +677,7 @@ void CBaseLibraryManager::RegisterItem(CBaseLibraryItem* pItem)
         {
             return;
         }
-        CBaseLibraryItem* pOldItem = stl::find_in_map(m_itemsGuidMap, pItem->GetGUID(), (CBaseLibraryItem*)0);
+        CBaseLibraryItem* pOldItem = stl::find_in_map(m_itemsGuidMap, pItem->GetGUID(), nullptr);
         if (!pOldItem)
         {
             m_itemsGuidMap[pItem->GetGUID()] = pItem;
@@ -789,7 +789,7 @@ QString CBaseLibraryManager::MakeFullItemName(IDataBaseLibrary* pLibrary, const 
 void CBaseLibraryManager::GatherUsedResources(CUsedResources& resources)
 {
     IDataBaseItemEnumerator* pEnum = GetItemEnumerator();
-    for (IDataBaseItem* pItem = pEnum->GetFirst(); pItem != NULL; pItem = pEnum->GetNext())
+    for (IDataBaseItem* pItem = pEnum->GetFirst(); pItem != nullptr; pItem = pEnum->GetNext())
     {
         pItem->GatherUsedResources(resources);
     }
@@ -815,15 +815,15 @@ void CBaseLibraryManager::OnEditorNotifyEvent(EEditorNotifyEvent event)
     switch (event)
     {
     case eNotify_OnBeginNewScene:
-        SetSelectedItem(0);
+        SetSelectedItem(nullptr);
         ClearAll();
         break;
     case eNotify_OnBeginSceneOpen:
-        SetSelectedItem(0);
+        SetSelectedItem(nullptr);
         ClearAll();
         break;
     case eNotify_OnCloseScene:
-        SetSelectedItem(0);
+        SetSelectedItem(nullptr);
         ClearAll();
         break;
     }
@@ -913,7 +913,7 @@ void CBaseLibraryManager::ChangeLibraryOrder(IDataBaseLibrary* lib, unsigned int
     {
         return;
     }
-    
+
     for (int i = 0; i < m_libs.size(); i++)
     {
         if (lib == m_libs[i])

--- a/Code/Editor/CheckOutDialog.h
+++ b/Code/Editor/CheckOutDialog.h
@@ -34,7 +34,7 @@ public:
         CANCEL = QDialog::Rejected
     };
 
-    CCheckOutDialog(const QString& file, QWidget* pParent = NULL);   // standard constructor
+    CCheckOutDialog(const QString& file, QWidget* pParent = nullptr);   // standard constructor
     virtual ~CCheckOutDialog();
 
     // Dialog Data

--- a/Code/Editor/ConfigGroup.cpp
+++ b/Code/Editor/ConfigGroup.cpp
@@ -48,7 +48,7 @@ namespace Config
             }
         }
 
-        return NULL;
+        return nullptr;
     }
 
     const IConfigVar* CConfigGroup::GetVar(const char* szName) const
@@ -63,7 +63,7 @@ namespace Config
             }
         }
 
-        return NULL;
+        return nullptr;
     }
 
     IConfigVar* CConfigGroup::GetVar(uint index)
@@ -73,7 +73,7 @@ namespace Config
             return m_vars[index];
         }
 
-        return NULL;
+        return nullptr;
     }
 
     const IConfigVar* CConfigGroup::GetVar(uint index) const
@@ -83,7 +83,7 @@ namespace Config
             return m_vars[index];
         }
 
-        return NULL;
+        return nullptr;
     }
 
     void CConfigGroup::SaveToXML(XmlNodeRef node)
@@ -127,7 +127,7 @@ namespace Config
 
                     case IConfigVar::eType_STRING:
                     {
-                        string currentValue = 0;
+                        string currentValue = nullptr;
                         var->Get(&currentValue);
                         node->setAttr(szName, currentValue);
                         break;
@@ -186,7 +186,7 @@ namespace Config
 
                 case IConfigVar::eType_STRING:
                 {
-                    string currentValue = 0;
+                    string currentValue = nullptr;
                     var->GetDefault(&currentValue);
                     QString readValue(currentValue.c_str());
                     if (node->getAttr(szName, readValue))

--- a/Code/Editor/ConfigGroup.h
+++ b/Code/Editor/ConfigGroup.h
@@ -37,11 +37,11 @@ namespace Config
             , m_description(szDescription)
             , m_type(varType)
             , m_flags(flags)
-            , m_ptr(NULL)
+            , m_ptr(nullptr)
         {};
 
         virtual ~IConfigVar() = default;
-        
+
         ILINE EType GetType() const
         {
             return m_type;

--- a/Code/Editor/ControlMRU.cpp
+++ b/Code/Editor/ControlMRU.cpp
@@ -28,7 +28,7 @@ void CControlMRU::OnCalcDynamicSize(DWORD dwMode)
 
     CString* pArrNames = pRecentFileList->m_arrNames;
 
-    assert(pArrNames != NULL);
+    assert(pArrNames != nullptr);
     if (!pArrNames)
     {
         return;
@@ -52,7 +52,7 @@ void CControlMRU::OnCalcDynamicSize(DWORD dwMode)
     if (m_pParent->IsCustomizeMode())
     {
         m_dwHideFlags = 0;
-        SetEnabled(TRUE);
+        SetEnabled(true);
         return;
     }
 
@@ -61,7 +61,7 @@ void CControlMRU::OnCalcDynamicSize(DWORD dwMode)
         SetCaption(CString(MAKEINTRESOURCE(IDS_NORECENTFILE_CAPTION)));
         SetDescription("No recently opened files");
         m_dwHideFlags = 0;
-        SetEnabled(FALSE);
+        SetEnabled(false);
 
         return;
     }
@@ -105,7 +105,7 @@ void CControlMRU::OnCalcDynamicSize(DWORD dwMode)
 
         int nId = iMRU + GetFirstMruID();
 
-        CXTPControl* pControl = m_pControls->Add(xtpControlButton, nId, _T(""), m_nIndex + iLastValidMRU + 1, TRUE);
+        CXTPControl* pControl = m_pControls->Add(xtpControlButton, nId, _T(""), m_nIndex + iLastValidMRU + 1, true);
         assert(pControl);
 
         pControl->SetCaption(CXTPControlWindowList::ConstructCaption(strName, iLastValidMRU + 1));
@@ -130,6 +130,6 @@ void CControlMRU::OnCalcDynamicSize(DWORD dwMode)
         SetCaption(CString(MAKEINTRESOURCE(IDS_NORECENTFILE_CAPTION)));
         SetDescription("No recently opened files");
         m_dwHideFlags = 0;
-        SetEnabled(FALSE);
+        SetEnabled(false);
     }
 }

--- a/Code/Editor/CrtDebug.cpp
+++ b/Code/Editor/CrtDebug.cpp
@@ -62,7 +62,7 @@ int crtAllocHook(int nAllocType, void* pvData,
 {
     if (nBlockUse == _CRT_BLOCK)
     {
-        return(TRUE);
+        return TRUE;
     }
 
     static int total_cnt = 0;

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -267,13 +267,13 @@ CCrySingleDocTemplate* CCryDocManager::SetDefaultTemplate(CCrySingleDocTemplate*
 // Copied from MFC to get rid of the silly ugly unoverridable doc-type pick dialog
 void CCryDocManager::OnFileNew()
 {
-    assert(m_pDefTemplate != NULL);
+    assert(m_pDefTemplate != nullptr);
 
-    m_pDefTemplate->OpenDocumentFile(NULL);
+    m_pDefTemplate->OpenDocumentFile(nullptr);
     // if returns NULL, the user has already been alerted
 }
-BOOL CCryDocManager::DoPromptFileName(QString& fileName, [[maybe_unused]] UINT nIDSTitle,
-    [[maybe_unused]] DWORD lFlags, BOOL bOpenFileDialog, [[maybe_unused]] CDocTemplate* pTemplate)
+bool CCryDocManager::DoPromptFileName(QString& fileName, [[maybe_unused]] UINT nIDSTitle,
+    [[maybe_unused]] DWORD lFlags, bool bOpenFileDialog, [[maybe_unused]] CDocTemplate* pTemplate)
 {
     CLevelFileDialog levelFileDialog(bOpenFileDialog);
     levelFileDialog.show();
@@ -287,15 +287,15 @@ BOOL CCryDocManager::DoPromptFileName(QString& fileName, [[maybe_unused]] UINT n
 
     return false;
 }
-CCryEditDoc* CCryDocManager::OpenDocumentFile(LPCTSTR lpszFileName, BOOL bAddToMRU)
+CCryEditDoc* CCryDocManager::OpenDocumentFile(LPCTSTR lpszFileName, bool bAddToMRU)
 {
-    assert(lpszFileName != NULL);
+    assert(lpszFileName != nullptr);
 
     // find the highest confidence
     auto pos = m_templateList.begin();
     CCrySingleDocTemplate::Confidence bestMatch = CCrySingleDocTemplate::noAttempt;
-    CCrySingleDocTemplate* pBestTemplate = NULL;
-    CCryEditDoc* pOpenDocument = NULL;
+    CCrySingleDocTemplate* pBestTemplate = nullptr;
+    CCryEditDoc* pOpenDocument = nullptr;
 
     if (lpszFileName[0] == '\"')
     {
@@ -312,7 +312,7 @@ CCryEditDoc* CCryDocManager::OpenDocumentFile(LPCTSTR lpszFileName, BOOL bAddToM
         auto pTemplate = *(pos++);
 
         CCrySingleDocTemplate::Confidence match;
-        assert(pOpenDocument == NULL);
+        assert(pOpenDocument == nullptr);
         match = pTemplate->MatchDocType(szPath.toUtf8().data(), pOpenDocument);
         if (match > bestMatch)
         {
@@ -325,18 +325,18 @@ CCryEditDoc* CCryDocManager::OpenDocumentFile(LPCTSTR lpszFileName, BOOL bAddToM
         }
     }
 
-    if (pOpenDocument != NULL)
+    if (pOpenDocument != nullptr)
     {
         return pOpenDocument;
     }
 
-    if (pBestTemplate == NULL)
+    if (pBestTemplate == nullptr)
     {
         QMessageBox::critical(AzToolsFramework::GetActiveWindow(), QString(), QObject::tr("Failed to open document."));
-        return NULL;
+        return nullptr;
     }
 
-    return pBestTemplate->OpenDocumentFile(szPath.toUtf8().data(), bAddToMRU, FALSE);
+    return pBestTemplate->OpenDocumentFile(szPath.toUtf8().data(), bAddToMRU, false);
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -464,7 +464,7 @@ void CCryEditApp::RegisterActionHandlers()
     ON_COMMAND(ID_FILE_SAVE_LEVEL, OnFileSave)
     ON_COMMAND(ID_FILE_EXPORTOCCLUSIONMESH, OnFileExportOcclusionMesh)
 
-    // Project Manager 
+    // Project Manager
     ON_COMMAND(ID_FILE_PROJECT_MANAGER_SETTINGS, OnOpenProjectManagerSettings)
     ON_COMMAND(ID_FILE_PROJECT_MANAGER_NEW, OnOpenProjectManagerNew)
     ON_COMMAND(ID_FILE_PROJECT_MANAGER_OPEN, OnOpenProjectManager)
@@ -657,7 +657,7 @@ struct SharedData
 //
 //      This function uses a technique similar to that described in KB
 //      article Q141752 to locate the previous instance of the application. .
-BOOL CCryEditApp::FirstInstance(bool bForceNewInstance)
+bool CCryEditApp::FirstInstance(bool bForceNewInstance)
 {
     QSystemSemaphore sem(QString(O3DEApplicationName) + "_sem", 1);
     sem.acquire();
@@ -805,12 +805,12 @@ void CCryEditApp::InitDirectory()
 // Needed to work with custom memory manager.
 //////////////////////////////////////////////////////////////////////////
 
-CCryEditDoc* CCrySingleDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, BOOL bMakeVisible /*= true*/)
+CCryEditDoc* CCrySingleDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, bool bMakeVisible /*= true*/)
 {
     return OpenDocumentFile(lpszPathName, true, bMakeVisible);
 }
 
-CCryEditDoc* CCrySingleDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, BOOL bAddToMRU, [[maybe_unused]] BOOL bMakeVisible)
+CCryEditDoc* CCrySingleDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, bool bAddToMRU, [[maybe_unused]] bool bMakeVisible)
 {
     CCryEditDoc* pCurDoc = GetIEditor()->GetDocument();
 
@@ -851,8 +851,8 @@ CCryEditDoc* CCrySingleDocTemplate::OpenDocumentFile(LPCTSTR lpszPathName, BOOL 
 
 CCrySingleDocTemplate::Confidence CCrySingleDocTemplate::MatchDocType(LPCTSTR lpszPathName, CCryEditDoc*& rpDocMatch)
 {
-    assert(lpszPathName != NULL);
-    rpDocMatch = NULL;
+    assert(lpszPathName != nullptr);
+    rpDocMatch = nullptr;
 
     // go through all documents
     CCryEditDoc* pDoc = GetIEditor()->GetDocument();
@@ -1059,7 +1059,7 @@ AZ::Outcome<void, AZStd::string> CCryEditApp::InitGameSystem(HWND hwndForInputSy
 }
 
 /////////////////////////////////////////////////////////////////////////////
-BOOL CCryEditApp::CheckIfAlreadyRunning()
+bool CCryEditApp::CheckIfAlreadyRunning()
 {
     bool bForceNewInstance = false;
 
@@ -1303,7 +1303,7 @@ void CCryEditApp::InitLevel(const CEditCommandLineInfo& cmdInfo)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-BOOL CCryEditApp::InitConsole()
+bool CCryEditApp::InitConsole()
 {
     // Execute command from cmdline -exec_line if applicable
     if (!m_execLineCmd.isEmpty())
@@ -1435,7 +1435,7 @@ struct CCryEditApp::PythonOutputHandler
         AzToolsFramework::EditorPythonConsoleNotificationBus::Handler::BusConnect();
     }
 
-    virtual ~PythonOutputHandler()
+    ~PythonOutputHandler() override
     {
         AzToolsFramework::EditorPythonConsoleNotificationBus::Handler::BusDisconnect();
     }
@@ -1467,7 +1467,7 @@ struct PythonTestOutputHandler final
     : public CCryEditApp::PythonOutputHandler
 {
     PythonTestOutputHandler() = default;
-    virtual ~PythonTestOutputHandler() = default;
+    ~PythonTestOutputHandler() override = default;
 
     void OnTraceMessage(AZStd::string_view message) override
     {
@@ -1593,7 +1593,7 @@ void CCryEditApp::RunInitPythonScript(CEditCommandLineInfo& cmdInfo)
 
 /////////////////////////////////////////////////////////////////////////////
 // CCryEditApp initialization
-BOOL CCryEditApp::InitInstance()
+bool CCryEditApp::InitInstance()
 {
     QElapsedTimer startupTimer;
     startupTimer.start();
@@ -1620,7 +1620,7 @@ BOOL CCryEditApp::InitInstance()
     {
         CAboutDialog aboutDlg(FormatVersion(m_pEditor->GetFileVersion()), FormatRichTextCopyrightNotice());
         aboutDlg.exec();
-        return FALSE;
+        return false;
     }
 
     // Reflect property control classes to the serialize context...
@@ -1775,7 +1775,7 @@ BOOL CCryEditApp::InitInstance()
         }
     }
 
-    SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), 0);
+    SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), nullptr);
     if (!GetIEditor()->IsInMatEditMode())
     {
         m_pEditor->InitFinished();
@@ -1860,8 +1860,8 @@ void CCryEditApp::RegisterEventLoopHook(IEventLoopHook* pHook)
 
 void CCryEditApp::UnregisterEventLoopHook(IEventLoopHook* pHookToRemove)
 {
-    IEventLoopHook* pPrevious = 0;
-    for (IEventLoopHook* pHook = m_pEventLoopHook; pHook != 0; pHook = pHook->pNextHook)
+    IEventLoopHook* pPrevious = nullptr;
+    for (IEventLoopHook* pHook = m_pEventLoopHook; pHook != nullptr; pHook = pHook->pNextHook)
     {
         if (pHook == pHookToRemove)
         {
@@ -1874,7 +1874,7 @@ void CCryEditApp::UnregisterEventLoopHook(IEventLoopHook* pHookToRemove)
                 m_pEventLoopHook = pHookToRemove->pNextHook;
             }
 
-            pHookToRemove->pNextHook = 0;
+            pHookToRemove->pNextHook = nullptr;
             return;
         }
     }
@@ -1897,7 +1897,7 @@ void CCryEditApp::LoadFile(QString fileName)
 
     if (MainWindow::instance() || m_pConsoleDialog)
     {
-        SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
+        SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
     }
 
     GetIEditor()->SetModifiedFlag(false);
@@ -1938,7 +1938,7 @@ void CCryEditApp::EnableAccelerator([[maybe_unused]] bool bEnable)
         CMainFrame *mainFrame = (CMainFrame*)m_pMainWnd;
         if (mainFrame->m_hAccelTable)
             DestroyAcceleratorTable( mainFrame->m_hAccelTable );
-        mainFrame->m_hAccelTable = NULL;
+        mainFrame->m_hAccelTable = nullptr;
         mainFrame->LoadAccelTable( MAKEINTRESOURCE(IDR_GAMEACCELERATOR) );
         CLogFile::WriteLine( "Disable Accelerators" );
     }
@@ -2281,7 +2281,7 @@ void CCryEditApp::EnableIdleProcessing()
     AZ_Assert(m_disableIdleProcessingCounter >= 0, "m_disableIdleProcessingCounter must be nonnegative");
 }
 
-BOOL CCryEditApp::OnIdle([[maybe_unused]] LONG lCount)
+bool CCryEditApp::OnIdle([[maybe_unused]] LONG lCount)
 {
     if (0 == m_disableIdleProcessingCounter)
     {
@@ -2289,7 +2289,7 @@ BOOL CCryEditApp::OnIdle([[maybe_unused]] LONG lCount)
     }
     else
     {
-        return 0;
+        return false;
     }
 }
 
@@ -3233,7 +3233,7 @@ void CCryEditApp::OnCreateLevel()
 //////////////////////////////////////////////////////////////////////////
 bool CCryEditApp::CreateLevel(bool& wasCreateLevelOperationCancelled)
 {
-    BOOL bIsDocModified = GetIEditor()->GetDocument()->IsModified();
+    bool bIsDocModified = GetIEditor()->GetDocument()->IsModified();
     if (GetIEditor()->GetDocument()->IsDocumentReady() && bIsDocModified)
     {
         QString str = QObject::tr("Level %1 has been changed. Save Level?").arg(GetIEditor()->GetGameEngine()->GetLevelName());
@@ -3321,11 +3321,11 @@ bool CCryEditApp::CreateLevel(bool& wasCreateLevelOperationCancelled)
 
 #ifdef WIN32
         FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            NULL,
+            nullptr,
             dw,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
             windowsErrorMessage.data(),
-            windowsErrorMessage.length(), NULL);
+            windowsErrorMessage.length(), nullptr);
         _getcwd(cwd.data(), cwd.length());
 #else
         windowsErrorMessage = strerror(dw);
@@ -3912,7 +3912,7 @@ bool CCryEditApp::IsInRegularEditorMode()
 
 void CCryEditApp::OnOpenQuickAccessBar()
 {
-    if (m_pQuickAccessBar == NULL)
+    if (m_pQuickAccessBar == nullptr)
     {
         return;
     }
@@ -4260,7 +4260,7 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
 
         int exitCode = 0;
 
-        BOOL didCryEditStart = CCryEditApp::instance()->InitInstance();
+        bool didCryEditStart = CCryEditApp::instance()->InitInstance();
         AZ_Error("Editor", didCryEditStart, "O3DE Editor did not initialize correctly, and will close."
             "\nThis could be because of incorrectly configured components, or missing required gems."
             "\nSee other errors for more details.");

--- a/Code/Editor/CryEdit.h
+++ b/Code/Editor/CryEdit.h
@@ -135,16 +135,16 @@ public:
     virtual void AddToRecentFileList(const QString& lpszPathName);
     ECreateLevelResult CreateLevel(const QString& levelName, QString& fullyQualifiedLevelName);
     static void InitDirectory();
-    BOOL FirstInstance(bool bForceNewInstance = false);
+    bool FirstInstance(bool bForceNewInstance = false);
     void InitFromCommandLine(CEditCommandLineInfo& cmdInfo);
-    BOOL CheckIfAlreadyRunning();
+    bool CheckIfAlreadyRunning();
     //! @return successful outcome if initialization succeeded. or failed outcome with error message.
     AZ::Outcome<void, AZStd::string> InitGameSystem(HWND hwndForInputSystem);
     void CreateSplashScreen();
     void InitPlugins();
     bool InitGame();
 
-    BOOL InitConsole();
+    bool InitConsole();
     int IdleProcessing(bool bBackground);
     bool IsWindowInForeground();
     void RunInitPythonScript(CEditCommandLineInfo& cmdInfo);
@@ -171,9 +171,9 @@ public:
     // Overrides
     // ClassWizard generated virtual function overrides
 public:
-    virtual BOOL InitInstance();
+    virtual bool InitInstance();
     virtual int ExitInstance(int exitCode = 0);
-    virtual BOOL OnIdle(LONG lCount);
+    virtual bool OnIdle(LONG lCount);
     virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszFileName);
 
     CCryDocManager* GetDocManager() { return m_pDocManager; }
@@ -353,7 +353,7 @@ private:
 // Disable warning for dll export since this member won't be used outside this class
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AZ::IO::FileDescriptorRedirector m_stdoutRedirection = AZ::IO::FileDescriptorRedirector(1); // < 1 for STDOUT
-AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING 
+AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 private:
     static inline constexpr const char* DefaultLevelTemplateName = "Prefabs/Default_Level.prefab";
@@ -426,7 +426,7 @@ public:
 };
 
 //////////////////////////////////////////////////////////////////////////
-class CCrySingleDocTemplate 
+class CCrySingleDocTemplate
     : public QObject
 {
 private:
@@ -454,8 +454,8 @@ public:
     ~CCrySingleDocTemplate() {};
     // avoid creating another CMainFrame
     // close other type docs before opening any things
-    virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszPathName, BOOL bAddToMRU, BOOL bMakeVisible);
-    virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszPathName, BOOL bMakeVisible = TRUE);
+    virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszPathName, bool bAddToMRU, bool bMakeVisible);
+    virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszPathName, bool bMakeVisible = true);
     virtual Confidence MatchDocType(LPCTSTR lpszPathName, CCryEditDoc*& rpDocMatch);
 
 private:
@@ -471,9 +471,9 @@ public:
     CCrySingleDocTemplate* SetDefaultTemplate(CCrySingleDocTemplate* pNew);
     // Copied from MFC to get rid of the silly ugly unoverridable doc-type pick dialog
     virtual void OnFileNew();
-    virtual BOOL DoPromptFileName(QString& fileName, UINT nIDSTitle,
-        DWORD lFlags, BOOL bOpenFileDialog, CDocTemplate* pTemplate);
-    virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszFileName, BOOL bAddToMRU);
+    virtual bool DoPromptFileName(QString& fileName, UINT nIDSTitle,
+        DWORD lFlags, bool bOpenFileDialog, CDocTemplate* pTemplate);
+    virtual CCryEditDoc* OpenDocumentFile(LPCTSTR lpszFileName, bool bAddToMRU);
 
     QVector<CCrySingleDocTemplate*> m_templateList;
 };

--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -95,7 +95,7 @@ namespace Internal
 {
     bool SaveLevel()
     {
-        if (!GetIEditor()->GetDocument()->DoSave(GetIEditor()->GetDocument()->GetActivePathName(), TRUE))
+        if (!GetIEditor()->GetDocument()->DoSave(GetIEditor()->GetDocument()->GetActivePathName(), true))
         {
             return false;
         }
@@ -108,7 +108,7 @@ namespace Internal
 // CCryEditDoc construction/destruction
 
 CCryEditDoc::CCryEditDoc()
-    : doc_validate_surface_types(0)
+    : doc_validate_surface_types(nullptr)
     , m_modifiedModuleFlags(eModifiedNothing)
     // It assumes loaded levels have already been exported. Can be a big fat lie, though.
     // The right way would require us to save to the level folder the export status of the
@@ -271,7 +271,7 @@ void CCryEditDoc::DeleteContents()
     GetIEditor()->GetObjectManager()->DeleteAllObjects();
 
     // Load scripts data
-    SetModifiedFlag(FALSE);
+    SetModifiedFlag(false);
     SetModifiedModules(eModifiedNothing);
     // Clear error reports if open.
     CErrorReportDialog::Clear();
@@ -313,7 +313,7 @@ void CCryEditDoc::Save(TDocMultiArchive& arrXmlAr)
     {
         CAutoDocNotReady autoDocNotReady;
 
-        if (arrXmlAr[DMAS_GENERAL] != NULL)
+        if (arrXmlAr[DMAS_GENERAL] != nullptr)
         {
             (*arrXmlAr[DMAS_GENERAL]).root = XmlHelpers::CreateXmlNode("Level");
             (*arrXmlAr[DMAS_GENERAL]).root->setAttr("WaterColor", m_waterColor);
@@ -491,7 +491,7 @@ void CCryEditDoc::Load(TDocMultiArchive& arrXmlAr, const QString& szFilename)
 
                     if (!pObj)
                     {
-                        pObj = GetIEditor()->GetObjectManager()->NewObject("SequenceObject", 0, fullname);
+                        pObj = GetIEditor()->GetObjectManager()->NewObject("SequenceObject", nullptr, fullname);
                     }
                 }
             }
@@ -675,7 +675,7 @@ int CCryEditDoc::GetModifiedModule()
     return m_modifiedModuleFlags;
 }
 
-BOOL CCryEditDoc::CanCloseFrame()
+bool CCryEditDoc::CanCloseFrame()
 {
     // Ask the base class to ask for saving, which also includes the save
     // status of the plugins. Additionaly we query if all the plugins can exit
@@ -684,21 +684,21 @@ BOOL CCryEditDoc::CanCloseFrame()
     // are not serialized in the project file
     if (!SaveModified())
     {
-        return FALSE;
+        return false;
     }
 
     if (!GetIEditor()->GetPluginManager()->CanAllPluginsExitNow())
     {
-        return FALSE;
+        return false;
     }
 
     // If there is an export in process, exiting will corrupt it
     if (CGameExporter::GetCurrentExporter() != nullptr)
     {
-        return FALSE;
+        return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::SaveModified()
@@ -742,7 +742,7 @@ bool CCryEditDoc::OnOpenDocument(const QString& lpszPathName)
     TOpenDocContext context;
     if (!BeforeOpenDocument(lpszPathName, context))
     {
-        return FALSE;
+        return false;
     }
     return DoOpenDocument(context);
 }
@@ -785,7 +785,7 @@ bool CCryEditDoc::BeforeOpenDocument(const QString& lpszPathName, TOpenDocContex
         context.absoluteLevelPath = absolutePath;
         context.absoluteSlicePath = "";
     }
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
@@ -822,7 +822,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
         if (!LoadXmlArchiveArray(arrXmlAr, levelFilePath, levelFolderAbsolutePath))
         {
             m_bLoadFailed = true;
-            return FALSE;
+            return false;
         }
     }
     if (!LoadLevel(arrXmlAr, context.absoluteLevelPath))
@@ -834,7 +834,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
 
     if (m_bLoadFailed)
     {
-        return FALSE;
+        return false;
     }
 
     // Load AZ entities for the editor.
@@ -855,7 +855,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
 
     if (m_bLoadFailed)
     {
-        return FALSE;
+        return false;
     }
 
     StartStreamingLoad();
@@ -872,7 +872,7 @@ bool CCryEditDoc::DoOpenDocument(TOpenDocContext& context)
     // level.
     SetLevelExported(true);
 
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::OnNewDocument()
@@ -969,7 +969,7 @@ bool CCryEditDoc::BeforeSaveDocument(const QString& lpszPathName, TSaveDocContex
     bool bSaved(true);
 
     context.bSaved = bSaved;
-    return TRUE;
+    return true;
 }
 
 bool CCryEditDoc::HasLayerNameConflicts()
@@ -1055,7 +1055,7 @@ bool CCryEditDoc::AfterSaveDocument([[maybe_unused]] const QString& lpszPathName
     else
     {
         CLogFile::WriteLine("$3Document successfully saved");
-        SetModifiedFlag(FALSE);
+        SetModifiedFlag(false);
         SetModifiedModules(eModifiedNothing);
         MainWindow::instance()->ResetAutoSaveTimers();
     }
@@ -1608,7 +1608,7 @@ bool CCryEditDoc::LoadLevel(TDocMultiArchive& arrXmlAr, const QString& absoluteC
     // Set level path directly *after* DeleteContents(), since that will unload the previous level and clear the level path.
     GetIEditor()->GetGameEngine()->SetLevelPath(folderPath);
 
-    SetModifiedFlag(TRUE);  // dirty during de-serialize
+    SetModifiedFlag(true);  // dirty during de-serialize
     SetModifiedModules(eModifiedAll);
     Load(arrXmlAr, absoluteCryFilePath);
 
@@ -1618,7 +1618,7 @@ bool CCryEditDoc::LoadLevel(TDocMultiArchive& arrXmlAr, const QString& absoluteC
     {
         pIPak->GetResourceList(AZ::IO::IArchive::RFOM_NextLevel)->Clear();
     }
-    SetModifiedFlag(FALSE); // start off with unmodified
+    SetModifiedFlag(false); // start off with unmodified
     SetModifiedModules(eModifiedNothing);
     SetDocumentReady(true);
     GetIEditor()->Notify(eNotify_OnEndLoad);
@@ -1997,7 +1997,7 @@ void CCryEditDoc::OnStartLevelResourceList()
     gEnv->pCryPak->GetResourceList(AZ::IO::IArchive::RFOM_Level)->Clear();
 }
 
-BOOL CCryEditDoc::DoFileSave()
+bool CCryEditDoc::DoFileSave()
 {
     if (GetEditMode() == CCryEditDoc::DocumentEditingMode::LevelEdit)
     {
@@ -2015,15 +2015,15 @@ BOOL CCryEditDoc::DoFileSave()
                     QString newLevelPath = filename.left(filename.lastIndexOf('/') + 1);
                     GetIEditor()->GetDocument()->SetPathName(filename);
                     GetIEditor()->GetGameEngine()->SetLevelPath(newLevelPath);
-                    return TRUE;
+                    return true;
                 }
             }
-            return FALSE;
+            return false;
         }
     }
     if (!IsDocumentReady())
     {
-        return FALSE;
+        return false;
     }
 
     return Internal::SaveLevel();
@@ -2081,7 +2081,7 @@ void CCryEditDoc::InitEmptyLevel(int /*resolution*/, int /*unitSize*/, bool /*bU
     GetISystem()->GetISystemEventDispatcher()->OnSystemEvent(ESYSTEM_EVENT_LEVEL_LOAD_END, 0, 0);
 
     GetIEditor()->Notify(eNotify_OnEndNewScene);
-    SetModifiedFlag(FALSE);
+    SetModifiedFlag(false);
     SetLevelExported(false);
     SetModifiedModules(eModifiedNothing);
 
@@ -2095,13 +2095,13 @@ void CCryEditDoc::CreateDefaultLevelAssets([[maybe_unused]] int resolution, [[ma
 
 void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
 {
-    if (pVar == NULL)
+    if (pVar == nullptr)
     {
         return;
     }
 
     XmlNodeRef node = GetEnvironmentTemplate();
-    if (node == NULL)
+    if (node == nullptr)
     {
         return;
     }
@@ -2119,7 +2119,7 @@ void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
 
     XmlNodeRef groupNode = node->getChild(nGroup);
 
-    if (groupNode == NULL)
+    if (groupNode == nullptr)
     {
         return;
     }
@@ -2130,7 +2130,7 @@ void CCryEditDoc::OnEnvironmentPropertyChanged(IVariable* pVar)
     }
 
     XmlNodeRef childNode = groupNode->getChild(nChild);
-    if (childNode == NULL)
+    if (childNode == nullptr)
     {
         return;
     }
@@ -2159,7 +2159,7 @@ QString CCryEditDoc::GetCryIndexPath(const LPCTSTR levelFilePath)
     return Path::AddPathSlash(levelPath + levelName + "_editor");
 }
 
-BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath)
+bool CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath)
 {
     auto pIPak = GetIEditor()->GetSystem()->GetIPak();
 
@@ -2168,7 +2168,7 @@ BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString&
         CXmlArchive* pXmlAr = new CXmlArchive();
         if (!pXmlAr)
         {
-            return FALSE;
+            return false;
         }
 
         CXmlArchive& xmlAr = *pXmlAr;
@@ -2179,7 +2179,7 @@ BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString&
         bool openLevelPakFileSuccess = pIPak->OpenPack(levelPath.toUtf8().data(), absoluteLevelPath.toUtf8().data());
         if (!openLevelPakFileSuccess)
         {
-            return FALSE;
+            return false;
         }
 
         CPakFile pakFile;
@@ -2188,13 +2188,13 @@ BOOL CCryEditDoc::LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString&
         pIPak->ClosePack(absoluteLevelPath.toUtf8().data());
         if (!loadFromPakSuccess)
         {
-            return FALSE;
+            return false;
         }
 
         FillXmlArArray(arrXmlAr, &xmlAr);
     }
 
-    return TRUE;
+    return true;
 }
 
 void CCryEditDoc::ReleaseXmlArchiveArray(TDocMultiArchive& arrXmlAr)

--- a/Code/Editor/CryEditDoc.h
+++ b/Code/Editor/CryEditDoc.h
@@ -26,7 +26,7 @@ struct ICVar;
 
 // Filename of the temporary file used for the hold / fetch operation
 // conform to the "$tmp[0-9]_" naming convention
-#define HOLD_FETCH_FILE "$tmp_hold" 
+#define HOLD_FETCH_FILE "$tmp_hold"
 
 class CCryEditDoc
     : public QObject
@@ -36,7 +36,7 @@ class CCryEditDoc
     Q_PROPERTY(bool modified READ IsModified WRITE SetModifiedFlag);
     Q_PROPERTY(QString pathName READ GetLevelPathName WRITE SetPathName);
     Q_PROPERTY(QString title READ GetTitle WRITE SetTitle);
- 
+
 public: // Create from serialization only
     enum DocumentEditingMode
     {
@@ -82,7 +82,7 @@ public: // Create from serialization only
 
     bool DoSave(const QString& pathName, bool replace);
     SANDBOX_API bool Save();
-    virtual BOOL DoFileSave();
+    virtual bool DoFileSave();
     bool SaveModified();
 
     virtual bool BackupBeforeSave(bool bForce = false);
@@ -102,7 +102,7 @@ public: // Create from serialization only
     bool IsLevelExported() const;
     void SetLevelExported(bool boExported = true);
 
-    BOOL CanCloseFrame();
+    bool CanCloseFrame();
 
     enum class FetchPolicy
     {
@@ -144,7 +144,7 @@ protected:
     };
     bool BeforeOpenDocument(const QString& lpszPathName, TOpenDocContext& context);
     bool DoOpenDocument(TOpenDocContext& context);
-    virtual BOOL LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath);
+    virtual bool LoadXmlArchiveArray(TDocMultiArchive& arrXmlAr, const QString& absoluteLevelPath, const QString& levelPath);
     virtual void ReleaseXmlArchiveArray(TDocMultiArchive& arrXmlAr);
 
     virtual void Load(TDocMultiArchive& arrXmlAr, const QString& szFilename);

--- a/Code/Editor/CryEditPy.cpp
+++ b/Code/Editor/CryEditPy.cpp
@@ -359,7 +359,7 @@ namespace
             {
                 AZ::TickBus::Handler::BusConnect();
             }
-            ~Ticker()
+            ~Ticker() override
             {
                 AZ::TickBus::Handler::BusDisconnect();
             }

--- a/Code/Editor/CustomAspectRatioDlg.cpp
+++ b/Code/Editor/CustomAspectRatioDlg.cpp
@@ -22,7 +22,7 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #define MIN_ASPECT 1
 #define MAX_ASPECT 16384
 
-CCustomAspectRatioDlg::CCustomAspectRatioDlg(int x, int y, QWidget* pParent /*=NULL*/)
+CCustomAspectRatioDlg::CCustomAspectRatioDlg(int x, int y, QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_xDefault(x)
     , m_yDefault(y)

--- a/Code/Editor/CustomResolutionDlg.cpp
+++ b/Code/Editor/CustomResolutionDlg.cpp
@@ -25,7 +25,7 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #define MIN_RES 64
 #define MAX_RES 8192
 
-CCustomResolutionDlg::CCustomResolutionDlg(int w, int h, QWidget* pParent /*=NULL*/)
+CCustomResolutionDlg::CCustomResolutionDlg(int w, int h, QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_wDefault(w)
     , m_hDefault(h)
@@ -50,12 +50,12 @@ void CCustomResolutionDlg::OnInitDialog()
     m_ui->m_height->setValue(m_hDefault);
 
     QString maxDimensionString;
-    QTextStream(&maxDimensionString) 
-        << "Maximum Dimension: " << MAX_RES << Qt::endl 
+    QTextStream(&maxDimensionString)
+        << "Maximum Dimension: " << MAX_RES << Qt::endl
         << Qt::endl
         << "Note: Dimensions over 8K may be" << Qt::endl
         << "unstable depending on hardware.";
-    
+
     m_ui->m_maxDimension->setText(maxDimensionString);
 }
 

--- a/Code/Editor/CustomizeKeyboardDialog.cpp
+++ b/Code/Editor/CustomizeKeyboardDialog.cpp
@@ -87,7 +87,7 @@ public:
         : QAbstractListModel(parent)
     {
     }
-    virtual ~MenuActionsModel() {}
+    ~MenuActionsModel() override {}
 
     int rowCount([[maybe_unused]] const QModelIndex& parent = QModelIndex()) const override
     {
@@ -134,7 +134,7 @@ public:
         , m_action(nullptr)
     {
     }
-    virtual ~ActionShortcutsModel() {}
+    ~ActionShortcutsModel() override {}
 
     int rowCount([[maybe_unused]] const QModelIndex& parent = QModelIndex()) const override
     {

--- a/Code/Editor/EditorDefs.h
+++ b/Code/Editor/EditorDefs.h
@@ -37,7 +37,6 @@
 #pragma warning (disable : 4786) // identifier was truncated to 'number' characters in the debug information.
 #pragma warning (disable : 4244) // conversion from 'long' to 'float', possible loss of data
 #pragma warning (disable : 4018) // signed/unsigned mismatch
-#pragma warning (disable : 4800) // BOOL bool conversion
 
 // Disable warning when a function returns a value inside an __asm block
 #pragma warning (disable : 4035)
@@ -85,17 +84,17 @@
 #endif
 
 #ifndef SAFE_DELETE
-#define SAFE_DELETE(p)          { if (p) { delete (p);       (p) = NULL; } \
+#define SAFE_DELETE(p)          { if (p) { delete (p);       (p) = nullptr; } \
 }
 #endif
 
 #ifndef SAFE_DELETE_ARRAY
-#define SAFE_DELETE_ARRAY(p)    { if (p) { delete[] (p);     (p) = NULL; } \
+#define SAFE_DELETE_ARRAY(p)    { if (p) { delete[] (p);     (p) = nullptr; } \
 }
 #endif
 
 #ifndef SAFE_RELEASE
-#define SAFE_RELEASE(p)         { if (p) { (p)->Release();   (p) = NULL; } \
+#define SAFE_RELEASE(p)         { if (p) { (p)->Release();   (p) = nullptr; } \
 }
 #endif
 

--- a/Code/Editor/EditorFileMonitor.cpp
+++ b/Code/Editor/EditorFileMonitor.cpp
@@ -162,7 +162,7 @@ QString RemoveGameName(const QString &filename)
 void CEditorFileMonitor::OnFileMonitorChange(const SFileChangeInfo& rChange)
 {
     CCryEditApp* app = CCryEditApp::instance();
-    if (app == NULL || app->IsExiting())
+    if (app == nullptr || app->IsExiting())
     {
         return;
     }

--- a/Code/Editor/EditorFileMonitor.h
+++ b/Code/Editor/EditorFileMonitor.h
@@ -42,7 +42,7 @@ private:
         QString extension;
 
         SFileChangeCallback()
-            : pListener(NULL)
+            : pListener(nullptr)
         {}
 
         SFileChangeCallback(IFileChangeListener* pListener, const char* item, const char* extension)

--- a/Code/Editor/EditorPanelUtils.cpp
+++ b/Code/Editor/EditorPanelUtils.cpp
@@ -49,7 +49,7 @@ class CEditorPanelUtils_Impl
 {
     #pragma region Drag & Drop
 public:
-    virtual void SetViewportDragOperation(void(* dropCallback)(CViewport* viewport, int dragPointX, int dragPointY, void* custom), void* custom) override
+    void SetViewportDragOperation(void(* dropCallback)(CViewport* viewport, int dragPointX, int dragPointY, void* custom), void* custom) override
     {
         for (int i = 0; i < GetIEditor()->GetViewManager()->GetViewCount(); i++)
         {
@@ -60,13 +60,13 @@ public:
     #pragma region Preview Window
 public:
 
-    virtual int PreviewWindow_GetDisplaySettingsDebugFlags(CDisplaySettings* settings)
+    int PreviewWindow_GetDisplaySettingsDebugFlags(CDisplaySettings* settings) override
     {
         CRY_ASSERT(settings);
         return settings->GetDebugFlags();
     }
 
-    virtual void PreviewWindow_SetDisplaySettingsDebugFlags(CDisplaySettings* settings, int flags)
+    void PreviewWindow_SetDisplaySettingsDebugFlags(CDisplaySettings* settings, int flags) override
     {
         CRY_ASSERT(settings);
         settings->SetDebugFlags(flags);
@@ -79,7 +79,7 @@ protected:
     bool m_hotkeysAreEnabled;
 public:
 
-    virtual bool HotKey_Import() override
+    bool HotKey_Import() override
     {
         QVector<QPair<QString, QString> > keys;
         QString filepath = QFileDialog::getOpenFileName(nullptr, "Select shortcut configuration to load",
@@ -143,7 +143,7 @@ public:
         return result;
     }
 
-    virtual void HotKey_Export() override
+    void HotKey_Export() override
     {
         auto settingDir = AZ::IO::FixedMaxPath(AZ::Utils::GetEnginePath()) / "Editor" / "Plugins" / "ParticleEditorPlugin" / "settings";
         QString filepath = QFileDialog::getSaveFileName(nullptr, "Select shortcut configuration to load", settingDir.c_str(), "HotKey Config Files (*.hkxml)");
@@ -170,7 +170,7 @@ public:
         file.close();
     }
 
-    virtual QKeySequence HotKey_GetShortcut(const char* path) override
+    QKeySequence HotKey_GetShortcut(const char* path) override
     {
         for (HotKey combo : hotkeys)
         {
@@ -182,7 +182,7 @@ public:
         return QKeySequence();
     }
 
-    virtual bool HotKey_IsPressed(const QKeyEvent* event, const char* path) override
+    bool HotKey_IsPressed(const QKeyEvent* event, const char* path) override
     {
         if (!m_hotkeysAreEnabled)
         {
@@ -221,7 +221,7 @@ public:
         return false;
     }
 
-    virtual bool HotKey_IsPressed(const QShortcutEvent* event, const char* path) override
+    bool HotKey_IsPressed(const QShortcutEvent* event, const char* path) override
     {
         if (!m_hotkeysAreEnabled)
         {
@@ -239,7 +239,7 @@ public:
         return false;
     }
 
-    virtual bool HotKey_LoadExisting() override
+    bool HotKey_LoadExisting() override
     {
         QSettings settings("O3DE", "O3DE");
         QString group = "Hotkeys/";
@@ -275,7 +275,7 @@ public:
         return true;
     }
 
-    virtual void HotKey_SaveCurrent() override
+    void HotKey_SaveCurrent() override
     {
         QSettings settings("O3DE", "O3DE");
         QString group = "Hotkeys/";
@@ -296,7 +296,7 @@ public:
         settings.sync();
     }
 
-    virtual void HotKey_BuildDefaults() override
+    void HotKey_BuildDefaults() override
     {
         m_hotkeysAreEnabled = true;
         QVector<QPair<QString, QString> > keys;
@@ -356,17 +356,17 @@ public:
         }
     }
 
-    virtual void HotKey_SetKeys(QVector<HotKey> keys) override
+    void HotKey_SetKeys(QVector<HotKey> keys) override
     {
         hotkeys = keys;
     }
 
-    virtual QVector<HotKey> HotKey_GetKeys() override
+    QVector<HotKey> HotKey_GetKeys() override
     {
         return hotkeys;
     }
 
-    virtual QString HotKey_GetPressedHotkey(const QKeyEvent* event) override
+    QString HotKey_GetPressedHotkey(const QKeyEvent* event) override
     {
         if (!m_hotkeysAreEnabled)
         {
@@ -381,7 +381,7 @@ public:
         }
         return "";
     }
-    virtual QString HotKey_GetPressedHotkey(const QShortcutEvent* event) override
+    QString HotKey_GetPressedHotkey(const QShortcutEvent* event) override
     {
         if (!m_hotkeysAreEnabled)
         {
@@ -398,12 +398,12 @@ public:
     }
     //building the default hotkey list re-enables hotkeys
     //do not use this when rebuilding the default list is a possibility.
-    virtual void HotKey_SetEnabled(bool val) override
+    void HotKey_SetEnabled(bool val) override
     {
         m_hotkeysAreEnabled = val;
     }
 
-    virtual bool HotKey_IsEnabled() const override
+    bool HotKey_IsEnabled() const override
     {
         return m_hotkeysAreEnabled;
     }
@@ -457,13 +457,13 @@ protected:
     }
 
 public:
-    virtual void ToolTip_LoadConfigXML(QString filepath) override
+    void ToolTip_LoadConfigXML(QString filepath) override
     {
         XmlNodeRef node = GetIEditor()->GetSystem()->LoadXmlFromFile(filepath.toStdString().c_str());
         ToolTip_ParseNode(node);
     }
 
-    virtual void ToolTip_BuildFromConfig(IQToolTip* tooltip, QString path, QString option, QString optionalData = "", bool isEnabled = true)
+    void ToolTip_BuildFromConfig(IQToolTip* tooltip, QString path, QString option, QString optionalData = "", bool isEnabled = true) override
     {
         AZ_Assert(tooltip, "tooltip cannot be null");
 
@@ -488,7 +488,7 @@ public:
         }
     }
 
-    virtual QString ToolTip_GetTitle(QString path, QString option) override
+    QString ToolTip_GetTitle(QString path, QString option) override
     {
         if (!option.isEmpty() && GetToolTip(path + "." + option).isValid)
         {
@@ -501,7 +501,7 @@ public:
         return GetToolTip(path).title;
     }
 
-    virtual QString ToolTip_GetContent(QString path, QString option) override
+    QString ToolTip_GetContent(QString path, QString option) override
     {
         if (!option.isEmpty() && GetToolTip(path + "." + option).isValid)
         {
@@ -514,7 +514,7 @@ public:
         return GetToolTip(path).content;
     }
 
-    virtual QString ToolTip_GetSpecialContentType(QString path, QString option) override
+    QString ToolTip_GetSpecialContentType(QString path, QString option) override
     {
         if (!option.isEmpty() && GetToolTip(path + "." + option).isValid)
         {
@@ -527,7 +527,7 @@ public:
         return GetToolTip(path).specialContent;
     }
 
-    virtual QString ToolTip_GetDisabledContent(QString path, QString option) override
+    QString ToolTip_GetDisabledContent(QString path, QString option) override
     {
         if (!option.isEmpty() && GetToolTip(path + "." + option).isValid)
         {

--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -282,7 +282,7 @@ void EditorPreferencesDialog::CreatePages()
     {
         auto pUnknown = classes[i];
 
-        IPreferencesPageCreator* pPageCreator = 0;
+        IPreferencesPageCreator* pPageCreator = nullptr;
         if (FAILED(pUnknown->QueryInterface(&pPageCreator)))
         {
             continue;

--- a/Code/Editor/ErrorReport.cpp
+++ b/Code/Editor/ErrorReport.cpp
@@ -136,11 +136,11 @@ void CErrorReport::ReportError(CErrorRecord& err)
     }
     else
     {
-        if (err.pObject == NULL && m_pObject != NULL)
+        if (err.pObject == nullptr && m_pObject != nullptr)
         {
             err.pObject = m_pObject;
         }
-        else if (err.pItem == NULL && m_pItem != NULL)
+        else if (err.pItem == nullptr && m_pItem != nullptr)
         {
             err.pItem = m_pItem;
         }

--- a/Code/Editor/ErrorReportDialog.cpp
+++ b/Code/Editor/ErrorReportDialog.cpp
@@ -39,7 +39,7 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 
 //////////////////////////////////////////////////////////////////////////
-CErrorReportDialog* CErrorReportDialog::m_instance = 0;
+CErrorReportDialog* CErrorReportDialog::m_instance = nullptr;
 
 // CErrorReportDialog dialog
 
@@ -88,12 +88,12 @@ CErrorReportDialog::CErrorReportDialog(QWidget* parent)
     m_instance = this;
     //CErrorReport *report,
     //m_pErrorReport = report;
-    m_pErrorReport = 0;
+    m_pErrorReport = nullptr;
 }
 
 CErrorReportDialog::~CErrorReportDialog()
 {
-    m_instance = 0;
+    m_instance = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -141,7 +141,7 @@ void CErrorReportDialog::Clear()
 {
     if (m_instance)
     {
-        m_instance->SetReport(0);
+        m_instance->SetReport(nullptr);
         m_instance->UpdateErrors();
     }
 }
@@ -500,7 +500,7 @@ void CErrorReportDialog::OnReportItemDblClick(const QModelIndex& index)
 {
     bool bDone = false;
     const CErrorRecord* pError = index.data(Qt::UserRole).value<const CErrorRecord*>();
-    if (pError && pError->pObject != NULL)
+    if (pError && pError->pObject != nullptr)
     {
         CUndo undo("Select Object(s)");
         // Clear other selection.
@@ -563,7 +563,7 @@ void CErrorReportDialog::OnReportHyperlink(const QModelIndex& index)
 {
     const CErrorRecord* pError = index.data(Qt::UserRole).value<const CErrorRecord*>();
     bool bDone = false;
-    if (pError && pError->pObject != NULL)
+    if (pError && pError->pObject != nullptr)
     {
         CUndo undo("Select Object(s)");
         // Clear other selection.
@@ -593,8 +593,8 @@ void CErrorReportDialog::OnShowFieldChooser()
     CMainFrm* pMainFrm = (CMainFrame*)AfxGetMainWnd();
     if (pMainFrm)
     {
-        BOOL bShow = !pMainFrm->m_wndFieldChooser.IsVisible();
-        pMainFrm->ShowControlBar(&pMainFrm->m_wndFieldChooser, bShow, FALSE);
+        bool bShow = !pMainFrm->m_wndFieldChooser.IsVisible();
+        pMainFrm->ShowControlBar(&pMainFrm->m_wndFieldChooser, bShow, false);
     }
 }
 */

--- a/Code/Editor/ErrorReportTableModel.cpp
+++ b/Code/Editor/ErrorReportTableModel.cpp
@@ -105,7 +105,7 @@ void CErrorReportTableModel::setErrorReport(CErrorReport* report)
     {
         m_errorRecords.clear();
     }
-    if (report != 0)
+    if (report != nullptr)
     {
         const int count = report->GetErrorCount();
         m_errorRecords.reserve(count);

--- a/Code/Editor/GameEngine.cpp
+++ b/Code/Editor/GameEngine.cpp
@@ -57,12 +57,12 @@ struct SSystemUserCallback
     : public ISystemUserCallback
 {
     SSystemUserCallback(IInitializeUIInfo* logo) : m_threadErrorHandler(this) { m_pLogo = logo; };
-    virtual void OnSystemConnect(ISystem* pSystem)
+    void OnSystemConnect(ISystem* pSystem) override
     {
         ModuleInitISystem(pSystem, "Editor");
     }
 
-    virtual bool OnError(const char* szErrorString)
+    bool OnError(const char* szErrorString) override
     {
         // since we show a message box, we have to use the GUI thread
         if (QThread::currentThread() != qApp->thread())
@@ -95,7 +95,7 @@ struct SSystemUserCallback
 
         int res = IDNO;
 
-        ICVar* pCVar = gEnv->pConsole ? gEnv->pConsole->GetCVar("sys_no_crash_dialog") : NULL;
+        ICVar* pCVar = gEnv->pConsole ? gEnv->pConsole->GetCVar("sys_no_crash_dialog") : nullptr;
 
         if (!pCVar || pCVar->GetIVal() == 0)
         {
@@ -116,7 +116,7 @@ struct SSystemUserCallback
         return true;
     }
 
-    virtual bool OnSaveDocument()
+    bool OnSaveDocument() override
     {
         bool success = false;
 
@@ -133,7 +133,7 @@ struct SSystemUserCallback
         return success;
     }
 
-    virtual bool OnBackupDocument()
+    bool OnBackupDocument() override
     {
         CCryEditDoc* level = GetIEditor() ? GetIEditor()->GetDocument() : nullptr;
         if (level)
@@ -144,7 +144,7 @@ struct SSystemUserCallback
         return false;
     }
 
-    virtual void OnProcessSwitch()
+    void OnProcessSwitch() override
     {
         if (GetIEditor()->IsInGameMode())
         {
@@ -152,7 +152,7 @@ struct SSystemUserCallback
         }
     }
 
-    virtual void OnInitProgress(const char* sProgressMsg)
+    void OnInitProgress(const char* sProgressMsg) override
     {
         if (m_pLogo)
         {
@@ -160,7 +160,7 @@ struct SSystemUserCallback
         }
     }
 
-    virtual int ShowMessage(const char* text, const char* caption, unsigned int uType)
+    int ShowMessage(const char* text, const char* caption, unsigned int uType) override
     {
         if (CCryEditApp::instance()->IsInAutotestMode())
         {
@@ -176,7 +176,7 @@ struct SSystemUserCallback
         return CryMessageBox(text, caption, uType);
     }
 
-    virtual void GetMemoryUsage(ICrySizer* pSizer)
+    void GetMemoryUsage(ICrySizer* pSizer) override
     {
         GetIEditor()->GetMemoryUsage(pSizer);
     }
@@ -215,7 +215,7 @@ public:
     {
         AzFramework::AssetSystemConnectionNotificationsBus::Handler::BusConnect();
     };
-    ~AssetProcessConnectionStatus()
+    ~AssetProcessConnectionStatus() override
     {
         AzFramework::AssetSystemConnectionNotificationsBus::Handler::BusDisconnect();
     }
@@ -247,18 +247,18 @@ private:
 
 AZ_PUSH_DISABLE_WARNING(4273, "-Wunknown-warning-option")
 CGameEngine::CGameEngine()
-    : m_gameDll(0)
+    : m_gameDll(nullptr)
     , m_bIgnoreUpdates(false)
     , m_ePendingGameMode(ePGM_NotPending)
     , m_modalWindowDismisser(nullptr)
 AZ_POP_DISABLE_WARNING
 {
-    m_pISystem = NULL;
+    m_pISystem = nullptr;
     m_bLevelLoaded = false;
     m_bInGameMode = false;
     m_bSimulationMode = false;
     m_bSyncPlayerPosition = true;
-    m_hSystemHandle = 0;
+    m_hSystemHandle = nullptr;
     m_bJustCreated = false;
     m_levelName = "Untitled";
     m_levelExtension = EditorUtils::LevelFile::GetDefaultFileExtension();
@@ -271,7 +271,7 @@ CGameEngine::~CGameEngine()
 {
 AZ_POP_DISABLE_WARNING
     GetIEditor()->UnregisterNotifyListener(this);
-    m_pISystem->GetIMovieSystem()->SetCallback(NULL);
+    m_pISystem->GetIMovieSystem()->SetCallback(nullptr);
 
     if (m_gameDll)
     {
@@ -279,7 +279,7 @@ AZ_POP_DISABLE_WARNING
     }
 
     delete m_pISystem;
-    m_pISystem = NULL;
+    m_pISystem = nullptr;
 
     if (m_hSystemHandle)
     {
@@ -875,7 +875,7 @@ void CGameEngine::OnEditorNotifyEvent(EEditorNotifyEvent event)
     {
     case eNotify_OnSplashScreenDestroyed:
     {
-        if (m_pSystemUserCallback != NULL)
+        if (m_pSystemUserCallback != nullptr)
         {
             m_pSystemUserCallback->OnSplashScreenDone();
         }

--- a/Code/Editor/GameExporter.cpp
+++ b/Code/Editor/GameExporter.cpp
@@ -63,7 +63,7 @@ void SGameExporterSettings::SetHiQuality()
     nApplySS = 1;
 }
 
-CGameExporter* CGameExporter::m_pCurrentExporter = NULL;
+CGameExporter* CGameExporter::m_pCurrentExporter = nullptr;
 
 //////////////////////////////////////////////////////////////////////////
 // CGameExporter
@@ -76,7 +76,7 @@ CGameExporter::CGameExporter()
 
 CGameExporter::~CGameExporter()
 {
-    m_pCurrentExporter = NULL;
+    m_pCurrentExporter = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/GenericSelectItemDialog.cpp
+++ b/Code/Editor/GenericSelectItemDialog.cpp
@@ -17,7 +17,7 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
 // CGenericSelectItemDialog dialog
 
-CGenericSelectItemDialog::CGenericSelectItemDialog(QWidget* pParent /*=NULL*/)
+CGenericSelectItemDialog::CGenericSelectItemDialog(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , ui(new Ui::CGenericSelectItemDialog)
     , m_initialized(false)

--- a/Code/Editor/IEditor.h
+++ b/Code/Editor/IEditor.h
@@ -570,7 +570,7 @@ struct IEditor
     //////////////////////////////////////////////////////////////////////////
     virtual class CLevelIndependentFileMan* GetLevelIndependentFileMan() = 0;
     //! Notify all views that data is changed.
-    virtual void UpdateViews(int flags = 0xFFFFFFFF, const AABB* updateRegion = NULL) = 0;
+    virtual void UpdateViews(int flags = 0xFFFFFFFF, const AABB* updateRegion = nullptr) = 0;
     virtual void ResetViews() = 0;
     //! Update information in track view dialog.
     virtual void ReloadTrackView() = 0;
@@ -589,7 +589,7 @@ struct IEditor
     //! if bShow is true also returns a valid ITransformManipulator pointer.
     virtual ITransformManipulator* ShowTransformManipulator(bool bShow) = 0;
     //! Return a pointer to a ITransformManipulator pointer if shown.
-    //! NULL is manipulator is not shown.
+    //! nullptr if manipulator is not shown.
     virtual ITransformManipulator* GetTransformManipulator() = 0;
     //! Set constrain on specified axis for objects construction and modifications.
     //! @param axis one of AxisConstrains enumerations.

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -415,7 +415,7 @@ void CEditorImpl::Update()
     }
     if (IsInPreviewMode())
     {
-        SetModifiedFlag(FALSE);
+        SetModifiedFlag(false);
         SetModifiedModule(eModifiedNothing);
     }
 
@@ -550,7 +550,7 @@ QString CEditorImpl::GetResolvedUserFolder()
 
 void CEditorImpl::SetDataModified()
 {
-    GetDocument()->SetModifiedFlag(TRUE);
+    GetDocument()->SetModifiedFlag(true);
 }
 
 void CEditorImpl::SetStatusText(const QString& pszString)
@@ -597,9 +597,9 @@ ITransformManipulator* CEditorImpl::ShowTransformManipulator(bool bShow)
             GetObjectManager()->GetGizmoManager()->RemoveGizmo(m_pAxisGizmo);
             m_pAxisGizmo->Release();
         }
-        m_pAxisGizmo = 0;
+        m_pAxisGizmo = nullptr;
     }
-    return 0;
+    return nullptr;
 }
 
 ITransformManipulator* CEditorImpl::GetTransformManipulator()
@@ -614,7 +614,7 @@ void CEditorImpl::SetAxisConstraints(AxisConstrains axisFlags)
     SetTerrainAxisIgnoreObjects(false);
 
     // Update all views.
-    UpdateViews(eUpdateObjects, NULL);
+    UpdateViews(eUpdateObjects, nullptr);
 }
 
 AxisConstrains CEditorImpl::GetAxisConstrains()
@@ -637,15 +637,15 @@ void CEditorImpl::SetReferenceCoordSys(RefCoordSys refCoords)
     m_refCoordsSys = refCoords;
 
     // Update all views.
-    UpdateViews(eUpdateObjects, NULL);
+    UpdateViews(eUpdateObjects, nullptr);
 
     // Update the construction plane infos.
     CViewport* pViewport = GetActiveView();
     if (pViewport)
     {
         //Pre and Post widget rendering calls are made here to make sure that the proper camera state is set.
-        //MakeConstructionPlane will make a call to ViewToWorldRay which needs the correct camera state 
-        //in the CRenderViewport to be set. 
+        //MakeConstructionPlane will make a call to ViewToWorldRay which needs the correct camera state
+        //in the CRenderViewport to be set.
         pViewport->PreWidgetRendering();
 
         pViewport->MakeConstructionPlane(GetIEditor()->GetAxisConstrains());
@@ -671,7 +671,7 @@ CBaseObject* CEditorImpl::NewObject(const char* typeName, const char* fileName, 
         editor->SetModifiedFlag();
         editor->SetModifiedModule(eModifiedBrushes);
     }
-    CBaseObject* object = editor->GetObjectManager()->NewObject(typeName, 0, fileName, name);
+    CBaseObject* object = editor->GetObjectManager()->NewObject(typeName, nullptr, fileName, name);
     if (!object)
     {
         return nullptr;
@@ -932,7 +932,7 @@ void CEditorImpl::CloseView(const GUID& classId)
 
 IDataBaseManager* CEditorImpl::GetDBItemManager([[maybe_unused]] EDataBaseItemType itemType)
 {
-    return 0;
+    return nullptr;
 }
 
 bool CEditorImpl::SelectColor(QColor& color, QWidget* parent)
@@ -1109,7 +1109,7 @@ void CEditorImpl::DetectVersion()
 
     char ver[1024 * 8];
 
-    GetModuleFileName(NULL, exe, _MAX_PATH);
+    GetModuleFileName(nullptr, exe, _MAX_PATH);
 
     int verSize = GetFileVersionInfoSize(exe, &dwHandle);
     if (verSize > 0)
@@ -1431,7 +1431,7 @@ void CEditorImpl::NotifyExcept(EEditorNotifyEvent event, IEditorNotifyListener* 
         {
             m_pAxisGizmo->Release();
         }
-        m_pAxisGizmo = 0;
+        m_pAxisGizmo = nullptr;
     }
 
     if (event == eNotify_OnInit)
@@ -1472,7 +1472,7 @@ ISourceControl* CEditorImpl::GetSourceControl()
         for (int i = 0; i < classes.size(); i++)
         {
             IClassDesc* pClass = classes[i];
-            ISourceControl* pSCM = NULL;
+            ISourceControl* pSCM = nullptr;
             HRESULT hRes = pClass->QueryInterface(__uuidof(ISourceControl), (void**)&pSCM);
             if (!FAILED(hRes) && pSCM)
             {
@@ -1482,7 +1482,7 @@ ISourceControl* CEditorImpl::GetSourceControl()
         }
     }
 
-    return 0;
+    return nullptr;
 }
 
 bool CEditorImpl::IsSourceControlAvailable()

--- a/Code/Editor/IEditorImpl.h
+++ b/Code/Editor/IEditorImpl.h
@@ -22,7 +22,7 @@
 #include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 #include <AzCore/std/string/string.h>
 
-#include "Commands/CommandManager.h"                
+#include "Commands/CommandManager.h"
 
 #include "Include/IErrorReport.h"
 #include "ErrorReport.h"
@@ -63,7 +63,7 @@ namespace AssetDatabase
     class AssetDatabaseLocationListener;
 }
 
-class CEditorImpl 
+class CEditorImpl
     : public IEditor
 {
     Q_DECLARE_TR_FUNCTIONS(CEditorImpl)
@@ -176,7 +176,7 @@ public:
         {
             return m_pSystem->GetIMovieSystem();
         }
-        return NULL;
+        return nullptr;
     };
 
     CPluginManager* GetPluginManager() { return m_pPluginManager; }
@@ -210,7 +210,7 @@ public:
     RefCoordSys GetReferenceCoordSys();
     XmlNodeRef FindTemplate(const QString& templateName);
     void AddTemplate(const QString& templateName, XmlNodeRef& tmpl);
-   
+
     const QtViewPane* OpenView(QString sViewClassName, bool reuseOpened = true) override;
 
     /**

--- a/Code/Editor/IconManager.cpp
+++ b/Code/Editor/IconManager.cpp
@@ -81,7 +81,7 @@ void CIconManager::Reset()
         {
             m_objects[i]->Release();
         }
-        m_objects[i] = 0;
+        m_objects[i] = nullptr;
     }
     for (i = 0; i < eIcon_COUNT; i++)
     {
@@ -135,7 +135,7 @@ IStatObj*   CIconManager::GetObject(EStatObject)
 //////////////////////////////////////////////////////////////////////////
 QImage* CIconManager::GetIconBitmap(const char* filename, bool& bHaveAlpha, uint32 effects /*=0*/)
 {
-    QImage* pBitmap = 0;
+    QImage* pBitmap = nullptr;
 
     QString iconFilename = filename;
 
@@ -160,11 +160,11 @@ QImage* CIconManager::GetIconBitmap(const char* filename, bool& bHaveAlpha, uint
         return pBitmap;
     }
 
-    BOOL bAlphaBitmap = FALSE;
+    bool bAlphaBitmap = false;
     QPixmap pm(iconFilename);
     bAlphaBitmap = pm.hasAlpha();
 
-    bHaveAlpha = (bAlphaBitmap == TRUE);
+    bHaveAlpha = (bAlphaBitmap == true);
     if (!pm.isNull())
     {
         pBitmap = new QImage;
@@ -252,5 +252,5 @@ QImage* CIconManager::GetIconBitmap(const char* filename, bool& bHaveAlpha, uint
 
         return pBitmap;
     }
-    return NULL;
+    return nullptr;
 }

--- a/Code/Editor/LayoutConfigDialog.cpp
+++ b/Code/Editor/LayoutConfigDialog.cpp
@@ -68,7 +68,7 @@ QVariant LayoutConfigModel::data(const QModelIndex& index, int role) const
 
 // CLayoutConfigDialog dialog
 
-CLayoutConfigDialog::CLayoutConfigDialog(QWidget* pParent /*=NULL*/)
+CLayoutConfigDialog::CLayoutConfigDialog(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_model(new LayoutConfigModel(this))
     , ui(new Ui::CLayoutConfigDialog)

--- a/Code/Editor/LayoutWnd.cpp
+++ b/Code/Editor/LayoutWnd.cpp
@@ -98,7 +98,7 @@ CLayoutWnd::CLayoutWnd(QSettings* settings, QWidget* parent)
     , m_settings(settings)
 {
     m_bMaximized = false;
-    m_maximizedView = 0;
+    m_maximizedView = nullptr;
     m_layout = (EViewLayout) - 1;
 
     m_maximizedViewId = 0;
@@ -729,7 +729,7 @@ void CLayoutWnd::OnDestroy()
     if (m_maximizedView)
     {
         delete m_maximizedView;
-        m_maximizedView = 0;
+        m_maximizedView = nullptr;
     }
 }
 


### PR DESCRIPTION
A few 'typedefs' replaced by 'using's
This shouldn't have any functional changes at all, just c++17 modernization
It's a part 5 of a split #2847

*Note to reviewers this is a split PR meant to ease reviewing, but sadly I cannot say if this or any other part will compile correctly in isolation.*

Signed-off-by: Nemerle <nemerle5+git@gmail.com>