### PR TITLE
Fixed blast asset reflection

### DIFF
--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
@@ -107,7 +107,7 @@ namespace Blast
         BlastMeshData* m_meshDataComponent = nullptr;
 
         // Configurations
-        const AZ::Data::Asset<BlastAsset> m_blastAsset;
+        AZ::Data::Asset<BlastAsset> m_blastAsset;
         const BlastMaterialId m_materialId{};
         Physics::MaterialId m_physicsMaterialId;
         const BlastActorConfiguration m_actorConfiguration{};


### PR DESCRIPTION
The reflection `Field` function didn't register `Asset<BlastAsset>` class type correctly due to being 'const'.

When running the editor it doesn't crash because the editor blast family component does register the type correctly, since it also has a `Asset<BlastAsset>`, bit not const. But when running the launcher the type doesn't get registered to the generic uuid map and then later it's not able to deserialize it, causing the blast family component to assert.

Signed-off-by: moraaar <moraaar@amazon.com>