### PR TITLE
Fixed ragdoll panel being available in Animation Editor when PhysX gem is enabled.

### DIFF
--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.cpp
@@ -50,26 +50,21 @@ namespace EMotionFX
         return newPlugin;
     }
 
-    bool RagdollNodeInspectorPlugin::PhysXGemAvailable() const
+    bool RagdollNodeInspectorPlugin::IsPhysXGemAvailable() const
     {
         AZ::SerializeContext* serializeContext = nullptr;
         AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
-        if (serializeContext)
-        {
-            // TypeId of D6JointLimitConfiguration
-            const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(AZ::TypeId::CreateString("{90C5C23D-16C0-4F23-AD50-A190E402388E}"));
-            if (classData && ColliderHelpers::AreCollidersReflected())
-            {
-                return true;
-            }
-        }
 
-        return false;
+        // TypeId of PhysX::SystemComponent
+        const char* typeIDPhysXSystem = "{85F90819-4D9A-4A77-AB89-68035201F34B}";
+
+        return serializeContext
+            && serializeContext->FindClassData(AZ::TypeId::CreateString(typeIDPhysXSystem));
     }
 
     bool RagdollNodeInspectorPlugin::Init()
     {
-        if (PhysXGemAvailable())
+        if (IsPhysXGemAvailable() && ColliderHelpers::AreCollidersReflected())
         {
             m_nodeWidget = new RagdollNodeWidget();
             m_nodeWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeInspectorPlugin.h
@@ -80,7 +80,7 @@ namespace EMotionFX
         void OnPasteJointLimits();
 
     private:
-        bool PhysXGemAvailable() const;
+        bool IsPhysXGemAvailable() const;
 
         RagdollNodeWidget*          m_nodeWidget;
 

--- a/Gems/EMotionFX/Code/Tests/D6JointLimitConfiguration.h
+++ b/Gems/EMotionFX/Code/Tests/D6JointLimitConfiguration.h
@@ -14,14 +14,13 @@ namespace EMotionFX
 {
     // Add so that RagdollNodeInspectorPlugin::PhysXCharactersGemAvailable() will return the correct value
     // We duplicated the D6JointLimitConfiguration because it doesn't exist in the test environment.
-    class D6JointLimitConfiguration
+    struct D6JointLimitConfiguration
         : public AzPhysics::JointConfiguration
     {
     public:
         AZ_CLASS_ALLOCATOR(D6JointLimitConfiguration, AZ::SystemAllocator, 0);
         // This uses the same uuid as the production D6JointLimitConfiguration.
-        // The Ragdoll UI uses this UUID to see if physx is available.
-        AZ_RTTI(D6JointLimitConfiguration, "{90C5C23D-16C0-4F23-AD50-A190E402388E}", AzPhysics::JointConfiguration);
+        AZ_RTTI(D6JointLimitConfiguration, "{88E067B4-21E8-4FFA-9142-6C52605B704C}", AzPhysics::JointConfiguration);
 
         static void Reflect(AZ::ReflectContext* context);
 

--- a/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
+++ b/Gems/EMotionFX/Code/Tests/Mocks/PhysicsSystem.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
@@ -20,6 +22,20 @@ namespace Physics
         , AZ::Interface<Physics::System>::Registrar
     {
     public:
+        // This uses the same uuid as the production PhysX::SystemComponent.
+        // The Ragdoll UI uses this UUID to see if physx is available.
+        AZ_RTTI(MockPhysicsSystem, "{85F90819-4D9A-4A77-AB89-68035201F34B}");
+
+        static void Reflect(AZ::ReflectContext* context)
+        {
+            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serializeContext->Class<MockPhysicsSystem>()
+                    ->Version(0)
+                    ;
+            }
+        }
+
         MockPhysicsSystem()
         {
             BusConnect();

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteColliders.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteColliders.cpp
@@ -39,7 +39,10 @@ namespace EMotionFX
 
             UIFixture::SetUp();
 
-            D6JointLimitConfiguration::Reflect(GetSerializeContext());
+            AZ::SerializeContext* serializeContext = GetSerializeContext();
+
+            Physics::MockPhysicsSystem::Reflect(serializeContext); // Required by Ragdoll plugin to fake PhysX Gem is available
+            D6JointLimitConfiguration::Reflect(serializeContext);
 
             EXPECT_CALL(m_jointHelpers, GetSupportedJointTypeIds)
                 .WillRepeatedly(testing::Return(AZStd::vector<AZ::TypeId>{ azrtti_typeid<D6JointLimitConfiguration>() }));

--- a/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteJointLimits.cpp
+++ b/Gems/EMotionFX/Code/Tests/ProvidesUI/Ragdoll/CanCopyPasteJointLimits.cpp
@@ -41,7 +41,10 @@ namespace EMotionFX
     {
         using testing::_;
 
-        D6JointLimitConfiguration::Reflect(GetSerializeContext());
+        AZ::SerializeContext* serializeContext = GetSerializeContext();
+
+        Physics::MockPhysicsSystem::Reflect(serializeContext); // Required by Ragdoll plugin to fake PhysX Gem is available
+        D6JointLimitConfiguration::Reflect(serializeContext);
 
         EMStudio::GetMainWindow()->ApplicationModeChanged("Physics");
 

--- a/Gems/EMotionFX/Code/Tests/UI/CanAddToSimulatedObject.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanAddToSimulatedObject.cpp
@@ -41,6 +41,7 @@ namespace EMotionFX
             AZ::SerializeContext* serializeContext = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
+            Physics::MockPhysicsSystem::Reflect(serializeContext); // Required by Ragdoll plugin to fake PhysX Gem is available
             D6JointLimitConfiguration::Reflect(serializeContext);
 
             SetupPluginWindows();

--- a/Gems/EMotionFX/Code/Tests/UI/RagdollEditTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/RagdollEditTests.cpp
@@ -40,6 +40,7 @@ namespace EMotionFX
             AZ::SerializeContext* serializeContext = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
 
+            Physics::MockPhysicsSystem::Reflect(serializeContext); // Required by Ragdoll plugin to fake PhysX Gem is available
             D6JointLimitConfiguration::Reflect(serializeContext);
 
             EXPECT_CALL(m_jointHelpers, GetSupportedJointTypeIds)


### PR DESCRIPTION
Following the same approach as cloth plugin, which is to ask if the system component of the gem is available (in this case PhysX::SystemComponent).

Fixes #2540

Signed-off-by: moraaar <moraaar@amazon.com>