### PR TITLE
Reintroduce materialtype dependency on fbx files.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
@@ -80,7 +80,8 @@ namespace AZ
 
             bool includeMaterialPropertyNames = true;
             RPI::MaterialConverterBus::BroadcastResult(includeMaterialPropertyNames, &RPI::MaterialConverterBus::Events::ShouldIncludeMaterialPropertyNames);
-            if (conversionEnabled && !materialTypePath.empty() && !includeMaterialPropertyNames)
+            // TODO: Use includeMaterialPropertyNames to break materialtype dependency on fbx files. Materialasset's dependency on materialtypeasset will need to be decoupled first
+            if (conversionEnabled && !materialTypePath.empty() /*&& !includeMaterialPropertyNames*/)
             {
                 AssetBuilderSDK::SourceFileDependency materialTypeSource;
                 materialTypeSource.m_sourceFileDependencyPath = materialTypePath;


### PR DESCRIPTION
Testing:
- Testing with AR run on a clean cache
- Tested locally with clean cache, no errors. 