### PR TITLE
Adds the MARS benchmark script in AR

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -378,6 +378,25 @@ def TestMetrics(Map pipelineConfig, String workspace, String branchName, String 
     }
 }
 
+def BenchmarkMetrics(String workspace, String branchName, String outputDirectory) {
+    catchError(buildResult: null, stageResult: null) {
+        def cmakeBuildDir = [workspace, ENGINE_REPOSITORY_NAME, outputDirectory].join('/')
+        dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
+            checkout scm: [
+                $class: 'GitSCM',
+                branches: [[name: '*/main']],
+                extensions: [
+                    [$class: 'AuthorInChangelog'],
+                    [$class: 'RelativeTargetDirectory', relativeTargetDir: 'mars']
+                ],
+                userRemoteConfigs: [[url: "${env.MARS_REPO}", name: 'mars', credentialsId: "${env.GITHUB_USER}"]]
+            ]
+            def command = "${pipelineConfig.PYTHON_DIR}/python.cmd -u mars/scripts/python/benchmark_scraper.py ${cmakeBuildDir} ${branchName}"
+            palSh(command, "Publishing Benchmark Metrics")
+        }
+    }
+}
+
 def ExportTestResults(Map options, String platform, String type, String workspace, Map params) {
     catchError(message: "Error exporting tests results (this won't fail the build)", buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         def o3deroot = "${workspace}/${ENGINE_REPOSITORY_NAME}"
@@ -433,6 +452,7 @@ def CreateTestMetricsStage(Map pipelineConfig, String branchName, Map environmen
     return {
         stage("${buildJobName}_metrics") {
             TestMetrics(pipelineConfig, environmentVars['WORKSPACE'], branchName, env.DEFAULT_REPOSITORY_NAME, buildJobName, outputDirectory, configuration)
+            BenchmarkMetrics(environmentVars['WORKSPACE'], branchName, outputDirectory)
         }
     }
 }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -378,7 +378,7 @@ def TestMetrics(Map pipelineConfig, String workspace, String branchName, String 
     }
 }
 
-def BenchmarkMetrics(String workspace, String branchName, String outputDirectory) {
+def BenchmarkMetrics(Map pipelineConfig, String workspace, String branchName, String outputDirectory) {
     catchError(buildResult: null, stageResult: null) {
         def cmakeBuildDir = [workspace, ENGINE_REPOSITORY_NAME, outputDirectory].join('/')
         dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
@@ -452,7 +452,7 @@ def CreateTestMetricsStage(Map pipelineConfig, String branchName, Map environmen
     return {
         stage("${buildJobName}_metrics") {
             TestMetrics(pipelineConfig, environmentVars['WORKSPACE'], branchName, env.DEFAULT_REPOSITORY_NAME, buildJobName, outputDirectory, configuration)
-            BenchmarkMetrics(environmentVars['WORKSPACE'], branchName, outputDirectory)
+            BenchmarkMetrics(pipelineConfig, environmentVars['WORKSPACE'], branchName, outputDirectory)
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: evanchia <evanchia@amazon.com>

Do not submit until https://github.com/aws-lumberyard/o3de-mars/pull/21 is submitted.

Adds the benchmark script to the AR pipeline. Manual runtime of script is 264ms. The benchmark upload stage will also be non blocking on failure.