### PR TITLE
[SPEC-7931] Filter boto3 s3 list_buckets results based on region

### DIFF
--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_aws_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/tests/unit/utils/test_aws_utils.py
@@ -98,16 +98,52 @@ class TestAWSUtils(TestCase):
         mocked_s3_client.list_buckets.assert_called_once()
         assert not actual_buckets
 
-    def test_list_s3_buckets_return_expected_buckets(self) -> None:
+    def test_list_s3_buckets_return_empty_list_with_no_matching_region(self) -> None:
+        expected_region: str = "us-east-1"
         mocked_s3_client: MagicMock = self._mock_client.return_value
         expected_buckets: List[str] = [f"{TestAWSUtils._expected_bucket}1", f"{TestAWSUtils._expected_bucket}2"]
         mocked_s3_client.list_buckets.return_value = {"Buckets": [{"Name": expected_buckets[0]},
                                                                   {"Name": expected_buckets[1]}]}
+        mocked_s3_client.get_bucket_location.side_effect = [{"LocationConstraint": "us-east-2"},
+                                                            {"LocationConstraint": "us-west-1"}]
 
-        actual_buckets: List[str] = aws_utils.list_s3_buckets()
-        self._mock_client.assert_called_once_with(aws_utils.AWSConstants.S3_SERVICE_NAME)
+        actual_buckets: List[str] = aws_utils.list_s3_buckets(expected_region)
+        self._mock_client.assert_called_once_with(aws_utils.AWSConstants.S3_SERVICE_NAME,
+                                                  region_name=expected_region)
         mocked_s3_client.list_buckets.assert_called_once()
-        assert actual_buckets == expected_buckets
+        assert not actual_buckets
+
+    def test_list_s3_buckets_return_expected_buckets_matching_region(self) -> None:
+        expected_region: str = "us-west-2"
+        mocked_s3_client: MagicMock = self._mock_client.return_value
+        expected_buckets: List[str] = [f"{TestAWSUtils._expected_bucket}1", f"{TestAWSUtils._expected_bucket}2"]
+        mocked_s3_client.list_buckets.return_value = {"Buckets": [{"Name": expected_buckets[0]},
+                                                                  {"Name": expected_buckets[1]}]}
+        mocked_s3_client.get_bucket_location.side_effect = [{"LocationConstraint": "us-west-2"},
+                                                            {"LocationConstraint": "us-west-1"}]
+
+        actual_buckets: List[str] = aws_utils.list_s3_buckets(expected_region)
+        self._mock_client.assert_called_once_with(aws_utils.AWSConstants.S3_SERVICE_NAME,
+                                                  region_name=expected_region)
+        mocked_s3_client.list_buckets.assert_called_once()
+        assert len(actual_buckets) == 1
+        assert actual_buckets[0] == expected_buckets[0]
+
+    def test_list_s3_buckets_return_expected_iad_buckets(self) -> None:
+        expected_region: str = "us-east-1"
+        mocked_s3_client: MagicMock = self._mock_client.return_value
+        expected_buckets: List[str] = [f"{TestAWSUtils._expected_bucket}1", f"{TestAWSUtils._expected_bucket}2"]
+        mocked_s3_client.list_buckets.return_value = {"Buckets": [{"Name": expected_buckets[0]},
+                                                                  {"Name": expected_buckets[1]}]}
+        mocked_s3_client.get_bucket_location.side_effect = [{"LocationConstraint": None},
+                                                            {"LocationConstraint": "us-west-1"}]
+
+        actual_buckets: List[str] = aws_utils.list_s3_buckets(expected_region)
+        self._mock_client.assert_called_once_with(aws_utils.AWSConstants.S3_SERVICE_NAME,
+                                                  region_name=expected_region)
+        mocked_s3_client.list_buckets.assert_called_once()
+        assert len(actual_buckets) == 1
+        assert actual_buckets[0] == expected_buckets[0]
 
     def test_list_lambda_functions_return_empty_list(self) -> None:
         mocked_lambda_client: MagicMock = self._mock_client.return_value

--- a/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/aws_utils.py
+++ b/Gems/AWSCore/Code/Tools/ResourceMappingTool/utils/aws_utils.py
@@ -106,6 +106,8 @@ def list_s3_buckets(region: str = "") -> List[str]:
         try:
             bucket_name: str = bucket["Name"]
             location_response: Dict[str, any] = s3_client.get_bucket_location(Bucket=bucket_name)
+            # Buckets in Region us-east-1 have a LocationConstraint of null .
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_bucket_location
             if ((location_response["LocationConstraint"] == region) or
                     (not location_response["LocationConstraint"] and region == "us-east-1")):
                 bucket_names.append(bucket_name)


### PR DESCRIPTION
## Details
S3 boto3 client always returns all buckets even specify region while configuring client, have to add extra request call to query bucket location and filter results manually

Buckets in Region us-east-1 have a LocationConstraint of null , see https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_bucket_location

## Testings
Pass unit test

Signed-off-by: onecent1101 <liug@amazon.com>