### PR TITLE
Updated skeleton logic:

### DIFF
--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpBoneImporter.cpp
@@ -103,10 +103,6 @@ namespace AZ
                     }
                 }
 
-                if(!isBone)
-                {
-                    return Events::ProcessingResult::Ignored;
-                }
 
                 // If the current scene node (our eventual parent) contains bone data, we are not a root bone
                 AZStd::shared_ptr<SceneData::GraphData::BoneData> createdBoneData;

--- a/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Importers/AssImpImporterUtilities.cpp
@@ -135,17 +135,12 @@ namespace AZ
                 const aiBone* bone = FindFirstBoneByNodeName(node, boneByNameMap);
                 if (bone)
                 {
-                    const DataTypes::MatrixType inverseOffsetMatrix = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(bone->mOffsetMatrix).GetInverseFull();
-
                     const aiBone* parentBone = FindFirstBoneByNodeName(node->mParent, boneByNameMap);
                     if (parentBone)
                     {
+                        DataTypes::MatrixType inverseOffsetMatrix = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(bone->mOffsetMatrix).GetInverseFull();
                         const DataTypes::MatrixType parentBoneOffsetMatrix = AssImpSDKWrapper::AssImpTypeConverter::ToTransform(parentBone->mOffsetMatrix);
                         return parentBoneOffsetMatrix * inverseOffsetMatrix;
-                    }
-                    else
-                    {
-                        return inverseOffsetMatrix;
                     }
                 }
 


### PR DESCRIPTION
Import all nodes as bones. O3DE's concept of a bone is different than AssImp's.
Updated GetLocalSpaceBindPoseTransform to only use the offset matrix if the parent is also a bone.
Results:
All test assets I've tried match Blender's "Rest Position" when loaded in the Character tool.
All test animations I've tried work generally as well as they worked before, and a few better. This resolves the issue that was originally opened, an internal test asset loaded the skeleton incorrectly.

Signed-off-by: stankowi <4838196+AMZN-stankowi@users.noreply.github.com>