### PR TITLE
Typo fix in duplicate project progress window

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -189,7 +189,7 @@ namespace O3DE::ProjectManager
 
                     const QString copiedFileSizeString = locale.formattedDataSize(outCopiedFileSize);
                     const QString totalFileSizeString = locale.formattedDataSize(totalSizeToCopy);
-                    progressDialog->setLabelText(QString("Coping file %1 of %2 (%3 of %4) ...").arg(QString::number(outNumCopiedFiles),
+                    progressDialog->setLabelText(QString("Copying file %1 of %2 (%3 of %4) ...").arg(QString::number(outNumCopiedFiles),
                         QString::number(filesToCopyCount),
                         copiedFileSizeString,
                         totalFileSizeString));


### PR DESCRIPTION
Changed "Coping file" to "Copying file" in ProjectUtils.cpp
resolves #2926 