### PR TITLE
Auto-cut Github issue on build failures from main/development

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -750,10 +750,10 @@ finally {
             } else {
                 buildFailure = tm('${BUILD_FAILURE_ANALYZER}')
                 emailBody = "${BUILD_URL}\n${buildFailure}!"
-                if(env.SNS_TOPIC_GITHUB_ISSUE) {
+                if(env.SNS_TOPIC_BUILD_FAILURE) {
                     message_json = ["build_url":env.BUILD_URL, "repository_name":env.REPOSITORY_NAME, "branch_name":env.BRANCH_NAME, "build_failure":buildFailure]
                     snsPublish(
-                        topicArn: env.SNS_TOPIC_GITHUB_ISSUE,
+                        topicArn: env.SNS_TOPIC_BUILD_FAILURE,
                         subject:'Build Failure',
                         message:JsonOutput.toJson(message_json)
                     )

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -751,10 +751,10 @@ finally {
                 buildFailure = tm('${BUILD_FAILURE_ANALYZER}')
                 emailBody = "${BUILD_URL}\n${buildFailure}!"
                 if(env.SNS_TOPIC_GITHUB_ISSUE) {
-                    message_json = ["repository_name":env.REPOSITORY_NAME, "branch_name":env.BRANCH_NAME, "build_failure":buildFailure]
+                    message_json = ["build_url":env.BUILD_URL, "repository_name":env.REPOSITORY_NAME, "branch_name":env.BRANCH_NAME, "build_failure":buildFailure]
                     snsPublish(
                         topicArn: env.SNS_TOPIC_GITHUB_ISSUE,
-                        subject:'Build Result',
+                        subject:'Build Failure',
                         message:JsonOutput.toJson(message_json)
                     )
                 }

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -750,6 +750,13 @@ finally {
             } else {
                 buildFailure = tm('${BUILD_FAILURE_ANALYZER}')
                 emailBody = "${BUILD_URL}\n${buildFailure}!"
+                if(env.SNS_TOPIC_GITHUB_ISSUE) {
+                    snsPublish(
+                        topicArn: env.SNS_TOPIC_GITHUB_ISSUE,
+                        subject:'Build Result',
+                        message:"${scm.userRemoteConfigs}:${buildFailure}"
+                    )
+                }
             }
             emailext (
                 body: "${emailBody}",

--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+import groovy.json.JsonOutput
 PIPELINE_CONFIG_FILE = 'scripts/build/Jenkins/lumberyard.json'
 INCREMENTAL_BUILD_SCRIPT_PATH = 'scripts/build/bootstrap/incremental_build_util.py'
 
@@ -751,10 +751,11 @@ finally {
                 buildFailure = tm('${BUILD_FAILURE_ANALYZER}')
                 emailBody = "${BUILD_URL}\n${buildFailure}!"
                 if(env.SNS_TOPIC_GITHUB_ISSUE) {
+                    message_json = ["repository_name":env.REPOSITORY_NAME, "branch_name":env.BRANCH_NAME, "build_failure":buildFailure]
                     snsPublish(
                         topicArn: env.SNS_TOPIC_GITHUB_ISSUE,
                         subject:'Build Result',
-                        message:"${scm.userRemoteConfigs}:${buildFailure}"
+                        message:JsonOutput.toJson(message_json)
                     )
                 }
             }


### PR DESCRIPTION
Send build failure root cause data to SNS topic that triggers lambda function to automatically create Github issues.