### PR TITLE
Initial test coverage for viewport selection before introducing new 'single' select functionality

### DIFF
--- a/Code/Framework/AzManipulatorTestFramework/Source/IndirectManipulatorViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/IndirectManipulatorViewportInteraction.cpp
@@ -40,6 +40,8 @@ namespace AzManipulatorTestFramework
     {
         m_viewportInteraction.UpdateVisibility();
 
+        // ensure we call display viewport 2d to simulate this update step (some state may be
+        // updated here, e.g. box select)
         AzFramework::ViewportDebugDisplayEventBus::Event(
             AzToolsFramework::GetEntityContextId(), &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
             AzFramework::ViewportInfo{ m_viewportInteraction.GetViewportId() }, m_viewportInteraction.GetDebugDisplay());

--- a/Code/Framework/AzManipulatorTestFramework/Source/IndirectManipulatorViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/IndirectManipulatorViewportInteraction.cpp
@@ -40,6 +40,10 @@ namespace AzManipulatorTestFramework
     {
         m_viewportInteraction.UpdateVisibility();
 
+        AzFramework::ViewportDebugDisplayEventBus::Event(
+            AzToolsFramework::GetEntityContextId(), &AzFramework::ViewportDebugDisplayEvents::DisplayViewport2d,
+            AzFramework::ViewportInfo{ m_viewportInteraction.GetViewportId() }, m_viewportInteraction.GetDebugDisplay());
+
         DrawManipulators();
         AzToolsFramework::EditorInteractionSystemViewportSelectionRequestBus::Event(
             AzToolsFramework::GetEntityContextId(),

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.cpp
@@ -9,8 +9,8 @@
 #include "EditorBoxSelect.h"
 
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
-#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
+#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 
 #include <QApplication>
 
@@ -19,10 +19,14 @@ namespace AzToolsFramework
     static const AZ::Color s_boxSelectColor = AZ::Color(1.0f, 1.0f, 1.0f, 0.4f);
     static const float s_boxSelectLineWidth = 2.0f;
 
-    void EditorBoxSelect::HandleMouseInteraction(
-        const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
+    void EditorBoxSelect::HandleMouseInteraction(const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
+
+        if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Down)
+        {
+            m_cursorPositionAtDownEvent = mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates;
+        }
 
         m_cursorState.SetCurrentPosition(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
 
@@ -35,12 +39,7 @@ namespace AzToolsFramework
                 m_leftMouseDown(mouseInteraction);
             }
 
-            m_boxSelectRegion = QRect
-            {
-                ViewportInteraction::QPointFromScreenPoint(
-                    mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates),
-                QSize { 0, 0 }
-            };
+            m_boxSelectRegion = QRect{ ViewportInteraction::QPointFromScreenPoint(m_cursorPositionAtDownEvent), QSize{ 0, 0 } };
         }
 
         if (m_boxSelectRegion)
@@ -87,11 +86,11 @@ namespace AzToolsFramework
             AZ::Vector2 viewportSize = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId).m_viewportSize;
 
             debugDisplay.DrawWireQuad2d(
-                AZ::Vector2(
-                    aznumeric_cast<float>(m_boxSelectRegion->x()), aznumeric_cast<float>(m_boxSelectRegion->y())) / viewportSize,
+                AZ::Vector2(aznumeric_cast<float>(m_boxSelectRegion->x()), aznumeric_cast<float>(m_boxSelectRegion->y())) / viewportSize,
                 AZ::Vector2(
                     aznumeric_cast<float>(m_boxSelectRegion->x()) + aznumeric_cast<float>(m_boxSelectRegion->width()),
-                    aznumeric_cast<float>(m_boxSelectRegion->y()) + aznumeric_cast<float>(m_boxSelectRegion->height())) / viewportSize,
+                    aznumeric_cast<float>(m_boxSelectRegion->y()) + aznumeric_cast<float>(m_boxSelectRegion->height())) /
+                    viewportSize,
                 0.f);
 
             debugDisplay.DepthTestOn();
@@ -101,8 +100,7 @@ namespace AzToolsFramework
         }
     }
 
-    void EditorBoxSelect::DisplayScene(
-        const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
+    void EditorBoxSelect::DisplayScene(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
     {
         if (m_displayScene)
         {
@@ -122,15 +120,14 @@ namespace AzToolsFramework
         m_mouseMove = mouseMove;
     }
 
-    void EditorBoxSelect::InstallLeftMouseUp(
-        const AZStd::function<void()>& leftMouseUp)
+    void EditorBoxSelect::InstallLeftMouseUp(const AZStd::function<void()>& leftMouseUp)
     {
         m_leftMouseUp = leftMouseUp;
     }
 
     void EditorBoxSelect::InstallDisplayScene(
-        const AZStd::function<void(const AzFramework::ViewportInfo& viewportInfo,
-            AzFramework::DebugDisplayRequests& debugDisplay)>& displayScene)
+        const AZStd::function<void(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)>&
+            displayScene)
     {
         m_displayScene = displayScene;
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorBoxSelect.h
@@ -81,5 +81,6 @@ namespace AzToolsFramework
         ViewportInteraction::KeyboardModifiers m_previousModifiers; //!< Modifier keys active on the previous frame.
         AzFramework::ClickDetector m_clickDetector; //!< Utility type to detect if a mouse click or move has occurred.
         AzFramework::CursorState m_cursorState; //!< Utility type to track the current cursor position (and movement/delta).
+        AzFramework::ScreenPoint m_cursorPositionAtDownEvent; //!< The position of the cursor when first potentially starting a box select.
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1795,7 +1795,7 @@ namespace AzToolsFramework
 
         // for entities selected with no bounds of their own (just TransformComponent)
         // check selection against the selection indicator aabb
-        for (const AZ::EntityId entityId : m_selectedEntityIds)
+        for (const AZ::EntityId& entityId : m_selectedEntityIds)
         {
             if (const auto entityIndex = SelectableInVisibleViewportCache(*m_entityDataCache, entityId); entityIndex.has_value())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1723,14 +1723,6 @@ namespace AzToolsFramework
         m_pivotOverrideFrame.Reset();
     }
 
-    void EditorTransformComponentSelection::ChangeSelectedEntity(const AZ::EntityId entityId)
-    {
-        AZ_PROFILE_FUNCTION(AzToolsFramework);
-
-        DeselectEntities();
-        SelectDeselect(entityId);
-    }
-
     bool EditorTransformComponentSelection::SelectDeselect(const AZ::EntityId entityId)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -38,9 +38,6 @@
 #include <QApplication>
 #include <QRect>
 
-#pragma optimize("", off)
-#pragma inline_depth(0)
-
 namespace AzToolsFramework
 {
     AZ_CLASS_ALLOCATOR_IMPL(EditorTransformComponentSelection, AZ::SystemAllocator, 0)
@@ -1001,6 +998,7 @@ namespace AzToolsFramework
 
     // ask the visible entity data cache if the entity is selectable in the viewport
     // (useful in the context of drawing when we only care about entities we can see)
+    // note: return the index if it is selectable, nullopt otherwise
     static AZStd::optional<size_t> SelectableInVisibleViewportCache(
         const EditorVisibleEntityDataCache& entityDataCache, const AZ::EntityId entityId)
     {
@@ -3805,6 +3803,3 @@ namespace AzToolsFramework
     template ETCS::PivotOrientationResult ETCS::CalculateSelectionPivotOrientation<EntityIdManipulatorLookups>(
         const EntityIdManipulatorLookups&, const OptionalFrame&, const ReferenceFrame referenceFrame);
 } // namespace AzToolsFramework
-
-#pragma optimize("", on)
-#pragma inline_depth()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -207,7 +207,6 @@ namespace AzToolsFramework
         void SetSelectedEntities(const EntityIdList& entityIds);
         void DeselectEntities();
         bool SelectDeselect(AZ::EntityId entityId);
-        void ChangeSelectedEntity(AZ::EntityId entityId);
 
         void RefreshSelectedEntityIds();
         void RefreshSelectedEntityIds(const EntityIdList& selectedEntityIds);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -206,7 +206,8 @@ namespace AzToolsFramework
         bool IsEntitySelected(AZ::EntityId entityId) const;
         void SetSelectedEntities(const EntityIdList& entityIds);
         void DeselectEntities();
-        bool SelectDeselect(AZ::EntityId entityIdUnderCursor);
+        bool SelectDeselect(AZ::EntityId entityId);
+        void ChangeSelectedEntity(AZ::EntityId entityId);
 
         void RefreshSelectedEntityIds();
         void RefreshSelectedEntityIds(const EntityIdList& selectedEntityIds);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Console/IConsole.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/optional.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
@@ -32,6 +33,8 @@
 
 namespace AzToolsFramework
 {
+    AZ_CVAR_EXTERNED(bool, ed_viewportStickySelect);
+
     class EditorVisibleEntityDataCache;
 
     using EntityIdSet = AZStd::unordered_set<AZ::EntityId>; //!< Alias for unordered_set of EntityIds.
@@ -170,14 +173,11 @@ namespace AzToolsFramework
 
         //! ViewportInteraction::ViewportSelectionRequests
         //! Intercept all viewport mouse events and respond to inputs.
-        bool HandleMouseInteraction(
-            const ViewportInteraction::MouseInteractionEvent& mouseInteraction) override;
+        bool HandleMouseInteraction(const ViewportInteraction::MouseInteractionEvent& mouseInteraction) override;
         void DisplayViewportSelection(
-            const AzFramework::ViewportInfo& viewportInfo,
-            AzFramework::DebugDisplayRequests& debugDisplay) override;
+            const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
         void DisplayViewportSelection2d(
-            const AzFramework::ViewportInfo& viewportInfo,
-            AzFramework::DebugDisplayRequests& debugDisplay) override;
+            const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
 
         //! Add an entity to the current selection
         void AddEntityToSelection(AZ::EntityId entityId);
@@ -254,11 +254,10 @@ namespace AzToolsFramework
         void SnapSelectedEntitiesToWorldGrid(float gridSize) override;
 
         // EditorManipulatorCommandUndoRedoRequestBus ...
-        void UndoRedoEntityManipulatorCommand(
-            AZ::u8 pivotOverride, const AZ::Transform& transform, AZ::EntityId entityId) override;
+        void UndoRedoEntityManipulatorCommand(AZ::u8 pivotOverride, const AZ::Transform& transform, AZ::EntityId entityId) override;
 
         // EditorContextMenuBus...
-        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2 & point, int flags) override;
+        void PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2& point, int flags) override;
         int GetMenuPosition() const override;
         AZStd::string GetMenuIdentifier() const override;
 
@@ -267,8 +266,7 @@ namespace AzToolsFramework
 
         // ToolsApplicationNotificationBus ...
         void BeforeEntitySelectionChanged() override;
-        void AfterEntitySelectionChanged(
-            const EntityIdList& newlySelectedEntities, const EntityIdList& newlyDeselectedEntities) override;
+        void AfterEntitySelectionChanged(const EntityIdList& newlySelectedEntities, const EntityIdList& newlyDeselectedEntities) override;
 
         // TransformNotificationBus ...
         void OnTransformChanged(const AZ::Transform& localTM, const AZ::Transform& worldTM) override;
@@ -319,7 +317,8 @@ namespace AzToolsFramework
         EntityIdManipulators m_entityIdManipulators; //!< Mapping from a Manipulator to potentially many EntityIds.
 
         EditorBoxSelect m_boxSelect; //!< Type responsible for handling box select.
-        AZStd::unique_ptr<EntityManipulatorCommand> m_manipulatorMoveCommand; //!< Track adjustments to manipulator translation and orientation (during mouse press/move).
+        //! Track adjustments to manipulator translation and orientation (during mouse press/move).
+        AZStd::unique_ptr<EntityManipulatorCommand> m_manipulatorMoveCommand;
         AZStd::vector<AZStd::unique_ptr<QAction>> m_actions; //!< What actions are tied to this handler.
         ViewportInteraction::KeyboardModifiers m_previousModifiers; //!< What modifiers were held last frame.
         EditorContextMenu m_contextMenu; //!< Viewport right click context menu.
@@ -329,8 +328,10 @@ namespace AzToolsFramework
         ReferenceFrame m_referenceFrame = ReferenceFrame::Parent; //!< What reference frame is the Manipulator currently operating in.
         Frame m_axisPreview; //!< Axes of entity at the time of mouse down to indicate delta of translation.
         bool m_triedToRefresh = false; //!< Did a refresh event occur to recalculate the current Manipulator transform.
-        bool m_didSetSelectedEntities = false; //!< Was EditorTransformComponentSelection responsible for the most recent entity selection change.
-        bool m_selectedEntityIdsAndManipulatorsDirty = false; //!< Do the active manipulators need to recalculated after a modification (lock/visibility etc).
+        //! Was EditorTransformComponentSelection responsible for the most recent entity selection change.
+        bool m_didSetSelectedEntities = false;
+        //! Do the active manipulators need to recalculated after a modification (lock/visibility etc).
+        bool m_selectedEntityIdsAndManipulatorsDirty = false;
         bool m_transformChangedInternally = false; //!< Was an OnTransformChanged event triggered internally or not.
         ViewportUi::ClusterId m_transformModeClusterId; //!< Id of the Viewport UI cluster for changing transform mode.
         ViewportUi::ButtonId m_translateButtonId; //!< Id of the Viewport UI button for translate mode.
@@ -364,15 +365,13 @@ namespace AzToolsFramework
 
         //! Calculate the orientation for a group of entities based on the incoming reference frame.
         template<typename EntityIdMap>
-        PivotOrientationResult CalculatePivotOrientationForEntityIds(
-            const EntityIdMap& entityIdMap, const ReferenceFrame referenceFrame);
+        PivotOrientationResult CalculatePivotOrientationForEntityIds(const EntityIdMap& entityIdMap, const ReferenceFrame referenceFrame);
 
         //! Calculate the orientation for a group of entities based on the incoming
         //! reference frame with possible pivot override.
         template<typename EntityIdMap>
         PivotOrientationResult CalculateSelectionPivotOrientation(
-            const EntityIdMap& entityIdMap, const OptionalFrame& pivotOverrideFrame,
-            const ReferenceFrame referenceFrame);
+            const EntityIdMap& entityIdMap, const OptionalFrame& pivotOverrideFrame, const ReferenceFrame referenceFrame);
 
         void SetEntityWorldTranslation(AZ::EntityId entityId, const AZ::Vector3& worldTranslation, bool& internal);
         void SetEntityLocalTranslation(AZ::EntityId entityId, const AZ::Vector3& localTranslation, bool& internal);

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -54,6 +54,14 @@ namespace AZ
 
 namespace UnitTest
 {
+    AzToolsFramework::EntityIdList SelectedEntities()
+    {
+        AzToolsFramework::EntityIdList selectedEntitiesBefore;
+        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+            selectedEntitiesBefore, &AzToolsFramework::ToolsApplicationRequestBus::Events::GetSelectedEntities);
+        return selectedEntitiesBefore;
+    }
+
     class EditorEntityVisibilityCacheFixture : public ToolsApplicationFixture
     {
     public:
@@ -580,13 +588,19 @@ namespace UnitTest
             AZ::Transform::CreateFromQuaternionAndTranslation(
                 AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(0.0f, 0.0f, 90.0f)), AZ::Vector3(10.0f, 15.0f, 10.0f)));
 
+        using ::testing::Eq;
+        auto selectedEntitiesBefore = SelectedEntities();
+        EXPECT_TRUE(selectedEntitiesBefore.empty());
+
         // calculate the position in screen space of the initial position of the entity
         const auto initialPositionScreen = AzFramework::WorldToScreen(initialTransformWorld.GetTranslation(), m_cameraState);
 
+        // click the entity in the viewport
         m_actionDispatcher->CameraState(m_cameraState)->MousePosition(initialPositionScreen)->MouseLButtonDown()->MouseLButtonUp();
 
-        int i;
-        i = 0;
+        auto selectedEntitiesAfter = SelectedEntities();
+        EXPECT_THAT(selectedEntitiesAfter.size(), Eq(1));
+        EXPECT_THAT(selectedEntitiesAfter.front(), Eq(m_entityId1));
     }
 
     TEST_F(EditorTransformComponentSelectionManipulatorTestFixture, CanMoveEntityUsingManipulatorMouseMovement)

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -768,7 +768,7 @@ namespace UnitTest
         EXPECT_THAT(selectedEntitiesAfter, UnorderedElementsAre(m_entityId1));
     }
 
-    TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, BoxSelectWithNoInitialSelectionAddsEntitiesToSelection)
+    TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, DISABLED_BoxSelectWithNoInitialSelectionAddsEntitiesToSelection)
     {
         AzToolsFramework::ed_viewportStickySelect = true;
 


### PR DESCRIPTION
This PR adds a number of tests to verify the current behavior of entity selection in the Viewport Interaction Model.

A new AZ_CVAR (`ed_viewportStickySelect`) has been added in anticipation for toggling 'sticky' mode (what we have today) vs 'non-sticky' mode (in future this will almost certainly be moved to the Settings Registry).

There still need to be a few more box select tests, but then new functionality can be added to support the new type of selection that a host of users prefer.

There are a few other small fixes that were identified with the tests and some pretty minor formatting changes (after running `clang-format`).

Relates to https://github.com/o3de/o3de/issues/3578

```
Note: Google Test filter = EditorTransformComponentSelectionViewportPickingManipulatorTestFixture*
[==========] Running 6 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 6 tests from EditorTransformComponentSelectionViewportPickingManipulatorTestFixture
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.SingleClickWithNoSelectionWillSelectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.SingleClickWithNoSelectionWillSelectEntity (148 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.SingleClickOffEntityWithSelectionWillNotDeselectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.SingleClickOffEntityWithSelectionWillNotDeselectEntity (111 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.SingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.SingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity (110 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.CtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.CtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection (125 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.CtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.CtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection (112 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithNoInitialSelectionAddsEntitiesToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithNoInitialSelectionAddsEntitiesToSelection (128 ms)
[----------] 6 tests from EditorTransformComponentSelectionViewportPickingManipulatorTestFixture (738 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test case ran. (741 ms total)
[  PASSED  ] 6 tests.
OKAY AzRunUnitTests() returned 0
```