### PR TITLE
Editor code: tidy up BOOLs,NULLs and overrides pt6.

### DIFF
--- a/Code/Editor/LayoutWnd.h
+++ b/Code/Editor/LayoutWnd.h
@@ -103,7 +103,7 @@ public:
     static const char* GetConfigGroupName();
 
     CLayoutViewPane* FindViewByClass(const QString& viewClassName);
-    void BindViewport(CLayoutViewPane* vp, const QString& viewClassName, QWidget* pViewport = NULL);
+    void BindViewport(CLayoutViewPane* vp, const QString& viewClassName, QWidget* pViewport = nullptr);
     QString ViewportTypeToClassName(EViewportType viewType);
 
     //! Switch 2D viewports.

--- a/Code/Editor/LevelInfo.cpp
+++ b/Code/Editor/LevelInfo.cpp
@@ -93,7 +93,7 @@ void CLevelInfo::ValidateObjects()
 
         pObject->Validate(m_pReport);
 
-        m_pReport->SetCurrentValidatorObject(NULL);
+        m_pReport->SetCurrentValidatorObject(nullptr);
     }
 
     CLogFile::WriteLine("Validating Duplicate Objects...");

--- a/Code/Editor/LogFile.cpp
+++ b/Code/Editor/LogFile.cpp
@@ -380,7 +380,7 @@ AZ_POP_DISABLE_WARNING
     //////////////////////////////////////////////////////////////////////
 
 #if defined(AZ_PLATFORM_WINDOWS)
-    EnumDisplaySettings(NULL, ENUM_CURRENT_SETTINGS, &DisplayConfig);
+    EnumDisplaySettings(nullptr, ENUM_CURRENT_SETTINGS, &DisplayConfig);
     GetPrivateProfileString("boot.description", "display.drv",
         "(Unknown graphics card)", szProfileBuffer, sizeof(szProfileBuffer),
         "system.ini");

--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -160,45 +160,45 @@ public:
         }
     }
 
-    ~EngineConnectionListener()
+    ~EngineConnectionListener() override
     {
         AzFramework::AssetSystemInfoBus::Handler::BusDisconnect();
         AzFramework::EngineConnectionEvents::Bus::Handler::BusDisconnect();
     }
 
 public:
-    virtual void Connected([[maybe_unused]] AzFramework::SocketConnection* connection)
+    void Connected([[maybe_unused]] AzFramework::SocketConnection* connection) override
     {
         m_state = EConnectionState::Connected;
     }
-    virtual void Connecting([[maybe_unused]] AzFramework::SocketConnection* connection)
+    void Connecting([[maybe_unused]] AzFramework::SocketConnection* connection) override
     {
         m_state = EConnectionState::Connecting;
     }
-    virtual void Listening([[maybe_unused]] AzFramework::SocketConnection* connection)
+    void Listening([[maybe_unused]] AzFramework::SocketConnection* connection) override
     {
         m_state = EConnectionState::Listening;
     }
-    virtual void Disconnecting([[maybe_unused]] AzFramework::SocketConnection* connection)
+    void Disconnecting([[maybe_unused]] AzFramework::SocketConnection* connection) override
     {
         m_state = EConnectionState::Disconnecting;
     }
-    virtual void Disconnected([[maybe_unused]] AzFramework::SocketConnection* connection)
+    void Disconnected([[maybe_unused]] AzFramework::SocketConnection* connection) override
     {
         m_state = EConnectionState::Disconnected;
     }
 
-    virtual void AssetCompilationSuccess(const AZStd::string& assetPath) override
+    void AssetCompilationSuccess(const AZStd::string& assetPath) override
     {
         m_lastAssetProcessorTask = assetPath;
     }
 
-    virtual void AssetCompilationFailed(const AZStd::string& assetPath) override
+    void AssetCompilationFailed(const AZStd::string& assetPath) override
     {
         m_failedJobs.insert(assetPath);
     }
 
-    virtual void CountOfAssetsInQueue(const int& count) override
+    void CountOfAssetsInQueue(const int& count) override
     {
         m_pendingJobsCount = count;
     }
@@ -298,7 +298,7 @@ MainWindow::MainWindow(QWidget* parent)
     , m_undoStateAdapter(new UndoStackStateAdapter(this))
     , m_keyboardCustomization(nullptr)
     , m_activeView(nullptr)
-    , m_settings("O3DE", "O3DE") 
+    , m_settings("O3DE", "O3DE")
     , m_toolbarManager(new ToolbarManager(m_actionManager, this))
     , m_assetImporterManager(new AssetImporterManager(this))
     , m_levelEditorMenuHandler(new LevelEditorMenuHandler(this, m_viewPaneManager, m_settings))
@@ -573,7 +573,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
 
     if (GetIEditor()->GetDocument())
     {
-        GetIEditor()->GetDocument()->SetModifiedFlag(FALSE);
+        GetIEditor()->GetDocument()->SetModifiedFlag(false);
         GetIEditor()->GetDocument()->SetModifiedModules(eModifiedNothing);
     }
     // Close all edit panels.
@@ -581,7 +581,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     GetIEditor()->GetObjectManager()->EndEditParams();
 
     // force clean up of all deferred deletes, so that we don't have any issues with windows from plugins not being deleted yet
-    qApp->sendPostedEvents(0, QEvent::DeferredDelete);
+    qApp->sendPostedEvents(nullptr, QEvent::DeferredDelete);
 
     QMainWindow::closeEvent(event);
 }
@@ -1243,7 +1243,7 @@ void MainWindow::OnEditorNotifyEvent(EEditorNotifyEvent ev)
         auto cryEdit = CCryEditApp::instance();
         if (cryEdit)
         {
-            cryEdit->SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
+            cryEdit->SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), GetIEditor()->GetGameEngine()->GetLevelName());
         }
     }
     break;
@@ -1252,7 +1252,7 @@ void MainWindow::OnEditorNotifyEvent(EEditorNotifyEvent ev)
         auto cryEdit = CCryEditApp::instance();
         if (cryEdit)
         {
-            cryEdit->SetEditorWindowTitle(0, AZ::Utils::GetProjectName().c_str(), 0);
+            cryEdit->SetEditorWindowTitle(nullptr, AZ::Utils::GetProjectName().c_str(), nullptr);
         }
     }
     break;
@@ -1351,8 +1351,8 @@ void MainWindow::ResetAutoSaveTimers(bool bForceInit)
     {
         delete m_autoRemindTimer;
     }
-    m_autoSaveTimer = 0;
-    m_autoRemindTimer = 0;
+    m_autoSaveTimer = nullptr;
+    m_autoRemindTimer = nullptr;
 
     if (bForceInit)
     {
@@ -1389,7 +1389,7 @@ void MainWindow::ResetBackgroundUpdateTimer()
     if (m_backgroundUpdateTimer)
     {
         delete m_backgroundUpdateTimer;
-        m_backgroundUpdateTimer = 0;
+        m_backgroundUpdateTimer = nullptr;
     }
 
     ICVar* pBackgroundUpdatePeriod = gEnv->pConsole->GetCVar("ed_backgroundUpdatePeriod");
@@ -1435,7 +1435,7 @@ void MainWindow::OnRefreshAudioSystem()
 
     if (QString::compare(sLevelName, "Untitled", Qt::CaseInsensitive) == 0)
     {
-        // Rather pass NULL to indicate that no level is loaded!
+        // Rather pass nullptr to indicate that no level is loaded!
         sLevelName = QString();
     }
 
@@ -1868,7 +1868,7 @@ QWidget* MainWindow::CreateToolbarWidget(int actionId)
         break;
     case ID_TOOLBAR_WIDGET_SPACER_RIGHT:
         w = CreateSpacerRightWidget();
-        break; 
+        break;
     default:
         qWarning() << Q_FUNC_INFO << "Unknown id " << actionId;
         return nullptr;

--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -19,7 +19,7 @@
 #include <QToolButton>
 
 // Editor
-#include "NewTerrainDialog.h"  
+#include "NewTerrainDialog.h"
 
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <ui_NewLevelDialog.h>
@@ -54,7 +54,7 @@ private:
 
 // CNewLevelDialog dialog
 
-CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=NULL*/)
+CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_bUpdate(false)
     , ui(new Ui::CNewLevelDialog)
@@ -69,7 +69,7 @@ CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=NULL*/)
 
     m_bIsResize = false;
 
-    
+
     ui->TITLE->setText(tr("Assign a name and location to the new level."));
     ui->STATIC1->setText(tr("Location:"));
     ui->STATIC2->setText(tr("Name:"));
@@ -98,7 +98,7 @@ CNewLevelDialog::CNewLevelDialog(QWidget* pParent /*=NULL*/)
 
     m_levelFolders = GetLevelsFolder();
     m_level = "";
-    // First of all, keyboard focus is related to widget tab order, and the default tab order is based on the order in which 
+    // First of all, keyboard focus is related to widget tab order, and the default tab order is based on the order in which
     // widgets are constructed. Therefore, creating more widgets changes the keyboard focus. That is why setFocus() is called last.
     // Secondly, using singleShot() allows setFocus() slot of the QLineEdit instance to be invoked right after the event system
     // is ready to do so. Therefore, it is better to use singleShot() than directly call setFocus().

--- a/Code/Editor/NewTerrainDialog.cpp
+++ b/Code/Editor/NewTerrainDialog.cpp
@@ -19,7 +19,7 @@ AZ_POP_DISABLE_WARNING
 
 
 
-CNewTerrainDialog::CNewTerrainDialog(QWidget* pParent /*=NULL*/)
+CNewTerrainDialog::CNewTerrainDialog(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_terrainResolutionIndex(0)
     , m_terrainUnitsIndex(0)

--- a/Code/Editor/Plugin.cpp
+++ b/Code/Editor/Plugin.cpp
@@ -133,7 +133,7 @@ IClassDesc* CClassFactory::FindClass(const char* pClassName) const
 
     if (!pSubClassName)
     {
-        return NULL;
+        return nullptr;
     }
 
     QString name = QString(pClassName).left(pSubClassName - pClassName);
@@ -169,7 +169,7 @@ void CClassFactory::UnregisterClass(const char* pClassName)
 {
     IClassDesc* pClassDesc = FindClass(pClassName);
 
-    if (pClassDesc == NULL)
+    if (pClassDesc == nullptr)
     {
         return;
     }

--- a/Code/Editor/PluginManager.cpp
+++ b/Code/Editor/PluginManager.cpp
@@ -18,8 +18,8 @@
 #include "Include/IPlugin.h"
 
 
-typedef IPlugin* (* TPfnCreatePluginInstance)(PLUGIN_INIT_PARAM* pInitParam);
-typedef void (* TPfnQueryPluginSettings)(SPluginSettings&);
+using TPfnCreatePluginInstance = IPlugin *(*)(PLUGIN_INIT_PARAM *pInitParam);
+using TPfnQueryPluginSettings = void (*)(SPluginSettings &);
 
 CPluginManager::CPluginManager()
 {
@@ -210,7 +210,7 @@ bool CPluginManager::LoadPlugins(const char* pPathWithMask)
             continue;
         }
 
-        IPlugin* pPlugin = NULL;
+        IPlugin* pPlugin = nullptr;
         PLUGIN_INIT_PARAM sInitParam =
         {
             GetIEditor(),
@@ -279,7 +279,7 @@ IPlugin* CPluginManager::GetPluginByGUID(const char* pGUID)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 IPlugin* CPluginManager::GetPluginByUIID(uint8 iUserInterfaceID)
@@ -290,7 +290,7 @@ IPlugin* CPluginManager::GetPluginByUIID(uint8 iUserInterfaceID)
 
     if (it == m_uuidPluginMap.end())
     {
-        return NULL;
+        return nullptr;
     }
 
     return (*it).second;
@@ -302,7 +302,7 @@ IUIEvent* CPluginManager::GetEventByIDAndPluginID(uint8 aPluginID, uint8 aEventI
     // specified by its ID and the user interface ID of the plugin which
     // created the UI element
 
-    IPlugin* pPlugin = NULL;
+    IPlugin* pPlugin = nullptr;
     TEventHandlerIt eventIt;
     TPluginEventIt pluginIt;
 
@@ -310,21 +310,21 @@ IUIEvent* CPluginManager::GetEventByIDAndPluginID(uint8 aPluginID, uint8 aEventI
 
     if (!pPlugin)
     {
-        return NULL;
+        return nullptr;
     }
 
     pluginIt = m_pluginEventMap.find(pPlugin);
 
     if (pluginIt == m_pluginEventMap.end())
     {
-        return NULL;
+        return nullptr;
     }
 
     eventIt = (*pluginIt).second.find(aEventID);
 
     if (eventIt == (*pluginIt).second.end())
     {
-        return NULL;
+        return nullptr;
     }
 
     return (*eventIt).second;

--- a/Code/Editor/PythonEditorFuncs.cpp
+++ b/Code/Editor/PythonEditorFuncs.cpp
@@ -323,7 +323,7 @@ namespace
     //////////////////////////////////////////////////////////////////////////
     void GetPythonArgumentsVector(const char* pArguments, QStringList& inputArguments)
     {
-        if (pArguments == NULL)
+        if (pArguments == nullptr)
         {
             return;
         }

--- a/Code/Editor/ResizeResolutionDialog.cpp
+++ b/Code/Editor/ResizeResolutionDialog.cpp
@@ -89,7 +89,7 @@ int ResizeResolutionModel::SizeRow(uint32 dwSize) const
 // CResizeResolutionDialog dialog
 
 
-CResizeResolutionDialog::CResizeResolutionDialog(QWidget* pParent /*=NULL*/)
+CResizeResolutionDialog::CResizeResolutionDialog(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_model(new ResizeResolutionModel(this))
     , ui(new Ui::CResizeResolutionDialog)

--- a/Code/Editor/ResourceSelectorHost.cpp
+++ b/Code/Editor/ResourceSelectorHost.cpp
@@ -101,7 +101,7 @@ public:
     }
 
 private:
-    typedef std::map<string, const SStaticResourceSelectorEntry*, stl::less_stricmp<string> > TTypeMap;
+    using TTypeMap = std::map<string, const SStaticResourceSelectorEntry *, stl::less_stricmp<string>>;
     TTypeMap m_typeMap;
 
     std::map<string, string> m_globallySelectedResources;

--- a/Code/Editor/SelectEAXPresetDlg.cpp
+++ b/Code/Editor/SelectEAXPresetDlg.cpp
@@ -49,7 +49,7 @@ QString CSelectEAXPresetDlg::GetCurrPreset() const
     {
         return m_ui->listView->currentIndex().data().toString();
     }
-    // EXCEPTION: OCX Property Pages should return FALSE
+    // EXCEPTION: OCX Property Pages should return false
     return QString();
 }
 

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -243,7 +243,7 @@ SEditorSettings::SEditorSettings()
 
     gui.nToolbarIconSize = static_cast<int>(AzQtComponents::ToolBar::ToolBarIconSize::Default);
 
-    int lfHeight = 8;// -MulDiv(8, GetDeviceCaps(GetDC(NULL), LOGPIXELSY), 72);
+    int lfHeight = 8;// -MulDiv(8, GetDeviceCaps(GetDC(nullptr), LOGPIXELSY), 72);
     gui.nDefaultFontHieght = lfHeight;
     gui.hSystemFont = QFont("Ms Shell Dlg 2", lfHeight, QFont::Normal);
     gui.hSystemFontBold = QFont("Ms Shell Dlg 2", lfHeight, QFont::Bold);
@@ -530,7 +530,7 @@ void SEditorSettings::Save()
     SaveValue("Settings", "ShowTimeInConsole", bShowTimeInConsole);
 
     SaveValue("Settings", "EnableSceneInspector", enableSceneInspector);
-    
+
     //////////////////////////////////////////////////////////////////////////
     // Viewport settings.
     //////////////////////////////////////////////////////////////////////////
@@ -623,7 +623,7 @@ void SEditorSettings::Save()
     SaveValue("Settings\\AssetBrowser", "AutoFilterFromViewportSelection", sAssetBrowserSettings.bAutoFilterFromViewportSelection);
     SaveValue("Settings\\AssetBrowser", "VisibleColumnNames", sAssetBrowserSettings.sVisibleColumnNames);
     SaveValue("Settings\\AssetBrowser", "ColumnNames", sAssetBrowserSettings.sColumnNames);
-      
+
     //////////////////////////////////////////////////////////////////////////
     // Deep Selection Settings
     //////////////////////////////////////////////////////////////////////////
@@ -702,7 +702,7 @@ void SEditorSettings::Load()
     QString     strPlaceholderString;
     // Load settings from registry.
     LoadValue("Settings", "UndoLevels", undoLevels);
-    LoadValue("Settings", "UndoSliceOverrideSaveValue", m_undoSliceOverrideSaveValue);  
+    LoadValue("Settings", "UndoSliceOverrideSaveValue", m_undoSliceOverrideSaveValue);
     LoadValue("Settings", "ShowWelcomeScreenAtStartup", bShowDashboardAtStartup);
     LoadValue("Settings", "ShowCircularDependencyError", m_showCircularDependencyError);
     LoadValue("Settings", "LoadLastLevelAtStartup", bAutoloadLastLevelAtStartup);

--- a/Code/Editor/SettingsManager.cpp
+++ b/Code/Editor/SettingsManager.cpp
@@ -105,7 +105,7 @@ bool CSettingsManager::CreateDefaultLayoutSettingsFile()
 
 AZStd::vector<AZStd::string> CSettingsManager::BuildSettingsList()
 {
-    XmlNodeRef root = NULL;
+    XmlNodeRef root = nullptr;
 
     root = m_pSettingsManagerMemoryNode;
 
@@ -132,8 +132,8 @@ void CSettingsManager::BuildSettingsList_Helper(const XmlNodeRef& node, const AZ
 {
     for (int i = 0; i < node->getNumAttributes(); ++i)
     {
-        const char* key = NULL;
-        const char* value = NULL;
+        const char* key = nullptr;
+        const char* value = nullptr;
         node->getAttributeByIndex(i, &key, &value);
         if (!pathToNode.empty())
         {
@@ -163,7 +163,7 @@ void CSettingsManager::BuildSettingsList_Helper(const XmlNodeRef& node, const AZ
                     result
                 );
             }
-            
+
         }
     }
 }
@@ -190,7 +190,7 @@ void CSettingsManager::SaveSetting(const QString& path, const QString& attr, con
     // Spaces in node names not allowed
     writeAttr.replace(" ", "");
 
-    XmlNodeRef root = NULL;
+    XmlNodeRef root = nullptr;
 
     root = m_pSettingsManagerMemoryNode;
 
@@ -276,11 +276,11 @@ XmlNodeRef CSettingsManager::LoadSetting(const QString& path, const QString& att
     // Spaces in node names not allowed
     readAttr.replace(" ", "");
 
-    XmlNodeRef root = NULL;
+    XmlNodeRef root = nullptr;
 
     root = m_pSettingsManagerMemoryNode;
 
-    XmlNodeRef tmpNode = NULL;
+    XmlNodeRef tmpNode = nullptr;
 
     if (NeedSettingsNode(path))
     {
@@ -293,7 +293,7 @@ XmlNodeRef CSettingsManager::LoadSetting(const QString& path, const QString& att
 
     if (!tmpNode)
     {
-        return 0;
+        return nullptr;
     }
 
     for (int i = 0; i < strNodes.size(); ++i)
@@ -304,13 +304,13 @@ XmlNodeRef CSettingsManager::LoadSetting(const QString& path, const QString& att
         }
         else
         {
-            return 0;
+            return nullptr;
         }
     }
 
     if (!tmpNode->findChild(readAttr.toUtf8().data()))
     {
-        return 0;
+        return nullptr;
     }
     else
     {
@@ -360,7 +360,7 @@ void CSettingsManager::AddToolVersion(const QString& toolName, const QString& to
         return;
     }
 
-    if (stl::find_in_map(m_toolNames, toolName, NULL) == "")
+    if (stl::find_in_map(m_toolNames, toolName, nullptr) == "")
     {
         if (!toolVersion.isEmpty())
         {
@@ -380,7 +380,7 @@ void CSettingsManager::AddToolName(const QString& toolName, const QString& human
         return;
     }
 
-    if (stl::find_in_map(m_toolNames, toolName, NULL) == "")
+    if (stl::find_in_map(m_toolNames, toolName, nullptr) == "")
     {
         if (!humanReadableName.isEmpty())
         {
@@ -499,7 +499,7 @@ void CSettingsManager::GetMatchingLayoutNames(TToolNamesMap& foundTools, XmlNode
         return;
     }
 
-    TToolNamesMap* toolNames = NULL;
+    TToolNamesMap* toolNames = nullptr;
 
     if (!foundTools.empty())
     {
@@ -593,11 +593,11 @@ bool CSettingsManager::NeedSettingsNode(const QString& path)
 {
     if ((path != EDITOR_LAYOUT_ROOT_NODE) && (path != TOOLBOX_NODE) && (path != TOOLBOXMACROS_NODE))
     {
-        return TRUE;
+        return true;
     }
     else
     {
-        return FALSE;
+        return false;
     }
 }
 
@@ -605,13 +605,13 @@ void CSettingsManager::SerializeCVars(XmlNodeRef& node, bool bLoad)
 {
     int nNumberOfVariables(0);
     int nCurrentVariable(0);
-    IConsole* piConsole(NULL);
-    ICVar* piVariable(NULL);
+    IConsole* piConsole(nullptr);
+    ICVar* piVariable(nullptr);
     std::vector<char*>  cszVariableNames;
 
-    char* szKey(NULL);
-    char* szValue(NULL);
-    ICVar* piCVar(NULL);
+    char* szKey(nullptr);
+    char* szValue(nullptr);
+    ICVar* piCVar(nullptr);
 
     piConsole = gEnv->pConsole;
 
@@ -622,7 +622,7 @@ void CSettingsManager::SerializeCVars(XmlNodeRef& node, bool bLoad)
 
     if (bLoad)
     {
-        XmlNodeRef readNode = NULL;
+        XmlNodeRef readNode = nullptr;
         XmlNodeRef inputCVarsNode = node->findChild(CVARS_NODE);
 
         if (!inputCVarsNode)
@@ -649,7 +649,7 @@ void CSettingsManager::SerializeCVars(XmlNodeRef& node, bool bLoad)
     }
     else
     {
-        XmlNodeRef newCVarNode = NULL;
+        XmlNodeRef newCVarNode = nullptr;
         XmlNodeRef oldCVarsNode = node->findChild(CVARS_NODE);
 
         if (oldCVarsNode)
@@ -660,9 +660,9 @@ void CSettingsManager::SerializeCVars(XmlNodeRef& node, bool bLoad)
         XmlNodeRef cvarsNode = XmlHelpers::CreateXmlNode(CVARS_NODE);
 
         nNumberOfVariables = piConsole->GetNumVisibleVars();
-        cszVariableNames.resize(nNumberOfVariables, NULL);
+        cszVariableNames.resize(nNumberOfVariables, nullptr);
 
-        if (piConsole->GetSortedVars((const char**)&cszVariableNames.front(), nNumberOfVariables, NULL) != nNumberOfVariables)
+        if (piConsole->GetSortedVars((const char**)&cszVariableNames.front(), nNumberOfVariables, nullptr) != nNumberOfVariables)
         {
             assert(false);
             return;
@@ -711,8 +711,8 @@ void CSettingsManager::ReadValueStr(XmlNodeRef& sourceNode, const QString& path,
     // Spaces in node names not allowed
     readAttr.replace(" ", "");
 
-    XmlNodeRef root = NULL;
-    XmlNodeRef tmpNode = NULL;
+    XmlNodeRef root = nullptr;
+    XmlNodeRef tmpNode = nullptr;
 
     if (NeedSettingsNode(path))
     {
@@ -809,7 +809,7 @@ bool CSettingsManager::IsEventSafe(const SEventLog& event)
 
     if (!root)
     {
-        return TRUE;
+        return true;
     }
 
     QString eventName = event.m_eventName;
@@ -823,7 +823,7 @@ bool CSettingsManager::IsEventSafe(const SEventLog& event)
     // Log entry not found, so it is safe to start
     if (!resNode)
     {
-        return TRUE;
+        return true;
     }
 
     XmlNodeRef callerVersion = resNode->findChild(EVENT_LOG_CALLER_VERSION);
@@ -841,15 +841,15 @@ bool CSettingsManager::IsEventSafe(const SEventLog& event)
         {
             if (callerVersionStr != GetToolVersion(eventName))
             {
-                return TRUE;
+                return true;
             }
         }
 
         // The same version of tool/level found
-        return FALSE;
+        return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -947,15 +947,15 @@ XmlNodeRef CSettingsManager::LoadLogEventSetting(const QString& path, const QStr
 
     if (!root)
     {
-        return 0;
+        return nullptr;
     }
 
-    XmlNodeRef tmpNode = NULL;
+    XmlNodeRef tmpNode = nullptr;
     tmpNode = root;
 
     if (!tmpNode)
     {
-        return 0;
+        return nullptr;
     }
 
     for (int i = 0; i < strNodes.size(); ++i)
@@ -966,7 +966,7 @@ XmlNodeRef CSettingsManager::LoadLogEventSetting(const QString& path, const QStr
         }
         else
         {
-            return 0;
+            return nullptr;
         }
     }
 
@@ -975,7 +975,7 @@ XmlNodeRef CSettingsManager::LoadLogEventSetting(const QString& path, const QStr
         return tmpNode;
     }
 
-    return 0;
+    return nullptr;
 }
 
 QString CSettingsManager::GenerateContentHash(XmlNodeRef& node, QString sourceName)

--- a/Code/Editor/SettingsManagerDialog.cpp
+++ b/Code/Editor/SettingsManagerDialog.cpp
@@ -84,7 +84,7 @@ void CSettingsManagerDialog::OnReadBtnClick()
         ui->m_layoutListBox->clear();
 
         TToolNamesMap toolNames;
-        XmlNodeRef dummyNode = NULL;
+        XmlNodeRef dummyNode = nullptr;
 
         GetIEditor()->GetSettingsManager()->GetMatchingLayoutNames(toolNames, dummyNode, m_importFileStr);
 

--- a/Code/Editor/StartupLogoDialog.cpp
+++ b/Code/Editor/StartupLogoDialog.cpp
@@ -27,14 +27,14 @@ AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 /////////////////////////////////////////////////////////////////////////////
 // CStartupLogoDialog dialog
 
-CStartupLogoDialog* CStartupLogoDialog::s_pLogoWindow = 0;
+CStartupLogoDialog* CStartupLogoDialog::s_pLogoWindow = nullptr;
 
-CStartupLogoDialog::CStartupLogoDialog(QString versionText, QString richTextCopyrightNotice, QWidget* pParent /*=NULL*/)
+CStartupLogoDialog::CStartupLogoDialog(QString versionText, QString richTextCopyrightNotice, QWidget* pParent /*=nullptr*/)
     : QWidget(pParent, Qt::Dialog | Qt::FramelessWindowHint)
     , m_ui(new Ui::StartupLogoDialog)
 {
     m_ui->setupUi(this);
- 
+
     s_pLogoWindow = this;
 
     m_backgroundImage = QPixmap(QStringLiteral(":/StartupLogoDialog/splashscreen_background_developer_preview.jpg"));
@@ -61,7 +61,7 @@ CStartupLogoDialog::CStartupLogoDialog(QString versionText, QString richTextCopy
 
 CStartupLogoDialog::~CStartupLogoDialog()
 {
-    s_pLogoWindow = 0;
+    s_pLogoWindow = nullptr;
 }
 
 void CStartupLogoDialog::SetText(const char* text)

--- a/Code/Editor/StringDlg.h
+++ b/Code/Editor/StringDlg.h
@@ -25,7 +25,7 @@ typedef bool (StringDlgPredicate)(QString input);
 class StringDlg : public QInputDialog
 {
 public:
-    StringDlg(const QString &title, QWidget* pParent = NULL, bool bFileNameLimitation = false);
+    StringDlg(const QString &title, QWidget* pParent = nullptr, bool bFileNameLimitation = false);
 
     void SetCheckCallback(const std::function<StringDlgPredicate>& Check) {
         m_Check = Check;

--- a/Code/Editor/ToolBox.cpp
+++ b/Code/Editor/ToolBox.cpp
@@ -186,7 +186,7 @@ const CToolBoxMacro* CToolBoxManager::GetMacro(int iIndex, bool bToolbox) const
         assert(0 <= iIndex && iIndex < m_shelveMacros.size());
         return m_shelveMacros[iIndex];
     }
-    return NULL;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -202,7 +202,7 @@ CToolBoxMacro* CToolBoxManager::GetMacro(int iIndex, bool bToolbox)
         assert(0 <= iIndex && iIndex < m_shelveMacros.size());
         return m_shelveMacros[iIndex];
     }
-    return NULL;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -240,14 +240,14 @@ CToolBoxMacro* CToolBoxManager::NewMacro(const QString& title, bool bToolbox, in
         const int macroCount = m_macros.size();
         if (macroCount > ID_TOOL_LAST - ID_TOOL_FIRST + 1)
         {
-            return NULL;
+            return nullptr;
         }
 
         for (size_t i = 0; i < macroCount; ++i)
         {
             if (QString::compare(m_macros[i]->GetTitle(), title, Qt::CaseInsensitive) == 0)
             {
-                return NULL;
+                return nullptr;
             }
         }
 
@@ -264,7 +264,7 @@ CToolBoxMacro* CToolBoxManager::NewMacro(const QString& title, bool bToolbox, in
         const int shelveMacroCount = m_shelveMacros.size();
         if (shelveMacroCount > ID_TOOL_SHELVE_LAST - ID_TOOL_SHELVE_FIRST + 1)
         {
-            return NULL;
+            return nullptr;
         }
 
         CToolBoxMacro* pNewTool = new CToolBoxMacro(title);
@@ -275,7 +275,7 @@ CToolBoxMacro* CToolBoxManager::NewMacro(const QString& title, bool bToolbox, in
         m_shelveMacros.push_back(pNewTool);
         return pNewTool;
     }
-    return NULL;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -333,7 +333,7 @@ void CToolBoxManager::Load([[maybe_unused]] ActionManager* actionManager)
 void CToolBoxManager::Load(QString xmlpath, AmazonToolbar* pToolbar, bool bToolbox, ActionManager* actionManager)
 {
     XmlNodeRef toolBoxNode = XmlHelpers::LoadXmlFromFile(xmlpath.toUtf8().data());
-    if (toolBoxNode == NULL)
+    if (toolBoxNode == nullptr)
     {
         return;
     }

--- a/Code/Editor/ToolBox.h
+++ b/Code/Editor/ToolBox.h
@@ -137,7 +137,7 @@ public:
     CToolBoxMacro* GetMacro(int iIndex, bool bToolbox);
     //! Get the index of a macro from its title.
     int GetMacroIndex(const QString& title, bool bToolbox) const;
-    //! Creates a new macro in the manager. If the title is duplicate, this returns NULL.
+    //! Creates a new macro in the manager. If the title is duplicate, this returns nullptr.
     CToolBoxMacro* NewMacro(const QString& title, bool bToolbox, int* newIdx);
     //! Try to change the title of a macro. If the title is duplicate, the change is aborted and this returns false.
     bool SetMacroTitle(int index, const QString& title, bool bToolbox);

--- a/Code/Editor/ToolsConfigPage.cpp
+++ b/Code/Editor/ToolsConfigPage.cpp
@@ -109,7 +109,7 @@ private:
     QStringList m_iconFiles;
 };
 
-CIconListDialog::CIconListDialog(QWidget* pParent /* = NULL */)
+CIconListDialog::CIconListDialog(QWidget* pParent /* = nullptr */)
     : QDialog(pParent)
     , m_ui(new Ui::IconListDialog)
 {
@@ -498,7 +498,7 @@ CToolsConfigPage::CToolsConfigPage(QWidget* parent)
             QKeySequence shortcut(value);
             m_ui->m_macroShortcutKey->setKeySequence(shortcut);
         }
-        
+
         if (m_ui->m_macroShortcutKey->keySequence().count() >= 1)
         {
             m_ui->m_assignShortcut->setEnabled(true);
@@ -703,7 +703,7 @@ void CToolsConfigPage::OnAssignMacroShortcut()
 {
     auto pShortcutMgr = MainWindow::instance()->GetShortcutManager();
 
-    if (pShortcutMgr  == NULL)
+    if (pShortcutMgr  == nullptr)
     {
         return;
     }

--- a/Code/Editor/UIEnumsDatabase.cpp
+++ b/Code/Editor/UIEnumsDatabase.cpp
@@ -59,7 +59,7 @@ void CUIEnumsDatabase::SetEnumStrings(const QString& enumName, const QStringList
 {
     int nStringCount = sStringsArray.size();
 
-    CUIEnumsDatabase_SEnum* pEnum = stl::find_in_map(m_enums, enumName, 0);
+    CUIEnumsDatabase_SEnum* pEnum = stl::find_in_map(m_enums, enumName, nullptr);
     if (!pEnum)
     {
         pEnum = new CUIEnumsDatabase_SEnum;
@@ -86,6 +86,6 @@ void CUIEnumsDatabase::SetEnumStrings(const QString& enumName, const QStringList
 //////////////////////////////////////////////////////////////////////////
 CUIEnumsDatabase_SEnum* CUIEnumsDatabase::FindEnum(const QString& enumName) const
 {
-    CUIEnumsDatabase_SEnum* pEnum = stl::find_in_map(m_enums, enumName, 0);
+    CUIEnumsDatabase_SEnum* pEnum = stl::find_in_map(m_enums, enumName, nullptr);
     return pEnum;
 }

--- a/Code/Editor/UndoDropDown.cpp
+++ b/Code/Editor/UndoDropDown.cpp
@@ -56,7 +56,7 @@ public:
         m_manager.AddListener(this);
     }
 
-    virtual ~UndoDropDownListModel()
+    ~UndoDropDownListModel() override
     {
         m_manager.RemoveListener(this);
     }
@@ -81,7 +81,7 @@ public:
         return m_stackNames[index.row()];
     }
 
-    void SignalNumUndoRedo(const unsigned int& numUndo, const unsigned int& numRedo)
+    void SignalNumUndoRedo(const unsigned int& numUndo, const unsigned int& numRedo) override
     {
         std::vector<QString> fresh;
         if (UndoRedoDirection::Undo == m_direction && m_stackNames.size() != numUndo)

--- a/Code/Editor/ViewManager.cpp
+++ b/Code/Editor/ViewManager.cpp
@@ -55,7 +55,7 @@ CViewManager::CViewManager()
     m_updateRegion.min = Vec3(-100000, -100000, -100000);
     m_updateRegion.max = Vec3(100000, 100000, 100000);
 
-    m_pSelectedView = NULL;
+    m_pSelectedView = nullptr;
 
     m_nGameViewports = 0;
     m_bGameViewportsUpdated = false;
@@ -117,7 +117,7 @@ void CViewManager::UnregisterViewport(CViewport* pViewport)
 {
     if (m_pSelectedView == pViewport)
     {
-        m_pSelectedView = NULL;
+        m_pSelectedView = nullptr;
     }
     stl::find_and_erase(m_viewports, pViewport);
     m_bGameViewportsUpdated = false;
@@ -137,7 +137,7 @@ CViewport* CViewManager::GetViewport(EViewportType type) const
             return m_viewports[i];
         }
     }
-    return 0;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -150,7 +150,7 @@ CViewport* CViewManager::GetViewport(const QString& name) const
             return m_viewports[i];
         }
     }
-    return 0;
+    return nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -234,7 +234,7 @@ void CViewManager::SelectViewport(CViewport* pViewport)
 {
     // Audio: Handle viewport change for listeners
 
-    if (m_pSelectedView != NULL && m_pSelectedView != pViewport)
+    if (m_pSelectedView != nullptr && m_pSelectedView != pViewport)
     {
         m_pSelectedView->SetSelected(false);
 
@@ -242,7 +242,7 @@ void CViewManager::SelectViewport(CViewport* pViewport)
 
     m_pSelectedView = pViewport;
 
-    if (m_pSelectedView != NULL)
+    if (m_pSelectedView != nullptr)
     {
         m_pSelectedView->SetSelected(true);
     }

--- a/Code/Editor/ViewManager.h
+++ b/Code/Editor/ViewManager.h
@@ -93,7 +93,7 @@ public:
 
     //////////////////////////////////////////////////////////////////////////
     //! Get current layout window.
-    //! @return Pointer to the layout window, can be NULL.
+    //! @return Pointer to the layout window, can be nullptr.
     virtual CLayoutWnd* GetLayout() const;
 
     //! Cycle between different 2D viewports type on same view pane.

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -159,8 +159,8 @@ CLayoutViewPane::CLayoutViewPane(QWidget* parent)
     , m_viewportTitleDlg(this)
     , m_expanderWatcher(new ViewportTitleExpanderWatcher(this, &m_viewportTitleDlg))
 {
-    m_viewport = 0;
-    m_active = 0;
+    m_viewport = nullptr;
+    m_active = false;
     m_nBorder = VIEW_BORDER;
 
     m_bFullscreen = false;
@@ -338,7 +338,7 @@ void CLayoutViewPane::DetachViewport()
 {
     DisconnectRenderViewportInteractionRequestBus();
     OnFOVChanged(gSettings.viewports.fDefaultFov);
-    m_viewport = 0;
+    m_viewport = nullptr;
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -348,7 +348,7 @@ void CLayoutViewPane::ReleaseViewport()
     {
         DisconnectRenderViewportInteractionRequestBus();
         m_viewport->deleteLater();
-        m_viewport = 0;
+        m_viewport = nullptr;
     }
 }
 

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -192,7 +192,7 @@ QtViewport::QtViewport(QWidget* parent)
     m_viewTM.SetIdentity();
     m_screenTM.SetIdentity();
 
-    m_pMouseOverObject = 0;
+    m_pMouseOverObject = nullptr;
 
     m_bAdvancedSelectMode = false;
 
@@ -398,7 +398,7 @@ void QtViewport::OnDeactivate()
 //////////////////////////////////////////////////////////////////////////
 void QtViewport::ResetContent()
 {
-    m_pMouseOverObject = 0;
+    m_pMouseOverObject = nullptr;
 
     // Need to clear visual object cache.
     // Right after loading new level, some code(e.g. OnMouseMove) access invalid

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -113,7 +113,7 @@ public:
     virtual void AddPostRenderer(IPostRenderer* pPostRenderer) = 0;
     virtual bool RemovePostRenderer(IPostRenderer* pPostRenderer) = 0;
 
-    virtual BOOL DestroyWindow() { return FALSE; }
+    virtual bool DestroyWindow() { return false; }
 
     /** Get type of this viewport.
     */
@@ -252,7 +252,7 @@ public:
     virtual void SetCursorString(const QString& str) = 0;
 
     virtual void SetFocus() = 0;
-    virtual void Invalidate(BOOL bErase = 1) = 0;
+    virtual void Invalidate(bool bErase = 1) = 0;
 
     // Is overridden by RenderViewport
     virtual void SetFOV([[maybe_unused]] float fov) {}
@@ -266,8 +266,8 @@ public:
     void SetViewPane(CLayoutViewPane* viewPane) { m_viewPane = viewPane; }
 
     //Child classes can override these to provide extra logic that wraps
-    //widget rendering. Needed by the RenderViewport to handle raycasts 
-    //from screen-space to world-space. 
+    //widget rendering. Needed by the RenderViewport to handle raycasts
+    //from screen-space to world-space.
     virtual void PreWidgetRendering() {}
     virtual void PostWidgetRendering() {}
 
@@ -346,7 +346,7 @@ public:
     QString GetName() const;
 
     virtual void SetFocus() { setFocus(); }
-    virtual void Invalidate([[maybe_unused]] BOOL bErase = 1) { update(); }
+    virtual void Invalidate([[maybe_unused]] bool bErase = 1) { update(); }
 
     // Is overridden by RenderViewport
     virtual void SetFOV([[maybe_unused]] float fov) {}

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -91,7 +91,7 @@ namespace
         void ViewportInfoStatusUpdated(int newIndex);
 
     private:
-        void OnViewportInfoDisplayStateChanged(AZ::AtomBridge::ViewportInfoDisplayState state)
+        void OnViewportInfoDisplayStateChanged(AZ::AtomBridge::ViewportInfoDisplayState state) override
         {
             emit ViewportInfoStatusUpdated(static_cast<int>(state));
         }

--- a/Code/Editor/WipFeatureManager.cpp
+++ b/Code/Editor/WipFeatureManager.cpp
@@ -19,7 +19,7 @@ const char* CWipFeatureManager::kWipFeaturesFilename = "@user@\\Editor\\UI\\WipF
 #else
 const char* CWipFeatureManager::kWipFeaturesFilename = "@user@/Editor/UI/WipFeatures.xml";
 #endif
-CWipFeatureManager* CWipFeatureManager::s_pInstance = NULL;
+CWipFeatureManager* CWipFeatureManager::s_pInstance = nullptr;
 
 static void WipFeatureVarChange(ICVar* pVar)
 {
@@ -162,7 +162,7 @@ void CWipFeatureManager::Shutdown()
 {
     CWipFeatureManager::Instance()->Save();
     delete s_pInstance;
-    s_pInstance = NULL;
+    s_pInstance = nullptr;
 }
 
 bool CWipFeatureManager::Load(const char* pFilename, bool bClearExisting)
@@ -350,7 +350,7 @@ void CWipFeatureManager::ShowFeature(int aFeatureId, bool bShow)
 
     if (m_features[aFeatureId].m_pfnUpdateFeature)
     {
-        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, &bShow, NULL, NULL, NULL);
+        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, &bShow, nullptr, nullptr, nullptr);
     }
 }
 
@@ -360,7 +360,7 @@ void CWipFeatureManager::EnableFeature(int aFeatureId, bool bEnable)
 
     if (m_features[aFeatureId].m_pfnUpdateFeature)
     {
-        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, NULL, &bEnable, NULL, NULL);
+        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, nullptr, &bEnable, nullptr, nullptr);
     }
 }
 
@@ -370,7 +370,7 @@ void CWipFeatureManager::SetFeatureSafeMode(int aFeatureId, bool bSafeMode)
 
     if (m_features[aFeatureId].m_pfnUpdateFeature)
     {
-        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, NULL, NULL, &bSafeMode, NULL);
+        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, nullptr, nullptr, &bSafeMode, nullptr);
     }
 }
 
@@ -380,7 +380,7 @@ void CWipFeatureManager::SetFeatureParams(int aFeatureId, const char* pParams)
 
     if (m_features[aFeatureId].m_pfnUpdateFeature)
     {
-        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, NULL, NULL, NULL, pParams);
+        m_features[aFeatureId].m_pfnUpdateFeature(aFeatureId, nullptr, nullptr, nullptr, pParams);
     }
 }
 
@@ -392,7 +392,7 @@ void CWipFeatureManager::ShowAllFeatures(bool bShow)
 
         if (iter->second.m_pfnUpdateFeature)
         {
-            iter->second.m_pfnUpdateFeature(iter->first, &bShow, NULL, NULL, NULL);
+            iter->second.m_pfnUpdateFeature(iter->first, &bShow, nullptr, nullptr, nullptr);
         }
     }
 }
@@ -405,7 +405,7 @@ void CWipFeatureManager::EnableAllFeatures(bool bEnable)
 
         if (iter->second.m_pfnUpdateFeature)
         {
-            iter->second.m_pfnUpdateFeature(iter->first, NULL, &bEnable, NULL, NULL);
+            iter->second.m_pfnUpdateFeature(iter->first, nullptr, &bEnable, nullptr, nullptr);
         }
     }
 }
@@ -418,7 +418,7 @@ void CWipFeatureManager::SetAllFeaturesSafeMode(bool bSafeMode)
 
         if (iter->second.m_pfnUpdateFeature)
         {
-            iter->second.m_pfnUpdateFeature(iter->first, NULL, NULL, &bSafeMode, NULL);
+            iter->second.m_pfnUpdateFeature(iter->first, nullptr, nullptr, &bSafeMode, nullptr);
         }
     }
 }
@@ -431,7 +431,7 @@ void CWipFeatureManager::SetAllFeaturesParams(const char* pParams)
 
         if (iter->second.m_pfnUpdateFeature)
         {
-            iter->second.m_pfnUpdateFeature(iter->first, NULL, NULL, NULL, pParams);
+            iter->second.m_pfnUpdateFeature(iter->first, nullptr, nullptr, nullptr, pParams);
         }
     }
 }

--- a/Code/Editor/WipFeatureManager.h
+++ b/Code/Editor/WipFeatureManager.h
@@ -48,7 +48,7 @@ public:
     static const char* kWipFeaturesFilename;
 
     // Used to register a callback function to update the state of features whitin the editor
-    // pbVisible, pbEnabled, pbSafeMode, pParams - if the pointer is NULL, then that attribute was not changed
+    // pbVisible, pbEnabled, pbSafeMode, pParams - if the pointer is nullptr, then that attribute was not changed
     typedef void (* TWipFeatureUpdateCallback)(int aFeatureId, const bool* const pbVisible, const bool* const pbEnabled, const bool* const pbSafeMode, const char* pParams);
 
     // wip feature registerer auto create object, used for static auto feature creation with the REGISTER_WIP_FEATURE macro
@@ -71,7 +71,7 @@ public:
             , m_bVisible(true)
             , m_bEnabled(true)
             , m_bSafeMode(false)
-            , m_pfnUpdateFeature(NULL)
+            , m_pfnUpdateFeature(nullptr)
             , m_bLoadedFromXml(false)
         {}
 

--- a/Code/Editor/WipFeaturesDlg.cpp
+++ b/Code/Editor/WipFeaturesDlg.cpp
@@ -152,7 +152,7 @@ public:
     }
 };
 
-CWipFeaturesDlg::CWipFeaturesDlg(QWidget* pParent /*=NULL*/)
+CWipFeaturesDlg::CWipFeaturesDlg(QWidget* pParent /*=nullptr*/)
     : QDialog(pParent)
     , m_ui(new Ui::WipFeaturesDlg)
 {

--- a/Code/Editor/WipFeaturesDlg.h
+++ b/Code/Editor/WipFeaturesDlg.h
@@ -29,7 +29,7 @@ class CWipFeaturesDlg
 {
     Q_OBJECT
 public:
-    CWipFeaturesDlg(QWidget* pParent = NULL);   // standard constructor
+    CWipFeaturesDlg(QWidget* pParent = nullptr);   // standard constructor
     virtual ~CWipFeaturesDlg();
 
 private:


### PR DESCRIPTION
A few 'typedefs' replaced by 'using's
This shouldn't have any functional changes at all, just c++17 modernization
It's a part 6 of a split #2847

*Note to reviewers this is a split PR meant to ease reviewing, but sadly I cannot say if this or any other part will compile correctly in isolation.*

Signed-off-by: Nemerle <nemerle5+git@gmail.com>