### PR TITLE
Multiple RHI related fixes as described below

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CapsuleLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CapsuleLightFeatureProcessor.cpp
@@ -107,8 +107,7 @@ namespace AZ
 
             if (m_deviceBufferNeedsUpdate)
             {
-                [[maybe_unused]] bool success = m_lightBufferHandler.UpdateBuffer(m_capsuleLightData.GetDataVector());
-                AZ_Error(FeatureProcessorName, success, "Unable to update buffer during Simulate().");
+                m_lightBufferHandler.UpdateBuffer(m_capsuleLightData.GetDataVector());
                 m_deviceBufferNeedsUpdate = false;
             }
         }

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalFeatureProcessor.cpp
@@ -112,8 +112,7 @@ namespace AZ
 
             if (m_deviceBufferNeedsUpdate)
             {
-                [[maybe_unused]] bool success = m_decalBufferHandler.UpdateBuffer(m_decalData.GetDataVector<0>());
-                AZ_Error(FeatureProcessorName, success, "Unable to update buffer during Simulate().");
+                m_decalBufferHandler.UpdateBuffer(m_decalData.GetDataVector<0>());
                 m_deviceBufferNeedsUpdate = false;
             }
         }

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArrayFeatureProcessor.cpp
@@ -150,8 +150,7 @@ namespace AZ
 
             if (m_deviceBufferNeedsUpdate)
             {
-                [[maybe_unused]] bool success = m_decalBufferHandler.UpdateBuffer(m_decalData.GetDataVector());
-                AZ_Error(FeatureProcessorName, success, "Unable to update buffer during Simulate().");
+                m_decalBufferHandler.UpdateBuffer(m_decalData.GetDataVector());
                 m_deviceBufferNeedsUpdate = false;
             }
         }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/BufferPool.h
@@ -223,6 +223,9 @@ namespace AZ
             /// Called when a buffer is being streamed asynchronously.
             virtual ResultCode StreamBufferInternal(const BufferStreamRequest& request);
 
+            //Called in order to do a simple mem copy allowing Null rhi to opt out
+            virtual void BufferCopy(void* destination, const void* source, size_t num);
+
             //////////////////////////////////////////////////////////////////////////
 
             BufferPoolDescriptor m_descriptor;

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -143,7 +143,7 @@ namespace AZ
                 resultCode = MapBufferInternal(mapRequest, mapResponse);
                 if (resultCode == ResultCode::Success)
                 {
-                    memcpy(mapResponse.m_data, initRequest.m_initialData, initRequest.m_descriptor.m_byteCount);
+                    BufferCopy(mapResponse.m_data, initRequest.m_initialData, initRequest.m_descriptor.m_byteCount);
                     UnmapBufferInternal(*initRequest.m_buffer);
                 }
             }
@@ -217,6 +217,11 @@ namespace AZ
         const BufferPoolDescriptor& BufferPool::GetDescriptor() const
         {
             return m_descriptor;
+        }
+
+        void BufferPool::BufferCopy(void* destination, const void* source, size_t num)
+        {
+            memcpy(destination, source, num);
         }
 
         ResultCode BufferPool::StreamBufferInternal([[maybe_unused]] const BufferStreamRequest& request)

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPoolBase.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPoolBase.cpp
@@ -34,7 +34,7 @@ namespace AZ
 
                 if (!isDataValid)
                 {
-                    AZ_Warning("BufferPoolBase", false, "Failed to map buffer '%s'.", buffer.GetName().GetCStr());
+                    AZ_Error("BufferPoolBase", false, "Failed to map buffer '%s'.", buffer.GetName().GetCStr());
                 }
                 ++buffer.m_mapRefCount;
                 ++m_mapRefCount;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/IndirectBufferSignature.cpp
@@ -111,6 +111,8 @@ namespace AZ
 
         void IndirectBufferSignature::ShutdownInternal()
         {
+            auto& device = static_cast<Device&>(GetDevice());
+            device.QueueForRelease(m_signature);
             m_signature = nullptr;
             m_stride = 0;
         }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/QueryPool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/QueryPool.cpp
@@ -237,5 +237,14 @@ namespace AZ
             static constexpr D3D12_RANGE InvalidRange = {0,0};
             m_readBackBuffer->Unmap(0, &InvalidRange);
         }
+
+        void QueryPool::ShutdownInternal()
+        {
+            auto& device = static_cast<Device&>(GetDevice());
+            device.QueueForRelease(m_queryHeap);
+            m_queryHeap = nullptr;
+            device.QueueForRelease(m_readBackBuffer);
+            m_readBackBuffer = nullptr;
+        }
     }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/QueryPool.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/QueryPool.h
@@ -44,6 +44,7 @@ namespace AZ
             RHI::ResultCode InitInternal(RHI::Device& device, const RHI::QueryPoolDescriptor& descriptor) override;
             RHI::ResultCode InitQueryInternal(RHI::Query& query) override;
             RHI::ResultCode GetResultsInternal(uint32_t startIndex, uint32_t queryCount, uint64_t* results, uint32_t resultsCount, RHI::QueryResultFlagBits flags) override;
+            void ShutdownInternal() override;
             //////////////////////////////////////////////////////////////////////////
 
             //////////////////////////////////////////////////////////////////////////

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/BufferPool.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/BufferPool.h
@@ -39,9 +39,10 @@ namespace AZ
             RHI::ResultCode InitBufferInternal([[maybe_unused]] RHI::Buffer& buffer, [[maybe_unused]] const RHI::BufferDescriptor& rhiDescriptor) override{ return RHI::ResultCode::Success;}
             void ShutdownResourceInternal([[maybe_unused]] RHI::Resource& resource) override {}
             RHI::ResultCode OrphanBufferInternal([[maybe_unused]] RHI::Buffer& buffer) override { return RHI::ResultCode::Success;}
-            RHI::ResultCode MapBufferInternal([[maybe_unused]] const RHI::BufferMapRequest& mapRequest, [[maybe_unused]] RHI::BufferMapResponse& response) override { return RHI::ResultCode::Unimplemented;}
+            RHI::ResultCode MapBufferInternal([[maybe_unused]] const RHI::BufferMapRequest& mapRequest, [[maybe_unused]] RHI::BufferMapResponse& response) override { return RHI::ResultCode::Success;}
             void UnmapBufferInternal([[maybe_unused]] RHI::Buffer& buffer) override {}
             RHI::ResultCode StreamBufferInternal([[maybe_unused]] const RHI::BufferStreamRequest& request) override { return RHI::ResultCode::Success;}
+            void BufferCopy([[maybe_unused]] void* destination, [[maybe_unused]] const void* source, [[maybe_unused]] size_t num) override {}
             //////////////////////////////////////////////////////////////////////////
 
         };

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/Buffer.cpp
@@ -176,8 +176,7 @@ namespace AZ
                 return RHI::ResultCode::Success;
             }
 
-            // ResultCode::Unimplemented is used by Null Renderer and hence is a valid use case
-            AZ_Error("Buffer", resultCode == AZ::RHI::ResultCode::Unimplemented, "Buffer::Init() failed to initialize RHI buffer. Error code: %d", static_cast<uint32_t>(resultCode));
+            AZ_Error("Buffer", false, "Buffer::Init() failed to initialize RHI buffer. Error code: %d", static_cast<uint32_t>(resultCode));
             return resultCode;
         }
         
@@ -240,11 +239,6 @@ namespace AZ
             if (result == RHI::ResultCode::Success)
             {
                 return response.m_data;
-            }
-            else if (result == RHI::ResultCode::Unimplemented)
-            {
-                // ResultCode::Unimplemented is used by Null Renderer and hence is a valid use case
-                return nullptr;
             }
             else
             {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
@@ -136,6 +136,7 @@ namespace AZ
                 return false;
             }
 
+            bufferPool->SetName(Name(AZStd::string::format("RPI::CommonBufferPool_%i", static_cast<uint32_t>(poolType))));
             RHI::ResultCode resultCode = bufferPool->Init(*device, bufferPoolDesc);
             if (resultCode != RHI::ResultCode::Success)
             {

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -1107,7 +1107,7 @@ namespace AZ
             {
                 ImGui::TableSetupColumn("Parent pool");
                 ImGui::TableSetupColumn("Name");
-                ImGui::TableSetupColumn("Size (MB)", 0, 100.0f);
+                ImGui::TableSetupColumn("Size (MB)");
                 ImGui::TableSetupColumn("BindFlags", ImGuiTableColumnFlags_NoSort);
                 ImGui::TableHeadersRow();
                 ImGui::TableNextColumn();
@@ -1133,7 +1133,7 @@ namespace AZ
                     ImGui::TableNextColumn();
                     ImGui::Text(tableRow.m_bufImgName.GetCStr());
                     ImGui::TableNextColumn();
-                    ImGui::Text("%.2f", 1.0f * tableRow.m_sizeInBytes / GpuProfilerImGuiHelper::MB);
+                    ImGui::Text("%.4f", 1.0f * tableRow.m_sizeInBytes / GpuProfilerImGuiHelper::MB);
                     ImGui::TableNextColumn();
                     ImGui::Text(tableRow.m_bindFlags.c_str());
                     ImGui::TableNextColumn();
@@ -1271,6 +1271,7 @@ namespace AZ
                 m_nameFilter.Draw("Search");
                 DrawTable();
             }
+            ImGui::End();
         }
 
         // --- ImGuiGpuProfiler ---


### PR DESCRIPTION
Fixes asserts related to buffer allocation using null rhi
Fixes GPU crashes when releasing Indirect draw and query related dx12 objects
Fixes imgui profiler related to viewing buffer allocations
Removed buffer update related asserts from RPI as they can happen within RHI

Signed-off-by: moudgils <moudgils@amazon.com>