### PR TITLE
Added a deferred queue to the AZ Console class

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -667,6 +667,10 @@ namespace AZ
         m_settingsRegistry->Get(platformCachePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder);
         m_console->ExecuteConfigFile((platformCachePath / "user.cfg").Native());
 
+        // Execute any deferred console commands after the module has loaded to account for the scenario
+        // when CVars are added by loaded dynamic modules
+        m_console->ExecuteDeferredConsoleCommands();
+
         // Parse the command line parameters for console commands after modules have loaded
         m_console->ExecuteCommandLine(m_commandLine);
     }

--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -667,10 +667,6 @@ namespace AZ
         m_settingsRegistry->Get(platformCachePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder);
         m_console->ExecuteConfigFile((platformCachePath / "user.cfg").Native());
 
-        // Execute any deferred console commands after the module has loaded to account for the scenario
-        // when CVars are added by loaded dynamic modules
-        m_console->ExecuteDeferredConsoleCommands();
-
         // Parse the command line parameters for console commands after modules have loaded
         m_console->ExecuteCommandLine(m_commandLine);
     }

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -178,7 +178,7 @@ namespace AZ
     {
         auto DeferredCommandCallable = [this](const DeferredCommand& deferredCommand)
         {
-            return DispatchCommand(deferredCommand.m_command, deferredCommand.m_arguments, deferredCommand.m_silentMode,
+            return this->DispatchCommand(deferredCommand.m_command, deferredCommand.m_arguments, deferredCommand.m_silentMode,
                 deferredCommand.m_invokedFrom, deferredCommand.m_requiredSet, deferredCommand.m_requiredClear);
         };
         // Attempt to invoke the deferred command and remove it from the queue if successful
@@ -355,12 +355,6 @@ namespace AZ
         }
 
         deferredHead = nullptr;
-
-        // Execute any deferred console commands after linking any new deferred functors
-        // LinkDeferredFunctors is invoked after a module has loaded
-        // So this allows console commands dispatched before a module is loaded
-        // to now execute each time a module loads and registers new functors
-        ExecuteDeferredConsoleCommands();
     }
 
     void Console::MoveFunctorsToDeferredHead(ConsoleFunctorBase*& deferredHead)

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -355,6 +355,12 @@ namespace AZ
         }
 
         deferredHead = nullptr;
+
+        // Execute any deferred console commands after linking any new deferred functors
+        // LinkDeferredFunctors is invoked after a module has loaded
+        // So this allows console commands dispatched before a module is loaded
+        // to now execute each time a module loads and registers new functors
+        ExecuteDeferredConsoleCommands();
     }
 
     void Console::MoveFunctorsToDeferredHead(ConsoleFunctorBase*& deferredHead)

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -512,7 +512,8 @@ namespace AZ
 
             AZ::IO::PathView consoleRootCommandKey{ IConsole::ConsoleRootCommandKey, AZ::IO::PosixPathSeparator };
             AZ::IO::PathView inputKey{ path, AZ::IO::PosixPathSeparator };
-            if (inputKey.IsRelativeTo(consoleRootCommandKey))
+            // The ConsoleRootComamndKey is not a command itself so strictly children keys are being examined
+            if (inputKey.IsRelativeTo(consoleRootCommandKey) && inputKey != consoleRootCommandKey)
             {
                 FixedValueString command = inputKey.LexicallyRelative(consoleRootCommandKey).Native();
                 ConsoleCommandContainer commandArgs;

--- a/Code/Framework/AzCore/AzCore/Console/Console.h
+++ b/Code/Framework/AzCore/AzCore/Console/Console.h
@@ -60,9 +60,13 @@ namespace AZ
         ) override;
         void ExecuteConfigFile(AZStd::string_view configFileName) override;
         void ExecuteCommandLine(const AZ::CommandLine& commandLine) override;
-        bool HasCommand(const char* command) override;
-        ConsoleFunctorBase* FindCommand(const char* command) override;
-        AZStd::string AutoCompleteCommand(const char* command, AZStd::vector<AZStd::string>* matches = nullptr) override;
+        bool ExecuteDeferredConsoleCommands() override;
+
+        void ClearDeferredConsoleCommands() override;
+
+        bool HasCommand(AZStd::string_view command) override;
+        ConsoleFunctorBase* FindCommand(AZStd::string_view command) override;
+        AZStd::string AutoCompleteCommand(AZStd::string_view command, AZStd::vector<AZStd::string>* matches = nullptr) override;
         void VisitRegisteredFunctors(const FunctorVisitor& visitor) override;
         void RegisterFunctor(ConsoleFunctorBase* functor) override;
         void UnregisterFunctor(ConsoleFunctorBase* functor) override;
@@ -98,7 +102,20 @@ namespace AZ
         using CommandMap = AZStd::unordered_map<CVarFixedString, AZStd::vector<ConsoleFunctorBase*>>;
         CommandMap m_commands;
         AZ::SettingsRegistryInterface::NotifyEventHandler m_consoleCommandKeyHandler;
+        struct DeferredCommand
+        {
+            using DeferredArguments = AZStd::vector<AZStd::string>;
+            AZStd::string m_command;
+            DeferredArguments m_arguments;
+            ConsoleSilentMode m_silentMode;
+            ConsoleInvokedFrom m_invokedFrom;
+            ConsoleFunctorFlags m_requiredSet;
+            ConsoleFunctorFlags m_requiredClear;
+        };
+        using DeferredCommandQueue = AZStd::deque<DeferredCommand>;
+        DeferredCommandQueue m_deferredCommands;
 
+        friend struct ConsoleCommandKeyNotificationHandler;
         friend class ConsoleFunctorBase;
     };
 }

--- a/Code/Framework/AzCore/AzCore/Console/IConsole.h
+++ b/Code/Framework/AzCore/AzCore/Console/IConsole.h
@@ -99,8 +99,7 @@ namespace AZ
         //! @return boolean true if any deferred console commands have executed, false otherwise
         virtual bool ExecuteDeferredConsoleCommands() = 0;
 
-        //! Clear out any deffered console commands that have failed to execute from
-        //! the deferred queue
+        //! Clear out any deferred console commands queue
         virtual void ClearDeferredConsoleCommands() = 0;
 
         //! HasCommand is used to determine if the console knows about a command.

--- a/Code/Framework/AzCore/AzCore/Console/IConsole.h
+++ b/Code/Framework/AzCore/AzCore/Console/IConsole.h
@@ -94,22 +94,31 @@ namespace AZ
         //! @param commandLine the concatenated command-line string to execute
         virtual void ExecuteCommandLine(const AZ::CommandLine& commandLine) = 0;
 
+        //! Attempts to invoke a "deferred console command", which is a console command
+        //! that has failed to execute previously due to the command not being registered yet.
+        //! @return boolean true if any deferred console commands have executed, false otherwise
+        virtual bool ExecuteDeferredConsoleCommands() = 0;
+
+        //! Clear out any deffered console commands that have failed to execute from
+        //! the deferred queue
+        virtual void ClearDeferredConsoleCommands() = 0;
+
         //! HasCommand is used to determine if the console knows about a command.
         //! @param command the command we are checking for
         //! @return boolean true on if the command is registered, false otherwise
-        virtual bool HasCommand(const char* command) = 0;
+        virtual bool HasCommand(AZStd::string_view command) = 0;
 
         //! FindCommand finds the console command with the specified console string.
         //! @param command the command that is being searched for
         //! @return non-null pointer to the console command if found
-        virtual ConsoleFunctorBase* FindCommand(const char* command) = 0;
+        virtual ConsoleFunctorBase* FindCommand(AZStd::string_view command) = 0;
 
         //! Finds all commands where the input command is a prefix and returns
         //! the longest matching substring prefix the results have in common.
         //! @param command The prefix string to find all matching commands for.
         //! @param matches The list of all commands that match the input prefix.
         //! @return The longest matching substring prefix the results have in common.
-        virtual AZStd::string AutoCompleteCommand(const char* command,
+        virtual AZStd::string AutoCompleteCommand(AZStd::string_view command,
                                                   AZStd::vector<AZStd::string>* matches = nullptr) = 0;
 
         //! Retrieves the value of the requested cvar.
@@ -117,7 +126,7 @@ namespace AZ
         //! @param outValue reference to the instance to write the current cvar value to
         //! @return GetValueResult::Success if the operation succeeded, or an error result if the operation failed
         template<typename RETURN_TYPE>
-        GetValueResult GetCvarValue(const char* command, RETURN_TYPE& outValue);
+        GetValueResult GetCvarValue(AZStd::string_view command, RETURN_TYPE& outValue);
 
         //! Visits all registered console functors.
         //! @param visitor the instance to visit all functors with
@@ -176,7 +185,7 @@ namespace AZ
     }
 
     template<typename RETURN_TYPE>
-    inline GetValueResult IConsole::GetCvarValue(const char* command, RETURN_TYPE& outValue)
+    inline GetValueResult IConsole::GetCvarValue(AZStd::string_view command, RETURN_TYPE& outValue)
     {
         ConsoleFunctorBase* cvarFunctor = FindCommand(command);
         if (cvarFunctor == nullptr)

--- a/Code/Framework/AzCore/AzCore/Module/Module.h
+++ b/Code/Framework/AzCore/AzCore/Module/Module.h
@@ -98,19 +98,26 @@ namespace AZ
 ///
 /// \param MODULE_NAME      Name of module.
 /// \param MODULE_CLASSNAME Name of AZ::Module class (include namespace).
+///
+/// Execute any deferred console commands after linking any new deferred functors
+/// This allows deferred console commands defined within the module to now execute
+/// at this point now that the module has been loaded
 #if defined(AZ_MONOLITHIC_BUILD)
 #   define AZ_DECLARE_MODULE_CLASS(MODULE_NAME, MODULE_CLASSNAME) \
     extern "C" AZ::Module * CreateModuleClass_##MODULE_NAME() { return aznew MODULE_CLASSNAME; }
 #else
 #   define AZ_DECLARE_MODULE_CLASS(MODULE_NAME, MODULE_CLASSNAME)                                \
     AZ_DECLARE_MODULE_INITIALIZATION                                                             \
-    extern "C" AZ_DLL_EXPORT AZ::Module * CreateModuleClass()                                    \
+    extern "C" AZ_DLL_EXPORT AZ::Module* CreateModuleClass()                                     \
     {                                                                                            \
-        AZ::ConsoleFunctorBase*& deferredHead = AZ::ConsoleFunctorBase::GetDeferredHead();       \
-        AZ::Interface<AZ::IConsole>::Get()->LinkDeferredFunctors(deferredHead);                  \
+        if (auto console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)               \
+        {                                                                                        \
+             console->LinkDeferredFunctors(AZ::ConsoleFunctorBase::GetDeferredHead());           \
+             console->ExecuteDeferredConsoleCommands();                                          \
+        }                                                                                        \
         return aznew MODULE_CLASSNAME;                                                           \
     }                                                                                            \
-    extern "C" AZ_DLL_EXPORT void DestroyModuleClass(AZ::Module * module) { delete module; }
+    extern "C" AZ_DLL_EXPORT void DestroyModuleClass(AZ::Module* module) { delete module; }
 #endif
 
 #endif // AZCORE_MODULE_INCLUDE_H

--- a/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
+++ b/Code/Framework/AzCore/Tests/Console/ConsoleTests.cpp
@@ -507,6 +507,68 @@ namespace ConsoleSettingsRegistryTests
         AZ::Interface<AZ::IConsole>::Unregister(&testConsole);
     }
 
+    TEST_P(ConsoleSettingsRegistryFixture, Console_RecordsUnregisteredCommands_And_IsAbleToDeferDispatchCommand_Successfully)
+    {
+        AZ::Console testConsole(*m_registry);
+        AZ::Interface<AZ::IConsole>::Register(&testConsole);
+        // GetDeferredHead is invoked for the side effect of to set the s_deferredHeadInvoked value to true
+        // This allows scoped console variables to be attached immediately
+        [[maybe_unused]] auto deferredHead =  AZ::ConsoleFunctorBase::GetDeferredHead();
+
+        AZ_CVAR_SCOPED(int32_t, testInit, 0, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(char, testChar, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(bool, testBool, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        s_consoleFreeFunctionInvoked = false;
+        testInit = {};
+        testChar = {};
+        testBool = {};
+
+        // Invoke the Commands for Scoped CVar variables above
+        auto configFileParams = GetParam();
+        auto testFilePath = m_testFolder / configFileParams.m_testConfigFileName;
+        EXPECT_TRUE(AZ::IO::SystemFile::Exists(testFilePath.c_str()));
+        testConsole.ExecuteConfigFile(testFilePath.Native());
+
+        EXPECT_EQ(3, testInit);
+        EXPECT_TRUE(static_cast<bool>(testBool));
+        EXPECT_EQ('Q', AZ::testChar);
+
+        // The following commands from the config files should have been deferred
+        AZ_CVAR_SCOPED(int8_t, testInt8, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(int16_t, testInt16, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(int32_t, testInt32, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(int64_t, testInt64, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(uint8_t, testUInt8, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(uint16_t, testUInt16, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(uint32_t, testUInt32, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(uint64_t, testUInt64, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(float, testFloat, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(double, testDouble, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+        AZ_CVAR_SCOPED(AZ::CVarFixedString, testString, {}, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+
+        // The scoped cvars just above should have all been deferred for execution
+        // Each of them should have executed resulting in the expected return value
+        EXPECT_TRUE(testConsole.ExecuteDeferredConsoleCommands());
+
+        EXPECT_EQ(24, testInt8);
+        EXPECT_EQ(-32, testInt16);
+        EXPECT_EQ(41, testInt32);
+        EXPECT_EQ(-51, testInt64);
+        EXPECT_EQ(3, testUInt8);
+        EXPECT_EQ(5, testUInt16);
+        EXPECT_EQ(6, testUInt32);
+        EXPECT_EQ(0xFFFF'FFFF'FFFF'FFFF, testUInt64);
+        EXPECT_FLOAT_EQ(1.0f, testFloat);
+        EXPECT_DOUBLE_EQ(2, testDouble);
+        EXPECT_STREQ("Stable", static_cast<AZ::CVarFixedString>(AZ::testString).c_str());
+
+        // All of the deferred console commands should have executed at this point
+        // Therefore this invocation should return false
+        EXPECT_FALSE(testConsole.ExecuteDeferredConsoleCommands());
+
+        AZ::Interface<AZ::IConsole>::Unregister(&testConsole);
+    }
+
 
     static constexpr AZStd::string_view UserINIStyleContent =
         R"(


### PR DESCRIPTION
An AZ Console instance will now store any console commands that could be
dispatched from a configuration file into a deferred queue, that can be
invoked later.

This can be used to defer execution of console commands in configuration files such as
.cfg, .setreg and .setregpatch files that are defined in gem modules that
have not been loaded yet.
The defered execution can then be invoked at any point later in the
application

Updated the Component Application CreateCommon function to invoke deferred console commands
after all the gems have loaded

fixes #2062

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>