### PR TITLE
Fix compile errors in the Wwise Gem

### DIFF
--- a/Gems/AudioEngineWwise/Code/Source/Engine/Config_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/Config_wwise.cpp
@@ -11,8 +11,8 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/FileFunc/FileFunc.h>
 
 // For AZ_Printf statements...
 #define WWISE_CONFIG_WINDOW "WwiseConfig"
@@ -56,7 +56,7 @@ namespace Audio::Wwise
     bool ConfigurationSettings::Load(const AZStd::string& filePath)
     {
         AZ::IO::Path fileIoPath(filePath);
-        auto outcome = AzFramework::FileFunc::ReadJsonFile(fileIoPath);
+        auto outcome = AZ::JsonSerializationUtils::ReadJsonFile(fileIoPath.Native());
         if (!outcome)
         {
             AZ_Printf(WWISE_CONFIG_WINDOW, "ERROR: %s\n", outcome.GetError().c_str());
@@ -92,7 +92,7 @@ namespace Audio::Wwise
             return false;
         }
 
-        auto outcome = AzFramework::FileFunc::WriteJsonFile(jsonDoc, filePath);
+        auto outcome = AZ::JsonSerializationUtils::WriteJsonFile(jsonDoc, filePath);
         if (!outcome)
         {
             AZ_Printf(WWISE_CONFIG_WINDOW, "ERROR: %s\n", outcome.GetError().c_str());

--- a/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Engine/FileIOHandler_wwise.cpp
@@ -19,9 +19,7 @@
 #include <AudioEngineWwise_Traits_Platform.h>
 #include <cinttypes>
 
-#define MAX_NUMBER_STRING_SIZE      (10)    // 4G
-#define ID_TO_STRING_FORMAT_BANK    AKTEXT("%u.bnk")
-#define ID_TO_STRING_FORMAT_WEM     AKTEXT("%u.wem")
+#define MAX_NUMBER_STRING_SIZE      (10)    // max digits in u32 base-10 number
 #define MAX_EXTENSION_SIZE          (4)     // .xxx
 #define MAX_FILETITLE_SIZE          (MAX_NUMBER_STRING_SIZE + MAX_EXTENSION_SIZE + 1)   // null-terminated
 
@@ -442,11 +440,16 @@ namespace Audio
                 }
             }
 
-            AkOSChar fileName[MAX_FILETITLE_SIZE] = { '\0' };
+            AkOSChar fileName[MAX_FILETITLE_SIZE] = { 0 };
 
-            const AkOSChar* const filenameFormat = (flags->uCodecID == AKCODECID_BANK ? ID_TO_STRING_FORMAT_BANK : ID_TO_STRING_FORMAT_WEM);
-
-            AK_OSPRINTF(fileName, MAX_FILETITLE_SIZE, filenameFormat, static_cast<int unsigned>(fileID));
+            if (flags->uCodecID == AKCODECID_BANK)
+            {
+                AK_OSPRINTF(fileName, MAX_FILETITLE_SIZE, AKTEXT("%u.bnk"), static_cast<unsigned int>(fileID));
+            }
+            else
+            {
+                AK_OSPRINTF(fileName, MAX_FILETITLE_SIZE, AKTEXT("%u.wem"), static_cast<unsigned int>(fileID));
+            }
 
             AKPLATFORM::SafeStrCat(finalFilePath, fileName, AK_MAX_PATH);
 


### PR DESCRIPTION
One fixes string literal format specifiers warnings that were recently enabled.
One fixes a FileFunc utility that was removed.
