### PR TITLE
Visualizer: finish deserialization of captures

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/CpuProfilerImpl.h
@@ -173,13 +173,14 @@ namespace AZ
                 static void Reflect(AZ::ReflectContext* context);
 
                 CpuProfilingStatisticsSerializerEntry() = default;
-                CpuProfilingStatisticsSerializerEntry(const RHI::CachedTimeRegion& cachedTimeRegion);
+                CpuProfilingStatisticsSerializerEntry(const RHI::CachedTimeRegion& cachedTimeRegion, AZStd::thread_id threadId);
 
                 Name m_groupName;
                 Name m_regionName;
                 uint16_t m_stackDepth;
                 AZStd::sys_time_t m_startTick;
                 AZStd::sys_time_t m_endTick;
+                size_t m_threadId;
             };
 
             AZ_TYPE_INFO(CpuProfilingStatisticsSerializer, "{D5B02946-0D27-474F-9A44-364C2706DD41}");

--- a/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CpuProfilerImpl.cpp
@@ -417,14 +417,14 @@ namespace AZ
             // Create serializable entries
             for (const auto& timeRegionMap : continuousData)
             {
-                for (const auto& threadEntry : timeRegionMap)
+                for (const auto& [threadId, regionMap] : timeRegionMap)
                 {
-                    for (const auto& cachedRegionEntry : threadEntry.second)
+                    for (const auto& [regionName, regionVec] : regionMap)
                     {
-                        m_cpuProfilingStatisticsSerializerEntries.insert(
-                            m_cpuProfilingStatisticsSerializerEntries.end(),
-                            cachedRegionEntry.second.begin(),
-                            cachedRegionEntry.second.end());
+                        for (const auto& region : regionVec)
+                        {
+                            m_cpuProfilingStatisticsSerializerEntries.emplace_back(region, threadId);
+                        }
                     }
                 }
             }
@@ -445,13 +445,15 @@ namespace AZ
 
         // --- CpuProfilingStatisticsSerializerEntry ---
 
-        CpuProfilingStatisticsSerializer::CpuProfilingStatisticsSerializerEntry::CpuProfilingStatisticsSerializerEntry(const RHI::CachedTimeRegion& cachedTimeRegion)
+        CpuProfilingStatisticsSerializer::CpuProfilingStatisticsSerializerEntry::CpuProfilingStatisticsSerializerEntry(
+            const RHI::CachedTimeRegion& cachedTimeRegion, AZStd::thread_id threadId)
         {
             m_groupName = cachedTimeRegion.m_groupRegionName->m_groupName;
             m_regionName = cachedTimeRegion.m_groupRegionName->m_regionName;
             m_stackDepth = cachedTimeRegion.m_stackDepth;
             m_startTick = cachedTimeRegion.m_startTick;
             m_endTick = cachedTimeRegion.m_endTick;
+            m_threadId = AZStd::hash<AZStd::thread_id>{}(threadId);
         }
 
         void CpuProfilingStatisticsSerializer::CpuProfilingStatisticsSerializerEntry::Reflect(AZ::ReflectContext* context)
@@ -465,6 +467,7 @@ namespace AZ
                     ->Field("stackDepth", &CpuProfilingStatisticsSerializerEntry::m_stackDepth)
                     ->Field("startTick", &CpuProfilingStatisticsSerializerEntry::m_startTick)
                     ->Field("endTick", &CpuProfilingStatisticsSerializerEntry::m_endTick)
+                    ->Field("threadId", &CpuProfilingStatisticsSerializerEntry::m_threadId)
                     ;
             }
         }

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -213,6 +213,12 @@ namespace AZ
 
             // Index into the file picker, used to determine which file to load when "Load File" is pressed.
             int m_currentFileIndex = 0;
+
+
+            // --- Loading capture state ---
+            AZStd::unordered_set<AZStd::string> m_loadedNameBuf;
+            AZStd::unordered_set<RHI::CachedTimeRegion::GroupRegionName, RHI::CachedTimeRegion::GroupRegionName::Hash> m_loadedGroupRegionNames;
+            bool m_usingOfflineData = false;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -95,7 +95,7 @@ namespace AZ
             void Draw(bool& keepDrawing, const AZ::RHI::CpuTimingStatistics& cpuTimingStatistics);
 
         private:
-            static constexpr float RowHeight = 50.0;
+            static constexpr float RowHeight = 35.0;
             static constexpr int DefaultFramesToCollect = 50;
             static constexpr float MediumFrameTimeLimit = 16.6; // 60 fps
             static constexpr float HighFrameTimeLimit = 33.3; // 30 fps
@@ -218,9 +218,8 @@ namespace AZ
 
 
             // --- Loading capture state ---
-            AZStd::unordered_set<AZStd::string> m_loadedNameBuf;
-            AZStd::unordered_set<RHI::CachedTimeRegion::GroupRegionName, RHI::CachedTimeRegion::GroupRegionName::Hash> m_loadedGroupRegionNames;
-            bool m_usingOfflineData = false;
+            AZStd::unordered_set<AZStd::string> m_deserializedStringPool;
+            AZStd::unordered_set<RHI::CachedTimeRegion::GroupRegionName, RHI::CachedTimeRegion::GroupRegionName::Hash> m_deserializedGroupRegionNamePool;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiCpuProfiler.h
@@ -43,7 +43,7 @@ namespace AZ
             };
 
             // Update running statistics with new region data 
-            void RecordRegion(const AZ::RHI::CachedTimeRegion& region, AZStd::thread_id threadId);
+            void RecordRegion(const AZ::RHI::CachedTimeRegion& region, size_t threadId);
 
             void ResetPerFrameStatistics();
 
@@ -58,7 +58,7 @@ namespace AZ
             u64 m_invocationsLastFrame = 0;
 
             // NOTE: set over unordered_set so the threads can be shown in increasing order in tooltip.
-            AZStd::set<AZStd::thread_id> m_executingThreads;
+            AZStd::set<size_t> m_executingThreads;
 
             AZStd::sys_time_t m_lastFrameTotalTicks = 0;
 
@@ -134,7 +134,7 @@ namespace AZ
             void DrawThreadSeparator(u64 threadBoundary, u64 maxDepth);
 
             // Draw the "Thread XXXXX" label onto the viewport
-            void DrawThreadLabel(u64 baseRow, AZStd::thread_id threadId);
+            void DrawThreadLabel(u64 baseRow, size_t threadId);
 
             // Draw the vertical lines separating frames in the timeline
             void DrawFrameBoundaries();
@@ -169,7 +169,9 @@ namespace AZ
             AZStd::sys_time_t m_viewportEndTick;
 
             // Map to store each thread's TimeRegions, individual vectors are sorted by start tick
-            AZStd::unordered_map<AZStd::thread_id, AZStd::vector<TimeRegion>> m_savedData;
+            // note: we use size_t as a proxy for thread_id because native_thread_id_type differs differs from
+            // platform to platform, which causes problems when deserializing saved captures.
+            AZStd::unordered_map<size_t, AZStd::vector<TimeRegion>> m_savedData;
 
             // Region color cache
             AZStd::unordered_map<const GroupRegionName*, ImVec4> m_regionColorMap;


### PR DESCRIPTION
## Please [start a build](https://jenkins.build.o3de.org/job/O3DE/view/change-requests/job/PR-3293/) and request @o3de/sig-presentation 

This PR implements the second half of saved capture deserialization. The main challenge here was figuring out a way to deserialize the thread id, since we're pulling an integral value from disk (which is fine for some platforms) but others require thread ids to be pointers. I swapped out using `AZStd::thread_id` for just a simple `size_t` that we get from hashing the thread id, tested deserialization + normal use and everything works the same. This pattern is repeated in other places throughout the codebase so it should be platform safe. 

Also includes some minor fixes throughout the visualizer to get rid of fudge factors and do a little optimization. 