### PR TITLE
Hultonha gh 2802 camera input 4

### DIFF
--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -33,6 +33,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraTranslateSmoothnessSetting = "/Amazon/Preferences/Editor/Camera/TranslateSmoothness";
     constexpr AZStd::string_view CameraTranslateSmoothingSetting = "/Amazon/Preferences/Editor/Camera/TranslateSmoothing";
     constexpr AZStd::string_view CameraRotateSmoothingSetting = "/Amazon/Preferences/Editor/Camera/RotateSmoothing";
+    constexpr AZStd::string_view CameraCaptureCursorSetting = "/Amazon/Preferences/Editor/Camera/CaptureCursor";
     constexpr AZStd::string_view CameraTranslateForwardIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateForwardId";
     constexpr AZStd::string_view CameraTranslateBackwardIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateBackwardId";
     constexpr AZStd::string_view CameraTranslateLeftIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateLeftId";
@@ -279,6 +280,16 @@ namespace SandboxEditor
     void SetCameraTranslateSmoothingEnabled(const bool enabled)
     {
         SetRegistry(CameraTranslateSmoothingSetting, enabled);
+    }
+
+    bool CameraCaptureCursorForLook()
+    {
+        return GetRegistry(CameraCaptureCursorSetting, true);
+    }
+
+    void SetCameraCaptureCursorForLook(const bool capture)
+    {
+        SetRegistry(CameraCaptureCursorSetting, capture);
     }
 
     AzFramework::InputChannelId CameraTranslateForwardChannelId()

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -33,7 +33,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraTranslateSmoothnessSetting = "/Amazon/Preferences/Editor/Camera/TranslateSmoothness";
     constexpr AZStd::string_view CameraTranslateSmoothingSetting = "/Amazon/Preferences/Editor/Camera/TranslateSmoothing";
     constexpr AZStd::string_view CameraRotateSmoothingSetting = "/Amazon/Preferences/Editor/Camera/RotateSmoothing";
-    constexpr AZStd::string_view CameraCaptureCursorSetting = "/Amazon/Preferences/Editor/Camera/CaptureCursor";
+    constexpr AZStd::string_view CameraCaptureCursorLookSetting = "/Amazon/Preferences/Editor/Camera/CaptureCursorLook";
     constexpr AZStd::string_view CameraTranslateForwardIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateForwardId";
     constexpr AZStd::string_view CameraTranslateBackwardIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateBackwardId";
     constexpr AZStd::string_view CameraTranslateLeftIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateLeftId";
@@ -284,12 +284,12 @@ namespace SandboxEditor
 
     bool CameraCaptureCursorForLook()
     {
-        return GetRegistry(CameraCaptureCursorSetting, true);
+        return GetRegistry(CameraCaptureCursorLookSetting, true);
     }
 
     void SetCameraCaptureCursorForLook(const bool capture)
     {
-        SetRegistry(CameraCaptureCursorSetting, capture);
+        SetRegistry(CameraCaptureCursorLookSetting, capture);
     }
 
     AzFramework::InputChannelId CameraTranslateForwardChannelId()

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -61,7 +61,7 @@ namespace SandboxEditor
     AZStd::remove_cvref_t<T> GetRegistry(const AZStd::string_view setting, T&& defaultValue)
     {
         AZStd::remove_cvref_t<T> value = AZStd::forward<T>(defaultValue);
-        if (auto* registry = AZ::SettingsRegistry::Get())
+        if (const auto* registry = AZ::SettingsRegistry::Get())
         {
             registry->Get(value, setting);
         }

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -86,6 +86,9 @@ namespace SandboxEditor
     SANDBOX_API bool CameraTranslateSmoothingEnabled();
     SANDBOX_API void SetCameraTranslateSmoothingEnabled(bool enabled);
 
+    SANDBOX_API bool CameraCaptureCursorForLook();
+    SANDBOX_API void SetCameraCaptureCursorForLook(bool capture);
+
     SANDBOX_API AzFramework::InputChannelId CameraTranslateForwardChannelId();
     SANDBOX_API void SetCameraTranslateForwardChannelId(AZStd::string_view cameraTranslateForwardId);
 

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1100,6 +1100,7 @@ AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateMod
             };
 
             // default behavior is to hide the cursor but this can be disabled (useful for remote desktop)
+            // note: See CaptureCursorLook in the Settings Registry
             firstPersonRotateCamera->SetActivationBeganFn(hideCursor);
             firstPersonRotateCamera->SetActivationEndedFn(showCursor);
 

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -102,9 +102,17 @@
 #include <IPhysics.h>
 #include <IStatObj.h>
 
+#pragma optimize("", off)
+#pragma inline_depth(0)
+
 AZ_CVAR(
     bool, ed_visibility_logTiming, false, nullptr, AZ::ConsoleFunctorFlags::Null, "Output the timing of the new IVisibilitySystem query");
 AZ_CVAR(bool, ed_showCursorCameraLook, true, nullptr, AZ::ConsoleFunctorFlags::Null, "Show the cursor when using free look with the new camera system");
+
+void CaptureCursorForCameraLook(bool captureCursor)
+{
+    ed_showCursorCameraLook = !captureCursor;
+}
 
 EditorViewportWidget* EditorViewportWidget::m_pPrimaryViewport = nullptr;
 

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -394,7 +394,3 @@ private:
 //! Creates a modular camera controller in the configuration used by the editor viewport.
 SANDBOX_API AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateModularViewportCameraController(
     const AzFramework::ViewportId viewportId);
-
-//! Set if the cursor should be captured during camera look.
-//! @note This is a config setting usually set at start-up (ed_showCursorCameraLook), this utility function is used to aid with testing.
-SANDBOX_API void CaptureCursorForCameraLook(bool captureCursor);

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -394,3 +394,7 @@ private:
 //! Creates a modular camera controller in the configuration used by the editor viewport.
 SANDBOX_API AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateModularViewportCameraController(
     const AzFramework::ViewportId viewportId);
+
+//! Set if the cursor should be captured during camera look.
+//! @note This is a config setting usually set at start-up (ed_showCursorCameraLook), this utility function is used to aid with testing.
+SANDBOX_API void CaptureCursorForCameraLook(bool captureCursor);

--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -13,9 +13,6 @@
 #include <EditorViewportWidget.h>
 #include <Mocks/MockWindowRequests.h>
 
-#pragma optimize("", off)
-#pragma inline_depth(0)
-
 namespace UnitTest
 {
     const QSize WidgetSize = QSize(1920, 1080);
@@ -270,7 +267,7 @@ namespace UnitTest
     TEST_F(ModularViewportCameraControllerFixture, Mouse_movement_orientates_camera_when_cursor_is_captured)
     {
         // Given
-        CaptureCursorForCameraLook(true);
+        SandboxEditor::SetCameraCaptureCursorForLook(true);
         PrepareCollaborators();
 
         const float deltaTime = 1.0f / 60.0f;
@@ -302,7 +299,7 @@ namespace UnitTest
         using ::testing::FloatNear;
         EXPECT_THAT(eulerAngles.GetZ(), FloatNear(1.0f, 0.001f));
 
-        CaptureCursorForCameraLook(false);
+        SandboxEditor::SetCameraCaptureCursorForLook(false);
 
         // Clean-up
         HaltCollaborators();

--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -291,12 +291,13 @@ namespace UnitTest
         MouseMove(m_rootWidget.get(), start, QPoint(0, 0));
         m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(deltaTime), AZ::ScriptTimePoint() });
 
-        // move the cursor right
         const auto mouseDelta = QPoint(5, 0);
 
+        // initial movement to begin the camera behavior
         MousePressAndMove(m_rootWidget.get(), start, mouseDelta, Qt::MouseButton::RightButton);
         m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(deltaTime), AZ::ScriptTimePoint() });
 
+        // move the cursor right
         for (int i = 0; i < 50; ++i)
         {
             MousePressAndMove(m_rootWidget.get(), start + mouseDelta, mouseDelta, Qt::MouseButton::RightButton);
@@ -318,6 +319,7 @@ namespace UnitTest
         const AZ::Quaternion cameraRotation = m_cameraViewportContextView->GetCameraTransform().GetRotation();
         const auto eulerAngles = AzFramework::EulerAngles(AZ::Matrix3x3::CreateFromQuaternion(cameraRotation));
 
+        // camera should be back at the center (no yaw)
         using ::testing::FloatNear;
         EXPECT_THAT(eulerAngles.GetZ(), FloatNear(0.0f, 0.001f));
 
@@ -354,6 +356,7 @@ namespace UnitTest
         const AZ::Quaternion cameraRotation = m_cameraViewportContextView->GetCameraTransform().GetRotation();
         const auto eulerAngles = AzFramework::EulerAngles(AZ::Matrix3x3::CreateFromQuaternion(cameraRotation));
 
+        // initial amount of rotation after first mouse move
         using ::testing::FloatNear;
         EXPECT_THAT(eulerAngles.GetZ(), FloatNear(-0.025f, 0.001f));
 

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -114,8 +114,8 @@ namespace SandboxEditor
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
                 const auto screenPoint = AzFramework::ScreenPoint(
-                    static_cast<int>(position->m_normalizedPosition.GetX() * windowSize.m_width),
-                    static_cast<int>(position->m_normalizedPosition.GetY() * windowSize.m_height));
+                    aznumeric_cast<int>(position->m_normalizedPosition.GetX() * windowSize.m_width),
+                    aznumeric_cast<int>(position->m_normalizedPosition.GetY() * windowSize.m_height));
 
                 m_mouseInteraction.m_mousePick.m_screenCoordinates = screenPoint;
                 AZStd::optional<ProjectedViewportRay> ray;

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
+#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
 #include <AzCore/Script/ScriptTimePoint.h>
 
@@ -112,7 +113,7 @@ namespace SandboxEditor
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                auto screenPoint = AzFramework::ScreenPoint(
+                const auto screenPoint = AzFramework::ScreenPoint(
                     static_cast<int>(position->m_normalizedPosition.GetX() * windowSize.m_width),
                     static_cast<int>(position->m_normalizedPosition.GetY() * windowSize.m_height));
 
@@ -207,20 +208,27 @@ namespace SandboxEditor
                 ? &InteractionBus::Events::InternalHandleMouseManipulatorInteraction
                 : &InteractionBus::Events::InternalHandleMouseViewportInteraction;
 
-            const auto mouseInteractionEvent = [mouseInteraction, event = eventType.value(), wheelDelta] {
+            auto currentCursorState = AzFramework::SystemCursorState::Unknown;
+            AzFramework::InputSystemCursorRequestBus::EventResult(
+                currentCursorState, event.m_inputChannel.GetInputDevice().GetInputDeviceId(),
+                &AzFramework::InputSystemCursorRequestBus::Events::GetSystemCursorState);
+
+            const auto mouseInteractionEvent = [mouseInteraction, event = eventType.value(), wheelDelta,
+                                                cursorCaptured = currentCursorState == AzFramework::SystemCursorState::ConstrainedAndHidden]
+            {
                 switch (event)
                 {
                 case MouseEvent::Up:
                 case MouseEvent::Down:
                 case MouseEvent::Move:
                 case MouseEvent::DoubleClick:
-                    return MouseInteractionEvent(AZStd::move(mouseInteraction), event);
+                    return MouseInteractionEvent(AZStd::move(mouseInteraction), event, cursorCaptured);
                 case MouseEvent::Wheel:
                     return MouseInteractionEvent(AZStd::move(mouseInteraction), wheelDelta);
                 }
 
                 AZ_Assert(false, "Unhandled MouseEvent");
-                return MouseInteractionEvent(MouseInteraction{}, MouseEvent::Up);
+                return MouseInteractionEvent(MouseInteraction{}, MouseEvent::Up, false);
             }();
 
             InteractionBus::EventResult(

--- a/Code/Framework/AzCore/AzCore/std/math.h
+++ b/Code/Framework/AzCore/AzCore/std/math.h
@@ -22,6 +22,8 @@ namespace AZStd
     using std::exp2;
     using std::floor;
     using std::fmod;
+    using std::llround;
+    using std::lround;
     using std::pow;
     using std::round;
     using std::sin;

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -144,7 +144,7 @@ namespace AzFramework
         if (const auto& cursor = AZStd::get_if<CursorEvent>(&event))
         {
             m_cursorState.SetCurrentPosition(cursor->m_position);
-            m_cursorState.SetConstrained(cursor->m_constrained);
+            m_cursorState.SetCaptured(cursor->m_captured);
         }
         else if (const auto& horizontalMotion = AZStd::get_if<HorizontalMotionEvent>(&event))
         {

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -15,9 +15,6 @@
 #include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
 #include <AzFramework/Windowing/WindowBus.h>
 
-#pragma optimize("", off)
-#pragma inline_depth(0)
-
 namespace AzFramework
 {
     AZ_CVAR(
@@ -794,31 +791,25 @@ namespace AzFramework
                 const auto* position = inputChannel.GetCustomData<AzFramework::InputChannel::PositionData2D>();
                 AZ_Assert(position, "Expected PositionData2D but found nullptr");
 
-                auto x = position->m_normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width);
-                auto y = position->m_normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height);
-
-                auto xi = std::lround(x);
-                auto yi = std::lround(y);
+                const auto x = position->m_normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width);
+                const auto y = position->m_normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height);
 
                 auto currentCursorState = AzFramework::SystemCursorState::Unknown;
                 AzFramework::InputSystemCursorRequestBus::EventResult(
                     currentCursorState, inputDeviceId, &AzFramework::InputSystemCursorRequestBus::Events::GetSystemCursorState);
 
-                return CursorEvent{ ScreenPoint(xi, yi), currentCursorState == AzFramework::SystemCursorState::ConstrainedAndHidden };
+                return CursorEvent{ ScreenPoint(AZStd::lround(x), AZStd::lround(y)),
+                                    currentCursorState == AzFramework::SystemCursorState::ConstrainedAndHidden };
             }
             else if (inputChannelId == InputDeviceMouse::Movement::X)
             {
-                auto x = inputChannel.GetValue();
-                auto xi = std::lround(x);
-
-                return HorizontalMotionEvent{ aznumeric_cast<int>(xi) };
+                const auto x = inputChannel.GetValue();
+                return HorizontalMotionEvent{ aznumeric_cast<int>(AZStd::lround(x)) };
             }
             else if (inputChannelId == InputDeviceMouse::Movement::Y)
             {
-                auto y = inputChannel.GetValue();
-                auto yi = std::lround(y);
-
-                return VerticalMotionEvent{ aznumeric_cast<int>(yi) };
+                const auto y = inputChannel.GetValue();
+                return VerticalMotionEvent{ aznumeric_cast<int>(AZStd::lround(y)) };
             }
             else if (inputChannelId == InputDeviceMouse::Movement::Z)
             {

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -791,14 +791,13 @@ namespace AzFramework
                 const auto* position = inputChannel.GetCustomData<AzFramework::InputChannel::PositionData2D>();
                 AZ_Assert(position, "Expected PositionData2D but found nullptr");
 
-                const auto x = position->m_normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width);
-                const auto y = position->m_normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height);
-
                 auto currentCursorState = AzFramework::SystemCursorState::Unknown;
                 AzFramework::InputSystemCursorRequestBus::EventResult(
                     currentCursorState, inputDeviceId, &AzFramework::InputSystemCursorRequestBus::Events::GetSystemCursorState);
 
-                return CursorEvent{ ScreenPoint(AZStd::lround(x), AZStd::lround(y)),
+                const auto x = position->m_normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width);
+                const auto y = position->m_normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height);
+                return CursorEvent{ ScreenPoint(aznumeric_cast<int>(AZStd::lround(x)), aznumeric_cast<int>(AZStd::lround(y))),
                                     currentCursorState == AzFramework::SystemCursorState::ConstrainedAndHidden };
             }
             else if (inputChannelId == InputDeviceMouse::Movement::X)

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -88,7 +88,7 @@ namespace AzFramework
     struct CursorEvent
     {
         ScreenPoint m_position;
-        bool m_constrained = false;
+        bool m_captured = false;
     };
 
     struct ScrollEvent

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -88,6 +88,7 @@ namespace AzFramework
     struct CursorEvent
     {
         ScreenPoint m_position;
+        bool m_constrained = false;
     };
 
     struct ScrollEvent

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CursorState.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CursorState.h
@@ -22,7 +22,7 @@ namespace AzFramework
         //! Call this in a 'handle event' call to update the most recent cursor position.
         void SetCurrentPosition(const ScreenPoint& currentPosition);
         //! Set whether the cursor is currently being constrained (and hidden).
-        void SetConstrained(bool constrained);
+        void SetCaptured(bool captured);
         //! Call this in an 'update' call to copy the current cursor position to the last
         //! cursor position.
         void Update();
@@ -30,12 +30,12 @@ namespace AzFramework
     private:
         AZStd::optional<ScreenPoint> m_lastCursorPosition;
         AZStd::optional<ScreenPoint> m_currentCursorPosition;
-        bool m_constrained = false;
+        bool m_captured = false;
     };
 
-    inline void CursorState::SetConstrained(const bool constrained)
+    inline void CursorState::SetCaptured(const bool captured)
     {
-        m_constrained = constrained;
+        m_captured = captured;
     }
 
     inline void CursorState::SetCurrentPosition(const ScreenPoint& currentPosition)
@@ -52,7 +52,7 @@ namespace AzFramework
 
     inline void CursorState::Update()
     {
-        if (!m_constrained)
+        if (!m_captured)
         {
             if (m_currentCursorPosition.has_value())
             {

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CursorState.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CursorState.h
@@ -21,6 +21,8 @@ namespace AzFramework
         [[nodiscard]] ScreenVector CursorDelta() const;
         //! Call this in a 'handle event' call to update the most recent cursor position.
         void SetCurrentPosition(const ScreenPoint& currentPosition);
+        //! Set whether the cursor is currently being constrained (and hidden).
+        void SetConstrained(bool constrained);
         //! Call this in an 'update' call to copy the current cursor position to the last
         //! cursor position.
         void Update();
@@ -28,7 +30,13 @@ namespace AzFramework
     private:
         AZStd::optional<ScreenPoint> m_lastCursorPosition;
         AZStd::optional<ScreenPoint> m_currentCursorPosition;
+        bool m_constrained = false;
     };
+
+    inline void CursorState::SetConstrained(const bool constrained)
+    {
+        m_constrained = constrained;
+    }
 
     inline void CursorState::SetCurrentPosition(const ScreenPoint& currentPosition)
     {
@@ -44,9 +52,16 @@ namespace AzFramework
 
     inline void CursorState::Update()
     {
-        if (m_currentCursorPosition.has_value())
+        if (!m_constrained)
         {
-            m_lastCursorPosition = m_currentCursorPosition;
+            if (m_currentCursorPosition.has_value())
+            {
+                m_lastCursorPosition = m_currentCursorPosition;
+            }
+        }
+        else
+        {
+            m_currentCursorPosition = m_lastCursorPosition;
         }
     }
 } // namespace AzFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
@@ -22,9 +22,6 @@
 #include <QWheelEvent>
 #include <QWidget>
 
-#pragma optimize("", off)
-#pragma inline_depth(0)
-
 namespace AzToolsFramework
 {
     void QtEventToAzInputMapper::InitializeKeyMappings()
@@ -161,7 +158,7 @@ namespace AzToolsFramework
         SetImplementation(nullptr);
     }
 
-    void QtEventToAzInputMapper::EditorQtMouseDevice::SetSystemCursorState(AzFramework::SystemCursorState systemCursorState)
+    void QtEventToAzInputMapper::EditorQtMouseDevice::SetSystemCursorState(const AzFramework::SystemCursorState systemCursorState)
     {
         m_systemCursorState = systemCursorState;
     }
@@ -276,7 +273,7 @@ namespace AzToolsFramework
         else if (
             eventType == QEvent::Type::KeyPress || eventType == QEvent::Type::KeyRelease || eventType == QEvent::Type::ShortcutOverride)
         {
-            QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+            auto keyEvent = static_cast<QKeyEvent*>(event);
             HandleKeyEvent(keyEvent);
         }
         // Map mouse events to input channels.
@@ -284,7 +281,7 @@ namespace AzToolsFramework
             eventType == QEvent::Type::MouseButtonPress || eventType == QEvent::Type::MouseButtonRelease ||
             eventType == QEvent::Type::MouseButtonDblClick)
         {
-            QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+            auto mouseEvent = static_cast<QMouseEvent*>(event);
             HandleMouseButtonEvent(mouseEvent);
         }
         // Map mouse movement to the movement input channels.
@@ -297,7 +294,7 @@ namespace AzToolsFramework
         // Map wheel events to the mouse Z movement channel.
         else if (eventType == QEvent::Type::Wheel)
         {
-            QWheelEvent* wheelEvent = static_cast<QWheelEvent*>(event);
+            auto wheelEvent = static_cast<QWheelEvent*>(event);
             HandleWheelEvent(wheelEvent);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
@@ -220,6 +220,7 @@ namespace AzToolsFramework
         if (m_capturingCursor != enabled)
         {
             m_capturingCursor = enabled;
+
             if (m_capturingCursor)
             {
                 m_mouseDevice->SetSystemCursorState(AzFramework::SystemCursorState::ConstrainedAndHidden);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
@@ -105,7 +105,13 @@ namespace AzToolsFramework
         public:
             EditorQtMouseDevice(AzFramework::InputDeviceId id);
 
+            void SetSystemCursorState(AzFramework::SystemCursorState systemCursorState) override;
+            AzFramework::SystemCursorState GetSystemCursorState() const override;
+
             friend class QtEventToAzInputMapper;
+
+        private:
+            AzFramework::SystemCursorState m_systemCursorState = AzFramework::SystemCursorState::UnconstrainedAndVisible;
         };
 
         // Emits InputChannelUpdated if channel has transitioned in state (i.e. has gone from active to inactive or vice versa).
@@ -122,7 +128,8 @@ namespace AzToolsFramework
         // Handle mouse click events.
         void HandleMouseButtonEvent(QMouseEvent* mouseEvent);
         // Handle mouse move events.
-        void HandleMouseMoveEvent(QMouseEvent* mouseEvent);
+        // Return the mouse delta for this mouse move event.
+        QPoint HandleMouseMoveEvent(const QPoint& cursorPosition);
         // Handles key press / release events (or ShortcutOverride events for keys listed in m_highPriorityKeys).
         void HandleKeyEvent(QKeyEvent* keyEvent);
         // Handles mouse wheel events.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
@@ -105,6 +105,7 @@ namespace AzToolsFramework
         public:
             EditorQtMouseDevice(AzFramework::InputDeviceId id);
 
+            // AzFramework::InputDeviceMouse overrides ...
             void SetSystemCursorState(AzFramework::SystemCursorState systemCursorState) override;
             AzFramework::SystemCursorState GetSystemCursorState() const override;
 
@@ -128,7 +129,6 @@ namespace AzToolsFramework
         // Handle mouse click events.
         void HandleMouseButtonEvent(QMouseEvent* mouseEvent);
         // Handle mouse move events.
-        // Return the mouse delta for this mouse move event.
         void HandleMouseMoveEvent(const QPoint& cursorPosition);
         // Handles key press / release events (or ShortcutOverride events for keys listed in m_highPriorityKeys).
         void HandleKeyEvent(QKeyEvent* keyEvent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
@@ -129,7 +129,7 @@ namespace AzToolsFramework
         void HandleMouseButtonEvent(QMouseEvent* mouseEvent);
         // Handle mouse move events.
         // Return the mouse delta for this mouse move event.
-        QPoint HandleMouseMoveEvent(const QPoint& cursorPosition);
+        void HandleMouseMoveEvent(const QPoint& cursorPosition);
         // Handles key press / release events (or ShortcutOverride events for keys listed in m_highPriorityKeys).
         void HandleKeyEvent(QKeyEvent* keyEvent);
         // Handles mouse wheel events.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.cpp
@@ -115,7 +115,7 @@ namespace UnitTest
                     handled, AzToolsFramework::GetEntityContextId(),
                     &EditorInteractionSystemViewportSelectionRequestBus::Events::InternalHandleMouseViewportInteraction,
                     AzToolsFramework::ViewportInteraction::MouseInteractionEvent(
-                        mouseInteraction, AzToolsFramework::ViewportInteraction::MouseEvent::Down));
+                        mouseInteraction, AzToolsFramework::ViewportInteraction::MouseEvent::Down, /*captured=*/false));
                 return handled;
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -40,8 +40,12 @@ namespace AzToolsFramework
             const QPoint currentScreenCoords =
                 ViewportInteraction::QPointFromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
 
+            AZ_Printf("tom-debug", "click point           (x: %d, y: %d)\n", contextMenu.m_clickPoint.x(), contextMenu.m_clickPoint.y());
+            AZ_Printf("tom-debug", "current screen coords (x: %d, y: %d)\n", currentScreenCoords.x(), currentScreenCoords.y());
+
             // if the mouse hasn't moved, open the pop-up menu
-            if ((currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < ed_contextMenuDisplayThreshold)
+            if ((currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < ed_contextMenuDisplayThreshold &&
+                !mouseInteraction.m_wasCaptured)
             {
                 QWidget* parent = nullptr;
                 ViewportInteraction::MainEditorViewportInteractionRequestBus::EventResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/EditorContextMenu.cpp
@@ -40,12 +40,9 @@ namespace AzToolsFramework
             const QPoint currentScreenCoords =
                 ViewportInteraction::QPointFromScreenPoint(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
 
-            AZ_Printf("tom-debug", "click point           (x: %d, y: %d)\n", contextMenu.m_clickPoint.x(), contextMenu.m_clickPoint.y());
-            AZ_Printf("tom-debug", "current screen coords (x: %d, y: %d)\n", currentScreenCoords.x(), currentScreenCoords.y());
-
             // if the mouse hasn't moved, open the pop-up menu
             if ((currentScreenCoords - contextMenu.m_clickPoint).manhattanLength() < ed_contextMenuDisplayThreshold &&
-                !mouseInteraction.m_wasCaptured)
+                !mouseInteraction.m_captured)
             {
                 QWidget* parent = nullptr;
                 ViewportInteraction::MainEditorViewportInteractionRequestBus::EventResult(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportTypes.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportTypes.h
@@ -212,10 +212,10 @@ namespace AzToolsFramework
             static void Reflect(AZ::SerializeContext& context);
 
             //! Constructor to create a default MouseInteractionEvent
-            MouseInteractionEvent(MouseInteraction mouseInteraction, const MouseEvent mouseEvent, const bool wasCaptured)
+            MouseInteractionEvent(MouseInteraction mouseInteraction, const MouseEvent mouseEvent, const bool captured)
                 : m_mouseInteraction(std::move(mouseInteraction))
                 , m_mouseEvent(mouseEvent)
-                , m_wasCaptured(wasCaptured)
+                , m_captured(captured)
             {
             }
 
@@ -229,7 +229,7 @@ namespace AzToolsFramework
 
             MouseInteraction m_mouseInteraction; //!< Mouse state.
             MouseEvent m_mouseEvent; //!< Mouse event.
-            bool m_wasCaptured = false; //!< Was the mouse cursor captured directly before this event.
+            bool m_captured = false; //!< Is the mouse cursor being captured during the event.
 
             //! Special friend function to return the mouse wheel delta (scroll amount)
             //! if the event was of type MouseEvent::Wheel.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportTypes.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportTypes.h
@@ -212,9 +212,10 @@ namespace AzToolsFramework
             static void Reflect(AZ::SerializeContext& context);
 
             //! Constructor to create a default MouseInteractionEvent
-            MouseInteractionEvent(MouseInteraction mouseInteraction, const MouseEvent mouseEvent)
+            MouseInteractionEvent(MouseInteraction mouseInteraction, const MouseEvent mouseEvent, const bool wasCaptured)
                 : m_mouseInteraction(std::move(mouseInteraction))
                 , m_mouseEvent(mouseEvent)
+                , m_wasCaptured(wasCaptured)
             {
             }
 
@@ -228,6 +229,7 @@ namespace AzToolsFramework
 
             MouseInteraction m_mouseInteraction; //!< Mouse state.
             MouseEvent m_mouseEvent; //!< Mouse event.
+            bool m_wasCaptured = false; //!< Was the mouse cursor captured directly before this event.
 
             //! Special friend function to return the mouse wheel delta (scroll amount)
             //! if the event was of type MouseEvent::Wheel.


### PR DESCRIPTION
Fixes #2251
Fixes #2493

This PR resolves both the problem with the Editor viewport context menu popping up too often and also provides the option to hide the mouse cursor when performing a mouse look (not this is currently just for RMB free look but could be extended in future for orbit if required).
