### PR TITLE
Fix some Qt runtime warnings

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/EntityOutliner.qss
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/EntityOutliner.qss
@@ -48,7 +48,6 @@ OutlinerCheckBox
     spacing: 0px;
     padding: 0px;
     line-height: 0px;
-    font-size: 0px;
     margin: 0px;
     background-color: none;
     max-height: 20px;
@@ -66,7 +65,6 @@ OutlinerCheckBox::indicator
     spacing: 0px;
     padding: 0px;
     line-height: 0px;
-    font-size: 0px;
     margin: 0;
 }
 

--- a/Code/Editor/Style/NewEditorStylesheet.qss
+++ b/Code/Editor/Style/NewEditorStylesheet.qss
@@ -2505,7 +2505,6 @@ OutlinerCheckBox
     spacing: 0px;
     padding: 0px;
     line-height: 0px;
-    font-size: 0px;
     margin: 2px 2px 0 2px;
     background-color: none;
     max-height: 20px;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutliner.qss
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutliner.qss
@@ -43,7 +43,6 @@ AzToolsFramework--EntityOutlinerCheckBox
     padding: 0;
 	padding-right: 2px;
     line-height: 0px;
-    font-size: 0px;
     margin: 0px;
     max-height: 20px;
     max-width: 18px;
@@ -59,7 +58,6 @@ AzToolsFramework--EntityOutlinerCheckBox::indicator
     spacing: 0px;
     padding: 0px;
     line-height: 0px;
-    font-size: 0px;
     margin: 3px 0 0 0;
     max-width: 18px;
     width: 18px;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.cpp
@@ -99,5 +99,6 @@ namespace AzToolsFramework
         
         // Draw border at the bottom
         painter->drawLine(rect.bottomLeft(), rect.bottomRight());
+        painter->restore();
     }
 }


### PR DESCRIPTION
-Fix a missing QPainter::restore call
-Remove 0px font sizes from our qss, which was just getting ignored by Qt and triggering a warning

Signed-off-by: nvsickle <nvsickle@amazon.com>