### PR TITLE
Set target_file variable since it's still being used in Mac runtime dependencies cmake file

### DIFF
--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -263,6 +263,7 @@ function(ly_delayed_generate_runtime_dependencies)
         # Generate the output file, note the STAMP_OUTPUT_FILE need to match with the one defined in LYWrappers.cmake
         set(STAMP_OUTPUT_FILE ${CMAKE_BINARY_DIR}/runtime_dependencies/$<CONFIG>/${target}_$<CONFIG>.stamp)
         set(target_file_dir "$<TARGET_FILE_DIR:${target}>")
+        set(target_file "$<TARGET_FILE:${target}>")
         ly_file_read(${LY_RUNTIME_DEPENDENCIES_TEMPLATE} template_file)
         string(CONFIGURE "${LY_COPY_COMMANDS}" LY_COPY_COMMANDS @ONLY)
         string(CONFIGURE "${template_file}" configured_template_file @ONLY)


### PR DESCRIPTION
Mac needs this path to fix the library load paths using install name tool for libraries that depend on Python.

Signed-off-by: amzn-sj <srikkant@amazon.com>