### PR TITLE
Remove Tab Overlay on Project Manager Startup + More Fixes

### DIFF
--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -213,6 +213,10 @@ QTabBar::tab:focus {
                             stop: 0 #555555, stop: 1.0 #777777);
 }
 
+#horizontalSeparatingLine {
+    color: #666666;
+}
+
 /************** Project Settings **************/
 #projectSettings {
     margin-top:42px;
@@ -293,8 +297,6 @@ QTabBar::tab:focus {
     border:none;
 }
 
-
-
 #projectSettingsTab::tab-bar {
     left: 60px;
 }
@@ -360,6 +362,10 @@ QTabBar::tab:focus {
     color: #1e70eb;
 }
 
+#firstTimeContent > QPushButton:focus {
+    border: 1px solid #1e70eb;
+}
+
 #firstTimeContent > QPushButton:pressed {
     border: 1px solid #0e60eb;
     color: #0e60eb;
@@ -400,7 +406,8 @@ QTabBar::tab:focus {
 }
 
 #projectButton > #labelButton:hover,
-#projectButton > #labelButton:pressed  {
+#projectButton > #labelButton:pressed,
+#projectButton > #labelButton:focus {
     border:1px solid #1e70eb;
 }
 

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -192,6 +192,7 @@ namespace O3DE::ProjectManager
         projectFooter->setLayout(hLayout);
         {
             QLabel* projectNameLabel = new QLabel(m_projectInfo.GetProjectDisplayName(), this);
+            projectNameLabel->setToolTip(m_projectInfo.m_path);
             hLayout->addWidget(projectNameLabel);
 
             QMenu* menu = new QMenu(this);

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -176,7 +176,7 @@ namespace O3DE::ProjectManager
     ProjectButton* ProjectsScreen::CreateProjectButton(const ProjectInfo& project)
     {
         ProjectButton* projectButton = new ProjectButton(project, this);
-        m_projectButtons.insert(project.m_path, projectButton);
+        m_projectButtons.insert(QDir::toNativeSeparators(project.m_path), projectButton);
         m_projectsFlowLayout->addWidget(projectButton);
 
         connect(projectButton, &ProjectButton::OpenProject, this, &ProjectsScreen::HandleOpenProject);
@@ -203,7 +203,7 @@ namespace O3DE::ProjectManager
             QSet<QString> keepProject;
             for (const ProjectInfo& project : projectsVector)
             {
-                keepProject.insert(project.m_path);
+                keepProject.insert(QDir::toNativeSeparators(project.m_path));
             }
 
             // Clear flow and delete buttons for removed projects
@@ -214,6 +214,7 @@ namespace O3DE::ProjectManager
 
                 if (!keepProject.contains(projectButtonsIter.key()))
                 {
+                    projectButtonsIter.value()->deleteLater();
                     projectButtonsIter = m_projectButtons.erase(projectButtonsIter);
                 }
                 else
@@ -225,7 +226,7 @@ namespace O3DE::ProjectManager
             QString buildProjectPath = "";
             if (m_currentBuilder)
             {
-                buildProjectPath = m_currentBuilder->GetProjectInfo().m_path;
+                buildProjectPath = QDir::toNativeSeparators(m_currentBuilder->GetProjectInfo().m_path);
             }
 
             // Put currently building project in front, then queued projects, then sorts alphabetically
@@ -259,13 +260,13 @@ namespace O3DE::ProjectManager
             // Add any missing project buttons and restore buttons to default state
             for (const ProjectInfo& project : projectsVector)
             {
-                if (!m_projectButtons.contains(project.m_path))
+                if (!m_projectButtons.contains(QDir::toNativeSeparators(project.m_path)))
                 {
-                    m_projectButtons.insert(project.m_path, CreateProjectButton(project));
+                    m_projectButtons.insert(QDir::toNativeSeparators(project.m_path), CreateProjectButton(project));
                 }
                 else
                 {
-                    auto projectButtonIter = m_projectButtons.find(project.m_path);
+                    auto projectButtonIter = m_projectButtons.find(QDir::toNativeSeparators(project.m_path));
                     if (projectButtonIter != m_projectButtons.end())
                     {
                         projectButtonIter.value()->RestoreDefaultState();
@@ -283,7 +284,7 @@ namespace O3DE::ProjectManager
 
             for (const ProjectInfo& project : m_buildQueue)
             {
-                auto projectIter = m_projectButtons.find(project.m_path);
+                auto projectIter = m_projectButtons.find(QDir::toNativeSeparators(project.m_path));
                 if (projectIter != m_projectButtons.end())
                 {
                     projectIter.value()->SetProjectButtonAction(
@@ -298,7 +299,7 @@ namespace O3DE::ProjectManager
 
             for (const ProjectInfo& project : m_requiresBuild)
             {
-                auto projectIter = m_projectButtons.find(project.m_path);
+                auto projectIter = m_projectButtons.find(QDir::toNativeSeparators(project.m_path));
                 if (projectIter != m_projectButtons.end())
                 {
                     if (project.m_buildFailed)

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -65,6 +65,16 @@ namespace O3DE::ProjectManager
         vLayout->addWidget(m_stack);
 
         connect(reinterpret_cast<ScreensCtrl*>(parent), &ScreensCtrl::NotifyBuildProject, this, &ProjectsScreen::SuggestBuildProject);
+
+        // Will focus whatever button it finds so the Project tab is not focused on start-up
+        QTimer::singleShot(0, this, [this]
+            {
+                QPushButton* foundButton = m_stack->currentWidget()->findChild<QPushButton*>();
+                if (foundButton)
+                {
+                    foundButton->setFocus();
+                }
+            });
     }
 
     ProjectsScreen::~ProjectsScreen()

--- a/Code/Tools/ProjectManager/Source/ScreensCtrl.h
+++ b/Code/Tools/ProjectManager/Source/ScreensCtrl.h
@@ -19,7 +19,7 @@ QT_FORWARD_DECLARE_CLASS(QTabWidget)
 
 namespace O3DE::ProjectManager
 {
-    class ScreenWidget;
+    QT_FORWARD_DECLARE_CLASS(ScreenWidget);
 
     class ScreensCtrl
         : public QWidget


### PR DESCRIPTION
Image right after starting O3DE.exe
![o3de_n9ANNTSXKk](https://user-images.githubusercontent.com/52797929/131201870-c7755652-8835-4c1a-94d8-e22146e42402.png)
Fixes issue similar to this: https://github.com/o3de/o3de/issues/3630

![Lf00oHYkbf](https://user-images.githubusercontent.com/52797929/131203569-e8235589-120b-4777-b2c6-fd1aea9a6805.gif)
Also adds tooltip to the project name that displays the path.
Also fixes issues where project buttons would fail to be found when changing their status because of different path separators.
Also fixed an issue where project buttons weren't deleted when they should be, 
closes #3629