### PR TITLE
Stabilization AWSTests.periodic failing on Linux due to a File Not Found error

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/AWS/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/AWS/CMakeLists.txt
@@ -12,6 +12,11 @@
 ################################################################################
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
+    # Only enable AWS automated tests on Windows
+    if(NOT "${PAL_PLATFORM_NAME}" STREQUAL "Windows")
+        return()
+    endif()
+
     # Enable after installing NodeJS and CDK on jenkins Windows AMI.
     ly_add_pytest(
         NAME AutomatedTesting::AWSTests


### PR DESCRIPTION
Signed-off-by: junbo <junbo@amazon.com>

Merged the fix from https://github.com/o3de/o3de/pull/2951 since the Stabilization branch is frozen now.
