### PR TITLE
Atom/antonmic/pass builder

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -139,8 +139,7 @@ namespace AZ
 
                 AssetBuilderSDK::JobDescriptor jobDescriptor;
                 jobDescriptor.m_priority = 2;
-                // [GFX TODO][ATOM-2830] Set 'm_critical' back to 'false' once proper fix for Atom startup issues are in 
-                jobDescriptor.m_critical = true;
+                jobDescriptor.m_critical = false;
                 jobDescriptor.m_jobKey = ShaderAssetBuilderJobKey;
                 jobDescriptor.SetPlatformIdentifier(platformInfo.m_identifier.c_str());
                 jobDescriptor.m_jobParameters.emplace(ShaderAssetBuildTimestampParam, AZStd::to_string(shaderAssetBuildTimestamp));

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -321,7 +321,7 @@ namespace AZ
                     AssetBuilderSDK::JobDescriptor jobDescriptor;
 
                     jobDescriptor.m_priority = -5000;
-                    jobDescriptor.m_critical = false;
+                    jobDescriptor.m_critical = true;
                     jobDescriptor.m_jobKey = ShaderVariantAssetBuilderJobKey;
                     jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
                     

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderVariantAssetBuilder.cpp
@@ -321,7 +321,7 @@ namespace AZ
                     AssetBuilderSDK::JobDescriptor jobDescriptor;
 
                     jobDescriptor.m_priority = -5000;
-                    jobDescriptor.m_critical = true;
+                    jobDescriptor.m_critical = false;
                     jobDescriptor.m_jobKey = ShaderVariantAssetBuilderJobKey;
                     jobDescriptor.SetPlatformIdentifier(info.m_identifier.data());
                     

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.cpp
@@ -322,7 +322,7 @@ namespace AZ
         {
             const char* auxGeomWorldShaderFilePath = "Shaders/auxgeom/auxgeomworld.azshader";
 
-            m_shader = RPI::LoadShader(auxGeomWorldShaderFilePath);
+            m_shader = RPI::LoadCriticalShader(auxGeomWorldShaderFilePath);
             if (!m_shader)
             {
                 AZ_Error("DynamicPrimitiveProcessor", false, "Failed to get shader");

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -1385,9 +1385,9 @@ namespace AZ
             const char* litObjectShaderFilePath = "Shaders/auxgeom/auxgeomobjectlit.azshader";
 
             // constant color shader
-            m_unlitShader = RPI::LoadShader(unlitObjectShaderFilePath);
+            m_unlitShader = RPI::LoadCriticalShader(unlitObjectShaderFilePath);
             // direction light shader
-            m_litShader = RPI::LoadShader(litObjectShaderFilePath);
+            m_litShader = RPI::LoadCriticalShader(litObjectShaderFilePath);
 
             if (m_unlitShader.get() == nullptr || m_litShader == nullptr)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridBlendDistancePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridBlendDistancePass.cpp
@@ -38,7 +38,7 @@ namespace AZ
             // load shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBlendDistance.azshader";
-            m_shader = RPI::LoadShader(shaderFilePath);
+            m_shader = RPI::LoadCriticalShader(shaderFilePath);
             if (m_shader == nullptr)
             {
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridBlendIrradiancePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridBlendIrradiancePass.cpp
@@ -38,7 +38,7 @@ namespace AZ
             // load shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBlendIrradiance.azshader";
-            m_shader = RPI::LoadShader(shaderFilePath);
+            m_shader = RPI::LoadCriticalShader(shaderFilePath);
             if (m_shader == nullptr)
             {
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridBorderUpdatePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridBorderUpdatePass.cpp
@@ -51,7 +51,7 @@ namespace AZ
         {
             // load shader
             // Note: the shader may not be available on all platforms
-            shader = RPI::LoadShader(shaderFilePath);
+            shader = RPI::LoadCriticalShader(shaderFilePath);
             if (shader == nullptr)
             {
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridClassificationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridClassificationPass.cpp
@@ -42,7 +42,7 @@ namespace AZ
             // load shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridClassification.azshader";
-            m_shader = RPI::LoadShader(shaderFilePath);
+            m_shader = RPI::LoadCriticalShader(shaderFilePath);
             if (m_shader == nullptr)
             {
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
@@ -74,7 +74,7 @@ namespace AZ
 
             // load shader
             // Note: the shader may not be available on all platforms
-            Data::Instance<RPI::Shader> shader = RPI::LoadShader("Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRender.azshader");
+            Data::Instance<RPI::Shader> shader = RPI::LoadCriticalShader("Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRender.azshader");
             if (shader)
             {
                 m_probeGridRenderData.m_drawListTag = shader->GetDrawListTag();

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingPass.cpp
@@ -52,7 +52,7 @@ namespace AZ
             // load the ray tracing shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracing.azshader";
-            m_rayTracingShader = RPI::LoadShader(shaderFilePath);
+            m_rayTracingShader = RPI::LoadCriticalShader(shaderFilePath);
             if (m_rayTracingShader == nullptr)
             {
                 return;
@@ -64,7 +64,7 @@ namespace AZ
 
             // closest hit shader
             AZStd::string closestHitShaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingClosestHit.azshader";
-            m_closestHitShader = RPI::LoadShader(closestHitShaderFilePath);
+            m_closestHitShader = RPI::LoadCriticalShader(closestHitShaderFilePath);
 
             auto closestHitShaderVariant = m_closestHitShader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId);
             RHI::PipelineStateDescriptorForRayTracing closestHitShaderDescriptor;
@@ -72,7 +72,7 @@ namespace AZ
 
             // miss shader
             AZStd::string missShaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingMiss.azshader";
-            m_missShader = RPI::LoadShader(missShaderFilePath);
+            m_missShader = RPI::LoadCriticalShader(missShaderFilePath);
 
             auto missShaderVariant = m_missShader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId);
             RHI::PipelineStateDescriptorForRayTracing missShaderDescriptor;

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRelocationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRelocationPass.cpp
@@ -42,7 +42,7 @@ namespace AZ
             // load shader
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRelocation.azshader";
-            m_shader = RPI::LoadShader(shaderFilePath);
+            m_shader = RPI::LoadCriticalShader(shaderFilePath);
             if (m_shader == nullptr)
             {
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRenderPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridRenderPass.cpp
@@ -30,7 +30,7 @@ namespace AZ
             // create the shader resource group
             // Note: the shader may not be available on all platforms
             AZStd::string shaderFilePath = "Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRender.azshader";
-            m_shader = RPI::LoadShader(shaderFilePath);
+            m_shader = RPI::LoadCriticalShader(shaderFilePath);
             if (m_shader == nullptr)
             {
                 return;

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -446,7 +446,7 @@ namespace AZ
             }
 
             {
-                m_shader = RPI::LoadShader(ImguiShaderFilePath);
+                m_shader = RPI::LoadCriticalShader(ImguiShaderFilePath);
 
                 m_pipelineState = aznew RPI::PipelineStateForDraw;
                 m_pipelineState->Init(m_shader);

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -487,7 +487,7 @@ namespace AZ
             RHI::DrawListTag& drawListTag)
         {
             // load shader
-            shader = RPI::LoadShader(filePath);
+            shader = RPI::LoadCriticalShader(filePath);
             AZ_Error("ReflectionProbeFeatureProcessor", shader, "Failed to find asset for shader [%s]", filePath);
 
             // store drawlist tag

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -52,7 +52,7 @@ namespace AZ
 
             // load shaders
             AZStd::string verticalBlurShaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceBlurVertical.azshader";
-            Data::Instance<AZ::RPI::Shader> verticalBlurShader = RPI::LoadShader(verticalBlurShaderFilePath);
+            Data::Instance<AZ::RPI::Shader> verticalBlurShader = RPI::LoadCriticalShader(verticalBlurShaderFilePath);
             if (verticalBlurShader == nullptr)
             {
                 AZ_Error("PassSystem", false, "[ReflectionScreenSpaceBlurPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), verticalBlurShaderFilePath.c_str());
@@ -60,7 +60,7 @@ namespace AZ
             }
 
             AZStd::string horizontalBlurShaderFilePath = "Shaders/Reflections/ReflectionScreenSpaceBlurHorizontal.azshader";
-            Data::Instance<AZ::RPI::Shader> horizontalBlurShader = RPI::LoadShader(horizontalBlurShaderFilePath);
+            Data::Instance<AZ::RPI::Shader> horizontalBlurShader = RPI::LoadCriticalShader(horizontalBlurShaderFilePath);
             if (horizontalBlurShader == nullptr)
             {
                 AZ_Error("PassSystem", false, "[ReflectionScreenSpaceBlurPass '%s']: Failed to load shader '%s'!", GetPathName().GetCStr(), horizontalBlurShaderFilePath.c_str());

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPIUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPIUtils.h
@@ -22,19 +22,21 @@ namespace AZ
         class Shader;
 
         //! Get the asset ID for a given shader file path
-        Data::AssetId GetShaderAssetId(const AZStd::string& shaderFilePath);
+        Data::AssetId GetShaderAssetId(const AZStd::string& shaderFilePath, bool isCritical = false);
 
         //! Finds a shader asset for the given shader asset ID. Optional shaderFilePath param for debugging.
         Data::Asset<ShaderAsset> FindShaderAsset(Data::AssetId shaderAssetId, const AZStd::string& shaderFilePath = "");
 
         //! Finds a shader asset for the given shader file path
         Data::Asset<ShaderAsset> FindShaderAsset(const AZStd::string& shaderFilePath);
+        Data::Asset<ShaderAsset> FindCriticalShaderAsset(const AZStd::string& shaderFilePath);
 
         //! Loads a shader for the given shader asset ID. Optional shaderFilePath param for debugging.
         Data::Instance<Shader> LoadShader(Data::AssetId shaderAssetId, const AZStd::string& shaderFilePath = "");
 
         //! Loads a shader for the given shader file path
         Data::Instance<Shader> LoadShader(const AZStd::string& shaderFilePath);
+        Data::Instance<Shader> LoadCriticalShader(const AZStd::string& shaderFilePath);
 
         //! Loads a streaming image asset for the given file path
         Data::Instance<RPI::StreamingImage> LoadStreamingTexture(AZStd::string_view path);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Pass/PassBuilder.h
@@ -37,7 +37,6 @@ namespace AZ
             void RegisterBuilder();
 
         private:
-            bool FindPassReferencedAssets(void* objectPtr, Uuid passAssetUuid, SerializeContext* context, AZStd::unordered_set<Data::AssetId> &referencedAssetList) const;
             bool m_isShuttingDown = false;
         };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -121,7 +121,7 @@ namespace AZ
 
             // Load shader and srg
             const char* ShaderPath = "shader/decomposemsimage.azshader";
-            m_decomposeShader = LoadShader(ShaderPath);
+            m_decomposeShader = LoadCriticalShader(ShaderPath);
 
             if (m_decomposeShader == nullptr)
             {

--- a/Gems/Atom/RPI/Code/Tests.Builders/PassBuilderTest.cpp
+++ b/Gems/Atom/RPI/Code/Tests.Builders/PassBuilderTest.cpp
@@ -112,9 +112,6 @@ namespace UnitTest
         EXPECT_TRUE(response.m_resultCode == AssetBuilderSDK::ProcessJobResult_Success);
         EXPECT_TRUE(response.m_outputProducts.size() == 1);
 
-        // Verify the dependency was registered
-        EXPECT_TRUE(response.m_outputProducts[0].m_dependencies.size() == 1);
-
         // Verify input and output names are the same
         Data::Asset<Data::AssetData> readAsset = LoadAssetFromFile(response.m_outputProducts[0].m_productFileName.c_str());
         RPI::PassAsset* readPassAsset = static_cast<RPI::PassAsset*>(readAsset.GetData());

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -79,7 +79,7 @@ void CDraw2d::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstrapSc
 
     // Load the shader to be used for 2d drawing
     const char* shaderFilepath = "Shaders/SimpleTextured.azshader";
-    AZ::Data::Instance<AZ::RPI::Shader> shader = AZ::RPI::LoadShader(shaderFilepath);
+    AZ::Data::Instance<AZ::RPI::Shader> shader = AZ::RPI::LoadCriticalShader(shaderFilepath);
 
     // Set scene to be associated with the dynamic draw context
     AZ::RPI::ScenePtr scene;

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -58,7 +58,7 @@ void UiRenderer::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstra
 
     // Load the UI shader
     const char* uiShaderFilepath = "Shaders/LyShineUI.azshader";
-    AZ::Data::Instance<AZ::RPI::Shader> uiShader = AZ::RPI::LoadShader(uiShaderFilepath);
+    AZ::Data::Instance<AZ::RPI::Shader> uiShader = AZ::RPI::LoadCriticalShader(uiShaderFilepath);
 
     // Create scene to be used by the dynamic draw context
     if (m_viewportContext)


### PR DESCRIPTION
See https://github.com/o3de/o3de/issues/2402
PassBuilder now finds .shader references in Create Jobs phase and correctly sets them as job dependencies.
Removed critical flag from shader jobs as it is no longer needed.
Added a LoadCriticalShader method to block on load, this was needed to avoid crashing when the shader builder critical job flag was removed.
Tested: can now start the editor with an empty cache and it will correctly wait until all the passes and their respective dependent shaders are ready.