### PR TITLE
Fix for input not being reenabled after game mode

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -640,7 +640,7 @@ void EditorViewportWidget::OnEditorNotifyEvent(EEditorNotifyEvent event)
 
         if (m_renderViewport)
         {
-            m_renderViewport->GetControllerList()->SetEnabled(true);
+            m_renderViewport->SetInputProcessingEnabled(true);
         }
         break;
 


### PR DESCRIPTION
This looks like it might have been a bad merge, but the input was no longer being fully reenabled after game mode.

Signed-off-by: abrmich <abrmich@amazon.com>