### PR TITLE
GpuMemory: add missing end() call + fix width

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -1271,6 +1271,7 @@ namespace AZ
                 m_nameFilter.Draw("Search");
                 DrawTable();
             }
+            ImGui::End();
         }
 
         // --- ImGuiGpuProfiler ---

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -1107,7 +1107,7 @@ namespace AZ
             {
                 ImGui::TableSetupColumn("Parent pool");
                 ImGui::TableSetupColumn("Name");
-                ImGui::TableSetupColumn("Size (MB)", 0, 100.0f);
+                ImGui::TableSetupColumn("Size (MB)");
                 ImGui::TableSetupColumn("BindFlags", ImGuiTableColumnFlags_NoSort);
                 ImGui::TableHeadersRow();
                 ImGui::TableNextColumn();


### PR DESCRIPTION
Fixes crash due to missing `ImGui::End()` call and invalid width