### PR TITLE
Fix UI Editor crashing on initialization when restoring from layout.

### DIFF
--- a/Gems/LyShine/Code/Editor/HierarchyWidget.h
+++ b/Gems/LyShine/Code/Editor/HierarchyWidget.h
@@ -29,6 +29,8 @@ class HierarchyWidget
 
 public:
 
+    AZ_CLASS_ALLOCATOR(HierarchyWidget, AZ::SystemAllocator, 0);
+
     HierarchyWidget(EditorWindow* editorWindow);
     virtual ~HierarchyWidget();
 


### PR DESCRIPTION
After recent changes to unify the StyledTreeWidget functionality, I have been getting a crash whenever I opened the UI Editor.
![image](https://user-images.githubusercontent.com/82231674/130839163-0a1b3937-2513-4bc0-848b-a451bdd5f97c.png)

Adding the allocator explicitly solves the issue.

Thanks @michabr for the fix :D

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>