### PR TITLE
fix: Switch local environment detection to depend on BUILD_NUMBER instead of CI

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/benchmark/data_aggregator.py
+++ b/Tools/LyTestTools/ly_test_tools/benchmark/data_aggregator.py
@@ -22,7 +22,7 @@ class BenchmarkDataAggregator(object):
     def __init__(self, workspace, logger, test_suite):
         self.build_dir = workspace.paths.build_directory()
         self.results_dir = Path(workspace.paths.project(), 'user/Scripts/PerformanceBenchmarks')
-        self.test_suite = test_suite if os.environ.get('CI') else 'local'
+        self.test_suite = test_suite if os.environ.get('BUILD_NUMBER') else 'local'
         self.filebeat_client = FilebeatClient(logger)
 
     def _update_pass(self, pass_stats, entry):


### PR DESCRIPTION
CI is only available on Jenkins v2.289.1, nightly builds are still run on Jenkins 2.277.4

