### PR TITLE
[AWSCore] Game launcher can crash when send requests via invalid AWS credentials

### DIFF
--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJob.h
@@ -380,9 +380,9 @@ namespace AWSCore
                     responseContent.c_str()
                 );
 
-                // This is determined by AZ::g_maxMessageLength defined in in dev\Code\Framework\AzCore\AzCore\Debug\Trace.cpp.
-                // It has the value 4096, but there is the timestamp, etc., to account for so we reduce it by a few characters.
-                const int MAX_MESSAGE_LENGTH = 4096 - 128;
+                // This is determined by the SLogMsg struct defined in Code\Legacy\CrySystem\Log.h.
+                // The maximum size of a log message is 512 characters, but there is the timestamp, etc., to account for so we reduce it by a few characters.
+                const int MAX_MESSAGE_LENGTH = 512 - 128;
 
                 // Replace the character "%" with "%%" to prevent the error when printing the string that contains the percentage sign
                 message = EscapePercentCharsInString(message);


### PR DESCRIPTION
Signed-off-by: junbo <junbo@amazon.com>

this issue is because of a latest commit in main: https://github.com/o3de/o3de/commit/ceab4a794cca5a9a4815dd9ad28395977b0fd73e#diff-9c71b4c7a057586490a2ba4391cbbb2609600af75a095b3d04fc22b2a53f0297

The maximum size for a log message is set to be 512.

- Verified that the client stops crashing and error messages are printed out in the log.