### PR TITLE
Fixed Asset Browser path related context menu options.

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -260,9 +260,7 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
         return;
     }
 
-    AZStd::string fullFileDirectory;
     AZStd::string fullFilePath;
-    AZStd::string fileName;
     AZStd::string extension;
 
     switch (entry->GetEntryType())
@@ -281,8 +279,6 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
     {
         AZ::Uuid sourceID = azrtti_cast<SourceAssetBrowserEntry*>(entry)->GetSourceUuid();
         fullFilePath = entry->GetFullPath();
-        fullFileDirectory = fullFilePath.substr(0, fullFilePath.find_last_of(AZ_CORRECT_DATABASE_SEPARATOR));
-        fileName = entry->GetName();
         AzFramework::StringFunc::Path::GetExtension(fullFilePath.c_str(), extension);
 
         // Add the "Open" menu item.
@@ -369,19 +365,19 @@ void AzAssetBrowserRequestHandler::AddContextMenuActions(QWidget* caller, QMenu*
         {
             if (entry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Source)
             {
-                CFileUtil::PopulateQMenu(caller, menu, fileName.c_str(), fullFileDirectory.c_str());
+                CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
             }
             return;
         }
       
-        CFileUtil::PopulateQMenu(caller, menu, fileName.c_str(), fullFileDirectory.c_str());
+        CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
     }
     break;
     case AssetBrowserEntry::AssetEntryType::Folder:
     {
-        fullFileDirectory = entry->GetFullPath();
-        // we are sending an empty filename to indicate that it is a folder and not a file
-        CFileUtil::PopulateQMenu(caller, menu, fileName.c_str(), fullFileDirectory.c_str());
+        fullFilePath = entry->GetFullPath();
+
+        CFileUtil::PopulateQMenu(caller, menu, fullFilePath);
     }
     break;
     default:

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -1900,12 +1900,12 @@ IFileUtil::ECopyTreeResult   CFileUtil::MoveTree(const QString& strSourceDirecto
     return eCopyResult;
 }
 
-void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath)
+void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, AZStd::string_view fullGamePath)
 {
     PopulateQMenu(caller, menu, fullGamePath, nullptr);
 }
 
-void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath, bool* isSelected)
+void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, AZStd::string_view fullGamePath, bool* isSelected)
 {
     // Normalize the full path so we get consistent separators
     AZStd::string fullFilePath(fullGamePath);

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -1900,74 +1900,23 @@ IFileUtil::ECopyTreeResult   CFileUtil::MoveTree(const QString& strSourceDirecto
     return eCopyResult;
 }
 
-QString CFileUtil::PopupQMenu(const QString& filename, const QString& fullGamePath, QWidget* parent)
+void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath)
 {
-    QStringList extraItemsFront;
-    return PopupQMenu(filename, fullGamePath, parent, nullptr, extraItemsFront);
+    PopulateQMenu(caller, menu, fullGamePath, nullptr);
 }
 
-QString CFileUtil::PopupQMenu(const QString& filename, const QString& fullGamePath, QWidget* parent, [[maybe_unused]] bool* pIsSelected, const QStringList& extraItemsFront)
+void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath, bool* isSelected)
 {
-    QStringList extraItemsBack;
-    return PopupQMenu(filename, fullGamePath, parent, nullptr, extraItemsFront, extraItemsBack);
-}
+    // Normalize the full path so we get consistent separators
+    AZStd::string fullFilePath(fullGamePath);
+    AzFramework::StringFunc::Path::Normalize(fullFilePath);
 
-QString CFileUtil::PopupQMenu(const QString& filename, const QString& fullGamePath, QWidget* parent, bool* pIsSelected, const QStringList& extraItemsFront, const QStringList& extraItemsBack)
-{
-    QMenu menu;
-
-    foreach(QString text, extraItemsFront)
-    {
-        if (!text.isEmpty())
-        {
-            menu.addAction(text);
-        }
-    }
-    if (extraItemsFront.count())
-    {
-        menu.addSeparator();
-    }
-
-    PopulateQMenu(parent, &menu, filename, fullGamePath, pIsSelected);
-    if (extraItemsBack.count())
-    {
-        menu.addSeparator();
-    }
-    foreach(QString text, extraItemsBack)
-    {
-        if (!text.isEmpty())
-        {
-            menu.addAction(text);
-        }
-    }
-
-    QAction* result = menu.exec(QCursor::pos());
-    return result ? result->text() : QString();
-}
-
-void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const QString& filename, const QString& fullGamePath)
-{
-    PopulateQMenu(caller, menu, filename, fullGamePath, nullptr);
-}
-
-void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const QString& filename, const QString& fullGamePath, bool* isSelected)
-{
-    QString fullPath;
+    QString fullPath(fullFilePath.c_str());
+    QFileInfo fileInfo(fullPath);
 
     if (isSelected)
     {
         *isSelected = false;
-    }
-
-    if (!filename.isEmpty())
-    {
-        QString path = Path::MakeGamePath(fullGamePath);
-        path = Path::AddSlash(path) + filename;
-        fullPath = Path::GamePathToFullPath(path);
-    }
-    else
-    {
-        fullPath = fullGamePath;
     }
 
     uint32 nFileAttr = CFileUtil::GetAttributes(fullPath.toUtf8().data());
@@ -2005,21 +1954,13 @@ void CFileUtil::PopulateQMenu(QWidget* caller, QMenu* menu, const QString& filen
 
     action = menu->addAction(QObject::tr("Copy Name To Clipboard"), [=]()
     {
-        if (filename.isEmpty())
-        {
-            QFileInfo fi(fullGamePath);
-            QString file = fi.completeBaseName();
-            QApplication::clipboard()->setText(file);
-        }
-        else
-        {
-            QApplication::clipboard()->setText(filename);
-        }
+        QString fileName = fileInfo.completeBaseName();
+        QApplication::clipboard()->setText(fileName);
     });
 
     action = menu->addAction(QObject::tr("Copy Path To Clipboard"), [fullPath]() { QApplication::clipboard()->setText(fullPath); });
 
-    if (!filename.isEmpty() && GetIEditor()->IsSourceControlAvailable() && nFileAttr != SCC_FILE_ATTRIBUTE_INVALID)
+    if (fileInfo.isFile() && GetIEditor()->IsSourceControlAvailable() && nFileAttr != SCC_FILE_ATTRIBUTE_INVALID)
     {
         bool isEnableSC = nFileAttr & SCC_FILE_ATTRIBUTE_MANAGED;
         bool isInPak = nFileAttr & SCC_FILE_ATTRIBUTE_INPAK;

--- a/Code/Editor/Util/FileUtil.h
+++ b/Code/Editor/Util/FileUtil.h
@@ -134,7 +134,7 @@ public:
     // THIS FUNCTION IS NOT DESIGNED FOR MULTI-THREADED USAGE
     static IFileUtil::ECopyTreeResult   MoveTree(const QString& strSourceDirectory, const QString& strTargetDirectory, bool boRecurse = true, bool boConfirmOverwrite = false);
 
-    static void PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath);
+    static void PopulateQMenu(QWidget* caller, QMenu* menu, AZStd::string_view fullGamePath);
 
     static void GatherAssetFilenamesFromLevel(std::set<QString>& rOutFilenames, bool bMakeLowerCase = false, bool bMakeUnixPath = false);
 
@@ -161,7 +161,7 @@ private:
     static bool s_multiFileDlgPref[IFileUtil::EFILE_TYPE_LAST];
 
     // Keep this variant of this method private! pIsSelected is captured in a lambda, and so requires menu use exec() and never use show()
-    static void PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath, bool* pIsSelected);
+    static void PopulateQMenu(QWidget* caller, QMenu* menu, AZStd::string_view fullGamePath, bool* pIsSelected);
 
     static bool ExtractDccFilenameFromAssetDatabase(const QString& assetFilename, QString& dccFilename);
     static bool ExtractDccFilenameUsingNamingConventions(const QString& assetFilename, QString& dccFilename);

--- a/Code/Editor/Util/FileUtil.h
+++ b/Code/Editor/Util/FileUtil.h
@@ -134,18 +134,7 @@ public:
     // THIS FUNCTION IS NOT DESIGNED FOR MULTI-THREADED USAGE
     static IFileUtil::ECopyTreeResult   MoveTree(const QString& strSourceDirectory, const QString& strTargetDirectory, bool boRecurse = true, bool boConfirmOverwrite = false);
 
-    // Show Popup Menu with file commands include Source Control commands
-    // filename: a name of file without path
-    // fullGamePath: a game path to folder like "/Game/Objects" without filename
-    // wnd: pointer to window class, can be nullptr
-    // isSelected: output value indicated if Select menu item was chosen, if pointer is 0 - no Select menu item.
-    // pItems: you can specify additional menu items and get the result of selection using this parameter.
-    // return false if source control operation failed
-    static QString PopupQMenu(const QString& filename, const QString& fullGamePath, QWidget* parent);
-    static QString PopupQMenu(const QString& filename, const QString& fullGamePath, QWidget* parent, bool* pIsSelected, const QStringList& extraItemsFront);
-    static QString PopupQMenu(const QString& filename, const QString& fullGamePath, QWidget* parent, bool* pIsSelected, const QStringList& extraItemsFront, const QStringList& extraItemsBack);
-
-    static void PopulateQMenu(QWidget* caller, QMenu* menu, const QString& filename, const QString& fullGamePath);
+    static void PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath);
 
     static void GatherAssetFilenamesFromLevel(std::set<QString>& rOutFilenames, bool bMakeLowerCase = false, bool bMakeUnixPath = false);
 
@@ -172,7 +161,7 @@ private:
     static bool s_multiFileDlgPref[IFileUtil::EFILE_TYPE_LAST];
 
     // Keep this variant of this method private! pIsSelected is captured in a lambda, and so requires menu use exec() and never use show()
-    static void PopulateQMenu(QWidget* caller, QMenu* menu, const QString& filename, const QString& fullGamePath, bool* pIsSelected);
+    static void PopulateQMenu(QWidget* caller, QMenu* menu, const AZStd::string& fullGamePath, bool* pIsSelected);
 
     static bool ExtractDccFilenameFromAssetDatabase(const QString& assetFilename, QString& dccFilename);
     static bool ExtractDccFilenameUsingNamingConventions(const QString& assetFilename, QString& dccFilename);


### PR DESCRIPTION
Most of the path-related context menu options in the Asset Browser were not working. Fixed the logic to make sure it deals with a full, normalized path, which removed some guess-work the former logic was trying to do with files vs. folders.

Tested the following context menu options on both files and folders and verified they now perform the expected behaviors:

- Open in Explorer
- Copy Name to Clipboard
- Copy Path to Clipboard

Also tested the additional context menu options specific for files (e.g. Open in Asset Editor, Open in associated application, etc...)

Fixes #2533
Fixes #2433 
Fixes #2558 

Signed-off-by: Chris Galvan <chgalvan@amazon.com>