### PR TITLE
Fix script canvases not loading if on a UI canvas element

### DIFF
--- a/Gems/LyShine/Code/Source/UiCanvasFileObject.h
+++ b/Gems/LyShine/Code/Source/UiCanvasFileObject.h
@@ -24,7 +24,8 @@ public:
     AZ_CLASS_ALLOCATOR(UiCanvasFileObject, AZ::SystemAllocator, 0);
     AZ_RTTI(UiCanvasFileObject, "{1F02632F-F113-49B1-85AD-8CD0FA78B8AA}");
 
-    static UiCanvasFileObject* LoadCanvasFromStream(AZ::IO::GenericStream& stream, const AZ::ObjectStream::FilterDescriptor& filterDesc = AZ::ObjectStream::FilterDescriptor(AZ::ObjectStream::AssetFilterAssetTypesOnly<AZ::SliceAsset, AZ::ScriptAsset>));
+    // Load canvas from stream with an optional asset filter. No asset references are ignored by default
+    static UiCanvasFileObject* LoadCanvasFromStream(AZ::IO::GenericStream& stream, const AZ::ObjectStream::FilterDescriptor& filterDesc = AZ::ObjectStream::FilterDescriptor());
     static void SaveCanvasToStream(AZ::IO::GenericStream& stream, UiCanvasFileObject* canvasFileObject);
 
     static AZ::Entity* LoadCanvasEntitiesFromStream(AZ::IO::GenericStream& stream, AZ::Entity*& rootSliceEntity);


### PR DESCRIPTION
An asset filter was being applied when loading a UI canvas from stream to ignore all assets other than Slices and Lua scripts, so script canvas assets were not being preloaded. The fix is to remove the filter and allow all asset types to go through.

We don't want Asset Processor to load unnecessary assets such as textures, but this doesn't happen because the UI canvas builder passes in a custom filter to only load slice assets when it loads the UI canvas for building.

Signed-off-by: abrmich <abrmich@amazon.com>