### PR TITLE
Fix ebus node slots not checked for vars

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.cpp
@@ -78,6 +78,8 @@ namespace ScriptCanvas
                         variableIds.insert(scopedVariableId->m_identifier);
                     }
                 }
+                
+                Node::CollectVariableReferences(variableIds);
             }
 
             bool EBusEventHandler::ContainsReferencesToVariables(const AZStd::unordered_set< ScriptCanvas::VariableId >& variableIds) const
@@ -90,11 +92,14 @@ namespace ScriptCanvas
 
                     if (scopedVariableId)
                     {
-                        return variableIds.find(scopedVariableId->m_identifier) != variableIds.end();
+                        if(variableIds.find(scopedVariableId->m_identifier) != variableIds.end())
+                        {
+                            return true;
+                        }
                     }
                 }
 
-                return false;
+                return Node::ContainsReferencesToVariables(variableIds);
             }
 
             size_t EBusEventHandler::GenerateFingerprint() const


### PR DESCRIPTION
Fixed an issue where EBusEventHandler nodes did not consider variables in slots.  The 'Remove unused variables' function and slot highlighting relies on this functionality, and possibly the GraphVariablesTableView

![8GITbOZumC](https://user-images.githubusercontent.com/26804013/132559116-af8c5e90-d415-4646-b10d-e4f6dd0eac17.gif)


Signed-off-by: AMZN-alexpete <26804013+AMZN-alexpete@users.noreply.github.com>