### PR TITLE
Added a helper function for constructing CollisionGroup from CollisionGroups::Id. Removed remaining touch bending related code

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.cpp
@@ -310,7 +310,7 @@ namespace AzPhysics
         return group;
     }
 
-    CollisionGroup MakeCollisionGroup(const CollisionGroups::Id& id)
+    CollisionGroup GetCollisionGroupById(const CollisionGroups::Id& id)
     {
         CollisionGroup group;
         Physics::CollisionRequestBus::BroadcastResult(group, &Physics::CollisionRequests::GetCollisionGroupById, id);

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.cpp
@@ -309,5 +309,12 @@ namespace AzPhysics
         group.SetLayer(layer, true);
         return group;
     }
+
+    CollisionGroup MakeCollisionGroup(const CollisionGroups::Id& id)
+    {
+        CollisionGroup group;
+        Physics::CollisionRequestBus::BroadcastResult(group, &Physics::CollisionRequests::GetCollisionGroupById, id);
+        return group;
+    }
 }
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.h
@@ -34,7 +34,6 @@ namespace AzPhysics
 
         static const CollisionGroup None; //!< Collide with nothing
         static const CollisionGroup All; //!< Collide with everything
-        static const CollisionGroup All_NoTouchBend; //!< Collide with everything, except Touch Bendable Vegetation.
 
         //! Construct a Group with the given bitmask.
         //! The each bit in the bitmask corresponds to a CollisionLayer.
@@ -174,4 +173,9 @@ namespace AzPhysics
     private:
         AZStd::vector<Preset> m_groups;
     };
+
+    //! Construct a Group with the given Id of a collision group.
+    //! This will lookup the group Id to retrieve the group mask. If not found, CollisionGroup::All is returned.
+    //! @param id The Id of the group to look up the group mask.
+    CollisionGroup MakeCollisionGroup(const CollisionGroups::Id& id);
 }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionGroups.h
@@ -174,8 +174,8 @@ namespace AzPhysics
         AZStd::vector<Preset> m_groups;
     };
 
-    //! Construct a Group with the given Id of a collision group.
+    //! Retrieves a Group with the given Id of a collision group.
     //! This will lookup the group Id to retrieve the group mask. If not found, CollisionGroup::All is returned.
     //! @param id The Id of the group to look up the group mask.
-    CollisionGroup MakeCollisionGroup(const CollisionGroups::Id& id);
+    CollisionGroup GetCollisionGroupById(const CollisionGroups::Id& id);
 }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionLayers.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Collision/CollisionLayers.h
@@ -31,7 +31,6 @@ namespace AzPhysics
         static void Reflect(AZ::ReflectContext* context);
 
         static const CollisionLayer Default; //!< Default collision layer, 0.
-        static const CollisionLayer TouchBend; //!< Touch Bendable Vegetation collision layer.
 
         //! Construct a layer with the given index.
         //! @param index The index of the layer. Must be between 0 - CollisionLayers::MaxCollisionLayers. Default CollisionLayer::Default.

--- a/Gems/PhysX/Code/Include/PhysX/UserDataTypes.h
+++ b/Gems/PhysX/Code/Include/PhysX/UserDataTypes.h
@@ -60,9 +60,9 @@ namespace PhysX
         ///This is an arbitary value used to verify the cast from void* userdata pointer on a pxActor to ActorData
         ///is safe. If m_sanity does not have this value, then it is not safe to use the casted pointer.
         ///Helps to debug if someone is setting userData pointer to something other than this class during development
-        static const AZ::u32 s_sanityValue = 0xba5eba11;
+        static constexpr AZ::u32 SanityValue = 0xba5eba11;
 
-        AZ::u32 m_sanity = s_sanityValue;
+        AZ::u32 m_sanity = SanityValue;
         PxActorUniquePtr m_actor;
 
         struct Payload

--- a/Gems/PhysX/Code/Include/PhysX/UserDataTypes.h
+++ b/Gems/PhysX/Code/Include/PhysX/UserDataTypes.h
@@ -22,49 +22,15 @@ namespace AzPhysics
 
 namespace PhysX
 {
-    enum class BaseActorType : AZ::u32
-    {
-        PHYSX_DEFAULT = 0,
-        TOUCHBENDING_TRIGGER,
-    };
-
     ///PxActor.userData is the custom data pointer that NVIDIA PhysX provides for applications to attach
-    ///private data. The PhysX Gem requires that this userData points to objects that subclass BaseActorData.
-    ///For Example:
-    ///The TouchBending Gem defines "struct TouchBendingInstanceHandle : public PhysX::BaseActorData",
-    ///While regular PhysX Gem Components use "class ActorData : public BaseActorData".
-    class BaseActorData
-    {
-    protected:
-        using PxActorUniquePtr = AZStd::unique_ptr<physx::PxActor, AZStd::function<void(physx::PxActor*)> >;
-
-        ///This is an arbitary value used to verify the cast from void* userdata pointer on a pxActor to BaseActorData
-        ///is safe. If m_sanity does not have this value, then it is not safe to use the casted pointer.
-        ///Helps to debug if someone is setting userData pointer to something other than this class during development
-        static const AZ::u32 s_sanityValue = 0xba5eba11;
-
-        AZ::u32 m_sanity = s_sanityValue;
-        BaseActorType m_actorType = BaseActorType::PHYSX_DEFAULT;
-        PxActorUniquePtr m_actor;
-
-        BaseActorData() = default;
-        BaseActorData(BaseActorType type, physx::PxActor* actor);
-        BaseActorData(BaseActorData&& other);
-        BaseActorData& operator=(BaseActorData&& other);
-
-    public:
-        bool IsValid() const;
-        BaseActorType GetType() const;
-    };
-
-
-    class ActorData : public BaseActorData
+    ///private data. The PhysX Gem requires that this userData points to ActorData objects.
+    class ActorData
     {
     public:
         ActorData() = default;
         ActorData(physx::PxActor* actor);
-        ActorData(ActorData&& actorData) = default;
-        ActorData& operator=(ActorData&& actorData) = default;
+        ActorData(ActorData&& actorData);
+        ActorData& operator=(ActorData&& actorData);
 
         void Invalidate();
         AZ::EntityId GetEntityId() const;
@@ -86,7 +52,18 @@ namespace PhysX
 
         AzPhysics::SimulatedBody* GetSimulatedBody() const;
 
+        bool IsValid() const;
+
     private:
+        using PxActorUniquePtr = AZStd::unique_ptr<physx::PxActor, AZStd::function<void(physx::PxActor*)> >;
+
+        ///This is an arbitary value used to verify the cast from void* userdata pointer on a pxActor to ActorData
+        ///is safe. If m_sanity does not have this value, then it is not safe to use the casted pointer.
+        ///Helps to debug if someone is setting userData pointer to something other than this class during development
+        static const AZ::u32 s_sanityValue = 0xba5eba11;
+
+        AZ::u32 m_sanity = s_sanityValue;
+        PxActorUniquePtr m_actor;
 
         struct Payload
         {

--- a/Gems/PhysX/Code/Include/PhysX/UserDataTypes.inl
+++ b/Gems/PhysX/Code/Include/PhysX/UserDataTypes.inl
@@ -10,7 +10,6 @@
 namespace PhysX
 {
     inline ActorData::ActorData(physx::PxActor* actor)
-        : m_sanity(s_sanityValue)
     {
         auto nullUserData = [](physx::PxActor* actorToSet)
         {
@@ -23,23 +22,25 @@ namespace PhysX
     }
 
     inline ActorData::ActorData(ActorData&& other)
-        : m_sanity(s_sanityValue)
+        : m_sanity(other.m_sanity)
         , m_actor(AZStd::move(other.m_actor))
+        , m_payload(AZStd::move(other.m_payload))
     {
         m_actor->userData = this;
     }
 
     inline ActorData& ActorData::operator=(ActorData&& other)
     {
-        m_sanity = s_sanityValue;
+        m_sanity = other.m_sanity;
         m_actor = AZStd::move(other.m_actor);
         m_actor->userData = this;
+        m_payload = AZStd::move(other.m_payload);
         return *this;
     }
 
     inline bool ActorData::IsValid() const
     {
-        return m_sanity == s_sanityValue;
+        return m_sanity == SanityValue;
     }
 
     inline void ActorData::Invalidate()
@@ -136,5 +137,4 @@ namespace PhysX
             return nullptr;
         }
     }
-    // ActorData END ********************************************************
 } //namespace PhysX

--- a/Gems/PhysX/Code/Include/PhysX/UserDataTypes.inl
+++ b/Gems/PhysX/Code/Include/PhysX/UserDataTypes.inl
@@ -9,9 +9,8 @@
 
 namespace PhysX
 {
-    // BaseActorData START ****************************************************
-    inline BaseActorData::BaseActorData(BaseActorType type, physx::PxActor* actor) :
-        m_sanity(s_sanityValue), m_actorType(type)
+    inline ActorData::ActorData(physx::PxActor* actor)
+        : m_sanity(s_sanityValue)
     {
         auto nullUserData = [](physx::PxActor* actorToSet)
         {
@@ -23,36 +22,24 @@ namespace PhysX
         actor->userData = this;
     }
 
-    inline BaseActorData::BaseActorData(BaseActorData&& other) :
-        m_sanity(s_sanityValue), m_actorType(other.m_actorType), m_actor(AZStd::move(other.m_actor))
+    inline ActorData::ActorData(ActorData&& other)
+        : m_sanity(s_sanityValue)
+        , m_actor(AZStd::move(other.m_actor))
     {
         m_actor->userData = this;
     }
 
-    inline BaseActorData& BaseActorData::operator=(BaseActorData&& other)
+    inline ActorData& ActorData::operator=(ActorData&& other)
     {
         m_sanity = s_sanityValue;
-        m_actorType = other.m_actorType;
         m_actor = AZStd::move(other.m_actor);
         m_actor->userData = this;
         return *this;
     }
 
-    inline bool BaseActorData::IsValid() const
+    inline bool ActorData::IsValid() const
     {
         return m_sanity == s_sanityValue;
-    }
-
-    inline BaseActorType BaseActorData::GetType() const
-    {
-        return m_actorType;
-    }
-    // BaseActorData END ******************************************************
-
-
-    // ActorData START ********************************************************
-    inline ActorData::ActorData(physx::PxActor* actor) : BaseActorData(BaseActorType::PHYSX_DEFAULT, actor)
-    {
     }
 
     inline void ActorData::Invalidate()


### PR DESCRIPTION
* Added a helper function for constructing CollisionGroup from CollisionGroups::Id. 
* Removed remaining touch bending related code
Signed-off-by: pereslav <pereslav@amazon.com>