### PR TITLE
fixes a flaky lytesttools unit test

### DIFF
--- a/Tools/LyTestTools/tests/unit/test_builtin_helpers.py
+++ b/Tools/LyTestTools/tests/unit/test_builtin_helpers.py
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 Unit tests for ly_test_tools.builtin.helpers functions.
 """
 import unittest.mock as mock
+import os
 
 import pytest
 
@@ -41,6 +42,8 @@ class MockedWorkspaceManager(ly_test_tools._internal.managers.workspace.Abstract
         )
 
 
+@mock.patch('ly_test_tools._internal.managers.abstract_resource_locator._find_project_json',
+            mock.MagicMock(return_value=os.path.join("mocked", "path")))
 @mock.patch(
     'ly_test_tools._internal.managers.abstract_resource_locator.AbstractResourceLocator',
     mock.MagicMock(return_value=MockedAbstractResourceLocator)


### PR DESCRIPTION
Signed-off-by: evanchia <evanchia@amazon.com>

There was a random failure in the unit tests because of a new _find_project_json() function in the AbstractResourceLocator class that needs to be mocked in a test that is dependent on that class. Tested by running unit tests locally and verifying that the function in question is mocked properly.