### PR TITLE
Move undefs of problematic Windows defines to PlatformIncl_Windows.h

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.h
@@ -77,11 +77,4 @@ namespace AZ::Debug
     };
 } // namespace AZ::Debug
 
-#ifdef USE_PIX
-// The pix3 header unfortunately brings in other Windows macros we need to undef
-#undef DeleteFile
-#undef LoadImage
-#undef GetCurrentTime
-#endif
-
 #include <AzCore/Debug/Profiler.inl>

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/PlatformIncl_Windows.h
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/PlatformIncl_Windows.h
@@ -74,3 +74,13 @@
 #if defined(GetCommandLine)
 #undef GetCommandLine
 #endif
+#if defined(LoadImage)
+#undef LoadImage
+#endif
+#if defined(DeleteFile)
+#undef DeleteFile
+#endif
+#if defined(GetCurrentTime)
+#undef GetCurrentTime
+#endif
+

--- a/Code/Tools/GridHub/GridHub/main.cpp
+++ b/Code/Tools/GridHub/GridHub/main.cpp
@@ -361,7 +361,7 @@ public:
         else
         {
             // remove from start up folder
-            DeleteFile(fullLinkName);
+            DeleteFileW(fullLinkName);
         }
 #endif
 #if AZ_TRAIT_OS_PLATFORM_APPLE


### PR DESCRIPTION
Compilation when Pix is enabled will fail with recent builds due to changes in the order in which headers are included. This PR promotes the `undef`s for common function names to the system header.