### PR TITLE
Expose setting to adjust angular manipulator circle bound

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportGizmo.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGizmo.cpp
@@ -16,7 +16,10 @@
 
 void CEditorPreferencesPage_ViewportManipulator::Reflect(AZ::SerializeContext& serialize)
 {
-    serialize.Class<Manipulators>()->Version(1)->Field("LineBoundWidth", &Manipulators::m_manipulatorLineBoundWidth);
+    serialize.Class<Manipulators>()
+        ->Version(1)
+        ->Field("LineBoundWidth", &Manipulators::m_manipulatorLineBoundWidth)
+        ->Field("CircleBoundWidth", &Manipulators::m_manipulatorCircleBoundWidth);
 
     serialize.Class<CEditorPreferencesPage_ViewportManipulator>()->Version(2)->Field(
         "Manipulators", &CEditorPreferencesPage_ViewportManipulator::m_manipulators);
@@ -27,6 +30,11 @@ void CEditorPreferencesPage_ViewportManipulator::Reflect(AZ::SerializeContext& s
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorLineBoundWidth, "Line Bound Width",
                 "Manipulator Line Bound Width")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
+            ->Attribute(AZ::Edit::Attributes::Max, 2.0f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &Manipulators::m_manipulatorCircleBoundWidth, "Circle Bound Width",
+                "Manipulator Circle Bound Width")
             ->Attribute(AZ::Edit::Attributes::Min, 0.001f)
             ->Attribute(AZ::Edit::Attributes::Max, 2.0f);
 
@@ -53,9 +61,11 @@ QIcon& CEditorPreferencesPage_ViewportManipulator::GetIcon()
 void CEditorPreferencesPage_ViewportManipulator::OnApply()
 {
     SandboxEditor::SetManipulatorLineBoundWidth(m_manipulators.m_manipulatorLineBoundWidth);
+    SandboxEditor::SetManipulatorCircleBoundWidth(m_manipulators.m_manipulatorCircleBoundWidth);
 }
 
 void CEditorPreferencesPage_ViewportManipulator::InitializeSettings()
 {
     m_manipulators.m_manipulatorLineBoundWidth = SandboxEditor::ManipulatorLineBoundWidth();
+    m_manipulators.m_manipulatorCircleBoundWidth = SandboxEditor::ManipulatorCircleBoundWidth();
 }

--- a/Code/Editor/EditorPreferencesPageViewportGizmo.h
+++ b/Code/Editor/EditorPreferencesPageViewportGizmo.h
@@ -54,6 +54,7 @@ private:
         AZ_TYPE_INFO(Manipulators, "{2974439C-4839-41F6-B526-F317999B9DB9}")
 
         float m_manipulatorLineBoundWidth;
+        float m_manipulatorCircleBoundWidth;
     };
 
     Manipulators m_manipulators;

--- a/Code/Editor/EditorPreferencesPageViewportGizmo.h
+++ b/Code/Editor/EditorPreferencesPageViewportGizmo.h
@@ -53,8 +53,8 @@ private:
     {
         AZ_TYPE_INFO(Manipulators, "{2974439C-4839-41F6-B526-F317999B9DB9}")
 
-        float m_manipulatorLineBoundWidth;
-        float m_manipulatorCircleBoundWidth;
+        float m_manipulatorLineBoundWidth = 0.0f;
+        float m_manipulatorCircleBoundWidth = 0.0f;
     };
 
     Manipulators m_manipulators;

--- a/Code/Editor/EditorPreferencesPageViewportMovement.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportMovement.cpp
@@ -100,29 +100,30 @@ void CEditorPreferencesPage_ViewportMovement::Reflect(AZ::SerializeContext& seri
 
     if (AZ::EditContext* editContext = serialize.GetEditContext())
     {
+        const float minValue = 0.0001f;
         editContext->Class<CameraMovementSettings>("Camera Movement Settings", "")
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSpeed, "Camera Movement Speed", "Camera movement speed")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSpeed, "Camera Rotation Speed", "Camera rotation speed")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_boostMultiplier, "Camera Boost Multiplier",
                 "Camera boost multiplier to apply to movement speed")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_scrollSpeed, "Camera Scroll Speed",
                 "Camera movement speed while using scroll/wheel input")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_dollySpeed, "Camera Dolly Speed",
                 "Camera movement speed while using mouse motion to move in and out")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_panSpeed, "Camera Pan Speed",
                 "Camera movement speed while panning using the mouse")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_rotateSmoothing, "Camera Rotate Smoothing",
                 "Is camera rotation smoothing enabled or disabled")
@@ -130,7 +131,7 @@ void CEditorPreferencesPage_ViewportMovement::Reflect(AZ::SerializeContext& seri
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_rotateSmoothness, "Camera Rotate Smoothness",
                 "Amount of camera smoothing to apply while rotating the camera")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::RotateSmoothingVisibility)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_translateSmoothing, "Camera Translate Smoothing",
@@ -139,7 +140,7 @@ void CEditorPreferencesPage_ViewportMovement::Reflect(AZ::SerializeContext& seri
             ->DataElement(
                 AZ::Edit::UIHandlers::SpinBox, &CameraMovementSettings::m_translateSmoothness, "Camera Translate Smoothness",
                 "Amount of camera smoothing to apply while translating the camera")
-            ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
+            ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::TranslateSmoothingVisibility)
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_orbitYawRotationInverted, "Camera Orbit Yaw Inverted",

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -21,6 +21,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view AngleSizeSetting = "/Amazon/Preferences/Editor/AngleSize";
     constexpr AZStd::string_view ShowGridSetting = "/Amazon/Preferences/Editor/ShowGrid";
     constexpr AZStd::string_view ManipulatorLineBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/LineBoundWidth";
+    constexpr AZStd::string_view ManipulatorCircleBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/CircleBoundWidth";
     constexpr AZStd::string_view CameraTranslateSpeedSetting = "/Amazon/Preferences/Editor/Camera/TranslateSpeed";
     constexpr AZStd::string_view CameraBoostMultiplierSetting = "/Amazon/Preferences/Editor/Camera/BoostMultiplier";
     constexpr AZStd::string_view CameraRotateSpeedSetting = "/Amazon/Preferences/Editor/Camera/RotateSpeed";
@@ -165,6 +166,16 @@ namespace SandboxEditor
     void SetManipulatorLineBoundWidth(const float lineBoundWidth)
     {
         SetRegistry(ManipulatorLineBoundWidthSetting, lineBoundWidth);
+    }
+
+    float ManipulatorCircleBoundWidth()
+    {
+        return aznumeric_cast<float>(GetRegistry(ManipulatorCircleBoundWidthSetting, 0.1));
+    }
+
+    void SetManipulatorCircleBoundWidth(const float circleBoundWidth)
+    {
+        SetRegistry(ManipulatorCircleBoundWidthSetting, circleBoundWidth);
     }
 
     float CameraTranslateSpeed()

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -50,6 +50,9 @@ namespace SandboxEditor
     SANDBOX_API float ManipulatorLineBoundWidth();
     SANDBOX_API void SetManipulatorLineBoundWidth(float lineBoundWidth);
 
+    SANDBOX_API float ManipulatorCircleBoundWidth();
+    SANDBOX_API void SetManipulatorCircleBoundWidth(float circleBoundWidth);
+
     SANDBOX_API float CameraTranslateSpeed();
     SANDBOX_API void SetCameraTranslateSpeed(float speed);
 

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2563,6 +2563,11 @@ float EditorViewportSettings::ManipulatorLineBoundWidth() const
     return SandboxEditor::ManipulatorLineBoundWidth();
 }
 
+float EditorViewportSettings::ManipulatorCircleBoundWidth() const
+{
+    return SandboxEditor::ManipulatorCircleBoundWidth();
+}
+
 AZ_CVAR_EXTERNED(bool, ed_previewGameInFullscreen_once);
 
 bool EditorViewportWidget::ShouldPreviewFullscreen() const

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -113,19 +113,6 @@ void StartFixedCursorMode(QObject *viewport);
 #define RENDER_MESH_TEST_DISTANCE (0.2f)
 #define CURSOR_FONT_HEIGHT  8.0f
 
-//! Viewport settings for the EditorViewportWidget
-struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::ViewportSettings
-{
-    bool GridSnappingEnabled() const override;
-    float GridSize() const override;
-    bool ShowGrid() const override;
-    bool AngleSnappingEnabled() const override;
-    float AngleStep() const override;
-    float ManipulatorLineBoundWidth() const override;
-};
-
-static const EditorViewportSettings g_EditorViewportSettings;
-
 namespace AZ::ViewportHelpers
 {
     static const char TextCantCreateCameraNoLevel[] = "Cannot create camera when no level is loaded.";
@@ -219,6 +206,7 @@ EditorViewportWidget::~EditorViewportWidget()
         m_pPrimaryViewport = nullptr;
     }
 
+    m_editorViewportSettings.Disconnect();
     DisconnectViewportInteractionRequestBus();
     m_editorEntityNotifications.reset();
     Camera::EditorCameraRequestBus::Handler::BusDisconnect();
@@ -1074,7 +1062,7 @@ void EditorViewportWidget::SetViewportId(int id)
     m_editorModularViewportCameraComposer = AZStd::make_unique<SandboxEditor::EditorModularViewportCameraComposer>(AzFramework::ViewportId(id));
     m_renderViewport->GetControllerList()->Add(m_editorModularViewportCameraComposer->CreateModularViewportCameraController());
 
-    m_renderViewport->SetViewportSettings(&g_EditorViewportSettings);
+    m_editorViewportSettings.Connect(AzFramework::ViewportId(id));
 
     UpdateScene();
 
@@ -2533,6 +2521,16 @@ void EditorViewportWidget::SetAsActiveViewport()
             viewportContextManager->RenameViewportContext(viewportContext, defaultContextName);
         }
     }
+}
+
+void EditorViewportSettings::Connect(const AzFramework::ViewportId viewportId)
+{
+    AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler::BusConnect(viewportId);
+}
+
+void EditorViewportSettings::Disconnect()
+{
+    AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler::BusDisconnect();
 }
 
 bool EditorViewportSettings::GridSnappingEnabled() const

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -63,6 +63,21 @@ namespace AzToolsFramework
     class ManipulatorManager;
 }
 
+//! Viewport settings for the EditorViewportWidget
+struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler
+{
+    void Connect(AzFramework::ViewportId viewportId);
+    void Disconnect();
+
+    // ViewportSettingsRequestBus overrides ...
+    bool GridSnappingEnabled() const override;
+    float GridSize() const override;
+    bool ShowGrid() const override;
+    bool AngleSnappingEnabled() const override;
+    float AngleStep() const override;
+    float ManipulatorLineBoundWidth() const override;
+};
+
 // EditorViewportWidget window
 AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
@@ -338,7 +353,7 @@ private:
     // Note that any attempts to draw anything with this object will crash. Exists here for legacy "reasons"
     DisplayContext m_displayContext;
 
-    // Re-entrency guard for on paint events
+    // Reentrancy guard for on paint events
     bool m_isOnPaint = false;
 
     // Shapes of various safe frame helpers which can be displayed in the editor
@@ -380,6 +395,9 @@ private:
 
     // Atom debug display
     AzFramework::DebugDisplayRequests* m_debugDisplay = nullptr;
+
+    // Type to return current state of editor viewport settings
+    EditorViewportSettings m_editorViewportSettings;
 
     // The default view created for the viewport context, which is used as the "Editor Camera"
     AZ::RPI::ViewPtr m_defaultView;

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -76,6 +76,7 @@ struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::Vi
     bool AngleSnappingEnabled() const override;
     float AngleStep() const override;
     float ManipulatorLineBoundWidth() const override;
+    float ManipulatorCircleBoundWidth() const override;
 };
 
 // EditorViewportWidget window

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
@@ -17,14 +17,14 @@ namespace AzManipulatorTestFramework
     //! Implementation of the viewport interaction model to handle viewport interaction requests.
     class ViewportInteraction
         : public ViewportInteractionInterface
-        , private AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler
+        , public AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler
+        , public AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler
     {
     public:
         ViewportInteraction();
         ~ViewportInteraction();
 
-        // ViewportInteractionInterface ...
-        AzFramework::CameraState GetCameraState() override;
+        // ViewportInteractionInterface overrides ...
         void SetCameraState(const AzFramework::CameraState& cameraState) override;
         AzFramework::DebugDisplayRequests& GetDebugDisplay() override;
         void EnableGridSnaping() override;
@@ -34,20 +34,23 @@ namespace AzManipulatorTestFramework
         void SetGridSize(float size) override;
         void SetAngularStep(float step) override;
         int GetViewportId() const override;
+
+        // ViewportInteractionRequestBus overrides ...
+        AzFramework::CameraState GetCameraState() override;
+        AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition);
         AZStd::optional<AZ::Vector3> ViewportScreenToWorld(const AzFramework::ScreenPoint& screenPosition, float depth) override;
         AZStd::optional<AzToolsFramework::ViewportInteraction::ProjectedViewportRay> ViewportScreenToWorldRay(
             const AzFramework::ScreenPoint& screenPosition) override;
         float DeviceScalingFactor() override;
-    private:
-        // ViewportInteractionRequestBus ...
-        bool GridSnappingEnabled() override;
-        float GridSize() override;
-        bool ShowGrid() override;
-        bool AngleSnappingEnabled() override;
-        float AngleStep() override;
-        float ManipulatorLineBoundWidth() override;
 
-        AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition);
+        // ViewportSettingsRequestBus overrides ...
+        bool GridSnappingEnabled() const override;
+        float GridSize() const override;
+        bool ShowGrid() const override;
+        bool AngleSnappingEnabled() const override;
+        float AngleStep() const override;
+        float ManipulatorLineBoundWidth() const override;
+
     private:
         AZStd::unique_ptr<NullDebugDisplayRequests> m_nullDebugDisplayRequests;
         const int m_viewportId = 1234; // Arbitrary viewport id for manipulator tests

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
@@ -50,6 +50,7 @@ namespace AzManipulatorTestFramework
         bool AngleSnappingEnabled() const override;
         float AngleStep() const override;
         float ManipulatorLineBoundWidth() const override;
+        float ManipulatorCircleBoundWidth() const override;
 
     private:
         AZStd::unique_ptr<NullDebugDisplayRequests> m_nullDebugDisplayRequests;

--- a/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
@@ -69,6 +69,11 @@ namespace AzManipulatorTestFramework
         return 0.1f;
     }
 
+    float ViewportInteraction::ManipulatorCircleBoundWidth() const
+    {
+        return 0.1f;
+    }
+
     AzFramework::ScreenPoint ViewportInteraction::ViewportWorldToScreen(const AZ::Vector3& worldPosition)
     {
         return AzFramework::WorldToScreen(worldPosition, m_cameraState);

--- a/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
@@ -25,10 +25,12 @@ namespace AzManipulatorTestFramework
         : m_nullDebugDisplayRequests(AZStd::make_unique<NullDebugDisplayRequests>())
     {
         AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler::BusConnect(m_viewportId);
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler::BusConnect(m_viewportId);
     }
 
     ViewportInteraction::~ViewportInteraction()
     {
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler::BusDisconnect();
     }
 
@@ -37,32 +39,32 @@ namespace AzManipulatorTestFramework
         return m_cameraState;
     }
 
-    bool ViewportInteraction::GridSnappingEnabled()
+    bool ViewportInteraction::GridSnappingEnabled() const
     {
         return m_gridSnapping;
     }
 
-    float ViewportInteraction::GridSize()
+    float ViewportInteraction::GridSize() const
     {
         return m_gridSize;
     }
 
-    bool ViewportInteraction::ShowGrid()
+    bool ViewportInteraction::ShowGrid() const
     {
         return false;
     }
 
-    bool ViewportInteraction::AngleSnappingEnabled()
+    bool ViewportInteraction::AngleSnappingEnabled() const
     {
         return m_angularSnapping;
     }
 
-    float ViewportInteraction::AngleStep()
+    float ViewportInteraction::AngleStep() const
     {
         return m_angularStep;
     }
 
-    float ViewportInteraction::ManipulatorLineBoundWidth()
+    float ViewportInteraction::ManipulatorLineBoundWidth() const
     {
         return 0.1f;
     }

--- a/Code/Framework/AzManipulatorTestFramework/Tests/ViewportInteractionTest.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Tests/ViewportInteractionTest.cpp
@@ -49,9 +49,9 @@ namespace UnitTest
         bool snapping = false;
 
         m_viewportInteraction->EnableGridSnaping();
-        AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
-            &AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Events::GridSnappingEnabled);
+            &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::GridSnappingEnabled);
 
         EXPECT_TRUE(snapping);
     }
@@ -61,9 +61,9 @@ namespace UnitTest
         bool snapping = true;
 
         m_viewportInteraction->DisableGridSnaping();
-        AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
-            &AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Events::GridSnappingEnabled);
+            &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::GridSnappingEnabled);
 
         EXPECT_FALSE(snapping);
     }
@@ -76,9 +76,9 @@ namespace UnitTest
         m_viewportInteraction->SetGridSize(expectedGridSize);
 
         m_viewportInteraction->DisableGridSnaping();
-        AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             gridSize, m_viewportInteraction->GetViewportId(),
-            &AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Events::GridSize);
+            &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::GridSize);
 
         EXPECT_EQ(gridSize, expectedGridSize);
     }
@@ -88,9 +88,9 @@ namespace UnitTest
         bool snapping = false;
 
         m_viewportInteraction->EnableAngularSnaping();
-        AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
-            &AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Events::AngleSnappingEnabled);
+            &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::AngleSnappingEnabled);
 
         EXPECT_TRUE(snapping);
     }
@@ -100,9 +100,9 @@ namespace UnitTest
         bool snapping = true;
 
         m_viewportInteraction->DisableAngularSnaping();
-        AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
-            &AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Events::AngleSnappingEnabled);
+            &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::AngleSnappingEnabled);
 
         EXPECT_FALSE(snapping);
     }
@@ -114,9 +114,9 @@ namespace UnitTest
 
         m_viewportInteraction->SetAngularStep(expectedAngularStep);
 
-        AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::EventResult(
+        AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             angularStep, m_viewportInteraction->GetViewportId(),
-            &AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Events::AngleStep);
+            &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::AngleStep);
 
         EXPECT_EQ(angularStep, expectedAngularStep);
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -226,8 +226,7 @@ namespace AzToolsFramework
         m_translationManipulator = AZStd::make_shared<IndexedTranslationManipulator<Vertex>>(
             Dimensions(), vertexIndex, vertex, WorldFromLocalWithUniformScale(entityComponentIdPair.GetEntityId()),
             GetNonUniformScale(entityComponentIdPair.GetEntityId()));
-        m_translationManipulator->m_manipulator.SetLineBoundWidth(
-            AzToolsFramework::ManipulatorLineBoundWidth(AzFramework::InvalidViewportId));
+        m_translationManipulator->m_manipulator.SetLineBoundWidth(AzToolsFramework::ManipulatorLineBoundWidth());
 
         // setup how the manipulator should look
         m_manipulatorConfiguratorFn(&m_translationManipulator->m_manipulator);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorSnapping.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorSnapping.cpp
@@ -137,8 +137,8 @@ namespace AzToolsFramework
     bool GridSnapping(const int viewportId)
     {
         bool snapping = false;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            snapping, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::GridSnappingEnabled);
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            snapping, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::GridSnappingEnabled);
 
         return snapping;
     }
@@ -146,8 +146,8 @@ namespace AzToolsFramework
     float GridSize(const int viewportId)
     {
         float gridSize = 0.0f;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            gridSize, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::GridSize);
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            gridSize, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::GridSize);
 
         return gridSize;
     }
@@ -168,8 +168,8 @@ namespace AzToolsFramework
     bool AngleSnapping(const int viewportId)
     {
         bool snapping = false;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            snapping, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::AngleSnappingEnabled);
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            snapping, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::AngleSnappingEnabled);
 
         return snapping;
     }
@@ -177,8 +177,8 @@ namespace AzToolsFramework
     float AngleStep(const int viewportId)
     {
         float angle = 0.0f;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            angle, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::AngleStep);
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            angle, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::AngleStep);
 
         return angle;
     }
@@ -186,8 +186,8 @@ namespace AzToolsFramework
     bool ShowingGrid(const int viewportId)
     {
         bool show = false;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            show, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::ShowGrid);
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            show, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ShowGrid);
 
         return show;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.cpp
@@ -130,11 +130,13 @@ namespace AzToolsFramework
         for (size_t manipulatorIndex = 0; manipulatorIndex < m_localAngularManipulators.size(); ++manipulatorIndex)
         {
             m_localAngularManipulators[manipulatorIndex]->SetView(CreateManipulatorViewCircle(
-                *m_localAngularManipulators[manipulatorIndex], colors[manipulatorIndex], radius, 0.05f, DrawHalfDottedCircle));
+                *m_localAngularManipulators[manipulatorIndex], colors[manipulatorIndex], radius, m_circleBoundWidth, DrawHalfDottedCircle));
         }
 
+        const float viewAlignedScale = 1.12f;
         m_viewAngularManipulator->SetView(CreateManipulatorViewCircle(
-            *m_viewAngularManipulator, AZ::Color(1.0f, 1.0f, 1.0f, 1.0f), radius + (radius * 0.12f), 0.05f, DrawFullCircle));
+            *m_viewAngularManipulator, AZ::Color(1.0f, 1.0f, 1.0f, 1.0f), radius * viewAlignedScale, m_circleBoundWidth,
+            DrawFullCircle));
     }
 
     bool RotationManipulators::PerformingActionViewAxis() const
@@ -150,5 +152,10 @@ namespace AzToolsFramework
         }
 
         manipulatorFn(m_viewAngularManipulator.get());
+    }
+
+    void RotationManipulators::SetCircleBoundWidth(const float circleBoundWidth)
+    {
+        m_circleBoundWidth = circleBoundWidth;
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/RotationManipulators.h
@@ -42,6 +42,9 @@ namespace AzToolsFramework
 
         bool PerformingActionViewAxis() const;
 
+        //! Sets the bound width to use for the circle (torus) of an angular manipulator.
+        void SetCircleBoundWidth(float circleBoundWidth);
+
     private:
         AZ_DISABLE_COPY_MOVE(RotationManipulators)
 
@@ -49,5 +52,6 @@ namespace AzToolsFramework
 
         AZStd::array<AZStd::shared_ptr<AngularManipulator>, 3> m_localAngularManipulators;
         AZStd::shared_ptr<AngularManipulator> m_viewAngularManipulator;
+        float m_circleBoundWidth = 0.1f;  //!< The default circle bound width for the angular manipulator torus.
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
+
+namespace AzToolsFramework
+{
+    float ManipulatorLineBoundWidth(const AzFramework::ViewportId viewportId /*= AzFramework::InvalidViewportId*/)
+    {
+        float lineBoundWidth = 0.0f;
+        if (viewportId != AzFramework::InvalidViewportId)
+        {
+            ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+                lineBoundWidth, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorLineBoundWidth);
+        }
+        else
+        {
+            ViewportInteraction::ViewportSettingsRequestBus::BroadcastResult(
+                lineBoundWidth, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorLineBoundWidth);
+        }
+
+        return lineBoundWidth;
+    }
+
+    float ManipulatorCicleBoundWidth(const AzFramework::ViewportId viewportId /*= AzFramework::InvalidViewportId*/)
+    {
+        float circleBoundWidth = 0.0f;
+        if (viewportId != AzFramework::InvalidViewportId)
+        {
+            ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+                circleBoundWidth, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorCircleBoundWidth);
+        }
+        else
+        {
+            ViewportInteraction::ViewportSettingsRequestBus::BroadcastResult(
+                circleBoundWidth, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorCircleBoundWidth);
+        }
+
+        return circleBoundWidth;
+    }
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -341,39 +341,9 @@ namespace AzToolsFramework
 
     //! Wrap EBus call to retrieve manipulator line bound width.
     //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
-    inline float ManipulatorLineBoundWidth(const AzFramework::ViewportId viewportId)
-    {
-        float lineBoundWidth = 0.0f;
-        if (viewportId != AzFramework::InvalidViewportId)
-        {
-            ViewportInteraction::ViewportSettingsRequestBus::EventResult(
-                lineBoundWidth, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorLineBoundWidth);
-        }
-        else
-        {
-            ViewportInteraction::ViewportSettingsRequestBus::BroadcastResult(
-                lineBoundWidth, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorLineBoundWidth);
-        }
-
-        return lineBoundWidth;
-    }
+    float ManipulatorLineBoundWidth(AzFramework::ViewportId viewportId = AzFramework::InvalidViewportId);
 
     //! Wrap EBus call to retrieve manipulator line bound width.
     //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
-    inline float ManipulatorCicleBoundWidth(const AzFramework::ViewportId viewportId)
-    {
-        float circleBoundWidth = 0.0f;
-        if (viewportId != AzFramework::InvalidViewportId)
-        {
-            ViewportInteraction::ViewportSettingsRequestBus::EventResult(
-                circleBoundWidth, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorCircleBoundWidth);
-        }
-        else
-        {
-            ViewportInteraction::ViewportSettingsRequestBus::BroadcastResult(
-                circleBoundWidth, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorCircleBoundWidth);
-        }
-
-        return circleBoundWidth;
-    }
+    float ManipulatorCicleBoundWidth(AzFramework::ViewportId viewportId = AzFramework::InvalidViewportId);
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -194,6 +194,8 @@ namespace AzToolsFramework
             virtual float AngleStep() const = 0;
             //! Returns the current line bound width for manipulators.
             virtual float ManipulatorLineBoundWidth() const = 0;
+            //! Returns the current circle (torus) bound width for manipulators.
+            virtual float ManipulatorCircleBoundWidth() const = 0;
 
         protected:
             ~ViewportSettingsRequests() = default;
@@ -354,5 +356,24 @@ namespace AzToolsFramework
         }
 
         return lineBoundWidth;
+    }
+
+    //! Wrap EBus call to retrieve manipulator line bound width.
+    //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
+    inline float ManipulatorCicleBoundWidth(const AzFramework::ViewportId viewportId)
+    {
+        float circleBoundWidth = 0.0f;
+        if (viewportId != AzFramework::InvalidViewportId)
+        {
+            ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+                circleBoundWidth, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorCircleBoundWidth);
+        }
+        else
+        {
+            ViewportInteraction::ViewportSettingsRequestBus::BroadcastResult(
+                circleBoundWidth, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorCircleBoundWidth);
+        }
+
+        return circleBoundWidth;
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -340,10 +340,10 @@ namespace AzToolsFramework
     }
 
     //! Wrap EBus call to retrieve manipulator line bound width.
-    //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
+    //! @note It is possible to pass AzFramework::InvalidViewportId (the default) to perform a Broadcast as opposed to a targeted Event.
     float ManipulatorLineBoundWidth(AzFramework::ViewportId viewportId = AzFramework::InvalidViewportId);
 
-    //! Wrap EBus call to retrieve manipulator line bound width.
-    //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
+    //! Wrap EBus call to retrieve manipulator circle bound width.
+    //! @note It is possible to pass AzFramework::InvalidViewportId (the default) to perform a Broadcast as opposed to a targeted Event.
     float ManipulatorCicleBoundWidth(AzFramework::ViewportId viewportId = AzFramework::InvalidViewportId);
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -158,18 +158,6 @@ namespace AzToolsFramework
         public:
             //! Returns the current camera state for this viewport.
             virtual AzFramework::CameraState GetCameraState() = 0;
-            //! Returns if grid snapping is enabled.
-            virtual bool GridSnappingEnabled() = 0;
-            //! Returns the grid snapping size.
-            virtual float GridSize() = 0;
-            //! Does the grid currently want to be displayed.
-            virtual bool ShowGrid() = 0;
-            //! Returns if angle snapping is enabled.
-            virtual bool AngleSnappingEnabled() = 0;
-            //! Returns the angle snapping/step size.
-            virtual float AngleStep() = 0;
-            //! Returns the current line bound width for manipulators.
-            virtual float ManipulatorLineBoundWidth() = 0;
             //! Transforms a point in world space to screen space coordinates in Qt Widget space.
             //! Multiply by DeviceScalingFactor to get the position in viewport pixel space.
             virtual AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition) = 0;
@@ -187,12 +175,13 @@ namespace AzToolsFramework
             ~ViewportInteractionRequests() = default;
         };
 
+        //! Type to inherit to implement ViewportInteractionRequests.
+        using ViewportInteractionRequestBus = AZ::EBus<ViewportInteractionRequests, ViewportEBusTraits>;
+
         //! Interface to return only viewport specific settings (e.g. snapping).
-        class ViewportSettings
+        class ViewportSettingsRequests
         {
         public:
-            virtual ~ViewportSettings() = default;
-
             //! Return if grid snapping is enabled.
             virtual bool GridSnappingEnabled() const = 0;
             //! Return the grid snapping size.
@@ -205,10 +194,13 @@ namespace AzToolsFramework
             virtual float AngleStep() const = 0;
             //! Returns the current line bound width for manipulators.
             virtual float ManipulatorLineBoundWidth() const = 0;
+
+        protected:
+            ~ViewportSettingsRequests() = default;
         };
 
-        //! Type to inherit to implement ViewportInteractionRequests.
-        using ViewportInteractionRequestBus = AZ::EBus<ViewportInteractionRequests, ViewportEBusTraits>;
+        //! Type to inherit to implement ViewportSettingsRequests.
+        using ViewportSettingsRequestBus = AZ::EBus<ViewportSettingsRequests, ViewportEBusTraits>;
 
         //! An interface to notify when changes to viewport settings have happened.
         class ViewportSettingNotifications
@@ -347,18 +339,18 @@ namespace AzToolsFramework
 
     //! Wrap EBus call to retrieve manipulator line bound width.
     //! @note It is possible to pass AzFramework::InvalidViewportId to perform a Broadcast as opposed to a targeted Event.
-    inline float ManipulatorLineBoundWidth(AzFramework::ViewportId viewportId)
+    inline float ManipulatorLineBoundWidth(const AzFramework::ViewportId viewportId)
     {
         float lineBoundWidth = 0.0f;
         if (viewportId != AzFramework::InvalidViewportId)
         {
-            ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-                lineBoundWidth, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::ManipulatorLineBoundWidth);
+            ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+                lineBoundWidth, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorLineBoundWidth);
         }
         else
         {
-            ViewportInteraction::ViewportInteractionRequestBus::BroadcastResult(
-                lineBoundWidth, &ViewportInteraction::ViewportInteractionRequestBus::Events::ManipulatorLineBoundWidth);
+            ViewportInteraction::ViewportSettingsRequestBus::BroadcastResult(
+                lineBoundWidth, &ViewportInteraction::ViewportSettingsRequestBus::Events::ManipulatorLineBoundWidth);
         }
 
         return lineBoundWidth;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -488,8 +488,8 @@ namespace AzToolsFramework
     void SnappingCluster::TrySetVisible(const bool visible)
     {
         bool snapping = false;
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            snapping, ViewportUi::DefaultViewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::GridSnappingEnabled);
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            snapping, ViewportUi::DefaultViewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::GridSnappingEnabled);
 
         // show snapping viewport ui only if there are entities selected and snapping is enabled
         SetViewportUiClusterVisible(m_clusterId, visible && snapping);
@@ -2546,8 +2546,8 @@ namespace AzToolsFramework
             if (buttonId == m_snappingCluster.m_snapToWorldButtonId)
             {
                 float gridSize = 1.0f;
-                ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-                    gridSize, ViewportUi::DefaultViewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::GridSize);
+                ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+                    gridSize, ViewportUi::DefaultViewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::GridSize);
 
                 SnapSelectedEntitiesToWorldGrid(gridSize);
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1377,6 +1377,7 @@ namespace AzToolsFramework
 
         AZStd::unique_ptr<RotationManipulators> rotationManipulators =
             AZStd::make_unique<RotationManipulators>(AZ::Transform::CreateIdentity());
+        rotationManipulators->SetCircleBoundWidth(ManipulatorCicleBoundWidth(ViewportUi::DefaultViewportId));
 
         InitializeManipulators(*rotationManipulators);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -481,6 +481,7 @@ set(FILES
     Viewport/VertexContainerDisplay.h
     Viewport/VertexContainerDisplay.cpp
     Viewport/ViewportMessages.h
+    Viewport/ViewportMessages.cpp
     Viewport/ViewportTypes.h
     Viewport/ViewportTypes.cpp
     ViewportUi/Button.h

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -92,20 +92,11 @@ namespace AtomToolsFramework
 
         // AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler ...
         AzFramework::CameraState GetCameraState() override;
-        bool GridSnappingEnabled() override;
-        float GridSize() override;
-        bool ShowGrid() override;
-        bool AngleSnappingEnabled() override;
-        float AngleStep() override;
-        float ManipulatorLineBoundWidth() override;
         AzFramework::ScreenPoint ViewportWorldToScreen(const AZ::Vector3& worldPosition) override;
         AZStd::optional<AZ::Vector3> ViewportScreenToWorld(const AzFramework::ScreenPoint& screenPosition, float depth) override;
         AZStd::optional<AzToolsFramework::ViewportInteraction::ProjectedViewportRay> ViewportScreenToWorldRay(
             const AzFramework::ScreenPoint& screenPosition) override;
         float DeviceScalingFactor() override;
-
-        //! Set interface for providing viewport specific settings (e.g. snapping properties).
-        void SetViewportSettings(const AzToolsFramework::ViewportInteraction::ViewportSettings* viewportSettings);
 
         // AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Handler ...
         void BeginCursorCapture() override;
@@ -148,7 +139,7 @@ namespace AtomToolsFramework
         AzFramework::ViewportControllerListPtr m_controllerList;
         // The default camera for our viewport i.e. the one used when a camera entity hasn't been activated.
         AZ::RPI::ViewPtr m_defaultCamera;
-        // Our viewport-local auxgeom pipeline for supplemental rendering.
+        // Our viewport-local aux geom pipeline for supplemental rendering.
         AZ::RPI::AuxGeomDrawPtr m_auxGeom;
         // Used to keep track of a pending resize event to avoid initialization before window activate.
         bool m_windowResizedEvent = false;
@@ -160,8 +151,6 @@ namespace AtomToolsFramework
         QElapsedTimer m_renderTimer;
         // The time of the last recorded tick event from the system tick bus.
         AZ::ScriptTimePoint m_time;
-        // The viewport settings (e.g. grid snapping, grid size) for this viewport.
-        const AzToolsFramework::ViewportInteraction::ViewportSettings* m_viewportSettings = nullptr;
         // Maps our internal Qt events into AzFramework InputChannels for our ViewportControllerList.
         AzToolsFramework::QtEventToAzInputMapper* m_inputChannelMapper = nullptr;
     };

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -315,41 +315,6 @@ namespace AtomToolsFramework
         return cameraState;
     }
 
-    bool RenderViewportWidget::GridSnappingEnabled()
-    {
-        return m_viewportSettings ? m_viewportSettings->GridSnappingEnabled() : false;
-    }
-
-    float RenderViewportWidget::GridSize()
-    {
-        return m_viewportSettings ? m_viewportSettings->GridSize() : 0.0f;
-    }
-
-    bool RenderViewportWidget::ShowGrid()
-    {
-        return m_viewportSettings ? m_viewportSettings->ShowGrid() : false;
-    }
-
-    bool RenderViewportWidget::AngleSnappingEnabled()
-    {
-        return m_viewportSettings ? m_viewportSettings->AngleSnappingEnabled() : false;
-    }
-
-    float RenderViewportWidget::AngleStep()
-    {
-        return m_viewportSettings ? m_viewportSettings->AngleStep() : 0.0f;
-    }
-
-    float RenderViewportWidget::ManipulatorLineBoundWidth()
-    {
-        return m_viewportSettings ? m_viewportSettings->ManipulatorLineBoundWidth() : 0.1f;
-    }
-
-    void RenderViewportWidget::SetViewportSettings(const AzToolsFramework::ViewportInteraction::ViewportSettings* viewportSettings)
-    {
-        m_viewportSettings = viewportSettings;
-    }
-
     AzFramework::ScreenPoint RenderViewportWidget::ViewportWorldToScreen(const AZ::Vector3& worldPosition)
     {
         if (AZ::RPI::ViewPtr currentView = m_viewportContext->GetDefaultView();

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponentMode.cpp
@@ -126,7 +126,7 @@ namespace LmbrCentral
         ManipulatorViews views;
         views.emplace_back(CreateManipulatorViewLine(
             *m_heightManipulator, AZ::Color(0.0f, 0.0f, 1.0f, 1.0f),
-            lineLength, AzToolsFramework::ManipulatorLineBoundWidth(AzFramework::InvalidViewportId)));
+            lineLength, AzToolsFramework::ManipulatorLineBoundWidth()));
         views.emplace_back(CreateManipulatorViewCone(*m_heightManipulator,
             AZ::Color(0.0f, 0.0f, 1.0f, 1.0f), m_heightManipulator->GetAxis() *
             (lineLength - coneLength), coneLength, coneRadius));

--- a/Gems/PhysX/Code/Editor/ColliderRotationMode.cpp
+++ b/Gems/PhysX/Code/Editor/ColliderRotationMode.cpp
@@ -21,7 +21,7 @@ namespace PhysX
     ColliderRotationMode::ColliderRotationMode()
         : m_rotationManipulators(AZ::Transform::Identity())
     {
-        m_rotationManipulators.SetCircleBoundWidth(AzToolsFramework::ManipulatorCicleBoundWidth(AzFramework::InvalidViewportId));
+        m_rotationManipulators.SetCircleBoundWidth(AzToolsFramework::ManipulatorCicleBoundWidth());
     }
 
     void ColliderRotationMode::Setup(const AZ::EntityComponentIdPair& idPair)

--- a/Gems/PhysX/Code/Editor/ColliderRotationMode.cpp
+++ b/Gems/PhysX/Code/Editor/ColliderRotationMode.cpp
@@ -21,7 +21,7 @@ namespace PhysX
     ColliderRotationMode::ColliderRotationMode()
         : m_rotationManipulators(AZ::Transform::Identity())
     {
-
+        m_rotationManipulators.SetCircleBoundWidth(AzToolsFramework::ManipulatorCicleBoundWidth(AzFramework::InvalidViewportId));
     }
 
     void ColliderRotationMode::Setup(const AZ::EntityComponentIdPair& idPair)

--- a/Gems/PhysX/Code/Editor/EditorSubComponentModeAngleCone.cpp
+++ b/Gems/PhysX/Code/Editor/EditorSubComponentModeAngleCone.cpp
@@ -345,7 +345,7 @@ namespace PhysX
         {
             AzToolsFramework::ManipulatorViews views;
             views.emplace_back(CreateManipulatorViewLine(
-                *linearManipulator, color, axisLength, AzToolsFramework::ManipulatorLineBoundWidth(AzFramework::InvalidViewportId)));
+                *linearManipulator, color, axisLength, AzToolsFramework::ManipulatorLineBoundWidth()));
             views.emplace_back(CreateManipulatorViewCone(
                 *linearManipulator, color, linearManipulator->GetAxis() * (axisLength - coneLength),
                 coneLength, coneRadius));

--- a/Gems/PhysX/Code/Editor/EditorSubComponentModeRotation.cpp
+++ b/Gems/PhysX/Code/Editor/EditorSubComponentModeRotation.cpp
@@ -84,10 +84,9 @@ namespace PhysX
             m_rotationManipulators[i]->SetAxis(axes[i]);
             m_rotationManipulators[i]->SetLocalTransform(localTransform);
             const float manipulatorRadius = 2.0f;
-            const float manipulatorWidth = 0.05f;
             m_rotationManipulators[i]->SetView(AzToolsFramework::CreateManipulatorViewCircle(
-                *m_rotationManipulators[i], colors[i],
-                manipulatorRadius, manipulatorWidth, AzToolsFramework::DrawHalfDottedCircle));
+                *m_rotationManipulators[i], colors[i], manipulatorRadius,
+                AzToolsFramework::ManipulatorCicleBoundWidth(AzFramework::InvalidViewportId), AzToolsFramework::DrawHalfDottedCircle));
         }
         
         Refresh();

--- a/Gems/PhysX/Code/Editor/EditorSubComponentModeRotation.cpp
+++ b/Gems/PhysX/Code/Editor/EditorSubComponentModeRotation.cpp
@@ -86,7 +86,7 @@ namespace PhysX
             const float manipulatorRadius = 2.0f;
             m_rotationManipulators[i]->SetView(AzToolsFramework::CreateManipulatorViewCircle(
                 *m_rotationManipulators[i], colors[i], manipulatorRadius,
-                AzToolsFramework::ManipulatorCicleBoundWidth(AzFramework::InvalidViewportId), AzToolsFramework::DrawHalfDottedCircle));
+                AzToolsFramework::ManipulatorCicleBoundWidth(), AzToolsFramework::DrawHalfDottedCircle));
         }
         
         Refresh();


### PR DESCRIPTION
This PR compliments the previous change https://github.com/o3de/o3de/pull/3890 by providing the option to customize the angular manipulator bounds separate to the linear manipulator line bounds.

This PR also splits up the `ViewportInteractionRequests` into `ViewportSettingsRequests` which can more simply be implemented just for `EditorViewportWidget` - this is a better separation as thing like GridSnapping did not make sense being in `RenderViewportWidget` now.