### PR TITLE
Added context menu on game folder status bar item to open project path in file explorer.

### DIFF
--- a/Code/Editor/MainStatusBar.cpp
+++ b/Code/Editor/MainStatusBar.cpp
@@ -15,6 +15,7 @@
 // AzQtComponents
 #include <AzQtComponents/Components/Widgets/CheckBox.h>
 #include <AzQtComponents/Components/Style.h>
+#include <AzQtComponents/Utilities/DesktopUtilities.h>
 
 // Qt
 #include <QMenu>
@@ -209,7 +210,7 @@ MainStatusBar::MainStatusBar(QWidget* parent)
 
     addPermanentWidget(new StatusBarItem(QStringLiteral("connection"), true, this, true), 1);
 
-    addPermanentWidget(new StatusBarItem(QStringLiteral("game_info"), this, true), 1);
+    addPermanentWidget(new GameInfoItem(QStringLiteral("game_info"), this), 1);
 
     addPermanentWidget(new MemoryStatusItem(QStringLiteral("memory"), this), 1);
 }
@@ -220,11 +221,6 @@ void MainStatusBar::Init()
     const int statusbarTimerUpdateInterval{
         500
     };                                             //in ms, so 2 FPS
-
-    AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
-    QString strGameInfo;
-    strGameInfo = tr("GameFolder: '%1'").arg(projectPath.c_str());
-    SetItem(QStringLiteral("game_info"), strGameInfo, tr("Game Info"), QPixmap());
 
     //ask for updates for items regularly. This is basically what MFC does
     auto timer = new QTimer(this);
@@ -434,6 +430,30 @@ QString GeneralStatusItem::CurrentText() const
     }
 
     return StatusBarItem::CurrentText();
+}
+
+GameInfoItem::GameInfoItem(QString name, MainStatusBar* parent)
+    : StatusBarItem(name, parent, true)
+{
+    m_projectPath = QString::fromUtf8(AZ::Utils::GetProjectPath().c_str());
+
+    SetText(QObject::tr("GameFolder: '%1'").arg(m_projectPath));
+    SetToolTip(QObject::tr("Game Info"));
+
+    setContextMenuPolicy(Qt::CustomContextMenu);
+    QObject::connect(this, &QWidget::customContextMenuRequested, this, &GameInfoItem::OnShowContextMenu);
+}
+
+void GameInfoItem::OnShowContextMenu(const QPoint& pos)
+{
+    QMenu contextMenu(this);
+
+    // Context menu action to open the project folder in file browser
+    contextMenu.addAction(AzQtComponents::fileBrowserActionName(), this, [this]() {
+        AzQtComponents::ShowFileOnDesktop(m_projectPath);
+    });
+
+    contextMenu.exec(mapToGlobal(pos));
 }
 
 #include <moc_MainStatusBar.cpp>

--- a/Code/Editor/MainStatusBarItems.h
+++ b/Code/Editor/MainStatusBarItems.h
@@ -71,3 +71,17 @@ public:
 private:
     void updateStatus();
 };
+
+class GameInfoItem
+    : public StatusBarItem
+{
+    Q_OBJECT
+public:
+    GameInfoItem(QString name, MainStatusBar* parent);
+
+private Q_SLOTS:
+    void OnShowContextMenu(const QPoint& pos);
+
+private:
+    QString m_projectPath;
+};


### PR DESCRIPTION
Fixes #3553 

Added context menu to the game folder status bar item with action to open the project path in the file explorer. This uses the ```Code\Framework\AzQtComponents\AzQtComponents\Utilities\DesktopUtilities.cpp``` APIs so will work cross-platform (e.g. will say "Open in Explorer" on windows and open in a windows explorer file browser, will say "Open in Finder" on mac and will open in Finder).

![OpenProjectPathInExplorerFromStatusBar](https://user-images.githubusercontent.com/7519264/131015314-0dfb1ad9-664b-4c1e-815b-a905973c7514.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>