### PR TITLE
Disabling RootSpawnable warning

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
@@ -239,10 +239,11 @@ namespace AzFramework
         }
         else if (rootSpawnableKeyType == AZ::SettingsRegistryInterface::Type::NoType)
         {
-            AZ_Warning(
+            // [LYN-4146] - temporarily disabled
+            /*AZ_Warning(
                 "Spawnables", false,
                 "No root spawnable assigned. The root spawnable can be assigned in the Settings Registry under the key '%s'.\n",
-                RootSpawnableRegistryKey);
+                RootSpawnableRegistryKey);*/
             ReleaseRootSpawnable();
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
@@ -239,10 +239,6 @@ namespace AzFramework
         }
         else if (rootSpawnableKeyType == AZ::SettingsRegistryInterface::Type::NoType)
         {
-            AZ_Warning(
-                "Spawnables", false,
-                "No root spawnable assigned. The root spawnable can be assigned in the Settings Registry under the key '%s'.\n",
-                RootSpawnableRegistryKey);
             ReleaseRootSpawnable();
         }
     }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableSystemComponent.cpp
@@ -239,6 +239,10 @@ namespace AzFramework
         }
         else if (rootSpawnableKeyType == AZ::SettingsRegistryInterface::Type::NoType)
         {
+            AZ_Warning(
+                "Spawnables", false,
+                "No root spawnable assigned. The root spawnable can be assigned in the Settings Registry under the key '%s'.\n",
+                RootSpawnableRegistryKey);
             ReleaseRootSpawnable();
         }
     }


### PR DESCRIPTION
RootSpawnable was meant to replace the level system but the update to the level system never quite reached the point where that fully worked. There's just too much legacy code to go over.

LYN-4146