### PR TITLE
hot fix for json AZ::Event (as input into nodes) serialization

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -408,7 +408,7 @@ namespace ScriptCanvasEditor::Nodes
         AZ::BehaviorAzEventDescription behaviorAzEventDesc;
         AZ::AttributeReader azEventDescAttributeReader(nullptr, azEventDescAttribute);
         azEventDescAttributeReader.Read<decltype(behaviorAzEventDesc)>(behaviorAzEventDesc);
-        if(behaviorAzEventDesc.m_eventName.empty())
+        if (behaviorAzEventDesc.m_eventName.empty())
         {
             AZ_Error("NodeUtils", false, "Cannot create an AzEvent node with empty event name")
             return {};

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -140,21 +140,10 @@ namespace
         // If the reflected method returns an AZ::Event, reflect it to the SerializeContext
         if (AZ::MethodReturnsAzEventByReferenceOrPointer(method))
         {
-            AZ::SerializeContext* serializeContext{};
-            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
             const AZ::BehaviorParameter* resultParameter = method.GetResult();
-            AZ::SerializeContext::ClassData classData;
-            classData.m_name = resultParameter->m_name;
-            classData.m_typeId = resultParameter->m_typeId;
-            classData.m_azRtti = resultParameter->m_azRtti;
-
-            auto EventPlaceholderAnyCreator = [](AZ::SerializeContext*) -> AZStd::any
-            {
-                return AZStd::make_any<AZStd::monostate>();
-            };
-            serializeContext->RegisterType(resultParameter->m_typeId, AZStd::move(classData), EventPlaceholderAnyCreator);
-
+            ScriptCanvas::ReflectEventTypeOnDemand(resultParameter->m_typeId, resultParameter->m_name, resultParameter->m_azRtti);
         }
+
         nodePaletteModel.RegisterClassNode(categoryPath, behaviorClass ? behaviorClass->m_name : "", name, &method, &behaviorContext, propertyStatus, isOverloaded);
     }
 
@@ -177,19 +166,8 @@ namespace
         // If the reflected method returns an AZ::Event, reflect it to the SerializeContext
         if (AZ::MethodReturnsAzEventByReferenceOrPointer(behaviorMethod))
         {
-            AZ::SerializeContext* serializeContext{};
-            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
             const AZ::BehaviorParameter* resultParameter = behaviorMethod.GetResult();
-            AZ::SerializeContext::ClassData classData;
-            classData.m_name = resultParameter->m_name;
-            classData.m_typeId = resultParameter->m_typeId;
-            classData.m_azRtti = resultParameter->m_azRtti;
-
-            auto EventPlaceholderAnyCreator = [](AZ::SerializeContext*) -> AZStd::any
-            {
-                return AZStd::make_any<AZStd::monostate>();
-            };
-            serializeContext->RegisterType(resultParameter->m_typeId, AZStd::move(classData), EventPlaceholderAnyCreator);
+            ScriptCanvas::ReflectEventTypeOnDemand(resultParameter->m_typeId, resultParameter->m_name, resultParameter->m_azRtti);
 
         }
         nodePaletteModel.RegisterMethodNode(behaviorContext, behaviorMethod);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -153,4 +153,22 @@ namespace ScriptCanvas
         grammarVersion = GrammarVersion::Current;
         runtimeVersion = RuntimeVersion::Current;
     }
+
+    void ReflectEventTypeOnDemand(const AZ::TypeId& typeId, AZStd::string_view name, AZ::IRttiHelper* rttiHelper)
+    {
+        AZ::SerializeContext* serializeContext{};
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+        AZ::SerializeContext::ClassData classData;
+        classData.m_name = name.data();
+        classData.m_typeId = typeId;
+        classData.m_azRtti = rttiHelper;
+
+        auto EventPlaceholderAnyCreator = [](AZ::SerializeContext*) -> AZStd::any
+        {
+            return AZStd::make_any<AZStd::monostate>();
+        };
+
+        serializeContext->RegisterType(typeId, AZStd::move(classData), EventPlaceholderAnyCreator);
+    }
+
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
@@ -279,6 +279,8 @@ namespace ScriptCanvas
         bool m_wasAdded = false;
         AZ::Entity* m_buildEntity = nullptr;
     };
+
+    void ReflectEventTypeOnDemand(const AZ::TypeId& typeId, AZStd::string_view name, AZ::IRttiHelper* rttiHelper = nullptr);
 }
 
 namespace AZStd


### PR DESCRIPTION
Signed-off-by: chcurran <82187351+carlitosan@users.noreply.github.com>

When users write graphs that use the AZ::Event mechanism, the input into their "connect to AZ::Event" nodes can't be serialized in Json. This is now fixed.