### PR TITLE
Fixed memory stomping leading to Track View nodes with invalid labels and crash.

### DIFF
--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -2033,7 +2033,8 @@ void CTrackViewDialog::UpdateTracksToolBar()
                     continue;
                 }
 
-                name = pAnimNode->GetParamName(paramType);
+                AZStd::string paramName = pAnimNode->GetParamName(paramType);
+                name = paramName.c_str();
 
                 QString sToolTipText("Add " + name + " Track");
                 QIcon hIcon = m_wndNodesCtrl->GetIconForTrack(pTrack);

--- a/Code/Editor/TrackView/TrackViewNodes.cpp
+++ b/Code/Editor/TrackView/TrackViewNodes.cpp
@@ -616,7 +616,8 @@ CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddAnimNodeRecord(CRecord* pP
 {
     CRecord* pNewRecord = new CRecord(animNode);
 
-    pNewRecord->setText(0, animNode->GetName());
+    AZStd::string nodeName = animNode->GetName();
+    pNewRecord->setText(0, nodeName.c_str());
     UpdateAnimNodeRecord(pNewRecord, animNode);
     pParentRecord->insertChild(GetInsertPosition(pParentRecord, animNode), pNewRecord);
     FillNodesRec(pNewRecord, animNode);
@@ -629,7 +630,8 @@ CTrackViewNodesCtrl::CRecord* CTrackViewNodesCtrl::AddTrackRecord(CRecord* pPare
 {
     CRecord* pNewTrackRecord = new CRecord(pTrack);
     pNewTrackRecord->setSizeHint(0, QSize(30, 18));
-    pNewTrackRecord->setText(0, pTrack->GetName());
+    AZStd::string trackName = pTrack->GetName();
+    pNewTrackRecord->setText(0, trackName.c_str());
     UpdateTrackRecord(pNewTrackRecord, pTrack);
     pParentRecord->insertChild(GetInsertPosition(pParentRecord, pTrack), pNewTrackRecord);
     FillNodesRec(pNewTrackRecord, pTrack);
@@ -2348,13 +2350,13 @@ bool CTrackViewNodesCtrl::FillAddTrackMenu(STrackMenuTreeNode& menuAddTrack, con
                 continue;
             }
         }
-        name = animNode->GetParamName(paramType);
+        AZStd::string paramName = animNode->GetParamName(paramType);
+        name = paramName.c_str();
         QStringList splittedName = name.split("/", Qt::SkipEmptyParts);
 
         STrackMenuTreeNode* pCurrentNode = &menuAddTrack;
-        for (int j = 0; j < splittedName.size() - 1; ++j)
+        for (const QString& segment : splittedName)
         {
-            const QString& segment = splittedName[j];
             auto findIter = pCurrentNode->children.find(segment);
             if (findIter != pCurrentNode->children.end())
             {
@@ -2370,7 +2372,7 @@ bool CTrackViewNodesCtrl::FillAddTrackMenu(STrackMenuTreeNode& menuAddTrack, con
 
         // only add tracks to the that STrackMenuTreeNode tree that haven't already been added
         CTrackViewTrackBundle matchedTracks = animNode->GetTracksByParam(paramType);
-        if (matchedTracks.GetCount() == 0)
+        if (matchedTracks.GetCount() == 0 && !splittedName.isEmpty())
         {
             STrackMenuTreeNode* pParamNode = new STrackMenuTreeNode;
             pCurrentNode->children[splittedName.back()] = std::unique_ptr<STrackMenuTreeNode>(pParamNode);
@@ -2580,10 +2582,11 @@ void CTrackViewNodesCtrl::Update()
             {
                 const CTrackViewAnimNode* track = static_cast<const CTrackViewAnimNode*>(node);
                 if (track)
-                { 
-                    record->setText(0, track->GetName());
+                {
+                    AZStd::string trackName = track->GetName();
+                    record->setText(0, trackName.c_str());
                 }
-            }            
+            }
         }
     }
 }

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -625,7 +625,7 @@ public:
             , valueType(_valueType)
             , flags(_flags) {};
 
-        const char* name;           // parameter name.
+        AZStd::string name;           // parameter name.
         CAnimParamType paramType;     // parameter id.
         AnimValueType valueType;       // value type, defines type of track to use for animating this parameter.
         ESupportedParamFlags flags; // combination of flags from ESupportedParamFlags.

--- a/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimComponentNode.h
@@ -150,16 +150,16 @@ private:
         }
         BehaviorPropertyInfo(const BehaviorPropertyInfo& other)
         {
-            m_displayName = other.m_displayName;
-            m_animNodeParamInfo.paramType = other.m_displayName;
-            m_animNodeParamInfo.name = &m_displayName[0];
+            m_displayName = AZStd::move(other.m_displayName);
+            m_animNodeParamInfo.paramType = m_displayName;
+            m_animNodeParamInfo.name = m_displayName;
         }
         BehaviorPropertyInfo& operator=(const AZStd::string& str)
         {
             // TODO: clean this up - this weird memory sharing was copied from legacy Cry - could be better.
             m_displayName = str;
             m_animNodeParamInfo.paramType = str;   // set type to AnimParamType::ByString by assigning a string
-            m_animNodeParamInfo.name = &m_displayName[0];
+            m_animNodeParamInfo.name = m_displayName;
             return *this;
         }
 

--- a/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimNode.cpp
@@ -82,7 +82,7 @@ const char* CAnimNode::GetParamName(const CAnimParamType& paramType) const
     SParamInfo info;
     if (GetParamInfoFromType(paramType, info))
     {
-        return info.name;
+        return info.name.c_str();
     }
 
     return "Unknown";


### PR DESCRIPTION
Fixes #3105 

There were two issues: I fixed the actual crash, which was trying to dereference a null pointer, but the underlying issue was that the track view node names were getting stomped due to some other changes made recently. Ideally I would've liked to rework the API to return a string_view instead of a const char* but it is a legacy API in CryCommon that spirals out to a lot usages so I wanted to minimize the number of files changed.

Before:
![TrackViewBrokenNodes](https://user-images.githubusercontent.com/7519264/130685999-3fef24b9-fc24-41cc-9fcc-bb3b3349d4d9.png)

After:
![TrackViewFixedNodes](https://user-images.githubusercontent.com/7519264/130686015-a8f141c0-29ce-407c-80ce-dfc5075f6d25.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>