### PR TITLE
Fix for PathLib unlink wrong version parameter.

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -89,7 +89,7 @@
       "CONFIGURATION": "profile",
       "SCRIPT_PATH": "scripts/build/TestImpactAnalysis/tiaf_driver.py",
       "SCRIPT_PARAMETERS": 
-      "--config=\"!OUTPUT_DIRECTORY!/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=!BRANCH_NAME! --dst-branch=!BRANCH_NAME! --commit=!CHANGE_ID! --s3-bucket=!TEST_IMPACT_S3_BUCKET! --mars-index-prefix=jonawals --suite=main --test-failure-policy=continue"
+      "--config=\"!OUTPUT_DIRECTORY!/bin/TestImpactFramework/profile/Persistent/tiaf.json\" --src-branch=!BRANCH_NAME! --dst-branch=!CHANGE_TARGET! --commit=!CHANGE_ID! --s3-bucket=!TEST_IMPACT_S3_BUCKET! --mars-index-prefix=jonawals --suite=main --test-failure-policy=continue"
     }
   },
   "debug_vs2019": {

--- a/scripts/build/TestImpactAnalysis/git_utils.py
+++ b/scripts/build/TestImpactAnalysis/git_utils.py
@@ -32,7 +32,9 @@ class Repo:
 
         try:
             # Remove the existing file (if any) and create the parent directory
-            output_path.unlink(missing_ok=True)
+            # output_path.unlink(missing_ok=True) # missing_ok is only available in Python 3.8+
+            if output_path.is_file():
+                output_path.unlink()
             output_path.parent.mkdir(exist_ok=True)
         except EnvironmentError as e:
             raise RuntimeError(f"Could not create path for output file '{output_path}'")

--- a/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
@@ -48,12 +48,6 @@ class PersistentStorageS3(PersistentStorage):
             for object in self._bucket.objects.filter(Prefix=self._historic_data_key):
                 logger.info(f"Historic data found for branch '{branch}'.")
 
-                # Archive the existing object with the name of the existing last commit hash
-                archive_key = f"{self._dir}/archive/{self._last_commit_hash}.{object_extension}"
-                logger.info(f"Archiving existing historic data to {archive_key}...")
-                self._bucket.copy({"Bucket": self._bucket.name, "Key": self._historic_data_key}, archive_key)
-                logger.info(f"Archiving complete.")
-
                 # Decode the historic data object into raw bytes
                 logger.info(f"Attempting to decode historic data object...")
                 response = object.get()

--- a/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
@@ -76,7 +76,7 @@ class PersistentStorageS3(PersistentStorage):
         try:
             data = BytesIO(zlib.compress(bytes(historic_data_json, "UTF-8")))
             logger.info(f"Uploading historic data to location '{self._historic_data_key}'...")
-            self._bucket.upload_fileobj(data, self._historic_data_key)
+            self._bucket.upload_fileobj(data, self._historic_data_key, ExtraArgs={'ACL': 'bucket-owner-full-control'})
             logger.info("Upload complete.")
         except botocore.exceptions.BotoCoreError as e:
             logger.error(f"There was a problem with the s3 bucket: {e}")

--- a/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
@@ -52,10 +52,13 @@ class PersistentStorageS3(PersistentStorage):
                 archive_key = f"{self._dir}/archive/{self._last_commit_hash}.{object_extension}"
                 logger.info(f"Archiving existing historic data to {archive_key}...")
                 self._bucket.copy({"Bucket": self._bucket.name, "Key": self._historic_data_key}, archive_key)
+                logger.info(f"Archiving complete.")
 
                 # Decode the historic data object into raw bytes
+                logger.info(f"Attempting to decode historic data object...")
                 response = object.get()
                 file_stream = response['Body']
+                logger.info(f"Decoding complete.")
 
                 # Decompress and unpack the zipped historic data JSON
                 historic_data_json = zlib.decompress(file_stream.read()).decode('UTF-8')


### PR DESCRIPTION
The `missing_ok` parameter for `PathLib`'s `unlink()` method requires Python 3.8+ whereas we currently use version Python 3.7.10. This fix simply makes a call to `is_file()` before calling `unlink()`.

The unrelated commit with the change to the TIAF jenkins job has been OK'd my @amzn-changml offline and fixes the erroneous use of using `!BRANCH_NAME!` instead of `!CHANGE_TARGET!` for the `dst-branch` script parameter. This was causing all PR builds to seed but the fix will now correctly ensure PR builds draw from the appropriate destination branch's TIAF coverage data. Likewise, the archiving of the historical data objects in the S3 persistent storage has been removed as a) this was causing a permissions issue and b) the data in this bucket is no longer human accessible anyway.

Signed-off-by: John <jonawals@amazon.com>