### PR TITLE
Fix type error with Server to Authority RPC generation

### DIFF
--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Header.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Header.jinja
@@ -132,7 +132,7 @@ void {{ PropertyName }}({{ ', '.join(paramDefines) }});
 #}
 {% macro DeclareRpcInvocations(Component, Section, HandleOn, ProctectedSection) %}
 {% call(Property) AutoComponentMacros.ParseRemoteProcedures(Component, Section, HandleOn) %}
-{%    if Property.attrib['IsPublic']|booleanTrue == ProctectedSection %}
+{%    if Property.attrib['IsPublic']|booleanTrue != ProctectedSection %}
 {{ DeclareRpcInvocation(Property, HandleOn) -}}
 {%    endif %}
 {% endcall %}
@@ -386,8 +386,6 @@ namespace {{ Component.attrib['Namespace'] }}
         {{ DeclareNetworkPropertyAccessors(Component, 'Autonomous', 'Authority', false)|indent(8) -}}
         {{ DeclareNetworkPropertyAccessors(Component, 'Autonomous', 'Authority', true)|indent(8) -}}
         {{ DeclareArchetypePropertyGetters(Component)|indent(8) -}}
-        {{ DeclareRpcInvocations(Component, 'Server', 'Authority', false)|indent(8) -}}
-        {{ DeclareRpcInvocations(Component, 'Server', 'Authority', true)|indent(8) -}}
         {{ DeclareRpcInvocations(Component, 'Client', 'Authority', false)|indent(8) -}}
         {{ DeclareRpcInvocations(Component, 'Client', 'Authority', true)|indent(8) -}}
         {{ DeclareRpcInvocations(Component, 'Autonomous', 'Authority', false)|indent(8) -}}

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Header.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Header.jinja
@@ -130,9 +130,9 @@ void {{ PropertyName }}({{ ', '.join(paramDefines) }});
 {#
 
 #}
-{% macro DeclareRpcInvocations(Component, Section, HandleOn, ProctectedSection) %}
+{% macro DeclareRpcInvocations(Component, Section, HandleOn, IsProtected) %}
 {% call(Property) AutoComponentMacros.ParseRemoteProcedures(Component, Section, HandleOn) %}
-{%    if Property.attrib['IsPublic']|booleanTrue != ProctectedSection %}
+{%    if Property.attrib['IsPublic']|booleanTrue != IsProtected %}
 {{ DeclareRpcInvocation(Property, HandleOn) -}}
 {%    endif %}
 {% endcall %}

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -1544,8 +1544,8 @@ namespace {{ Component.attrib['Namespace'] }}
 {{ DefineNetworkPropertyGets(Component, 'Authority', 'Client', true, ComponentBaseName)|indent(4) }}
 {{ DefineNetworkPropertyGets(Component, 'Autonomous', 'Authority', true, ComponentBaseName)|indent(4) }}
 {{ DefineArchetypePropertyGets(Component, ClassType, ComponentBaseName)|indent(4) -}}
-{{ DefineRpcInvocations(Component, ComponentBaseName, 'Server', 'Authority', false)|indent(4) -}}
-{{ DefineRpcInvocations(Component, ComponentBaseName, 'Server', 'Authority', true)|indent(4) }}
+{{ DefineRpcInvocations(Component, ControllerBaseName, 'Server', 'Authority', false)|indent(4) -}}
+{{ DefineRpcInvocations(Component, ControllerBaseName, 'Server', 'Authority', true)|indent(4) }}
 
     void {{ ComponentBaseName }}::SetOwningConnectionId([[maybe_unused]] AzNetworking::ConnectionId connectionId)
     {

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -318,7 +318,7 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.join(par
     constexpr AzNetworking::ReliabilityType isReliable = Multiplayer::ReliabilityType::Unreliable;
 {% endif %}
 
-{%     if (InvokeFrom == 'Server' or InvokeFrom =="Client") and HandleOn == 'Authority' %}
+{%     if InvokeFrom == 'Server' or InvokeFrom =='Client' %}
     const Multiplayer::NetComponentId netComponentId = GetNetComponentId();
 {%     else %}
     const Multiplayer::NetComponentId netComponentId = GetParent().GetNetComponentId();

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -349,9 +349,9 @@ void {{ ClassName }}::Signal{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.jo
 {#
 
 #}
-{% macro DefineRpcInvocations(Component, ClassName, InvokeFrom, HandleOn, ProctectedSection) %}
+{% macro DefineRpcInvocations(Component, ClassName, InvokeFrom, HandleOn, IsProtected) %}
 {% call(Property) AutoComponentMacros.ParseRemoteProcedures(Component, InvokeFrom, HandleOn) %}
-{%    if Property.attrib['IsPublic']|booleanTrue == ProctectedSection %}
+{%    if Property.attrib['IsPublic']|booleanTrue == IsProtected %}
 {{ DefineRpcInvocation(Component, ClassName, Property, InvokeFrom, HandleOn) -}}
 {%    if Property.attrib['GenerateEventBindings']|booleanTrue == true %}
 {{ DefineRpcSignal(Component, ClassName, Property, InvokeFrom) -}}

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -351,7 +351,7 @@ void {{ ClassName }}::Signal{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.jo
 #}
 {% macro DefineRpcInvocations(Component, ClassName, InvokeFrom, HandleOn, IsProtected) %}
 {% call(Property) AutoComponentMacros.ParseRemoteProcedures(Component, InvokeFrom, HandleOn) %}
-{%    if Property.attrib['IsPublic']|booleanTrue == IsProtected %}
+{%    if Property.attrib['IsPublic']|booleanTrue != IsProtected %}
 {{ DefineRpcInvocation(Component, ClassName, Property, InvokeFrom, HandleOn) -}}
 {%    if Property.attrib['GenerateEventBindings']|booleanTrue == true %}
 {{ DefineRpcSignal(Component, ClassName, Property, InvokeFrom) -}}

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -318,7 +318,7 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.join(par
     constexpr AzNetworking::ReliabilityType isReliable = Multiplayer::ReliabilityType::Unreliable;
 {% endif %}
 
-{%     if InvokeFrom == 'Server' and HandleOn == 'Authority' %}
+{%     if (InvokeFrom == 'Server' or InvokeFrom =="Client") and HandleOn == 'Authority' %}
     const Multiplayer::NetComponentId netComponentId = GetNetComponentId();
 {%     else %}
     const Multiplayer::NetComponentId netComponentId = GetParent().GetNetComponentId();

--- a/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
+++ b/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
@@ -318,7 +318,11 @@ void {{ ClassName }}::{{ UpperFirst(Property.attrib['Name']) }}({{ ', '.join(par
     constexpr AzNetworking::ReliabilityType isReliable = Multiplayer::ReliabilityType::Unreliable;
 {% endif %}
 
+{%     if InvokeFrom == 'Server' and HandleOn == 'Authority' %}
+    const Multiplayer::NetComponentId netComponentId = GetNetComponentId();
+{%     else %}
     const Multiplayer::NetComponentId netComponentId = GetParent().GetNetComponentId();
+{%     endif %}
     Multiplayer::NetworkEntityRpcMessage rpcMessage(Multiplayer::RpcDeliveryType::{{ InvokeFrom }}To{{ HandleOn }}, GetNetEntityId(), netComponentId, rpcId, isReliable);
 {%     if paramNames|count > 0 %}
     {{ UpperFirst(Component.attrib['Name']) }}Internal::{{ UpperFirst(Property.attrib['Name']) }}RpcStruct rpcStruct({{ ', '.join(paramNames) }});
@@ -1544,8 +1548,8 @@ namespace {{ Component.attrib['Namespace'] }}
 {{ DefineNetworkPropertyGets(Component, 'Authority', 'Client', true, ComponentBaseName)|indent(4) }}
 {{ DefineNetworkPropertyGets(Component, 'Autonomous', 'Authority', true, ComponentBaseName)|indent(4) }}
 {{ DefineArchetypePropertyGets(Component, ClassType, ComponentBaseName)|indent(4) -}}
-{{ DefineRpcInvocations(Component, ControllerBaseName, 'Server', 'Authority', false)|indent(4) -}}
-{{ DefineRpcInvocations(Component, ControllerBaseName, 'Server', 'Authority', true)|indent(4) }}
+{{ DefineRpcInvocations(Component, ComponentBaseName, 'Server', 'Authority', false)|indent(4) -}}
+{{ DefineRpcInvocations(Component, ComponentBaseName, 'Server', 'Authority', true)|indent(4) }}
 
     void {{ ComponentBaseName }}::SetOwningConnectionId([[maybe_unused]] AzNetworking::ConnectionId connectionId)
     {


### PR DESCRIPTION
DefineRpcInvocations requires the ControllerBase not the ComponentBase (see the other usages of DefineRpcInvocations). This fixes issues with Server to Authority RPCs where GetParent is undefined due to the wrong base type.

Signed-off-by: puvvadar <puvvadar@amazon.com>