### PR TITLE
Fix android gradle scripts to prevent `cmake_dependencies.<game>.<game>_gamelauncher` from being wiped out of the APK

### DIFF
--- a/cmake/Tools/Platform/Android/android_support.py
+++ b/cmake/Tools/Platform/Android/android_support.py
@@ -372,9 +372,12 @@ CUSTOM_GRADLE_COPY_NATIVE_CONFIG_BUILD_ARTIFACTS_FORMAT_STR = """
     }}
 
     compile{config}Sources.dependsOn copyNativeArtifacts{config}
+"""
+
+CUSTOM_GRADLE_COPY_NATIVE_CONFIG_BUILD_ARTIFACTS_DEPENDENCY_FORMAT_STR = """
 
     copyNativeArtifacts{config}.mustRunAfter {{
-        tasks.findAll {{ task->task.name.contains('externalNativeBuild{config}') }}
+        tasks.findAll {{ task->task.name.contains('syncLYLayoutMode{config}') }}
     }}
 """
 
@@ -383,7 +386,13 @@ CUSTOM_APPLY_ASSET_LAYOUT_TASK_FORMAT_STR = """
         workingDir '{working_dir}'
         commandLine '{python_full_path}', 'layout_tool.py', '--project-path', '{project_path}', '-p', 'Android', '-a', '{asset_type}', '-m', '{asset_mode}', '--create-layout-root', '-l', '{asset_layout_folder}'
     }}
+    
     compile{config}Sources.dependsOn syncLYLayoutMode{config}
+
+    syncLYLayoutMode{config}.mustRunAfter {{
+        tasks.findAll {{ task->task.name.contains('externalNativeBuild{config}') }}
+    }}
+
 """
 
 
@@ -832,25 +841,28 @@ class AndroidProjectGenerator(object):
                                                                                        asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix(),
                                                                                        file_includes='Test.Assets/**/*.*')
             else:
-                # Copy over settings registry files from the Registry folder with build output directory
                 gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] = \
+                    CUSTOM_APPLY_ASSET_LAYOUT_TASK_FORMAT_STR.format(working_dir=common.normalize_path_for_settings(self.engine_root / 'cmake/Tools'),
+                                                                     python_full_path=common.normalize_path_for_settings(self.engine_root / 'python' / PYTHON_SCRIPT),
+                                                                     asset_type=self.asset_type,
+                                                                     project_path=self.project_path.as_posix(),
+                                                                     asset_mode=self.asset_mode if native_config != 'Release' else 'PAK',
+                                                                     asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix(),
+                                                                     config=native_config)
+                # Copy over settings registry files from the Registry folder with build output directory
+                gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] += \
                     CUSTOM_GRADLE_COPY_NATIVE_CONFIG_BUILD_ARTIFACTS_FORMAT_STR.format(config=native_config,
                                                                                        config_lower=native_config_lower,
                                                                                        asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix(),
                                                                                        file_includes='**/Registry/*.setreg')
-
-            if self.include_assets_in_apk:
-                if not self.is_test_project:
+                if self.include_assets_in_apk:
+                    # This is a dependency of the layout sync only if we are including assets in the APK
                     gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] += \
-                        CUSTOM_APPLY_ASSET_LAYOUT_TASK_FORMAT_STR.format(working_dir=common.normalize_path_for_settings(self.engine_root / 'cmake/Tools'),
-                                                                         python_full_path=common.normalize_path_for_settings(self.engine_root / 'python' / PYTHON_SCRIPT),
-                                                                         asset_type=self.asset_type,
-                                                                         project_path=self.project_path.as_posix(),
-                                                                         asset_mode=self.asset_mode if native_config != 'Release' else 'PAK',
-                                                                         asset_layout_folder=(self.build_dir / 'app/src/main/assets').resolve().as_posix(),
-                                                                         config=native_config)
-            else:
-                gradle_build_env[f'CUSTOM_APPLY_ASSET_LAYOUT_{native_config_upper}_TASK'] = ''
+                        CUSTOM_GRADLE_COPY_NATIVE_CONFIG_BUILD_ARTIFACTS_DEPENDENCY_FORMAT_STR.format(config=native_config)
+
+
+
+
             if self.signing_config:
                 gradle_build_env[f'SIGNING_{native_config_upper}_CONFIG'] = f'signingConfig signingConfigs.{native_config_lower}' if self.signing_config else ''
             else:


### PR DESCRIPTION
Fixes #3117

**Root Cause**

There are 2 custom tasks that occur during the android gradle build:

* syncLYLayoutMode{config}
  Use the layout tool to sync the android assets (through a directory junction) from `app\src\main\assets` to the android cache files for a project
* copyNativeArtifacts{config}
  Copy files from the Registry in the build output folder to the same `app\src\main\assets`

If `copyNativeArtifacts` occurs before `syncLYLayoutMode`, then what happens is that the .setreg files are copied into `app\src\main\assets` just fine, but when `syncLYLayoutMode` task is executed, it will wipe out the `app\src\main\assets` folder and replace it with the directory junction.

The original build.gradle script for app did not declare a rule that `copyNativeArtifacts` must occur after 'syncLYLayoutMode`. It also did not enforce when `syncLYLayoutMode` is called, so it was possible for it to be called after 'copyNativeArtifacts'. 

It was observed that when build through Android Studio, `syncLYLayoutMode` did occur before `copyNativeArtifacts`, but not when invoked from the command line ( through `gradle assembleProfile` )

**Fix**
The fix is to update the android script generator to enforce the rule that:
* `copyNativeArtifacts` must run AFTER `syncLYLayoutMode`
* `syncLYLayoutMode` must run AFTER `externalNativeBuild` (to ensure cmake build is invoked at the source Registry is in place)

**Side Effect**
Out of scope for this fix is the fact that the current behavior will copy the setreg file into the Cache since its a junction inside the android build folder.

  
















Signed-off-by: Steve Pham <spham@amazon.com>