### PR TITLE
Allow customized Jenkins parameters for different pipelines and add aws integration deployment pipeline

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -651,19 +651,19 @@ try {
                                         pipelineParameters.add(stringParam(defaultValue: defaultValue,
                                                                        description: jenkinsParameter['description'],
                                                                        name: jenkinsParameter['name']
-                                                                       )
+                                                                       ))
                                         break
                                     case 'boolean':
                                         pipelineParameters.add(booleanParam(defaultValue: defaultValue,
                                                                        description: jenkinsParameter['description'],
                                                                        name: jenkinsParameter['name']
-                                                                       )
+                                                                       ))
                                         break
                                     case 'password':
                                         pipelineParameters.add(password(defaultValue: defaultValue,
                                                                        description: jenkinsParameter['description'],
                                                                        name: jenkinsParameter['name']
-                                                                       )
+                                                                       ))
                                         break
                                 }
                             }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -634,6 +634,40 @@ try {
                             pipelineParameters.add(booleanParam(defaultValue: true, description: '', name: platform.key))
                         }
                     }
+                    // Add additional Jenkins parameters
+                    pipelineConfig.platforms.each { platform ->
+                        platformEnv = platform.value.PIPELINE_ENV
+                        pipelineJenkinsParameters = platformEnv['PIPELINE_JENKINS_PARAMETERS'] ?: [:]
+                        jenkinsParametersToAdd = pipelineJenkinsParameters[pipelineName] ?: [:]
+                        jenkinsParametersToAdd.each{ jenkinsParameters ->
+                            jenkinsParameters.each { jenkinsParameter ->
+                                switch (jenkinsParameter['parameter_type']) {
+                                    defaultValue = jenkinsParameter['default_value']
+                                    // Use last run's value as default value so we can save values in different Jenkins environment
+                                    if (jenkinsParameter['use_last_run_value']?.toBoolean()) {
+                                        defaultValue = params["$jenkinsParameter['name']"] ?: jenkinsParameter['default_value']
+                                    }
+                                    case 'string':
+                                        pipelineParameters.add(stringParam(defaultValue: defaultValue,
+                                                                       description: jenkinsParameter['description'],
+                                                                       name: jenkinsParameter['name']
+                                                                       )
+                                        break
+                                    case 'boolean':
+                                        pipelineParameters.add(booleanParam(defaultValue: defaultValue,
+                                                                       description: jenkinsParameter['description'],
+                                                                       name: jenkinsParameter['name']
+                                                                       )
+                                    case 'password':
+                                        pipelineParameters.add(password(defaultValue: defaultValue,
+                                                                       description: jenkinsParameter['description'],
+                                                                       name: jenkinsParameter['name']
+                                                                       )
+                                }
+                            }
+                        }
+                    }
+
                     pipelineProperties.add(parameters(pipelineParameters))
                     properties(pipelineProperties)
 

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -639,33 +639,31 @@ try {
                         platformEnv = platform.value.PIPELINE_ENV
                         pipelineJenkinsParameters = platformEnv['PIPELINE_JENKINS_PARAMETERS'] ?: [:]
                         jenkinsParametersToAdd = pipelineJenkinsParameters[pipelineName] ?: [:]
-                        jenkinsParametersToAdd.each{ jenkinsParameters ->
-                            jenkinsParameters.each { jenkinsParameter ->
-                                defaultValue = jenkinsParameter['default_value']
-                                // Use last run's value as default value so we can save values in different Jenkins environment
-                                if (jenkinsParameter['use_last_run_value']?.toBoolean()) {
-                                    defaultValue = params["$jenkinsParameter['name']"] ?: jenkinsParameter['default_value']
-                                }
-                                switch (jenkinsParameter['parameter_type']) {
-                                    case 'string':
-                                        pipelineParameters.add(stringParam(defaultValue: defaultValue,
-                                                                       description: jenkinsParameter['description'],
-                                                                       name: jenkinsParameter['name']
-                                                                       ))
-                                        break
-                                    case 'boolean':
-                                        pipelineParameters.add(booleanParam(defaultValue: defaultValue,
-                                                                       description: jenkinsParameter['description'],
-                                                                       name: jenkinsParameter['name']
-                                                                       ))
-                                        break
-                                    case 'password':
-                                        pipelineParameters.add(password(defaultValue: defaultValue,
-                                                                       description: jenkinsParameter['description'],
-                                                                       name: jenkinsParameter['name']
-                                                                       ))
-                                        break
-                                }
+                        jenkinsParametersToAdd.each{ jenkinsParameter ->
+                            defaultValue = jenkinsParameter['default_value']
+                            // Use last run's value as default value so we can save values in different Jenkins environment
+                            if (jenkinsParameter['use_last_run_value']?.toBoolean()) {
+                                defaultValue = params."$jenkinsParameter['parameter_name']" ?: jenkinsParameter['default_value']
+                            }
+                            switch (jenkinsParameter['parameter_type']) {
+                                case 'string':
+                                    pipelineParameters.add(stringParam(defaultValue: defaultValue,
+                                                                   description: jenkinsParameter['description'],
+                                                                   name: jenkinsParameter['parameter_name']
+                                                                   ))
+                                    break
+                                case 'boolean':
+                                    pipelineParameters.add(booleanParam(defaultValue: defaultValue,
+                                                                   description: jenkinsParameter['description'],
+                                                                   name: jenkinsParameter['parameter_name']
+                                                                   ))
+                                    break
+                                case 'password':
+                                    pipelineParameters.add(password(defaultValue: defaultValue,
+                                                                   description: jenkinsParameter['description'],
+                                                                   name: jenkinsParameter['parameter_name']
+                                                                   ))
+                                    break
                             }
                         }
                     }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -641,12 +641,12 @@ try {
                         jenkinsParametersToAdd = pipelineJenkinsParameters[pipelineName] ?: [:]
                         jenkinsParametersToAdd.each{ jenkinsParameters ->
                             jenkinsParameters.each { jenkinsParameter ->
+                                defaultValue = jenkinsParameter['default_value']
+                                // Use last run's value as default value so we can save values in different Jenkins environment
+                                if (jenkinsParameter['use_last_run_value']?.toBoolean()) {
+                                    defaultValue = params["$jenkinsParameter['name']"] ?: jenkinsParameter['default_value']
+                                }
                                 switch (jenkinsParameter['parameter_type']) {
-                                    defaultValue = jenkinsParameter['default_value']
-                                    // Use last run's value as default value so we can save values in different Jenkins environment
-                                    if (jenkinsParameter['use_last_run_value']?.toBoolean()) {
-                                        defaultValue = params["$jenkinsParameter['name']"] ?: jenkinsParameter['default_value']
-                                    }
                                     case 'string':
                                         pipelineParameters.add(stringParam(defaultValue: defaultValue,
                                                                        description: jenkinsParameter['description'],
@@ -658,11 +658,13 @@ try {
                                                                        description: jenkinsParameter['description'],
                                                                        name: jenkinsParameter['name']
                                                                        )
+                                        break
                                     case 'password':
                                         pipelineParameters.add(password(defaultValue: defaultValue,
                                                                        description: jenkinsParameter['description'],
                                                                        name: jenkinsParameter['name']
                                                                        )
+                                        break
                                 }
                             }
                         }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -376,5 +376,9 @@
       "install_profile_vs2019",
       "project_engineinstall_profile_vs2019"
     ]
+  },
+  "awsi_deployment": {
+    "TAGS": ["awsi-deployment"],
+    "COMMAND": "deploy_cdk_applications.cmd"
   }
 }

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -379,6 +379,7 @@
   },
   "awsi_deployment": {
     "TAGS": ["awsi-deployment"],
-    "COMMAND": "deploy_cdk_applications.cmd"
+    "COMMAND": "deploy_cdk_applications.cmd",
+    "PARAMETERS": {}
   }
 }

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -39,7 +39,14 @@
                 "default_value": "",
                 "use_last_run_value": true,
                 "description": ""
-            }
+            },
+            {
+                "parameter_name": "COMMIT_ID",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": ""
+            },
         ]
     }
 }

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -46,7 +46,7 @@
                 "default_value": "",
                 "use_last_run_value": true,
                 "description": ""
-            },
+            }
         ]
     }
 }

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -16,5 +16,30 @@
         "nightly-clean": {
             "CLEAN_WORKSPACE": true
         }
+    },
+    "PIPELINE_JENKINS_PARAMETERS": {
+        "awsi-deployment": [
+            {
+                "parameter_name": "O3DE_AWS_PROJECT_NAME",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": ""
+            },
+            {
+                "parameter_name": "O3DE_AWS_DEPLOY_REGION",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": ""
+            },
+            {
+                "parameter_name": "ASSUME_ROLE_ARN",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": ""
+            }
+        ]
     }
 }


### PR DESCRIPTION
Allow customized Jenkins parameters for different pipelines so that we can define different Jenkins parameters for a new pipeline and doesn't affect AR build parameters.

Add aws integration deployment pipeline.