### PR TITLE
Fixing the softening boundary width editor options

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
@@ -124,6 +124,9 @@ namespace AZ
 
             //! Returns true if exponential shadow maps are disabled.
             bool IsEsmDisabled() const;
+
+            //! Returns true if the softening boundary width parameter is disabled. 
+            bool IsSofteningBoundaryWidthDisabled() const;
         };
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
@@ -121,6 +121,8 @@ namespace AZ
             bool IsShadowFilteringDisabled() const;
             bool IsShadowPcfDisabled() const;
             bool IsPcfBoundarySearchDisabled() const;
+            bool IsSofteningBoundaryWidthDisabled() const;
+            bool IsEsmDisabled() const;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -197,5 +197,16 @@ namespace AZ
             return !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
 
+        bool AreaLightComponentConfig::IsSofteningBoundaryWidthDisabled() const
+        {
+            // softening boundary width is always available with ESM. It controls the width of the blur kernel during the ESM gaussian
+            // blur passes
+            if (!IsEsmDisabled())
+                return false;
+
+            // with PCF, softening boundary width is used with the boundary search method and NOT the bicubic pcf methods
+            return IsPcfBoundarySearchDisabled();
+        }
+
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
@@ -128,5 +128,21 @@ namespace AZ
             return m_pcfMethod != PcfMethod::BoundarySearch;
         }
 
+        bool DirectionalLightComponentConfig::IsEsmDisabled() const
+        {
+            return !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
+        }
+
+        bool DirectionalLightComponentConfig::IsSofteningBoundaryWidthDisabled() const
+        {
+            // softening boundary width is always available with ESM. It controls the width of the blur kernel during the ESM gaussian
+            // blur passes
+            if (!IsEsmDisabled())
+                return false;
+
+            // with PCF, softening boundary width is used with the boundary search method and NOT the bicubic pcf methods
+            return IsPcfBoundarySearchDisabled();
+        }
+
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -162,7 +162,7 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Max, 1.f)
                             ->Attribute(Edit::Attributes::Suffix, " deg")
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsShadows)
-                            ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsPcfBoundarySearchDisabled)
+                            ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsSofteningBoundaryWidthDisabled)
                         ->DataElement(Edit::UIHandlers::Slider, &AreaLightComponentConfig::m_predictionSampleCount, "Prediction sample count",
                             "Sample count for prediction of whether the pixel is on the boundary. Specific to PCF and ESM+PCF.")
                             ->Attribute(Edit::Attributes::Min, 4)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -141,7 +141,7 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Max, 0.1f)
                             ->Attribute(Edit::Attributes::Suffix, " m")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-                        ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsPcfBoundarySearchDisabled)
+                        ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsSofteningBoundaryWidthDisabled)
                         ->DataElement(Edit::UIHandlers::Slider, &DirectionalLightComponentConfig::m_predictionSampleCount, "Prediction sample count",
                             "Sample count for prediction of whether the pixel is on the boundary. "
                             "Specific to PCF and ESM+PCF.")


### PR DESCRIPTION
The editor slider for the softening boundary width is not correct. It goes gray and not selectable for combinations that should be selectable.

Basically we want it always on for ESM, or ESM+PCF options since it controls the ESM filter kernel size.
For PCF, we ONLY want it on when using boundary search. Bicubic doesn't use it. Also, no-filtering doesn't use it either.

Tested all the above combinations for both directional and area lights.