### PR TITLE
Attempt to fix potential race condition in test_MaterialEditorBasicTests() test.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomMaterialEditor_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomMaterialEditor_BasicTests.py
@@ -67,6 +67,7 @@ def run():
     material_editor.save_document_as_child(document_id, target_path)
     material_editor.wait_for_condition(lambda: os.path.exists(target_path), 2.0)
     print(f"New asset created: {os.path.exists(target_path)}")
+    time.sleep(2.0)
 
     # Verify if the newly created document is open
     new_document_id = material_editor.open_material(target_path)
@@ -101,6 +102,7 @@ def run():
     expected_color = math.Color(0.25, 0.25, 0.25, 1.0)
     material_editor.set_property(document_id, property_name, expected_color)
     material_editor.save_document(document_id)
+    time.sleep(2.0)
 
     # 7) Test Case: Saving as a New Material
     # Assign new color to the material file and save the document as copy

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -299,7 +299,7 @@ class TestMaterialEditorBasicTests(object):
             generic_launcher,
             "hydra_AtomMaterialEditor_BasicTests.py",
             run_python="--runpython",
-            timeout=80,
+            timeout=EDITOR_TIMEOUT,
             expected_lines=expected_lines,
             unexpected_lines=unexpected_lines,
             halt_on_unexpected=True,


### PR DESCRIPTION
- Unsure as to the root cause of this error, but it was suggested that it may be race condition related with the AssetProcessor.
- I noticed that some existing "save" calls from `atom_renderer.atom_utils.material_editor_utils.py` had `time.sleep()` calls associated with them, so I did a ctrl+f for other "save" calls in the hydra script and added some where none existed before.
- Also increased the test timeout value itself from 80 to 120 as some of the logs indicate it may be related to that timing as well (it failed after 140 seconds).
```
Executing CTest iteration 1/30
Cannot find file: C:/git/o3de/build/DartConfiguration.tcl
   Site:
   Build name: (empty)
Cannot find file: C:/git/o3de/build/DartConfiguration.tcl
Test project C:/git/o3de/build
    Start 14: AutomatedTesting::AtomRenderer_HydraTests_Main.main::TEST_RUN
1/1 Test #14: AutomatedTesting::AtomRenderer_HydraTests_Main.main::TEST_RUN ...   Passed   37.00 sec
...
...
// a bit further down....
...
...
Test stability summary:
All tests were executed 30 times and passed 100% of the time.
```