### PR TITLE
Fix the DefaultGem template's Editor target

### DIFF
--- a/Gems/LyShine/Code/CMakeLists.txt
+++ b/Gems/LyShine/Code/CMakeLists.txt
@@ -29,7 +29,7 @@ ly_add_target(
             Gem::Atom_Utils.Static
             Gem::Atom_Bootstrap.Headers
             Gem::AtomFont
-            Gem::TextureAtlas       
+            Gem::TextureAtlas
 )
 
 ly_add_target(
@@ -151,12 +151,11 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_RPI.Public
                 Gem::Atom_Utils.Static
                 Gem::Atom_Bootstrap.Headers
-    )    
+    )
 
     ly_add_target(
         NAME LyShine.Builders GEM_MODULE
         NAMESPACE Gem
-        OUTPUT_NAME Gem.LyShine.Builders
         FILES_CMAKE
             lyshine_common_module_files.cmake
         COMPILE_DEFINITIONS

--- a/Gems/Terrain/Code/CMakeLists.txt
+++ b/Gems/Terrain/Code/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #
@@ -44,7 +44,7 @@ ly_add_target(
         Gem::LmbrCentral
 )
 
-# the above module is for use in all client/server types 
+# the above module is for use in all client/server types
 ly_create_alias(NAME Terrain.Servers  NAMESPACE Gem TARGETS Gem::Terrain)
 ly_create_alias(NAME Terrain.Clients  NAMESPACE Gem TARGETS Gem::Terrain)
 
@@ -55,7 +55,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME Terrain.Editor MODULE
         NAMESPACE Gem
         AUTOMOC
-        OUTPUT_NAME Gem.Terrain.Editor
         FILES_CMAKE
             terrain_editor_shared_files.cmake
         COMPILE_DEFINITIONS

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -85,7 +85,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME ${Name}.Editor GEM_MODULE
         NAMESPACE Gem
         AUTOMOC
-        OUTPUT_NAME Gem.${Name}.Editor
         FILES_CMAKE
             ${NameLower}_editor_shared_files.cmake
         INCLUDE_DIRECTORIES


### PR DESCRIPTION
Removes the OUTPUT_NAME from the .Editor target in the Gem template.
Removes the same from Gems that have it currently.

relates #3189 