### PR TITLE
Expose the ability to control manipulator line bounds

### DIFF
--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -65,7 +65,7 @@ EditorPreferencesDialog::EditorPreferencesDialog(QWidget* pParent)
             CEditorPreferencesPage_General::Reflect(*serializeContext);
             CEditorPreferencesPage_Files::Reflect(*serializeContext);
             CEditorPreferencesPage_ViewportGeneral::Reflect(*serializeContext);
-            CEditorPreferencesPage_ViewportGizmo::Reflect(*serializeContext);
+            CEditorPreferencesPage_ViewportManipulator::Reflect(*serializeContext);
             CEditorPreferencesPage_ViewportMovement::Reflect(*serializeContext);
             CEditorPreferencesPage_ViewportDebug::Reflect(*serializeContext);
             CEditorPreferencesPage_ExperimentalLighting::Reflect(*serializeContext);

--- a/Code/Editor/EditorPreferencesPageViewportGizmo.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGizmo.cpp
@@ -5,96 +5,57 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "EditorDefs.h"
 
 #include "EditorPreferencesPageViewportGizmo.h"
 
 // Editor
+#include "EditorViewportSettings.h"
 #include "Settings.h"
 
-
-void CEditorPreferencesPage_ViewportGizmo::Reflect(AZ::SerializeContext& serialize)
+void CEditorPreferencesPage_ViewportManipulator::Reflect(AZ::SerializeContext& serialize)
 {
-    serialize.Class<AxisGizmo>()
-        ->Version(1)
-        ->Field("Size", &AxisGizmo::m_size)
-        ->Field("Text", &AxisGizmo::m_text)
-        ->Field("MaxCount", &AxisGizmo::m_maxCount);
+    serialize.Class<Manipulators>()->Version(1)->Field("LineBoundWidth", &Manipulators::m_manipulatorLineBoundWidth);
 
-    serialize.Class<Helpers>()
-        ->Version(1)
-        ->Field("LabelsOn", &Helpers::m_helpersGlobalScale)
-        ->Field("LabelsOn", &Helpers::m_tagpointScaleMulti)
-        ->Field("LabelsOn", &Helpers::m_rulerSphereScale)
-        ->Field("LabelsDistance", &Helpers::m_rulerSphereTrans);
+    serialize.Class<CEditorPreferencesPage_ViewportManipulator>()->Version(2)->Field(
+        "Manipulators", &CEditorPreferencesPage_ViewportManipulator::m_manipulators);
 
-    serialize.Class<CEditorPreferencesPage_ViewportGizmo>()
-        ->Version(1)
-        ->Field("Axis Gizmo", &CEditorPreferencesPage_ViewportGizmo::m_axisGizmo)
-        ->Field("Helpers", &CEditorPreferencesPage_ViewportGizmo::m_helpers);
-
-    AZ::EditContext* editContext = serialize.GetEditContext();
-    if (editContext)
+    if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
-        editContext->Class<AxisGizmo>("Axis Gizmo", "")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AxisGizmo::m_size, "Size", "Axis Gizmo Size")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &AxisGizmo::m_text, "Text Labels", "Text Labels on Axis Gizmo")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &AxisGizmo::m_maxCount, "Max Count", "Max Count of Axis Gizmos");
+        editContext->Class<Manipulators>("Manipulators", "")
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorLineBoundWidth, "Line Bound Width",
+                "Manipulator Line Bound Width")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
+            ->Attribute(AZ::Edit::Attributes::Max, 2.0f);
 
-        editContext->Class<Helpers>("Helpers", "")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Helpers::m_helpersGlobalScale, "Helpers Scale", "Helpers Scale")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
-                ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Helpers::m_tagpointScaleMulti, "Tagpoint Scale Multiplier", "Tagpoint Scale Multiplier")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
-                ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Helpers::m_rulerSphereScale, "Ruler Sphere Scale", "Ruler Sphere Scale")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.1f)
-                ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
-                ->Attribute(AZ::Edit::Attributes::Step, 0.1f)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Helpers::m_rulerSphereTrans, "Ruler Sphere Transparency", "Ruler Sphere Transparency")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
-                ->Attribute(AZ::Edit::Attributes::Max, 100.0f);
-
-        editContext->Class<CEditorPreferencesPage_ViewportGizmo>("Gizmo Viewport Preferences", "Gizmo Viewport Preferences")
+        editContext
+            ->Class<CEditorPreferencesPage_ViewportManipulator>("Manipulator Viewport Preferences", "Manipulator Viewport Preferences")
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC("PropertyVisibility_ShowChildrenOnly", 0xef428f20))
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGizmo::m_axisGizmo, "Axis Gizmo", "Axis Gizmo")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGizmo::m_helpers, "Helpers", "Helpers");
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportManipulator::m_manipulators, "Manipulators", "Manipulators");
     }
 }
 
-CEditorPreferencesPage_ViewportGizmo::CEditorPreferencesPage_ViewportGizmo()
+CEditorPreferencesPage_ViewportManipulator::CEditorPreferencesPage_ViewportManipulator()
 {
     InitializeSettings();
     m_icon = QIcon(":/res/Gizmos.svg");
 }
 
-QIcon& CEditorPreferencesPage_ViewportGizmo::GetIcon()
+QIcon& CEditorPreferencesPage_ViewportManipulator::GetIcon()
 {
     return m_icon;
 }
 
-void CEditorPreferencesPage_ViewportGizmo::OnApply()
+void CEditorPreferencesPage_ViewportManipulator::OnApply()
 {
-    gSettings.gizmo.axisGizmoSize = m_axisGizmo.m_size;
-    gSettings.gizmo.axisGizmoText = m_axisGizmo.m_text;
-    gSettings.gizmo.axisGizmoMaxCount = m_axisGizmo.m_maxCount;
-
-    gSettings.gizmo.helpersScale = m_helpers.m_helpersGlobalScale;
-    gSettings.gizmo.tagpointScaleMulti = m_helpers.m_tagpointScaleMulti;
-    gSettings.gizmo.rulerSphereScale = m_helpers.m_rulerSphereScale;
-    gSettings.gizmo.rulerSphereTrans = m_helpers.m_rulerSphereTrans;
+    SandboxEditor::SetManipulatorLineBoundWidth(m_manipulators.m_manipulatorLineBoundWidth);
 }
 
-void CEditorPreferencesPage_ViewportGizmo::InitializeSettings()
+void CEditorPreferencesPage_ViewportManipulator::InitializeSettings()
 {
-    m_axisGizmo.m_size = gSettings.gizmo.axisGizmoSize;
-    m_axisGizmo.m_text = gSettings.gizmo.axisGizmoText;
-    m_axisGizmo.m_maxCount = gSettings.gizmo.axisGizmoMaxCount;
-
-    m_helpers.m_helpersGlobalScale = gSettings.gizmo.helpersScale;
-    m_helpers.m_tagpointScaleMulti = gSettings.gizmo.tagpointScaleMulti;
-    m_helpers.m_rulerSphereScale = gSettings.gizmo.rulerSphereScale;
-    m_helpers.m_rulerSphereTrans = gSettings.gizmo.rulerSphereTrans;
+    m_manipulators.m_manipulatorLineBoundWidth = SandboxEditor::ManipulatorLineBoundWidth();
 }

--- a/Code/Editor/EditorPreferencesPageViewportGizmo.h
+++ b/Code/Editor/EditorPreferencesPageViewportGizmo.h
@@ -5,59 +5,57 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
 
 #include "Include/IPreferencesPage.h"
-#include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Math/Vector3.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <QIcon>
 
-
-class CEditorPreferencesPage_ViewportGizmo
-    : public IPreferencesPage
+class CEditorPreferencesPage_ViewportManipulator : public IPreferencesPage
 {
 public:
-    AZ_RTTI(CEditorPreferencesPage_ViewportGizmo, "{14433511-8175-4348-954E-82D903475B06}", IPreferencesPage)
+    AZ_RTTI(CEditorPreferencesPage_ViewportManipulator, "{14433511-8175-4348-954E-82D903475B06}", IPreferencesPage)
 
     static void Reflect(AZ::SerializeContext& serialize);
 
-    CEditorPreferencesPage_ViewportGizmo();
-    virtual ~CEditorPreferencesPage_ViewportGizmo() = default;
+    CEditorPreferencesPage_ViewportManipulator();
+    virtual ~CEditorPreferencesPage_ViewportManipulator() = default;
 
-    virtual const char* GetCategory() override { return "Viewports"; }
-    virtual const char* GetTitle() override { return "Gizmos"; }
+    virtual const char* GetCategory() override
+    {
+        return "Viewports";
+    }
+
+    virtual const char* GetTitle() override
+    {
+        return "Manipulators";
+    }
+
     virtual QIcon& GetIcon() override;
     virtual void OnApply() override;
-    virtual void OnCancel() override {}
-    virtual bool OnQueryCancel() override { return true; }
+    virtual void OnCancel() override
+    {
+    }
+
+    virtual bool OnQueryCancel() override
+    {
+        return true;
+    }
 
 private:
     void InitializeSettings();
 
-    struct AxisGizmo
+    struct Manipulators
     {
-        AZ_TYPE_INFO(AxisGizmo, "{7D90D60E-996B-4F54-8748-B26EFA781EE2}")
+        AZ_TYPE_INFO(Manipulators, "{2974439C-4839-41F6-B526-F317999B9DB9}")
 
-        float m_size;
-        bool m_text;
-        int m_maxCount;
+        float m_manipulatorLineBoundWidth;
     };
 
-    struct Helpers
-    {
-        AZ_TYPE_INFO(Helpers, "{EC99922E-F61C-4AA0-9A51-630E09AB55AA}")
-
-        float m_helpersGlobalScale;
-        float m_tagpointScaleMulti;
-        float m_rulerSphereScale;
-        float m_rulerSphereTrans;
-    };
-
-    AxisGizmo m_axisGizmo;
-    Helpers m_helpers;
+    Manipulators m_manipulators;
     QIcon m_icon;
 };
-
-

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -20,6 +20,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view AngleSnappingSetting = "/Amazon/Preferences/Editor/AngleSnapping";
     constexpr AZStd::string_view AngleSizeSetting = "/Amazon/Preferences/Editor/AngleSize";
     constexpr AZStd::string_view ShowGridSetting = "/Amazon/Preferences/Editor/ShowGrid";
+    constexpr AZStd::string_view ManipulatorLineBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/LineBoundWidth";
     constexpr AZStd::string_view CameraTranslateSpeedSetting = "/Amazon/Preferences/Editor/Camera/TranslateSpeed";
     constexpr AZStd::string_view CameraBoostMultiplierSetting = "/Amazon/Preferences/Editor/Camera/BoostMultiplier";
     constexpr AZStd::string_view CameraRotateSpeedSetting = "/Amazon/Preferences/Editor/Camera/RotateSpeed";
@@ -154,6 +155,16 @@ namespace SandboxEditor
     void SetShowingGrid(const bool showing)
     {
         SetRegistry(ShowGridSetting, showing);
+    }
+
+    float ManipulatorLineBoundWidth()
+    {
+        return aznumeric_cast<float>(GetRegistry(ManipulatorLineBoundWidthSetting, 0.1));
+    }
+
+    void SetManipulatorLineBoundWidth(const float lineBoundWidth)
+    {
+        SetRegistry(ManipulatorLineBoundWidthSetting, lineBoundWidth);
     }
 
     float CameraTranslateSpeed()

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -47,6 +47,9 @@ namespace SandboxEditor
     SANDBOX_API bool ShowingGrid();
     SANDBOX_API void SetShowingGrid(bool showing);
 
+    SANDBOX_API float ManipulatorLineBoundWidth();
+    SANDBOX_API void SetManipulatorLineBoundWidth(float lineBoundWidth);
+
     SANDBOX_API float CameraTranslateSpeed();
     SANDBOX_API void SetCameraTranslateSpeed(float speed);
 

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -121,6 +121,7 @@ struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::Vi
     bool ShowGrid() const override;
     bool AngleSnappingEnabled() const override;
     float AngleStep() const override;
+    float ManipulatorLineBoundWidth() const override;
 };
 
 static const EditorViewportSettings g_EditorViewportSettings;
@@ -2557,6 +2558,11 @@ bool EditorViewportSettings::AngleSnappingEnabled() const
 float EditorViewportSettings::AngleStep() const
 {
     return SandboxEditor::AngleSnappingSize();
+}
+
+float EditorViewportSettings::ManipulatorLineBoundWidth() const
+{
+    return SandboxEditor::ManipulatorLineBoundWidth();
 }
 
 AZ_CVAR_EXTERNED(bool, ed_previewGameInFullscreen_once);

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -680,8 +680,8 @@ const SGizmoParameters& CEditorImpl::GetGlobalGizmoParameters()
 
     m_pGizmoParameters->axisConstraint = m_selectedAxis;
     m_pGizmoParameters->referenceCoordSys = m_refCoordsSys;
-    m_pGizmoParameters->axisGizmoScale = gSettings.gizmo.axisGizmoSize;
-    m_pGizmoParameters->axisGizmoText = gSettings.gizmo.axisGizmoText;
+    m_pGizmoParameters->axisGizmoScale = 1.0f;
+    m_pGizmoParameters->axisGizmoText = false;
 
     return *m_pGizmoParameters;
 }

--- a/Code/Editor/Objects/ObjectManager.cpp
+++ b/Code/Editor/Objects/ObjectManager.cpp
@@ -2378,7 +2378,7 @@ void CObjectManager::SetObjectSelected(CBaseObject* pObject, bool bSelect)
 
     if (bSelect && !GetIEditor()->GetTransformManipulator())
     {
-        if (CAxisGizmo::GetGlobalAxisGizmoCount() < gSettings.gizmo.axisGizmoMaxCount)
+        if (CAxisGizmo::GetGlobalAxisGizmoCount() < 1 /*legacy axisGizmoMaxCount*/)
         {
             // Create axis gizmo for this object.
             m_gizmoManager->AddGizmo(new CAxisGizmo(pObject));

--- a/Code/Editor/PreferencesStdPages.cpp
+++ b/Code/Editor/PreferencesStdPages.cpp
@@ -36,7 +36,7 @@ CStdPreferencesClassDesc::CStdPreferencesClassDesc()
         [](){ return new CEditorPreferencesPage_Files(); },
         [](){ return new CEditorPreferencesPage_ViewportGeneral(); },
         [](){ return new CEditorPreferencesPage_ViewportMovement(); },
-        [](){ return new CEditorPreferencesPage_ViewportGizmo(); },
+        [](){ return new CEditorPreferencesPage_ViewportManipulator(); },
         [](){ return new CEditorPreferencesPage_ViewportDebug(); }
     };
 

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -82,7 +82,6 @@ private:
 
 namespace
 {
-
     class QtApplicationListener
         : public AzToolsFramework::EditorEvents::Bus::Handler
     {
@@ -99,20 +98,8 @@ namespace
             delete this;
         }
     };
-
 }
 
-//////////////////////////////////////////////////////////////////////////
-SGizmoSettings::SGizmoSettings()
-{
-    axisGizmoSize = 0.2f;
-    axisGizmoText = true;
-    axisGizmoMaxCount = 50;
-    helpersScale = 1.f;
-    tagpointScaleMulti = 0.5f;
-    rulerSphereScale = 0.5f;
-    rulerSphereTrans = 0.5f;
-}
 //////////////////////////////////////////////////////////////////////////
 SEditorSettings::SEditorSettings()
 {
@@ -564,18 +551,6 @@ void SEditorSettings::Save()
     SaveValue("Settings", "ShowScaleWarnings", viewports.bShowScaleWarnings);
     SaveValue("Settings", "ShowRotationWarnings", viewports.bShowRotationWarnings);
 
-    //////////////////////////////////////////////////////////////////////////
-    // Gizmos.
-    //////////////////////////////////////////////////////////////////////////
-    SaveValue("Settings", "AxisGizmoSize", gizmo.axisGizmoSize);
-    SaveValue("Settings", "AxisGizmoText", gizmo.axisGizmoText);
-    SaveValue("Settings", "AxisGizmoMaxCount", gizmo.axisGizmoMaxCount);
-    SaveValue("Settings", "HelpersScale", gizmo.helpersScale);
-    SaveValue("Settings", "TagPointScaleMulti", gizmo.tagpointScaleMulti);
-    SaveValue("Settings", "RulerSphereScale", gizmo.rulerSphereScale);
-    SaveValue("Settings", "RulerSphereTrans", gizmo.rulerSphereTrans);
-    //////////////////////////////////////////////////////////////////////////
-
     SaveValue("Settings", "TextEditorScript", textEditorForScript);
     SaveValue("Settings", "TextEditorShaders", textEditorForShaders);
     SaveValue("Settings", "TextEditorBSpaces", textEditorForBspaces);
@@ -768,18 +743,6 @@ void SEditorSettings::Load()
     LoadValue("Settings", "WarningIconsDrawDistance", viewports.fWarningIconsDrawDistance);
     LoadValue("Settings", "ShowScaleWarnings", viewports.bShowScaleWarnings);
     LoadValue("Settings", "ShowRotationWarnings", viewports.bShowRotationWarnings);
-
-    //////////////////////////////////////////////////////////////////////////
-    // Gizmos.
-    //////////////////////////////////////////////////////////////////////////
-    LoadValue("Settings", "AxisGizmoSize", gizmo.axisGizmoSize);
-    LoadValue("Settings", "AxisGizmoText", gizmo.axisGizmoText);
-    LoadValue("Settings", "AxisGizmoMaxCount", gizmo.axisGizmoMaxCount);
-    LoadValue("Settings", "HelpersScale", gizmo.helpersScale);
-    LoadValue("Settings", "TagPointScaleMulti", gizmo.tagpointScaleMulti);
-    LoadValue("Settings", "RulerSphereScale", gizmo.rulerSphereScale);
-    LoadValue("Settings", "RulerSphereTrans", gizmo.rulerSphereTrans);
-    //////////////////////////////////////////////////////////////////////////
 
     LoadValue("Settings", "TextEditorScript", textEditorForScript);
     LoadValue("Settings", "TextEditorShaders", textEditorForShaders);

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -22,22 +22,6 @@
 
 #include <AzQtComponents/Components/Widgets/ToolBar.h>
 
-struct SGizmoSettings
-{
-    float axisGizmoSize;
-    bool axisGizmoText;
-    int axisGizmoMaxCount;
-
-    float helpersScale;
-    float tagpointScaleMulti;
-
-    // Scale size and transparency for debug spheres when using Ruler tool
-    float rulerSphereScale;
-    float rulerSphereTrans;
-
-    SGizmoSettings();
-};
-
 //////////////////////////////////////////////////////////////////////////
 // Settings for snapping in the viewports.
 //////////////////////////////////////////////////////////////////////////
@@ -380,8 +364,6 @@ AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 
     //! Keeps the editor active even if no focus is set
     int keepEditorActive;
-
-    SGizmoSettings gizmo;
 
     // Settings of the snapping.
     SSnapSettings snap;

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
@@ -40,11 +40,13 @@ namespace AzManipulatorTestFramework
         float DeviceScalingFactor() override;
     private:
         // ViewportInteractionRequestBus ...
-        bool GridSnappingEnabled();
-        float GridSize();
-        bool ShowGrid();
-        bool AngleSnappingEnabled();
-        float AngleStep();
+        bool GridSnappingEnabled() override;
+        float GridSize() override;
+        bool ShowGrid() override;
+        bool AngleSnappingEnabled() override;
+        float AngleStep() override;
+        float ManipulatorLineBoundWidth() override;
+
         AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition);
     private:
         AZStd::unique_ptr<NullDebugDisplayRequests> m_nullDebugDisplayRequests;

--- a/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
@@ -62,6 +62,11 @@ namespace AzManipulatorTestFramework
         return m_angularStep;
     }
 
+    float ViewportInteraction::ManipulatorLineBoundWidth()
+    {
+        return 0.1f;
+    }
+
     AzFramework::ScreenPoint ViewportInteraction::ViewportWorldToScreen(const AZ::Vector3& worldPosition)
     {
         return AzFramework::WorldToScreen(worldPosition, m_cameraState);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -226,6 +226,8 @@ namespace AzToolsFramework
         m_translationManipulator = AZStd::make_shared<IndexedTranslationManipulator<Vertex>>(
             Dimensions(), vertexIndex, vertex, WorldFromLocalWithUniformScale(entityComponentIdPair.GetEntityId()),
             GetNonUniformScale(entityComponentIdPair.GetEntityId()));
+        m_translationManipulator->m_manipulator.SetLineBoundWidth(
+            AzToolsFramework::ManipulatorLineBoundWidth(AzFramework::InvalidViewportId));
 
         // setup how the manipulator should look
         m_manipulatorConfiguratorFn(&m_translationManipulator->m_manipulator);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ScaleManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ScaleManipulators.cpp
@@ -120,18 +120,18 @@ namespace AzToolsFramework
         const float axisLength, const AZ::Color& axis1Color, const AZ::Color& axis2Color, const AZ::Color& axis3Color)
     {
         const float boxSize = 0.1f;
-        const float lineWidth = 0.05f;
-
         const AZ::Color colors[] = { axis1Color, axis2Color, axis3Color };
 
         for (size_t manipulatorIndex = 0; manipulatorIndex < m_axisScaleManipulators.size(); ++manipulatorIndex)
         {
+            const auto lineLength = axisLength - boxSize;
+
             ManipulatorViews views;
             views.emplace_back(
-                CreateManipulatorViewLine(*m_axisScaleManipulators[manipulatorIndex], colors[manipulatorIndex], axisLength, lineWidth));
+                CreateManipulatorViewLine(*m_axisScaleManipulators[manipulatorIndex], colors[manipulatorIndex], axisLength, m_lineBoundWidth));
             views.emplace_back(CreateManipulatorViewBox(
                 AZ::Transform::CreateIdentity(), colors[manipulatorIndex],
-                m_axisScaleManipulators[manipulatorIndex]->GetAxis() * (axisLength - boxSize), AZ::Vector3(boxSize)));
+                m_axisScaleManipulators[manipulatorIndex]->GetAxis() * lineLength, AZ::Vector3(boxSize)));
             m_axisScaleManipulators[manipulatorIndex]->SetViews(AZStd::move(views));
         }
 
@@ -149,5 +149,10 @@ namespace AzToolsFramework
         }
 
         manipulatorFn(m_uniformScaleManipulator.get());
+    }
+
+    void ScaleManipulators::SetLineBoundWidth(const float lineBoundWidth)
+    {
+        m_lineBoundWidth = lineBoundWidth;
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ScaleManipulators.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ScaleManipulators.h
@@ -41,6 +41,9 @@ namespace AzToolsFramework
 
         void ConfigureView(float axisLength, const AZ::Color& axis1Color, const AZ::Color& axis2Color, const AZ::Color& axis3Color);
 
+        //! Sets the bound width to use for the line/axis of a linear manipulator.
+        void SetLineBoundWidth(float lineBoundWidth);
+
     private:
         AZ_DISABLE_COPY_MOVE(ScaleManipulators)
 
@@ -49,5 +52,6 @@ namespace AzToolsFramework
 
         AZStd::array<AZStd::shared_ptr<LinearManipulator>, 3> m_axisScaleManipulators;
         AZStd::shared_ptr<LinearManipulator> m_uniformScaleManipulator;
+        float m_lineBoundWidth = 0.01f; //!< The default line bound width for the linear manipulator axis.
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
@@ -235,24 +235,25 @@ namespace AzToolsFramework
     }
 
     void TranslationManipulators::ConfigureLinearView(
-        float axisLength,
+        const float axisLength,
         const AZ::Color& axis1Color,
         const AZ::Color& axis2Color,
         const AZ::Color& axis3Color /*= AZ::Color(0.0f, 0.0f, 1.0f, 0.5f)*/)
     {
         const float coneLength = 0.28f;
         const float coneRadius = 0.07f;
-        const float lineWidth = 0.05f;
 
         const AZ::Color axesColor[] = { axis1Color, axis2Color, axis3Color };
 
-        const auto configureLinearView =
-            [lineWidth, coneLength, axisLength, coneRadius](LinearManipulator* linearManipulator, const AZ::Color& color)
+        const auto configureLinearView = [lineBoundWidth = m_lineBoundWidth, coneLength, axisLength,
+                                          coneRadius](LinearManipulator* linearManipulator, const AZ::Color& color)
         {
+            const auto lineLength = axisLength - coneLength;
+
             ManipulatorViews views;
-            views.emplace_back(CreateManipulatorViewLine(*linearManipulator, color, axisLength, lineWidth));
-            views.emplace_back(CreateManipulatorViewCone(
-                *linearManipulator, color, linearManipulator->GetAxis() * (axisLength - coneLength), coneLength, coneRadius));
+            views.emplace_back(CreateManipulatorViewLine(*linearManipulator, color, lineLength, lineBoundWidth));
+            views.emplace_back(
+                CreateManipulatorViewCone(*linearManipulator, color, linearManipulator->GetAxis() * lineLength, coneLength, coneRadius));
             linearManipulator->SetViews(AZStd::move(views));
         };
 
@@ -314,6 +315,11 @@ namespace AzToolsFramework
         {
             manipulatorFn(m_surfaceManipulator.get());
         }
+    }
+
+    void TranslationManipulators::SetLineBoundWidth(const float lineBoundWidth)
+    {
+        m_lineBoundWidth = lineBoundWidth;
     }
 
     void ConfigureTranslationManipulatorAppearance3d(TranslationManipulators* translationManipulators)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.h
@@ -65,7 +65,7 @@ namespace AzToolsFramework
 
         void ConfigureSurfaceView(float radius, const AZ::Color& color);
 
-        //! Sets the bound size to use for the line/axis of a linear manipulator.
+        //! Sets the bound width to use for the line/axis of a linear manipulator.
         void SetLineBoundWidth(float lineBoundWidth);
 
     private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.h
@@ -65,6 +65,9 @@ namespace AzToolsFramework
 
         void ConfigureSurfaceView(float radius, const AZ::Color& color);
 
+        //! Sets the bound size to use for the line/axis of a linear manipulator.
+        void SetLineBoundWidth(float lineBoundWidth);
+
     private:
         AZ_DISABLE_COPY_MOVE(TranslationManipulators)
 
@@ -76,6 +79,7 @@ namespace AzToolsFramework
         AZStd::vector<AZStd::shared_ptr<LinearManipulator>> m_linearManipulators;
         AZStd::vector<AZStd::shared_ptr<PlanarManipulator>> m_planarManipulators;
         AZStd::shared_ptr<SurfaceManipulator> m_surfaceManipulator = nullptr;
+        float m_lineBoundWidth = 0.01f; //!< The default line bound width for the linear manipulator axis.
     };
 
     //! IndexedTranslationManipulator wraps a standard TranslationManipulators and allows it to be linked

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -214,8 +214,12 @@ namespace AzToolsFramework
         class ViewportSettingNotifications
         {
         public:
-            virtual void OnGridSnappingChanged([[maybe_unused]] bool enabled) {}
-            virtual void OnDrawHelpersChanged([[maybe_unused]] bool enabled) {}
+            virtual void OnGridSnappingChanged([[maybe_unused]] bool enabled)
+            {
+            }
+            virtual void OnDrawHelpersChanged([[maybe_unused]] bool enabled)
+            {
+            }
 
         protected:
             ~ViewportSettingNotifications() = default;
@@ -339,5 +343,24 @@ namespace AzToolsFramework
             }
         }
         return AzFramework::ClickDetector::ClickEvent::Nil;
+    }
+
+    //! Wrap EBus call to retrieve manipulator line bound width.
+    //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
+    inline float ManipulatorLineBoundWidth(AzFramework::ViewportId viewportId)
+    {
+        float lineBoundWidth = 0.0f;
+        if (viewportId != AzFramework::InvalidViewportId)
+        {
+            ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+                lineBoundWidth, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::ManipulatorLineBoundWidth);
+        }
+        else
+        {
+            ViewportInteraction::ViewportInteractionRequestBus::BroadcastResult(
+                lineBoundWidth, &ViewportInteraction::ViewportInteractionRequestBus::Events::ManipulatorLineBoundWidth);
+        }
+
+        return lineBoundWidth;
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -156,22 +156,24 @@ namespace AzToolsFramework
         class ViewportInteractionRequests
         {
         public:
-            //! Return the current camera state for this viewport.
+            //! Returns the current camera state for this viewport.
             virtual AzFramework::CameraState GetCameraState() = 0;
-            //! Return if grid snapping is enabled.
+            //! Returns if grid snapping is enabled.
             virtual bool GridSnappingEnabled() = 0;
-            //! Return the grid snapping size.
+            //! Returns the grid snapping size.
             virtual float GridSize() = 0;
             //! Does the grid currently want to be displayed.
             virtual bool ShowGrid() = 0;
-            //! Return if angle snapping is enabled.
+            //! Returns if angle snapping is enabled.
             virtual bool AngleSnappingEnabled() = 0;
-            //! Return the angle snapping/step size.
+            //! Returns the angle snapping/step size.
             virtual float AngleStep() = 0;
-            //! Transform a point in world space to screen space coordinates in Qt Widget space.
+            //! Returns the current line bound width for manipulators.
+            virtual float ManipulatorLineBoundWidth() = 0;
+            //! Transforms a point in world space to screen space coordinates in Qt Widget space.
             //! Multiply by DeviceScalingFactor to get the position in viewport pixel space.
             virtual AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition) = 0;
-            //! Transform a point from Qt widget screen space to world space based on the given clip space depth.
+            //! Transforms a point from Qt widget screen space to world space based on the given clip space depth.
             //! Depth specifies a relative camera depth to project in the range of [0.f, 1.f].
             //! Returns the world space position if successful.
             virtual AZStd::optional<AZ::Vector3> ViewportScreenToWorld(const AzFramework::ScreenPoint& screenPosition, float depth) = 0;
@@ -201,6 +203,8 @@ namespace AzToolsFramework
             virtual bool AngleSnappingEnabled() const = 0;
             //! Return the angle snapping/step size.
             virtual float AngleStep() const = 0;
+            //! Returns the current line bound width for manipulators.
+            virtual float ManipulatorLineBoundWidth() const = 0;
         };
 
         //! Type to inherit to implement ViewportInteractionRequests.
@@ -214,7 +218,7 @@ namespace AzToolsFramework
             virtual void OnDrawHelpersChanged([[maybe_unused]] bool enabled) {}
 
         protected:
-            ViewportSettingNotifications() = default;
+            ~ViewportSettingNotifications() = default;
         };
 
         using ViewportSettingsNotificationBus = AZ::EBus<ViewportSettingNotifications, ViewportEBusTraits>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1249,13 +1249,7 @@ namespace AzToolsFramework
 
         AZStd::unique_ptr<TranslationManipulators> translationManipulators = AZStd::make_unique<TranslationManipulators>(
             TranslationManipulators::Dimensions::Three, AZ::Transform::CreateIdentity(), AZ::Vector3::CreateOne());
-
-        float lineBoundWidth = 0.0f;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            lineBoundWidth, ViewportUi::DefaultViewportId,
-            &ViewportInteraction::ViewportInteractionRequestBus::Events::ManipulatorLineBoundWidth);
-
-        translationManipulators->SetLineBoundWidth(lineBoundWidth);
+        translationManipulators->SetLineBoundWidth(ManipulatorLineBoundWidth(ViewportUi::DefaultViewportId));
 
         InitializeManipulators(*translationManipulators);
 
@@ -1552,6 +1546,7 @@ namespace AzToolsFramework
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         AZStd::unique_ptr<ScaleManipulators> scaleManipulators = AZStd::make_unique<ScaleManipulators>(AZ::Transform::CreateIdentity());
+        scaleManipulators->SetLineBoundWidth(ManipulatorLineBoundWidth(ViewportUi::DefaultViewportId));
 
         InitializeManipulators(*scaleManipulators);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1250,6 +1250,13 @@ namespace AzToolsFramework
         AZStd::unique_ptr<TranslationManipulators> translationManipulators = AZStd::make_unique<TranslationManipulators>(
             TranslationManipulators::Dimensions::Three, AZ::Transform::CreateIdentity(), AZ::Vector3::CreateOne());
 
+        float lineBoundWidth = 0.0f;
+        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+            lineBoundWidth, ViewportUi::DefaultViewportId,
+            &ViewportInteraction::ViewportInteractionRequestBus::Events::ManipulatorLineBoundWidth);
+
+        translationManipulators->SetLineBoundWidth(lineBoundWidth);
+
         InitializeManipulators(*translationManipulators);
 
         ConfigureTranslationManipulatorAppearance3d(&*translationManipulators);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -97,6 +97,7 @@ namespace AtomToolsFramework
         bool ShowGrid() override;
         bool AngleSnappingEnabled() override;
         float AngleStep() override;
+        float ManipulatorLineBoundWidth() override;
         AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition) override;
         AZStd::optional<AZ::Vector3> ViewportScreenToWorld(const AzFramework::ScreenPoint& screenPosition, float depth) override;
         AZStd::optional<AzToolsFramework::ViewportInteraction::ProjectedViewportRay> ViewportScreenToWorldRay(

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -340,6 +340,11 @@ namespace AtomToolsFramework
         return m_viewportSettings ? m_viewportSettings->AngleStep() : 0.0f;
     }
 
+    float RenderViewportWidget::ManipulatorLineBoundWidth()
+    {
+        return m_viewportSettings ? m_viewportSettings->ManipulatorLineBoundWidth() : 0.1f;
+    }
+
     void RenderViewportWidget::SetViewportSettings(const AzToolsFramework::ViewportInteraction::ViewportSettings* viewportSettings)
     {
         m_viewportSettings = viewportSettings;

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
@@ -121,13 +121,12 @@ namespace LmbrCentral
         m_heightManipulator->SetAxis(AZ::Vector3::CreateAxisZ());
 
         const float lineLength = 0.5f;
-        const float lineWidth = 0.05f;
         const float coneLength = 0.28f;
         const float coneRadius = 0.07f;
         ManipulatorViews views;
         views.emplace_back(CreateManipulatorViewLine(
             *m_heightManipulator, AZ::Color(0.0f, 0.0f, 1.0f, 1.0f),
-            lineLength, lineWidth));
+            lineLength, AzToolsFramework::ManipulatorLineBoundWidth(AzFramework::InvalidViewportId)));
         views.emplace_back(CreateManipulatorViewCone(*m_heightManipulator,
             AZ::Color(0.0f, 0.0f, 1.0f, 1.0f), m_heightManipulator->GetAxis() *
             (lineLength - coneLength), coneLength, coneRadius));

--- a/Gems/PhysX/Code/Editor/EditorSubComponentModeAngleCone.cpp
+++ b/Gems/PhysX/Code/Editor/EditorSubComponentModeAngleCone.cpp
@@ -339,14 +339,13 @@ namespace PhysX
     {
         const float coneLength = 0.28f;
         const float coneRadius = 0.07f;
-        const float lineWidth = 0.05f;
 
-        const auto configureLinearView = [lineWidth, coneLength, axisLength, coneRadius](
+        const auto configureLinearView = [coneLength, axisLength, coneRadius](
             AzToolsFramework::LinearManipulator* linearManipulator, const AZ::Color& color)
         {
             AzToolsFramework::ManipulatorViews views;
             views.emplace_back(CreateManipulatorViewLine(
-                *linearManipulator, color, axisLength, lineWidth));
+                *linearManipulator, color, axisLength, AzToolsFramework::ManipulatorLineBoundWidth(AzFramework::InvalidViewportId)));
             views.emplace_back(CreateManipulatorViewCone(
                 *linearManipulator, color, linearManipulator->GetAxis() * (axisLength - coneLength),
                 coneLength, coneRadius));


### PR DESCRIPTION
Resolves #3579 and Fixes #2425

This PR provides the ability to control the manipulator line bound width (the threshold to use for mouse (ray) picking intersections).

It also updates the EditorPreferences page to reflect the relevant manipulator settings and removes the old Gizmo values (these were no longer used). As I don't want to confuse git with the renames + changes, I'm going to leave the filenames as-is for now and will do a follow-up PR to rename to `CEditorPreferencesPage_ViewportManipulator`.

I also added some helpful debug drawing for the manipulator bounds (see `ed_manipulatorDisplayBoundDebug) to visualize what the bounds are, even if the visuals are still just using a line. Might be worth discussing with UX in future if we want to use the cylinder rendering to give a more chunky look for the manipulator, but we'd likely need to have this coincide with updating other manipulators as well (this has just reminded me there might be some other instances I need to update which I'll add to this PR shortly).