### PR TITLE
AtomTools: fixing status bar messages

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -16,8 +16,8 @@
 #include <AzQtComponents/Components/StyledDockWidget.h>
 #include <AzQtComponents/Components/Widgets/TabWidget.h>
 
+#include <QLabel>
 #include <QMenuBar>
-#include <QStatusBar>
 #include <QToolBar>
 
 namespace AtomToolsFramework
@@ -53,10 +53,9 @@ namespace AtomToolsFramework
         virtual void SelectNextTab();
 
         AzQtComponents::FancyDocking* m_advancedDockManager = nullptr;
-        QWidget* m_centralWidget = nullptr;
         QMenuBar* m_menuBar = nullptr;
         AzQtComponents::TabWidget* m_tabWidget = nullptr;
-        QStatusBar* m_statusBar = nullptr;
+        QLabel* m_statusMessage = nullptr;
 
         AZStd::unordered_map<AZStd::string, AzQtComponents::StyledDockWidget*> m_dockWidgets;
     };

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
+#include <QStatusBar>
+#include <QVBoxLayout>
 
 namespace AtomToolsFramework
 {
@@ -21,11 +23,15 @@ namespace AtomToolsFramework
         setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
         setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
 
-        m_statusBar = new QStatusBar(this);
-        m_statusBar->setObjectName("StatusBar");
-        statusBar()->addPermanentWidget(m_statusBar, 1);
+        m_statusMessage = new QLabel(statusBar());
+        statusBar()->addPermanentWidget(m_statusMessage, 1);
 
-        m_centralWidget = new QWidget(this);
+        auto centralWidget = new QWidget(this);
+        auto centralWidgetLayout = new QVBoxLayout(centralWidget);
+        centralWidgetLayout->setMargin(0);
+        centralWidgetLayout->setContentsMargins(0, 0, 0, 0);
+        centralWidget->setLayout(centralWidgetLayout);
+        setCentralWidget(centralWidget);
 
         AtomToolsMainWindowRequestBus::Handler::BusConnect();
     }
@@ -111,7 +117,7 @@ namespace AtomToolsFramework
 
     void AtomToolsMainWindow::CreateTabBar()
     {
-        m_tabWidget = new AzQtComponents::TabWidget(m_centralWidget);
+        m_tabWidget = new AzQtComponents::TabWidget(centralWidget());
         m_tabWidget->setObjectName("TabWidget");
         m_tabWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
         m_tabWidget->setContentsMargins(0, 0, 0, 0);
@@ -131,6 +137,8 @@ namespace AtomToolsFramework
             {
                 OpenTabContextMenu();
             });
+
+        centralWidget()->layout()->addWidget(m_tabWidget);
     }
 
     void AtomToolsMainWindow::AddTabForDocumentId(

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
@@ -416,7 +416,7 @@ namespace MaterialEditor
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to perform Undo on document: %1").arg(documentPath);
+                const QString status = QString("Failed to perform undo on document: %1").arg(documentPath);
                 m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Undo);
@@ -428,7 +428,7 @@ namespace MaterialEditor
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to perform Redo on document: %1").arg(documentPath);
+                const QString status = QString("Failed to perform redo on document: %1").arg(documentPath);
                 m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Redo);

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
@@ -36,8 +36,6 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 #include <QCloseEvent>
 #include <QDesktopWidget>
 #include <QFileDialog>
-#include <QVBoxLayout>
-#include <QVariant>
 #include <QWindow>
 AZ_POP_DISABLE_WARNING
 
@@ -77,20 +75,13 @@ namespace MaterialEditor
         m_toolBar->setObjectName("ToolBar");
         addToolBar(m_toolBar);
 
-        m_materialViewport = new MaterialViewportWidget(m_centralWidget);
-        m_materialViewport->setObjectName("Viewport");
-        m_materialViewport->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
-
         CreateMenu();
         CreateTabBar();
 
-        QVBoxLayout* vl = new QVBoxLayout(m_centralWidget);
-        vl->setMargin(0);
-        vl->setContentsMargins(0, 0, 0, 0);
-        vl->addWidget(m_tabWidget);
-        vl->addWidget(m_materialViewport);
-        m_centralWidget->setLayout(vl);
-        setCentralWidget(m_centralWidget);
+        m_materialViewport = new MaterialViewportWidget(centralWidget());
+        m_materialViewport->setObjectName("Viewport");
+        m_materialViewport->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+        centralWidget()->layout()->addWidget(m_materialViewport);
 
         AddDockWidget("Asset Browser", new MaterialBrowserWidget, Qt::BottomDockWidgetArea, Qt::Vertical);
         AddDockWidget("Inspector", new MaterialInspector, Qt::RightDockWidgetArea, Qt::Horizontal);
@@ -200,7 +191,7 @@ namespace MaterialEditor
             // Create a new tab for the document ID and assign it's label to the file name of the document.
             AddTabForDocumentId(documentId, filename, absolutePath, [this]{
                 // The tab widget requires a dummy page per tab
-                auto contentWidget = new QWidget(m_centralWidget);
+                auto contentWidget = new QWidget(centralWidget());
                 contentWidget->setContentsMargins(0, 0, 0, 0);
                 contentWidget->setFixedSize(0, 0);
                 return contentWidget;
@@ -247,8 +238,8 @@ namespace MaterialEditor
         const QString documentPath = GetDocumentPath(documentId);
         if (!documentPath.isEmpty())
         {
-            const QString status = QString("Material closed: %1").arg(documentPath);
-            m_statusBar->setWindowIconText(QString("<font color=\"White\">%1</font>").arg(status));
+            const QString status = QString("Document closed: %1").arg(documentPath);
+            m_statusMessage->setText(QString("<font color=\"White\">%1</font>").arg(status));
         }
     }
 
@@ -257,8 +248,8 @@ namespace MaterialEditor
         RemoveTabForDocumentId(documentId);
 
         const QString documentPath = GetDocumentPath(documentId);
-        const QString status = QString("Material closed: %1").arg(documentPath);
-        m_statusBar->setWindowIconText(QString("<font color=\"White\">%1</font>").arg(status));
+        const QString status = QString("Document closed: %1").arg(documentPath);
+        m_statusMessage->setText(QString("<font color=\"White\">%1</font>").arg(status));
     }
 
     void MaterialEditorWindow::OnDocumentModified(const AZ::Uuid& documentId)
@@ -296,8 +287,8 @@ namespace MaterialEditor
         UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
 
         const QString documentPath = GetDocumentPath(documentId);
-        const QString status = QString("Material closed: %1").arg(documentPath);
-        m_statusBar->setWindowIconText(QString("<font color=\"White\">%1</font>").arg(status));
+        const QString status = QString("Document closed: %1").arg(documentPath);
+        m_statusMessage->setText(QString("<font color=\"White\">%1</font>").arg(status));
     }
 
     void MaterialEditorWindow::CreateMenu()
@@ -341,8 +332,8 @@ namespace MaterialEditor
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to save material: %1").arg(documentPath);
-                m_statusBar->setWindowIconText(QString("<font color=\"Red\">%1</font>").arg(status));
+                const QString status = QString("Failed to save document: %1").arg(documentPath);
+                m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Save);
 
@@ -355,8 +346,8 @@ namespace MaterialEditor
                 documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
             if (!result)
             {
-                const QString status = QString("Failed to save material: %1").arg(documentPath);
-                m_statusBar->setWindowIconText(QString("<font color=\"Red\">%1</font>").arg(status));
+                const QString status = QString("Failed to save document: %1").arg(documentPath);
+                m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::SaveAs);
 
@@ -369,8 +360,8 @@ namespace MaterialEditor
                 documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
             if (!result)
             {
-                const QString status = QString("Failed to save material: %1").arg(documentPath);
-                m_statusBar->setWindowIconText(QString("<font color=\"Red\">%1</font>").arg(status));
+                const QString status = QString("Failed to save document: %1").arg(documentPath);
+                m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         });
 
@@ -379,8 +370,8 @@ namespace MaterialEditor
             MaterialDocumentSystemRequestBus::BroadcastResult(result, &MaterialDocumentSystemRequestBus::Events::SaveAllDocuments);
             if (!result)
             {
-                const QString status = QString("Failed to save materials.");
-                m_statusBar->setWindowIconText(QString("<font color=\"Red\">%1</font>").arg(status));
+                const QString status = QString("Failed to save documents.");
+                m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         });
 
@@ -425,8 +416,8 @@ namespace MaterialEditor
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to perform Undo in material: %1").arg(documentPath);
-                m_statusBar->setWindowIconText(QString("<font color=\"Red\">%1</font>").arg(status));
+                const QString status = QString("Failed to perform Undo on document: %1").arg(documentPath);
+                m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Undo);
 
@@ -437,8 +428,8 @@ namespace MaterialEditor
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to perform Undo in material: %1").arg(documentPath);
-                m_statusBar->setWindowIconText(QString("<font color=\"Red\">%1</font>").arg(status));
+                const QString status = QString("Failed to perform Redo on document: %1").arg(documentPath);
+                m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Redo);
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -278,7 +278,7 @@ namespace ShaderManagementConsole
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to perform Undo on document: %1").arg(documentPath);
+                const QString status = QString("Failed to perform undo on document: %1").arg(documentPath);
                 m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Undo);
@@ -290,7 +290,7 @@ namespace ShaderManagementConsole
             if (!result)
             {
                 const QString documentPath = GetDocumentPath(documentId);
-                const QString status = QString("Failed to perform Redo on document: %1").arg(documentPath);
+                const QString status = QString("Failed to perform redo on document: %1").arg(documentPath);
                 m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(status));
             }
         }, QKeySequence::Redo);

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -52,6 +52,9 @@ namespace ShaderManagementConsole
 
         void CreateMenu() override;
         void CreateTabBar() override;
+
+        QString GetDocumentPath(const AZ::Uuid& documentId) const;
+
         void OpenTabContextMenu() override;
 
         void SelectDocumentForTab(const int tabIndex);


### PR DESCRIPTION
fixed problems with status bar messages not appearing
added status bar messages to shader management console
got rid of central widget variable and moved layout to atom tools window base class
added window save state to shader management console