### PR TITLE
Settings registry notification deadlock fix

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/Event.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Event.h
@@ -58,6 +58,12 @@ namespace AZ
 
         Event& operator=(Event&& rhs);
 
+        //! Take the handlers registered with the other event
+        //! and move them to this event. The other will event
+        //! will be cleared after call
+        //! @param other event to move handlers
+        Event& StealHandlers(Event&& other);
+
         //! Returns true if at least one handler is connected to this event.
         bool HasHandlerConnected() const;
 

--- a/Code/Framework/AzCore/AzCore/EBus/Event.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Event.h
@@ -62,7 +62,7 @@ namespace AZ
         //! and move them to this event. The other will event
         //! will be cleared after call
         //! @param other event to move handlers
-        Event& StealHandlers(Event&& other);
+        Event& ClaimHandlers(Event&& other);
 
         //! Returns true if at least one handler is connected to this event.
         bool HasHandlerConnected() const;

--- a/Code/Framework/AzCore/AzCore/EBus/Event.inl
+++ b/Code/Framework/AzCore/AzCore/EBus/Event.inl
@@ -208,10 +208,10 @@ namespace AZ
 
 
     template <typename... Params>
-    auto Event<Params...>::StealHandlers(Event&& other) -> Event&
+    auto Event<Params...>::ClaimHandlers(Event&& other) -> Event&
     {
-        decltype(other.m_handlers) handlers = AZStd::move(other.m_handlers);
-        decltype(other.m_addList) addList = AZStd::move(other.m_addList);
+        auto handlers = AZStd::move(other.m_handlers);
+        auto addList = AZStd::move(other.m_addList);
         other.m_freeList = {};
         other.m_updating = false;
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.cpp
@@ -249,7 +249,7 @@ namespace AZ
             AZStd::scoped_lock lock(m_notifierMutex);
             AZStd::swap(m_notifiers, localNotifierEvent);
             // Append any added handlers to the m_notifier structure
-            m_notifiers.StealHandlers(AZStd::move(localNotifierEvent));
+            m_notifiers.ClaimHandlers(AZStd::move(localNotifierEvent));
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryImpl.h
@@ -89,7 +89,7 @@ namespace AZ
         using RegistryFileList = AZStd::fixed_vector<RegistryFile, MaxRegistryFolderEntries>;
 
         template<typename T>
-        bool SetValueInternal(AZStd::string_view path, T value, SettingsRegistryInterface::Type type);
+        bool SetValueInternal(AZStd::string_view path, T value);
         template<typename T>
         bool GetValueInternal(T& result, AZStd::string_view path) const;
         VisitResponse Visit(Visitor& visitor, StackedString& path, AZStd::string_view valueName,
@@ -100,8 +100,11 @@ namespace AZ
             const rapidjson::Pointer& historyPointer, AZStd::string_view folderPath);
         bool ExtractFileDescription(RegistryFile& output, const char* filename, const Specializations& specializations);
         bool MergeSettingsFileInternal(const char* path, Format format, AZStd::string_view rootKey, AZStd::vector<char>& scratchBuffer);
+
+        void SignalNotifier(AZStd::string_view jsonPath, Type type);
         
         mutable AZStd::recursive_mutex m_settingMutex;
+        mutable AZStd::recursive_mutex m_notifierMutex;
         NotifyEvent m_notifiers;
         rapidjson::Document m_settings;
         JsonSerializerSettings m_serializationSettings;

--- a/Code/Framework/AzCore/Tests/EventTests.cpp
+++ b/Code/Framework/AzCore/Tests/EventTests.cpp
@@ -240,6 +240,37 @@ namespace UnitTest
         static_assert(!AZStd::is_copy_assignable_v<AZ::Event<int32_t>>, "AZ Events should not be copy assignable");
     }
 
+    TEST_F(EventTests, TestStealHandlers_TakesAllSourceHandlers)
+    {
+        AZ::Event<> testEvent1;
+        AZ::Event<> testEvent2;
+
+        int32_t handlerInvokeCount{};
+        auto handlerCallback = [&handlerInvokeCount]()
+        {
+            ++handlerInvokeCount;
+        };
+        AZ::Event<>::Handler testHandler1(handlerCallback);
+        AZ::Event<>::Handler testHandler2(handlerCallback);
+
+        testHandler1.Connect(testEvent1);
+        testHandler2.Connect(testEvent2);
+
+        EXPECT_TRUE(testEvent1.HasHandlerConnected());
+        EXPECT_TRUE(testEvent2.HasHandlerConnected());
+
+        testEvent1.StealHandlers(AZStd::move(testEvent2));
+        EXPECT_TRUE(testEvent1.HasHandlerConnected());
+        EXPECT_FALSE(testEvent2.HasHandlerConnected());
+
+        // testEvent1 should have both handlers
+        testEvent1.Signal();
+        EXPECT_EQ(2, handlerInvokeCount);
+        // testEvent2 should have neither of the handlers
+        testEvent2.Signal();
+        EXPECT_EQ(2, handlerInvokeCount);
+    }
+
     TEST_F(EventTests, HandlerMoveAssignment_ProperlyDisconnectsFromOldEvent)
     {
         AZ::Event<> testEvent1;

--- a/Code/Framework/AzCore/Tests/EventTests.cpp
+++ b/Code/Framework/AzCore/Tests/EventTests.cpp
@@ -240,7 +240,7 @@ namespace UnitTest
         static_assert(!AZStd::is_copy_assignable_v<AZ::Event<int32_t>>, "AZ Events should not be copy assignable");
     }
 
-    TEST_F(EventTests, TestStealHandlers_TakesAllSourceHandlers)
+    TEST_F(EventTests, TestClaimHandlers_TakesAllSourceHandlers)
     {
         AZ::Event<> testEvent1;
         AZ::Event<> testEvent2;
@@ -259,7 +259,7 @@ namespace UnitTest
         EXPECT_TRUE(testEvent1.HasHandlerConnected());
         EXPECT_TRUE(testEvent2.HasHandlerConnected());
 
-        testEvent1.StealHandlers(AZStd::move(testEvent2));
+        testEvent1.ClaimHandlers(AZStd::move(testEvent2));
         EXPECT_TRUE(testEvent1.HasHandlerConnected());
         EXPECT_FALSE(testEvent2.HasHandlerConnected());
 


### PR DESCRIPTION
- Added a `StealHandlers` function to AZ::Event to allow one event to "steal" all the handlers from another event.
- Split the Settings Registry mutex out to a setting modification mutex and a notification event mutex
- Wrapped the Settings Registry notification event signaling into a function that uses a lock and swap algorithm to allow signaling connected event handlers without having any mutex locked
- Added more fine-grained locking of the Settings Registry modification mutex to reduce lock time.

resolves #3066 