### PR TITLE
Fixed console variables crash.

### DIFF
--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -3133,6 +3133,9 @@ char* CXConsole::GetCheatVarAt(uint32 nOffset)
 //////////////////////////////////////////////////////////////////////////
 size_t CXConsole::GetSortedVars(AZStd::vector<AZStd::string_view>& pszArray, const char* szPrefix)
 {
+    // This method used to insert instead of push_back, so we need to clear first
+    pszArray.clear();
+
     size_t iPrefixLen = szPrefix ? strlen(szPrefix) : 0;
 
     // variables


### PR DESCRIPTION
Fixes #3357 

There was a change recently that switched CXConsole::GetSortedVars from inserting into the input array to push_back, and almost all usages of GetSortedVars would do a resize on count before invoking, so you would wind up with a vector of empty strings for the first half, and the actually variables in the second half. Instead of updating all the usages of GetSortedVars (since this is legacy code anyways), just updated it to do a clear before it starts appending to the vector.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>