### PR TITLE
Fixed a crash issue with RHI::Fence when trying to capture screenshot…

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/FrameCaptureBus.h
@@ -31,6 +31,11 @@ namespace AZ
         {
         public:
             virtual ~FrameCaptureRequests() = default;
+
+            //! Return true if frame capture is available.
+            //! It may return false if null renderer is used.
+            //! If the frame capture is not available, all capture functions in this interface would return false
+            virtual bool CanCapture() const = 0;
             
             //! Capture final screen output for the specified window and save it to given file path.
             //! The image format is determinate by file extension

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -8,6 +8,8 @@
 
 #include "FrameCaptureSystemComponent.h"
 
+#include <Atom/RHI/RHIUtils.h>
+
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
@@ -254,8 +256,18 @@ namespace AZ
             return AZStd::string(resolvedPath);
         }
 
+        bool FrameCaptureSystemComponent::CanCapture() const
+        {
+            return !AZ::RHI::IsNullRenderer();
+        }
+
         bool FrameCaptureSystemComponent::CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle)
         {
+            if (!CanCapture())
+            {
+                return false;
+            }
+
             InitReadback();
 
             if (m_state != State::Idle)
@@ -301,6 +313,11 @@ namespace AZ
 
         bool FrameCaptureSystemComponent::CaptureScreenshotWithPreview(const AZStd::string& outputFilePath)
         {
+            if (!CanCapture())
+            {
+                return false;
+            }
+
             InitReadback();
 
             if (m_state != State::Idle)
@@ -350,6 +367,11 @@ namespace AZ
         bool FrameCaptureSystemComponent::CapturePassAttachment(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slot,
             const AZStd::string& outputFilePath, RPI::PassAttachmentReadbackOption option)
         {
+            if (!CanCapture())
+            {
+                return false;
+            }
+
             InitReadback();
 
             if (m_state != State::Idle)
@@ -396,6 +418,11 @@ namespace AZ
         bool FrameCaptureSystemComponent::CapturePassAttachmentWithCallback(const AZStd::vector<AZStd::string>& passHierarchy, const AZStd::string& slotName
             , RPI::AttachmentReadback::CallbackFunction callback, RPI::PassAttachmentReadbackOption option)
         {
+            if (!CanCapture())
+            {
+                return false;
+            }
+
             bool result = CapturePassAttachment(passHierarchy, slotName, "", option);
 
             // Append state change to user provided call back

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.h
@@ -34,6 +34,7 @@ namespace AZ
             void Deactivate() override;
 
             // FrameCaptureRequestBus overrides ...
+            bool CanCapture() const override;
             bool CaptureScreenshot(const AZStd::string& filePath) override;
             bool CaptureScreenshotForWindow(const AZStd::string& filePath, AzFramework::NativeWindowHandle windowHandle) override;
             bool CaptureScreenshotWithPreview(const AZStd::string& outputFilePath) override;

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/Fence.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <RHI/Fence.h>
+
+
+namespace AZ
+{
+    namespace Null
+    {
+        RHI::Ptr<Fence> Fence::Create()
+        {
+            return aznew Fence();
+        }
+    }
+}

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/Fence.h
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/Fence.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RHI/Fence.h>
+
+namespace AZ
+{
+    namespace Null
+    {
+        class Fence
+            : public RHI::Fence
+        {
+            using Base = RHI::Fence;
+        public:
+            AZ_RTTI(Fence, "{34908F40-A7DE-4EE8-A871-71ACE0C24972}", Base);
+            AZ_CLASS_ALLOCATOR(Fence, AZ::SystemAllocator, 0);
+
+            static RHI::Ptr<Fence> Create();
+            
+        private:
+            Fence() = default;
+            
+            //////////////////////////////////////////////////////////////////////////
+            // RHI::Fence
+            RHI::ResultCode InitInternal([[maybe_unused]] RHI::Device& device, [[maybe_unused]] RHI::FenceState initialState) override { return RHI::ResultCode::Success;}
+            void ShutdownInternal() override {}
+            void SignalOnCpuInternal() override {}
+            void WaitOnCpuInternal() const override {}
+            void ResetInternal() override {}
+            RHI::FenceState GetFenceStateInternal() const override { return RHI::FenceState::Signaled;};
+            //////////////////////////////////////////////////////////////////////////
+        };
+    }
+}

--- a/Gems/Atom/RHI/Null/Code/Source/RHI/SystemComponent.cpp
+++ b/Gems/Atom/RHI/Null/Code/Source/RHI/SystemComponent.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <RHI/BufferPool.h>
 #include <RHI/BufferView.h>
+#include <RHI/Fence.h>
 #include <RHI/FrameGraphExecuter.h>
 #include <RHI/FrameGraphCompiler.h>
 #include <RHI/Image.h>
@@ -99,7 +100,7 @@ namespace AZ
 
         RHI::Ptr<RHI::Fence> SystemComponent::CreateFence()
         {
-            return nullptr;
+            return Fence::Create();
         }
 
         RHI::Ptr<RHI::Buffer> SystemComponent::CreateBuffer()

--- a/Gems/Atom/RHI/Null/Code/atom_rhi_null_private_common_files.cmake
+++ b/Gems/Atom/RHI/Null/Code/atom_rhi_null_private_common_files.cmake
@@ -21,6 +21,8 @@ set(FILES
     Source/RHI/CommandQueue.h
     Source/RHI/Device.cpp
     Source/RHI/Device.h
+    Source/RHI/Fence.cpp
+    Source/RHI/Fence.h
     Source/RHI/FrameGraphCompiler.cpp
     Source/RHI/FrameGraphCompiler.h
     Source/RHI/FrameGraphExecuter.cpp

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/AttachmentReadback.cpp
@@ -21,6 +21,7 @@
 #include <Atom/RHI/FrameGraphExecuteContext.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/RHISystemInterface.h>
+#include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
 
 #include <AzCore/Serialization/Json/JsonUtils.h>
@@ -175,6 +176,11 @@ namespace AZ
 
         bool AttachmentReadback::ReadPassAttachment(const PassAttachment* attachment, const AZ::Name& readbackName)
         {
+            if (AZ::RHI::IsNullRenderer())
+            {
+                return false;
+            }
+
             if (!IsReady())
             {
                 AZ_Assert(false, "AttachmentReadback is not ready to readback an attachment");


### PR DESCRIPTION
… which null renderer is used.

ATOM-16292, ATOM-16243, ATOM-15493

Changes include: 
* Added Fence class to null renderer.
* Return early in frame capture functions and readback function. 

Signed-off-by: qingtao <qingtao@amazon.com>