### PR TITLE
AtomTools: moved remaining document and window common code from ME and SMC to base class

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -37,26 +37,25 @@ namespace AtomToolsFramework
 
         QString GetDocumentPath(const AZ::Uuid& documentId) const;
 
-        AZ::Uuid GetDocumentIdFromTab(const int tabIndex) const;
+        AZ::Uuid GetDocumentTabId(const int tabIndex) const;
 
-        void AddTabForDocumentId(
+        void AddDocumentTab(
             const AZ::Uuid& documentId,
             const AZStd::string& label,
             const AZStd::string& toolTip);
 
-        void RemoveTabForDocumentId(const AZ::Uuid& documentId);
+        void RemoveDocumentTab(const AZ::Uuid& documentId);
 
-        void UpdateTabForDocumentId(
+        void UpdateDocumentTab(
             const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified);
 
-        void SelectPreviousTab();
+        void SelectPrevDocumentTab();
+        void SelectNextDocumentTab();
 
-        void SelectNextTab();
-
-        virtual void OpenTabContextMenu();
-        virtual bool GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath);
-        virtual bool GetOpenFileInfo(AZStd::string& openPath);
-        virtual QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId);
+        virtual QWidget* CreateDocumentTabView(const AZ::Uuid& documentId);
+        virtual void OpenDocumentTabContextMenu();
+        virtual bool GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath);
+        virtual bool GetOpenDocumentParams(AZStd::string& openPath);
 
         // AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -12,41 +12,27 @@
 #include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
 #include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
 #include <AzCore/Memory/SystemAllocator.h>
-
-AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
-#include <Viewport/MaterialViewportWidget.h>
-#include <Window/ToolBar/MaterialEditorToolBar.h>
-AZ_POP_DISABLE_WARNING
 #endif
 
-namespace MaterialEditor
+namespace AtomToolsFramework
 {
-    /**
-     * MaterialEditorWindow is the main class. Its responsibility is limited to initializing and connecting
-     * its panels, managing selection of assets, and performing high-level actions like saving. It contains...
-     * 1) MaterialBrowser        - The user browses for Material (.material) assets.
-     * 2) MaterialViewport        - The user can see the selected Material applied to a model.
-     * 3) MaterialPropertyInspector  - The user edits the properties of the selected Material.
-     */
-    class MaterialEditorWindow
-        : public AtomToolsFramework::AtomToolsMainWindow
-        , private AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler
+    //! AtomToolsDocumentMainWindow
+    class AtomToolsDocumentMainWindow
+        : public AtomToolsMainWindow
+        , private AtomToolsDocumentNotificationBus::Handler
     {
         Q_OBJECT
     public:
-        AZ_CLASS_ALLOCATOR(MaterialEditorWindow, AZ::SystemAllocator, 0);
+        AZ_CLASS_ALLOCATOR(AtomToolsDocumentMainWindow, AZ::SystemAllocator, 0);
 
-        using Base = AtomToolsFramework::AtomToolsMainWindow;
+        using Base = AtomToolsMainWindow;
 
-        MaterialEditorWindow(QWidget* parent = 0);
-        ~MaterialEditorWindow();
+        AtomToolsDocumentMainWindow(QWidget* parent = 0);
+        ~AtomToolsDocumentMainWindow();
 
     private:
-        void ResizeViewportRenderTarget(uint32_t width, uint32_t height) override;
-        void LockViewportRenderTargetSize(uint32_t width, uint32_t height) override;
-        void UnlockViewportRenderTargetSize() override;
 
-        // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
+        // AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
         void OnDocumentClosed(const AZ::Uuid& documentId) override;
         void OnDocumentModified(const AZ::Uuid& documentId) override;
@@ -61,9 +47,6 @@ namespace MaterialEditor
         void OpenTabContextMenu() override;
 
         void closeEvent(QCloseEvent* closeEvent) override;
-
-        MaterialViewportWidget* m_materialViewport = nullptr;
-        MaterialEditorToolBar* m_toolBar = nullptr;
 
         QMenu* m_menuFile = {};
         QAction* m_actionNew = {};
@@ -84,12 +67,6 @@ namespace MaterialEditor
         QAction* m_actionSettings = {};
 
         QMenu* m_menuView = {};
-        QAction* m_actionAssetBrowser = {};
-        QAction* m_actionInspector = {};
-        QAction* m_actionConsole = {};
-        QAction* m_actionPythonTerminal = {};
-        QAction* m_actionPerfMonitor = {};
-        QAction* m_actionViewportSettings = {};
         QAction* m_actionNextTab = {};
         QAction* m_actionPreviousTab = {};
 
@@ -97,4 +74,4 @@ namespace MaterialEditor
         QAction* m_actionHelp = {};
         QAction* m_actionAbout = {};
     };
-} // namespace MaterialEditor
+} // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -53,13 +53,10 @@ namespace AtomToolsFramework
 
         void SelectNextTab();
 
-        virtual void OpenTabContextMenu() const;
-        virtual bool GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath) const;
-        virtual bool GetOpenFileInfo(AZStd::string& openPath) const;
-        virtual QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId) const;
-        virtual void OpenSettings() const;
-        virtual void OpenHelp() const;
-        virtual void OpenAbout() const;
+        virtual void OpenTabContextMenu();
+        virtual bool GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath);
+        virtual bool GetOpenFileInfo(AZStd::string& openPath);
+        virtual QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId);
 
         // AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
@@ -70,10 +67,11 @@ namespace AtomToolsFramework
 
         void closeEvent(QCloseEvent* closeEvent) override;
 
-        QMenu* m_menuFile = {};
+        template<typename Functor>
+        QAction* CreateAction(const QString& text, Functor functor, const QKeySequence& shortcut = 0);
+
         QAction* m_actionNew = {};
         QAction* m_actionOpen = {};
-        QAction* m_actionOpenRecent = {};
         QAction* m_actionClose = {};
         QAction* m_actionCloseAll = {};
         QAction* m_actionCloseOthers = {};
@@ -81,20 +79,13 @@ namespace AtomToolsFramework
         QAction* m_actionSaveAsCopy = {};
         QAction* m_actionSaveAsChild = {};
         QAction* m_actionSaveAll = {};
-        QAction* m_actionExit = {};
 
-        QMenu* m_menuEdit = {};
         QAction* m_actionUndo = {};
         QAction* m_actionRedo = {};
-        QAction* m_actionSettings = {};
 
-        QMenu* m_menuView = {};
         QAction* m_actionNextTab = {};
         QAction* m_actionPreviousTab = {};
 
-        QMenu* m_menuHelp = {};
-        QAction* m_actionHelp = {};
-        QAction* m_actionAbout = {};
         AzQtComponents::TabWidget* m_tabWidget = {};
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
+#include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
+#include <AzCore/Memory/SystemAllocator.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
+#include <Viewport/MaterialViewportWidget.h>
+#include <Window/ToolBar/MaterialEditorToolBar.h>
+AZ_POP_DISABLE_WARNING
+#endif
+
+namespace MaterialEditor
+{
+    /**
+     * MaterialEditorWindow is the main class. Its responsibility is limited to initializing and connecting
+     * its panels, managing selection of assets, and performing high-level actions like saving. It contains...
+     * 1) MaterialBrowser        - The user browses for Material (.material) assets.
+     * 2) MaterialViewport        - The user can see the selected Material applied to a model.
+     * 3) MaterialPropertyInspector  - The user edits the properties of the selected Material.
+     */
+    class MaterialEditorWindow
+        : public AtomToolsFramework::AtomToolsMainWindow
+        , private AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler
+    {
+        Q_OBJECT
+    public:
+        AZ_CLASS_ALLOCATOR(MaterialEditorWindow, AZ::SystemAllocator, 0);
+
+        using Base = AtomToolsFramework::AtomToolsMainWindow;
+
+        MaterialEditorWindow(QWidget* parent = 0);
+        ~MaterialEditorWindow();
+
+    private:
+        void ResizeViewportRenderTarget(uint32_t width, uint32_t height) override;
+        void LockViewportRenderTargetSize(uint32_t width, uint32_t height) override;
+        void UnlockViewportRenderTargetSize() override;
+
+        // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
+        void OnDocumentOpened(const AZ::Uuid& documentId) override;
+        void OnDocumentClosed(const AZ::Uuid& documentId) override;
+        void OnDocumentModified(const AZ::Uuid& documentId) override;
+        void OnDocumentUndoStateChanged(const AZ::Uuid& documentId) override;
+        void OnDocumentSaved(const AZ::Uuid& documentId) override;
+
+        void CreateMenu() override;
+        void CreateTabBar() override;
+
+        QString GetDocumentPath(const AZ::Uuid& documentId) const;
+
+        void OpenTabContextMenu() override;
+
+        void closeEvent(QCloseEvent* closeEvent) override;
+
+        MaterialViewportWidget* m_materialViewport = nullptr;
+        MaterialEditorToolBar* m_toolBar = nullptr;
+
+        QMenu* m_menuFile = {};
+        QAction* m_actionNew = {};
+        QAction* m_actionOpen = {};
+        QAction* m_actionOpenRecent = {};
+        QAction* m_actionClose = {};
+        QAction* m_actionCloseAll = {};
+        QAction* m_actionCloseOthers = {};
+        QAction* m_actionSave = {};
+        QAction* m_actionSaveAsCopy = {};
+        QAction* m_actionSaveAsChild = {};
+        QAction* m_actionSaveAll = {};
+        QAction* m_actionExit = {};
+
+        QMenu* m_menuEdit = {};
+        QAction* m_actionUndo = {};
+        QAction* m_actionRedo = {};
+        QAction* m_actionSettings = {};
+
+        QMenu* m_menuView = {};
+        QAction* m_actionAssetBrowser = {};
+        QAction* m_actionInspector = {};
+        QAction* m_actionConsole = {};
+        QAction* m_actionPythonTerminal = {};
+        QAction* m_actionPerfMonitor = {};
+        QAction* m_actionViewportSettings = {};
+        QAction* m_actionNextTab = {};
+        QAction* m_actionPreviousTab = {};
+
+        QMenu* m_menuHelp = {};
+        QAction* m_actionHelp = {};
+        QAction* m_actionAbout = {};
+    };
+} // namespace MaterialEditor

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
@@ -12,6 +12,7 @@
 #include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
 #include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzQtComponents/Components/Widgets/TabWidget.h>
 #endif
 
 namespace AtomToolsFramework
@@ -30,7 +31,35 @@ namespace AtomToolsFramework
         AtomToolsDocumentMainWindow(QWidget* parent = 0);
         ~AtomToolsDocumentMainWindow();
 
-    private:
+    protected:
+        void AddDocumentMenus();
+        void AddDocumentTabBar();
+
+        QString GetDocumentPath(const AZ::Uuid& documentId) const;
+
+        AZ::Uuid GetDocumentIdFromTab(const int tabIndex) const;
+
+        void AddTabForDocumentId(
+            const AZ::Uuid& documentId,
+            const AZStd::string& label,
+            const AZStd::string& toolTip);
+
+        void RemoveTabForDocumentId(const AZ::Uuid& documentId);
+
+        void UpdateTabForDocumentId(
+            const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified);
+
+        void SelectPreviousTab();
+
+        void SelectNextTab();
+
+        virtual void OpenTabContextMenu() const;
+        virtual bool GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath) const;
+        virtual bool GetOpenFileInfo(AZStd::string& openPath) const;
+        virtual QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId) const;
+        virtual void OpenSettings() const;
+        virtual void OpenHelp() const;
+        virtual void OpenAbout() const;
 
         // AtomToolsDocumentNotificationBus::Handler overrides...
         void OnDocumentOpened(const AZ::Uuid& documentId) override;
@@ -38,13 +67,6 @@ namespace AtomToolsFramework
         void OnDocumentModified(const AZ::Uuid& documentId) override;
         void OnDocumentUndoStateChanged(const AZ::Uuid& documentId) override;
         void OnDocumentSaved(const AZ::Uuid& documentId) override;
-
-        void CreateMenu() override;
-        void CreateTabBar() override;
-
-        QString GetDocumentPath(const AZ::Uuid& documentId) const;
-
-        void OpenTabContextMenu() override;
 
         void closeEvent(QCloseEvent* closeEvent) override;
 
@@ -73,5 +95,6 @@ namespace AtomToolsFramework
         QMenu* m_menuHelp = {};
         QAction* m_actionHelp = {};
         QAction* m_actionAbout = {};
+        AzQtComponents::TabWidget* m_tabWidget = {};
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -7,18 +7,14 @@
  */
 
 #pragma once
+
 #include <AtomToolsFramework/Window/AtomToolsMainWindowRequestBus.h>
-
 #include <AzCore/Memory/SystemAllocator.h>
-
 #include <AzQtComponents/Components/DockMainWindow.h>
 #include <AzQtComponents/Components/FancyDocking.h>
 #include <AzQtComponents/Components/StyledDockWidget.h>
-#include <AzQtComponents/Components/Widgets/TabWidget.h>
 
 #include <QLabel>
-#include <QMenuBar>
-#include <QToolBar>
 
 namespace AtomToolsFramework
 {
@@ -38,26 +34,11 @@ namespace AtomToolsFramework
         bool IsDockWidgetVisible(const AZStd::string& name) const override;
         AZStd::vector<AZStd::string> GetDockWidgetNames() const override;
 
-        virtual void CreateMenu();
-        virtual void CreateTabBar();
-
-        virtual void AddTabForDocumentId(
-            const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, AZStd::function<QWidget*()> widgetCreator);
-        virtual void RemoveTabForDocumentId(const AZ::Uuid& documentId);
-        virtual void UpdateTabForDocumentId(
-            const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified);
-        virtual AZ::Uuid GetDocumentIdFromTab(const int tabIndex) const;
-
-        virtual void OpenTabContextMenu();
-        virtual void SelectPreviousTab();
-        virtual void SelectNextTab();
-
         void SetStatusMessage(const QString& message);
         void SetStatusWarning(const QString& message);
         void SetStatusError(const QString& message);
 
         AzQtComponents::FancyDocking* m_advancedDockManager = nullptr;
-        AzQtComponents::TabWidget* m_tabWidget = nullptr;
         QLabel* m_statusMessage = nullptr;
 
         AZStd::unordered_map<AZStd::string, AzQtComponents::StyledDockWidget*> m_dockWidgets;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -54,5 +54,6 @@ namespace AtomToolsFramework
         QMenu* m_menuHelp = {};
 
         AZStd::unordered_map<AZStd::string, AzQtComponents::StyledDockWidget*> m_dockWidgets;
+        AZStd::unordered_map<AZStd::string, QAction*> m_dockActions;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Window/AtomToolsMainWindow.h
@@ -38,8 +38,20 @@ namespace AtomToolsFramework
         void SetStatusWarning(const QString& message);
         void SetStatusError(const QString& message);
 
-        AzQtComponents::FancyDocking* m_advancedDockManager = nullptr;
-        QLabel* m_statusMessage = nullptr;
+        void AddCommonMenus();
+
+        virtual void OpenSettings();
+        virtual void OpenHelp();
+        virtual void OpenAbout();
+
+        AzQtComponents::FancyDocking* m_advancedDockManager = {};
+
+        QLabel* m_statusMessage = {};
+
+        QMenu* m_menuFile = {};
+        QMenu* m_menuEdit = {};
+        QMenu* m_menuView = {};
+        QMenu* m_menuHelp = {};
 
         AZStd::unordered_map<AZStd::string, AzQtComponents::StyledDockWidget*> m_dockWidgets;
     };

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -320,7 +320,7 @@ namespace AtomToolsFramework
         }
     }
 
-    inline QWidget* AtomToolsDocumentMainWindow::CreateDocumentTabView(const AZ::Uuid& documentId)
+    QWidget* AtomToolsDocumentMainWindow::CreateDocumentTabView(const AZ::Uuid& documentId)
     {
         AZ_UNUSED(documentId);
         auto contentWidget = new QWidget(centralWidget());
@@ -356,14 +356,14 @@ namespace AtomToolsFramework
         }
     }
 
-    inline bool AtomToolsDocumentMainWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath)
+    bool AtomToolsDocumentMainWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath)
     {
         AZ_UNUSED(openPath);
         AZ_UNUSED(savePath);
         return false;
     }
 
-    inline bool AtomToolsDocumentMainWindow::GetOpenDocumentParams(AZStd::string& openPath)
+    bool AtomToolsDocumentMainWindow::GetOpenDocumentParams(AZStd::string& openPath)
     {
         AZ_UNUSED(openPath);
         return false;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -21,6 +21,9 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 #include <QCloseEvent>
 #include <QDesktopWidget>
 #include <QFileDialog>
+#include <QLayout>
+#include <QMenu>
+#include <QMenuBar>
 #include <QWindow>
 AZ_POP_DISABLE_WARNING
 
@@ -30,7 +33,8 @@ namespace AtomToolsFramework
         : AtomToolsMainWindow(parent)
     {
         setObjectName("AtomToolsDocumentMainWindow");
-
+        AddDocumentMenus();
+        AddDocumentTabBar();
         AtomToolsDocumentNotificationBus::Handler::BusConnect();
     }
 
@@ -39,157 +43,27 @@ namespace AtomToolsFramework
         AtomToolsDocumentNotificationBus::Handler::BusDisconnect();
     }
 
-    void AtomToolsDocumentMainWindow::closeEvent(QCloseEvent* closeEvent)
+    void AtomToolsDocumentMainWindow::AddDocumentMenus()
     {
-        bool didClose = true;
-        AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
-        if (!didClose)
-        {
-            closeEvent->ignore();
-            return;
-        }
-
-        AtomToolsMainWindowNotificationBus::Broadcast(&AtomToolsMainWindowNotifications::OnMainWindowClosing);
-    }
-
-    void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)
-    {
-        bool isOpen = false;
-        AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
-        bool isSavable = false;
-        AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsDocumentRequestBus::Events::IsSavable);
-        bool isModified = false;
-        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
-        bool canUndo = false;
-        AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
-        bool canRedo = false;
-        AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
-        AZStd::string absolutePath;
-        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-
-        // Update UI to display the new document
-        if (!documentId.IsNull() && isOpen)
-        {
-            // Create a new tab for the document ID and assign it's label to the file name of the document.
-            AddTabForDocumentId(documentId, filename, absolutePath, [this]{
-                // The tab widget requires a dummy page per tab
-                auto contentWidget = new QWidget(centralWidget());
-                contentWidget->setContentsMargins(0, 0, 0, 0);
-                contentWidget->setFixedSize(0, 0);
-                return contentWidget;
-            });
-
-            UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-        }
-
-        const bool hasTabs = m_tabWidget->count() > 0;
-
-        // Update menu options
-        m_actionNew->setEnabled(true);
-        m_actionOpen->setEnabled(true);
-        m_actionOpenRecent->setEnabled(false);
-        m_actionClose->setEnabled(hasTabs);
-        m_actionCloseAll->setEnabled(hasTabs);
-        m_actionCloseOthers->setEnabled(hasTabs);
-
-        m_actionSave->setEnabled(isOpen && isSavable);
-        m_actionSaveAsCopy->setEnabled(isOpen && isSavable);
-        m_actionSaveAsChild->setEnabled(isOpen);
-        m_actionSaveAll->setEnabled(hasTabs);
-
-        m_actionExit->setEnabled(true);
-
-        m_actionUndo->setEnabled(canUndo);
-        m_actionRedo->setEnabled(canRedo);
-        m_actionSettings->setEnabled(true);
-
-        m_actionPreviousTab->setEnabled(m_tabWidget->count() > 1);
-        m_actionNextTab->setEnabled(m_tabWidget->count() > 1);
-
-        m_actionAbout->setEnabled(false);
-
-        activateWindow();
-        raise();
-
-        const QString documentPath = GetDocumentPath(documentId);
-        if (!documentPath.isEmpty())
-        {
-            SetStatusMessage(tr("Document opened: %1").arg(documentPath));
-        }
-    }
-
-    void AtomToolsDocumentMainWindow::OnDocumentClosed(const AZ::Uuid& documentId)
-    {
-        RemoveTabForDocumentId(documentId);
-        SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
-    }
-
-    void AtomToolsDocumentMainWindow::OnDocumentModified(const AZ::Uuid& documentId)
-    {
-        bool isModified = false;
-        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-    }
-
-    void AtomToolsDocumentMainWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
-    {
-        if (documentId == GetDocumentIdFromTab(m_tabWidget->currentIndex()))
-        {
-            bool canUndo = false;
-            AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
-            bool canRedo = false;
-            AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
-            m_actionUndo->setEnabled(canUndo);
-            m_actionRedo->setEnabled(canRedo);
-        }
-    }
-
-    void AtomToolsDocumentMainWindow::OnDocumentSaved(const AZ::Uuid& documentId)
-    {
-        bool isModified = false;
-        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-        SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
-    }
-
-    void AtomToolsDocumentMainWindow::CreateMenu()
-    {
-        Base::CreateMenu();
-
         // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
         m_menuFile = menuBar()->addMenu("&File");
 
         m_actionNew = m_menuFile->addAction("&New...", [this]() {
-            //CreateMaterialDialog createDialog(this);
-            //createDialog.adjustSize();
-
-            //if (createDialog.exec() == QDialog::Accepted &&
-            //    !createDialog.m_materialFileInfo.absoluteFilePath().isEmpty() &&
-            //    !createDialog.m_materialTypeFileInfo.absoluteFilePath().isEmpty())
-            //{
-            //    AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFile,
-            //        createDialog.m_materialTypeFileInfo.absoluteFilePath().toUtf8().constData(),
-            //        createDialog.m_materialFileInfo.absoluteFilePath().toUtf8().constData());
-            //}
+            AZStd::string openPath;
+            AZStd::string savePath;
+            if (GetCreateFileInfo(openPath, savePath))
+            {
+                AtomToolsDocumentSystemRequestBus::Broadcast(
+                    &AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFile, openPath, savePath);
+            }
         }, QKeySequence::New);
 
         m_actionOpen = m_menuFile->addAction("&Open...", [this]() {
-            //const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
-            //const AZStd::string filePath = GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
-            //if (!filePath.empty())
-            //{
-            //    AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::OpenDocument, filePath);
-            //}
+            AZStd::string openPath;
+            if (GetOpenFileInfo(openPath))
+            {
+                AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::OpenDocument, openPath);
+            }
         }, QKeySequence::Open);
 
         m_actionOpenRecent = m_menuFile->addAction("Open &Recent");
@@ -298,10 +172,8 @@ namespace AtomToolsFramework
         m_menuEdit->addSeparator();
 
         m_actionSettings = m_menuEdit->addAction("&Settings...", [this]() {
-            //SettingsDialog dialog(this);
-            //dialog.exec();
+            OpenSettings();
         }, QKeySequence::Preferences);
-        m_actionSettings->setEnabled(true);
 
         m_menuView = menuBar()->addMenu("&View");
 
@@ -318,17 +190,27 @@ namespace AtomToolsFramework
         m_menuHelp = menuBar()->addMenu("&Help");
 
         m_actionHelp = m_menuHelp->addAction("&Help...", [this]() {
-            //HelpDialog dialog(this);
-            //dialog.exec();
+            OpenHelp();
         });
 
         m_actionAbout = m_menuHelp->addAction("&About...", [this]() {
+            OpenAbout();
         });
     }
 
-    void AtomToolsDocumentMainWindow::CreateTabBar()
+    void AtomToolsDocumentMainWindow::AddDocumentTabBar()
     {
-        Base::CreateTabBar();
+        m_tabWidget = new AzQtComponents::TabWidget(centralWidget());
+        m_tabWidget->setObjectName("TabWidget");
+        m_tabWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+        m_tabWidget->setContentsMargins(0, 0, 0, 0);
+
+        // The tab bar should only be visible if it has active documents
+        m_tabWidget->setVisible(false);
+        m_tabWidget->setTabBarAutoHide(false);
+        m_tabWidget->setMovable(true);
+        m_tabWidget->setTabsClosable(true);
+        m_tabWidget->setUsesScrollButtons(true);
 
         // This signal will be triggered whenever a tab is added, removed, selected, clicked, dragged
         // When the last tab is removed tabIndex will be -1 and the document ID will be null
@@ -342,6 +224,14 @@ namespace AtomToolsFramework
             const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
             AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
         });
+
+        // Add context menu for right-clicking on tabs
+        m_tabWidget->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+        connect(m_tabWidget, &QWidget::customContextMenuRequested, this, [this]() {
+            OpenTabContextMenu();
+        });
+
+        centralWidget()->layout()->addWidget(m_tabWidget);
     }
 
     QString AtomToolsDocumentMainWindow::GetDocumentPath(const AZ::Uuid& documentId) const
@@ -351,7 +241,109 @@ namespace AtomToolsFramework
         return absolutePath.c_str();
     }
 
-    void AtomToolsDocumentMainWindow::OpenTabContextMenu()
+    AZ::Uuid AtomToolsDocumentMainWindow::GetDocumentIdFromTab(const int tabIndex) const
+    {
+        const QVariant tabData = m_tabWidget->tabBar()->tabData(tabIndex);
+        if (!tabData.isNull())
+        {
+            // We need to be able to convert between a UUID and a string to store and retrieve a document ID from the tab bar
+            const QString documentIdString = tabData.toString();
+            const QByteArray documentIdBytes = documentIdString.toUtf8();
+            const AZ::Uuid documentId(documentIdBytes.data(), documentIdBytes.size());
+            return documentId;
+        }
+        return AZ::Uuid::CreateNull();
+    }
+
+    void AtomToolsDocumentMainWindow::AddTabForDocumentId(
+        const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip)
+    {
+        // Blocking signals from the tab bar so the currentChanged signal is not sent while a document is already being opened.
+        // This prevents the OnDocumentOpened notification from being sent recursively.
+        const QSignalBlocker blocker(m_tabWidget);
+
+        // If a tab for this document already exists then select it instead of creating a new one
+        for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
+        {
+            if (documentId == GetDocumentIdFromTab(tabIndex))
+            {
+                m_tabWidget->setCurrentIndex(tabIndex);
+                m_tabWidget->repaint();
+                return;
+            }
+        }
+
+        const int tabIndex = m_tabWidget->addTab(CreateViewForDocumemt(documentId), label.c_str());
+
+        // The user can manually reorder tabs which will invalidate any association by index.
+        // We need to store the document ID with the tab using the tab instead of a separate mapping.
+        m_tabWidget->tabBar()->setTabData(tabIndex, QVariant(documentId.ToString<QString>()));
+        m_tabWidget->setTabToolTip(tabIndex, toolTip.c_str());
+        m_tabWidget->setCurrentIndex(tabIndex);
+        m_tabWidget->setVisible(true);
+        m_tabWidget->repaint();
+    }
+
+    void AtomToolsDocumentMainWindow::RemoveTabForDocumentId(const AZ::Uuid& documentId)
+    {
+        // We are not blocking signals here because we want closing tabs to close the associated document
+        // and automatically select the next document.
+        for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
+        {
+            if (documentId == GetDocumentIdFromTab(tabIndex))
+            {
+                m_tabWidget->removeTab(tabIndex);
+                m_tabWidget->setVisible(m_tabWidget->count() > 0);
+                m_tabWidget->repaint();
+                break;
+            }
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::UpdateTabForDocumentId(
+        const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified)
+    {
+        // Whenever a document is opened, saved, or modified we need to update the tab label
+        if (!documentId.IsNull())
+        {
+            // Because tab order and indexes can change from user interactions, we cannot store a map
+            // between a tab index and document ID.
+            // We must iterate over all of the tabs to find the one associated with this document.
+            for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
+            {
+                if (documentId == GetDocumentIdFromTab(tabIndex))
+                {
+                    // We use an asterisk prepended to the file name to denote modified document
+                    // Appending is standard and preferred but the tabs elide from the
+                    // end (instead of middle) and cut it off
+                    const AZStd::string modifiedLabel = isModified ? "* " + label : label;
+                    m_tabWidget->setTabText(tabIndex, modifiedLabel.c_str());
+                    m_tabWidget->setTabToolTip(tabIndex, toolTip.c_str());
+                    m_tabWidget->repaint();
+                    break;
+                }
+            }
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::SelectPreviousTab()
+    {
+        if (m_tabWidget->count() > 1)
+        {
+            // Adding count to wrap around when index <= 0
+            m_tabWidget->setCurrentIndex((m_tabWidget->currentIndex() + m_tabWidget->count() - 1) % m_tabWidget->count());
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::SelectNextTab()
+    {
+        if (m_tabWidget->count() > 1)
+        {
+            m_tabWidget->setCurrentIndex((m_tabWidget->currentIndex() + 1) % m_tabWidget->count());
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::OpenTabContextMenu() const
     {
         const QTabBar* tabBar = m_tabWidget->tabBar();
         const QPoint position = tabBar->mapFromGlobal(QCursor::pos());
@@ -376,6 +368,157 @@ namespace AtomToolsFramework
             closeOthersAction->setEnabled(tabBar->count() > 1);
             tabMenu.exec(QCursor::pos());
         }
+    }
+
+    inline bool AtomToolsDocumentMainWindow::GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath) const
+    {
+        AZ_UNUSED(openPath);
+        AZ_UNUSED(savePath);
+        return false;
+    }
+
+    inline bool AtomToolsDocumentMainWindow::GetOpenFileInfo(AZStd::string& openPath) const
+    {
+        AZ_UNUSED(openPath);
+        return false;
+    }
+
+    inline QWidget* AtomToolsDocumentMainWindow::CreateViewForDocumemt(const AZ::Uuid& documentId) const
+    {
+        AZ_UNUSED(documentId);
+        auto contentWidget = new QWidget(centralWidget());
+        contentWidget->setContentsMargins(0, 0, 0, 0);
+        contentWidget->setFixedSize(0, 0);
+        return contentWidget;
+    }
+
+    inline void AtomToolsDocumentMainWindow::OpenSettings() const
+    {
+    }
+
+    inline void AtomToolsDocumentMainWindow::OpenHelp() const
+    {
+    }
+
+    inline void AtomToolsDocumentMainWindow::OpenAbout() const
+    {
+    }
+
+    void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)
+    {
+        bool isOpen = false;
+        AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
+        bool isSavable = false;
+        AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsDocumentRequestBus::Events::IsSavable);
+        bool isModified = false;
+        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
+        bool canUndo = false;
+        AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
+        bool canRedo = false;
+        AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
+        AZStd::string absolutePath;
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+
+        // Update UI to display the new document
+        if (!documentId.IsNull() && isOpen)
+        {
+            // Create a new tab for the document ID and assign it's label to the file name of the document.
+            AddTabForDocumentId(documentId, filename, absolutePath);
+            UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+        }
+
+        const bool hasTabs = m_tabWidget->count() > 0;
+
+        // Update menu options
+        m_actionNew->setEnabled(true);
+        m_actionOpen->setEnabled(true);
+        m_actionOpenRecent->setEnabled(false);
+        m_actionClose->setEnabled(hasTabs);
+        m_actionCloseAll->setEnabled(hasTabs);
+        m_actionCloseOthers->setEnabled(hasTabs);
+
+        m_actionSave->setEnabled(isOpen && isSavable);
+        m_actionSaveAsCopy->setEnabled(isOpen && isSavable);
+        m_actionSaveAsChild->setEnabled(isOpen);
+        m_actionSaveAll->setEnabled(hasTabs);
+
+        m_actionExit->setEnabled(true);
+
+        m_actionUndo->setEnabled(canUndo);
+        m_actionRedo->setEnabled(canRedo);
+        m_actionSettings->setEnabled(true);
+
+        m_actionPreviousTab->setEnabled(m_tabWidget->count() > 1);
+        m_actionNextTab->setEnabled(m_tabWidget->count() > 1);
+
+        m_actionAbout->setEnabled(false);
+
+        activateWindow();
+        raise();
+
+        const QString documentPath = GetDocumentPath(documentId);
+        if (!documentPath.isEmpty())
+        {
+            SetStatusMessage(tr("Document opened: %1").arg(documentPath));
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::OnDocumentClosed(const AZ::Uuid& documentId)
+    {
+        RemoveTabForDocumentId(documentId);
+        SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
+    }
+
+    void AtomToolsDocumentMainWindow::OnDocumentModified(const AZ::Uuid& documentId)
+    {
+        bool isModified = false;
+        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
+        AZStd::string absolutePath;
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+    }
+
+    void AtomToolsDocumentMainWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
+    {
+        if (documentId == GetDocumentIdFromTab(m_tabWidget->currentIndex()))
+        {
+            bool canUndo = false;
+            AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
+            bool canRedo = false;
+            AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
+            m_actionUndo->setEnabled(canUndo);
+            m_actionRedo->setEnabled(canRedo);
+        }
+    }
+
+    void AtomToolsDocumentMainWindow::OnDocumentSaved(const AZ::Uuid& documentId)
+    {
+        bool isModified = false;
+        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
+        AZStd::string absolutePath;
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+        SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
+    }
+
+
+    void AtomToolsDocumentMainWindow::closeEvent(QCloseEvent* closeEvent)
+    {
+        bool didClose = true;
+        AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
+        if (!didClose)
+        {
+            closeEvent->ignore();
+            return;
+        }
+
+        AtomToolsMainWindowNotificationBus::Broadcast(&AtomToolsMainWindowNotifications::OnMainWindowClosing);
     }
 } // namespace AtomToolsFramework
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Document/MaterialDocumentRequestBus.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/Window/MaterialEditorWindowSettings.h>
+#include <AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h>
+#include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
+#include <AtomToolsFramework/Util/Util.h>
+#include <AtomToolsFramework/Window/AtomToolsMainWindowNotificationBus.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <AzQtComponents/Components/StyleManager.h>
+#include <AzQtComponents/Components/WindowDecorationWrapper.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
+#include <AzToolsFramework/PythonTerminal/ScriptTermDialog.h>
+#include <Viewport/MaterialViewportWidget.h>
+#include <Window/CreateMaterialDialog/CreateMaterialDialog.h>
+#include <Window/HelpDialog/HelpDialog.h>
+#include <Window/MaterialBrowserWidget.h>
+#include <Window/MaterialEditorWindow.h>
+#include <Window/MaterialInspector/MaterialInspector.h>
+#include <Window/PerformanceMonitor/PerformanceMonitorWidget.h>
+#include <Window/SettingsDialog/SettingsDialog.h>
+#include <Window/ViewportSettingsInspector/ViewportSettingsInspector.h>
+
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
+#include <QApplication>
+#include <QByteArray>
+#include <QCloseEvent>
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QWindow>
+AZ_POP_DISABLE_WARNING
+
+namespace MaterialEditor
+{
+    MaterialEditorWindow::MaterialEditorWindow(QWidget* parent /* = 0 */)
+        : AtomToolsFramework::AtomToolsMainWindow(parent)
+    {
+        resize(1280, 1024);
+
+        // Among other things, we need the window wrapper to save the main window size, position, and state
+        auto mainWindowWrapper =
+            new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionAutoTitleBarButtons);
+        mainWindowWrapper->setGuest(this);
+        mainWindowWrapper->enableSaveRestoreGeometry("O3DE", "MaterialEditor", "mainWindowGeometry");
+
+        // set the style sheet for RPE highlighting and other styling
+        AzQtComponents::StyleManager::setStyleSheet(this, QStringLiteral(":/MaterialEditor.qss"));
+
+        QApplication::setWindowIcon(QIcon(":/Icons/materialeditor.svg"));
+
+        AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
+        if (!apiName.IsEmpty())
+        {
+            QString title = QString{ "%1 (%2)" }.arg(QApplication::applicationName()).arg(apiName.GetCStr());
+            setWindowTitle(title);
+        }
+        else
+        {
+            AZ_Assert(false, "Render API name not found");
+            setWindowTitle(QApplication::applicationName());
+        }
+
+        setObjectName("MaterialEditorWindow");
+
+        m_toolBar = new MaterialEditorToolBar(this);
+        m_toolBar->setObjectName("ToolBar");
+        addToolBar(m_toolBar);
+
+        CreateMenu();
+        CreateTabBar();
+
+        m_materialViewport = new MaterialViewportWidget(centralWidget());
+        m_materialViewport->setObjectName("Viewport");
+        m_materialViewport->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+        centralWidget()->layout()->addWidget(m_materialViewport);
+
+        AddDockWidget("Asset Browser", new MaterialBrowserWidget, Qt::BottomDockWidgetArea, Qt::Vertical);
+        AddDockWidget("Inspector", new MaterialInspector, Qt::RightDockWidgetArea, Qt::Horizontal);
+        AddDockWidget("Viewport Settings", new ViewportSettingsInspector, Qt::LeftDockWidgetArea, Qt::Horizontal);
+        AddDockWidget("Performance Monitor", new PerformanceMonitorWidget, Qt::RightDockWidgetArea, Qt::Horizontal);
+        AddDockWidget("Python Terminal", new AzToolsFramework::CScriptTermDialog, Qt::BottomDockWidgetArea, Qt::Horizontal);
+
+        SetDockWidgetVisible("Viewport Settings", false);
+        SetDockWidgetVisible("Performance Monitor", false);
+        SetDockWidgetVisible("Python Terminal", false);
+
+        // Restore geometry and show the window
+        mainWindowWrapper->showFromSettings();
+
+        // Restore additional state for docked windows
+        auto windowSettings = AZ::UserSettings::CreateFind<MaterialEditorWindowSettings>(
+            AZ::Crc32("MaterialEditorWindowSettings"), AZ::UserSettings::CT_GLOBAL);
+
+        if (!windowSettings->m_mainWindowState.empty())
+        {
+            QByteArray windowState(windowSettings->m_mainWindowState.data(), static_cast<int>(windowSettings->m_mainWindowState.size()));
+            m_advancedDockManager->restoreState(windowState);
+        }
+
+        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusConnect();
+        OnDocumentOpened(AZ::Uuid::CreateNull());
+    }
+
+    MaterialEditorWindow::~MaterialEditorWindow()
+    {
+        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusDisconnect();
+    }
+
+    
+    void MaterialEditorWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
+    {
+        QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();
+        QSize currentViewportSize = m_materialViewport->size();
+        QSize offset = requestedViewportSize - currentViewportSize;
+        QSize requestedWindowSize = size() + offset;
+        resize(requestedWindowSize);
+
+        AZ_Assert(
+            m_materialViewport->size() == requestedViewportSize,
+            "Resizing the window did not give the expected viewport size. Requested %d x %d but got %d x %d.",
+            requestedViewportSize.width(), requestedViewportSize.height(), m_materialViewport->size().width(),
+            m_materialViewport->size().height());
+
+        QSize newDeviceSize = m_materialViewport->size();
+        AZ_Warning(
+            "Material Editor", static_cast<uint32_t>(newDeviceSize.width()) == width && static_cast<uint32_t>(newDeviceSize.height()) == height,
+            "Resizing the window did not give the expected frame size. Requested %d x %d but got %d x %d.", width, height,
+            newDeviceSize.width(), newDeviceSize.height());
+    }
+
+    void MaterialEditorWindow::LockViewportRenderTargetSize(uint32_t width, uint32_t height)
+    {
+        m_materialViewport->LockRenderTargetSize(width, height);
+    }
+
+    void MaterialEditorWindow::UnlockViewportRenderTargetSize()
+    {
+        m_materialViewport->UnlockRenderTargetSize();
+    }
+
+    void MaterialEditorWindow::closeEvent(QCloseEvent* closeEvent)
+    {
+        bool didClose = true;
+        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
+        if (!didClose)
+        {
+            closeEvent->ignore();
+            return;
+        }
+
+        // Capture docking state before shutdown
+        auto windowSettings = AZ::UserSettings::CreateFind<MaterialEditorWindowSettings>(
+            AZ::Crc32("MaterialEditorWindowSettings"), AZ::UserSettings::CT_GLOBAL);
+
+        QByteArray windowState = m_advancedDockManager->saveState();
+        windowSettings->m_mainWindowState.assign(windowState.begin(), windowState.end());
+
+        AtomToolsFramework::AtomToolsMainWindowNotificationBus::Broadcast(
+            &AtomToolsFramework::AtomToolsMainWindowNotifications::OnMainWindowClosing);
+    }
+
+    void MaterialEditorWindow::OnDocumentOpened(const AZ::Uuid& documentId)
+    {
+        bool isOpen = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsOpen);
+        bool isSavable = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsSavable);
+        bool isModified = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
+        bool canUndo = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
+        bool canRedo = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
+        AZStd::string absolutePath;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+
+        // Update UI to display the new document
+        if (!documentId.IsNull() && isOpen)
+        {
+            // Create a new tab for the document ID and assign it's label to the file name of the document.
+            AddTabForDocumentId(documentId, filename, absolutePath, [this]{
+                // The tab widget requires a dummy page per tab
+                auto contentWidget = new QWidget(centralWidget());
+                contentWidget->setContentsMargins(0, 0, 0, 0);
+                contentWidget->setFixedSize(0, 0);
+                return contentWidget;
+            });
+        }
+
+        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+
+        const bool hasTabs = m_tabWidget->count() > 0;
+
+        // Update menu options
+        m_actionNew->setEnabled(true);
+        m_actionOpen->setEnabled(true);
+        m_actionOpenRecent->setEnabled(false);
+        m_actionClose->setEnabled(hasTabs);
+        m_actionCloseAll->setEnabled(hasTabs);
+        m_actionCloseOthers->setEnabled(hasTabs);
+
+        m_actionSave->setEnabled(isOpen && isSavable);
+        m_actionSaveAsCopy->setEnabled(isOpen && isSavable);
+        m_actionSaveAsChild->setEnabled(isOpen);
+        m_actionSaveAll->setEnabled(hasTabs);
+
+        m_actionExit->setEnabled(true);
+
+        m_actionUndo->setEnabled(canUndo);
+        m_actionRedo->setEnabled(canRedo);
+        m_actionSettings->setEnabled(true);
+
+        m_actionAssetBrowser->setEnabled(true);
+        m_actionInspector->setEnabled(true);
+        m_actionConsole->setEnabled(false);
+        m_actionPythonTerminal->setEnabled(true);
+        m_actionPerfMonitor->setEnabled(true);
+        m_actionViewportSettings->setEnabled(true);
+        m_actionPreviousTab->setEnabled(m_tabWidget->count() > 1);
+        m_actionNextTab->setEnabled(m_tabWidget->count() > 1);
+
+        m_actionAbout->setEnabled(false);
+
+        activateWindow();
+        raise();
+
+        const QString documentPath = GetDocumentPath(documentId);
+        if (!documentPath.isEmpty())
+        {
+            SetStatusMessage(tr("Document opened: %1").arg(documentPath));
+        }
+    }
+
+    void MaterialEditorWindow::OnDocumentClosed(const AZ::Uuid& documentId)
+    {
+        RemoveTabForDocumentId(documentId);
+        SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
+    }
+
+    void MaterialEditorWindow::OnDocumentModified(const AZ::Uuid& documentId)
+    {
+        bool isModified = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
+        AZStd::string absolutePath;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+    }
+
+    void MaterialEditorWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
+    {
+        if (documentId == GetDocumentIdFromTab(m_tabWidget->currentIndex()))
+        {
+            bool canUndo = false;
+            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
+            bool canRedo = false;
+            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
+            m_actionUndo->setEnabled(canUndo);
+            m_actionRedo->setEnabled(canRedo);
+        }
+    }
+
+    void MaterialEditorWindow::OnDocumentSaved(const AZ::Uuid& documentId)
+    {
+        bool isModified = false;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
+        AZStd::string absolutePath;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AZStd::string filename;
+        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
+        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+        SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
+    }
+
+    void MaterialEditorWindow::CreateMenu()
+    {
+        Base::CreateMenu();
+
+        // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
+        m_menuFile = menuBar()->addMenu("&File");
+
+        m_actionNew = m_menuFile->addAction("&New...", [this]() {
+            CreateMaterialDialog createDialog(this);
+            createDialog.adjustSize();
+
+            if (createDialog.exec() == QDialog::Accepted &&
+                !createDialog.m_materialFileInfo.absoluteFilePath().isEmpty() &&
+                !createDialog.m_materialTypeFileInfo.absoluteFilePath().isEmpty())
+            {
+                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFile,
+                    createDialog.m_materialTypeFileInfo.absoluteFilePath().toUtf8().constData(),
+                    createDialog.m_materialFileInfo.absoluteFilePath().toUtf8().constData());
+            }
+        }, QKeySequence::New);
+
+        m_actionOpen = m_menuFile->addAction("&Open...", [this]() {
+            const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
+            const AZStd::string filePath = AtomToolsFramework::GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
+            if (!filePath.empty())
+            {
+                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::OpenDocument, filePath);
+            }
+        }, QKeySequence::Open);
+
+        m_actionOpenRecent = m_menuFile->addAction("Open &Recent");
+
+        m_menuFile->addSeparator();
+
+        m_actionSave = m_menuFile->addAction("&Save", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            bool result = false;
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
+            if (!result)
+            {
+                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
+            }
+        }, QKeySequence::Save);
+
+        m_actionSaveAsCopy = m_menuFile->addAction("Save &As...", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            const QString documentPath = GetDocumentPath(documentId);
+
+            bool result = false;
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy,
+                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
+            if (!result)
+            {
+                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
+            }
+        }, QKeySequence::SaveAs);
+
+        m_actionSaveAsChild = m_menuFile->addAction("Save As &Child...", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            const QString documentPath = GetDocumentPath(documentId);
+
+            bool result = false;
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild,
+                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
+            if (!result)
+            {
+                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
+            }
+        });
+
+        m_actionSaveAll = m_menuFile->addAction("Save A&ll", [this]() {
+            bool result = false;
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments);
+            if (!result)
+            {
+                SetStatusError(tr("Document save all failed"));
+            }
+        });
+
+        m_menuFile->addSeparator();
+
+        m_actionClose = m_menuFile->addAction("&Close", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+        }, QKeySequence::Close);
+
+        m_actionCloseAll = m_menuFile->addAction("Close All", [this]() {
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
+        });
+
+        m_actionCloseOthers = m_menuFile->addAction("Close Others", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
+        });
+
+        m_menuFile->addSeparator();
+
+        m_menuFile->addAction("Run &Python...", [this]() {
+            const QString script = QFileDialog::getOpenFileName(this, "Run Script", QString(), QString("*.py"));
+            if (!script.isEmpty())
+            {
+                AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(&AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
+            }
+        });
+
+        m_menuFile->addSeparator();
+
+        m_actionExit = m_menuFile->addAction("E&xit", [this]() {
+            close();
+        }, QKeySequence::Quit);
+
+        m_menuEdit = menuBar()->addMenu("&Edit");
+
+        m_actionUndo = m_menuEdit->addAction("&Undo", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            bool result = false;
+            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Undo);
+            if (!result)
+            {
+                SetStatusError(tr("Document undo failed: %1").arg(GetDocumentPath(documentId)));
+            }
+        }, QKeySequence::Undo);
+
+        m_actionRedo = m_menuEdit->addAction("&Redo", [this]() {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
+            bool result = false;
+            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Redo);
+            if (!result)
+            {
+                SetStatusError(tr("Document redo failed: %1").arg(GetDocumentPath(documentId)));
+            }
+        }, QKeySequence::Redo);
+
+        m_menuEdit->addSeparator();
+
+        m_actionSettings = m_menuEdit->addAction("&Settings...", [this]() {
+            SettingsDialog dialog(this);
+            dialog.exec();
+        }, QKeySequence::Preferences);
+        m_actionSettings->setEnabled(true);
+
+        m_menuView = menuBar()->addMenu("&View");
+
+        m_actionAssetBrowser = m_menuView->addAction("&Asset Browser", [this]() {
+            const AZStd::string label = "Asset Browser";
+            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
+        });
+
+        m_actionInspector = m_menuView->addAction("&Inspector", [this]() {
+            const AZStd::string label = "Inspector";
+            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
+        });
+
+        m_actionConsole = m_menuView->addAction("&Console", [this]() {
+        });
+
+        m_actionPythonTerminal = m_menuView->addAction("Python &Terminal", [this]() {
+            const AZStd::string label = "Python Terminal";
+            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
+        });
+
+        m_actionPerfMonitor = m_menuView->addAction("Performance &Monitor", [this]() {
+            const AZStd::string label = "Performance Monitor";
+            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
+        });
+
+        m_actionViewportSettings = m_menuView->addAction("Viewport Settings", [this]() {
+            const AZStd::string label = "Viewport Settings";
+            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
+        });
+
+        m_menuView->addSeparator();
+
+        m_actionPreviousTab = m_menuView->addAction("&Previous Tab", [this]() {
+            SelectPreviousTab();
+        }, Qt::CTRL | Qt::SHIFT | Qt::Key_Tab); //QKeySequence::PreviousChild is mapped incorrectly in Qt
+
+        m_actionNextTab = m_menuView->addAction("&Next Tab", [this]() {
+            SelectNextTab();
+        }, Qt::CTRL | Qt::Key_Tab); //QKeySequence::NextChild works as expected but mirroring Previous
+
+        m_menuHelp = menuBar()->addMenu("&Help");
+
+        m_actionHelp = m_menuHelp->addAction("&Help...", [this]() {
+            HelpDialog dialog(this);
+            dialog.exec();
+        });
+
+        m_actionAbout = m_menuHelp->addAction("&About...", [this]() {
+        });
+    }
+
+    void MaterialEditorWindow::CreateTabBar()
+    {
+        Base::CreateTabBar();
+
+        // This signal will be triggered whenever a tab is added, removed, selected, clicked, dragged
+        // When the last tab is removed tabIndex will be -1 and the document ID will be null
+        // This should automatically clear the active document
+        connect(m_tabWidget, &QTabWidget::currentChanged, this, [this](int tabIndex) {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
+            AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+        });
+
+        connect(m_tabWidget, &QTabWidget::tabCloseRequested, this, [this](int tabIndex) {
+            const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
+            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+        });
+    }
+
+    QString MaterialEditorWindow::GetDocumentPath(const AZ::Uuid& documentId) const
+    {
+        AZStd::string absolutePath;
+        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Handler::GetAbsolutePath);
+        return absolutePath.c_str();
+    }
+
+    void MaterialEditorWindow::OpenTabContextMenu()
+    {
+        const QTabBar* tabBar = m_tabWidget->tabBar();
+        const QPoint position = tabBar->mapFromGlobal(QCursor::pos());
+        const int clickedTabIndex = tabBar->tabAt(position);
+        const int currentTabIndex = tabBar->currentIndex();
+        if (clickedTabIndex >= 0)
+        {
+            QMenu tabMenu;
+            const QString selectActionName = (currentTabIndex == clickedTabIndex) ? "Select in Browser" : "Select";
+            tabMenu.addAction(selectActionName, [this, clickedTabIndex]() {
+                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
+                AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+            });
+            tabMenu.addAction("Close", [this, clickedTabIndex]() {
+                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
+                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+            });
+            auto closeOthersAction = tabMenu.addAction("Close Others", [this, clickedTabIndex]() {
+                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
+                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
+            });
+            closeOthersAction->setEnabled(tabBar->count() > 1);
+            tabMenu.exec(QCursor::pos());
+        }
+    }
+} // namespace MaterialEditor
+
+#include <Window/moc_MaterialEditorWindow.cpp>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentMainWindow.cpp
@@ -6,28 +6,14 @@
  *
  */
 
-#include <Atom/Document/MaterialDocumentRequestBus.h>
-#include <Atom/RHI/Factory.h>
-#include <Atom/Window/MaterialEditorWindowSettings.h>
+#include <AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h>
 #include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
 #include <AtomToolsFramework/Util/Util.h>
 #include <AtomToolsFramework/Window/AtomToolsMainWindowNotificationBus.h>
 #include <AzFramework/StringFunc/StringFunc.h>
-#include <AzQtComponents/Components/StyleManager.h>
-#include <AzQtComponents/Components/WindowDecorationWrapper.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
-#include <AzToolsFramework/PythonTerminal/ScriptTermDialog.h>
-#include <Viewport/MaterialViewportWidget.h>
-#include <Window/CreateMaterialDialog/CreateMaterialDialog.h>
-#include <Window/HelpDialog/HelpDialog.h>
-#include <Window/MaterialBrowserWidget.h>
-#include <Window/MaterialEditorWindow.h>
-#include <Window/MaterialInspector/MaterialInspector.h>
-#include <Window/PerformanceMonitor/PerformanceMonitorWidget.h>
-#include <Window/SettingsDialog/SettingsDialog.h>
-#include <Window/ViewportSettingsInspector/ViewportSettingsInspector.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QApplication>
@@ -38,149 +24,48 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 #include <QWindow>
 AZ_POP_DISABLE_WARNING
 
-namespace MaterialEditor
+namespace AtomToolsFramework
 {
-    MaterialEditorWindow::MaterialEditorWindow(QWidget* parent /* = 0 */)
-        : AtomToolsFramework::AtomToolsMainWindow(parent)
+    AtomToolsDocumentMainWindow::AtomToolsDocumentMainWindow(QWidget* parent /* = 0 */)
+        : AtomToolsMainWindow(parent)
     {
-        resize(1280, 1024);
+        setObjectName("AtomToolsDocumentMainWindow");
 
-        // Among other things, we need the window wrapper to save the main window size, position, and state
-        auto mainWindowWrapper =
-            new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionAutoTitleBarButtons);
-        mainWindowWrapper->setGuest(this);
-        mainWindowWrapper->enableSaveRestoreGeometry("O3DE", "MaterialEditor", "mainWindowGeometry");
-
-        // set the style sheet for RPE highlighting and other styling
-        AzQtComponents::StyleManager::setStyleSheet(this, QStringLiteral(":/MaterialEditor.qss"));
-
-        QApplication::setWindowIcon(QIcon(":/Icons/materialeditor.svg"));
-
-        AZ::Name apiName = AZ::RHI::Factory::Get().GetName();
-        if (!apiName.IsEmpty())
-        {
-            QString title = QString{ "%1 (%2)" }.arg(QApplication::applicationName()).arg(apiName.GetCStr());
-            setWindowTitle(title);
-        }
-        else
-        {
-            AZ_Assert(false, "Render API name not found");
-            setWindowTitle(QApplication::applicationName());
-        }
-
-        setObjectName("MaterialEditorWindow");
-
-        m_toolBar = new MaterialEditorToolBar(this);
-        m_toolBar->setObjectName("ToolBar");
-        addToolBar(m_toolBar);
-
-        CreateMenu();
-        CreateTabBar();
-
-        m_materialViewport = new MaterialViewportWidget(centralWidget());
-        m_materialViewport->setObjectName("Viewport");
-        m_materialViewport->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
-        centralWidget()->layout()->addWidget(m_materialViewport);
-
-        AddDockWidget("Asset Browser", new MaterialBrowserWidget, Qt::BottomDockWidgetArea, Qt::Vertical);
-        AddDockWidget("Inspector", new MaterialInspector, Qt::RightDockWidgetArea, Qt::Horizontal);
-        AddDockWidget("Viewport Settings", new ViewportSettingsInspector, Qt::LeftDockWidgetArea, Qt::Horizontal);
-        AddDockWidget("Performance Monitor", new PerformanceMonitorWidget, Qt::RightDockWidgetArea, Qt::Horizontal);
-        AddDockWidget("Python Terminal", new AzToolsFramework::CScriptTermDialog, Qt::BottomDockWidgetArea, Qt::Horizontal);
-
-        SetDockWidgetVisible("Viewport Settings", false);
-        SetDockWidgetVisible("Performance Monitor", false);
-        SetDockWidgetVisible("Python Terminal", false);
-
-        // Restore geometry and show the window
-        mainWindowWrapper->showFromSettings();
-
-        // Restore additional state for docked windows
-        auto windowSettings = AZ::UserSettings::CreateFind<MaterialEditorWindowSettings>(
-            AZ::Crc32("MaterialEditorWindowSettings"), AZ::UserSettings::CT_GLOBAL);
-
-        if (!windowSettings->m_mainWindowState.empty())
-        {
-            QByteArray windowState(windowSettings->m_mainWindowState.data(), static_cast<int>(windowSettings->m_mainWindowState.size()));
-            m_advancedDockManager->restoreState(windowState);
-        }
-
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusConnect();
-        OnDocumentOpened(AZ::Uuid::CreateNull());
+        AtomToolsDocumentNotificationBus::Handler::BusConnect();
     }
 
-    MaterialEditorWindow::~MaterialEditorWindow()
+    AtomToolsDocumentMainWindow::~AtomToolsDocumentMainWindow()
     {
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusDisconnect();
+        AtomToolsDocumentNotificationBus::Handler::BusDisconnect();
     }
 
-    
-    void MaterialEditorWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
-    {
-        QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();
-        QSize currentViewportSize = m_materialViewport->size();
-        QSize offset = requestedViewportSize - currentViewportSize;
-        QSize requestedWindowSize = size() + offset;
-        resize(requestedWindowSize);
-
-        AZ_Assert(
-            m_materialViewport->size() == requestedViewportSize,
-            "Resizing the window did not give the expected viewport size. Requested %d x %d but got %d x %d.",
-            requestedViewportSize.width(), requestedViewportSize.height(), m_materialViewport->size().width(),
-            m_materialViewport->size().height());
-
-        QSize newDeviceSize = m_materialViewport->size();
-        AZ_Warning(
-            "Material Editor", static_cast<uint32_t>(newDeviceSize.width()) == width && static_cast<uint32_t>(newDeviceSize.height()) == height,
-            "Resizing the window did not give the expected frame size. Requested %d x %d but got %d x %d.", width, height,
-            newDeviceSize.width(), newDeviceSize.height());
-    }
-
-    void MaterialEditorWindow::LockViewportRenderTargetSize(uint32_t width, uint32_t height)
-    {
-        m_materialViewport->LockRenderTargetSize(width, height);
-    }
-
-    void MaterialEditorWindow::UnlockViewportRenderTargetSize()
-    {
-        m_materialViewport->UnlockRenderTargetSize();
-    }
-
-    void MaterialEditorWindow::closeEvent(QCloseEvent* closeEvent)
+    void AtomToolsDocumentMainWindow::closeEvent(QCloseEvent* closeEvent)
     {
         bool didClose = true;
-        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
+        AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
         if (!didClose)
         {
             closeEvent->ignore();
             return;
         }
 
-        // Capture docking state before shutdown
-        auto windowSettings = AZ::UserSettings::CreateFind<MaterialEditorWindowSettings>(
-            AZ::Crc32("MaterialEditorWindowSettings"), AZ::UserSettings::CT_GLOBAL);
-
-        QByteArray windowState = m_advancedDockManager->saveState();
-        windowSettings->m_mainWindowState.assign(windowState.begin(), windowState.end());
-
-        AtomToolsFramework::AtomToolsMainWindowNotificationBus::Broadcast(
-            &AtomToolsFramework::AtomToolsMainWindowNotifications::OnMainWindowClosing);
+        AtomToolsMainWindowNotificationBus::Broadcast(&AtomToolsMainWindowNotifications::OnMainWindowClosing);
     }
 
-    void MaterialEditorWindow::OnDocumentOpened(const AZ::Uuid& documentId)
+    void AtomToolsDocumentMainWindow::OnDocumentOpened(const AZ::Uuid& documentId)
     {
         bool isOpen = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsOpen);
+        AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsDocumentRequestBus::Events::IsOpen);
         bool isSavable = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsSavable);
+        AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsDocumentRequestBus::Events::IsSavable);
         bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
+        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
         bool canUndo = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
+        AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
         bool canRedo = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
+        AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
         AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
         AZStd::string filename;
         AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
 
@@ -195,9 +80,9 @@ namespace MaterialEditor
                 contentWidget->setFixedSize(0, 0);
                 return contentWidget;
             });
-        }
 
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+            UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
+        }
 
         const bool hasTabs = m_tabWidget->count() > 0;
 
@@ -220,12 +105,6 @@ namespace MaterialEditor
         m_actionRedo->setEnabled(canRedo);
         m_actionSettings->setEnabled(true);
 
-        m_actionAssetBrowser->setEnabled(true);
-        m_actionInspector->setEnabled(true);
-        m_actionConsole->setEnabled(false);
-        m_actionPythonTerminal->setEnabled(true);
-        m_actionPerfMonitor->setEnabled(true);
-        m_actionViewportSettings->setEnabled(true);
         m_actionPreviousTab->setEnabled(m_tabWidget->count() > 1);
         m_actionNextTab->setEnabled(m_tabWidget->count() > 1);
 
@@ -241,49 +120,49 @@ namespace MaterialEditor
         }
     }
 
-    void MaterialEditorWindow::OnDocumentClosed(const AZ::Uuid& documentId)
+    void AtomToolsDocumentMainWindow::OnDocumentClosed(const AZ::Uuid& documentId)
     {
         RemoveTabForDocumentId(documentId);
         SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
     }
 
-    void MaterialEditorWindow::OnDocumentModified(const AZ::Uuid& documentId)
+    void AtomToolsDocumentMainWindow::OnDocumentModified(const AZ::Uuid& documentId)
     {
         bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
+        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
         AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
         AZStd::string filename;
         AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
         UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
     }
 
-    void MaterialEditorWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
+    void AtomToolsDocumentMainWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
     {
         if (documentId == GetDocumentIdFromTab(m_tabWidget->currentIndex()))
         {
             bool canUndo = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
+            AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsDocumentRequestBus::Events::CanUndo);
             bool canRedo = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
+            AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsDocumentRequestBus::Events::CanRedo);
             m_actionUndo->setEnabled(canUndo);
             m_actionRedo->setEnabled(canRedo);
         }
     }
 
-    void MaterialEditorWindow::OnDocumentSaved(const AZ::Uuid& documentId)
+    void AtomToolsDocumentMainWindow::OnDocumentSaved(const AZ::Uuid& documentId)
     {
         bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
+        AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsDocumentRequestBus::Events::IsModified);
         AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
         AZStd::string filename;
         AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
         UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
         SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
     }
 
-    void MaterialEditorWindow::CreateMenu()
+    void AtomToolsDocumentMainWindow::CreateMenu()
     {
         Base::CreateMenu();
 
@@ -291,26 +170,26 @@ namespace MaterialEditor
         m_menuFile = menuBar()->addMenu("&File");
 
         m_actionNew = m_menuFile->addAction("&New...", [this]() {
-            CreateMaterialDialog createDialog(this);
-            createDialog.adjustSize();
+            //CreateMaterialDialog createDialog(this);
+            //createDialog.adjustSize();
 
-            if (createDialog.exec() == QDialog::Accepted &&
-                !createDialog.m_materialFileInfo.absoluteFilePath().isEmpty() &&
-                !createDialog.m_materialTypeFileInfo.absoluteFilePath().isEmpty())
-            {
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFile,
-                    createDialog.m_materialTypeFileInfo.absoluteFilePath().toUtf8().constData(),
-                    createDialog.m_materialFileInfo.absoluteFilePath().toUtf8().constData());
-            }
+            //if (createDialog.exec() == QDialog::Accepted &&
+            //    !createDialog.m_materialFileInfo.absoluteFilePath().isEmpty() &&
+            //    !createDialog.m_materialTypeFileInfo.absoluteFilePath().isEmpty())
+            //{
+            //    AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFile,
+            //        createDialog.m_materialTypeFileInfo.absoluteFilePath().toUtf8().constData(),
+            //        createDialog.m_materialFileInfo.absoluteFilePath().toUtf8().constData());
+            //}
         }, QKeySequence::New);
 
         m_actionOpen = m_menuFile->addAction("&Open...", [this]() {
-            const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
-            const AZStd::string filePath = AtomToolsFramework::GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
-            if (!filePath.empty())
-            {
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::OpenDocument, filePath);
-            }
+            //const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
+            //const AZStd::string filePath = GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
+            //if (!filePath.empty())
+            //{
+            //    AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::OpenDocument, filePath);
+            //}
         }, QKeySequence::Open);
 
         m_actionOpenRecent = m_menuFile->addAction("Open &Recent");
@@ -320,7 +199,7 @@ namespace MaterialEditor
         m_actionSave = m_menuFile->addAction("&Save", [this]() {
             const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
             bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
+            AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
             if (!result)
             {
                 SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
@@ -332,8 +211,8 @@ namespace MaterialEditor
             const QString documentPath = GetDocumentPath(documentId);
 
             bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy,
-                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
+            AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy,
+                documentId, GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
             if (!result)
             {
                 SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
@@ -345,8 +224,8 @@ namespace MaterialEditor
             const QString documentPath = GetDocumentPath(documentId);
 
             bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild,
-                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
+            AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild,
+                documentId, GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
             if (!result)
             {
                 SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
@@ -355,7 +234,7 @@ namespace MaterialEditor
 
         m_actionSaveAll = m_menuFile->addAction("Save A&ll", [this]() {
             bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments);
+            AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments);
             if (!result)
             {
                 SetStatusError(tr("Document save all failed"));
@@ -366,16 +245,16 @@ namespace MaterialEditor
 
         m_actionClose = m_menuFile->addAction("&Close", [this]() {
             const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+            AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
         }, QKeySequence::Close);
 
         m_actionCloseAll = m_menuFile->addAction("Close All", [this]() {
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
+            AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
         });
 
         m_actionCloseOthers = m_menuFile->addAction("Close Others", [this]() {
             const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
+            AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
         });
 
         m_menuFile->addSeparator();
@@ -399,7 +278,7 @@ namespace MaterialEditor
         m_actionUndo = m_menuEdit->addAction("&Undo", [this]() {
             const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
             bool result = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Undo);
+            AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::Undo);
             if (!result)
             {
                 SetStatusError(tr("Document undo failed: %1").arg(GetDocumentPath(documentId)));
@@ -409,7 +288,7 @@ namespace MaterialEditor
         m_actionRedo = m_menuEdit->addAction("&Redo", [this]() {
             const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
             bool result = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Redo);
+            AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsDocumentRequestBus::Events::Redo);
             if (!result)
             {
                 SetStatusError(tr("Document redo failed: %1").arg(GetDocumentPath(documentId)));
@@ -419,40 +298,12 @@ namespace MaterialEditor
         m_menuEdit->addSeparator();
 
         m_actionSettings = m_menuEdit->addAction("&Settings...", [this]() {
-            SettingsDialog dialog(this);
-            dialog.exec();
+            //SettingsDialog dialog(this);
+            //dialog.exec();
         }, QKeySequence::Preferences);
         m_actionSettings->setEnabled(true);
 
         m_menuView = menuBar()->addMenu("&View");
-
-        m_actionAssetBrowser = m_menuView->addAction("&Asset Browser", [this]() {
-            const AZStd::string label = "Asset Browser";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionInspector = m_menuView->addAction("&Inspector", [this]() {
-            const AZStd::string label = "Inspector";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionConsole = m_menuView->addAction("&Console", [this]() {
-        });
-
-        m_actionPythonTerminal = m_menuView->addAction("Python &Terminal", [this]() {
-            const AZStd::string label = "Python Terminal";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionPerfMonitor = m_menuView->addAction("Performance &Monitor", [this]() {
-            const AZStd::string label = "Performance Monitor";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionViewportSettings = m_menuView->addAction("Viewport Settings", [this]() {
-            const AZStd::string label = "Viewport Settings";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
 
         m_menuView->addSeparator();
 
@@ -467,15 +318,15 @@ namespace MaterialEditor
         m_menuHelp = menuBar()->addMenu("&Help");
 
         m_actionHelp = m_menuHelp->addAction("&Help...", [this]() {
-            HelpDialog dialog(this);
-            dialog.exec();
+            //HelpDialog dialog(this);
+            //dialog.exec();
         });
 
         m_actionAbout = m_menuHelp->addAction("&About...", [this]() {
         });
     }
 
-    void MaterialEditorWindow::CreateTabBar()
+    void AtomToolsDocumentMainWindow::CreateTabBar()
     {
         Base::CreateTabBar();
 
@@ -484,23 +335,23 @@ namespace MaterialEditor
         // This should automatically clear the active document
         connect(m_tabWidget, &QTabWidget::currentChanged, this, [this](int tabIndex) {
             const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
-            AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+            AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
         });
 
         connect(m_tabWidget, &QTabWidget::tabCloseRequested, this, [this](int tabIndex) {
             const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+            AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
         });
     }
 
-    QString MaterialEditorWindow::GetDocumentPath(const AZ::Uuid& documentId) const
+    QString AtomToolsDocumentMainWindow::GetDocumentPath(const AZ::Uuid& documentId) const
     {
         AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Handler::GetAbsolutePath);
+        AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsDocumentRequestBus::Handler::GetAbsolutePath);
         return absolutePath.c_str();
     }
 
-    void MaterialEditorWindow::OpenTabContextMenu()
+    void AtomToolsDocumentMainWindow::OpenTabContextMenu()
     {
         const QTabBar* tabBar = m_tabWidget->tabBar();
         const QPoint position = tabBar->mapFromGlobal(QCursor::pos());
@@ -512,20 +363,20 @@ namespace MaterialEditor
             const QString selectActionName = (currentTabIndex == clickedTabIndex) ? "Select in Browser" : "Select";
             tabMenu.addAction(selectActionName, [this, clickedTabIndex]() {
                 const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
+                AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
             });
             tabMenu.addAction("Close", [this, clickedTabIndex]() {
                 const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
+                AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
             });
             auto closeOthersAction = tabMenu.addAction("Close Others", [this, clickedTabIndex]() {
                 const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
+                AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
             });
             closeOthersAction->setEnabled(tabBar->count() > 1);
             tabMenu.exec(QCursor::pos());
         }
     }
-} // namespace MaterialEditor
+} // namespace AtomToolsFramework
 
-#include <Window/moc_MaterialEditorWindow.cpp>
+//#include <Document/moc_AtomToolsDocumentMainWindow.cpp>

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -7,6 +7,10 @@
  */
 
 #include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
+#include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
+
+#include <QFileDialog>
+#include <QMenu>
 #include <QMenuBar>
 #include <QStatusBar>
 #include <QVBoxLayout>
@@ -24,12 +28,10 @@ namespace AtomToolsFramework
         setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
         setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
 
+        AddCommonMenus();
+
         m_statusMessage = new QLabel(statusBar());
         statusBar()->addPermanentWidget(m_statusMessage, 1);
-
-        auto menuBar = new QMenuBar(this);
-        menuBar->setObjectName("MenuBar");
-        setMenuBar(menuBar);
 
         auto centralWidget = new QWidget(this);
         auto centralWidgetLayout = new QVBoxLayout(centralWidget);
@@ -126,5 +128,51 @@ namespace AtomToolsFramework
     void AtomToolsMainWindow::SetStatusError(const QString& message)
     {
         m_statusMessage->setText(QString("<font color=\"Red\">%1</font>").arg(message));
+    }
+
+    void AtomToolsMainWindow::AddCommonMenus()
+    {
+        m_menuFile = menuBar()->addMenu("&File");
+        m_menuEdit = menuBar()->addMenu("&Edit");
+        m_menuView = menuBar()->addMenu("&View");
+        m_menuHelp = menuBar()->addMenu("&Help");
+
+        m_menuFile->addAction("Run &Python...", [this]() {
+            const QString script = QFileDialog::getOpenFileName(this, "Run Script", QString(), QString("*.py"));
+            if (!script.isEmpty())
+            {
+                AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(&AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
+            }
+        });
+
+        m_menuFile->addSeparator();
+
+        m_menuFile->addAction("E&xit", [this]() {
+            close();
+        }, QKeySequence::Quit);
+
+        m_menuEdit->addAction("&Settings...", [this]() {
+            OpenSettings();
+        }, QKeySequence::Preferences);
+
+        m_menuHelp->addAction("&Help...", [this]() {
+            OpenHelp();
+        });
+
+        m_menuHelp->addAction("&About...", [this]() {
+            OpenAbout();
+        });
+    }
+
+    void AtomToolsMainWindow::OpenSettings()
+    {
+    }
+
+    void AtomToolsMainWindow::OpenHelp()
+    {
+    }
+
+    void AtomToolsMainWindow::OpenAbout()
+    {
     }
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -72,6 +72,10 @@ namespace AtomToolsFramework
         addDockWidget(aznumeric_cast<Qt::DockWidgetArea>(area), dockWidget);
         resizeDocks({ dockWidget }, { 400 }, aznumeric_cast<Qt::Orientation>(orientation));
         m_dockWidgets[name] = dockWidget;
+
+        m_dockActions[name] = m_menuView->addAction(name.c_str(), [this, name](){
+            SetDockWidgetVisible(name, !IsDockWidgetVisible(name));
+        });
         return true;
     }
 
@@ -82,6 +86,12 @@ namespace AtomToolsFramework
         {
             delete dockWidgetItr->second;
             m_dockWidgets.erase(dockWidgetItr);
+        }
+        auto dockActionItr = m_dockActions.find(name);
+        if (dockActionItr != m_dockActions.end())
+        {
+            delete dockActionItr->second;
+            m_dockActions.erase(dockActionItr);
         }
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
+#include <QMenuBar>
 #include <QStatusBar>
 #include <QVBoxLayout>
 
@@ -25,6 +26,10 @@ namespace AtomToolsFramework
 
         m_statusMessage = new QLabel(statusBar());
         statusBar()->addPermanentWidget(m_statusMessage, 1);
+
+        auto menuBar = new QMenuBar(this);
+        menuBar->setObjectName("MenuBar");
+        setMenuBar(menuBar);
 
         auto centralWidget = new QWidget(this);
         auto centralWidgetLayout = new QVBoxLayout(centralWidget);
@@ -106,145 +111,6 @@ namespace AtomToolsFramework
             names.push_back(dockWidgetPair.first);
         }
         return names;
-    }
-
-    void AtomToolsMainWindow::CreateMenu()
-    {
-        auto menuBar = new QMenuBar(this);
-        menuBar->setObjectName("MenuBar");
-        setMenuBar(menuBar);
-    }
-
-    void AtomToolsMainWindow::CreateTabBar()
-    {
-        m_tabWidget = new AzQtComponents::TabWidget(centralWidget());
-        m_tabWidget->setObjectName("TabWidget");
-        m_tabWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
-        m_tabWidget->setContentsMargins(0, 0, 0, 0);
-
-        // The tab bar should only be visible if it has active documents
-        m_tabWidget->setVisible(false);
-        m_tabWidget->setTabBarAutoHide(false);
-        m_tabWidget->setMovable(true);
-        m_tabWidget->setTabsClosable(true);
-        m_tabWidget->setUsesScrollButtons(true);
-
-        // Add context menu for right-clicking on tabs
-        m_tabWidget->setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
-        connect(
-            m_tabWidget, &QWidget::customContextMenuRequested, this,
-            [this]()
-            {
-                OpenTabContextMenu();
-            });
-
-        centralWidget()->layout()->addWidget(m_tabWidget);
-    }
-
-    void AtomToolsMainWindow::AddTabForDocumentId(
-        const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, AZStd::function<QWidget*()> widgetCreator)
-    {
-        // Blocking signals from the tab bar so the currentChanged signal is not sent while a document is already being opened.
-        // This prevents the OnDocumentOpened notification from being sent recursively.
-        const QSignalBlocker blocker(m_tabWidget);
-
-        // If a tab for this document already exists then select it instead of creating a new one
-        for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
-        {
-            if (documentId == GetDocumentIdFromTab(tabIndex))
-            {
-                m_tabWidget->setCurrentIndex(tabIndex);
-                m_tabWidget->repaint();
-                return;
-            }
-        }
-
-        const int tabIndex = m_tabWidget->addTab(widgetCreator(), label.c_str());
-
-        // The user can manually reorder tabs which will invalidate any association by index.
-        // We need to store the document ID with the tab using the tab instead of a separate mapping.
-        m_tabWidget->tabBar()->setTabData(tabIndex, QVariant(documentId.ToString<QString>()));
-        m_tabWidget->setTabToolTip(tabIndex, toolTip.c_str());
-        m_tabWidget->setCurrentIndex(tabIndex);
-        m_tabWidget->setVisible(true);
-        m_tabWidget->repaint();
-    }
-
-    void AtomToolsMainWindow::RemoveTabForDocumentId(const AZ::Uuid& documentId)
-    {
-        // We are not blocking signals here because we want closing tabs to close the associated document
-        // and automatically select the next document.
-        for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
-        {
-            if (documentId == GetDocumentIdFromTab(tabIndex))
-            {
-                m_tabWidget->removeTab(tabIndex);
-                m_tabWidget->setVisible(m_tabWidget->count() > 0);
-                m_tabWidget->repaint();
-                break;
-            }
-        }
-    }
-
-    void AtomToolsMainWindow::UpdateTabForDocumentId(
-        const AZ::Uuid& documentId, const AZStd::string& label, const AZStd::string& toolTip, bool isModified)
-    {
-        // Whenever a document is opened, saved, or modified we need to update the tab label
-        if (!documentId.IsNull())
-        {
-            // Because tab order and indexes can change from user interactions, we cannot store a map
-            // between a tab index and document ID.
-            // We must iterate over all of the tabs to find the one associated with this document.
-            for (int tabIndex = 0; tabIndex < m_tabWidget->count(); ++tabIndex)
-            {
-                if (documentId == GetDocumentIdFromTab(tabIndex))
-                {
-                    // We use an asterisk prepended to the file name to denote modified document
-                    // Appending is standard and preferred but the tabs elide from the
-                    // end (instead of middle) and cut it off
-                    const AZStd::string modifiedLabel = isModified ? "* " + label : label;
-                    m_tabWidget->setTabText(tabIndex, modifiedLabel.c_str());
-                    m_tabWidget->setTabToolTip(tabIndex, toolTip.c_str());
-                    m_tabWidget->repaint();
-                    break;
-                }
-            }
-        }
-    }
-
-    AZ::Uuid AtomToolsMainWindow::GetDocumentIdFromTab(const int tabIndex) const
-    {
-        const QVariant tabData = m_tabWidget->tabBar()->tabData(tabIndex);
-        if (!tabData.isNull())
-        {
-            // We need to be able to convert between a UUID and a string to store and retrieve a document ID from the tab bar
-            const QString documentIdString = tabData.toString();
-            const QByteArray documentIdBytes = documentIdString.toUtf8();
-            const AZ::Uuid documentId(documentIdBytes.data(), documentIdBytes.size());
-            return documentId;
-        }
-        return AZ::Uuid::CreateNull();
-    }
-
-    void AtomToolsMainWindow::OpenTabContextMenu()
-    {
-    }
-    
-    void AtomToolsMainWindow::SelectPreviousTab()
-    {
-        if (m_tabWidget->count() > 1)
-        {
-            // Adding count to wrap around when index <= 0
-            m_tabWidget->setCurrentIndex((m_tabWidget->currentIndex() + m_tabWidget->count() - 1) % m_tabWidget->count());
-        }
-    }
-
-    void AtomToolsMainWindow::SelectNextTab()
-    {
-        if (m_tabWidget->count() > 1)
-        {
-            m_tabWidget->setCurrentIndex((m_tabWidget->currentIndex() + 1) % m_tabWidget->count());
-        }
     }
 
     void AtomToolsMainWindow::SetStatusMessage(const QString& message)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/atomtoolsframework_files.cmake
@@ -12,6 +12,7 @@ set(FILES
     Include/AtomToolsFramework/Communication/LocalSocket.h
     Include/AtomToolsFramework/Debug/TraceRecorder.h
     Include/AtomToolsFramework/Document/AtomToolsDocument.h
+    Include/AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h
     Include/AtomToolsFramework/Document/AtomToolsDocumentSystemSettings.h
     Include/AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h
     Include/AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h
@@ -38,6 +39,7 @@ set(FILES
     Source/Communication/LocalSocket.cpp
     Source/Debug/TraceRecorder.cpp
     Source/Document/AtomToolsDocument.cpp
+    Source/Document/AtomToolsDocumentMainWindow.cpp
     Source/Document/AtomToolsDocumentSystemSettings.cpp
     Source/Document/AtomToolsDocumentSystemComponent.cpp
     Source/Document/AtomToolsDocumentSystemComponent.h

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
@@ -98,10 +98,6 @@ namespace MaterialEditor
         OnDocumentOpened(AZ::Uuid::CreateNull());
     }
 
-    MaterialEditorWindow::~MaterialEditorWindow()
-    {
-    }
-    
     void MaterialEditorWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
     {
         QSize requestedViewportSize = QSize(width, height) / devicePixelRatioF();
@@ -133,7 +129,7 @@ namespace MaterialEditor
         m_materialViewport->UnlockRenderTargetSize();
     }
 
-    bool MaterialEditorWindow::GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath)
+    bool MaterialEditorWindow::GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath)
     {
         CreateMaterialDialog createDialog(this);
         createDialog.adjustSize();
@@ -149,20 +145,11 @@ namespace MaterialEditor
         return false;
     }
 
-    bool MaterialEditorWindow::GetOpenFileInfo(AZStd::string& openPath)
+    bool MaterialEditorWindow::GetOpenDocumentParams(AZStd::string& openPath)
     {
         const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
         openPath = AtomToolsFramework::GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
         return !openPath.empty();
-    }
-
-    QWidget* MaterialEditorWindow::CreateViewForDocumemt(const AZ::Uuid& documentId)
-    {
-        AZ_UNUSED(documentId);
-        auto contentWidget = new QWidget(centralWidget());
-        contentWidget->setContentsMargins(0, 0, 0, 0);
-        contentWidget->setFixedSize(0, 0);
-        return contentWidget;
     }
 
     void MaterialEditorWindow::OpenSettings()
@@ -175,10 +162,6 @@ namespace MaterialEditor
     {
         HelpDialog dialog(this);
         dialog.exec();
-    }
-
-    void MaterialEditorWindow::OpenAbout()
-    {
     }
 
     void MaterialEditorWindow::closeEvent(QCloseEvent* closeEvent)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.cpp
@@ -9,15 +9,9 @@
 #include <Atom/Document/MaterialDocumentRequestBus.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/Window/MaterialEditorWindowSettings.h>
-#include <AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h>
-#include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
 #include <AtomToolsFramework/Util/Util.h>
-#include <AtomToolsFramework/Window/AtomToolsMainWindowNotificationBus.h>
-#include <AzFramework/StringFunc/StringFunc.h>
 #include <AzQtComponents/Components/StyleManager.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
-#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
-#include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
 #include <AzToolsFramework/PythonTerminal/ScriptTermDialog.h>
 #include <Viewport/MaterialViewportWidget.h>
 #include <Window/CreateMaterialDialog/CreateMaterialDialog.h>
@@ -33,7 +27,6 @@ AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnin
 #include <QApplication>
 #include <QByteArray>
 #include <QCloseEvent>
-#include <QDesktopWidget>
 #include <QFileDialog>
 #include <QWindow>
 AZ_POP_DISABLE_WARNING
@@ -41,7 +34,7 @@ AZ_POP_DISABLE_WARNING
 namespace MaterialEditor
 {
     MaterialEditorWindow::MaterialEditorWindow(QWidget* parent /* = 0 */)
-        : AtomToolsFramework::AtomToolsMainWindow(parent)
+        : AtomToolsFramework::AtomToolsDocumentMainWindow(parent)
     {
         resize(1280, 1024);
 
@@ -74,9 +67,6 @@ namespace MaterialEditor
         m_toolBar->setObjectName("ToolBar");
         addToolBar(m_toolBar);
 
-        CreateMenu();
-        CreateTabBar();
-
         m_materialViewport = new MaterialViewportWidget(centralWidget());
         m_materialViewport->setObjectName("Viewport");
         m_materialViewport->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
@@ -105,15 +95,12 @@ namespace MaterialEditor
             m_advancedDockManager->restoreState(windowState);
         }
 
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusConnect();
         OnDocumentOpened(AZ::Uuid::CreateNull());
     }
 
     MaterialEditorWindow::~MaterialEditorWindow()
     {
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusDisconnect();
     }
-
     
     void MaterialEditorWindow::ResizeViewportRenderTarget(uint32_t width, uint32_t height)
     {
@@ -146,16 +133,56 @@ namespace MaterialEditor
         m_materialViewport->UnlockRenderTargetSize();
     }
 
+    bool MaterialEditorWindow::GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath)
+    {
+        CreateMaterialDialog createDialog(this);
+        createDialog.adjustSize();
+
+        if (createDialog.exec() == QDialog::Accepted &&
+            !createDialog.m_materialFileInfo.absoluteFilePath().isEmpty() &&
+            !createDialog.m_materialTypeFileInfo.absoluteFilePath().isEmpty())
+        {
+            savePath = createDialog.m_materialFileInfo.absoluteFilePath().toUtf8().constData();
+            openPath = createDialog.m_materialTypeFileInfo.absoluteFilePath().toUtf8().constData();
+            return true;
+        }
+        return false;
+    }
+
+    bool MaterialEditorWindow::GetOpenFileInfo(AZStd::string& openPath)
+    {
+        const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
+        openPath = AtomToolsFramework::GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
+        return !openPath.empty();
+    }
+
+    QWidget* MaterialEditorWindow::CreateViewForDocumemt(const AZ::Uuid& documentId)
+    {
+        AZ_UNUSED(documentId);
+        auto contentWidget = new QWidget(centralWidget());
+        contentWidget->setContentsMargins(0, 0, 0, 0);
+        contentWidget->setFixedSize(0, 0);
+        return contentWidget;
+    }
+
+    void MaterialEditorWindow::OpenSettings()
+    {
+        SettingsDialog dialog(this);
+        dialog.exec();
+    }
+
+    void MaterialEditorWindow::OpenHelp()
+    {
+        HelpDialog dialog(this);
+        dialog.exec();
+    }
+
+    void MaterialEditorWindow::OpenAbout()
+    {
+    }
+
     void MaterialEditorWindow::closeEvent(QCloseEvent* closeEvent)
     {
-        bool didClose = true;
-        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
-        if (!didClose)
-        {
-            closeEvent->ignore();
-            return;
-        }
-
         // Capture docking state before shutdown
         auto windowSettings = AZ::UserSettings::CreateFind<MaterialEditorWindowSettings>(
             AZ::Crc32("MaterialEditorWindowSettings"), AZ::UserSettings::CT_GLOBAL);
@@ -163,368 +190,7 @@ namespace MaterialEditor
         QByteArray windowState = m_advancedDockManager->saveState();
         windowSettings->m_mainWindowState.assign(windowState.begin(), windowState.end());
 
-        AtomToolsFramework::AtomToolsMainWindowNotificationBus::Broadcast(
-            &AtomToolsFramework::AtomToolsMainWindowNotifications::OnMainWindowClosing);
-    }
-
-    void MaterialEditorWindow::OnDocumentOpened(const AZ::Uuid& documentId)
-    {
-        bool isOpen = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsOpen);
-        bool isSavable = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsSavable);
-        bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
-        bool canUndo = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
-        bool canRedo = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-
-        // Update UI to display the new document
-        if (!documentId.IsNull() && isOpen)
-        {
-            // Create a new tab for the document ID and assign it's label to the file name of the document.
-            AddTabForDocumentId(documentId, filename, absolutePath, [this]{
-                // The tab widget requires a dummy page per tab
-                auto contentWidget = new QWidget(centralWidget());
-                contentWidget->setContentsMargins(0, 0, 0, 0);
-                contentWidget->setFixedSize(0, 0);
-                return contentWidget;
-            });
-        }
-
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-
-        const bool hasTabs = m_tabWidget->count() > 0;
-
-        // Update menu options
-        m_actionNew->setEnabled(true);
-        m_actionOpen->setEnabled(true);
-        m_actionOpenRecent->setEnabled(false);
-        m_actionClose->setEnabled(hasTabs);
-        m_actionCloseAll->setEnabled(hasTabs);
-        m_actionCloseOthers->setEnabled(hasTabs);
-
-        m_actionSave->setEnabled(isOpen && isSavable);
-        m_actionSaveAsCopy->setEnabled(isOpen && isSavable);
-        m_actionSaveAsChild->setEnabled(isOpen);
-        m_actionSaveAll->setEnabled(hasTabs);
-
-        m_actionExit->setEnabled(true);
-
-        m_actionUndo->setEnabled(canUndo);
-        m_actionRedo->setEnabled(canRedo);
-        m_actionSettings->setEnabled(true);
-
-        m_actionAssetBrowser->setEnabled(true);
-        m_actionInspector->setEnabled(true);
-        m_actionConsole->setEnabled(false);
-        m_actionPythonTerminal->setEnabled(true);
-        m_actionPerfMonitor->setEnabled(true);
-        m_actionViewportSettings->setEnabled(true);
-        m_actionPreviousTab->setEnabled(m_tabWidget->count() > 1);
-        m_actionNextTab->setEnabled(m_tabWidget->count() > 1);
-
-        m_actionAbout->setEnabled(false);
-
-        activateWindow();
-        raise();
-
-        const QString documentPath = GetDocumentPath(documentId);
-        if (!documentPath.isEmpty())
-        {
-            SetStatusMessage(tr("Document opened: %1").arg(documentPath));
-        }
-    }
-
-    void MaterialEditorWindow::OnDocumentClosed(const AZ::Uuid& documentId)
-    {
-        RemoveTabForDocumentId(documentId);
-        SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
-    }
-
-    void MaterialEditorWindow::OnDocumentModified(const AZ::Uuid& documentId)
-    {
-        bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-    }
-
-    void MaterialEditorWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
-    {
-        if (documentId == GetDocumentIdFromTab(m_tabWidget->currentIndex()))
-        {
-            bool canUndo = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
-            bool canRedo = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
-            m_actionUndo->setEnabled(canUndo);
-            m_actionRedo->setEnabled(canRedo);
-        }
-    }
-
-    void MaterialEditorWindow::OnDocumentSaved(const AZ::Uuid& documentId)
-    {
-        bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-        SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
-    }
-
-    void MaterialEditorWindow::CreateMenu()
-    {
-        Base::CreateMenu();
-
-        // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
-        m_menuFile = menuBar()->addMenu("&File");
-
-        m_actionNew = m_menuFile->addAction("&New...", [this]() {
-            CreateMaterialDialog createDialog(this);
-            createDialog.adjustSize();
-
-            if (createDialog.exec() == QDialog::Accepted &&
-                !createDialog.m_materialFileInfo.absoluteFilePath().isEmpty() &&
-                !createDialog.m_materialTypeFileInfo.absoluteFilePath().isEmpty())
-            {
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CreateDocumentFromFile,
-                    createDialog.m_materialTypeFileInfo.absoluteFilePath().toUtf8().constData(),
-                    createDialog.m_materialFileInfo.absoluteFilePath().toUtf8().constData());
-            }
-        }, QKeySequence::New);
-
-        m_actionOpen = m_menuFile->addAction("&Open...", [this]() {
-            const AZStd::vector<AZ::Data::AssetType> assetTypes = { azrtti_typeid<AZ::RPI::MaterialAsset>() };
-            const AZStd::string filePath = AtomToolsFramework::GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
-            if (!filePath.empty())
-            {
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::OpenDocument, filePath);
-            }
-        }, QKeySequence::Open);
-
-        m_actionOpenRecent = m_menuFile->addAction("Open &Recent");
-
-        m_menuFile->addSeparator();
-
-        m_actionSave = m_menuFile->addAction("&Save", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
-            if (!result)
-            {
-                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::Save);
-
-        m_actionSaveAsCopy = m_menuFile->addAction("Save &As...", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            const QString documentPath = GetDocumentPath(documentId);
-
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy,
-                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
-            if (!result)
-            {
-                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::SaveAs);
-
-        m_actionSaveAsChild = m_menuFile->addAction("Save As &Child...", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            const QString documentPath = GetDocumentPath(documentId);
-
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsChild,
-                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
-            if (!result)
-            {
-                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        });
-
-        m_actionSaveAll = m_menuFile->addAction("Save A&ll", [this]() {
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments);
-            if (!result)
-            {
-                SetStatusError(tr("Document save all failed"));
-            }
-        });
-
-        m_menuFile->addSeparator();
-
-        m_actionClose = m_menuFile->addAction("&Close", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-        }, QKeySequence::Close);
-
-        m_actionCloseAll = m_menuFile->addAction("Close All", [this]() {
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
-        });
-
-        m_actionCloseOthers = m_menuFile->addAction("Close Others", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
-        });
-
-        m_menuFile->addSeparator();
-
-        m_menuFile->addAction("Run &Python...", [this]() {
-            const QString script = QFileDialog::getOpenFileName(this, "Run Script", QString(), QString("*.py"));
-            if (!script.isEmpty())
-            {
-                AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(&AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
-            }
-        });
-
-        m_menuFile->addSeparator();
-
-        m_actionExit = m_menuFile->addAction("E&xit", [this]() {
-            close();
-        }, QKeySequence::Quit);
-
-        m_menuEdit = menuBar()->addMenu("&Edit");
-
-        m_actionUndo = m_menuEdit->addAction("&Undo", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Undo);
-            if (!result)
-            {
-                SetStatusError(tr("Document undo failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::Undo);
-
-        m_actionRedo = m_menuEdit->addAction("&Redo", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Redo);
-            if (!result)
-            {
-                SetStatusError(tr("Document redo failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::Redo);
-
-        m_menuEdit->addSeparator();
-
-        m_actionSettings = m_menuEdit->addAction("&Settings...", [this]() {
-            SettingsDialog dialog(this);
-            dialog.exec();
-        }, QKeySequence::Preferences);
-        m_actionSettings->setEnabled(true);
-
-        m_menuView = menuBar()->addMenu("&View");
-
-        m_actionAssetBrowser = m_menuView->addAction("&Asset Browser", [this]() {
-            const AZStd::string label = "Asset Browser";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionInspector = m_menuView->addAction("&Inspector", [this]() {
-            const AZStd::string label = "Inspector";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionConsole = m_menuView->addAction("&Console", [this]() {
-        });
-
-        m_actionPythonTerminal = m_menuView->addAction("Python &Terminal", [this]() {
-            const AZStd::string label = "Python Terminal";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionPerfMonitor = m_menuView->addAction("Performance &Monitor", [this]() {
-            const AZStd::string label = "Performance Monitor";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionViewportSettings = m_menuView->addAction("Viewport Settings", [this]() {
-            const AZStd::string label = "Viewport Settings";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_menuView->addSeparator();
-
-        m_actionPreviousTab = m_menuView->addAction("&Previous Tab", [this]() {
-            SelectPreviousTab();
-        }, Qt::CTRL | Qt::SHIFT | Qt::Key_Tab); //QKeySequence::PreviousChild is mapped incorrectly in Qt
-
-        m_actionNextTab = m_menuView->addAction("&Next Tab", [this]() {
-            SelectNextTab();
-        }, Qt::CTRL | Qt::Key_Tab); //QKeySequence::NextChild works as expected but mirroring Previous
-
-        m_menuHelp = menuBar()->addMenu("&Help");
-
-        m_actionHelp = m_menuHelp->addAction("&Help...", [this]() {
-            HelpDialog dialog(this);
-            dialog.exec();
-        });
-
-        m_actionAbout = m_menuHelp->addAction("&About...", [this]() {
-        });
-    }
-
-    void MaterialEditorWindow::CreateTabBar()
-    {
-        Base::CreateTabBar();
-
-        // This signal will be triggered whenever a tab is added, removed, selected, clicked, dragged
-        // When the last tab is removed tabIndex will be -1 and the document ID will be null
-        // This should automatically clear the active document
-        connect(m_tabWidget, &QTabWidget::currentChanged, this, [this](int tabIndex) {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
-            AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-        });
-
-        connect(m_tabWidget, &QTabWidget::tabCloseRequested, this, [this](int tabIndex) {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-        });
-    }
-
-    QString MaterialEditorWindow::GetDocumentPath(const AZ::Uuid& documentId) const
-    {
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Handler::GetAbsolutePath);
-        return absolutePath.c_str();
-    }
-
-    void MaterialEditorWindow::OpenTabContextMenu()
-    {
-        const QTabBar* tabBar = m_tabWidget->tabBar();
-        const QPoint position = tabBar->mapFromGlobal(QCursor::pos());
-        const int clickedTabIndex = tabBar->tabAt(position);
-        const int currentTabIndex = tabBar->currentIndex();
-        if (clickedTabIndex >= 0)
-        {
-            QMenu tabMenu;
-            const QString selectActionName = (currentTabIndex == clickedTabIndex) ? "Select in Browser" : "Select";
-            tabMenu.addAction(selectActionName, [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-            });
-            tabMenu.addAction("Close", [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-            });
-            auto closeOthersAction = tabMenu.addAction("Close Others", [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
-            });
-            closeOthersAction->setEnabled(tabBar->count() > 1);
-            tabMenu.exec(QCursor::pos());
-        }
+        Base::closeEvent(closeEvent);
     }
 } // namespace MaterialEditor
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.h
@@ -9,9 +9,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
-#include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
-#include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
-#include <AzCore/Memory/SystemAllocator.h>
+#include <AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <Viewport/MaterialViewportWidget.h>
@@ -29,72 +27,32 @@ namespace MaterialEditor
      * 3) MaterialPropertyInspector  - The user edits the properties of the selected Material.
      */
     class MaterialEditorWindow
-        : public AtomToolsFramework::AtomToolsMainWindow
-        , private AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler
+        : public AtomToolsFramework::AtomToolsDocumentMainWindow
     {
         Q_OBJECT
     public:
         AZ_CLASS_ALLOCATOR(MaterialEditorWindow, AZ::SystemAllocator, 0);
 
-        using Base = AtomToolsFramework::AtomToolsMainWindow;
+        using Base = AtomToolsFramework::AtomToolsDocumentMainWindow;
 
         MaterialEditorWindow(QWidget* parent = 0);
         ~MaterialEditorWindow();
 
-    private:
+    protected:
         void ResizeViewportRenderTarget(uint32_t width, uint32_t height) override;
         void LockViewportRenderTargetSize(uint32_t width, uint32_t height) override;
         void UnlockViewportRenderTargetSize() override;
 
-        // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
-        void OnDocumentOpened(const AZ::Uuid& documentId) override;
-        void OnDocumentClosed(const AZ::Uuid& documentId) override;
-        void OnDocumentModified(const AZ::Uuid& documentId) override;
-        void OnDocumentUndoStateChanged(const AZ::Uuid& documentId) override;
-        void OnDocumentSaved(const AZ::Uuid& documentId) override;
-
-        void CreateMenu() override;
-        void CreateTabBar() override;
-
-        QString GetDocumentPath(const AZ::Uuid& documentId) const;
-
-        void OpenTabContextMenu() override;
+        bool GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath) override;
+        bool GetOpenFileInfo(AZStd::string& openPath) override;
+        QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId) override;
+        void OpenSettings() override;
+        void OpenHelp() override;
+        void OpenAbout() override;
 
         void closeEvent(QCloseEvent* closeEvent) override;
 
         MaterialViewportWidget* m_materialViewport = nullptr;
         MaterialEditorToolBar* m_toolBar = nullptr;
-
-        QMenu* m_menuFile = {};
-        QAction* m_actionNew = {};
-        QAction* m_actionOpen = {};
-        QAction* m_actionOpenRecent = {};
-        QAction* m_actionClose = {};
-        QAction* m_actionCloseAll = {};
-        QAction* m_actionCloseOthers = {};
-        QAction* m_actionSave = {};
-        QAction* m_actionSaveAsCopy = {};
-        QAction* m_actionSaveAsChild = {};
-        QAction* m_actionSaveAll = {};
-        QAction* m_actionExit = {};
-
-        QMenu* m_menuEdit = {};
-        QAction* m_actionUndo = {};
-        QAction* m_actionRedo = {};
-        QAction* m_actionSettings = {};
-
-        QMenu* m_menuView = {};
-        QAction* m_actionAssetBrowser = {};
-        QAction* m_actionInspector = {};
-        QAction* m_actionConsole = {};
-        QAction* m_actionPythonTerminal = {};
-        QAction* m_actionPerfMonitor = {};
-        QAction* m_actionViewportSettings = {};
-        QAction* m_actionNextTab = {};
-        QAction* m_actionPreviousTab = {};
-
-        QMenu* m_menuHelp = {};
-        QAction* m_actionHelp = {};
-        QAction* m_actionAbout = {};
     };
 } // namespace MaterialEditor

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Window/MaterialEditorWindow.h
@@ -19,13 +19,11 @@ AZ_POP_DISABLE_WARNING
 
 namespace MaterialEditor
 {
-    /**
-     * MaterialEditorWindow is the main class. Its responsibility is limited to initializing and connecting
-     * its panels, managing selection of assets, and performing high-level actions like saving. It contains...
-     * 1) MaterialBrowser        - The user browses for Material (.material) assets.
-     * 2) MaterialViewport        - The user can see the selected Material applied to a model.
-     * 3) MaterialPropertyInspector  - The user edits the properties of the selected Material.
-     */
+    //! MaterialEditorWindow is the main class. Its responsibility is limited to initializing and connecting
+    //! its panels, managing selection of assets, and performing high-level actions like saving. It contains...
+    //! 1) MaterialBrowser        - The user browses for Material (.material) assets.
+    //! 2) MaterialViewport        - The user can see the selected Material applied to a model.
+    //! 3) MaterialPropertyInspector  - The user edits the properties of the selected Material.
     class MaterialEditorWindow
         : public AtomToolsFramework::AtomToolsDocumentMainWindow
     {
@@ -36,19 +34,17 @@ namespace MaterialEditor
         using Base = AtomToolsFramework::AtomToolsDocumentMainWindow;
 
         MaterialEditorWindow(QWidget* parent = 0);
-        ~MaterialEditorWindow();
+        ~MaterialEditorWindow() = default;
 
     protected:
         void ResizeViewportRenderTarget(uint32_t width, uint32_t height) override;
         void LockViewportRenderTargetSize(uint32_t width, uint32_t height) override;
         void UnlockViewportRenderTargetSize() override;
 
-        bool GetCreateFileInfo(AZStd::string& openPath, AZStd::string& savePath) override;
-        bool GetOpenFileInfo(AZStd::string& openPath) override;
-        QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId) override;
+        bool GetCreateDocumentParams(AZStd::string& openPath, AZStd::string& savePath) override;
+        bool GetOpenDocumentParams(AZStd::string& openPath) override;
         void OpenSettings() override;
         void OpenHelp() override;
-        void OpenAbout() override;
 
         void closeEvent(QCloseEvent* closeEvent) override;
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -7,22 +7,13 @@
  */
  
 #include <AzCore/Name/Name.h>
-#include <AzFramework/StringFunc/StringFunc.h>
-#include <AzQtComponents/Components/StyleManager.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
-#include <AzToolsFramework/API/EditorPythonRunnerRequestsBus.h>
-#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/PythonTerminal/ScriptTermDialog.h>
 #include <AtomToolsFramework/Util/Util.h>
-#include <AtomToolsFramework/Window/AtomToolsMainWindowNotificationBus.h>
 #include <Atom/Document/ShaderManagementConsoleDocumentRequestBus.h>
-#include <AtomToolsFramework/Document/AtomToolsDocumentRequestBus.h>
-#include <AtomToolsFramework/Document/AtomToolsDocumentSystemRequestBus.h>
 #include <Window/ShaderManagementConsoleWindow.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
-#include <QCloseEvent>
-#include <QFileDialog>
 #include <QHeaderView>
 #include <QStandardItemModel>
 #include <QTableView>
@@ -32,7 +23,7 @@ AZ_POP_DISABLE_WARNING
 namespace ShaderManagementConsole
 {
     ShaderManagementConsoleWindow::ShaderManagementConsoleWindow(QWidget* parent /* = 0 */)
-        : AtomToolsFramework::AtomToolsMainWindow(parent)
+        : AtomToolsFramework::AtomToolsDocumentMainWindow(parent)
     {
         resize(1280, 1024);
 
@@ -50,9 +41,6 @@ namespace ShaderManagementConsole
         m_toolBar->setObjectName("ToolBar");
         addToolBar(m_toolBar);
 
-        CreateMenu();
-        CreateTabBar();
-
         AddDockWidget("Asset Browser", new ShaderManagementConsoleBrowserWidget, Qt::BottomDockWidgetArea, Qt::Vertical);
         AddDockWidget("Python Terminal", new AzToolsFramework::CScriptTermDialog, Qt::BottomDockWidgetArea, Qt::Horizontal);
 
@@ -61,356 +49,34 @@ namespace ShaderManagementConsole
         // Restore geometry and show the window
         mainWindowWrapper->showFromSettings();
 
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusConnect();
         OnDocumentOpened(AZ::Uuid::CreateNull());
     }
 
     ShaderManagementConsoleWindow::~ShaderManagementConsoleWindow()
     {
-        AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler::BusDisconnect();
     }
 
-    void ShaderManagementConsoleWindow::closeEvent(QCloseEvent* closeEvent)
-    {
-        bool didClose = true;
-        AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(didClose, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
-        if (!didClose)
-        {
-            closeEvent->ignore();
-            return;
-        }
-
-        AtomToolsFramework::AtomToolsMainWindowNotificationBus::Broadcast(
-            &AtomToolsFramework::AtomToolsMainWindowNotifications::OnMainWindowClosing);
-    }
-
-    void ShaderManagementConsoleWindow::OnDocumentOpened(const AZ::Uuid& documentId)
-    {
-        bool isOpen = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isOpen, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsOpen);
-        bool isSavable = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isSavable, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsSavable);
-        bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
-        bool canUndo = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
-        bool canRedo = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-
-        // Update UI to display the new document
-        if (!documentId.IsNull() && isOpen)
-        {
-            // Create a new tab for the document ID and assign it's label to the file name of the document.
-            AddTabForDocumentId(documentId, filename, absolutePath, [this, documentId]{
-                // The document tab contains a table view.
-                auto contentWidget = new QTableView(centralWidget());
-                contentWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
-                contentWidget->setModel(CreateDocumentContent(documentId));
-                return contentWidget;
-            });
-        }
-
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-
-        const bool hasTabs = m_tabWidget->count() > 0;
-
-        // Update menu options
-        m_actionOpen->setEnabled(true);
-        m_actionOpenRecent->setEnabled(false);
-        m_actionClose->setEnabled(hasTabs);
-        m_actionCloseAll->setEnabled(hasTabs);
-        m_actionCloseOthers->setEnabled(hasTabs);
-
-        m_actionSave->setEnabled(isOpen && isSavable);
-        m_actionSaveAsCopy->setEnabled(isOpen && isSavable);
-        m_actionSaveAll->setEnabled(hasTabs);
-
-        m_actionExit->setEnabled(true);
-
-        m_actionUndo->setEnabled(canUndo);
-        m_actionRedo->setEnabled(canRedo);
-        m_actionSettings->setEnabled(false);
-
-        m_actionAssetBrowser->setEnabled(true);
-        m_actionPythonTerminal->setEnabled(true);
-        m_actionPreviousTab->setEnabled(m_tabWidget->count() > 1);
-        m_actionNextTab->setEnabled(m_tabWidget->count() > 1);
-
-        m_actionHelp->setEnabled(false);
-        m_actionAbout->setEnabled(false);
-
-        activateWindow();
-        raise();
-
-        const QString documentPath = GetDocumentPath(documentId);
-        if (!documentPath.isEmpty())
-        {
-            SetStatusMessage(tr("Document opened: %1").arg(documentPath));
-        }
-    }
-
-    void ShaderManagementConsoleWindow::OnDocumentClosed(const AZ::Uuid& documentId)
-    {
-        RemoveTabForDocumentId(documentId);
-        SetStatusMessage(tr("Document closed: %1").arg(GetDocumentPath(documentId)));
-    }
-
-    void ShaderManagementConsoleWindow::OnDocumentModified(const AZ::Uuid& documentId)
-    {
-        bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-    }
-
-    void ShaderManagementConsoleWindow::OnDocumentUndoStateChanged(const AZ::Uuid& documentId)
-    {
-        if (documentId == GetDocumentIdFromTab(m_tabWidget->currentIndex()))
-        {
-            bool canUndo = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canUndo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanUndo);
-            bool canRedo = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(canRedo, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::CanRedo);
-            m_actionUndo->setEnabled(canUndo);
-            m_actionRedo->setEnabled(canRedo);
-        }
-    }
-
-    void ShaderManagementConsoleWindow::OnDocumentSaved(const AZ::Uuid& documentId)
-    {
-        bool isModified = false;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(isModified, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::IsModified);
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
-        AZStd::string filename;
-        AzFramework::StringFunc::Path::GetFullFileName(absolutePath.c_str(), filename);
-        UpdateTabForDocumentId(documentId, filename, absolutePath, isModified);
-        SetStatusMessage(tr("Document saved: %1").arg(GetDocumentPath(documentId)));
-    }
-
-    void ShaderManagementConsoleWindow::CreateMenu()
-    {
-        Base::CreateMenu();
-
-        // Generating the main menu manually because it's easier and we will have some dynamic or data driven entries
-        m_menuFile = menuBar()->addMenu("&File");
-
-        m_actionOpen = m_menuFile->addAction("&Open...", [this]() {
-            const AZStd::vector<AZ::Data::AssetType> assetTypes = {
-            };
-
-            const AZStd::string filePath = AtomToolsFramework::GetOpenFileInfo(assetTypes).absoluteFilePath().toUtf8().constData();
-            if (!filePath.empty())
-            {
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::OpenDocument, filePath);
-            }
-        }, QKeySequence::Open);
-
-        m_actionOpenRecent = m_menuFile->addAction("Open &Recent");
-
-        m_menuFile->addSeparator();
-
-        m_actionSave = m_menuFile->addAction("&Save", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocument, documentId);
-            if (!result)
-            {
-                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::Save);
-
-        m_actionSaveAsCopy = m_menuFile->addAction("Save &As...", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            const QString documentPath = GetDocumentPath(documentId);
-
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveDocumentAsCopy,
-                documentId, AtomToolsFramework::GetSaveFileInfo(documentPath).absoluteFilePath().toUtf8().constData());
-            if (!result)
-            {
-                SetStatusError(tr("Document save failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::SaveAs);
-
-        m_actionSaveAll = m_menuFile->addAction("Save A&ll", [this]() {
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::BroadcastResult(result, &AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::SaveAllDocuments);
-            if (!result)
-            {
-                SetStatusError(tr("Document save all failed"));
-            }
-        });
-
-        m_menuFile->addSeparator();
-
-        m_actionClose = m_menuFile->addAction("&Close", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-        }, QKeySequence::Close);
-
-        m_actionCloseAll = m_menuFile->addAction("Close All", [this]() {
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocuments);
-        });
-
-        m_actionCloseOthers = m_menuFile->addAction("Close Others", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
-        });
-
-        m_menuFile->addSeparator();
-
-        m_menuFile->addAction("Run &Python...", [this]() {
-            const QString script = QFileDialog::getOpenFileName(this, "Run Script", QString(), QString("*.py"));
-            if (!script.isEmpty())
-            {
-                AzToolsFramework::EditorPythonRunnerRequestBus::Broadcast(&AzToolsFramework::EditorPythonRunnerRequestBus::Events::ExecuteByFilename, script.toUtf8().constData());
-            }
-        });
-
-        m_menuFile->addSeparator();
-
-        m_actionExit = m_menuFile->addAction("E&xit", [this]() {
-            close();
-        }, QKeySequence::Quit);
-
-        m_menuEdit = menuBar()->addMenu("&Edit");
-
-        m_actionUndo = m_menuEdit->addAction("&Undo", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Undo);
-            if (!result)
-            {
-                SetStatusError(tr("Document undo failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::Undo);
-
-        m_actionRedo = m_menuEdit->addAction("&Redo", [this]() {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(m_tabWidget->currentIndex());
-            bool result = false;
-            AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(result, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Events::Redo);
-            if (!result)
-            {
-                SetStatusError(tr("Document redo failed: %1").arg(GetDocumentPath(documentId)));
-            }
-        }, QKeySequence::Redo);
-
-        m_menuEdit->addSeparator();
-
-        m_actionSettings = m_menuEdit->addAction("&Settings...", [this]() {
-        }, QKeySequence::Preferences);
-        m_actionSettings->setEnabled(false);
-
-        m_menuView = menuBar()->addMenu("&View");
-
-        m_actionAssetBrowser = m_menuView->addAction("&Asset Browser", [this]() {
-            const AZStd::string label = "Asset Browser";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-        m_actionPythonTerminal = m_menuView->addAction("Python &Terminal", [this]() {
-            const AZStd::string label = "Python Terminal";
-            SetDockWidgetVisible(label, !IsDockWidgetVisible(label));
-        });
-
-
-        m_menuView->addSeparator();
-
-        m_actionPreviousTab = m_menuView->addAction("&Previous Tab", [this]() {
-            SelectPreviousTab();
-        }, Qt::CTRL | Qt::SHIFT | Qt::Key_Tab); //QKeySequence::PreviousChild is mapped incorrectly in Qt
-
-        m_actionNextTab = m_menuView->addAction("&Next Tab", [this]() {
-            SelectNextTab();
-        }, Qt::CTRL | Qt::Key_Tab); //QKeySequence::NextChild works as expected but mirroring Previous
-
-        m_menuHelp = menuBar()->addMenu("&Help");
-
-        m_actionHelp = m_menuHelp->addAction("&Help...", [this]() {
-        });
-
-        m_actionAbout = m_menuHelp->addAction("&About...", [this]() {
-        });
-    }
-
-    void ShaderManagementConsoleWindow::CreateTabBar()
-    {
-        Base::CreateTabBar();
-
-        // This signal will be triggered whenever a tab is added, removed, selected, clicked, dragged
-        // When the last tab is removed tabIndex will be -1 and the document ID will be null
-        // This should automatically clear the active document
-        connect(m_tabWidget, &QTabWidget::currentChanged, this, [this](int tabIndex) {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
-            AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-        });
-
-        connect(m_tabWidget, &QTabWidget::tabCloseRequested, this, [this](int tabIndex) {
-            const AZ::Uuid documentId = GetDocumentIdFromTab(tabIndex);
-            AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-        });
-    }
-
-    QString ShaderManagementConsoleWindow::GetDocumentPath(const AZ::Uuid& documentId) const
-    {
-        AZStd::string absolutePath;
-        AtomToolsFramework::AtomToolsDocumentRequestBus::EventResult(absolutePath, documentId, &AtomToolsFramework::AtomToolsDocumentRequestBus::Handler::GetAbsolutePath);
-        return absolutePath.c_str();
-    }
-
-    void ShaderManagementConsoleWindow::OpenTabContextMenu()
-    {
-        const QTabBar* tabBar = m_tabWidget->tabBar();
-        const QPoint position = tabBar->mapFromGlobal(QCursor::pos());
-        const int clickedTabIndex = tabBar->tabAt(position);
-        const int currentTabIndex = tabBar->currentIndex();
-        if (clickedTabIndex >= 0)
-        {
-            QMenu tabMenu;
-            const QString selectActionName = (currentTabIndex == clickedTabIndex) ? "Select in Browser" : "Select";
-            tabMenu.addAction(selectActionName, [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentNotificationBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentNotificationBus::Events::OnDocumentOpened, documentId);
-            });
-            tabMenu.addAction("Close", [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseDocument, documentId);
-            });
-            auto closeOthersAction = tabMenu.addAction("Close Others", [this, clickedTabIndex]() {
-                const AZ::Uuid documentId = GetDocumentIdFromTab(clickedTabIndex);
-                AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Broadcast(&AtomToolsFramework::AtomToolsDocumentSystemRequestBus::Events::CloseAllDocumentsExcept, documentId);
-            });
-            closeOthersAction->setEnabled(tabBar->count() > 1);
-            tabMenu.exec(QCursor::pos());
-        }
-    }
-
-    QStandardItemModel* ShaderManagementConsoleWindow::CreateDocumentContent(const AZ::Uuid& documentId)
+    QWidget* ShaderManagementConsoleWindow::CreateViewForDocumemt(const AZ::Uuid& documentId)
     {
         AZStd::unordered_set<AZStd::string> optionNames;
 
         size_t shaderOptionCount = 0;
-        ShaderManagementConsoleDocumentRequestBus::EventResult(shaderOptionCount, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderOptionCount);
+        ShaderManagementConsoleDocumentRequestBus::EventResult(
+            shaderOptionCount, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderOptionCount);
 
         for (size_t optionIndex = 0; optionIndex < shaderOptionCount; ++optionIndex)
         {
             AZ::RPI::ShaderOptionDescriptor shaderOptionDesc;
-            ShaderManagementConsoleDocumentRequestBus::EventResult(shaderOptionDesc, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderOptionDescriptor, optionIndex);
+            ShaderManagementConsoleDocumentRequestBus::EventResult(
+                shaderOptionDesc, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderOptionDescriptor, optionIndex);
 
             const char* optionName = shaderOptionDesc.GetName().GetCStr();
             optionNames.insert(optionName);
         }
 
         size_t shaderVariantCount = 0;
-        ShaderManagementConsoleDocumentRequestBus::EventResult(shaderVariantCount, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderVariantCount);
+        ShaderManagementConsoleDocumentRequestBus::EventResult(
+            shaderVariantCount, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderVariantCount);
 
         auto model = new QStandardItemModel();
         model->setRowCount(static_cast<int>(shaderVariantCount));
@@ -425,7 +91,8 @@ namespace ShaderManagementConsole
         for (int variantIndex = 0; variantIndex < shaderVariantCount; ++variantIndex)
         {
             AZ::RPI::ShaderVariantListSourceData::VariantInfo shaderVariantInfo;
-            ShaderManagementConsoleDocumentRequestBus::EventResult(shaderVariantInfo, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderVariantInfo, variantIndex);
+            ShaderManagementConsoleDocumentRequestBus::EventResult(
+                shaderVariantInfo, documentId, &ShaderManagementConsoleDocumentRequestBus::Events::GetShaderVariantInfo, variantIndex);
 
             model->setHeaderData(variantIndex, Qt::Vertical, QString::number(variantIndex));
 
@@ -442,7 +109,11 @@ namespace ShaderManagementConsole
             }
         }
 
-        return model;
+        // The document tab contains a table view.
+        auto contentWidget = new QTableView(centralWidget());
+        contentWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+        contentWidget->setModel(model);
+        return contentWidget;
     }
 } // namespace ShaderManagementConsole
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.cpp
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
+#include <Atom/Document/ShaderManagementConsoleDocumentRequestBus.h>
+#include <AtomToolsFramework/Util/Util.h>
 #include <AzCore/Name/Name.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
 #include <AzToolsFramework/PythonTerminal/ScriptTermDialog.h>
-#include <AtomToolsFramework/Util/Util.h>
-#include <Atom/Document/ShaderManagementConsoleDocumentRequestBus.h>
 #include <Window/ShaderManagementConsoleWindow.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
@@ -49,14 +49,16 @@ namespace ShaderManagementConsole
         // Restore geometry and show the window
         mainWindowWrapper->showFromSettings();
 
+        // Disable unused actions
+        m_actionNew->setVisible(false);
+        m_actionNew->setEnabled(false);
+        m_actionSaveAsChild->setVisible(false);
+        m_actionSaveAsChild->setEnabled(false);
+
         OnDocumentOpened(AZ::Uuid::CreateNull());
     }
 
-    ShaderManagementConsoleWindow::~ShaderManagementConsoleWindow()
-    {
-    }
-
-    QWidget* ShaderManagementConsoleWindow::CreateViewForDocumemt(const AZ::Uuid& documentId)
+    QWidget* ShaderManagementConsoleWindow::CreateDocumentTabView(const AZ::Uuid& documentId)
     {
         AZStd::unordered_set<AZStd::string> optionNames;
 

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -23,10 +23,8 @@ AZ_POP_DISABLE_WARNING
 
 namespace ShaderManagementConsole
 {
-    /**
-     * ShaderManagementConsoleWindow is the main class. Its responsibility is limited to initializing and connecting
-     * its panels, managing selection of assets, and performing high-level actions like saving. It contains...
-     */
+    //! ShaderManagementConsoleWindow is the main class. Its responsibility is limited to initializing and connecting
+    //! its panels, managing selection of assets, and performing high-level actions like saving. It contains...
     class ShaderManagementConsoleWindow
         : public AtomToolsFramework::AtomToolsDocumentMainWindow
     {
@@ -37,10 +35,10 @@ namespace ShaderManagementConsole
         using Base = AtomToolsFramework::AtomToolsDocumentMainWindow;
 
         ShaderManagementConsoleWindow(QWidget* parent = 0);
-        ~ShaderManagementConsoleWindow();
+        ~ShaderManagementConsoleWindow() = default;
 
     protected:
-        QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId) override;
+        QWidget* CreateDocumentTabView(const AZ::Uuid& documentId) override;
 
         ShaderManagementConsoleToolBar* m_toolBar = nullptr;
     };

--- a/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
+++ b/Gems/Atom/Tools/ShaderManagementConsole/Code/Source/Window/ShaderManagementConsoleWindow.h
@@ -11,9 +11,7 @@
 #if !defined(Q_MOC_RUN)
 #include <Atom/RPI.Edit/Shader/ShaderVariantListSourceData.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
-#include <AtomToolsFramework/Document/AtomToolsDocumentNotificationBus.h>
-#include <AtomToolsFramework/Window/AtomToolsMainWindow.h>
-#include <AzCore/Memory/SystemAllocator.h>
+#include <AtomToolsFramework/Document/AtomToolsDocumentMainWindow.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <Window/ShaderManagementConsoleBrowserWidget.h>
@@ -30,64 +28,20 @@ namespace ShaderManagementConsole
      * its panels, managing selection of assets, and performing high-level actions like saving. It contains...
      */
     class ShaderManagementConsoleWindow
-        : public AtomToolsFramework::AtomToolsMainWindow
-        , private AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler
+        : public AtomToolsFramework::AtomToolsDocumentMainWindow
     {
         Q_OBJECT
     public:
         AZ_CLASS_ALLOCATOR(ShaderManagementConsoleWindow, AZ::SystemAllocator, 0);
 
-        using Base = AtomToolsFramework::AtomToolsMainWindow;
+        using Base = AtomToolsFramework::AtomToolsDocumentMainWindow;
 
         ShaderManagementConsoleWindow(QWidget* parent = 0);
         ~ShaderManagementConsoleWindow();
 
-    private:
-        // AtomToolsFramework::AtomToolsDocumentNotificationBus::Handler overrides...
-        void OnDocumentOpened(const AZ::Uuid& documentId) override;
-        void OnDocumentClosed(const AZ::Uuid& documentId) override;
-        void OnDocumentModified(const AZ::Uuid& documentId) override;
-        void OnDocumentUndoStateChanged(const AZ::Uuid& documentId) override;
-        void OnDocumentSaved(const AZ::Uuid& documentId) override;
-
-        void CreateMenu() override;
-        void CreateTabBar() override;
-
-        QString GetDocumentPath(const AZ::Uuid& documentId) const;
-
-        void OpenTabContextMenu() override;
-
-        void closeEvent(QCloseEvent* closeEvent) override;
-
-        QStandardItemModel* CreateDocumentContent(const AZ::Uuid& documentId);
+    protected:
+        QWidget* CreateViewForDocumemt(const AZ::Uuid& documentId) override;
 
         ShaderManagementConsoleToolBar* m_toolBar = nullptr;
-
-        QMenu* m_menuFile = {};
-        QMenu* m_menuNew = {};
-        QAction* m_actionOpen = {};
-        QAction* m_actionOpenRecent = {};
-        QAction* m_actionClose = {};
-        QAction* m_actionCloseAll = {};
-        QAction* m_actionCloseOthers = {};
-        QAction* m_actionSave = {};
-        QAction* m_actionSaveAsCopy = {};
-        QAction* m_actionSaveAll = {};
-        QAction* m_actionExit = {};
-
-        QMenu* m_menuEdit = {};
-        QAction* m_actionUndo = {};
-        QAction* m_actionRedo = {};
-        QAction* m_actionSettings = {};
-
-        QMenu* m_menuView = {};
-        QAction* m_actionAssetBrowser = {};
-        QAction* m_actionPythonTerminal = {};
-        QAction* m_actionNextTab = {};
-        QAction* m_actionPreviousTab = {};
-
-        QMenu* m_menuHelp = {};
-        QAction* m_actionHelp = {};
-        QAction* m_actionAbout = {};
     };
 } // namespace ShaderManagementConsole


### PR DESCRIPTION
- this change consolidates and cleans up the remaining common code between the material editor and shader management console main window classes
- all code that integrates the document system with the main window lives in AtomToolsDocumentMainWindow
- AtomToolsDocumentMainWindow was basically a copy of what remained from the material editor main window with a few virtual functions replacing material editor specific logic 
- there should not be any functional changes in either application, just significantly less divergent code that needs to be tested, and less code needed to create a new multi document application with tabbed views
