### PR TITLE
[ATOM-5441] Shader Builders May Fail When Multiple  New Files Are Added

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/CMakeLists.txt
@@ -46,4 +46,15 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
             AutomatedTesting.Assets
             Editor
     )
+    ly_add_pytest(
+        NAME AutomatedTesting::AtomRenderer_HydraTests_ShaderBuildPipeline
+        TEST_SUITE main
+        PATH ${CMAKE_CURRENT_LIST_DIR}/test_Atom_ShaderBuildPipelineSuite.py
+        TEST_SERIAL
+        TIMEOUT 600
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
+            Editor
+    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.azsl.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.azsl.txt
@@ -13,7 +13,7 @@
 #include <Atom/Features/SrgSemantics.azsli>
 
 #include "Test1Color.azsli"
-#include "Test3Color.azsli"
+#include <Test3Color.azsli>
 
 ShaderResourceGroup DummySrg : SRG_PerDraw
 {

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.azsl.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.azsl.txt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ /*
+    This is a dummy shader used to validate detection of "#included files"
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+#include "Test1Color.azsli"
+#include "Test3Color.azsli"
+
+ShaderResourceGroup DummySrg : SRG_PerDraw
+{
+    float4 m_color;
+}
+
+struct VSInput
+{
+    float3 m_position : POSITION;
+    float4 m_color : COLOR0;
+};
+
+struct VSOutput
+{
+    float4 m_position : SV_Position;
+    float4 m_color : COLOR0;
+};
+
+VSOutput MainVS(VSInput vsInput)
+{
+    VSOutput OUT;
+    OUT.m_position = float4(vsInput.m_position, 1.0);
+    OUT.m_color = vsInput.m_color;
+    return OUT;
+}
+
+struct PSOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+PSOutput MainPS(VSOutput vsOutput)
+{
+    PSOutput OUT;
+
+    OUT.m_color = GetTest1Color(DummySrg::m_color) + GetTest3Color(DummySrg::m_color);
+
+    return OUT;
+}

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.shader.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.shader.txt
@@ -1,0 +1,25 @@
+{
+    "Source" : "DependencyValidation.azsl",
+
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }
+    },
+
+    "DrawList" : "forward",
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    }
+    
+}

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.shader.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/DependencyValidation.shader.txt
@@ -1,3 +1,4 @@
+// This is a dummy shader used to validate detection of "#included files"
 {
     "Source" : "DependencyValidation.azsl",
 

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/Test1Color.azsli.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/Test1Color.azsli.txt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ /*
+    This is a dummy shader used to validate detection of "#included files"
+ */
+
+#include "Test2Color.azsli"
+
+float4 GetTest1Color(float4 color)
+{
+    return color + GetTest2Color(color);
+}

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/Test2Color.azsli.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/Test2Color.azsli.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ /*
+    This is a dummy shader used to validate detection of "#included files"
+ */
+
+float4 GetTest2Color(float4 color)
+{
+    return color * 0.5; 
+}

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/Test3Color.azsli.txt
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/TestAssets/ShaderAssetBuilder/Test3Color.azsli.txt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ /*
+    This is a dummy shader used to validate detection of "#included files"
+ */
+
+float4 GetTest3Color(float4 color)
+{
+    return color * 0.13; 
+}

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
@@ -56,7 +56,7 @@ def _asset_exists(cache_relative_path):
     asset_id = azasset.AssetCatalogRequestBus(azbus.Broadcast, "GetAssetIdByPath", cache_relative_path, azmath.Uuid(), False)
     return asset_id.is_valid()
 
-# List of results that we want to check, this is not 100% necessary but its a good
+# List of results that we want to check, this is not 100% necessary but it's a good
 # practice to make it easier to debug tests.
 # Here we define a tuple of tests
 class Results():

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
@@ -1,3 +1,11 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+"""
+
 import os
 import shutil
 

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
@@ -131,7 +131,7 @@ def ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges():
         # reported source dependency exists. Once the last file is copied then all source
         # dependencies are fully satisfied and the shader should compile successfully.
         # And this summarizes the importance of this Test: The previous version
-        # of ShaderAssetBuilder::CreateJobs was incapable of compiling the shader unders the conditions
+        # of ShaderAssetBuilder::CreateJobs was incapable of compiling the shader under the conditions
         # presented in this test, but with the new version of ShaderAssetBuilder::CreateJobs, which
         # doesn't use MCPP for #include files discovery, it should eventually compile the shader
         # once all the source files are in place.
@@ -175,7 +175,6 @@ if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Tracer
-    from editor_python_test_tools.asset_utils import Asset
     import ly_test_tools.environment.file_system as fs
 
     Report.start_test(ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges)

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges.py
@@ -1,0 +1,181 @@
+import os
+import shutil
+
+def _copy_file(src_file, src_path, target_file, target_path):
+    # type: (str, str, str, str) -> None
+    """
+    Copies the [src_file] located in [src_path] to the [target_file] located at [target_path].
+    Leaves the [target_file] unlocked for reading and writing privileges
+    :param src_file: The source file to copy (file name)
+    :param src_path: The source file's path
+    :param target_file: The target file to copy into (file name)
+    :param target_path: The target file's path
+    :return: None
+    """
+    target_file_path = os.path.join(target_path, target_file)
+    src_file_path = os.path.join(src_path, src_file)
+    if os.path.exists(target_file_path):
+        fs.unlock_file(target_file_path)
+    shutil.copyfile(src_file_path, target_file_path)
+
+def _copy_tmp_files_in_order(src_directory, file_list, dst_directory, wait_time_in_between = 0.0):
+    # type: (str, list, str, float) -> None
+    """
+    This function assumes that for each file name listed in @file_list
+    there's file named "@filename.txt" which the original source file
+    but they will be copied with just the @filename (.txt removed).
+    """
+    for filename in file_list:
+        src_name = f"{filename}.txt"
+        _copy_file(src_name, src_directory, filename, dst_directory)
+        if wait_time_in_between > 0.0: 
+            print(f"Created {filename} in {dst_directory}")
+            general.idle_wait(wait_time_in_between)
+
+
+def _remove_file(src_file, src_path):
+    # type: (str, str) -> None
+    """
+    Removes the [src_file] located in [src_path].
+    :param src_file: The source file to copy (file name)
+    :param src_path: The source file's path
+    :return: None
+    """
+    src_file_path = os.path.join(src_path, src_file)
+    if os.path.exists(src_file_path):
+        fs.unlock_file(src_file_path)
+        os.remove(src_file_path)
+
+
+def _remove_files(directory, file_list):
+    for filename in file_list:
+        _remove_file(filename, directory)
+
+
+def _asset_exists(cache_relative_path):
+    asset_id = azasset.AssetCatalogRequestBus(azbus.Broadcast, "GetAssetIdByPath", cache_relative_path, azmath.Uuid(), False)
+    return asset_id.is_valid()
+
+# List of results that we want to check, this is not 100% necessary but its a good
+# practice to make it easier to debug tests.
+# Here we define a tuple of tests
+class Results():
+    azshader_was_removed          = ("azshader was removed",        "Failed to remove azshader")
+    azshader_was_compiled         = ("azshader was compiled",       "Failed to compile azshader")
+
+
+def ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges():
+    """
+    This test validates [ATOM-5441] Shader Builders May Fail When Multiple New Files Are Added
+    It creates source assets to compile a particular shader.
+    1- The first phase generates the source assets out of order and slowly. The AP should
+       wakeup each time one of the source dependencies appears but will fail each time. Only when the
+       last dependency appears then the shader should build successfully. 
+    2- The second phase is similar as above, except that all source assets will be created
+       at once and We also expect that in the end the shader is built successfully.
+    """
+    # Required for automated tests
+    helper.init_idle()
+
+    game_root_path = os.path.normpath(general.get_game_folder())
+    game_asset_path = os.path.join(game_root_path, "Assets")
+
+    base_dir = os.path.dirname(__file__)
+    src_assets_subdir = os.path.join(base_dir, "TestAssets", "ShaderAssetBuilder") 
+
+    with Tracer() as error_tracer:
+        # The script drives the execution of the test, to return the flow back to the editor,
+        # we will tick it one time
+        general.idle_wait_frames(1)
+ 
+        # This is the order in which the source assets should be deployed
+        # to avoid source dependency issues with the old MCPP-based CreateJobs. 
+        file_list = [
+            "Test2Color.azsli",
+            "Test3Color.azsli",
+            "Test1Color.azsli",
+            "DependencyValidation.azsl",
+            "DependencyValidation.shader"
+        ]
+
+        reverse_file_list = file_list[::-1]
+
+        # Remove files in reverse order
+        _remove_files(game_asset_path, reverse_file_list)
+
+        # Wait here until the azshader doesn't exist anymore.
+        azshader_name = "assets/dependencyvalidation.azshader"
+        helper.wait_for_condition(lambda: not _asset_exists(azshader_name), 5.0)
+
+        Report.critical_result(Results.azshader_was_removed, not _asset_exists(azshader_name))
+
+        _copy_tmp_files_in_order(src_assets_subdir, file_list, game_asset_path, 1.0)
+
+        # Give enough time to AP to compile the shader
+        helper.wait_for_condition(lambda: _asset_exists(azshader_name), 60.0)
+
+        Report.critical_result(Results.azshader_was_compiled, _asset_exists(azshader_name))
+
+        # The first part was about compiling the shader under normal conditions.
+        # Let's remove the files from the previous phase and will proceed
+        # to make the source files visible to the AP in reverse order. The
+        # ShaderAssetBuilder will only succeed when the last file becomes visible.
+        _remove_files(game_asset_path, reverse_file_list)
+        helper.wait_for_condition(lambda: not _asset_exists(azshader_name), 5.0)
+        Report.critical_result(Results.azshader_was_removed, not _asset_exists(azshader_name))
+
+        # Remark, if you are running this test manually from the Editor with "pyRunFile",
+        # You'll notice how the AP issues notifications that it fails to compile the shader
+        # as the source files are being copied to the "Assets" subfolder.
+        # Those errors are OK and also expected because We need the AP to wake up as each
+        # reported source dependency exists. Once the last file is copied then all source
+        # dependencies are fully satisfied and the shader should compile successfully.
+        # And this summarizes the importance of this Test: The previous version
+        # of ShaderAssetBuilder::CreateJobs was incapable of compiling the shader unders the conditions
+        # presented in this test, but with the new version of ShaderAssetBuilder::CreateJobs, which
+        # doesn't use MCPP for #include files discovery, it should eventually compile the shader
+        # once all the source files are in place.
+        _copy_tmp_files_in_order(src_assets_subdir, reverse_file_list, game_asset_path, 3.0)
+
+        # Give enough time to AP to compile the shader
+        helper.wait_for_condition(lambda: _asset_exists(azshader_name), 60.0)
+
+        Report.critical_result(Results.azshader_was_compiled, _asset_exists(azshader_name))
+
+        # The last phase of the test puts stress on potential race conditions
+        # when all required files appear as soon as possible.
+
+        # First Clean up.
+        # Remove left over files.
+        _remove_files(game_asset_path, reverse_file_list)
+        helper.wait_for_condition(lambda: not _asset_exists(azshader_name), 5.0)
+        Report.critical_result(Results.azshader_was_removed, not _asset_exists(azshader_name))
+
+        # Now let's copy all the source files to the "Assets" folder as fast as possible.
+        _copy_tmp_files_in_order(src_assets_subdir, reverse_file_list, game_asset_path)
+
+        # Give enough time to AP to compile the shader
+        helper.wait_for_condition(lambda: _asset_exists(azshader_name), 60.0)
+
+        Report.critical_result(Results.azshader_was_compiled, _asset_exists(azshader_name))
+
+        # All good, let's cleanup leftover files before closing the test.
+        _remove_files(game_asset_path, reverse_file_list)
+        helper.wait_for_condition(lambda: not _asset_exists(azshader_name), 5.0)
+
+
+if __name__ == "__main__":
+    # All exposed python bindings are in azlmbr
+    import azlmbr.legacy.general as general
+    import azlmbr.bus as azbus
+    import azlmbr.asset as azasset
+    import azlmbr.math as azmath
+
+    # Import report and test helper utilities
+    from editor_python_test_tools.utils import Report
+    from editor_python_test_tools.utils import TestHelper as helper
+    from editor_python_test_tools.utils import Tracer
+    from editor_python_test_tools.asset_utils import Asset
+    import ly_test_tools.environment.file_system as fs
+
+    Report.start_test(ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges)

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_ShaderBuildPipelineSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_ShaderBuildPipelineSuite.py
@@ -1,0 +1,19 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+
+Main suite tests for the Shader Build Pipeline.
+"""
+import pytest
+from ly_test_tools import LAUNCHERS
+from ly_test_tools.o3de.editor_test import EditorTestSuite, EditorSingleTest
+
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+class TestShaderBuildPipelineMain(EditorTestSuite):
+    """Holds tests for Shader Build Pipeline validation"""
+
+    class ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges(EditorSingleTest):
+        from .atom_hydra_scripts import hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges as test_module

--- a/Gems/Atom/Asset/Shader/Code/CMakeLists.txt
+++ b/Gems/Atom/Asset/Shader/Code/CMakeLists.txt
@@ -65,6 +65,7 @@ ly_add_target(
             AZ::AzFramework
             AZ::AzToolsFramework
             Gem::Atom_RHI.Edit
+            Gem::Atom_RPI.Edit
             Gem::Atom_RPI.Public
 )
 

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.h
@@ -141,6 +141,29 @@ namespace AZ
                 const uint32_t rhiUniqueIndex, const AZStd::string& platformIdentifier, const AZStd::string& shaderJsonPath,
                 const uint32_t supervariantIndex, RPI::ShaderAssetSubId shaderAssetSubId);
 
+
+            class IncludedFilesParser
+            {
+            public:
+                IncludedFilesParser();
+                ~IncludedFilesParser() = default;
+
+                //! This static function was made public for testability purposes only.
+                //! Parses the string @haystack, looking for "#include file" lines with a regular expression.
+                //! Returns the list of relative paths as included by the file.
+                //! REMARK: The algorithm may over prescribe what files to include because it doesn't discern between comments, etc.
+                //!         Also, a #include line may be protected by #ifdef macros but this algorithm doesn't care.
+                //! Over prescribing is not a real problem, albeit potential waste in processing. Under prescribing would be a real problem.
+                AZStd::vector<AZStd::string> ParseStringAndGetIncludedFiles(AZStd::string_view haystack) const;
+
+                //! This static function was made public for testability purposes only.
+                //! Opens the file @sourceFilePath, loads the content into a string and returns ParseStringAndGetIncludedFiles(content)
+                AZ::Outcome<AZStd::vector<AZStd::string>, AZStd::string> ParseFileAndGetIncludedFiles(AZStd::string_view sourceFilePath) const;
+
+            private:
+                AZStd::regex m_includeRegex;
+            };
+
         }  // ShaderBuilderUtility namespace
     } // ShaderBuilder namespace
 } // AZ

--- a/Gems/Atom/Asset/Shader/Code/Tests/ShaderBuilderUtilityTests.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Tests/ShaderBuilderUtilityTests.cpp
@@ -49,19 +49,35 @@ namespace UnitTest
         it = AZStd::find(fileList.begin(), fileList.end(), "valid_file3.azsli");
         EXPECT_TRUE(it != fileList.end());
 
-        it = AZStd::find(fileList.begin(), fileList.end(), "a\\dire-ctory\\invalid-file4.azsli");
-        EXPECT_TRUE(it == fileList.end());
-
-        // Remark: Originally this path is using '/' for directory separator, but AZ::ShaderBuilder::ShaderBuilderUtility::IncludedFilesParser
+        // Remark: From now on We must normalize because internally AZ::ShaderBuilder::ShaderBuilderUtility::IncludedFilesParser
         // always returns normalized paths.
-        it = AZStd::find(fileList.begin(), fileList.end(), "a\\directory\\valid-file5.azsli");
-        EXPECT_TRUE(it != fileList.end());
+        {
+            AZStd::string fileName("a\\dire-ctory\\invalid-file4.azsli");
+            AzFramework::StringFunc::Path::Normalize(fileName);
+            it = AZStd::find(fileList.begin(), fileList.end(), fileName);
+            EXPECT_TRUE(it == fileList.end());
+        }
 
-        it = AZStd::find(fileList.begin(), fileList.end(), "a\\dire-ctory\\valid-file6.azsli");
-        EXPECT_TRUE(it != fileList.end());
+        {
+            AZStd::string fileName("a\\directory\\valid-file5.azsli");
+            AzFramework::StringFunc::Path::Normalize(fileName);
+            it = AZStd::find(fileList.begin(), fileList.end(), fileName);
+            EXPECT_TRUE(it != fileList.end());
+        }
 
-        it = AZStd::find(fileList.begin(), fileList.end(), "a\\dire-ctory\\invalid-file7.azsli");
-        EXPECT_TRUE(it == fileList.end());
+        {
+            AZStd::string fileName("a\\dire-ctory\\valid-file6.azsli");
+            AzFramework::StringFunc::Path::Normalize(fileName);
+            it = AZStd::find(fileList.begin(), fileList.end(), fileName);
+            EXPECT_TRUE(it != fileList.end());
+        }
+
+        {
+            AZStd::string fileName("a\\dire-ctory\\invalid-file7.azsli");
+            AzFramework::StringFunc::Path::Normalize(fileName);
+            it = AZStd::find(fileList.begin(), fileList.end(), fileName);
+            EXPECT_TRUE(it == fileList.end());
+        }
     }
 
 } //namespace UnitTest

--- a/Gems/Atom/Asset/Shader/Code/Tests/ShaderBuilderUtilityTests.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Tests/ShaderBuilderUtilityTests.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzTest/AzTest.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+#include "Common/ShaderBuilderTestFixture.h"
+
+#include <ShaderBuilderUtility.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+
+    // The main purpose of this class is to test ShaderBuilderUtility functions
+    class ShaderBuilderUtilityTests : public ShaderBuilderTestFixture
+    {
+    }; // class ShaderBuilderUtilityTests
+
+
+    TEST_F(ShaderBuilderUtilityTests, IncludedFilesParser_ParseStringAndGetIncludedFiles)
+    {
+        AZStd::string haystack(
+            "Some content to parse\n"
+            "#include <valid_file1.azsli>\n"
+            "// #include <valid_file2.azsli>\n"
+            "blah # include \"valid_file3.azsli\"\n"
+            "bar include <a\\dire-ctory\\invalid-file4.azsli>\n"
+            "foo #   include \"a/directory/valid-file5.azsli\"\n"
+            "# include <a\\dire-ctory\\valid-file6.azsli>\n"
+            "#includ \"a\\dire-ctory\\invalid-file7.azsli\"\n"
+        );
+
+        AZ::ShaderBuilder::ShaderBuilderUtility::IncludedFilesParser includedFilesParser;
+        auto fileList = includedFilesParser.ParseStringAndGetIncludedFiles(haystack);
+        EXPECT_EQ(fileList.size(), 5);
+
+        auto it = AZStd::find(fileList.begin(), fileList.end(), "valid_file1.azsli");
+        EXPECT_TRUE(it != fileList.end());
+
+        it = AZStd::find(fileList.begin(), fileList.end(), "valid_file2.azsli");
+        EXPECT_TRUE(it != fileList.end());
+
+        it = AZStd::find(fileList.begin(), fileList.end(), "valid_file3.azsli");
+        EXPECT_TRUE(it != fileList.end());
+
+        it = AZStd::find(fileList.begin(), fileList.end(), "a\\dire-ctory\\invalid-file4.azsli");
+        EXPECT_TRUE(it == fileList.end());
+
+        // Remark: Originally this path is using '/' for directory separator, but AZ::ShaderBuilder::ShaderBuilderUtility::IncludedFilesParser
+        // always returns normalized paths.
+        it = AZStd::find(fileList.begin(), fileList.end(), "a\\directory\\valid-file5.azsli");
+        EXPECT_TRUE(it != fileList.end());
+
+        it = AZStd::find(fileList.begin(), fileList.end(), "a\\dire-ctory\\valid-file6.azsli");
+        EXPECT_TRUE(it != fileList.end());
+
+        it = AZStd::find(fileList.begin(), fileList.end(), "a\\dire-ctory\\invalid-file7.azsli");
+        EXPECT_TRUE(it == fileList.end());
+    }
+
+} //namespace UnitTest
+
+//AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV);
+

--- a/Gems/Atom/Asset/Shader/Code/atom_asset_shader_builders_tests_files.cmake
+++ b/Gems/Atom/Asset/Shader/Code/atom_asset_shader_builders_tests_files.cmake
@@ -11,4 +11,5 @@ set(FILES
     Tests/Common/ShaderBuilderTestFixture.cpp
     Tests/SupervariantCmdArgumentTests.cpp
     Tests/McppBinderTests.cpp
+    Tests/ShaderBuilderUtilityTests.cpp
 )

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurHor.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurHor.azsl
@@ -55,7 +55,7 @@ int GetLdsIndex(int2 ldsPosition)
 
 // --- Common file start ---
 
-// #include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli>
+// include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli> (# removed on purpose)
 // This include fails with the asset processor when generating the .shader for this file
 // Everything below this is copy pasted from FastDepthAwareBlurCommon.azsli up until the
 // "Common file end" marker below

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurHor.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurHor.azsl
@@ -55,7 +55,7 @@ int GetLdsIndex(int2 ldsPosition)
 
 // --- Common file start ---
 
-// include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli> (# removed on purpose)
+// include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli> ('#' symbol before 'include' was removed on purpose to avoid parsing this azsli file during ShaderAssetBuilder::CreateJobs)
 // This include fails with the asset processor when generating the .shader for this file
 // Everything below this is copy pasted from FastDepthAwareBlurCommon.azsli up until the
 // "Common file end" marker below

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurVer.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurVer.azsl
@@ -55,7 +55,7 @@ int GetLdsIndex(int2 ldsPosition)
 
 // --- Common file start ---
 
-// #include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli>
+// include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli> (# removed on purpose)
 // This include fails with the asset processor when generating the .shader for this file
 // Everything below this is copy pasted from FastDepthAwareBlurCommon.azsli up until the
 // "Common file end" marker below

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurVer.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurVer.azsl
@@ -55,7 +55,7 @@ int GetLdsIndex(int2 ldsPosition)
 
 // --- Common file start ---
 
-// include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli> (# removed on purpose)
+// include <Atom/Features/PostProcessing/FastDepthAwareBlurCommon.azsli> ('#' symbol before 'include' was removed on purpose to avoid parsing this azsli file during ShaderAssetBuilder::CreateJobs)
 // This include fails with the asset processor when generating the .shader for this file
 // Everything below this is copy pasted from FastDepthAwareBlurCommon.azsli up until the
 // "Common file end" marker below

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAA.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAA.azsli
@@ -157,7 +157,7 @@
  *         #define SMAA_RT_METRICS float4(1.0 / 1280.0, 1.0 / 720.0, 1280.0, 720.0)
  *         #define SMAA_HLSL_4
  *         #define SMAA_PRESET_HIGH
- *         include "SMAA.h" (# removed on purpose)
+ *         include "SMAA.h" ('#' symbol before 'include' was removed on purpose to avoid parsing this azsli file during ShaderAssetBuilder::CreateJobs)
  *
  *     Note that SMAA_RT_METRICS doesn't need to be a macro, it can be a
  *     uniform variable. The code is designed to minimize the impact of not

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAA.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAA.azsli
@@ -157,7 +157,7 @@
  *         #define SMAA_RT_METRICS float4(1.0 / 1280.0, 1.0 / 720.0, 1280.0, 720.0)
  *         #define SMAA_HLSL_4
  *         #define SMAA_PRESET_HIGH
- *         #include "SMAA.h"
+ *         include "SMAA.h" (# removed on purpose)
  *
  *     Note that SMAA_RT_METRICS doesn't need to be a macro, it can be a
  *     uniform variable. The code is designed to minimize the impact of not


### PR DESCRIPTION
[ATOM-5441] Shader Builders May Fail When Multiple
    New Files Are Added

    ShaderAssetBuilder::CreateJobs now recursively parses *.azsl files
    looking for #include lines and builds the list of source dependencies
    using a depth-first algorithm. It was using MCPP before but not anymore
    (during CreateJobs).

    The new algorithm may over prescribe, but fixes the issues
    when multiple new shader related files are added, at once or out of order, to a game project
    or Gem.

    Overall the new ShaderAssetBuilder::CreateJobs() is around 40% faster
    and, of course, handles source dependencies in a robust way.

Signed-off-by: garrieta <garrieta@amazon.com>