### PR TITLE
ATOM-16346 Change Atom setreg path

### DIFF
--- a/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
+++ b/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
@@ -55,6 +55,12 @@ namespace AzGameFramework
 
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_TargetBuildDependencyRegistry(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
 
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM && defined (AZ_DEBUG_BUILD) || defined(AZ_PROFILE_BUILD)
+        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_EngineRegistry(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
+        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_GemRegistries(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
+        AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_ProjectRegistry(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
+#endif
+
         // Used the lowercase the platform name since the bootstrap.game.<config>.<platform>.setreg is being loaded
         // from the asset cache root where all the files are in lowercased from regardless of the filesystem case-sensitivity
         static constexpr char filename[] = "bootstrap.game." AZ_BUILD_CONFIGURATION_TYPE "." AZ_TRAIT_OS_PLATFORM_CODENAME_LOWER ".setreg";

--- a/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
+++ b/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
@@ -55,7 +55,7 @@ namespace AzGameFramework
 
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_TargetBuildDependencyRegistry(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
 
-#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM && defined (AZ_DEBUG_BUILD) || defined(AZ_PROFILE_BUILD)
+#if AZ_TRAIT_OS_IS_HOST_OS_PLATFORM && (defined (AZ_DEBUG_BUILD) || defined(AZ_PROFILE_BUILD))
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_EngineRegistry(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_GemRegistries(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);
         AZ::SettingsRegistryMergeUtils::MergeSettingsToRegistry_ProjectRegistry(registry, AZ_TRAIT_OS_PLATFORM_CODENAME, specializations, &scratchBuffer);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI.Reflect/PlatformLimitsDescriptor.h
@@ -68,7 +68,7 @@ namespace AZ
             HeapMemoryHintParameters m_usageHintParameters;
             HeapAllocationStrategy m_heapAllocationStrategy = HeapAllocationStrategy::MemoryHint;
 
-            void LoadPlatformLimitsDescriptor(const char* rhiName);
+            virtual void LoadPlatformLimitsDescriptor(const char* rhiName);
         };
 
         class PlatformLimits final

--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/PlatformLimitsDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/PlatformLimitsDescriptor.cpp
@@ -77,7 +77,7 @@ namespace AZ
         void PlatformLimitsDescriptor::LoadPlatformLimitsDescriptor(const char* rhiName)
         {
             auto settingsRegistry = AZ::SettingsRegistry::Get();
-            AZStd::string platformLimitsRegPath = AZStd::string::format("/Amazon/Atom/RHI/PlatformLimits/%s", rhiName);
+            AZStd::string platformLimitsRegPath = AZStd::string::format("/O3DE/Atom/RHI/PlatformLimits/%s", rhiName);
             if (!(settingsRegistry &&
                   settingsRegistry->GetObject(this, azrtti_typeid(this), platformLimitsRegPath.c_str())))
             {

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -155,7 +155,7 @@ namespace AZ
             // Some GPU drivers have known issues and it is recommended to update or use other versions.
             auto settingsRegistry = AZ::SettingsRegistry::Get();
             PhysicalDeviceDriverValidator physicalDriverValidator;
-            if (!(settingsRegistry && settingsRegistry->GetObject(physicalDriverValidator, "/Amazon/Atom/RHI/PhysicalDeviceDriverInfo")))
+            if (!(settingsRegistry && settingsRegistry->GetObject(physicalDriverValidator, "/O3DE/Atom/RHI/PhysicalDeviceDriverInfo")))
             {
                 AZ_Printf("RHISystem", "Failed to get settings registry for GPU driver Info.");
             }

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h
@@ -65,6 +65,8 @@ namespace AZ
             AZStd::unordered_map<AZStd::string, AZStd::array<uint32_t, NumHeapFlags>> m_descriptorHeapLimits;
 
             FrameGraphExecuterData m_frameGraphExecuterData;
+
+            void LoadPlatformLimitsDescriptor(const char* rhiName) override;
         };
     }
 }

--- a/Gems/Atom/RHI/Registry/PhysicalDeviceDriverInfo.setreg
+++ b/Gems/Atom/RHI/Registry/PhysicalDeviceDriverInfo.setreg
@@ -8,7 +8,7 @@
 //
 
 {
-    "Amazon":
+    "O3DE":
     {
         "Atom":
         {

--- a/Gems/Atom/RHI/Registry/Platform/Android/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Android/PlatformLimits.setreg
@@ -8,7 +8,7 @@
 //
 
 {
-    "Amazon":
+    "O3DE":
     {
         "Atom":
         {

--- a/Gems/Atom/RHI/Registry/Platform/Linux/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Linux/PlatformLimits.setreg
@@ -8,7 +8,7 @@
 //
 
 {
-    "Amazon":
+    "O3DE":
     {
         "Atom":
         {

--- a/Gems/Atom/RHI/Registry/Platform/Mac/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Mac/PlatformLimits.setreg
@@ -8,7 +8,7 @@
 //
 
 {
-    "Amazon":
+    "O3DE":
     {
         "Atom":
         {

--- a/Gems/Atom/RHI/Registry/Platform/Windows/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Windows/PlatformLimits.setreg
@@ -8,7 +8,7 @@
 //
 
 {
-    "Amazon":
+    "O3DE":
     {
         "Atom":
         {

--- a/Gems/Atom/RHI/Registry/Platform/iOS/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/iOS/PlatformLimits.setreg
@@ -8,7 +8,7 @@
 //
 
 {
-    "Amazon":
+    "O3DE":
     {
         "Atom":
         {


### PR DESCRIPTION
Changed path Amazon to O3DE. Fixed issues that setreg is not loaded in game launchers.