### PR TITLE
performance benchmarks: Aggregate and report CPU frame times.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_GPUTest_AtomFeatureIntegrationBenchmark.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_GPUTest_AtomFeatureIntegrationBenchmark.py
@@ -93,6 +93,7 @@ def run():
     general.idle_wait_frames(100)
     for i in range(1, 101):
         benchmarker.capture_pass_timestamp(i)
+        benchmarker.capture_cpu_frame_time(i)
     general.exit_game_mode()
     helper.wait_for_condition(function=lambda: not general.is_in_game_mode(), timeout_in_seconds=2.0)
     general.log("Capturing complete.")

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_utils/benchmark_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_utils/benchmark_utils.py
@@ -61,6 +61,25 @@ class BenchmarkHelper(object):
             general.log('Failed to capture pass timestamps.')
         return self.capturedData
 
+    def capture_cpu_frame_time(self, frame_number):
+        """
+        Capture CPU frame times and block further execution until it has been written to the disk.
+        """
+        self.handler = azlmbr.atom.ProfilingCaptureNotificationBusHandler()
+        self.handler.connect()
+        self.handler.add_callback('OnCaptureCpuFrameTimeFinished', self.on_data_captured)
+
+        self.done = False
+        self.capturedData = False
+        success = azlmbr.atom.ProfilingCaptureRequestBus(
+            azlmbr.bus.Broadcast, "CaptureCpuFrameTime", f'{self.output_path}/cpu_frame{frame_number}_time.json')
+        if success:
+            self.wait_until_data()
+            general.log('CPU frame time captured.')
+        else:
+            general.log('Failed to capture CPU frame time.')
+        return self.capturedData
+
     def on_data_captured(self, parameters):
         # the parameters come in as a tuple
         if parameters[0]:

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_GPUTests.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_GPUTests.py
@@ -99,6 +99,7 @@ class TestPerformanceBenchmarkSuite(object):
         expected_lines = [
             "Benchmark metadata captured.",
             "Pass timestamps captured.",
+            "CPU frame time captured.",
             "Capturing complete.",
             "Captured data successfully."
         ]
@@ -106,6 +107,7 @@ class TestPerformanceBenchmarkSuite(object):
         unexpected_lines = [
             "Failed to capture data.",
             "Failed to capture pass timestamps.",
+            "Failed to capture CPU frame time.",
             "Failed to capture benchmark metadata."
         ]
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ProfilingCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/ProfilingCaptureBus.h
@@ -22,6 +22,9 @@ namespace AZ
             //! Dump the Timestamp from passes to a json file.
             virtual bool CapturePassTimestamp(const AZStd::string& outputFilePath) = 0;
 
+            //! Dump the Cpu frame time statistics to a json file.
+            virtual bool CaptureCpuFrameTime(const AZStd::string& outputFilePath) = 0;
+
             //! Dump the PipelineStatistics from passes to a json file.
             virtual bool CapturePassPipelineStatistics(const AZStd::string& outputFilePath) = 0;
 
@@ -43,6 +46,11 @@ namespace AZ
             //! @param result Set to true if it's finished successfully
             //! @param info The output file path or error information which depends on the return.
             virtual void OnCaptureQueryTimestampFinished(bool result, const AZStd::string& info) = 0;
+
+            //! Notify when the current CpuFrameTimeStatistics capture is finished
+            //! @param result Set to true if it's finished successfully
+            //! @param info The output file path or error information which depends on the return.
+            virtual void OnCaptureCpuFrameTimeFinished(bool result, const AZStd::string& info) = 0;
 
             //! Notify when the current PipelineStatistics query capture is finished
             //! @param result Set to true if it's finished successfully

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -68,6 +68,7 @@ namespace AZ
 
             // ProfilingCaptureRequestBus overrides...
             bool CapturePassTimestamp(const AZStd::string& outputFilePath) override;
+            bool CaptureCpuFrameTime(const AZStd::string& outputFilePath) override;
             bool CapturePassPipelineStatistics(const AZStd::string& outputFilePath) override;
             bool CaptureCpuProfilingStatistics(const AZStd::string& outputFilePath) override;
             bool CaptureBenchmarkMetadata(const AZStd::string& benchmarkName, const AZStd::string& outputFilePath) override;
@@ -81,6 +82,7 @@ namespace AZ
             AZStd::vector<AZ::RPI::Pass*> FindPasses(AZStd::vector<AZStd::string>&& passHierarchy) const;
 
             DelayedQueryCaptureHelper m_timestampCapture;
+            DelayedQueryCaptureHelper m_cpuFrameTimeStatisticsCapture;
             DelayedQueryCaptureHelper m_pipelineStatisticsCapture;
             DelayedQueryCaptureHelper m_cpuProfilingStatisticsCapture;
             DelayedQueryCaptureHelper m_benchmarkMetadataCapture;


### PR DESCRIPTION
The CPU times logged are about ~8.2-8.3ms for CullingAndLod and SponzaBenchmark, 16-17ms for AtomFeatureIntegrationBenchmark

The ProfilingCaptureSystem seems to be limited to only take data from a single frame in a single invocation, so calculating statistics of the CPU frame times has been delegated to the Python side after refactoring.