### PR TITLE
Add [[maybe_unused]] to some local variables.

### DIFF
--- a/Code/Legacy/CrySystem/SystemCFG.cpp
+++ b/Code/Legacy/CrySystem/SystemCFG.cpp
@@ -178,7 +178,7 @@ void CSystem::LogVersion()
     strftime(s, 128, "%d %b %y (%H %M %S)", today);
 #endif
 
-    const SFileVersion& ver = GetFileVersion();
+    [[maybe_unused]] const SFileVersion& ver = GetFileVersion();
 
     CryLogAlways("BackupNameAttachment=\" Build(%d) %s\"  -- used by backup system\n", ver.v[0], s);          // read by CreateBackupFile()
 
@@ -249,7 +249,7 @@ void CSystem::LogVersion()
 //////////////////////////////////////////////////////////////////////////
 void CSystem::LogBuildInfo()
 {
-    auto projectName = AZ::Utils::GetProjectName();
+    [[maybe_unused]] auto projectName = AZ::Utils::GetProjectName();
     CryLogAlways("GameName: %s", projectName.c_str());
     CryLogAlways("BuildTime: " __DATE__ " " __TIME__);
 }


### PR DESCRIPTION
Add [[maybe_unused]] to some local variables that are only referenced as arguments to CryLogAlways that is not compiled in release.

Signed-off-by: bosnichd <bosnichd@amazon.com>