### PR TITLE
Fix input priority conflict with LyShine and ImGuiPass

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -67,8 +67,8 @@ namespace AZ
 
         ImGuiPass::ImGuiPass(const RPI::PassDescriptor& descriptor)
             : Base(descriptor)
-            , AzFramework::InputChannelEventListener(AzFramework::InputChannelEventListener::GetPriorityUI())
-            , AzFramework::InputTextEventListener(AzFramework::InputTextEventListener::GetPriorityUI())
+            , AzFramework::InputChannelEventListener(AzFramework::InputChannelEventListener::GetPriorityUI() + 1) // Prioritize ImGui input over in-game UI such as LyShine
+            , AzFramework::InputTextEventListener(AzFramework::InputTextEventListener::GetPriorityUI() + 1) // Prioritize ImGui input over in-game UI such as LyShine
         {
 
             const ImGuiPassData* imguiPassData = RPI::PassUtils::GetPassData<ImGuiPassData>(descriptor);
@@ -155,11 +155,6 @@ namespace AZ
             auto& io = ImGui::GetIO();
             io.AddInputCharactersUTF8(textUTF8.c_str());
             return io.WantTextInput;
-        }
-
-        AZ::s32 ImGuiPass::GetPriority() const
-        {
-            return AzFramework::InputChannelEventListener::GetPriorityUI();
         }
 
         bool ImGuiPass::OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel)

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -84,7 +84,6 @@ namespace AZ
 
             // AzFramework::InputChannelEventListener overrides...
             bool OnInputChannelEventFiltered(const AzFramework::InputChannel& inputChannel) override;
-            AZ::s32 GetPriority() const override;
 
         protected:
             explicit ImGuiPass(const RPI::PassDescriptor& descriptor);


### PR DESCRIPTION
ImGuiPass does some input handling, and it was using the same input priority value as LyShine resulting in UI Canvases handling input before the ImGuiPass. This indirectly caused a bug with the Debug Console where navigation and backspace keys as well as mouse events were being consumed by the UI Canvas and not propagating to the Debug Console (when UI Canvas was configured to "consume all input").

Signed-off-by: abrmich <abrmich@amazon.com>