### PR TITLE
Expose camera settings to the Editor UI

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportMovement.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportMovement.cpp
@@ -71,7 +71,7 @@ void CEditorPreferencesPage_ViewportMovement::Reflect(AZ::SerializeContext& seri
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSmoothness, "Camera Rotate Smoothness",
                 "Amount of camera smoothing to apply while rotating the camera")
             ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
-            ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::RotateSmoothing)
+            ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::RotateSmoothingVisibility)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_translateSmoothing, "Camera Translate Smoothing",
                 "Is camera translation smoothing enabled or disabled")
@@ -80,7 +80,7 @@ void CEditorPreferencesPage_ViewportMovement::Reflect(AZ::SerializeContext& seri
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSmoothness, "Camera Translate Smoothness",
                 "Amount of camera smoothing to apply while translating the camera")
             ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
-            ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::TranslateSmoothing)
+            ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::TranslateSmoothingVisibility)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_orbitYawRotationInverted, "Camera Orbit Yaw Inverted",
                 "Inverted yaw rotation while orbiting")

--- a/Code/Editor/EditorPreferencesPageViewportMovement.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportMovement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "EditorDefs.h"
 
 #include "EditorPreferencesPageViewportMovement.h"
@@ -12,43 +13,95 @@
 #include <AzQtComponents/Components/StyleManager.h>
 
 // Editor
-#include "Settings.h"
 #include "EditorViewportSettings.h"
+#include "Settings.h"
 
 void CEditorPreferencesPage_ViewportMovement::Reflect(AZ::SerializeContext& serialize)
 {
     serialize.Class<CameraMovementSettings>()
-        ->Version(1)
-        ->Field("MoveSpeed", &CameraMovementSettings::m_moveSpeed)
+        ->Version(2)
+        ->Field("TranslateSpeed", &CameraMovementSettings::m_translateSpeed)
         ->Field("RotateSpeed", &CameraMovementSettings::m_rotateSpeed)
-        ->Field("FastMoveSpeed", &CameraMovementSettings::m_fastMoveSpeed)
-        ->Field("WheelZoomSpeed", &CameraMovementSettings::m_wheelZoomSpeed)
-        ->Field("InvertYAxis", &CameraMovementSettings::m_invertYRotation)
-        ->Field("InvertPan", &CameraMovementSettings::m_invertPan);
+        ->Field("BoostMultiplier", &CameraMovementSettings::m_boostMultiplier)
+        ->Field("ScrollSpeed", &CameraMovementSettings::m_scrollSpeed)
+        ->Field("DollySpeed", &CameraMovementSettings::m_dollySpeed)
+        ->Field("PanSpeed", &CameraMovementSettings::m_panSpeed)
+        ->Field("RotateSmoothing", &CameraMovementSettings::m_rotateSmoothing)
+        ->Field("RotateSmoothness", &CameraMovementSettings::m_rotateSmoothness)
+        ->Field("TranslateSmoothing", &CameraMovementSettings::m_translateSmoothing)
+        ->Field("TranslateSmoothness", &CameraMovementSettings::m_translateSmoothness)
+        ->Field("CaptureCursorLook", &CameraMovementSettings::m_captureCursorLook)
+        ->Field("OrbitYawRotationInverted", &CameraMovementSettings::m_orbitYawRotationInverted)
+        ->Field("PanInvertedX", &CameraMovementSettings::m_panInvertedX)
+        ->Field("PanInvertedY", &CameraMovementSettings::m_panInvertedY);
 
-    serialize.Class<CEditorPreferencesPage_ViewportMovement>()
-        ->Version(1)
-        ->Field("CameraMovementSettings", &CEditorPreferencesPage_ViewportMovement::m_cameraMovementSettings);
+    serialize.Class<CEditorPreferencesPage_ViewportMovement>()->Version(1)->Field(
+        "CameraMovementSettings", &CEditorPreferencesPage_ViewportMovement::m_cameraMovementSettings);
 
-
-    AZ::EditContext* editContext = serialize.GetEditContext();
-    if (editContext)
+    if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
-        editContext->Class<CameraMovementSettings>("Camera Movement Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_moveSpeed, "Camera Movement Speed", "Camera Movement Speed")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSpeed, "Camera Rotation Speed", "Camera Rotation Speed")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_fastMoveSpeed, "Fast Movement Scale", "Fast Movement Scale (holding shift")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_wheelZoomSpeed, "Wheel Zoom Speed", "Wheel Zoom Speed")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_invertYRotation, "Invert Y Axis", "Invert Y Rotation (holding RMB)")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_invertPan, "Invert Pan", "Invert Pan (holding MMB)");
+        editContext->Class<CameraMovementSettings>("Camera Settings", "")
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSpeed, "Camera Movement Speed", "Camera movement speed")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSpeed, "Camera Rotation Speed", "Camera rotation speed")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_boostMultiplier, "Camera Boost Multiplier",
+                "Camera boost multiplier to apply to movement speed")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_scrollSpeed, "Camera Scroll Speed",
+                "Camera movement speed while using scroll/wheel input")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_dollySpeed, "Camera Dolly Speed",
+                "Camera movement speed while using mouse motion to move in and out")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_panSpeed, "Camera Pan Speed",
+                "Camera movement speed while panning using the mouse")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_rotateSmoothing, "Camera Rotate Smoothing",
+                "Is camera rotation smoothing enabled or disabled")
+            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSmoothness, "Camera Rotate Smoothness",
+                "Amount of camera smoothing to apply while rotating the camera")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::RotateSmoothing)
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_translateSmoothing, "Camera Translate Smoothing",
+                "Is camera translation smoothing enabled or disabled")
+            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSmoothness, "Camera Translate Smoothness",
+                "Amount of camera smoothing to apply while translating the camera")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::TranslateSmoothing)
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_orbitYawRotationInverted, "Camera Orbit Yaw Inverted",
+                "Inverted yaw rotation while orbiting")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_panInvertedX, "Invert Pan X",
+                "Invert direction of pan in local X axis")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_panInvertedY, "Invert Pan Y",
+                "Invert direction of pan in local Y axis")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_captureCursorLook, "Camera Capture Look Cursor",
+                "Should the cursor be captured (hidden) while performing free look");
 
-        editContext->Class<CEditorPreferencesPage_ViewportMovement>("Gizmo Movement Preferences", "Gizmo Movement Preferences")
+        editContext->Class<CEditorPreferencesPage_ViewportMovement>("Viewport Preferences", "Viewport Preferences")
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC("PropertyVisibility_ShowChildrenOnly", 0xef428f20))
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportMovement::m_cameraMovementSettings, "Camera Movement Settings", "Camera Movement Settings");
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportMovement::m_cameraMovementSettings,
+                "Camera Movement Settings", "Camera Movement Settings");
     }
 }
-
 
 CEditorPreferencesPage_ViewportMovement::CEditorPreferencesPage_ViewportMovement()
 {
@@ -68,21 +121,36 @@ QIcon& CEditorPreferencesPage_ViewportMovement::GetIcon()
 
 void CEditorPreferencesPage_ViewportMovement::OnApply()
 {
-    SandboxEditor::SetCameraTranslateSpeed(m_cameraMovementSettings.m_moveSpeed);
+    SandboxEditor::SetCameraTranslateSpeed(m_cameraMovementSettings.m_translateSpeed);
     SandboxEditor::SetCameraRotateSpeed(m_cameraMovementSettings.m_rotateSpeed);
-    SandboxEditor::SetCameraBoostMultiplier(m_cameraMovementSettings.m_fastMoveSpeed);
-    SandboxEditor::SetCameraScrollSpeed(m_cameraMovementSettings.m_wheelZoomSpeed);
-    SandboxEditor::SetCameraOrbitYawRotationInverted(m_cameraMovementSettings.m_invertYRotation);
-    SandboxEditor::SetCameraPanInvertedX(m_cameraMovementSettings.m_invertPan);
-    SandboxEditor::SetCameraPanInvertedY(m_cameraMovementSettings.m_invertPan);
+    SandboxEditor::SetCameraBoostMultiplier(m_cameraMovementSettings.m_boostMultiplier);
+    SandboxEditor::SetCameraScrollSpeed(m_cameraMovementSettings.m_scrollSpeed);
+    SandboxEditor::SetCameraDollyMotionSpeed(m_cameraMovementSettings.m_dollySpeed);
+    SandboxEditor::SetCameraPanSpeed(m_cameraMovementSettings.m_panSpeed);
+    SandboxEditor::SetCameraRotateSmoothness(m_cameraMovementSettings.m_rotateSmoothness);
+    SandboxEditor::SetCameraRotateSmoothingEnabled(m_cameraMovementSettings.m_rotateSmoothing);
+    SandboxEditor::SetCameraTranslateSmoothness(m_cameraMovementSettings.m_translateSmoothness);
+    SandboxEditor::SetCameraTranslateSmoothingEnabled(m_cameraMovementSettings.m_translateSmoothing);
+    SandboxEditor::SetCameraCaptureCursorForLook(m_cameraMovementSettings.m_captureCursorLook);
+    SandboxEditor::SetCameraOrbitYawRotationInverted(m_cameraMovementSettings.m_orbitYawRotationInverted);
+    SandboxEditor::SetCameraPanInvertedX(m_cameraMovementSettings.m_panInvertedX);
+    SandboxEditor::SetCameraPanInvertedY(m_cameraMovementSettings.m_panInvertedY);
 }
 
 void CEditorPreferencesPage_ViewportMovement::InitializeSettings()
 {
-    m_cameraMovementSettings.m_moveSpeed = SandboxEditor::CameraTranslateSpeed();
+    m_cameraMovementSettings.m_translateSpeed = SandboxEditor::CameraTranslateSpeed();
     m_cameraMovementSettings.m_rotateSpeed = SandboxEditor::CameraRotateSpeed();
-    m_cameraMovementSettings.m_fastMoveSpeed = SandboxEditor::CameraBoostMultiplier();
-    m_cameraMovementSettings.m_wheelZoomSpeed = SandboxEditor::CameraScrollSpeed();
-    m_cameraMovementSettings.m_invertYRotation = SandboxEditor::CameraOrbitYawRotationInverted();
-    m_cameraMovementSettings.m_invertPan = SandboxEditor::CameraPanInvertedX() && SandboxEditor::CameraPanInvertedY();
+    m_cameraMovementSettings.m_boostMultiplier = SandboxEditor::CameraBoostMultiplier();
+    m_cameraMovementSettings.m_scrollSpeed = SandboxEditor::CameraScrollSpeed();
+    m_cameraMovementSettings.m_dollySpeed = SandboxEditor::CameraDollyMotionSpeed();
+    m_cameraMovementSettings.m_panSpeed = SandboxEditor::CameraPanSpeed();
+    m_cameraMovementSettings.m_rotateSmoothness = SandboxEditor::CameraRotateSmoothness();
+    m_cameraMovementSettings.m_rotateSmoothing = SandboxEditor::CameraRotateSmoothingEnabled();
+    m_cameraMovementSettings.m_translateSmoothness = SandboxEditor::CameraTranslateSmoothness();
+    m_cameraMovementSettings.m_translateSmoothing = SandboxEditor::CameraTranslateSmoothingEnabled();
+    m_cameraMovementSettings.m_captureCursorLook = SandboxEditor::CameraCaptureCursorForLook();
+    m_cameraMovementSettings.m_orbitYawRotationInverted = SandboxEditor::CameraOrbitYawRotationInverted();
+    m_cameraMovementSettings.m_panInvertedX = SandboxEditor::CameraPanInvertedX();
+    m_cameraMovementSettings.m_panInvertedY = SandboxEditor::CameraPanInvertedY();
 }

--- a/Code/Editor/EditorPreferencesPageViewportMovement.h
+++ b/Code/Editor/EditorPreferencesPageViewportMovement.h
@@ -5,17 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
 
 #include "Include/IPreferencesPage.h"
-#include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <QIcon>
 
-
-class CEditorPreferencesPage_ViewportMovement
-    : public IPreferencesPage
+class CEditorPreferencesPage_ViewportMovement : public IPreferencesPage
 {
 public:
     AZ_RTTI(CEditorPreferencesPage_ViewportMovement, "{BC593332-7EAF-4171-8A35-1C5DE5B40909}", IPreferencesPage)
@@ -25,12 +24,22 @@ public:
     CEditorPreferencesPage_ViewportMovement();
     virtual ~CEditorPreferencesPage_ViewportMovement() = default;
 
-    virtual const char* GetCategory() override { return "Viewports"; }
+    virtual const char* GetCategory() override
+    {
+        return "Viewports";
+    }
+
     virtual const char* GetTitle();
     virtual QIcon& GetIcon() override;
     virtual void OnApply() override;
-    virtual void OnCancel() override {}
-    virtual bool OnQueryCancel() override { return true; }
+    virtual void OnCancel() override
+    {
+    }
+
+    virtual bool OnQueryCancel() override
+    {
+        return true;
+    }
 
 private:
     void InitializeSettings();
@@ -39,16 +48,32 @@ private:
     {
         AZ_TYPE_INFO(CameraMovementSettings, "{60B8C07E-5F48-4171-A50B-F45558B5CCA1}")
 
-        float m_moveSpeed;
+        float m_translateSpeed;
         float m_rotateSpeed;
-        float m_fastMoveSpeed;
-        float m_wheelZoomSpeed;
-        bool m_invertYRotation;
-        bool m_invertPan;
+        float m_scrollSpeed;
+        float m_dollySpeed;
+        float m_panSpeed;
+        float m_boostMultiplier;
+        float m_rotateSmoothness;
+        bool m_rotateSmoothing;
+        float m_translateSmoothness;
+        bool m_translateSmoothing;
+        bool m_captureCursorLook;
+        bool m_orbitYawRotationInverted;
+        bool m_panInvertedX;
+        bool m_panInvertedY;
+
+        AZ::Crc32 RotateSmoothing() const
+        {
+            return m_rotateSmoothing ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+        }
+
+        AZ::Crc32 TranslateSmoothing() const
+        {
+            return m_translateSmoothing ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+        }
     };
 
     CameraMovementSettings m_cameraMovementSettings;
     QIcon m_icon;
 };
-
-

--- a/Code/Editor/EditorPreferencesPageViewportMovement.h
+++ b/Code/Editor/EditorPreferencesPageViewportMovement.h
@@ -14,6 +14,11 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <QIcon>
 
+inline AZ::Crc32 EditorPropertyVisibility(const bool enabled)
+{
+    return enabled ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+}
+
 class CEditorPreferencesPage_ViewportMovement : public IPreferencesPage
 {
 public:
@@ -63,14 +68,14 @@ private:
         bool m_panInvertedX;
         bool m_panInvertedY;
 
-        AZ::Crc32 RotateSmoothing() const
+        AZ::Crc32 RotateSmoothingVisibility() const
         {
-            return m_rotateSmoothing ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+            return EditorPropertyVisibility(m_rotateSmoothing);
         }
 
-        AZ::Crc32 TranslateSmoothing() const
+        AZ::Crc32 TranslateSmoothingVisibility() const
         {
-            return m_translateSmoothing ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+            return EditorPropertyVisibility(m_translateSmoothing);
         }
     };
 


### PR DESCRIPTION
Note: This change does not yet include the control settings but I'd ideally like to do that as a separate PR (requires a little more investigation)

Note: The serialization changes do not need to persist as all values are actually stored in the Settings Registry. This is purely to support displaying things in the UI (until we have some sort of cool DOM for the Settings Registry 🙂)