### PR TITLE
Erase existing artifacts before generating new artifacts.

### DIFF
--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -448,8 +448,9 @@ function(ly_test_impact_post_step)
     # Directory for binaries built for this profile
     set(bin_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>")
 
-    # Erase any existing non-persistent data to avoid getting test impact framework out of sync with current repo state
+    # Erase any existing artifact and non-persistent data to avoid getting test impact framework out of sync with current repo state
     file(REMOVE_RECURSE "${LY_TEST_IMPACT_TEMP_DIR}")
+    file(REMOVE_RECURSE "${LY_TEST_IMPACT_ARTIFACT_DIR}")
 
     # Export the soruce to target mapping files
     ly_test_impact_export_source_target_mappings(


### PR DESCRIPTION
This fixes the bug where existing TIAF static artifacts were not being removed prior to being generated, resulting in target deletions to erroneously result in integrity errors due to the dynamic dependency map attempting to remove a source file that still exists in a build target (it doesn't, it's just that the deleted build target's source-to-target mapping artifact was still there, causing it to be parsed by the TIAF runtime).

Signed-off-by: John <jonawals@amazon.com>