### PR TITLE
Updates zlib to rev2 of the package, static only

### DIFF
--- a/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
+++ b/cmake/3rdParty/Platform/Android/BuiltInPackages_android.cmake
@@ -27,4 +27,4 @@ ly_associate_package(PACKAGE_NAME googletest-1.8.1-rev4-android      TARGETS goo
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.5.0-rev2-android TARGETS GoogleBenchmark PACKAGE_HASH 20b46e572211a69d7d94ddad1c89ec37bb958711d6ad4025368ac89ea83078fb)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-android   TARGETS libsamplerate   PACKAGE_HASH bf13662afe65d02bcfa16258a4caa9b875534978227d6f9f36c9cfa92b3fb12b)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev1-android        TARGETS OpenSSL         PACKAGE_HASH 4036d4019d722f0e1b7a1621bf60b5a17ca6a65c9c78fd8701cee1131eec8480)
-ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev1-android           TARGETS zlib            PACKAGE_HASH 832b163cae0cccbe4fddc5988f5725fac56ef7dba5bfe95bf8c71281fba2e12c)
+ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev2-android           TARGETS zlib            PACKAGE_HASH 85b730b97176772538cfcacd6b6aaf4655fc2d368d134d6dd55e02f28f183826)

--- a/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
+++ b/cmake/3rdParty/Platform/Linux/BuiltInPackages_linux.cmake
@@ -43,7 +43,7 @@ ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev2-linux                     
 ly_associate_package(PACKAGE_NAME DirectXShaderCompilerDxc-1.6.2104-o3de-rev3-linux TARGETS DirectXShaderCompilerDxc    PACKAGE_HASH 88c4a359325d749bc34090b9ac466424847f3b71ba0de15045cf355c17c07099)
 ly_associate_package(PACKAGE_NAME SPIRVCross-2021.04.29-rev1-linux                  TARGETS SPIRVCross                  PACKAGE_HASH 7889ee5460a688e9b910c0168b31445c0079d363affa07b25d4c8aeb608a0b80)
 ly_associate_package(PACKAGE_NAME azslc-1.7.23-rev2-linux                           TARGETS azslc                       PACKAGE_HASH 1ba84d8321a566d35a1e9aa7400211ba8e6d1c11c08e4be3c93e6e74b8f7aef1)
-ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev1-linux                            TARGETS zlib                        PACKAGE_HASH 6418e93b9f4e6188f3b62cbd3a7822e1c4398a716e786d1522b809a727d08ba9)
+ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev2-linux                            TARGETS zlib                        PACKAGE_HASH 16f3b9e11cda525efb62144f354c1cfc30a5def9eff020dbe49cb00ee7d8234f)
 ly_associate_package(PACKAGE_NAME squish-ccr-deb557d-rev1-linux                     TARGETS squish-ccr                  PACKAGE_HASH 85fecafbddc6a41a27c5f59ed4a5dfb123a94cb4666782cf26e63c0a4724c530)
 ly_associate_package(PACKAGE_NAME ISPCTexComp-36b80aa-rev1-linux                    TARGETS ISPCTexComp                 PACKAGE_HASH 065fd12abe4247dde247330313763cf816c3375c221da030bdec35024947f259)
 

--- a/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
+++ b/cmake/3rdParty/Platform/Mac/BuiltInPackages_mac.cmake
@@ -41,7 +41,7 @@ ly_associate_package(PACKAGE_NAME googlebenchmark-1.5.0-rev2-mac                
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev1-mac                           TARGETS OpenSSL                     PACKAGE_HASH 28adc1c0616ac0482b2a9d7b4a3a3635a1020e87b163f8aba687c501cf35f96c)
 ly_associate_package(PACKAGE_NAME qt-5.15.2-rev5-mac                                TARGETS Qt                          PACKAGE_HASH 9d25918351898b308ded3e9e571fff6f26311b2071aeafd00dd5b249fdf53f7e)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-mac                      TARGETS libsamplerate               PACKAGE_HASH b912af40c0ac197af9c43d85004395ba92a6a859a24b7eacd920fed5854a97fe)
-ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev1-mac                              TARGETS zlib                        PACKAGE_HASH 7fd8a77b3598423d9d6be5f8c60d52aecf346ab4224f563a5282db283aa0da02)
+ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev2-mac                              TARGETS zlib                        PACKAGE_HASH 21714e8a6de4f2523ee92a7f52d51fbee29c5f37ced334e00dc3c029115b472e)
 ly_associate_package(PACKAGE_NAME squish-ccr-deb557d-rev1-mac                       TARGETS squish-ccr                  PACKAGE_HASH 155bfbfa17c19a9cd2ef025de14c5db598f4290045d5b0d83ab58cb345089a77)
 ly_associate_package(PACKAGE_NAME ISPCTexComp-36b80aa-rev1-mac                      TARGETS ISPCTexComp                 PACKAGE_HASH 8a4e93277b8face6ea2fd57c6d017bdb55643ed3d6387110bc5f6b3b884dd169)
 

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -49,6 +49,6 @@ ly_associate_package(PACKAGE_NAME OpenMesh-8.1-rev1-windows                     
 ly_associate_package(PACKAGE_NAME civetweb-1.8-rev1-windows                             TARGETS civetweb                    PACKAGE_HASH 36d0e58a59bcdb4dd70493fb1b177aa0354c945b06c30416348fd326cf323dd4)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev2-windows                           TARGETS OpenSSL                     PACKAGE_HASH 9af1c50343f89146b4053101a7aeb20513319a3fe2f007e356d7ce25f9241040)
 ly_associate_package(PACKAGE_NAME Crashpad-0.8.0-rev1-windows                           TARGETS Crashpad                    PACKAGE_HASH d162aa3070147bc0130a44caab02c5fe58606910252caf7f90472bd48d4e31e2)
-ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev1-windows                              TARGETS zlib                        PACKAGE_HASH 6fb46a0ef8c8614cde3517b50fca47f2a6d1fd059b21f3b8ff13e635ca7f2fa6)
+ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev2-windows                              TARGETS zlib                        PACKAGE_HASH 9afab1d67641ed8bef2fb38fc53942da47f2ab339d9e77d3d20704a48af2da0b)
 ly_associate_package(PACKAGE_NAME squish-ccr-deb557d-rev1-windows                       TARGETS squish-ccr                  PACKAGE_HASH 5c3d9fa491e488ccaf802304ad23b932268a2b2846e383f088779962af2bfa84)
 ly_associate_package(PACKAGE_NAME ISPCTexComp-36b80aa-rev1-windows                      TARGETS ISPCTexComp                 PACKAGE_HASH b6fa6ea28a2808a9a5524c72c37789c525925e435770f2d94eb2d387360fa2d0)

--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -28,4 +28,4 @@ ly_associate_package(PACKAGE_NAME googletest-1.8.1-rev4-ios      TARGETS googlet
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.5.0-rev2-ios TARGETS GoogleBenchmark PACKAGE_HASH c2ffaed2b658892b1bcf81dee4b44cd1cb09fc78d55584ef5cb8ab87f2d8d1ae)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-ios   TARGETS libsamplerate   PACKAGE_HASH 7656b961697f490d4f9c35d2e61559f6fc38c32102e542a33c212cd618fc2119)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev1-ios        TARGETS OpenSSL         PACKAGE_HASH cd0dfce3086a7172777c63dadbaf0ac3695b676119ecb6d0614b5fb1da03462f)
-ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev1-ios           TARGETS zlib            PACKAGE_HASH 20bfccf3b98bd9a7d3506cf344ac48135035eb517752bf9bede1e821f163608d)
+ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev2-ios           TARGETS zlib            PACKAGE_HASH a59fc0f83a02c616b679799310e9d86fde84514c6d2acefa12c6def0ae4a880c)


### PR DESCRIPTION
The previous version of the package was dynamic on some platforms,
and static on others.  This makes it static across the board and
also makes it compatible with other 3p libraries wanting to use
zlib.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>