### PR TITLE
Add LyShine gem runtime dependency for Material Editor in AutomatedTesting Project

### DIFF
--- a/AutomatedTesting/Gem/Code/CMakeLists.txt
+++ b/AutomatedTesting/Gem/Code/CMakeLists.txt
@@ -57,6 +57,12 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
         TARGETS Editor
         VARIANTS Tools)
 
+    # The Material Editor needs the Lyshine "Tools" gem variant for the custom LyShine pass
+    ly_enable_gems(
+        PROJECT_NAME AutomatedTesting GEMS LyShine
+        TARGETS MaterialEditor
+        VARIANTS Tools)
+
     # The pipeline tools use "Builders" gem variants:
     ly_enable_gems(
         PROJECT_NAME AutomatedTesting GEM_FILE enabled_gems.cmake


### PR DESCRIPTION
Since AutomatedTesting contains a MainPipeline.pass file that includes a custom LyShine pass, other tools need to have a runtime dependency on LyShine.

An alternative is to have the Material Editor depend on the same "tools" gems as the main Editor. This is a bigger task however that can be addressed in a separate PR. It requires some code and/or CMakeLists modification in certain gems that don't expect to be running in a tool other than the main Editor (ex. gems that need to be fixed up are EditorPythonBindings and Gestures).

Signed-off-by: abrmich <abrmich@amazon.com>