### PR TITLE
Updated the CrySystem module to execute deferred console commands

### DIFF
--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1374,8 +1374,6 @@ AZ_POP_DISABLE_WARNING
             // Register any AZ CVar commands created above with the AZ Console system.
             AZ::ConsoleFunctorBase*& deferredHead = AZ::ConsoleFunctorBase::GetDeferredHead();
             AZ::Interface<AZ::IConsole>::Get()->LinkDeferredFunctors(deferredHead);
-            // Execute any deferred commands that uses the CVar commands that were just registered
-            AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
 
             // Callback
             if (m_pUserCallback && m_env.pConsole)
@@ -1628,6 +1626,9 @@ AZ_POP_DISABLE_WARNING
     // Send out EBus event
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);
 
+    // Execute any deferred commands that uses the CVar commands that were just registered
+    AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
+
     // Verify that the Maestro Gem initialized the movie system correctly. This can be removed if and when Maestro is not a required Gem
     if (gEnv->IsEditor() && !gEnv->pMovieSystem)
     {
@@ -1643,7 +1644,7 @@ AZ_POP_DISABLE_WARNING
 
     m_bInitializedSuccessfully = true;
 
-    return (true);
+    return true;
 }
 
 

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1374,6 +1374,8 @@ AZ_POP_DISABLE_WARNING
             // Register any AZ CVar commands created above with the AZ Console system.
             AZ::ConsoleFunctorBase*& deferredHead = AZ::ConsoleFunctorBase::GetDeferredHead();
             AZ::Interface<AZ::IConsole>::Get()->LinkDeferredFunctors(deferredHead);
+            // Execute any deferred commands that uses the CVar commands that were just registered
+            AZ::Interface<AZ::IConsole>::Get()->ExecuteDeferredConsoleCommands();
 
             // Callback
             if (m_pUserCallback && m_env.pConsole)


### PR DESCRIPTION
This allows the CVars declared in CrySystem module to execute commands
invoked before it was loaded.

This is particularly useful for the load level command.

For example the load level command can be placed in a setreg file
### load_level.setreg
```JSON
{
    "Amazon": {
        "AzCore": {
            "Runtime": {
                "ConsoleCommands": {
                    "LoadLevel": "Levels/main/main.spawnable"
                }
            }
        }
    }
}
```

resolves #2062

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>