### PR TITLE
Fix input not working in Ctrl-G mode after UI Editor is opened

### DIFF
--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_Windows.cpp
@@ -8,6 +8,7 @@
 
 #include <../Common/WinAPI/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard_WinAPI.h>
 #include <AzFramework/Input/Buses/Notifications/RawInputNotificationBus_Platform.h>
+#include <AzCore/Module/Environment.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace
@@ -118,12 +119,8 @@ namespace AzFramework
     {
         if (!s_instanceCount)
         {
-            s_instanceCount = AZ::Environment::CreateVariable<int>("InputDeviceKeyboardInstanceCount", 0);
-        }
+            s_instanceCount = AZ::Environment::CreateVariable<int>("InputDeviceKeyboardInstanceCount", 1);
 
-        int instanceCount = s_instanceCount.Get();
-        if (instanceCount++ == 0)
-        {
             // Register for raw keyboard input
             RAWINPUTDEVICE rawInputDevice;
             rawInputDevice.usUsagePage = RAW_INPUT_KEYBOARD_USAGE_PAGE;
@@ -134,7 +131,10 @@ namespace AzFramework
             AZ_Assert(result, "Failed to register raw input device: keyboard");
             AZ_UNUSED(result);
         }
-        s_instanceCount.Set(instanceCount);
+        else
+        {
+            s_instanceCount.Set(s_instanceCount.Get() + 1);
+        }
 
         RawInputNotificationBusWindows::Handler::BusConnect();
     }
@@ -156,8 +156,13 @@ namespace AzFramework
             const BOOL result = RegisterRawInputDevices(&rawInputDevice, 1, sizeof(rawInputDevice));
             AZ_Assert(result, "Failed to deregister raw input device: keyboard");
             AZ_UNUSED(result);
+
+            s_instanceCount.Reset();
         }
-        s_instanceCount.Set(instanceCount);
+        else
+        {
+            s_instanceCount.Set(instanceCount);
+        }   
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Input/Devices/Mouse/InputDeviceMouse_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Input/Devices/Mouse/InputDeviceMouse_Windows.cpp
@@ -140,12 +140,8 @@ namespace AzFramework
 
         if (!s_instanceCount)
         {
-            s_instanceCount = AZ::Environment::CreateVariable<int>("InputDeviceMouseInstanceCount", 0);
-        }
+            s_instanceCount = AZ::Environment::CreateVariable<int>("InputDeviceMouseInstanceCount", 1);
 
-        int instanceCount = s_instanceCount.Get();
-        if (instanceCount++ == 0)
-        {
             // Register for raw mouse input
             RAWINPUTDEVICE rawInputDevice;
             rawInputDevice.usUsagePage = RAW_INPUT_MOUSE_USAGE_PAGE;
@@ -156,7 +152,10 @@ namespace AzFramework
             AZ_Assert(result, "Failed to register raw input device: mouse");
             AZ_UNUSED(result);
         }
-        s_instanceCount.Set(instanceCount);
+        else
+        {
+            s_instanceCount.Set(s_instanceCount.Get() + 1);
+        }
 
         RawInputNotificationBusWindows::Handler::BusConnect();
     }
@@ -181,8 +180,13 @@ namespace AzFramework
             const BOOL result = RegisterRawInputDevices(&rawInputDevice, 1, sizeof(rawInputDevice));
             AZ_Assert(result, "Failed to deregister raw input device: mouse");
             AZ_UNUSED(result);
+
+            s_instanceCount.Reset();
         }
-        s_instanceCount.Set(instanceCount);
+        else
+        {
+            s_instanceCount.Set(instanceCount);
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The underlying issue was that the mouse and keyboard were being re-registered via RegisterRawInputDevices from the LyShine module. This occurred because the static variable that tracks whether a device has been registered wasn't persisting across dlls.

The RenderViewportWidget, which is used in the Main Editor viewport as well as the UI Editor viewport, creates new input devices when not in game mode in order to handle correct input event ordering between AzFramework input events and Qt events.

Signed-off-by: abrmich <abrmich@amazon.com>