### PR TITLE
Fix text descenders cutoff on Configure Gems page.

### DIFF
--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -157,15 +157,16 @@ QTabBar::tab:focus {
     font-size:14px;
     text-align:left;
     margin:0;
-    padding-top:10px;
-    padding-bottom:-5px;
-    min-height:15px;
-    max-height:15px;
+    padding-top:0px;
+    padding-bottom:0px;
+    min-height:20px;
+    max-height:20px;
 }
 #headerSubTitle {
     font-size:24px;
     text-align:left;
     margin:0;
+    padding-top:-5px;
     min-height:42px;
     max-height:42px;
 }


### PR DESCRIPTION
Fixed the "Edit Project Settings:" text so that the descender are not cut off.

![FixedProjectSettingsTextCutoff](https://user-images.githubusercontent.com/70403342/130536701-4ed1488d-2d14-4c6a-96ac-3ec6598c9668.jpg)

Signed-off-by: AMZN-Phil <pconroy@amazon.com>