### PR TITLE
Fixed Signed/Unsigned Mismatch fix in LyShine UiAnimViewAnimNode.cpp

### DIFF
--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewAnimNode.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewAnimNode.cpp
@@ -1482,7 +1482,7 @@ bool CUiAnimViewAnimNode::PasteNodesFromClipboard(QWidget* context)
     const bool bLightAnimationSetActive = GetSequence()->GetFlags() & IUiAnimSequence::eSeqFlags_LightAnimationSet;
 
     const unsigned int numNodes = animNodesRoot->getChildCount();
-    for (int i = 0; i < numNodes; ++i)
+    for (unsigned int i = 0; i < numNodes; ++i)
     {
         XmlNodeRef xmlNode = animNodesRoot->getChild(i);
 


### PR DESCRIPTION
Turns out there was another change needed for https://github.com/o3de/o3de/pull/3046

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>