### PR TITLE
Tiaf scripts logging and sanity checking

### DIFF
--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -235,7 +235,7 @@ class TestImpact:
                         logger.error(f"Source commit '{self._src_commit}' and destination commit '{self._dst_commit}', implying the integrity of the historic data is compromised.")
                         persistent_storage = None
                     else:
-                        self._attempt_to_generate_change_list(self._instance_id)
+                        self._attempt_to_generate_change_list()
                 else:
                     logger.info("No historic data found.")
                     

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -61,17 +61,13 @@ class TestImpact:
             logger.error(f"The config does not contain the key {str(e)}.")
             return
 
-    def _attempt_to_generate_change_list(self, last_commit_hash, instance_id: str):
+    def _attempt_to_generate_change_list(self):
         """
         Attempts to determine the change list bewteen now and the last tiaf run (if any).
-
-        @param last_commit_hash: The commit hash of the last TIAF run.
-        @param instance_id:      The unique id to derive the change list file name from.
         """
 
         self._has_change_list = False
         self._change_list_path = None
-        self._src_commit = last_commit_hash
 
         # Check whether or not a previous commit hash exists (no hash is not a failure)
         if self._src_commit:
@@ -92,7 +88,7 @@ class TestImpact:
             try:
                 # Attempt to generate a diff between the src and dst commits
                 logger.error(f"Source '{self._src_commit}' and destination '{self._dst_commit}' will be diff'd.")
-                diff_path = pathlib.Path(pathlib.PurePath(self._temp_workspace).joinpath(f"changelist.{instance_id}.diff"))
+                diff_path = pathlib.Path(pathlib.PurePath(self._temp_workspace).joinpath(f"changelist.{self._instance_id}.diff"))
                 self._repo.create_diff_file(self._src_commit, self._dst_commit, diff_path, multi_branch)
             except RuntimeError as e:
                 logger.error(e)
@@ -124,7 +120,7 @@ class TestImpact:
 
             # Serialize the change list to the JSON format the test impact analysis runtime expects
             change_list_json = json.dumps(self._change_list, indent = 4)
-            change_list_path = pathlib.PurePath(self._temp_workspace).joinpath(f"changelist.{instance_id}.json")
+            change_list_path = pathlib.PurePath(self._temp_workspace).joinpath(f"changelist.{self._instance_id}.json")
             f = open(change_list_path, "w")
             f.write(change_list_json)
             f.close()
@@ -215,7 +211,7 @@ class TestImpact:
         self._commit_distance = None
 
         # Generate a unique ID to be used as part of the file name for required runtime dynamic artifacts.
-        instance_id = uuid.uuid4().hex
+        self._instance_id = uuid.uuid4().hex
         
         if self._use_test_impact_analysis:
             logger.info("Test impact analysis is enabled.")
@@ -232,7 +228,14 @@ class TestImpact:
             if persistent_storage:
                 if persistent_storage.has_historic_data:
                     logger.info("Historic data found.")
-                    self._attempt_to_generate_change_list(persistent_storage.last_commit_hash, instance_id)
+                    self._src_commit = persistent_storage.last_commit_hash
+
+                    # Perform some basic sanity checks on the commit hashes to ensure confidence in the integrity of of the environment
+                    if self._src_commit == self._dst_commit:
+                        logger.error(f"Source commit '{self._src_commit}' and destination commit '{self._dst_commit}', implying the integrity of the historic data is compromised.")
+                        persistent_storage = None
+                    else:
+                        self._attempt_to_generate_change_list(self._instance_id)
                 else:
                     logger.info("No historic data found.")
                     
@@ -283,7 +286,7 @@ class TestImpact:
         logger.info(f"Test failure policy is set to '{test_failure_policy}'.")
 
         # Sequence report
-        report_file = pathlib.PurePath(self._temp_workspace).joinpath(f"report.{instance_id}.json")
+        report_file = pathlib.PurePath(self._temp_workspace).joinpath(f"report.{self._instance_id}.json")
         args.append(f"--report={report_file}")
         logger.info(f"Sequence report file is set to '{report_file}'.")
 

--- a/scripts/build/TestImpactAnalysis/tiaf_persistent_storage.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_persistent_storage.py
@@ -49,6 +49,7 @@ class PersistentStorage(ABC):
         try:
             historic_data = json.loads(historic_data_json)
             self._last_commit_hash = historic_data["last_commit_hash"]
+            logger.info(f"Last commit hash '{self._last_commit_hash}' found.")
 
             # Create the active workspace directory where the coverage data file will be placed and unpack the coverage data so 
             # it is accessible by the runtime
@@ -105,7 +106,10 @@ class PersistentStorage(ABC):
 
         historic_data_json = self._pack_historic_data(last_commit_hash)
         if historic_data_json:
+            logger.info(f"Attempting to store historic data with new last commit hash '{self._last_commit_hash}'...")
             self._store_historic_data(historic_data_json)
+            logger.info("The historic data was successfully stored.")
+
         else:
             logger.info("The historic data could not be successfully stored.")
 


### PR DESCRIPTION
There is a peculiar issue that arises in branch builds from time to time where the last commit hash as retrieved from the S3 storage is the same as the commit hash for the job being built. It does not appear that the problem is occurring client-side yet the alternative explanation of a server-side issue raises yet further questions as there should be no way that a job being run can retrieve its own commit hash from the historic data record in the s3 bucket, unless a job for that commit has already been run (which does not appear to be the case). As a consequence, additional logging and sanity checking has been added to the TIAF scripts to aid in debugging should this problem persist.