### PR TITLE
AtomTools: better script canvas support for material component 

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_find_overrides_demo.lua
@@ -66,20 +66,20 @@ function FindMaterialAssignmentTest:OnActivate()
 end
 
 function FindMaterialAssignmentTest:UpdateFactor(assignmentId)
-    local propertyName = Name("baseColor.factor")
+    local propertyName = "baseColor.factor"
     local propertyValue = math.random()
     MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
 function FindMaterialAssignmentTest:UpdateColor(assignmentId, color)
-    local propertyName = Name("baseColor.color")
+    local propertyName = "baseColor.color"
     local propertyValue = color
     MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
 function FindMaterialAssignmentTest:UpdateTexture(assignmentId)
     if (#self.Properties.Textures > 0) then
-        local propertyName = Name("baseColor.textureMap")
+        local propertyName = "baseColor.textureMap"
         local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
         Debug.Log(textureName)
         local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)

--- a/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
+++ b/Gems/Atom/Feature/Common/Assets/Scripts/material_property_overrides_demo.lua
@@ -64,20 +64,20 @@ function PropertyOverrideTest:OnActivate()
 end
 
 function PropertyOverrideTest:UpdateFactor(assignmentId)
-    local propertyName = Name("baseColor.factor")
+    local propertyName = "baseColor.factor"
     local propertyValue = math.random()
     MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
 function PropertyOverrideTest:UpdateColor(assignmentId, color)
-    local propertyName = Name("baseColor.color")
+    local propertyName = "baseColor.color"
     local propertyValue = color
     MaterialComponentRequestBus.Event.SetPropertyOverride(self.entityId, assignmentId, propertyName, propertyValue);
 end
 
 function PropertyOverrideTest:UpdateTexture(assignmentId)
     if (#self.Properties.Textures > 0) then
-        local propertyName = Name("baseColor.textureMap")
+        local propertyName = "baseColor.textureMap"
         local textureName = self.Properties.Textures[ math.random( #self.Properties.Textures ) ]
         Debug.Log(textureName)
         local textureAssetId = AssetCatalogRequestBus.Broadcast.GetAssetIdByPath(textureName, Uuid(), false)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/Material/MaterialComponentBus.h
@@ -41,12 +41,56 @@ namespace AZ
             virtual const AZ::Data::AssetId GetMaterialOverride(const MaterialAssignmentId& materialAssignmentId) const = 0;
             //! Clear material override
             virtual void ClearMaterialOverride(const MaterialAssignmentId& materialAssignmentId) = 0;
-            //! Set a material property value override
-            virtual void SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName, const AZStd::any& propertyValue) = 0;
-            //! Get a material property value override
-            virtual AZStd::any GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName) const = 0;
+            //! Set a material property override value wrapped by an AZStd::any
+            virtual void SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) = 0;
+            //! Set a material property override value to a bool
+            virtual void SetPropertyOverrideBool(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const bool& value) = 0;
+            //! Set a material property override value to a integer
+            virtual void SetPropertyOverrideInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const int32_t& value) = 0;
+            //! Set a material property override value to a unsigned integer
+            virtual void SetPropertyOverrideUInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const uint32_t& value) = 0;
+            //! Set a material property override value to a float
+            virtual void SetPropertyOverrideFloat(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const float& value) = 0;
+            //! Set a material property override value to a Vector2
+            virtual void SetPropertyOverrideVector2(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector2& value) = 0;
+            //! Set a material property override value to a Vector3
+            virtual void SetPropertyOverrideVector3(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector3& value) = 0;
+            //! Set a material property override value to a Vector4
+            virtual void SetPropertyOverrideVector4(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector4& value) = 0;
+            //! Set a material property override value to a color
+            virtual void SetPropertyOverrideColor(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Color& value) = 0;
+            //! Set a material property override value to an image asset
+            virtual void SetPropertyOverrideImageAsset(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Data::Asset<AZ::RPI::ImageAsset>& value) = 0;
+            //! Set a material property override value to an image instance
+            virtual void SetPropertyOverrideImageInstance(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Data::Instance<AZ::RPI::Image>& value) = 0;
+            //! Set a material property override value to a string
+            virtual void SetPropertyOverrideString(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::string& value) = 0;
+            //! Get a material property override value wrapped by an AZStd::any
+            virtual AZStd::any GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a bool
+            virtual bool GetPropertyOverrideBool(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as an integer
+            virtual int32_t GetPropertyOverrideInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as an unsigned integer
+            virtual uint32_t GetPropertyOverrideUInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a float
+            virtual float GetPropertyOverrideFloat(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a Vector2
+            virtual AZ::Vector2 GetPropertyOverrideVector2(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a Vector3
+            virtual AZ::Vector3 GetPropertyOverrideVector3(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a Vector4
+            virtual AZ::Vector4 GetPropertyOverrideVector4(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a Color
+            virtual AZ::Color GetPropertyOverrideColor(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as an image asset
+            virtual AZ::Data::Asset<AZ::RPI::ImageAsset> GetPropertyOverrideImageAsset(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as an image instance
+            virtual AZ::Data::Instance<AZ::RPI::Image> GetPropertyOverrideImageInstance(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
+            //! Get a material property override value as a string
+            virtual AZStd::string GetPropertyOverrideString(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const = 0;
             //! Clear property override for a specific material assignment
-            virtual void ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName) = 0;
+            virtual void ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) = 0;
             //! Clear property overrides for a specific material assignment
             virtual void ClearPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) = 0;
             //! Clear all property overrides

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -44,7 +44,29 @@ namespace AZ
                     ->Event("GetMaterialOverride", &MaterialComponentRequestBus::Events::GetMaterialOverride)
                     ->Event("ClearMaterialOverride", &MaterialComponentRequestBus::Events::ClearMaterialOverride)
                     ->Event("SetPropertyOverride", &MaterialComponentRequestBus::Events::SetPropertyOverride)
+                    ->Event("SetPropertyOverrideBool", &MaterialComponentRequestBus::Events::SetPropertyOverrideBool)
+                    ->Event("SetPropertyOverrideInt32", &MaterialComponentRequestBus::Events::SetPropertyOverrideInt32)
+                    ->Event("SetPropertyOverrideUInt32", &MaterialComponentRequestBus::Events::SetPropertyOverrideUInt32)
+                    ->Event("SetPropertyOverrideFloat", &MaterialComponentRequestBus::Events::SetPropertyOverrideFloat)
+                    ->Event("SetPropertyOverrideVector2", &MaterialComponentRequestBus::Events::SetPropertyOverrideVector2)
+                    ->Event("SetPropertyOverrideVector3", &MaterialComponentRequestBus::Events::SetPropertyOverrideVector3)
+                    ->Event("SetPropertyOverrideVector4", &MaterialComponentRequestBus::Events::SetPropertyOverrideVector4)
+                    ->Event("SetPropertyOverrideColor", &MaterialComponentRequestBus::Events::SetPropertyOverrideColor)
+                    ->Event("SetPropertyOverrideImageAsset", &MaterialComponentRequestBus::Events::SetPropertyOverrideImageAsset)
+                    ->Event("SetPropertyOverrideImageInstance", &MaterialComponentRequestBus::Events::SetPropertyOverrideImageInstance)
+                    ->Event("SetPropertyOverrideString", &MaterialComponentRequestBus::Events::SetPropertyOverrideString)
                     ->Event("GetPropertyOverride", &MaterialComponentRequestBus::Events::GetPropertyOverride)
+                    ->Event("GetPropertyOverrideBool", &MaterialComponentRequestBus::Events::GetPropertyOverrideBool)
+                    ->Event("GetPropertyOverrideInt32", &MaterialComponentRequestBus::Events::GetPropertyOverrideInt32)
+                    ->Event("GetPropertyOverrideUInt32", &MaterialComponentRequestBus::Events::GetPropertyOverrideUInt32)
+                    ->Event("GetPropertyOverrideFloat", &MaterialComponentRequestBus::Events::GetPropertyOverrideFloat)
+                    ->Event("GetPropertyOverrideVector2", &MaterialComponentRequestBus::Events::GetPropertyOverrideVector2)
+                    ->Event("GetPropertyOverrideVector3", &MaterialComponentRequestBus::Events::GetPropertyOverrideVector3)
+                    ->Event("GetPropertyOverrideVector4", &MaterialComponentRequestBus::Events::GetPropertyOverrideVector4)
+                    ->Event("GetPropertyOverrideColor", &MaterialComponentRequestBus::Events::GetPropertyOverrideColor)
+                    ->Event("GetPropertyOverrideImageAsset", &MaterialComponentRequestBus::Events::GetPropertyOverrideImageAsset)
+                    ->Event("GetPropertyOverrideImageInstance", &MaterialComponentRequestBus::Events::GetPropertyOverrideImageInstance)
+                    ->Event("GetPropertyOverrideString", &MaterialComponentRequestBus::Events::GetPropertyOverrideString)
                     ->Event("ClearPropertyOverride", &MaterialComponentRequestBus::Events::ClearPropertyOverride)
                     ->Event("ClearPropertyOverrides", &MaterialComponentRequestBus::Events::ClearPropertyOverrides)
                     ->Event("ClearAllPropertyOverrides", &MaterialComponentRequestBus::Events::ClearAllPropertyOverrides)
@@ -331,27 +353,97 @@ namespace AZ
             }
         }
 
-        void MaterialComponentController::SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName, const AZStd::any& propertyValue)
+        void MaterialComponentController::SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value)
         {
             auto& materialAssignment = m_configuration.m_materials[materialAssignmentId];
 
             // When applying property overrides for the first time, new instance needs to be created in case the current instance is already used somewhere else to keep overrides local
             if (materialAssignment.m_propertyOverrides.empty())
             {
-                materialAssignment.m_propertyOverrides[propertyName] = propertyValue;
+                materialAssignment.m_propertyOverrides[AZ::Name(propertyName)] = value;
                 materialAssignment.RebuildInstance();
                 QueueMaterialUpdateNotification();
             }
             else
             {
-                materialAssignment.m_propertyOverrides[propertyName] = propertyValue;
+                materialAssignment.m_propertyOverrides[AZ::Name(propertyName)] = value;
             }
 
             QueuePropertyChanges(materialAssignmentId);
             MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialsEdited, m_configuration.m_materials);
         }
 
-        AZStd::any MaterialComponentController::GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName) const
+        void MaterialComponentController::SetPropertyOverrideBool(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const bool& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideInt32(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const int32_t& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideUInt32(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const uint32_t& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideFloat(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const float& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideVector2(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector2& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideVector3(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector3& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideVector4(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector4& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideColor(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Color& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideImageAsset(
+            const MaterialAssignmentId& materialAssignmentId,
+            const AZStd::string& propertyName,
+            const AZ::Data::Asset<AZ::RPI::ImageAsset>& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideImageInstance(
+            const MaterialAssignmentId& materialAssignmentId,
+            const AZStd::string& propertyName,
+            const AZ::Data::Instance<AZ::RPI::Image>& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        void MaterialComponentController::SetPropertyOverrideString(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::string& value)
+        {
+            SetPropertyOverride(materialAssignmentId, propertyName, AZStd::any(value));
+        }
+
+        AZStd::any MaterialComponentController::GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
         {
             const auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
             if (materialIt == m_configuration.m_materials.end())
@@ -360,17 +452,94 @@ namespace AZ
                 return {};
             }
 
-            const auto propertyIt = materialIt->second.m_propertyOverrides.find(propertyName);
+            const auto propertyIt = materialIt->second.m_propertyOverrides.find(AZ::Name(propertyName));
             if (propertyIt == materialIt->second.m_propertyOverrides.end())
             {
-                AZ_Error("MaterialComponentController", false, "Property not found: %s.", propertyName.GetCStr());
+                AZ_Error("MaterialComponentController", false, "Property not found: %s.", propertyName.c_str());
                 return {};
             }
 
             return propertyIt->second;
         }
 
-        void MaterialComponentController::ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName)
+        bool MaterialComponentController::GetPropertyOverrideBool(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<bool>() ? AZStd::any_cast<bool>(value) : false;
+        }
+
+        int32_t MaterialComponentController::GetPropertyOverrideInt32(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<int32_t>() ? AZStd::any_cast<int32_t>(value) : 0;
+        }
+
+        uint32_t MaterialComponentController::GetPropertyOverrideUInt32(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<uint32_t>() ? AZStd::any_cast<uint32_t>(value) : 0;
+        }
+
+        float MaterialComponentController::GetPropertyOverrideFloat(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<float>() ? AZStd::any_cast<float>(value) : 0.0f;
+        }
+
+        AZ::Vector2 MaterialComponentController::GetPropertyOverrideVector2(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZ::Vector2>() ? AZStd::any_cast<AZ::Vector2>(value) : AZ::Vector2::CreateZero();
+        }
+
+        AZ::Vector3 MaterialComponentController::GetPropertyOverrideVector3(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZ::Vector3>() ? AZStd::any_cast<AZ::Vector3>(value) : AZ::Vector3::CreateZero();
+        }
+
+        AZ::Vector4 MaterialComponentController::GetPropertyOverrideVector4(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZ::Vector4>() ? AZStd::any_cast<AZ::Vector4>(value) : AZ::Vector4::CreateZero();
+        }
+
+        AZ::Color MaterialComponentController::GetPropertyOverrideColor(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZ::Color>() ? AZStd::any_cast<AZ::Color>(value) : AZ::Color::CreateZero();
+        }
+
+        AZ::Data::Asset<AZ::RPI::ImageAsset> MaterialComponentController::GetPropertyOverrideImageAsset(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZ::Data::Asset<AZ::RPI::ImageAsset>>() ? AZStd::any_cast<AZ::Data::Asset<AZ::RPI::ImageAsset>>(value) : AZ::Data::Asset<AZ::RPI::ImageAsset>();
+        }
+
+        AZ::Data::Instance<AZ::RPI::Image> MaterialComponentController::GetPropertyOverrideImageInstance(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZ::Data::Instance<AZ::RPI::Image>>() ? AZStd::any_cast<AZ::Data::Instance<AZ::RPI::Image>>(value) : AZ::Data::Instance<AZ::RPI::Image>();
+        }
+
+        AZStd::string MaterialComponentController::GetPropertyOverrideString(
+            const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const
+        {
+            const AZStd::any& value = GetPropertyOverride(materialAssignmentId, propertyName);
+            return !value.empty() && value.is<AZStd::string>() ? AZStd::any_cast<AZStd::string>(value) : AZStd::string();
+        }
+
+        void MaterialComponentController::ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName)
         {
             auto materialIt = m_configuration.m_materials.find(materialAssignmentId);
             if (materialIt == m_configuration.m_materials.end())
@@ -379,10 +548,10 @@ namespace AZ
                 return;
             }
 
-            auto propertyIt = materialIt->second.m_propertyOverrides.find(propertyName);
+            auto propertyIt = materialIt->second.m_propertyOverrides.find(AZ::Name(propertyName));
             if (propertyIt == materialIt->second.m_propertyOverrides.end())
             {
-                AZ_Error("MaterialComponentController", false, "Property not found: %s.", propertyName.GetCStr());
+                AZ_Error("MaterialComponentController", false, "Property not found: %s.", propertyName.c_str());
                 return;
             }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.h
@@ -57,9 +57,33 @@ namespace AZ
             const AZ::Data::AssetId GetMaterialOverride(const MaterialAssignmentId& materialAssignmentId) const override;
             void ClearMaterialOverride(const MaterialAssignmentId& materialAssignmentId) override;
 
-            void SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName, const AZStd::any& propertyValue) override;
-            AZStd::any GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName) const override;
-            void ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const Name& propertyName) override;
+            void SetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::any& value) override;
+            void SetPropertyOverrideBool(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const bool& value) override;
+            void SetPropertyOverrideInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const int32_t& value) override;
+            void SetPropertyOverrideUInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const uint32_t& value) override;
+            void SetPropertyOverrideFloat(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const float& value) override;
+            void SetPropertyOverrideVector2(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector2& value) override;
+            void SetPropertyOverrideVector3(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector3& value) override;
+            void SetPropertyOverrideVector4(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Vector4& value) override;
+            void SetPropertyOverrideColor(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Color& value) override;
+            void SetPropertyOverrideImageAsset(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Data::Asset<AZ::RPI::ImageAsset>& value) override;
+            void SetPropertyOverrideImageInstance(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZ::Data::Instance<AZ::RPI::Image>& value) override;
+            void SetPropertyOverrideString(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName, const AZStd::string& value) override;
+
+            AZStd::any GetPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            bool GetPropertyOverrideBool(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            int32_t GetPropertyOverrideInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            uint32_t GetPropertyOverrideUInt32(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            float GetPropertyOverrideFloat(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZ::Vector2 GetPropertyOverrideVector2(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZ::Vector3 GetPropertyOverrideVector3(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZ::Vector4 GetPropertyOverrideVector4(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZ::Color GetPropertyOverrideColor(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZ::Data::Asset<AZ::RPI::ImageAsset> GetPropertyOverrideImageAsset(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZ::Data::Instance<AZ::RPI::Image> GetPropertyOverrideImageInstance(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+            AZStd::string GetPropertyOverrideString(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) const override;
+
+            void ClearPropertyOverride(const MaterialAssignmentId& materialAssignmentId, const AZStd::string& propertyName) override;
             void ClearPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) override;
             void ClearAllPropertyOverrides() override;
             MaterialPropertyOverrideMap GetPropertyOverrides(const MaterialAssignmentId& materialAssignmentId) const override;


### PR DESCRIPTION
There were issues creating scripts in script canvas using the material component related buses. 

Material component bus functions used AZ name to look up material property names. Script canvas did not support editing these in nodes or the inspector. These were replaced with AZStd string.

Script canvas did not support AZStd any. Explicit functions had to be added to access and modify material properties with specified types.

There is still a known issue where script canvas will currently only allow selecting dynamic slice assets.