### PR TITLE
Prevent EMFX notifications from being modal, which was blocking input while visible.

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/NotificationWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/NotificationWindow.cpp
@@ -28,7 +28,7 @@ namespace EMStudio
         setWindowTitle("Notification");
 
         // window, no border, no focus, stays on top
-        setWindowFlags(Qt::Popup | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
+        setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus | Qt::WindowStaysOnTopHint);
 
         // enable the translucent background
         setAttribute(Qt::WA_TranslucentBackground);


### PR DESCRIPTION
Fixes #2496 

The EMFX toast notifications were using the Qt::Popup window flag, which makes them modal, which in turn blocks input while they are visible. I changed the window flags instead to be window and stay on top, so it will still get the same behavior as a modal without actually being modal.

![EMFXToastNotificationsFixed](https://user-images.githubusercontent.com/7519264/129239403-66901a11-3b95-461b-93bd-ab9470494132.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>