### PR TITLE
AtomTools: fix multiple material editor processes launching

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -46,6 +46,8 @@ namespace AtomToolsFramework
         AtomToolsApplication(int* argc, char*** argv);
         ~AtomToolsApplication();
 
+        virtual bool LaunchLocalServer();
+
         //////////////////////////////////////////////////////////////////////////
         // AzFramework::Application
         void CreateReflectionManager() override;
@@ -106,8 +108,6 @@ namespace AtomToolsFramework
         virtual void UnloadSettings();
         virtual void CompileCriticalAssets();
         virtual void ProcessCommandLine(const AZ::CommandLine& commandLine);
-        virtual bool LaunchDiscoveryService();
-        virtual void StartInternal();
 
         static void PyIdleWaitFrames(uint32_t frames);
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/main.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/main.cpp
@@ -28,9 +28,12 @@ int main(int argc, char** argv)
     AzQtComponents::AzQtApplication::InitializeDpiScaling();
 
     MaterialEditor::MaterialEditorApplication app(&argc, &argv);
+    if (!app.LaunchLocalServer())
+    {
+        return 0;
+    }
 
-    auto globalEventFilter = new AzQtComponents::GlobalEventFilter(&app);
-    app.installEventFilter(globalEventFilter);
+    app.installEventFilter(new AzQtComponents::GlobalEventFilter(&app));
 
     AZ::IO::FixedMaxPath engineRootPath;
     if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/main.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/main.cpp
@@ -28,6 +28,12 @@ int main(int argc, char** argv)
     AzQtComponents::AzQtApplication::InitializeDpiScaling();
 
     ShaderManagementConsole::ShaderManagementConsoleApplication app(&argc, &argv);
+    if (!app.LaunchLocalServer())
+    {
+        return 0;
+    }
+
+    app.installEventFilter(new AzQtComponents::GlobalEventFilter(&app));
 
     AZ::IO::FixedMaxPath engineRootPath;
     if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
@@ -35,13 +41,10 @@ int main(int argc, char** argv)
         settingsRegistry->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
     }
 
-    auto globalEventFilter = new AzQtComponents::GlobalEventFilter(&app);
-    app.installEventFilter(globalEventFilter);
-
     AzQtComponents::StyleManager styleManager(&app);
     styleManager.initialize(&app, engineRootPath);
 
-    app.Start({});
+    app.Start(AZ::ComponentApplication::Descriptor{});
     app.exec();
     app.Stop();
     return 0;


### PR DESCRIPTION
Atom tools launch or check for the existence of a local server in order to prevent multiple application processes from running. These checks were being done far too late, after initialization and asset processing, leaving time for multiple processes to start before the server or checks. Zombie processes could start and run indefinitely without user interaction because the event loop was being entered despite the request to exit the application early.

These changes launch the server and checks immediately after the application object is constructed and exit before any other work is done if the application will not be run.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>