### PR TITLE
Fix an issue with project-centric ninja builds [Linux]

### DIFF
--- a/cmake/Findo3de.cmake
+++ b/cmake/Findo3de.cmake
@@ -17,23 +17,27 @@ endfunction()
 
 o3de_current_file_path(current_path)
 
-# Make sure we are matching LY_ENGINE_NAME_TO_USE with the current engine
-file(READ ${current_path}/../engine.json engine_json)
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${current_path}/../engine.json)
+# Make sure the cmake configure dependency added here is a normalized path to engine.json,
+# because later it's read again using a path like ${LY_ROOT_FOLDER}/engine.json, which
+# is also normalized.  The should match to avoid errors on some build systems.
+cmake_path(SET engine_json_path NORMALIZE ${current_path}/../engine.json)
+file(READ ${engine_json_path} engine_json)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${engine_json_path})
 
 string(JSON this_engine_name ERROR_VARIABLE json_error GET ${engine_json} engine_name)
 if(json_error)
-    message(FATAL_ERROR "Unable to read key 'engine_name' from '${current_path}/../engine.json', error: ${json_error}")
+    message(FATAL_ERROR "Unable to read key 'engine_name' from '${engine_json_path}', error: ${json_error}")
 endif()
 
+# Make sure we are matching LY_ENGINE_NAME_TO_USE with the current engine
 set(found_matching_engine FALSE)
 if(this_engine_name STREQUAL LY_ENGINE_NAME_TO_USE)
     set(found_matching_engine TRUE)
 endif()
 
 find_package_handle_standard_args(o3de
-        "Could not find an engine with matching ${LY_ENGINE_NAME_TO_USE}"
-        found_matching_engine
+    "Could not find an engine with matching ${LY_ENGINE_NAME_TO_USE}"
+    found_matching_engine
 )
 
 macro(o3de_initialize)


### PR DESCRIPTION
Normalizes relative paths when adding engine.json as a cmake configure dependency.
It should match the dependency added later which uses absolute path.

relates #3189 

