### PR TITLE
[DO NOT MERGE] Experimental.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.cpp
@@ -1584,5 +1584,36 @@ namespace AzFramework
                     ->Field("CatalogSaved", &SaveAssetCatalogResponse::m_saved);
             }
         }
-} // namespace AssetSystem
+
+
+        //----------------------------------------------------------------------------
+
+        UpdateAssetPrioritySetRequest::UpdateAssetPrioritySetRequest(
+                  const AZ::OSString& name, UpdateOperation updateOperation, uint32_t priorityBoost)
+            :m_name(name) , m_updateOperation(updateOperation) , m_priorityBoost(priorityBoost) 
+        {
+            
+        }
+
+        void UpdateAssetPrioritySetRequest::Reflect(AZ::ReflectContext* context) 
+        {
+            auto serialize = azrtti_cast<AZ::SerializeContext*>(context);
+            if (serialize) 
+            {
+                serialize->Class<UpdateAssetPrioritySetRequest, BaseAssetProcessorMessage>() 
+                        ->Version(1)
+                        ->Field("Name", &UpdateAssetPrioritySetRequest::m_name) 
+                        ->Field("UpdateOperation", &UpdateAssetPrioritySetRequest::m_updateOperation) 
+                        ->Field("PriorityBoost", &UpdateAssetPrioritySetRequest::m_priorityBoost) 
+                        ->Field("AssetList", &UpdateAssetPrioritySetRequest::m_assetList);
+            }
+            
+        }
+
+        unsigned int UpdateAssetPrioritySetRequest::GetMessageType() const 
+        {
+            return UpdateAssetPrioritySetRequest::MessageType;
+            
+        }
+    } // namespace AssetSystem
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetProcessorMessages.h
@@ -78,7 +78,7 @@ namespace AzFramework
 
             NegotiationMessage() = default;
             unsigned int GetMessageType() const override;
-            int m_apiVersion = 7; // Changing the value will cause negotiation to fail between incompatible versions
+            int m_apiVersion = 8; // Changing the value will cause negotiation to fail between incompatible versions
             AZ::OSString m_identifier;
             typedef AZStd::unordered_map<unsigned int, AZ::OSString> NegotiationInfoMap;
             NegotiationInfoMap m_negotiationInfoMap;
@@ -1254,6 +1254,34 @@ namespace AzFramework
             FolderList m_folderList;
         };
 
+        class UpdateAssetPrioritySetRequest
+            : public BaseAssetProcessorMessage
+        {
+        public:
+            enum class UpdateOperation : unsigned int
+            {
+                Append, //< Add to the existing priority set.
+                        //< Creates the priority set if it doesn't exist.
+                Remove, //< Removes the assets (and their dependencies) from the given priority set.
+                        //< If the input list is empty it will remove the priority set.
+                        //< If the priority set doesn't exist nothing happens.
+            };
+
+            AZ_CLASS_ALLOCATOR(UpdateAssetPrioritySetRequest, AZ::OSAllocator, 0);
+            AZ_RTTI(UpdateAssetPrioritySetRequest, "{9CB661E8-A3C6-4430-975F-6690B069E134}", BaseAssetProcessorMessage);
+            static void Reflect(AZ::ReflectContext* context);
+            static constexpr unsigned int MessageType = AZ::Crc32("AssetSystem::UpdateAssetWorkingSet");
+
+            UpdateAssetPrioritySetRequest() = default;
+            UpdateAssetPrioritySetRequest(const AZ::OSString& name, UpdateOperation updateOperation, uint32_t priorityBoost = 0);
+            unsigned int GetMessageType() const override;
+
+            AZ::OSString m_name; //< Name of the priority set
+            UpdateOperation m_updateOperation;
+            uint32_t m_priorityBoost; // A value from 0 to 99. The range is validated by the consumer of the message. Higher values get
+                                      // higher priority.
+            AZStd::vector<AZ::Uuid> m_assetList; //< The assets listed here will be added/removed to/from the priority set.
+        };
 
     } // namespace AssetSystem
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.cpp
@@ -225,8 +225,8 @@ namespace AzFramework
             FileCopyRequest::Reflect(context);
             FileRenameRequest::Reflect(context);
             FindFilesRequest::Reflect(context);
-
             FileTreeRequest::Reflect(context);
+            UpdateAssetPrioritySetRequest::Reflect(context);
 
             // Responses
             GetUnresolvedDependencyCountsResponse::Reflect(context);
@@ -865,5 +865,56 @@ namespace AzFramework
 
             return false;
         }
+
+        bool AssetSystemComponent::AppendAssetToPrioritySet(const AZStd::string& prioritySetName, const AZ::Uuid& assetUuid, uint32_t priorityBoost) 
+        {
+            if (assetUuid.IsNull()) 
+            {
+                return AppendAssetsToPrioritySet(prioritySetName, {}, priorityBoost);
+                
+            }
+            return AppendAssetsToPrioritySet(prioritySetName, { assetUuid }, priorityBoost);
+            
+        }
+
+        bool AssetSystemComponent::AppendAssetsToPrioritySet(const AZStd::string& prioritySetName, const AZStd::vector<AZ::Uuid>& assetList, uint32_t priorityBoost) 
+        {
+            if (!ConnectedWithAssetProcessor()) 
+            {
+                return false;
+                
+            }
+            UpdateAssetPrioritySetRequest request(prioritySetName, UpdateAssetPrioritySetRequest::UpdateOperation::Append, priorityBoost);
+            request.m_assetList = assetList;
+            SendRequest(request);
+            return true;
+            
+        }
+
+        bool AssetSystemComponent::RemoveAssetFromPrioritySet(const AZStd::string& prioritySetName, const AZ::Uuid& assetUuid) 
+        {
+            if (assetUuid.IsNull()) 
+            {
+                return RemoveAssetsFromPrioritySet(prioritySetName, {});
+                
+            }
+            return RemoveAssetsFromPrioritySet(prioritySetName, { assetUuid });
+            
+        }
+
+        bool AssetSystemComponent::RemoveAssetsFromPrioritySet(const AZStd::string& prioritySetName, const AZStd::vector<AZ::Uuid>& assetList) 
+        {
+            if (!ConnectedWithAssetProcessor()) 
+            {
+                return false;
+                
+            }
+            UpdateAssetPrioritySetRequest request(prioritySetName, UpdateAssetPrioritySetRequest::UpdateOperation::Remove);
+            request.m_assetList = assetList;
+            SendRequest(request);
+            return true;
+            
+        }
+
     } // namespace AssetSystem
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.h
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetSystemComponent.h
@@ -154,6 +154,12 @@ namespace AzFramework
             float GetAssetProcessorPingTimeMilliseconds() override;
 
             bool SaveCatalog() override;
+
+            bool AppendAssetToPrioritySet(const AZStd::string& prioritySetName, const AZ::Uuid& assetUuid, uint32_t priorityBoost) override;
+            bool AppendAssetsToPrioritySet(const AZStd::string& prioritySetName, const AZStd::vector<AZ::Uuid>& assetUuidList, uint32_t priorityBoost) override;
+            bool RemoveAssetFromPrioritySet(const AZStd::string& prioritySetName, const AZ::Uuid& assetUuid) override;
+            bool RemoveAssetsFromPrioritySet(const AZStd::string& prioritySetName, const AZStd::vector<AZ::Uuid>& assetUuidList) override;
+
             //////////////////////////////////////////////////////////////////////////
 
             AssetStatus SendAssetStatusRequest(const RequestAssetStatus& request);

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.cpp
@@ -297,6 +297,29 @@ void AssetRequestHandler::HandleRequestEscalateAsset(MessageData<RequestEscalate
     }
 }
 
+ void AssetRequestHandler::HandleUpdateAssetPrioritySetRequest(MessageData<UpdateAssetPrioritySetRequest> messageData)
+{
+     if (messageData.m_message->m_updateOperation == AzFramework::AssetSystem::UpdateAssetPrioritySetRequest::UpdateOperation::Append) 
+    {
+         Q_EMIT AppendAssetsToPrioritySetRequest(
+            QString::fromUtf8(messageData.m_message->m_name.c_str()), messageData.m_message->m_assetList,
+            messageData.m_message->m_priorityBoost);
+        
+    }
+    else if (messageData.m_message->m_updateOperation == AzFramework::AssetSystem::UpdateAssetPrioritySetRequest::UpdateOperation::Remove) 
+    {
+        Q_EMIT RemoveAssetsFromPrioritySetRequest(
+            QString::fromUtf8(messageData.m_message->m_name.c_str()), messageData.m_message->m_assetList);
+        
+    }
+    else 
+    {
+        AZ_Warning(AssetProcessor::DebugChannel, false, "Invalid UpdateAssetPrioritySetRequest operation\n");
+        
+    }
+    
+}
+
 bool AssetRequestHandler::InvokeHandler(MessageData<AzFramework::AssetSystem::BaseAssetProcessorMessage> messageData)
 {
     // This function checks to see whether the incoming message is either one of those request, which require decoding the type of message and then invoking the appropriate EBUS handler.
@@ -434,6 +457,7 @@ AssetRequestHandler::AssetRequestHandler()
     m_requestRouter.RegisterMessageHandler(&HandleAssetInfoRequest);
     m_requestRouter.RegisterMessageHandler(&HandleAssetDependencyInfoRequest);
     m_requestRouter.RegisterMessageHandler(ToFunction(&AssetRequestHandler::HandleRequestEscalateAsset));
+    m_requestRouter.RegisterMessageHandler(ToFunction(&AssetRequestHandler::HandleUpdateAssetPrioritySetRequest));
 }
 
 QString AssetRequestHandler::CreateFenceFile(unsigned int fenceId)

--- a/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/AssetRequestHandler.h
@@ -209,6 +209,11 @@ Q_SIGNALS:
         void RequestEscalateAssetByUuid(QString platform, AZ::Uuid escalatedAssetUUID);
         void RequestEscalateAssetBySearchTerm(QString platform, QString escalatedSearchTerm);
 
+        //! See AssetSystemRequestBus::AppendAssetsToPrioritySet for details.
+        void AppendAssetsToPrioritySetRequest(QString prioritySetName, AZStd::vector<AZ::Uuid> assetList, uint32_t priorityBoost);
+        void RemoveAssetsFromPrioritySetRequest(QString prioritySetName, AZStd::vector<AZ::Uuid> assetList);
+
+
     public Q_SLOTS:
         //! ProcessGetAssetStatus - someone on the network wants to know about the status of an asset.
         //! isStatusRequest will be TRUE if its a status request.  If its false it means its a compile request
@@ -256,6 +261,8 @@ Q_SIGNALS:
         void SendAssetStatus(NetworkRequestID groupID, unsigned int type, AssetStatus status);
 
         void HandleRequestEscalateAsset(MessageData<AzFramework::AssetSystem::RequestEscalateAsset> messageData);
+
+        void HandleUpdateAssetPrioritySetRequest(MessageData<AzFramework::AssetSystem::UpdateAssetPrioritySetRequest> messageData);
 
         // we keep state about a request in this class:
         class AssetRequestLine

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -68,7 +68,8 @@ namespace AssetProcessor
     //! This enum stores all the different job escalation values
     enum JobEscalation
     {
-        ProcessAssetRequestSyncEscalation = 200,
+        ProcessAssetRequestSyncEscalation = 300,
+        PriotitySetEscalation = 200, // Space by 100 to allow the user for an additional margin of priority control.
         ProcessAssetRequestStatusEscalation = 150,
         AssetJobRequestEscalation = 100,
         Default = 0

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.h
@@ -123,6 +123,15 @@ Q_SIGNALS:
     void OnBuildersRegistered();
     void AssetProcesserManagerIdleStateChange(bool isIdle);
     void FullIdle(bool isIdle);
+
+    //! See AssetSystemRequestBus::AppendAssetsToPrioritySet for details.
+    void AppendAssetsToPrioritySetRequest(
+        AZStd::shared_ptr<AssetProcessor::AssetDatabaseConnection> databaseConnection, QString prioritySetName,
+        AZStd::vector<AZ::Uuid> assetList, uint32_t priorityBoost);
+    void RemoveAssetsFromPrioritySetRequest(
+        AZStd::shared_ptr<AssetProcessor::AssetDatabaseConnection> databaseConnection, QString prioritySetName,
+        AZStd::vector<AZ::Uuid> assetList);
+
 public Q_SLOTS:
     void OnAssetProcessorManagerIdleState(bool isIdle);
 


### PR DESCRIPTION
[ATOM-16185] AssetProcessor: Re-evaluate API For Persistent Escalation
 Of Asset Build Priority

This the 3rd time around of resurrecting this API that started
in P4, then CodeCommit and now github.

For the application/game developer the new APIs for persistent
escalation of asset build priority are:

virtual bool AppendAssetToPrioritySet(const AZStd::string&
prioritySetName, const AZ::Uuid& assetUuid, uint32_t priorityBoost) = 0;

virtual bool RemoveAssetFromPrioritySet(const AZStd::string&
prioritySetName, const AZ::Uuid& assetUuid) = 0;

Signed-off-by: garrieta <garrieta@amazon.com>