### PR TITLE
[DO NOT MERGE] Experimental

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -81,9 +81,13 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 102; // ATOM-15472
-            // .shader file changes trigger rebuilds
-            shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+            shaderAssetBuilderDescriptor.m_version = 103; // ATOM-5441
+            // *.azsl, *.azsli, *.srgi are used to track source dependencies.
+            shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", ShaderAssetBuilder::azslExtension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+            shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", ShaderAssetBuilder::azsliExtension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+            shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", ShaderAssetBuilder::srgiExtension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+            // *.shader file changes trigger rebuilds
+            shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();
             shaderAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderAssetBuilder::CreateJobs, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
             shaderAssetBuilderDescriptor.m_processJobFunction = AZStd::bind(&ShaderAssetBuilder::ProcessJob, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -84,7 +84,7 @@ namespace AZ
             }
 
             AZStd::string hayStack;
-            hayStack.resize(stream.GetLength());
+            hayStack.resize_no_construct(stream.GetLength());
             stream.Read(stream.GetLength(), hayStack.data());
 
             AZStd::vector<AZStd::string> listOfFilePaths;
@@ -180,24 +180,6 @@ namespace AZ
                     ShaderAssetBuilderName, false, "Shader program listed as the source entry does not exist: %s.", azslFullPath.c_str());
                 response.m_result = AssetBuilderSDK::CreateJobsResultCode::Failed;
                 return;
-            }
-
-            auto outcome = GetListOfIncludedFiles(azslFullPath);
-            if (!outcome.IsSuccess())
-            {
-                AZ_Error(ShaderAssetBuilderName, false, outcome.GetError().c_str());
-                response.m_result = AssetBuilderSDK::CreateJobsResultCode::Failed;
-                return;
-            }
-            const auto listOfRelativePaths = outcome.TakeValue();
-            for (auto includePath : listOfRelativePaths)
-            {
-                // m_sourceFileDependencyList does not support paths with "." or ".." for relative lookup.
-                AzFramework::StringFunc::Path::Normalize(includePath);
-
-                AssetBuilderSDK::SourceFileDependency includeFileDependency;
-                includeFileDependency.m_sourceFileDependencyPath = includePath;
-                response.m_sourceFileDependencyList.emplace_back(includeFileDependency);
             }
 
             {

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.h
@@ -36,7 +36,12 @@ namespace AZ
         public:
             AZ_TYPE_INFO(ShaderAssetBuilder, "{C94DA151-82BC-4475-86FA-E6C92A0BD6F8}");
 
-            static constexpr const char* ShaderAssetBuilderJobKey = "Shader Asset";
+            // Common extensions that a .azsl file may #include.
+            static constexpr char azslExtension[] = "azsl"; // Yes, some azsl files include other azsl files.
+            static constexpr char azsliExtension[] = "azsli"; // This is the most commonly included file type.
+            static constexpr char srgiExtension[] = "srgi";
+
+            static constexpr char ShaderAssetBuilderJobKey[] = "Shader Asset";
 
             ShaderAssetBuilder() = default;
             ~ShaderAssetBuilder() = default;

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/README.md
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/README.md
@@ -14,7 +14,7 @@ The preprocessor that works on behalf of the Shader Compiler defines the followi
 2.1. Folders specified in \<DevFolder>/AssetProcessorPlatformConfig.ini  
 2.2. The Asset/ subdirectory within each Gem enabled for the Game Project. (Recursive). Examples:  
 2.2.1. \<DevFolder>/Gems/Atom/Asset/  
-2.2.2. \<DevFolder>/Gems/Camera/Asset/
+2.2.2. \<DevFolder>/Gems/Camera/Asset/  
 2.3. The root folder of each Gem enabled for the Game Project. (Non Recursive). Examples:  
 2.2.1. \<DevFolder>/Gems/Atom/  
 2.2.2. \<DevFolder>/Gems/Camera/


### PR DESCRIPTION
[ATOM-5441] Shader Builders May Fail When Multiple New Files Are Added

The ShaderAssetBuilder now reports source dependencies directly
by parsing *.azsl, *.azsli & *.srgi files instead of using MCPP
in CreateJobs().

Signed-off-by: garrieta <garrieta@amazon.com>