### PR TITLE
Profiler: Runtime region name support

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -95,6 +95,9 @@ namespace AZ
             virtual void SetProfilerEnabled(bool enabled) = 0;
 
             virtual bool IsProfilerEnabled() const = 0 ;
+
+            //! Used by AZ_ATOM_PROFILE_DYNAMIC to create GroupRegionNames with known lifetimes.
+            virtual const CachedTimeRegion::GroupRegionName& InsertDynamicName(const char* groupName, const AZStd::string& regionName) = 0;
         };
 
     } // namespace RPI
@@ -120,3 +123,9 @@ namespace AZ
 #define AZ_ATOM_PROFILE_FUNCTION(groupName, regionName) \
     AZ_TRACE_METHOD(); \
     AZ_ATOM_PROFILE_TIME_GROUP_REGION(groupName, regionName) \
+
+//! Macro that allows for region names to be submitted at runtime. Use sparingly - this acquires a lock and allocates new objects within a map.
+#define AZ_ATOM_PROFILE_DYNAMIC(groupName, regionName) \
+    const AZ::RHI::CachedTimeRegion::GroupRegionName& AZ_JOIN(groupRegionName, __LINE__) = \
+        AZ::RHI::CpuProfiler::Get()->InsertDynamicName(groupName, regionName); \
+    AZ::RHI::TimeRegion AZ_JOIN(timeRegion, __LINE__)(&AZ_JOIN(groupRegionName, __LINE__));

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -30,6 +30,12 @@ namespace AZ
                 
                 const char* const m_groupName = nullptr;
                 const char* const m_regionName = nullptr;
+
+                struct Hash
+                {
+                    AZStd::size_t operator()(const GroupRegionName& name) const;
+                };
+                bool operator==(const GroupRegionName& other) const;
             };
 
             CachedTimeRegion() = default;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfiler.h
@@ -126,6 +126,7 @@ namespace AZ
 
 //! Macro that allows for region names to be submitted at runtime. Use sparingly - this acquires a lock and allocates new objects within a map.
 #define AZ_ATOM_PROFILE_DYNAMIC(groupName, regionName) \
-    const AZ::RHI::CachedTimeRegion::GroupRegionName& AZ_JOIN(groupRegionName, __LINE__) = \
-        AZ::RHI::CpuProfiler::Get()->InsertDynamicName(groupName, regionName); \
+    static_assert(AZStd::is_convertible_v<decltype(groupName), const char*>, "Runtime group names are not allowed, use a static string literal instead."); \
+    const AZ::RHI::CachedTimeRegion::GroupRegionName& AZ_JOIN(groupRegionName, __LINE__) =                                                                 \
+        AZ::RHI::CpuProfiler::Get()->InsertDynamicName(groupName, regionName);                                                                             \
     AZ::RHI::TimeRegion AZ_JOIN(timeRegion, __LINE__)(&AZ_JOIN(groupRegionName, __LINE__));

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -114,6 +114,7 @@ namespace AZ
             bool IsContinuousCaptureInProgress() const final override;
             void SetProfilerEnabled(bool enabled) final override;
             bool IsProfilerEnabled() const final override;
+            const CachedTimeRegion::GroupRegionName& InsertDynamicName(const char* groupName, const AZStd::string& regionName) final override;
 
         private:
             static constexpr AZStd::size_t MaxFramesToSave = 2 * 60 * 120; // 2 minutes of 120fps
@@ -128,6 +129,11 @@ namespace AZ
             // Set of registered threads when created
             AZStd::vector<RHI::Ptr<CpuTimingLocalStorage>, AZ::OSStdAllocator> m_registeredThreads;
             AZStd::mutex m_threadRegisterMutex;
+
+            // Storage for runtime GroupRegionNames
+            AZStd::unordered_map<AZStd::string, AZStd::string> m_dynamicRegionNameMap;
+            AZStd::unordered_map<AZStd::string, TimeRegion::GroupRegionName> m_dynamicGroupRegionNameMap;
+            AZStd::mutex m_dynamicNameMutex;
 
             // Thread local storage, gets lazily allocated when a thread is created
             static thread_local CpuTimingLocalStorage* ms_threadLocalStorage;

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -132,11 +132,7 @@ namespace AZ
             AZStd::mutex m_threadRegisterMutex;
 
             // Storage for runtime GroupRegionNames
-            using DynamicRegionNameMap = AZStd::unordered_map<AZStd::string, TimeRegion::GroupRegionName>;
-             
-            // Use string_view over the const char* as a key because equivalent string literals throughout the source files might be duplicated
-            // (and therefore have different addresses) if string pooling is disabled.
-            AZStd::unordered_map<AZStd::string_view, DynamicRegionNameMap> m_dynamicGroupRegionNameMap;
+            AZStd::unordered_set<CachedTimeRegion::GroupRegionName, CachedTimeRegion::GroupRegionName::Hash> m_dynamicGroupRegionNameSet;
             AZStd::unordered_set<AZStd::string> m_dynamicRegionNameSet;
             AZStd::mutex m_dynamicNameMutex;
 

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -13,6 +13,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Memory/OSAllocator.h>
 #include <AzCore/std/containers/map.h>
+#include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/parallel/shared_mutex.h>
 #include <AzCore/std/smart_ptr/intrusive_refcount.h>
@@ -131,8 +132,12 @@ namespace AZ
             AZStd::mutex m_threadRegisterMutex;
 
             // Storage for runtime GroupRegionNames
-            AZStd::unordered_map<AZStd::string, AZStd::string> m_dynamicRegionNameMap;
-            AZStd::unordered_map<AZStd::string, TimeRegion::GroupRegionName> m_dynamicGroupRegionNameMap;
+            using DynamicRegionNameMap = AZStd::unordered_map<AZStd::string, TimeRegion::GroupRegionName>;
+             
+            // Use string_view over the const char* as a key because equivalent string literals throughout the source files might be duplicated
+            // (and therefore have different addresses) if string pooling is disabled.
+            AZStd::unordered_map<AZStd::string_view, DynamicRegionNameMap> m_dynamicGroupRegionNameMap;
+            AZStd::unordered_set<AZStd::string> m_dynamicRegionNameSet;
             AZStd::mutex m_dynamicNameMutex;
 
             // Thread local storage, gets lazily allocated when a thread is created

--- a/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
@@ -235,11 +235,12 @@ namespace AZ
         const CachedTimeRegion::GroupRegionName& CpuProfilerImpl::InsertDynamicName(const char* groupName, const AZStd::string& regionName)
         {
             AZStd::scoped_lock lock(m_dynamicNameMutex);
-            AZ_Warning("CpuProfiler", m_dynamicRegionNameSet.size() < 16384, "Stored dynamic region names are accumulating. Consider removing a AZ_ATOM_PROFILE_DYNAMIC invocation.");
-            auto [regionNameItr, wasRegionInserted] =  m_dynamicRegionNameSet.insert(regionName);
+            AZ_Warning("CpuProfiler", m_regionNameStringPool.size() < MaxRegionStringPoolSize,
+                "Stored dynamic region names are accumulating. Consider removing a AZ_ATOM_PROFILE_DYNAMIC invocation.");
+            auto [regionNameItr, wasRegionInserted] =  m_regionNameStringPool.insert(regionName);
 
             CachedTimeRegion::GroupRegionName newGroupRegionName(groupName, regionNameItr->c_str());
-            auto [groupRegionNameItr, wasGroupRegionInserted] = m_dynamicGroupRegionNameSet.insert(newGroupRegionName);
+            auto [groupRegionNameItr, wasGroupRegionInserted] = m_dynamicGroupRegionNamePool.insert(newGroupRegionName);
 
             return *groupRegionNameItr;
         }

--- a/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
@@ -221,16 +221,14 @@ namespace AZ
         const CachedTimeRegion::GroupRegionName& CpuProfilerImpl::InsertDynamicName(const char* groupName, const AZStd::string& regionName)
         {
             AZStd::scoped_lock lock(m_dynamicNameMutex);
-            AZ_Warning("CpuProfiler", m_dynamicRegionNameMap.size() < 16384, "Stored dynamic region names are accumulating. Consider removing a AZ_ATOM_PROFILE_DYNAMIC invocation.");
-            auto [regionNameItr, inserted] = m_dynamicRegionNameMap.try_emplace(regionName, regionName);
+            AZ_Warning("CpuProfiler", m_dynamicRegionNameSet.size() < 16384, "Stored dynamic region names are accumulating. Consider removing a AZ_ATOM_PROFILE_DYNAMIC invocation.");
+            auto [regionNameItr, wasRegionInserted] =  m_dynamicRegionNameSet.insert(regionName);
 
-            // This is the first time we have constructed a dynamic region with this name, also create a GroupRegionName for the region
-            if (inserted)
-            {
-                m_dynamicGroupRegionNameMap.emplace(regionName, CachedTimeRegion::GroupRegionName{ groupName, regionNameItr->second.c_str() } );
-            }
+            // Since markers might have the same region name but different group names, always check if a new GroupRegionName needs to be constructed.
+            auto [groupRegionNameItr, wasGroupRegionConstructed] = m_dynamicGroupRegionNameMap[groupName].try_emplace(
+                 regionName, groupName, regionNameItr->c_str());
 
-            return m_dynamicGroupRegionNameMap.at(regionName);
+            return groupRegionNameItr->second;
         }
 
         void CpuProfilerImpl::OnSystemTick()


### PR DESCRIPTION
This PR adds a new profiling macro, `AZ_ATOM_PROFILE_DYNAMIC` to allow for region names determined at runtime. The main challenge here was finding a way to guarantee the lifetime of `GroupRegionName` objects, as they previously were static. I added members to `CpuProfilerImpl` to store `GroupRegionNames` and their corresponding region names. This storage is not garbage collected since `GroupRegionName` passes everything around through raw pointer, I did include a warning if the storage gets large.

### Demo: 
![runtimedemo](https://user-images.githubusercontent.com/64656371/128438476-ed21998e-9338-4dc8-b898-594adff77891.png)

![runtimemarker](https://user-images.githubusercontent.com/64656371/128438481-ca65f1ea-2a32-42f3-b714-9fd1cc63a4c7.png)




Completes ATOM-15954