### PR TITLE
Move BuildDebugSceneGraph function out of SceneProcessing gem

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.cpp
@@ -141,7 +141,7 @@ namespace AZ::SceneAPI::Utilities
         AZStd::string debugSceneFile;
 
         AzFramework::StringFunc::Path::ConstructFull(outputFolder, productName.c_str(), debugSceneFile);
-        AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "zoutputFolder %s, name %s.\n", outputFolder, productName.c_str());
+        AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "outputFolder %s, name %s.\n", outputFolder, productName.c_str());
         
         AZ::IO::SystemFile dbgFile;
         if (dbgFile.Open(debugSceneFile.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.cpp
@@ -9,6 +9,15 @@
 #include "DebugOutput.h"
 #include <AzCore/std/optional.h>
 
+#include <AzCore/IO/SystemFile.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <SceneAPI/SceneCore/Containers/Scene.h>
+#include <SceneAPI/SceneCore/Containers/Views/PairIterator.h>
+#include <SceneAPI/SceneCore/Containers/Views/SceneGraphDownwardsIterator.h>
+#include <SceneAPI/SceneCore/DataTypes/IGraphObject.h>
+#include <SceneAPI/SceneCore/Events/ExportProductList.h>
+#include <SceneAPI/SceneCore/Utilities/Reporting.h>
+
 namespace AZ::SceneAPI::Utilities
 {
     void DebugOutput::Write(const char* name, const char* data)
@@ -117,5 +126,64 @@ namespace AZ::SceneAPI::Utilities
     const AZStd::string& DebugOutput::GetOutput() const
     {
         return m_output;
+    }
+
+    void WriteAndLog(AZ::IO::SystemFile& dbgFile, const char* strToWrite)
+    {
+        AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "%s", strToWrite);
+        dbgFile.Write(strToWrite, strlen(strToWrite));
+        dbgFile.Write("\n", strlen("\n"));
+    }
+
+    void DebugOutput::BuildDebugSceneGraph(const char* outputFolder, AZ::SceneAPI::Events::ExportProductList& productList, const AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>& scene, AZStd::string productName)
+    {
+        const int debugSceneGraphVersion = 1;
+        AZStd::string debugSceneFile;
+
+        AzFramework::StringFunc::Path::ConstructFull(outputFolder, productName.c_str(), debugSceneFile);
+        AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "zoutputFolder %s, name %s.\n", outputFolder, productName.c_str());
+        
+        AZ::IO::SystemFile dbgFile;
+        if (dbgFile.Open(debugSceneFile.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
+        {
+            WriteAndLog(dbgFile, AZStd::string::format("ProductName: %s", productName.c_str()).c_str());
+            WriteAndLog(dbgFile, AZStd::string::format("debugSceneGraphVersion: %d", debugSceneGraphVersion).c_str());
+            WriteAndLog(dbgFile, scene->GetName().c_str());
+
+            const AZ::SceneAPI::Containers::SceneGraph& sceneGraph = scene->GetGraph();
+            auto names = sceneGraph.GetNameStorage();
+            auto content = sceneGraph.GetContentStorage();
+            auto pairView = AZ::SceneAPI::Containers::Views::MakePairView(names, content);
+            auto view = AZ::SceneAPI::Containers::Views::MakeSceneGraphDownwardsView<
+                AZ::SceneAPI::Containers::Views::BreadthFirst>(
+                    sceneGraph, sceneGraph.GetRoot(), pairView.cbegin(), true);
+
+            for (auto&& viewIt : view)
+            {
+                if (viewIt.second == nullptr)
+                {
+                    continue;
+                }
+
+                AZ::SceneAPI::DataTypes::IGraphObject* graphObject = const_cast<AZ::SceneAPI::DataTypes::IGraphObject*>(viewIt.second.get());
+                
+                WriteAndLog(dbgFile, AZStd::string::format("Node Name: %s", viewIt.first.GetName()).c_str());
+                WriteAndLog(dbgFile, AZStd::string::format("Node Path: %s", viewIt.first.GetPath()).c_str());
+                WriteAndLog(dbgFile, AZStd::string::format("Node Type: %s", graphObject->RTTI_GetTypeName()).c_str());
+
+                AZ::SceneAPI::Utilities::DebugOutput debugOutput;
+                viewIt.second->GetDebugOutput(debugOutput);
+
+                if (!debugOutput.GetOutput().empty())
+                {
+                    WriteAndLog(dbgFile, debugOutput.GetOutput().c_str());
+                }
+            }
+            dbgFile.Close();
+
+            static const AZ::Data::AssetType dbgSceneGraphAssetType("{07F289D1-4DC7-4C40-94B4-0A53BBCB9F0B}");
+            productList.AddProduct(productName, AZ::Uuid::CreateName(productName.c_str()), dbgSceneGraphAssetType,
+                AZStd::nullopt, AZStd::nullopt);
+        }
     }
 }

--- a/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.h
+++ b/Code/Tools/SceneAPI/SceneCore/Utilities/DebugOutput.h
@@ -16,6 +16,22 @@
 #include <AzCore/std/optional.h>
 #include <cinttypes>
 
+namespace AZ
+{
+    namespace SceneAPI
+    {
+        namespace Containers
+        {
+            class Scene;
+        }
+        namespace Events
+        {
+            struct ExportProduct;
+            class ExportProductList;
+        }
+    }
+}
+
 namespace AZ::SceneAPI::Utilities
 {
     class DebugOutput
@@ -41,6 +57,8 @@ namespace AZ::SceneAPI::Utilities
         SCENE_CORE_API void Write(const char* name, AZStd::optional<AZ::Vector3> data);
 
         SCENE_CORE_API const AZStd::string& GetOutput() const;
+
+        SCENE_CORE_API static void BuildDebugSceneGraph(const char* outputFolder, AZ::SceneAPI::Events::ExportProductList& productList, const AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>& scene, AZStd::string productName);
 
     protected:
         AZStd::string m_output;

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -10,9 +10,7 @@
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Serialization/Utils.h>
-#include <SceneAPI/SceneCore/Containers/Views/PairIterator.h>
 #include <SceneAPI/SceneCore/DataTypes/IGraphObject.h>
-#include <SceneAPI/SceneCore/Containers/Views/SceneGraphDownwardsIterator.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/containers/set.h>
 #include <AzFramework/Application/Application.h>

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -306,7 +306,10 @@ namespace SceneBuilder
 
         if (itr != request.m_jobDescription.m_jobParameters.end() && itr->second == "true")
         {
-            BuildDebugSceneGraph(outputFolder.c_str(), productList, scene);
+            AZStd::string productName;
+            AzFramework::StringFunc::Path::GetFullFileName(scene->GetSourceFilename().c_str(), productName);
+            AzFramework::StringFunc::Path::ReplaceExtension(productName, "dbgsg");
+            AZ::SceneAPI::Utilities::DebugOutput::BuildDebugSceneGraph(outputFolder.c_str(), productList, scene, productName);
         }
 
         AZ_TracePrintf(Utilities::LogWindow, "Collecting and registering products.\n");
@@ -370,67 +373,5 @@ namespace SceneBuilder
         }
 
         return id;
-    }
-
-    void WriteAndLog(AZ::IO::SystemFile& dbgFile, const char* strToWrite)
-    {
-        AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "%s", strToWrite);
-        dbgFile.Write(strToWrite, strlen(strToWrite));
-        dbgFile.Write("\n", strlen("\n"));
-
-    }
-
-    void SceneBuilderWorker::BuildDebugSceneGraph(const char* outputFolder, AZ::SceneAPI::Events::ExportProductList& productList, const AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>& scene) const
-    {
-        const int debugSceneGraphVersion = 1;
-        AZStd::string productName, debugSceneFile;
-
-        AzFramework::StringFunc::Path::GetFullFileName(scene->GetSourceFilename().c_str(), productName);
-        AzFramework::StringFunc::Path::ReplaceExtension(productName, "dbgsg");
-        AzFramework::StringFunc::Path::ConstructFull(outputFolder, productName.c_str(), debugSceneFile);
-        AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "outputFolder %s, name %s.\n", outputFolder, productName.c_str());
-        
-        AZ::IO::SystemFile dbgFile;
-        if (dbgFile.Open(debugSceneFile.c_str(), AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY))
-        {
-            WriteAndLog(dbgFile, AZStd::string::format("ProductName: %s", productName.c_str()).c_str());
-            WriteAndLog(dbgFile, AZStd::string::format("debugSceneGraphVersion: %d", debugSceneGraphVersion).c_str());
-            WriteAndLog(dbgFile, scene->GetName().c_str());
-
-            const AZ::SceneAPI::Containers::SceneGraph& sceneGraph = scene->GetGraph();
-            auto names = sceneGraph.GetNameStorage();
-            auto content = sceneGraph.GetContentStorage();
-            auto pairView = AZ::SceneAPI::Containers::Views::MakePairView(names, content);
-            auto view = AZ::SceneAPI::Containers::Views::MakeSceneGraphDownwardsView<
-                AZ::SceneAPI::Containers::Views::BreadthFirst>(
-                    sceneGraph, sceneGraph.GetRoot(), pairView.cbegin(), true);
-
-            for (auto&& viewIt : view)
-            {
-                if (viewIt.second == nullptr)
-                {
-                    continue;
-                }
-
-                AZ::SceneAPI::DataTypes::IGraphObject* graphObject = const_cast<AZ::SceneAPI::DataTypes::IGraphObject*>(viewIt.second.get());
-                
-                WriteAndLog(dbgFile, AZStd::string::format("Node Name: %s", viewIt.first.GetName()).c_str());
-                WriteAndLog(dbgFile, AZStd::string::format("Node Path: %s", viewIt.first.GetPath()).c_str());
-                WriteAndLog(dbgFile, AZStd::string::format("Node Type: %s", graphObject->RTTI_GetTypeName()).c_str());
-
-                AZ::SceneAPI::Utilities::DebugOutput debugOutput;
-                viewIt.second->GetDebugOutput(debugOutput);
-
-                if (!debugOutput.GetOutput().empty())
-                {
-                    WriteAndLog(dbgFile, debugOutput.GetOutput().c_str());
-                }
-            }
-            dbgFile.Close();
-
-            static const AZ::Data::AssetType dbgSceneGraphAssetType("{07F289D1-4DC7-4C40-94B4-0A53BBCB9F0B}");
-            productList.AddProduct(productName, AZ::Uuid::CreateName(productName.c_str()), dbgSceneGraphAssetType,
-                AZStd::nullopt, AZStd::nullopt);
-        }
     }
 } // namespace SceneBuilder

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.h
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.h
@@ -55,9 +55,6 @@ namespace SceneBuilder
         void PopulateProductDependencies(const AZ::SceneAPI::Events::ExportProduct& exportProduct, const char* watchFolder, AssetBuilderSDK::JobProduct& jobProduct) const;
 
     protected:
-
-        void BuildDebugSceneGraph(const char* outputFolder, AZ::SceneAPI::Events::ExportProductList& productList, const AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>& scene) const;
-
         bool LoadScene(AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene>& result, 
             const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response);
 


### PR DESCRIPTION
Moved BuildDebugSceneGraph out of SceneProcessing gem and into DebugOutput class to allow the function to be shared, which ensures the same dbgsg format is outputted among any calls to the function.