### PR TITLE
[SPEC-7971] Update gem module name to match cmake target name

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientModule.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientModule.cpp
@@ -42,4 +42,4 @@ namespace AWSGameLift
     };
 }// namespace AWSGameLift
 
-AZ_DECLARE_MODULE_CLASS(Gem_AWSGameLift_Client, AWSGameLift::AWSGameLiftClientModule)
+AZ_DECLARE_MODULE_CLASS(Gem_AWSGameLift_Clients, AWSGameLift::AWSGameLiftClientModule)

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerModule.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerModule.cpp
@@ -42,4 +42,4 @@ namespace AWSGameLift
     };
 }// namespace AWSGameLift
 
-AZ_DECLARE_MODULE_CLASS(Gem_AWSGameLift_Server, AWSGameLift::AWSGameLiftServerModule)
+AZ_DECLARE_MODULE_CLASS(Gem_AWSGameLift_Servers, AWSGameLift::AWSGameLiftServerModule)

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugModule.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugModule.cpp
@@ -28,4 +28,4 @@ namespace Multiplayer
     }
 }
 
-AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_Imgui, Multiplayer::MultiplayerDebugModule);
+AZ_DECLARE_MODULE_CLASS(Gem_Multiplayer_Debug, Multiplayer::MultiplayerDebugModule);


### PR DESCRIPTION
## Details
It is expected that gem module name match cmake target name

```
ly_add_target(
    NAME AWSGameLift.Clients ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
    NAMESPACE Gem
```

```
ly_add_target(
    NAME AWSGameLift.Servers ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
    NAMESPACE Gem
```

```
ly_add_target(
    NAME Multiplayer.Debug ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
    NAMESPACE Gem
```

Signed-off-by: onecent1101 <liug@amazon.com>