### PR TITLE
Fixed unused variable warnings

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -154,7 +154,7 @@ namespace AZ
     }
 
     bool
-    Trace::WaitForDebugger(float timeoutSeconds/*=-1.f*/)
+    Trace::WaitForDebugger([[maybe_unused]] float timeoutSeconds/*=-1.f*/)
     {
 #if defined(AZ_ENABLE_DEBUG_TOOLS)
         using AZStd::chrono::system_clock;

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Conversions.cpp
@@ -17,8 +17,6 @@ namespace AZ
 {
     namespace Metal
     {
-        static const int INVALID_OFFSET = 0xFFFFFFFF;
-        
         namespace Platform
         {
             MTLPixelFormat ConvertPixelFormat(RHI::Format format);


### PR DESCRIPTION
- Fixed error in iOS profile non-unity build `error: unused variable 'INVALID_OFFSET'`. The global variable is static const only visible to the cpp, removed since it's not used.
- Fixed error in windows release `'timeoutSeconds': unreferenced formal parameter`

Signed-off-by: moraaar <moraaar@amazon.com>