### PR TITLE
Hide RenderDoc integration behind LY_RENDERDOC_ENABLED option

### DIFF
--- a/Gems/Atom/RHI/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Code/CMakeLists.txt
@@ -11,20 +11,19 @@ ly_get_list_relative_pal_filename(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Sourc
 
 include(${pal_dir}/AtomRHITests_traits_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
+set(LY_RENDERDOC_ENABLED OFF CACHE BOOL "Enable RenderDoc integration.")
 set(RENDERDOC_CMAKE ${CMAKE_CURRENT_SOURCE_DIR}/${pal_dir}/renderdoc_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 if(EXISTS ${RENDERDOC_CMAKE})
     include(${RENDERDOC_CMAKE})
 endif()
 
-if(TARGET "3rdParty::renderdoc")
+if(LY_RENDERDOC_ENABLED AND TARGET "3rdParty::renderdoc")
     message(STATUS "Renderdoc found, adding as runtime dependency")
     set(USE_RENDERDOC_DEFINE "USE_RENDERDOC")
     set(RENDERDOC_BUILD_DEPENDENCY "3rdParty::renderdoc")
-    set(RENDERDOC_API_DEPENDENCY "3rdParty::renderdoc_api")
 else()
     set(USE_RENDERDOC_DEFINE "")
     set(RENDERDOC_BUILD_DEPENDENCY "")
-    set(RENDERDOC_API_DEPENDENCY "")
 endif()
 
 ly_add_target(
@@ -62,9 +61,8 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
             Gem::Atom_RHI.Reflect
-            ${RENDERDOC_BUILD_DEPENDENCY}
         PUBLIC
-            ${RENDERDOC_API_DEPENDENCY}
+            ${RENDERDOC_BUILD_DEPENDENCY}
     COMPILE_DEFINITIONS
         PUBLIC
             ${USE_RENDERDOC_DEFINE}

--- a/Gems/Atom/RHI/Code/Platform/Linux/renderdoc_linux.cmake
+++ b/Gems/Atom/RHI/Code/Platform/Linux/renderdoc_linux.cmake
@@ -24,13 +24,6 @@ if(NOT LY_MONOLITHIC_GAME)
                 INCLUDE_DIRECTORIES "."
                 RUNTIME_DEPENDENCIES "${RENDERDOC_PATH}/librenderdoc.so"
             )
-
-            ly_add_external_target(
-                NAME renderdoc_api
-                VERSION
-                3RDPARTY_ROOT_DIRECTORY ${RENDERDOC_PATH}
-                INCLUDE_DIRECTORIES "."
-            )
         endif()
     endif()
 endif()

--- a/Gems/Atom/RHI/Code/Platform/Windows/renderdoc_windows.cmake
+++ b/Gems/Atom/RHI/Code/Platform/Windows/renderdoc_windows.cmake
@@ -9,7 +9,7 @@
 # Prevent bundling the renderdoc dll with a packaged title
 if(NOT LY_MONOLITHIC_GAME)
     # Common installation path for renderdoc path
-    set(RENDERDOC_PATH "C:/Program Files/RenderDoc")
+    set(RENDERDOC_PATH "$ENV{PROGRAMFILES}/RenderDoc")
     if(DEFINED ENV{"ATOM_RENDERDOC_PATH"})
         set(RENDERDOC_PATH ENV{"ATOM_RENDERDOC_PATH"})
     endif()
@@ -25,13 +25,6 @@ if(NOT LY_MONOLITHIC_GAME)
                 3RDPARTY_ROOT_DIRECTORY ${RENDERDOC_PATH}
                 INCLUDE_DIRECTORIES "."
                 RUNTIME_DEPENDENCIES "${RENDERDOC_PATH}/renderdoc.dll"
-            )
-
-            ly_add_external_target(
-                NAME renderdoc_api
-                VERSION
-                3RDPARTY_ROOT_DIRECTORY ${RENDERDOC_PATH}
-                INCLUDE_DIRECTORIES "."
             )
         endif()
     endif()


### PR DESCRIPTION
Temporary workaround for #2990 