### PR TITLE
Fix Non-Unity compile error with Atom Sample Viewer and the Atom Gem

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.h
@@ -10,6 +10,7 @@
 #include <AzCore/Math/MathIntrinsics.h>
 #include <AzCore/std/containers/array.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/typetraits/aligned_storage.h>
 #include <AzCore/base.h>
 #include <stdint.h>
 


### PR DESCRIPTION
Fixes the following error

```
In file included from /src/github/o3de-atom-sampleviewer/Gem/Code/Source/SkinnedMeshContainer.cpp:9:
In file included from /src/github/o3de-atom-sampleviewer/Gem/Code/Source/SkinnedMeshContainer.h:15:
In file included from /src/github/o3de/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshFeatureProcessorInterface.h:10:
In file included from /src/github/o3de/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshRenderProxyInterface.h:11:
/src/github/o3de/Gems/Atom/Utils/Code/Include/Atom/Utils/StableDynamicArray.h:166:9: error: no template named 'aligned_storage_t' in namespace 'AZStd'; did you mean 'std::aligned_storage_t'?
        AZStd::aligned_storage_t<PageSize, alignof(T)> m_data; ///< aligned storage for all the actual data.
        ^~~~~~~~~~~~~~~~~~~~~~~~
        std::aligned_storage_t
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/type_traits:2374:5: note: 'std::aligned_storage_t' declared here
    using aligned_storage_t = typename aligned_storage<_Len, _Align>::type;
    ^
1 error generated.
[73/6561] Building CXX object o3de-atom-sampleviewer-2dcd6a22/Gem/Code/CMake...tomSampleViewer.Private.Static.dir/profile/Source/SsaoExampleComponent.cpp.o
ninja: build stopped: subcommand failed.
```


Signed-off-by: spham-amzn <spham@amazon.com>