### PR TITLE
Move packet dispatch to return an enum that includes a pending option

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/AutoGen/AutoPacketDispatcher_Header.jinja
+++ b/Code/Framework/AzNetworking/AzNetworking/AutoGen/AutoPacketDispatcher_Header.jinja
@@ -16,7 +16,7 @@ namespace {{ xml.attrib['Name'] }}
     //! @param handler      the handler used to handle the received packet
     //! @return boolean true on successful dispatch, false if the request was not handled
     template <typename HANDLER>
-    bool DispatchPacket(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer, HANDLER& handler);
+    AzNetworking::PacketDispatchResult DispatchPacket(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer, HANDLER& handler);
 }
 {% endfor %}
 

--- a/Code/Framework/AzNetworking/AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja
+++ b/Code/Framework/AzNetworking/AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja
@@ -13,7 +13,7 @@ namespace {{ xml.attrib['Name'] }}
 {%      if ('HandshakePacket' not in Packet.attrib) or (Packet.attrib['HandshakePacket'] == 'false') %}
                 if (!handler.IsHandshakeComplete())
                 {
-                    return AzNetworking::PacketDispatchResult::Pending;
+                    return AzNetworking::PacketDispatchResult::Skipped;
                 }
 {% endif %}
 

--- a/Code/Framework/AzNetworking/AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja
+++ b/Code/Framework/AzNetworking/AzNetworking/AutoGen/AutoPacketDispatcher_Inline.jinja
@@ -2,7 +2,7 @@
 namespace {{ xml.attrib['Name'] }}
 {
     template <typename HANDLER>
-    inline bool DispatchPacket(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer, HANDLER& handler)
+    inline AzNetworking::PacketDispatchResult DispatchPacket(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer, HANDLER& handler)
     {
         switch (aznumeric_cast<int32_t>(packetHeader.GetPacketType()))
         {
@@ -10,16 +10,26 @@ namespace {{ xml.attrib['Name'] }}
             case aznumeric_cast<int32_t>({{ Packet.attrib['Name'] }}::Type):
             {
                 AZLOG(Debug_DispatchPackets, "Received packet %s", "{{ Packet.attrib['Name'] }}");
+{%      if ('HandshakePacket' not in Packet.attrib) or (Packet.attrib['HandshakePacket'] == 'false') %}
+                if (!handler.IsHandshakeComplete())
+                {
+                    return AzNetworking::PacketDispatchResult::Pending;
+                }
+{% endif %}
+
                 {{ Packet.attrib['Name'] }} packet;
                 if (!serializer.Serialize(packet, "Packet"))
                 {
-                    return false;
+                    return AzNetworking::PacketDispatchResult::Failure;
                 }
-                return handler.HandleRequest(connection, packetHeader, packet);
+                if(handler.HandleRequest(connection, packetHeader, packet))
+                {
+                    return AzNetworking::PacketDispatchResult::Success;
+                }
             }
 {%      endfor %}
         }
-        return false;
+        return AzNetworking::PacketDispatchResult::Failure;
     }
 }
 {% endfor %}

--- a/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/IConnectionListener.h
+++ b/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/IConnectionListener.h
@@ -45,8 +45,8 @@ namespace AzNetworking
         //! @param connection   pointer to the connection instance generating the event
         //! @param packetHeader packet header of the associated payload
         //! @param serializer   serializer instance containing the transmitted payload
-        //! @return boolean true to signal success, false to disconnect with a transport error
-        virtual bool OnPacketReceived(IConnection* connection, const IPacketHeader& packetHeader, ISerializer& serializer) = 0;
+        //! @return PacketDispatchResult result of the packet handling attempt
+        virtual PacketDispatchResult OnPacketReceived(IConnection* connection, const IPacketHeader& packetHeader, ISerializer& serializer) = 0;
 
         //! Called when a packet is deemed lost by the remote connection.
         //! @param connection pointer to the connection instance generating the event

--- a/Code/Framework/AzNetworking/AzNetworking/PacketLayer/IPacketHeader.h
+++ b/Code/Framework/AzNetworking/AzNetworking/PacketLayer/IPacketHeader.h
@@ -15,6 +15,12 @@
 
 namespace AzNetworking
 {
+    AZ_ENUM_CLASS(PacketDispatchResult
+        , Success
+        , Pending
+        , Failure
+    );
+
     AZ_ENUM_CLASS(PacketFlag
         , Compressed
         , MAX

--- a/Code/Framework/AzNetworking/AzNetworking/PacketLayer/IPacketHeader.h
+++ b/Code/Framework/AzNetworking/AzNetworking/PacketLayer/IPacketHeader.h
@@ -17,7 +17,7 @@ namespace AzNetworking
 {
     AZ_ENUM_CLASS(PacketDispatchResult
         , Failure
-        , Pending
+        , Skipped
         , Success
     );
 

--- a/Code/Framework/AzNetworking/AzNetworking/PacketLayer/IPacketHeader.h
+++ b/Code/Framework/AzNetworking/AzNetworking/PacketLayer/IPacketHeader.h
@@ -16,9 +16,9 @@
 namespace AzNetworking
 {
     AZ_ENUM_CLASS(PacketDispatchResult
-        , Success
-        , Pending
         , Failure
+        , Pending
+        , Success
     );
 
     AZ_ENUM_CLASS(PacketFlag

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.cpp
@@ -236,14 +236,14 @@ namespace AzNetworking
         return true;
     }
 
-    bool UdpConnection::HandleCorePacket(IConnectionListener& connectionListener, UdpPacketHeader& header, ISerializer& serializer)
+    PacketDispatchResult UdpConnection::HandleCorePacket(IConnectionListener& connectionListener, UdpPacketHeader& header, ISerializer& serializer)
     {
         switch (static_cast<CorePackets::PacketType>(header.GetPacketType()))
         {
         case CorePackets::PacketType::InitiateConnectionPacket:
         {
             AZLOG(NET_CorePackets, "Received core packet %s", "InitiateConnection");
-            return true;
+            return PacketDispatchResult::Success;
         }
         break;
 
@@ -253,7 +253,7 @@ namespace AzNetworking
             CorePackets::ConnectionHandshakePacket packet;
             if (!serializer.Serialize(packet, "Packet"))
             {
-                return false;
+                return PacketDispatchResult::Failure;
             }
 
             if (m_state != ConnectionState::Connected)
@@ -264,7 +264,7 @@ namespace AzNetworking
                 }
             }
 
-            return true;
+            return PacketDispatchResult::Success;
         }
         break;
 
@@ -274,10 +274,10 @@ namespace AzNetworking
             CorePackets::TerminateConnectionPacket packet;
             if (!serializer.Serialize(packet, "Packet"))
             {
-                return false;
+                return PacketDispatchResult::Failure;
             }
             Disconnect(packet.GetDisconnectReason(), TerminationEndpoint::Remote);
-            return true;
+            return PacketDispatchResult::Success;
         }
         break;
 
@@ -287,10 +287,10 @@ namespace AzNetworking
             CorePackets::HeartbeatPacket packet;
             if (!serializer.Serialize(packet, "Packet"))
             {
-                return false;
+                return PacketDispatchResult::Failure;
             }
             // Do nothing, we've already processed our ack packets
-            return true;
+            return PacketDispatchResult::Success;
         }
         break;
 
@@ -302,6 +302,6 @@ namespace AzNetworking
             AZ_Assert(false, "Unhandled core packet type!");
         }
 
-        return false;
+        return PacketDispatchResult::Failure;
     }
 }

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.h
@@ -130,7 +130,7 @@ namespace AzNetworking
         //! @param listener   a connection listener to receive connection related events
         //! @param header     the packet header received to process
         //! @param serializer the output serializer containing the transmitted packet data
-        //! @return boolean true on successful handling of the received header
+        //! @return PacketDispatchResult result of processing the core packet
         PacketDispatchResult HandleCorePacket(IConnectionListener& listener, UdpPacketHeader& header, ISerializer& serializer);
 
         AZ_DISABLE_COPY_MOVE(UdpConnection);

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpConnection.h
@@ -131,7 +131,7 @@ namespace AzNetworking
         //! @param header     the packet header received to process
         //! @param serializer the output serializer containing the transmitted packet data
         //! @return boolean true on successful handling of the received header
-        bool HandleCorePacket(IConnectionListener& listener, UdpPacketHeader& header, ISerializer& serializer);
+        PacketDispatchResult HandleCorePacket(IConnectionListener& listener, UdpPacketHeader& header, ISerializer& serializer);
 
         AZ_DISABLE_COPY_MOVE(UdpConnection);
 

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpFragmentQueue.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpFragmentQueue.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzNetworking/PacketLayer/IPacket.h>
+#include <AzNetworking/PacketLayer/IPacketHeader.h>
 #include <AzNetworking/AutoGen/CorePackets.AutoPackets.h>
 #include <AzNetworking/ConnectionLayer/SequenceGenerator.h>
 #include <AzNetworking/DataStructures/RingBufferBitset.h>
@@ -44,8 +45,8 @@ namespace AzNetworking
         //! @param connectionListener the connection listener for delivery of completed packets
         //! @param header             the chunk packet header
         //! @param serializer         the serializer containing the chunk body
-        //! @return boolean true if the chunk was processed, false if an error was encountered
-        bool ProcessReceivedChunk(UdpConnection* connection, IConnectionListener& connectionListener, UdpPacketHeader& header, ISerializer& serializer);
+        //! @return PacketDispatchResult result of processing the chunk
+        PacketDispatchResult ProcessReceivedChunk(UdpConnection* connection, IConnectionListener& connectionListener, UdpPacketHeader& header, ISerializer& serializer);
 
     private:
 

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -277,7 +277,7 @@ namespace AzNetworking
 
                 timeoutItem->UpdateTimeoutTime(startTimeMs);
 
-                PacketDispatchResult handledPacket;
+                PacketDispatchResult handledPacket = PacketDispatchResult::Failure;
                 if (header.GetPacketType() < aznumeric_cast<PacketType>(CorePackets::PacketType::MAX))
                 {
                     handledPacket = connection->HandleCorePacket(m_connectionListener, header, packetSerializer);

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -306,7 +306,7 @@ namespace AzNetworking
                 }
                 else if (handledPacket == PacketDispatchResult::Pending)
                 {
-                    // If we did not handle due to a handshake pending completion, defer it
+                    // If we did not handle due to a handshake pending completion, skip it
                     continue;
                 }
                 else if (connection->GetConnectionState() != ConnectionState::Disconnecting)

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -304,9 +304,9 @@ namespace AzNetworking
                     // If it's not an expected unencrypted type then skip it for now
                     continue;
                 }
-                else if (handledPacket == PacketDispatchResult::Pending)
+                else if (handledPacket == PacketDispatchResult::Skipped)
                 {
-                    // If we did not handle due to a handshake pending completion, skip it
+                    // If the result is marked as skipped then do so (i.e. if a handshake is not yet complete)
                     continue;
                 }
                 else if (connection->GetConnectionState() != ConnectionState::Disconnecting)

--- a/Code/Framework/AzNetworking/Tests/TcpTransport/TcpTransportTests.cpp
+++ b/Code/Framework/AzNetworking/Tests/TcpTransport/TcpTransportTests.cpp
@@ -33,11 +33,11 @@ namespace UnitTest
             ;
         }
 
-        bool OnPacketReceived([[maybe_unused]] IConnection* connection, const IPacketHeader& packetHeader, [[maybe_unused]] ISerializer& serializer)
+        PacketDispatchResult OnPacketReceived([[maybe_unused]] IConnection* connection, const IPacketHeader& packetHeader, [[maybe_unused]] ISerializer& serializer)
         {
             EXPECT_TRUE((packetHeader.GetPacketType() == static_cast<PacketType>(CorePackets::PacketType::InitiateConnectionPacket))
                      || (packetHeader.GetPacketType() == static_cast<PacketType>(CorePackets::PacketType::HeartbeatPacket)));
-            return false;
+            return PacketDispatchResult::Failure;
         }
 
         void OnPacketLost([[maybe_unused]] IConnection* connection, [[maybe_unused]] PacketId packetId)

--- a/Code/Framework/AzNetworking/Tests/UdpTransport/UdpTransportTests.cpp
+++ b/Code/Framework/AzNetworking/Tests/UdpTransport/UdpTransportTests.cpp
@@ -36,11 +36,11 @@ namespace UnitTest
             ;
         }
 
-        bool OnPacketReceived([[maybe_unused]] IConnection* connection, const IPacketHeader& packetHeader, [[maybe_unused]] ISerializer& serializer)
+        PacketDispatchResult OnPacketReceived([[maybe_unused]] IConnection* connection, const IPacketHeader& packetHeader, [[maybe_unused]] ISerializer& serializer)
         {
             EXPECT_TRUE((packetHeader.GetPacketType() == static_cast<PacketType>(CorePackets::PacketType::InitiateConnectionPacket))
                      || (packetHeader.GetPacketType() == static_cast<PacketType>(CorePackets::PacketType::HeartbeatPacket)));
-            return false;
+            return PacketDispatchResult::Failure;
         }
 
         void OnPacketLost([[maybe_unused]] IConnection* connection, [[maybe_unused]] PacketId packetId)

--- a/Gems/Multiplayer/Code/Source/AutoGen/Multiplayer.AutoPackets.xml
+++ b/Gems/Multiplayer/Code/Source/AutoGen/Multiplayer.AutoPackets.xml
@@ -7,12 +7,12 @@
     <Include File="Multiplayer/NetworkEntity/NetworkEntityRpcMessage.h" />
     <Include File="Multiplayer/NetworkEntity/NetworkEntityUpdateMessage.h" />
 
-    <Packet Name="Connect" Desc="Client connection packet, on success the server will reply with an Accept">
+    <Packet Name="Connect" HandshakePacket="true" Desc="Client connection packet, on success the server will reply with an Accept">
         <Member Type="uint16_t" Name="networkProtocolVersion" Init="0" />
         <Member Type="Multiplayer::LongNetworkString" Name="ticket" />
     </Packet>
 
-    <Packet Name="Accept" Desc="Server accept packet">
+    <Packet Name="Accept" HandshakePacket="true" Desc="Server accept packet">
         <Member Type="Multiplayer::HostId" Name="hostId" Init="Multiplayer::InvalidHostId" />
         <Member Type="Multiplayer::LongNetworkString" Name="map" />
     </Packet>

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -168,7 +168,7 @@ namespace Multiplayer
         ;
     }
 
-    bool MultiplayerEditorConnection::OnPacketReceived(AzNetworking::IConnection* connection, const IPacketHeader& packetHeader, ISerializer& serializer)
+    AzNetworking::PacketDispatchResult MultiplayerEditorConnection::OnPacketReceived(AzNetworking::IConnection* connection, const IPacketHeader& packetHeader, ISerializer& serializer)
     {
         return MultiplayerEditorPackets::DispatchPacket(connection, packetHeader, serializer, *this);
     }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
@@ -33,6 +33,7 @@ namespace Multiplayer
         MultiplayerEditorConnection();
         ~MultiplayerEditorConnection() = default;
 
+        bool IsHandshakeComplete(){ return true; };
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerEditorPackets::EditorServerInit& packet);
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerEditorPackets::EditorServerReady& packet);
         
@@ -40,7 +41,7 @@ namespace Multiplayer
         //! @{
         AzNetworking::ConnectResult ValidateConnect(const AzNetworking::IpAddress& remoteAddress, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer) override;
         void OnConnect(AzNetworking::IConnection* connection) override;
-        bool OnPacketReceived(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer) override;
+        AzNetworking::PacketDispatchResult OnPacketReceived(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer) override;
         void OnPacketLost(AzNetworking::IConnection* connection, AzNetworking::PacketId packetId) override;
         void OnDisconnect(AzNetworking::IConnection* connection, AzNetworking::DisconnectReason reason, AzNetworking::TerminationEndpoint endpoint) override;
         //! @}

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.h
@@ -33,7 +33,7 @@ namespace Multiplayer
         MultiplayerEditorConnection();
         ~MultiplayerEditorConnection() = default;
 
-        bool IsHandshakeComplete(){ return true; };
+        bool IsHandshakeComplete() const { return true; };
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerEditorPackets::EditorServerInit& packet);
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerEditorPackets::EditorServerReady& packet);
         

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -441,7 +441,7 @@ namespace Multiplayer
         MultiplayerPackets::SyncConsole m_syncPacket;
     };
 
-    bool MultiplayerSystemComponent::IsHandshakeComplete()
+    bool MultiplayerSystemComponent::IsHandshakeComplete() const
     {
         return m_didHandshake;
     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.cpp
@@ -441,6 +441,11 @@ namespace Multiplayer
         MultiplayerPackets::SyncConsole m_syncPacket;
     };
 
+    bool MultiplayerSystemComponent::IsHandshakeComplete()
+    {
+        return m_didHandshake;
+    }
+
     bool MultiplayerSystemComponent::HandleRequest
     (
         [[maybe_unused]] AzNetworking::IConnection* connection,
@@ -465,6 +470,8 @@ namespace Multiplayer
 
         if (connection->SendReliablePacket(MultiplayerPackets::Accept(InvalidHostId, sv_map)))
         {
+            m_didHandshake = true;
+
             // Sync our console
             ConsoleReplicator consoleReplicator(connection);
             AZ::Interface<AZ::IConsole>::Get()->VisitRegisteredFunctors([&consoleReplicator](AZ::ConsoleFunctorBase* functor) { consoleReplicator.Visit(functor); });
@@ -480,6 +487,8 @@ namespace Multiplayer
         [[maybe_unused]] MultiplayerPackets::Accept& packet
     )
     {
+        m_didHandshake = true;
+
         AZ::CVarFixedString commandString = "sv_map " + packet.GetMap();
         AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
 
@@ -670,7 +679,7 @@ namespace Multiplayer
         }
     }
 
-    bool MultiplayerSystemComponent::OnPacketReceived(AzNetworking::IConnection* connection, const IPacketHeader& packetHeader, ISerializer& serializer)
+    AzNetworking::PacketDispatchResult MultiplayerSystemComponent::OnPacketReceived(AzNetworking::IConnection* connection, const IPacketHeader& packetHeader, ISerializer& serializer)
     {
         return MultiplayerPackets::DispatchPacket(connection, packetHeader, serializer, *this);
     }

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -76,7 +76,7 @@ namespace Multiplayer
         int GetTickOrder() override;
         //! @}
 
-        bool IsHandshakeComplete();
+        bool IsHandshakeComplete() const;
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerPackets::Connect& packet);
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerPackets::Accept& packet);
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerPackets::ReadyForEntityUpdates& packet);

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -76,6 +76,7 @@ namespace Multiplayer
         int GetTickOrder() override;
         //! @}
 
+        bool IsHandshakeComplete();
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerPackets::Connect& packet);
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerPackets::Accept& packet);
         bool HandleRequest(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, MultiplayerPackets::ReadyForEntityUpdates& packet);
@@ -89,7 +90,7 @@ namespace Multiplayer
         //! @{
         AzNetworking::ConnectResult ValidateConnect(const AzNetworking::IpAddress& remoteAddress, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer) override;
         void OnConnect(AzNetworking::IConnection* connection) override;
-        bool OnPacketReceived(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer) override;
+        AzNetworking::PacketDispatchResult OnPacketReceived(AzNetworking::IConnection* connection, const AzNetworking::IPacketHeader& packetHeader, AzNetworking::ISerializer& serializer) override;
         void OnPacketLost(AzNetworking::IConnection* connection, AzNetworking::PacketId packetId) override;
         void OnDisconnect(AzNetworking::IConnection* connection, AzNetworking::DisconnectReason reason, AzNetworking::TerminationEndpoint endpoint) override;
         //! @}
@@ -158,6 +159,7 @@ namespace Multiplayer
         double m_serverSendAccumulator = 0.0;
         float m_renderBlendFactor = 0.0f;
         float m_tickFactor = 0.0f;
+        bool m_didHandshake = false;
 
 #if !defined(AZ_RELEASE_BUILD)
         MultiplayerEditorConnection m_editorConnectionListener;


### PR DESCRIPTION
This change adds a mechanism for users to designate packets as part of a handshake such that
- Handlers for said packets must implement an IsHandshakeComplete
- Packets designated as HandshakePackets are always processed
- Packets which are not and are received while IsHandshakeComplete returns false, will be skipped (and ultimately retried)
- This is only applicable at the Handler scope, so MultiplayerSystemComponent can have different requirements than MultiplayerEditorConnection as an example

As part of this, this changes DispatchPacket and related functions from returning a bool to the enum PacketDispatchResult which has values for Success, Pending and Failure. Success and Failure map to what was true and false. Pending indicates that a datum should be skipped and retried.

This is used in the Multiplayer Gem where we use a bool var for IsHandshakeComplete which we set when we ack with the SessionProvider.

Signed-off-by: puvvadar <puvvadar@amazon.com>