### PR TITLE
Fixed assert: Avoid doing operations over invalid Aabb

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/MeshComponentController.cpp
@@ -578,15 +578,14 @@ namespace AZ
         {
             if (m_meshHandle.IsValid() && m_meshFeatureProcessor)
             {
-                Aabb aabb = m_meshFeatureProcessor->GetLocalAabb(m_meshHandle);
+                if (Aabb aabb = m_meshFeatureProcessor->GetLocalAabb(m_meshHandle); aabb.IsValid())
+                {
+                    aabb.MultiplyByScale(m_cachedNonUniformScale);
+                    return aabb;
+                }
+            }
 
-                aabb.MultiplyByScale(m_cachedNonUniformScale);
-                return aabb;
-            }
-            else
-            {
-                return Aabb::CreateNull();
-            }
+            return Aabb::CreateNull();
         }
 
         AzFramework::RenderGeometry::RayResult MeshComponentController::RenderGeometryIntersect(


### PR DESCRIPTION
Writing `MeshComponentController::GetLocalBounds` the same way as `MeshComponentController::GetWorldBounds` to check the `aabb` is correct before doing operations to it.

Signed-off-by: moraaar <moraaar@amazon.com>