### PR TITLE
Add extra logging for CHANGE_ID and COMMIT_ID.

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -619,7 +619,7 @@ try {
                     }
                     pipelineProperties.add(disableConcurrentBuilds())
 
-                    echo "Running repository: \"${repositoryName}\", pipeline: \"${pipelineName}\", branch: \"${branchName}\"..."
+                    echo "Running repository: \"${repositoryName}\", pipeline: \"${pipelineName}\", branch: \"${branchName}\", CHANGE_ID: \"${env.CHANGE_ID}\", GIT_COMMMIT: \"${scm.GIT_COMMIT}\"..."
 
                     CheckoutBootstrapScripts(branchName)
 


### PR DESCRIPTION
Adds logging for `CHANGE_ID` and `COMMIT_ID` to facilitate cross-referencing between Jenkins and TIAF for unexpected `CHANGE_ID` values in TIAF.

Signed-off-by: John <jonawals@amazon.com>