### PR TITLE
Replaced some Lumberyard references with O3DE.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/README.txt
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/README.txt
@@ -8,7 +8,7 @@ INTRODUCTION
 ------------
 
 EditorPythonBindings is a Python project that contains a collection of editor testing tools
-developed by the Lumberyard feature teams. The project contains tools for system level
+developed by the O3DE feature teams. The project contains tools for system level
 editor tests.
 
 
@@ -23,7 +23,7 @@ installed on your system.
 
 INSTALL
 -----------
-It is recommended to set up these these tools with Lumberyard's CMake build commands.
+It is recommended to set up these these tools with O3DE's CMake build commands.
 Assuming CMake is already setup on your operating system, below are some sample build commands:
     cd /path/to/od3e/
     mkdir windows_vs2019

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/AssetPicker_UI_UX.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/AssetPicker_UI_UX.py
@@ -61,7 +61,7 @@ class AssetPickerUIUXTest(EditorTestHelper):
         5) Verify if Mesh Asset is assigned via both OK/Enter options
 
         Note:
-        - This test file must be called from the Lumberyard Editor command terminal
+        - This test file must be called from the O3DE Editor command terminal
         - Any passed and failed tests are written to the Editor.log file.
                 Parsing the file or running a log_monitor are required to observe the test results.
 

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
@@ -37,7 +37,7 @@ class TestBasicEditorWorkflows(EditorTestHelper):
     async def run_test(self):
         """
         Summary:
-        Open Lumberyard editor and check if basic Editor workflows are completable.
+        Open O3DE editor and check if basic Editor workflows are completable.
 
         Expected Behavior:
         - A new level can be created
@@ -48,7 +48,7 @@ class TestBasicEditorWorkflows(EditorTestHelper):
         - Level can be exported
 
         Note:
-        - This test file must be called from the Lumberyard Editor command terminal
+        - This test file must be called from the O3DE Editor command terminal
         - Any passed and failed tests are written to the Editor.log file.
                 Parsing the file or running a log_monitor are required to observe the test results.
 

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_EditMenuOptions.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_EditMenuOptions.py
@@ -36,7 +36,7 @@ class TestEditMenuOptions(EditorTestHelper):
          2) Interact with Edit Menu options
 
         Note:
-        - This test file must be called from the Lumberyard Editor command terminal
+        - This test file must be called from the O3DE Editor command terminal
         - Any passed and failed tests are written to the Editor.log file.
                 Parsing the file or running a log_monitor are required to observe the test results.
 

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_FileMenuOptions.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_FileMenuOptions.py
@@ -32,7 +32,7 @@ class TestFileMenuOptions(EditorTestHelper):
          2) Interact with File Menu options
 
         Note:
-        - This test file must be called from the Lumberyard Editor command terminal
+        - This test file must be called from the O3DE Editor command terminal
         - Any passed and failed tests are written to the Editor.log file.
                 Parsing the file or running a log_monitor are required to observe the test results.
 

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_ViewMenuOptions.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/Menus_ViewMenuOptions.py
@@ -36,7 +36,7 @@ class TestViewMenuOptions(EditorTestHelper):
          2) Interact with View Menu options
 
         Note:
-        - This test file must be called from the Lumberyard Editor command terminal
+        - This test file must be called from the O3DE Editor command terminal
         - Any passed and failed tests are written to the Editor.log file.
                 Parsing the file or running a log_monitor are required to observe the test results.
 

--- a/AutomatedTesting/Gem/PythonTests/scripting/Pane_PropertiesChanged_RetainsOnRestart.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/Pane_PropertiesChanged_RetainsOnRestart.py
@@ -52,7 +52,7 @@ def Pane_PropertiesChanged_RetainsOnRestart():
     from utils import TestHelper as helper
     import pyside_utils
 
-    # Lumberyard Imports
+    # O3DE Imports
     import azlmbr.legacy.general as general
 
     # Pyside imports

--- a/AutomatedTesting/Gem/PythonTests/smoke/Editor_NewExistingLevels_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/Editor_NewExistingLevels_Works.py
@@ -53,7 +53,7 @@ def Editor_NewExistingLevels_Works():
     10) Save, Load and Export an existing level and close editor
 
     Note:
-    - This test file must be called from the Lumberyard Editor command terminal
+    - This test file must be called from the O3DE Editor command terminal
     - Any passed and failed tests are written to the Editor.log file.
             Parsing the file or running a log_monitor are required to observe the test results.
 

--- a/Gems/QtForPython/Editor/Scripts/tests/log_main_window.py
+++ b/Gems/QtForPython/Editor/Scripts/tests/log_main_window.py
@@ -5,7 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# bit more complex example set to demo connecting Lumberyard tech to PySide2 widgets
+# bit more complex example set to demo connecting O3DE tech to PySide2 widgets
 import azlmbr.bus
 from PySide2 import QtWidgets
 from PySide2 import QtGui

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityNodes.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityNodes.h
@@ -35,7 +35,7 @@ namespace ScriptCanvas
             vector.SetLength(aznumeric_cast<float>(scale));
             return vector;
         }
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetEntityRight, DefaultScale<1>, k_categoryName, "{C12282BE-29D2-497D-8C22-75B940E254E2}", "returns the right direction vector from the specified entity's world transform, scaled by a given value (Lumberyard uses Z up, right handed)", "EntityId", "Scale");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetEntityRight, DefaultScale<1>, k_categoryName, "{C12282BE-29D2-497D-8C22-75B940E254E2}", "returns the right direction vector from the specified entity's world transform, scaled by a given value (O3DE uses Z up, right handed)", "EntityId", "Scale");
 
         AZ_INLINE Vector3Type GetEntityForward(AZ::EntityId entityId, NumberType scale)
         {
@@ -46,7 +46,7 @@ namespace ScriptCanvas
             vector.SetLength(aznumeric_cast<float>(scale));
             return vector;
         }
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetEntityForward, DefaultScale<1>, k_categoryName, "{719D9F76-84D4-4B0F-BCEB-26D5D097C7D6}", "returns the forward direction vector from the specified entity' world transform, scaled by a given value (Lumberyard uses Z up, right handed)", "EntityId", "Scale");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetEntityForward, DefaultScale<1>, k_categoryName, "{719D9F76-84D4-4B0F-BCEB-26D5D097C7D6}", "returns the forward direction vector from the specified entity' world transform, scaled by a given value (O3DE uses Z up, right handed)", "EntityId", "Scale");
 
         AZ_INLINE Vector3Type GetEntityUp(AZ::EntityId entityId, NumberType scale)
         {
@@ -57,7 +57,7 @@ namespace ScriptCanvas
             vector.SetLength(aznumeric_cast<float>(scale));
             return vector;
         }
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetEntityUp, DefaultScale<1>, k_categoryName, "{96B86F3F-F022-4611-9AEA-175EA952C562}", "returns the up direction vector from the specified entity's world transform, scaled by a given value (Lumberyard uses Z up, right handed)", "EntityId", "Scale");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetEntityUp, DefaultScale<1>, k_categoryName, "{96B86F3F-F022-4611-9AEA-175EA952C562}", "returns the up direction vector from the specified entity's world transform, scaled by a given value (O3DE uses Z up, right handed)", "EntityId", "Scale");
 
         AZ_INLINE BooleanType IsActive(const EntityIDType& entityId)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/TransformNodes.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/TransformNodes.h
@@ -74,7 +74,7 @@ namespace ScriptCanvas
             vector.SetLength(aznumeric_cast<float>(scale));
             return vector;
         }
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetRight, DefaultScale<1>, k_categoryName, "{65811752-711F-4566-869E-5AEF53206342}", "returns the right direction vector from the specified transform scaled by a given value (Lumberyard uses Z up, right handed)", "Source", "Scale");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetRight, DefaultScale<1>, k_categoryName, "{65811752-711F-4566-869E-5AEF53206342}", "returns the right direction vector from the specified transform scaled by a given value (O3DE uses Z up, right handed)", "Source", "Scale");
 
         AZ_INLINE Vector3Type GetForward(const TransformType& source, NumberType scale)
         {
@@ -82,7 +82,7 @@ namespace ScriptCanvas
             vector.SetLength(aznumeric_cast<float>(scale));
             return vector;
         }
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetForward, DefaultScale<1>, k_categoryName, "{3602a047-9f12-46d4-9648-8f53770c8130}", "returns the forward direction vector from the specified transform scaled by a given value (Lumberyard uses Z up, right handed)", "Source", "Scale");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetForward, DefaultScale<1>, k_categoryName, "{3602a047-9f12-46d4-9648-8f53770c8130}", "returns the forward direction vector from the specified transform scaled by a given value (O3DE uses Z up, right handed)", "Source", "Scale");
 
         AZ_INLINE Vector3Type GetUp(const TransformType& source, NumberType scale)
         {
@@ -90,7 +90,7 @@ namespace ScriptCanvas
             vector.SetLength(aznumeric_cast<float>(scale));
             return vector;
         }
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetUp, DefaultScale<1>, k_categoryName, "{F10F52D2-E6F2-4E39-84D5-B4A561F186D3}", "returns the up direction vector from the specified transform scaled by a given value (Lumberyard uses Z up, right handed)", "Source", "Scale");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(GetUp, DefaultScale<1>, k_categoryName, "{F10F52D2-E6F2-4E39-84D5-B4A561F186D3}", "returns the up direction vector from the specified transform scaled by a given value (O3DE uses Z up, right handed)", "Source", "Scale");
 
         AZ_INLINE Vector3Type GetTranslation(const TransformType& source)
         {


### PR DESCRIPTION
Fixes #3138 

Replaced some Lumberyard references in Script Canvas tooltips and some comments with O3DE.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>