### PR TITLE
Add awsi deployment as a non-blocking step in nightly pipeline

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -476,6 +476,9 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                                 if (envVars['NONBLOCKING_STEP']?.toBoolean()) {
                                     unstable(message: "Build step ${build_step} failed but it's a non-blocking step in build job ${build_job.key}")
                                 }
+                                else {
+                                    error "FAILURE: ${e}"
+                                }
                             }
                         }
                     } else {

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -468,7 +468,15 @@ def CreateSingleNode(Map pipelineConfig, def platform, def build_job, Map envVar
                     if(build_job.value.steps) { //this is a pipe with many steps so create all the build stages
                         build_job.value.steps.each { build_step ->
                             build_job_name = build_step
-                            CreateBuildStage(pipelineConfig,  platform.key, build_step, envVars).call()
+                            envVars = GetBuildEnvVars(platform.value.PIPELINE_ENV ?: EMPTY_JSON, platform.value.build_types[build_step].PIPELINE_ENV ?: EMPTY_JSON, pipelineName)
+                            try {
+                                CreateBuildStage(pipelineConfig,  platform.key, build_step, envVars).call()
+                            }
+                            catch (Exception e) {
+                                if (envVars['NONBLOCKING_STEP']?.toBoolean()) {
+                                    unstable(message: "Build step ${build_step} failed but it's a non-blocking step in build job ${build_job.key}")
+                                }
+                            }
                         }
                     } else {
                         CreateBuildStage(pipelineConfig,  platform.key, build_job.key, envVars).call()

--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -213,10 +213,18 @@
       "ASSET_PROCESSOR_PLATFORMS": "pc,server"
     }
   },
-  "periodic_test_profile_vs2019": {
+  "periodic_test_profile_vs2019_pipe": {
     "TAGS": [
       "nightly-incremental",
-      "nightly-clean",
+      "nightly-clean"
+    ],
+    "steps": [
+      "awsi_deployment",
+      "periodic_test_profile_vs2019"
+    ]
+  },
+  "periodic_test_profile_vs2019": {
+    "TAGS": [
       "weekly-build-metrics"
     ],
     "COMMAND": "build_test_windows.cmd",
@@ -378,7 +386,10 @@
     ]
   },
   "awsi_deployment": {
-    "TAGS": ["awsi-deployment"],
+    "TAGS": [],
+    "PIPELINE_ENV": {
+      "NONBLOCKING_STEP": "True"
+    },
     "COMMAND": "deploy_cdk_applications.cmd",
     "PARAMETERS": {}
   }

--- a/scripts/build/Platform/Windows/pipeline.json
+++ b/scripts/build/Platform/Windows/pipeline.json
@@ -18,7 +18,37 @@
         }
     },
     "PIPELINE_JENKINS_PARAMETERS": {
-        "awsi-deployment": [
+        "nightly-incremental": [
+            {
+                "parameter_name": "O3DE_AWS_PROJECT_NAME",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": "The name of the O3DE project that stacks should be deployed for."
+            },
+            {
+                "parameter_name": "O3DE_AWS_DEPLOY_REGION",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": "The region to deploy the stacks into."
+            },
+            {
+                "parameter_name": "ASSUME_ROLE_ARN",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": "The ARN of the IAM role to assume to retrieve temporary AWS credentials."
+            },
+            {
+                "parameter_name": "COMMIT_ID",
+                "parameter_type": "string",
+                "default_value": "",
+                "use_last_run_value": true,
+                "description": "The commit ID for locking the version of CDK applications to deploy."
+            }
+        ],
+        "nightly-clean": [
             {
                 "parameter_name": "O3DE_AWS_PROJECT_NAME",
                 "parameter_type": "string",


### PR DESCRIPTION
1. Fix PIPELINE_ENV override issue in multi-steps pipeline, if a build configuration contains multiple steps, each step was using parent configuration's PIPELINE_ENV override, now it will use PIPELINE_ENV override defined in each step's configuration.
2. Add a new pipeline env "NONBLOCKING_STEP" to allow a multi-steps pipeline proceed to next step if current step fails.
3. Make AWS integration deployment as a non-blocking upstream step of periodic_test step in nightly pipeline.