### PR TITLE
Add CMakeUserPresets.json file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__
 AssetProcessorTemp/**
 [Bb]uild/**
 [Oo]ut/**
+CMakeUserPresets.json
 [Cc]ache/
 /install/
 Editor/EditorEventLog.xml


### PR DESCRIPTION
The `CMakeUserPresets.json` file is intended for use by users to save build configurations.