### PR TITLE
Defer spinbox property changes while user is editing

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.cpp
@@ -28,7 +28,7 @@ namespace AzToolsFramework
         setFocusProxy(m_sliderCombo);
 
         connect(m_sliderCombo, &AzQtComponents::SliderDoubleCombo::valueChanged, this, &PropertyDoubleSliderCtrl::onValueChange);
-        connect(m_sliderCombo, &AzQtComponents::SliderDoubleCombo::editingFinished, this, &PropertyDoubleSliderCtrl::editingFinished);
+        connect(m_sliderCombo, &AzQtComponents::SliderDoubleCombo::editingFinished, [this]() { onTextBoxLikeEditingFinished(); });
     }
 
     void PropertyDoubleSliderCtrl::onValueChange()
@@ -324,7 +324,7 @@ namespace AzToolsFramework
         (int)index;
         (void)node;
         GUI->blockSignals(true);
-        GUI->setValue(instance);
+        GUI->setValueFromSystem(instance);
         GUI->blockSignals(false);
         return false;
     }
@@ -334,7 +334,7 @@ namespace AzToolsFramework
         (int)index;
         (void)node;
         GUI->blockSignals(true);
-        GUI->setValue(instance);
+        GUI->setValueFromSystem(instance);
         GUI->blockSignals(false);
         return false;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSliderCtrl.hxx
@@ -16,14 +16,30 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzQtComponents/Components/Widgets/SliderCombo.h>
 #include "PropertyEditorAPI.h"
+#include <AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx>
 
 #endif
 
 namespace AzToolsFramework
 {
+    namespace Internal
+    {
+        struct PropertyDoubleSliderCtrl_DeferredTextboxLikeEdit_traits
+            : public DeferredTextboxLikeEdit_default_traits
+        {
+            template<class C>
+            static bool isUserEditing(const C* obj)
+            {
+                return obj->m_sliderCombo->spinbox()->hasFocus();
+            }
+        };
+    }
+
     class PropertyDoubleSliderCtrl
         : public QWidget
+        , public DeferredTextboxLikeEdit<PropertyDoubleSliderCtrl, double, Internal::PropertyDoubleSliderCtrl_DeferredTextboxLikeEdit_traits>
     {
+        friend struct Internal::PropertyDoubleSliderCtrl_DeferredTextboxLikeEdit_traits;
         Q_OBJECT
     public:
         AZ_CLASS_ALLOCATOR(PropertyDoubleSliderCtrl, AZ::SystemAllocator, 0);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.cpp
@@ -45,7 +45,7 @@ namespace AzToolsFramework
         setFocusPolicy(m_pSpinBox->focusPolicy());
 
         connect(m_pSpinBox, SIGNAL(valueChanged(double)), this, SLOT(onChildSpinboxValueChange(double)));
-        connect(m_pSpinBox, &QDoubleSpinBox::editingFinished, this, &PropertyDoubleSpinCtrl::editingFinished);
+        connect(m_pSpinBox, &QDoubleSpinBox::editingFinished, [this]() { onTextBoxLikeEditingFinished(); });
     }
 
     QWidget* PropertyDoubleSpinCtrl::GetFirstInTabOrder()
@@ -381,7 +381,7 @@ namespace AzToolsFramework
     {
         (int)index;
         (void)node;
-        GUI->setValue(instance * GUI->multiplier());
+        GUI->setValueFromSystem(instance * GUI->multiplier());
         return false;
     }
 
@@ -389,7 +389,7 @@ namespace AzToolsFramework
     {
         (int)index;
         (void)node;
-        GUI->setValue(instance * GUI->multiplier());
+        GUI->setValueFromSystem(instance * GUI->multiplier());
         return false;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyDoubleSpinCtrl.hxx
@@ -16,6 +16,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <QtWidgets/QWidget>
 #include "PropertyEditorAPI.h"
+#include <AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx>
 #endif
 
 namespace AzQtComponents
@@ -27,6 +28,7 @@ namespace AzToolsFramework
 {
     class PropertyDoubleSpinCtrl
         : public QWidget
+        , public DeferredTextboxLikeEdit<PropertyDoubleSpinCtrl, double>
     {
         Q_OBJECT
     public:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -270,7 +270,7 @@ namespace AzToolsFramework
                                                                                          const ValueType& instance, 
                                                                                          [[maybe_unused]] InstanceDataNode* node)
     {
-        GUI->setValue(instance);
+        GUI->setValueFromSystem(instance);
         return false;
     }
     

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.cpp
@@ -27,7 +27,7 @@ namespace AzToolsFramework
         setFocusProxy(m_sliderCombo);
 
         connect(m_sliderCombo, &AzQtComponents::SliderCombo::valueChanged, this, &PropertyIntSliderCtrl::onValueChange);
-        connect(m_sliderCombo, &AzQtComponents::SliderCombo::editingFinished, this, &PropertyIntSliderCtrl::editingFinished);
+        connect(m_sliderCombo, &AzQtComponents::SliderCombo::editingFinished, [this]() { onTextBoxLikeEditingFinished(); });
     }
 
     PropertyIntSliderCtrl::~PropertyIntSliderCtrl()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSliderCtrl.hxx
@@ -14,13 +14,29 @@
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h>
 #include <AzQtComponents/Components/Widgets/SliderCombo.h>
+#include <AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx>
 #endif
 
 namespace AzToolsFramework
 {
+    namespace Internal
+    {
+        struct PropertyIntSliderCtrl_DeferredTextboxLikeEdit_traits
+            : public DeferredTextboxLikeEdit_default_traits
+        {
+            template<class C>
+            static bool isUserEditing(const C* obj)
+            {
+                return obj->m_sliderCombo->spinbox()->hasFocus();
+            }
+        };
+    }
+
     class PropertyIntSliderCtrl
         : public QWidget
+        , public DeferredTextboxLikeEdit<PropertyIntSliderCtrl, AZ::s64, Internal::PropertyIntSliderCtrl_DeferredTextboxLikeEdit_traits>
     {
+        friend struct Internal::PropertyIntSliderCtrl_DeferredTextboxLikeEdit_traits;
         Q_OBJECT
     public:
         AZ_CLASS_ALLOCATOR(PropertyIntSliderCtrl, AZ::SystemAllocator, 0);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSpinCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSpinCtrl.cpp
@@ -44,7 +44,7 @@ namespace AzToolsFramework
         m_pSpinBox->setFocusPolicy(Qt::StrongFocus);
 
         connect(m_pSpinBox, SIGNAL(valueChanged(int)), this, SLOT(onChildSpinboxValueChange(int)));
-        connect(m_pSpinBox, &QSpinBox::editingFinished, this, &PropertyIntSpinCtrl::editingFinished);
+        connect(m_pSpinBox, &QSpinBox::editingFinished, [this]() { onTextBoxLikeEditingFinished(); });
     };
 
     QWidget* PropertyIntSpinCtrl::GetFirstInTabOrder()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSpinCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntSpinCtrl.hxx
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h>
+#include <AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx>
 #endif
 
 namespace AzQtComponents
@@ -21,6 +22,7 @@ namespace AzToolsFramework
 {   
     class PropertyIntSpinCtrl
         : public QWidget
+        , public DeferredTextboxLikeEdit<PropertyIntSpinCtrl, AZ::s64>
     {
         Q_OBJECT
     public:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.cpp
@@ -42,7 +42,7 @@ namespace AzToolsFramework
         ConnectWidgets();
     };
 
-    void PropertyStringLineEditCtrl::setValue(AZStd::string& value)
+    void PropertyStringLineEditCtrl::setValue(const AZStd::string& value)
     {
         QString text = m_pLineEdit->text();
         if (text.compare(value.data()) != 0)
@@ -62,6 +62,14 @@ namespace AzToolsFramework
     AZStd::string PropertyStringLineEditCtrl::value() const
     {
         return AZStd::string(m_pLineEdit->text().toUtf8().data());
+    }
+
+    void PropertyStringLineEditCtrl::setValueFromSystem(const AZStd::string& newValue)
+    {
+        if (!m_pLineEdit->hasFocus())
+        {
+            setValue(newValue);
+        }
     }
 
     QLineEdit* PropertyStringLineEditCtrl::GetLineEdit() const
@@ -153,7 +161,7 @@ namespace AzToolsFramework
         (int)index;
         (void)node;
         AZStd::string val = instance;
-        GUI->setValue(val);
+        GUI->setValueFromSystem(val);
         return false;
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyStringLineEditCtrl.hxx
@@ -41,11 +41,13 @@ namespace AzToolsFramework
         QWidget* GetLastInTabOrder();
         void UpdateTabOrder();
 
+        void setValueFromSystem(const AZStd::string&);
+
     signals:
-        void valueChanged(AZStd::string& newValue);
+        void valueChanged(const AZStd::string& newValue);
 
     public slots:
-        virtual void setValue(AZStd::string& val);
+        virtual void setValue(const AZStd::string& val);
         void setMaxLen(int maxLen);
 
     protected slots:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <AzCore/std/limits.h>
+#include <AzCore/std/optional.h>
+
+namespace AzToolsFramework
+{
+    struct DeferredTextboxLikeEdit_default_traits
+    {
+        template<class C>
+        using value_type = decltype(AZStd::declval<const C&>().value());
+
+        template<class C>
+        static auto get(const C* obj)
+        {
+            return obj->value();
+        }
+
+        template<class C, class T>
+        static void set(C* obj, const T& val)
+        {
+            obj->setValue(val);
+        }
+
+        template<class C>
+        static bool isUserEditing(const C* obj)
+        {
+            return obj->hasFocus();
+        }
+
+        template<class C>
+        static void emitEditingFinished(C* obj)
+        {
+            emit obj->editingFinished();
+        }
+    };
+
+    /*
+    A small helper for deferring `setValue' events while a user is editing a textbox-like property.
+    In these cases, any external `setValue' events shouldn't overwrite what the user enters.
+    */
+    template<class Derived, class T, class Traits = DeferredTextboxLikeEdit_default_traits>
+    class DeferredTextboxLikeEdit
+    {
+    public:
+        void setValueFromSystem(const T&);
+
+    protected:
+        template<class... Args>
+        void onTextBoxLikeEditingFinished(Args&&... args);
+
+        // Call to check if you should really set the new value
+        // This might record that value for later use
+        bool shouldReallySetValue(const T& prevValue, const T& newValue, bool isUserEditing);
+
+        // Call when the user is done editing the textbox-like property
+        // If this returns a value, you should set the property widget to have that value
+        AZStd::optional<T> getDeferredValuedToSet(const T& value, bool isUserEditing);
+        AZStd::optional<T> getDeferredValuedToSet();
+
+    private:
+        const Derived* GetDerived() const { return static_cast<const Derived*>(this); }
+              Derived* GetDerived()       { return static_cast<      Derived*>(this); }
+
+        struct DeferredSetValue
+        {
+            T prevValue;
+            T value;
+        };
+
+        //! If a value is editing, but not by the user, and the user is currently editing the value,
+        //! avoid overwriting their work, until they finish editing
+        AZStd::optional<DeferredSetValue> m_deferredExternalValue;
+    };
+
+    template<class Derived, class T, class Traits>
+    void DeferredTextboxLikeEdit<Derived, T, Traits>::setValueFromSystem(const T& newValue)
+    {
+        if (shouldReallySetValue(Traits::get(GetDerived()), newValue, Traits::isUserEditing(GetDerived())))
+        {
+            Traits::set(GetDerived(), newValue);
+        }
+    }
+
+    template<class Derived, class T, class Traits>
+    template<class... Args>
+    void DeferredTextboxLikeEdit<Derived, T, Traits>::onTextBoxLikeEditingFinished(Args&&... args)
+    {
+        if (auto newValue = getDeferredValuedToSet())
+        {
+            Traits::set(GetDerived(), *newValue);
+        };
+
+        Traits::emitEditingFinished(GetDerived(), AZStd::forward<Args>(args)...);
+    }
+
+    template<class Derived, class T, class Traits>
+    bool DeferredTextboxLikeEdit<Derived, T, Traits>::shouldReallySetValue(const T& prevValue, const T& newValue, bool isUserEditing)
+    {
+        if constexpr (AZStd::is_floating_point_v<T>)
+        {
+            // Nothing to do if the value is not actually changed
+            if (AZ::IsCloseMag(prevValue, newValue, AZStd::numeric_limits<T>::epsilon()))
+            {
+                return false;
+            }
+        }
+
+        // If the spin box currently has focus, the user is editing it, so we should not
+        // change the value from non-user input while they're in the middle of editing
+        if (isUserEditing)
+        {
+            auto& deferredValue = m_deferredExternalValue.emplace();
+            deferredValue.value = newValue;
+            deferredValue.prevValue = prevValue;
+            return false;
+        }
+
+        return true;
+    }
+
+    template<class Derived, class T, class Traits>
+    AZStd::optional<T> DeferredTextboxLikeEdit<Derived, T, Traits>::getDeferredValuedToSet(const T& value, [[maybe_unused]] bool isUserEditing)
+    {
+        if (m_deferredExternalValue)
+        {
+            DeferredSetValue deferredValue = *m_deferredExternalValue;
+            m_deferredExternalValue.reset();
+
+            if (value == deferredValue.prevValue)
+            {
+                return deferredValue.value;
+            }
+        }
+
+        return {};
+    }
+
+    template<class Derived, class T, class Traits>
+    AZStd::optional<T> DeferredTextboxLikeEdit<Derived, T, Traits>::getDeferredValuedToSet()
+    {
+        return getDeferredValuedToSet(Traits::get(GetDerived()), Traits::isUserEditing(GetDerived()));
+    }
+
+
+AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
+
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx
@@ -35,26 +35,38 @@ namespace AzToolsFramework
         }
     };
 
-    /*
-    A small helper for deferring `setValue' events while a user is editing a textbox-like property.
-    In these cases, any external `setValue' events shouldn't overwrite what the user enters.
-    */
+    //! A small helper for deferring `setValue' events while a user is editing a textbox-like property.
+    //! In these cases, any external `setValue' events shouldn't overwrite what the user enters.
     template<class Derived, class T, class Traits = DeferredTextboxLikeEdit_default_traits>
     class DeferredTextboxLikeEdit
     {
     public:
+        //! Set the value of the property, but if the user is editing the textbox-like widget,
+        //! don't overwrite their edits. Instead, save the given value for later use; when the
+        //! user complets editing, if they didn't actually change anything, then the latest
+        //! value passed to this method will be set on the textbox-like widget.
         void setValueFromSystem(const T&);
 
     protected:
+        //! When the textbox-like property editing finishes (typically from the user pressing enter
+        //! or the textbox-like widget losing focus), call this method to apply any deferred set-value
+        //! actions.
+        //! This method also signals the editing finished slot. All arguments passed to this method are
+        //! forwarded to that slot. To pass arguments here, you must override the traits to allow
+        //! `emitEditingFinished' to accept arguments.
         template<class... Args>
         void onTextBoxLikeEditingFinished(Args&&... args);
 
-        // Call to check if you should really set the new value
-        // This might record that value for later use
+        //! Call to check if you should really set the new value. This might record that value for later use.
+        //! Typically you should use `setValueFromSystem' instead of this method.
+        //! @param prevValue if the value were to be changed now, the previous value of the property.
+        //! @param newValue the value which
+        //! @return true iff you should now set the new value
         bool shouldReallySetValue(const T& prevValue, const T& newValue, bool isUserEditing);
 
-        // Call when the user is done editing the textbox-like property
-        // If this returns a value, you should set the property widget to have that value
+        //! Call when the user is done editing the textbox-like property.
+        //! If this returns a value, you should set the property widget to have that value.
+        //! Typically you should use `onTextBoxLikeEditingFinished' instead of this method.
         AZStd::optional<T> getDeferredValuedToSet(const T& value, bool isUserEditing);
         AZStd::optional<T> getDeferredValuedToSet();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -358,6 +358,7 @@ set(FILES
     UI/PropertyEditor/EntityIdQLineEdit.cpp
     UI/PropertyEditor/EntityPropertyEditor.hxx
     UI/PropertyEditor/EntityPropertyEditor.cpp
+    UI/PropertyEditor/TextBoxLikePropertyCtrl.hxx
     UI/PropertyEditor/GenericComboBoxCtrl.h
     UI/PropertyEditor/GenericComboBoxCtrl.cpp
     UI/PropertyEditor/GenericComboBoxCtrl.inl


### PR DESCRIPTION
This is a follow up to this other PR: https://github.com/o3de/o3de/pull/1468/ . Effectively the same change is applied, except higher up, to all AzQtComponents SpinBoxes. This then fixes the issue for double spin box property controls, double slider property controls, integer spin box property controls, and integer 

To summarize the problem:

Actor motion extraction applies at all times, sending transform change events to the Qt widget and overwriting any editing the user is doing.

If the user is in the middle of editing, do not overwrite the current spinbox value. If something ends up calling setValue while the user is editing the property, then save the new value until the user finishes editing the property. When editing completes, if the user did not change the value (which occurs for example if the user clicks the spin box but doesn't change the value, and then clicks out of the spin box), then set the live value of the widget to that saved value; if the user did change the value, keep the value which the user has set.