### PR TITLE
Fixed creating entities in the viewport logic to use hit test detection.

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2697,8 +2697,7 @@ void EditorViewportWidget::RestoreViewportAfterGameMode()
         QString(
             tr("When leaving \" Game Mode \" the engine will automatically restore your camera position to the default position before you "
             "had entered Game mode.<br/><br/><small>If you dislike this setting you can always change this anytime in the global "
-            "preferences.</small><br/><br/>"))
-            .arg(EditorPreferencesGeneralRestoreViewportCameraSettingName);
+            "preferences.</small><br/><br/>"));
     QString restoreOnExitGameModePopupDisabledRegKey("Editor/AutoHide/ViewportCameraRestoreOnExitGameMode");
 
     // Read the popup disabled registry value

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1452,7 +1452,7 @@ void SandboxIntegrationManager::ContextMenu_NewEntity()
     if (view)
     {
         const QPoint viewPoint(m_contextMenuViewPoint.GetX(), m_contextMenuViewPoint.GetY());
-        worldPosition = LYVec3ToAZVec3(view->SnapToGrid(view->ViewToWorld(viewPoint)));
+        worldPosition = view->GetHitLocation(viewPoint);
     }
 
     CreateNewEntityAtPosition(worldPosition);

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -46,24 +46,7 @@ void QtViewport::BuildDragDropContext(AzQtComponents::ViewportDragContext& conte
 
     PreWidgetRendering(); // required so that the current render cam is set.
 
-    Vec3 pos = Vec3(ZERO);
-    HitContext hit;
-    if (HitTest(pt, hit))
-    {
-        pos = hit.raySrc + hit.rayDir * hit.dist;
-        pos = SnapToGrid(pos);
-    }
-    else
-    {
-        bool hitTerrain;
-        pos = ViewToWorld(pt, &hitTerrain);
-        if (hitTerrain)
-        {
-            pos.z = GetIEditor()->GetTerrainElevation(pos.x, pos.y);
-        }
-        pos = SnapToGrid(pos);
-    }
-    context.m_hitLocation = AZ::Vector3(pos.x, pos.y, pos.z);
+    context.m_hitLocation = GetHitLocation(pt);
 
     PostWidgetRendering();
 }
@@ -1152,6 +1135,29 @@ bool QtViewport::HitTest(const QPoint& point, HitContext& hitInfo)
     }
 
     return false;
+}
+
+AZ::Vector3 QtViewport::GetHitLocation(const QPoint& point)
+{
+    Vec3 pos = Vec3(ZERO);
+    HitContext hit;
+    if (HitTest(point, hit))
+    {
+        pos = hit.raySrc + hit.rayDir * hit.dist;
+        pos = SnapToGrid(pos);
+    }
+    else
+    {
+        bool hitTerrain;
+        pos = ViewToWorld(point, &hitTerrain);
+        if (hitTerrain)
+        {
+            pos.z = GetIEditor()->GetTerrainElevation(pos.x, pos.y);
+        }
+        pos = SnapToGrid(pos);
+    }
+
+    return AZ::Vector3(pos.x, pos.y, pos.z);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -201,6 +201,7 @@ public:
 
     //! Performs hit testing of 2d point in view to find which object hit.
     virtual bool HitTest(const QPoint& point, HitContext& hitInfo) = 0;
+    virtual AZ::Vector3 GetHitLocation(const QPoint& point) = 0;
 
     virtual void MakeConstructionPlane(int axis) = 0;
 
@@ -436,6 +437,7 @@ public:
 
     //! Performs hit testing of 2d point in view to find which object hit.
     bool HitTest(const QPoint& point, HitContext& hitInfo) override;
+    AZ::Vector3 GetHitLocation(const QPoint& point) override;
 
     //! Do 2D hit testing of line in world space.
     // pToCameraDistance is an optional output parameter in which distance from the camera to the line is returned.


### PR DESCRIPTION
Fixes #2498 

Updated the logic when creating entities via the right-click menu in the viewport to use the same hit detection as dragging/dropping into the viewport from the Asset Browser.
NOTE: The previous logic being used for ViewToWorld currently has all of the input params for hit test as unused, so I'm guessing we are deprecating this function, from a quick search it looks like mostly legacy editor stuff (Editor/Objects) for CBaseObject is what is using those calls. If we do want to go the route of fixing that API so it works though I'm open to that.

![CreateEntitiesInViewport](https://user-images.githubusercontent.com/7519264/129273104-3243bad3-c98e-4a01-a33d-d85446e0d367.gif)

Also fixed a warning message due to an argument being passed to tr() that wasn't formatted to take any arguments as input anymore.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>