### PR TITLE
Fix level creation on Linux

### DIFF
--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -2157,7 +2157,6 @@ uint32 CFileUtil::GetAttributes(const char* filename, bool bUseSourceControl /*=
         return SCC_FILE_ATTRIBUTE_READONLY | SCC_FILE_ATTRIBUTE_INPAK;
     }
 
-
     const char* adjustedFile = file.GetAdjustedFilename();
     if (!AZ::IO::SystemFile::Exists(adjustedFile))
     {


### PR DESCRIPTION
Creating a new level on linux would fail due to backslashes being used in mkdir.
Fixed the slashes to use the AZ_CORRECT_FILESYSTEM_SEPARATOR.

relates #3189 