### PR TITLE
Allow Tag components to be added to UI elements.

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Scripting/EditorTagComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Scripting/EditorTagComponent.cpp
@@ -33,6 +33,7 @@ namespace LmbrCentral
                 editContext->Class<EditorTagComponent>("Tag", "The Tag component allows you to apply one or more labels to an entity")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game", 0x232b318c))
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("UI", 0x27ff46b0))
                         ->Attribute(AZ::Edit::Attributes::Category, "Gameplay")
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Tag.svg")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Tag.svg")


### PR DESCRIPTION
Fixes #3313 

Allow Tag components to be added to UI elements for ease of use. This allows the user another way of accessing UI elements instead of only by name.

Here is a simple Script Canvas example of showing elements by tag at different time delays:

![FindingUIElementsByTag](https://user-images.githubusercontent.com/7519264/130122386-21f0777c-da14-4a60-ac6e-c1eb42419d13.png)
![ShowingUIElementsByTag](https://user-images.githubusercontent.com/7519264/130122395-5333020f-0a04-4794-9977-3babc54be389.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>