### PR TITLE
[development] updated file regex when uploading latest tagged installer

### DIFF
--- a/cmake/Platform/Windows/PackagingPostBuild.cmake
+++ b/cmake/Platform/Windows/PackagingPostBuild.cmake
@@ -189,7 +189,7 @@ if(CPACK_AUTO_GEN_TAG)
     upload_to_s3(
         ${_latest_upload_url}
         ${_temp_dir}
-        "(${_non_versioned_exe}|build_tag.txt)$"
+        ".*(${_non_versioned_exe}|build_tag.txt)$"
     )
 
     # cleanup the temp files


### PR DESCRIPTION
The "Latest" tagged installer uploads were failing the file filter because the upload script now collects files as full path before performing the regex.

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>