### PR TITLE
Fix issue with white bar on bottom of Project Manager

### DIFF
--- a/Code/Tools/ProjectManager/Source/Application.cpp
+++ b/Code/Tools/ProjectManager/Source/Application.cpp
@@ -168,9 +168,13 @@ namespace O3DE::ProjectManager
         // the decoration wrapper is intended to remember window positioning and sizing 
         auto wrapper = new AzQtComponents::WindowDecorationWrapper();
         wrapper->setGuest(m_mainWindow.data());
+
+        // show the main window here to apply the stylesheet before restoring geometry or we
+        // can end up with empty white space at the bottom of the window until the frame is resized again
+        m_mainWindow->show();
+
         wrapper->enableSaveRestoreGeometry("O3DE", "ProjectManager", "mainWindowGeometry");
         wrapper->showFromSettings();
-        m_mainWindow->show();
 
         qApp->setQuitOnLastWindowClosed(true);
 


### PR DESCRIPTION
A white bar appeared at the bottom of the Project Manager on start-up until the window was resized.
![image (12)](https://user-images.githubusercontent.com/26804013/129271435-e2b4d0fc-b74c-4a7a-83c3-4366362ed125.png)

