### PR TITLE
Allow project path changing and auto-completion

### DIFF
--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.cpp
@@ -39,7 +39,7 @@ namespace O3DE::ProjectManager
     NewProjectSettingsScreen::NewProjectSettingsScreen(QWidget* parent)
         : ProjectSettingsScreen(parent)
     {
-        const QString defaultName{ "NewProject" };
+        const QString defaultName = GetDefaultProjectName();
         const QString defaultPath = QDir::toNativeSeparators(GetDefaultProjectPath() + "/" + defaultName);
 
         m_projectName->lineEdit()->setText(defaultName);
@@ -162,6 +162,17 @@ namespace O3DE::ProjectManager
         return defaultPath;
     }
 
+    QString NewProjectSettingsScreen::GetDefaultProjectName()
+    {
+        return "NewProject";
+    }
+
+    QString NewProjectSettingsScreen::GetProjectAutoPath()
+    {
+        const QString projectName = m_projectName->lineEdit()->text();
+        return QDir::toNativeSeparators(GetDefaultProjectPath() + "/" + projectName);
+    }
+
     ProjectManagerScreen NewProjectSettingsScreen::GetScreenEnum()
     {
         return ProjectManagerScreen::NewProjectSettings;
@@ -260,4 +271,22 @@ namespace O3DE::ProjectManager
             m_projectTemplateButtonGroup->blockSignals(false);
         }
     }
+    void NewProjectSettingsScreen::OnProjectNameUpdated()
+    {
+        if (ValidateProjectName() && !m_userChangedProjectPath)
+        {
+            m_projectPath->setText(GetProjectAutoPath());
+        }
+    }
+
+    void NewProjectSettingsScreen::OnProjectPathUpdated()
+    {
+        const QString defaultPath = QDir::toNativeSeparators(GetDefaultProjectPath() + "/" + GetDefaultProjectName());
+        const QString autoPath = GetProjectAutoPath();
+        const QString path = m_projectPath->lineEdit()->text();
+        m_userChangedProjectPath = path != defaultPath && path != autoPath;
+
+        ValidateProjectPath();
+    }
+
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.h
+++ b/Code/Tools/ProjectManager/Source/NewProjectSettingsScreen.h
@@ -40,8 +40,14 @@ namespace O3DE::ProjectManager
     signals:
         void OnTemplateSelectionChanged(int oldIndex, int newIndex);
 
+    protected:
+        void OnProjectNameUpdated() override;
+        void OnProjectPathUpdated() override;
+
     private:
+        QString GetDefaultProjectName();
         QString GetDefaultProjectPath();
+        QString GetProjectAutoPath();
         QFrame* CreateTemplateDetails(int margin);
         void UpdateTemplateDetails(const ProjectTemplateInfo& templateInfo);
 
@@ -51,6 +57,7 @@ namespace O3DE::ProjectManager
         TagContainerWidget* m_templateIncludedGems;
         QVector<ProjectTemplateInfo> m_templates;
         int m_selectedTemplateIndex = -1;
+        bool m_userChangedProjectPath = false;
 
         inline constexpr static int s_spacerSize = 20;
         inline constexpr static int s_templateDetailsContentMargin = 20;

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
@@ -117,7 +117,7 @@ namespace O3DE::ProjectManager
         if (!path.isAbsolute())
         {
             projectPathIsValid = false;
-            m_projectPath->setErrorLabelText(tr("Please provide a valid location."));
+            m_projectPath->setErrorLabelText(tr("Please provide an absolute path for the project location."));
         }
         else if (path.exists() && !path.isEmpty())
         {

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.cpp
@@ -40,12 +40,11 @@ namespace O3DE::ProjectManager
         m_verticalLayout->setAlignment(Qt::AlignTop);
 
         m_projectName = new FormLineEditWidget(tr("Project name"), "", this);
-        connect(m_projectName->lineEdit(), &QLineEdit::textChanged, this, &ProjectSettingsScreen::ValidateProjectName);
+        connect(m_projectName->lineEdit(), &QLineEdit::textChanged, this, &ProjectSettingsScreen::OnProjectNameUpdated);
         m_verticalLayout->addWidget(m_projectName);
 
         m_projectPath = new FormFolderBrowseEditWidget(tr("Project Location"), "", this);
-        m_projectPath->lineEdit()->setReadOnly(true);
-        connect(m_projectPath->lineEdit(), &QLineEdit::textChanged, this, &ProjectSettingsScreen::Validate);
+        connect(m_projectPath->lineEdit(), &QLineEdit::textChanged, this, &ProjectSettingsScreen::OnProjectPathUpdated);
         m_verticalLayout->addWidget(m_projectPath);
 
         projectSettingsFrame->setLayout(m_verticalLayout);
@@ -110,26 +109,34 @@ namespace O3DE::ProjectManager
         m_projectName->setErrorLabelVisible(!projectNameIsValid);
         return projectNameIsValid;
     }
+
     bool ProjectSettingsScreen::ValidateProjectPath()
     {
         bool projectPathIsValid = true;
-        if (m_projectPath->lineEdit()->text().isEmpty())
+        QDir path(m_projectPath->lineEdit()->text());
+        if (!path.isAbsolute())
         {
             projectPathIsValid = false;
             m_projectPath->setErrorLabelText(tr("Please provide a valid location."));
         }
-        else
+        else if (path.exists() && !path.isEmpty())
         {
-            QDir path(m_projectPath->lineEdit()->text());
-            if (path.exists() && !path.isEmpty())
-            {
-                projectPathIsValid = false;
-                m_projectPath->setErrorLabelText(tr("This folder exists and isn't empty.  Please choose a different location."));
-            }
+            projectPathIsValid = false;
+            m_projectPath->setErrorLabelText(tr("This folder exists and isn't empty.  Please choose a different location."));
         }
 
         m_projectPath->setErrorLabelVisible(!projectPathIsValid);
         return projectPathIsValid;
+    }
+
+    void ProjectSettingsScreen::OnProjectNameUpdated()
+    {
+        ValidateProjectName();
+    }
+
+    void ProjectSettingsScreen::OnProjectPathUpdated()
+    {
+        Validate();
     }
 
     bool ProjectSettingsScreen::Validate()

--- a/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.h
+++ b/Code/Tools/ProjectManager/Source/ProjectSettingsScreen.h
@@ -33,10 +33,13 @@ namespace O3DE::ProjectManager
         virtual bool Validate();
 
     protected slots:
-        virtual bool ValidateProjectName();
-        virtual bool ValidateProjectPath();
+        virtual void OnProjectNameUpdated();
+        virtual void OnProjectPathUpdated();
 
     protected:
+        bool ValidateProjectName();
+        virtual bool ValidateProjectPath();
+
         QString GetDefaultProjectPath();
 
         QHBoxLayout* m_horizontalLayout;

--- a/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
@@ -108,7 +108,8 @@ namespace O3DE::ProjectManager
     bool UpdateProjectSettingsScreen::ValidateProjectPath()
     {
         bool projectPathIsValid = true;
-        if (m_projectPath->lineEdit()->text().isEmpty())
+        QDir path(m_projectPath->lineEdit()->text());
+        if (!path.isAbsolute())
         {
             projectPathIsValid = false;
             m_projectPath->setErrorLabelText(tr("Please provide a valid location."));

--- a/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectSettingsScreen.cpp
@@ -112,7 +112,7 @@ namespace O3DE::ProjectManager
         if (!path.isAbsolute())
         {
             projectPathIsValid = false;
-            m_projectPath->setErrorLabelText(tr("Please provide a valid location."));
+            m_projectPath->setErrorLabelText(tr("Please provide an absolute path for the project location."));
         }
 
         m_projectPath->setErrorLabelVisible(!projectPathIsValid);


### PR DESCRIPTION
- Allow manually typing the path in the project location field
- Check for whether the path is absolute
- Automatically generate the path location when using the default path and changing the name only

Fixes #2446 

![ProjectLocationImprovements](https://user-images.githubusercontent.com/26804013/129108798-d06045d1-8901-4040-a6f9-2954ba582b4e.gif)


Signed-off-by: AMZN-alexpete <26804013+AMZN-alexpete@users.noreply.github.com>