### PR TITLE
Adding a template for nightly build failures

### DIFF
--- a/.github/ISSUE_TEMPLATE/nightly_build_failure_bug_template.md
+++ b/.github/ISSUE_TEMPLATE/nightly_build_failure_bug_template.md
@@ -1,0 +1,36 @@
+---
+name: Nightly Build Error bug report
+about: Create a report when the nightly build process fails
+title: 'Nightly Build Failure'
+labels: 'needs-triage,needs-sig,kind/bug,kind/nightlybuildfailure'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Failure type**
+Build | Asset Processing | Test Tools | Infrastructure | Test
+
+**To Reproduce Test Failures**
+ - Paste the command line that reproduces the test failure
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Logs**
+Attach the Jenkins logs that are relevant to the failure
+
+**Desktop/Device (please complete the following information):**
+ - Device: [e.g. PC, Mac, iPhone, Samsung] 
+ - OS: [e.g. Windows, macOS, iOS, Android]
+ - Version [e.g. 10, Bug Sur, Oreo]
+ - CPU [e.g. Intel I9-9900k , Ryzen 5900x, ]
+ - GPU [AMD 6800 XT, NVidia RTX 3090]
+ - Memory [e.g. 16GB]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Signed-off-by: mcphedar <mcphedar@amazon.com>

This template will be used for nightly build failure reporting.