### PR TITLE
Preparatory work to allow for more viewport integration tests

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -1087,6 +1087,7 @@ void EditorViewportWidget::ConnectViewportInteractionRequestBus()
 {
     AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Handler::BusConnect(GetViewportId());
     AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler::BusConnect(GetViewportId());
+    AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusConnect(GetViewportId());
     m_viewportUi.ConnectViewportUiBus(GetViewportId());
 
     AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusConnect();
@@ -1097,6 +1098,7 @@ void EditorViewportWidget::DisconnectViewportInteractionRequestBus()
     AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusDisconnect();
 
     m_viewportUi.DisconnectViewportUiBus();
+    AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusDisconnect();
     AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler::BusDisconnect();
     AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Handler::BusDisconnect();
 }

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -91,6 +91,7 @@ class SANDBOX_API EditorViewportWidget final
     , private AzFramework::InputSystemCursorConstraintRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler
+    , private AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler
     , private AzFramework::AssetCatalogEventBus::Handler
     , private AZ::RPI::SceneNotificationBus::Handler
 {
@@ -128,10 +129,12 @@ private:
         CameraComponent,
         ViewSourceTypesCount,
     };
+
     enum class PlayInEditorState
     {
         Editor, Starting, Started
     };
+
     enum class KeyPressedState
     {
         AllUp,
@@ -142,7 +145,7 @@ private:
     ////////////////////////////////////////////////////////////////////////
     // Method overrides ...
 
-    // QWidget
+    // QWidget overrides ...
     void focusOutEvent(QFocusEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     bool event(QEvent* event) override;
@@ -150,7 +153,7 @@ private:
     void paintEvent(QPaintEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
 
-    // QtViewport/IDisplayViewport/CViewport
+    // QtViewport/IDisplayViewport/CViewport overrides ...
     EViewportType GetType() const override { return ET_ViewportCamera; }
     void SetType([[maybe_unused]] EViewportType type) override { assert(type == ET_ViewportCamera); };
     AzToolsFramework::ViewportInteraction::MouseInteraction BuildMouseInteraction(
@@ -176,16 +179,17 @@ private:
     void Update() override;
     void UpdateContent(int flags) override;
 
-    // SceneNotificationBus
+    // SceneNotificationBus overrides ...
     void OnBeginPrepareRender() override;
 
-    // Camera::CameraNotificationBus
+    // Camera::CameraNotificationBus overrides ...
     void OnActiveViewChanged(const AZ::EntityId&) override;
 
-    // IEditorEventListener
+    // IEditorEventListener overrides ...
     void OnEditorNotifyEvent(EEditorNotifyEvent event) override;
 
-    // AzToolsFramework::EditorEntityContextNotificationBus (handler moved to cpp to resolve link issues in unity builds)
+    // AzToolsFramework::EditorEntityContextNotificationBus overrides ...
+    // note: handler moved to cpp to resolve link issues in unity builds
     void OnStartPlayInEditor();
     void OnStopPlayInEditor();
     void OnStartPlayInEditorBegin();
@@ -194,10 +198,10 @@ private:
     void BeginUndoTransaction() override;
     void EndUndoTransaction() override;
 
-    // AzFramework::InputSystemCursorConstraintRequestBus
+    // AzFramework::InputSystemCursorConstraintRequestBus overrides ...
     void* GetSystemCursorConstraintWindow() const override;
 
-    // AzToolsFramework::ViewportFreezeRequestBus
+    // AzToolsFramework::ViewportFreezeRequestBus overrides ...
     bool IsViewportInputFrozen() override;
     void FreezeViewportInput(bool freeze) override;
 
@@ -205,13 +209,15 @@ private:
     AZ::EntityId PickEntity(const AzFramework::ScreenPoint& point) override;
     AZ::Vector3 PickTerrain(const AzFramework::ScreenPoint& point) override;
     float TerrainHeight(const AZ::Vector2& position) override;
-    void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntitiesOut) override;
     bool ShowingWorldSpace() override;
     QWidget* GetWidgetForViewportContextMenu() override;
     void BeginWidgetContext() override;
     void EndWidgetContext() override;
 
-    // Camera::EditorCameraRequestBus
+    // EditorEntityViewportInteractionRequestBus overrides ...
+    void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) override;
+
+    // Camera::EditorCameraRequestBus overrides ...
     void SetViewFromEntityPerspective(const AZ::EntityId& entityId) override;
     void SetViewAndMovementLockFromEntityPerspective(const AZ::EntityId& entityId, bool lockCameraMovement) override;
     AZ::EntityId GetCurrentViewEntityId() override;
@@ -327,7 +333,7 @@ private:
     // Determines also if the current camera for this viewport is default editor camera
     ViewSourceType m_viewSourceType = ViewSourceType::None;
 
-    // During play game in editor, holds the editor entity ID of the last 
+    // During play game in editor, holds the editor entity ID of the last
     AZ::EntityId m_viewEntityIdCachedForEditMode;
 
     // The editor camera TM before switching to game mode

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -1092,9 +1092,8 @@ bool QtViewport::HitTest(const QPoint& point, HitContext& hitInfo)
     const int viewportId = GetViewportId();
 
     AzToolsFramework::EntityIdList visibleEntityIds;
-    AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Event(
-        viewportId,
-        &AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequests::FindVisibleEntities,
+    AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Event(
+        viewportId, &AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Events::FindVisibleEntities,
         visibleEntityIds);
 
     // Look through all visible entities to find the closest one to the specified mouse point

--- a/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/BoundsBus.h
@@ -45,6 +45,7 @@ namespace AzFramework
     protected:
         ~BoundsRequests() = default;
     };
+
     using BoundsRequestBus = AZ::EBus<BoundsRequests>;
 
     //! Returns a union of all local Aabbs provided by components implementing the BoundsRequestBus.

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/AzManipulatorTestFramework.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/AzManipulatorTestFramework.h
@@ -45,6 +45,9 @@ namespace AzManipulatorTestFramework
         virtual void SetAngularStep(float step) = 0;
         //! Get the viewport id.
         virtual int GetViewportId() const = 0;
+        //! Updates the visibility state.
+        //! Updates which entities are currently visible given the current camera state.
+        virtual void UpdateVisibility() = 0;
     };
 
     //! This interface is used to simulate the manipulator manager while the manipulators are under test.

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/AzManipulatorTestFrameworkTestHelpers.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/AzManipulatorTestFrameworkTestHelpers.h
@@ -12,8 +12,8 @@
 #include <AzManipulatorTestFramework/AzManipulatorTestFrameworkUtils.h>
 #include <AzManipulatorTestFramework/ImmediateModeActionDispatcher.h>
 #include <AzManipulatorTestFramework/IndirectManipulatorViewportInteraction.h>
-#include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 #include <AzToolsFramework/ViewportSelection/EditorDefaultSelection.h>
+#include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 #include <type_traits>
 
 namespace UnitTest
@@ -21,20 +21,18 @@ namespace UnitTest
     //! Fixture to provide the indirect call viewport interaction that is dependent on AzToolsFramework::ToolsApplication.
     //! \tparam ToolsApplicationFixtureT The fixture that provides the AzToolsFramework::ToolsApplication functionality.
     template<typename ToolsApplicationFixtureT>
-    class IndirectCallManipulatorViewportInteractionFixtureMixin
-        : public ToolsApplicationFixtureT
+    class IndirectCallManipulatorViewportInteractionFixtureMixin : public ToolsApplicationFixtureT
     {
-        using IndirectCallManipulatorViewportInteraction =
-            AzManipulatorTestFramework::IndirectCallManipulatorViewportInteraction;
+        using IndirectCallManipulatorViewportInteraction = AzManipulatorTestFramework::IndirectCallManipulatorViewportInteraction;
         using ImmediateModeActionDispatcher = AzManipulatorTestFramework::ImmediateModeActionDispatcher;
-    
+
         void SetUpEditorFixtureImpl() override
         {
             ToolsApplicationFixtureT::SetUpEditorFixtureImpl();
             m_viewportManipulatorInteraction = AZStd::make_unique<IndirectCallManipulatorViewportInteraction>();
             m_actionDispatcher = AZStd::make_unique<ImmediateModeActionDispatcher>(*m_viewportManipulatorInteraction);
-            m_cameraState = AzFramework::CreateIdentityDefaultCamera(
-                AZ::Vector3::CreateZero(), AzManipulatorTestFramework::DefaultViewportSize);
+            m_cameraState =
+                AzFramework::CreateIdentityDefaultCamera(AZ::Vector3::CreateZero(), AzManipulatorTestFramework::DefaultViewportSize);
         }
 
         void TearDownEditorFixtureImpl() override

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/IndirectManipulatorViewportInteraction.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/IndirectManipulatorViewportInteraction.h
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <AzManipulatorTestFramework/AzManipulatorTestFramework.h>
-#include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 #include <AzToolsFramework/ViewportSelection/EditorDefaultSelection.h>
+#include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 
 namespace AzManipulatorTestFramework
 {
@@ -18,13 +18,12 @@ namespace AzManipulatorTestFramework
     class IndirectCallManipulatorManager;
 
     //! Implementation of manipulator viewport interaction that manipulates the manager indirectly via bus calls.
-    class IndirectCallManipulatorViewportInteraction
-        : public ManipulatorViewportInteraction
+    class IndirectCallManipulatorViewportInteraction : public ManipulatorViewportInteraction
     {
     public:
         IndirectCallManipulatorViewportInteraction();
         ~IndirectCallManipulatorViewportInteraction();
-        
+
         // ManipulatorViewportInteractionInterface ...
         const ViewportInteractionInterface& GetViewportInteraction() const override;
         const ManipulatorManagerInterface& GetManipulatorManager() const override;

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AzFramework/Visibility/EntityVisibilityQuery.h>
 #include <AzManipulatorTestFramework/AzManipulatorTestFramework.h>
 
 namespace AzManipulatorTestFramework
@@ -19,6 +20,7 @@ namespace AzManipulatorTestFramework
         : public ViewportInteractionInterface
         , public AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler
         , public AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler
+        , private AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler
     {
     public:
         ViewportInteraction();
@@ -34,6 +36,7 @@ namespace AzManipulatorTestFramework
         void SetGridSize(float size) override;
         void SetAngularStep(float step) override;
         int GetViewportId() const override;
+        void UpdateVisibility() override;
 
         // ViewportInteractionRequestBus overrides ...
         AzFramework::CameraState GetCameraState() override;
@@ -52,7 +55,11 @@ namespace AzManipulatorTestFramework
         float ManipulatorLineBoundWidth() const override;
         float ManipulatorCircleBoundWidth() const override;
 
+        // EditorEntityViewportInteractionRequestBus overrides ...
+        void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) override;
+
     private:
+        AzFramework::EntityVisibilityQuery m_entityVisibilityQuery;
         AZStd::unique_ptr<NullDebugDisplayRequests> m_nullDebugDisplayRequests;
         const int m_viewportId = 1234; // Arbitrary viewport id for manipulator tests
         AzFramework::CameraState m_cameraState;

--- a/Code/Framework/AzManipulatorTestFramework/Source/AzManipulatorTestFrameworkUtils.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/AzManipulatorTestFrameworkUtils.cpp
@@ -91,12 +91,12 @@ namespace AzManipulatorTestFramework
     AzToolsFramework::ViewportInteraction::MousePick BuildMousePick(
         const AzFramework::ScreenPoint& screenPoint, const AzFramework::CameraState& cameraState)
     {
-        const auto screenToWorld = AzFramework::ScreenToWorld(screenPoint, cameraState);
+        const auto nearPlaneWorldPosition = AzFramework::ScreenToWorld(screenPoint, cameraState);
 
         AzToolsFramework::ViewportInteraction::MousePick mousePick;
         mousePick.m_screenCoordinates = screenPoint;
-        mousePick.m_rayOrigin = screenToWorld;
-        mousePick.m_rayDirection = (screenToWorld - cameraState.m_position).GetNormalized();
+        mousePick.m_rayOrigin = cameraState.m_position;
+        mousePick.m_rayDirection = (nearPlaneWorldPosition - cameraState.m_position).GetNormalized();
 
         return mousePick;
     }

--- a/Code/Framework/AzManipulatorTestFramework/Source/IndirectManipulatorViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/IndirectManipulatorViewportInteraction.cpp
@@ -16,8 +16,7 @@ namespace AzManipulatorTestFramework
     using MouseInteractionEvent = AzToolsFramework::ViewportInteraction::MouseInteractionEvent;
 
     //! Implementation of the manipulator interface using bus calls to access to the manipulator manager.
-    class IndirectCallManipulatorManager
-        : public ManipulatorManagerInterface
+    class IndirectCallManipulatorManager : public ManipulatorManagerInterface
     {
     public:
         IndirectCallManipulatorManager(ViewportInteractionInterface& viewportInteraction);
@@ -39,11 +38,12 @@ namespace AzManipulatorTestFramework
 
     void IndirectCallManipulatorManager::ConsumeMouseInteractionEvent(const MouseInteractionEvent& event)
     {
+        m_viewportInteraction.UpdateVisibility();
+
         DrawManipulators();
         AzToolsFramework::EditorInteractionSystemViewportSelectionRequestBus::Event(
             AzToolsFramework::GetEntityContextId(),
-            &AzToolsFramework::ViewportInteraction::InternalMouseViewportRequests::InternalHandleAllMouseInteractions,
-            event);
+            &AzToolsFramework::ViewportInteraction::InternalMouseViewportRequests::InternalHandleAllMouseInteractions, event);
         DrawManipulators();
     }
 

--- a/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
@@ -26,10 +26,12 @@ namespace AzManipulatorTestFramework
     {
         AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler::BusConnect(m_viewportId);
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler::BusConnect(m_viewportId);
+        AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusConnect(m_viewportId);
     }
 
     ViewportInteraction::~ViewportInteraction()
     {
+        AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler::BusDisconnect();
     }
@@ -72,6 +74,16 @@ namespace AzManipulatorTestFramework
     float ViewportInteraction::ManipulatorCircleBoundWidth() const
     {
         return 0.1f;
+    }
+
+    void ViewportInteraction::FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntitiesOut)
+    {
+        visibleEntitiesOut.assign(m_entityVisibilityQuery.Begin(), m_entityVisibilityQuery.End());
+    }
+
+    void ViewportInteraction::UpdateVisibility()
+    {
+        m_entityVisibilityQuery.UpdateVisibility(m_cameraState);
     }
 
     AzFramework::ScreenPoint ViewportInteraction::ViewportWorldToScreen(const AZ::Vector3& worldPosition)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntitySelectionBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ComponentEntitySelectionBus.h
@@ -96,7 +96,7 @@ namespace AzToolsFramework
     {
         AZ::EBusReduceResult<AZ::Aabb, AzFramework::AabbUnionAggregator> aabbResult(AZ::Aabb::CreateNull());
         EditorComponentSelectionRequestsBus::EventResult(
-            aabbResult, entityId, &EditorComponentSelectionRequests::GetEditorSelectionBoundsViewport, viewportInfo);
+            aabbResult, entityId, &EditorComponentSelectionRequestsBus::Events::GetEditorSelectionBoundsViewport, viewportInfo);
 
         return aabbResult.value;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
@@ -10,6 +10,25 @@
 
 namespace AzToolsFramework
 {
+    AzFramework::ClickDetector::ClickEvent ClickDetectorEventFromViewportInteraction(
+        const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
+    {
+        if (mouseInteraction.m_mouseInteraction.m_mouseButtons.Left())
+        {
+            if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Down)
+            {
+                return AzFramework::ClickDetector::ClickEvent::Down;
+            }
+
+            if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Up)
+            {
+                return AzFramework::ClickDetector::ClickEvent::Up;
+            }
+        }
+
+        return AzFramework::ClickDetector::ClickEvent::Nil;
+    }
+
     float ManipulatorLineBoundWidth(const AzFramework::ViewportId viewportId /*= AzFramework::InvalidViewportId*/)
     {
         float lineBoundWidth = 0.0f;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -250,8 +250,6 @@ namespace AzToolsFramework
             virtual AZ::Vector3 PickTerrain(const AzFramework::ScreenPoint& point) = 0;
             //! Return the terrain height given a world position in 2d (xy plane).
             virtual float TerrainHeight(const AZ::Vector2& position) = 0;
-            //! Given the current view frustum (viewport) return all visible entities.
-            virtual void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) = 0;
             //! Is the user holding a modifier key to move the manipulator space from local to world.
             virtual bool ShowingWorldSpace() = 0;
             //! Return the widget to use as the parent for the viewport context menu.
@@ -269,7 +267,20 @@ namespace AzToolsFramework
         //! Type to inherit to implement MainEditorViewportInteractionRequests.
         using MainEditorViewportInteractionRequestBus = AZ::EBus<MainEditorViewportInteractionRequests, ViewportEBusTraits>;
 
-        //! Viewport requests for managing the viewport's cursor state.
+        //! Editor entity requests to be made about the viewport.
+        class EditorEntityViewportInteractionRequests
+        {
+        public:
+            //! Given the current view frustum (viewport) return all visible entities.
+            virtual void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) = 0;
+
+        protected:
+            ~EditorEntityViewportInteractionRequests() = default;
+        };
+
+        using EditorEntityViewportInteractionRequestBus = AZ::EBus<EditorEntityViewportInteractionRequests, ViewportEBusTraits>;
+
+        //! Viewport requests for managing the viewports cursor state.
         class ViewportMouseCursorRequests
         {
         public:
@@ -321,23 +332,8 @@ namespace AzToolsFramework
 
     //! Maps a mouse interaction event to a ClickDetector event.
     //! @note Function only cares about up or down events, all other events are mapped to Nil (ignored).
-    inline AzFramework::ClickDetector::ClickEvent ClickDetectorEventFromViewportInteraction(
-        const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
-    {
-        if (mouseInteraction.m_mouseInteraction.m_mouseButtons.Left())
-        {
-            if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Down)
-            {
-                return AzFramework::ClickDetector::ClickEvent::Down;
-            }
-
-            if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Up)
-            {
-                return AzFramework::ClickDetector::ClickEvent::Up;
-            }
-        }
-        return AzFramework::ClickDetector::ClickEvent::Nil;
-    }
+    AzFramework::ClickDetector::ClickEvent ClickDetectorEventFromViewportInteraction(
+        const ViewportInteraction::MouseInteractionEvent& mouseInteraction);
 
     //! Wrap EBus call to retrieve manipulator line bound width.
     //! @note It is possible to pass AzFramework::InvalidViewportId (the default) to perform a Broadcast as opposed to a targeted Event.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -280,7 +280,7 @@ namespace AzToolsFramework
 
         using EditorEntityViewportInteractionRequestBus = AZ::EBus<EditorEntityViewportInteractionRequests, ViewportEBusTraits>;
 
-        //! Viewport requests for managing the viewports cursor state.
+        //! Viewport requests for managing the viewport cursor state.
         class ViewportMouseCursorRequests
         {
         public:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
@@ -19,7 +19,7 @@
 namespace AzToolsFramework
 {
     // default ray length for picking in the viewport
-    static const float s_pickRayLength = 1000.0f;
+    static const float EditorPickRayLength = 1000.0f;
 
     AZ::Vector3 CalculateCenterOffset(const AZ::EntityId entityId, const EditorTransformComponentSelectionRequests::Pivot pivot)
     {
@@ -60,16 +60,27 @@ namespace AzToolsFramework
         return screenPosition;
     }
 
-    bool AabbIntersectMouseRay(const ViewportInteraction::MouseInteraction& mouseInteraction, const AZ::Aabb& aabb)
+    bool AabbIntersectRay(const AZ::Vector3& origin, const AZ::Vector3& direction, const AZ::Aabb& aabb, float& distance)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
-        const AZ::Vector3 rayScaledDir = mouseInteraction.m_mousePick.m_rayDirection * s_pickRayLength;
+        const AZ::Vector3 rayScaledDir = direction * EditorPickRayLength;
 
-        AZ::Vector3 startNormal;
         float t, end;
-        return AZ::Intersect::IntersectRayAABB(
-                   mouseInteraction.m_mousePick.m_rayOrigin, rayScaledDir, rayScaledDir.GetReciprocal(), aabb, t, end, startNormal) > 0;
+        AZ::Vector3 startNormal;
+        if (AZ::Intersect::IntersectRayAABB(origin, rayScaledDir, rayScaledDir.GetReciprocal(), aabb, t, end, startNormal) > 0)
+        {
+            distance = t * EditorPickRayLength;
+            return true;
+        }
+
+        return false;
+    }
+
+    bool AabbIntersectMouseRay(const ViewportInteraction::MouseInteraction& mouseInteraction, const AZ::Aabb& aabb)
+    {
+        float unused;
+        return AabbIntersectRay(mouseInteraction.m_mousePick.m_rayOrigin, mouseInteraction.m_mousePick.m_rayDirection, aabb, unused);
     }
 
     bool PickEntity(
@@ -117,8 +128,7 @@ namespace AzToolsFramework
     {
         float scaling = 1.0f;
         ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            scaling, viewportId,
-            &ViewportInteraction::ViewportInteractionRequestBus::Events::DeviceScalingFactor);
+            scaling, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::DeviceScalingFactor);
 
         return scaling;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
@@ -46,6 +46,10 @@ namespace AzToolsFramework
     //! in screen space intersected an aabb in world space.
     bool AabbIntersectMouseRay(const ViewportInteraction::MouseInteraction& mouseInteraction, const AZ::Aabb& aabb);
 
+    //! Wrapper to perform an intersection between a ray and an aabb.
+    //! Note: direction should be normalized (it is scaled internally by the editor pick distance).
+    bool AabbIntersectRay(const AZ::Vector3& origin, const AZ::Vector3& direction, const AZ::Aabb& aabb, float& distance);
+
     //! Return if a mouse interaction (pick ray) did intersect the tested EntityId.
     bool PickEntity(
         AZ::EntityId entityId, const ViewportInteraction::MouseInteraction& mouseInteraction, float& closestDistance, int viewportId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.cpp
@@ -161,8 +161,8 @@ namespace AzToolsFramework
 
         // request list of visible entities from authoritative system
         EntityIdList nextVisibleEntityIds;
-        ViewportInteraction::MainEditorViewportInteractionRequestBus::Event(
-            viewportInfo.m_viewportId, &ViewportInteraction::MainEditorViewportInteractionRequestBus::Events::FindVisibleEntities,
+        ViewportInteraction::EditorEntityViewportInteractionRequestBus::Event(
+            viewportInfo.m_viewportId, &ViewportInteraction::EditorEntityViewportInteractionRequestBus::Events::FindVisibleEntities,
             nextVisibleEntityIds);
 
         // only bother resorting if we know the lists have changed

--- a/Code/Framework/AzToolsFramework/Tests/ComponentModeTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/ComponentModeTestFixture.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include "ComponentModeTestDoubles.h"
 #include "ComponentModeTestFixture.h"
+#include "ComponentModeTestDoubles.h"
 
 #include <AzCore/UserSettings/UserSettingsComponent.h>
 
@@ -15,17 +15,15 @@ namespace UnitTest
 {
     void ComponentModeTestFixture::SetUpEditorFixtureImpl()
     {
-        using namespace AzToolsFramework;
-        using namespace AzToolsFramework::ComponentModeFramework;
+        namespace AztfCmf = AzToolsFramework::ComponentModeFramework;
 
         auto* app = GetApplication();
-        ASSERT_TRUE(app);
 
-        app->RegisterComponentDescriptor(PlaceholderEditorComponent::CreateDescriptor());
-        app->RegisterComponentDescriptor(AnotherPlaceholderEditorComponent::CreateDescriptor());
-        app->RegisterComponentDescriptor(DependentPlaceholderEditorComponent::CreateDescriptor());
+        app->RegisterComponentDescriptor(AztfCmf::PlaceholderEditorComponent::CreateDescriptor());
+        app->RegisterComponentDescriptor(AztfCmf::AnotherPlaceholderEditorComponent::CreateDescriptor());
+        app->RegisterComponentDescriptor(AztfCmf::DependentPlaceholderEditorComponent::CreateDescriptor());
         app->RegisterComponentDescriptor(
-            TestComponentModeComponent<OverrideMouseInteractionComponentMode>::CreateDescriptor());
-        app->RegisterComponentDescriptor(IncompatiblePlaceholderEditorComponent::CreateDescriptor());
+            AztfCmf::TestComponentModeComponent<AztfCmf::OverrideMouseInteractionComponentMode>::CreateDescriptor());
+        app->RegisterComponentDescriptor(AztfCmf::IncompatiblePlaceholderEditorComponent::CreateDescriptor());
     }
 } // namespace UnitTest

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -73,6 +73,7 @@ namespace AtomToolsFramework
 
         return AZ::Transform::CreateIdentity();
     }
+
     void ModularCameraViewportContextImpl::SetCameraTransform(const AZ::Transform& transform)
     {
         if (auto viewportContext = RetrieveViewportContext(m_viewportId))
@@ -80,6 +81,7 @@ namespace AtomToolsFramework
             viewportContext->SetCameraTransform(transform);
         }
     }
+
     void ModularCameraViewportContextImpl::ConnectViewMatrixChangedHandler(AZ::RPI::ViewportContext::MatrixChangedEvent::Handler& handler)
     {
         if (auto viewportContext = RetrieveViewportContext(m_viewportId))


### PR DESCRIPTION
This PR is the beginning of resolving https://github.com/o3de/o3de/issues/3578. This change lays the groundwork for supporting better viewport interaction model integration tests by supporting the new visibility system work. This is currently implemented by `EditorViewportWidget` which is not instantiated at test time (for AzToolsFramework tests). The main 'visible entities' call has been split out from `MainEditorViewportInteractionRequestBus` (which will eventually be removed).

There's also a few minor tidy-up changes that I spotted along the way