### PR TITLE
Stabilization AWSTests.periodic failing on Linux due to a File Not Found error

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/AWS/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/AWS/CMakeLists.txt
@@ -11,6 +11,11 @@
 ################################################################################
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
+    # Only enable AWS automated tests on Windows
+    if(NOT "${PAL_PLATFORM_NAME}" STREQUAL "Windows")
+        return()
+    endif()
+
     # Enable after installing NodeJS and CDK on jenkins Windows AMI.
     ly_add_pytest(
         NAME AutomatedTesting::AWSTests


### PR DESCRIPTION
Signed-off-by: junbo <junbo@amazon.com>

Disable the automation tests on platforms other than Windows since there're AWS tests defined for Windows currently.

Verified that the tests are disabled on Linux but enabled on Windows.
https://jenkins-pipeline.agscollab.com/blue/organizations/jenkins/O3DE-LY-FORK/detail/SPEC-7906-stabilization/2/pipeline/164/