### PR TITLE
Adding null checks to Gestures gem if gEnv isn't set

### DIFF
--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerClickOrTap.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerClickOrTap.inl
@@ -73,7 +73,7 @@ inline Gestures::RecognizerClickOrTap::~RecognizerClickOrTap()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerClickOrTap::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -120,7 +120,7 @@ inline bool Gestures::RecognizerClickOrTap::OnPressedEvent(const AZ::Vector2& sc
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerClickOrTap::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -159,7 +159,7 @@ inline bool Gestures::RecognizerClickOrTap::OnDownEvent(const AZ::Vector2& scree
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerClickOrTap::OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDrag.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDrag.inl
@@ -59,7 +59,7 @@ inline Gestures::RecognizerDrag::~RecognizerDrag()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerDrag::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -90,7 +90,7 @@ inline bool Gestures::RecognizerDrag::OnPressedEvent(const AZ::Vector2& screenPo
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerDrag::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.h
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.h
@@ -64,7 +64,7 @@ namespace Gestures
         AZ::Vector2 GetStartPosition() const { return m_startPosition; }
         AZ::Vector2 GetCurrentPosition() const { return m_currentPosition; }
 
-        float GetDuration() const { return gEnv->pTimer->GetFrameStartTime().GetDifferenceInSeconds(m_startTime); }
+        float GetDuration() const { return (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime().GetDifferenceInSeconds(m_startTime) : 0.0f; }
 
     private:
         enum class State

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.inl
@@ -59,7 +59,7 @@ inline Gestures::RecognizerHold::~RecognizerHold()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerHold::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -90,7 +90,7 @@ inline bool Gestures::RecognizerHold::OnPressedEvent(const AZ::Vector2& screenPo
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerHold::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.inl
@@ -106,7 +106,7 @@ inline float AngleInDegreesBetweenVectors(const AZ::Vector2& vec0, const AZ::Vec
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerPinch::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex > s_maxPinchPointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex > s_maxPinchPointerIndex)
     {
         return false;
     }

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.inl
@@ -95,7 +95,7 @@ inline bool Gestures::RecognizerRotate::OnPressedEvent(const AZ::Vector2& screen
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerRotate::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex > s_maxRotatePointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex > s_maxRotatePointerIndex)
     {
         return false;
     }

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerSwipe.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerSwipe.inl
@@ -59,7 +59,7 @@ inline Gestures::RecognizerSwipe::~RecognizerSwipe()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerSwipe::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -89,7 +89,7 @@ inline bool Gestures::RecognizerSwipe::OnPressedEvent(const AZ::Vector2& screenP
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerSwipe::OnDownEvent([[maybe_unused]] const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -125,7 +125,7 @@ inline bool Gestures::RecognizerSwipe::OnDownEvent([[maybe_unused]] const AZ::Ve
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerSwipe::OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (pointerIndex != m_config.pointerIndex)
+    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
     {
         return false;
     }


### PR DESCRIPTION
Adding null pointer checks in case the global environment is not set up outside of the editor.

This is resulting in crashes now that tools like the material editor are loading the same gems as the main editor.

Will also explore adding cry system to atom tools to set up the environment which was previously not needed.