### PR TITLE
Improves numeric_cast compilation

### DIFF
--- a/Code/Framework/AzCore/AzCore/Casting/numeric_cast.h
+++ b/Code/Framework/AzCore/AzCore/Casting/numeric_cast.h
@@ -8,14 +8,25 @@
 
 #pragma once
 
+// This is disabled by default because it puts in costly runtime checking of casted values.
+// You can either change it here to enable it across the engine, or use push/pop_macro to enable per file/feature.
+// Note that if using push/pop_macro, you may get some of the functions not inline and the definition coming from
+// another compilation unit, in such case, you will have to push/pop_macro on that compilation unit as well.
+// #define AZ_NUMERICCAST_ENABLED 1
+
+#if AZ_NUMERICCAST_ENABLED != 1
+
+#define aznumeric_cast static_cast
+
+#else
+
+#include <AzCore/Casting/numeric_cast_internal.h>
 #include <AzCore/std/typetraits/is_arithmetic.h>
 #include <AzCore/std/typetraits/is_class.h>
 #include <AzCore/std/typetraits/is_enum.h>
 #include <AzCore/std/typetraits/is_floating_point.h>
 #include <AzCore/std/typetraits/is_integral.h>
-#include <AzCore/std/typetraits/is_same.h>
 #include <AzCore/std/typetraits/is_signed.h>
-#include <AzCore/std/typetraits/is_unsigned.h>
 #include <AzCore/std/typetraits/remove_cvref.h>
 #include <AzCore/std/typetraits/underlying_type.h>
 #include <AzCore/std/utils.h>
@@ -28,7 +39,7 @@
 // enabled.
 //
 // Because we can't do partial function specialization, I'm using enable_if to chop up the implementation into one of these
-// implementations. If none of these fit, then we will get a compile error because it is an unknown conversionr.
+// implementations. If none of these fit, then we will get a compile error because it is an unknown conversion.
 //
 //--------------------------------------------
 //              TYPE <- TYPE         DigitLoss
@@ -51,120 +62,42 @@
 // (K)    Floating      Floating         Y
 */
 
-// This is disabled by default because it puts in costly runtime checking of casted values.
-// You can either change it here to enable it across the engine, or use push/pop_macro to enable per file/feature.
-// Note that if using push/pop_macro, you may get some of the functions not inline and the definition coming from
-// another compilation unit, in such case, you will have to push/pop_macro on that compilation unit as well.
-// #define AZ_NUMERICCAST_ENABLED 1
-
-#if AZ_NUMERICCAST_ENABLED
 #define AZ_NUMERIC_ASSERT(expr, ...) AZ_Assert(expr, __VA_ARGS__)
-#else
-#define AZ_NUMERIC_ASSERT(expr, ...) void(0)
-#endif
-
-#pragma push_macro("max")
-#undef max
-
-namespace NumericCastInternal
-{
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    !AZStd::is_integral<FromType>::value || !AZStd::is_floating_point<ToType>::value
-    , bool> ::type UnderflowsToType(const FromType& value)
-    {
-        return (value < static_cast<FromType>(std::numeric_limits<ToType>::lowest()));
-    }
-
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value && AZStd::is_floating_point<ToType>::value
-    , bool> ::type UnderflowsToType(const FromType& value)
-    {
-        return (static_cast<ToType>(value) < std::numeric_limits<ToType>::lowest());
-    }
-
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    !AZStd::is_integral<FromType>::value || !AZStd::is_floating_point<ToType>::value
-    , bool> ::type OverflowsToType(const FromType& value)
-    {
-        return (value > static_cast<FromType>(std::numeric_limits<ToType>::max()));
-    }
-
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value && AZStd::is_floating_point<ToType>::value
-    , bool> ::type OverflowsToType(const FromType& value)
-    {
-        return (static_cast<ToType>(value) > std::numeric_limits<ToType>::max());
-    }
-
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value
-    && std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits
-    && AZStd::is_signed<FromType>::value && AZStd::is_unsigned<ToType>::value
-    , bool> ::type FitsInToType(const FromType& value)
-    {
-        return !NumericCastInternal::UnderflowsToType<ToType>(value);
-    }
-
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value
-    && (std::numeric_limits<FromType>::digits > std::numeric_limits<ToType>::digits)
-    && AZStd::is_unsigned<FromType>::value
-    , bool> ::type FitsInToType(const FromType& value)
-    {
-        return !NumericCastInternal::OverflowsToType<ToType>(value);
-    }
-
-    template <typename ToType, typename FromType>
-    inline constexpr typename AZStd::enable_if<
-    (!AZStd::is_integral<FromType>::value || !AZStd::is_integral<ToType>::value)
-    || ((std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits) && (AZStd::is_unsigned<FromType>::value || AZStd::is_signed<ToType>::value))
-    || ((std::numeric_limits<FromType>::digits > std::numeric_limits<ToType>::digits) && AZStd::is_signed<FromType>::value)
-    , bool> ::type FitsInToType(const FromType& value)
-    {
-        return !NumericCastInternal::OverflowsToType<ToType>(value) && !NumericCastInternal::UnderflowsToType<ToType>(value);
-    }
-} // namespace AZ
 
 // INTEGER -> INTEGER
 // (A) Not losing digits or risking sign loss
-template <typename ToType, typename FromType>
+template<typename ToType, typename FromType>
 inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value&& AZStd::is_integral<ToType>::value
-    && std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits
-    && (!std::numeric_limits<FromType>::is_signed || std::numeric_limits<ToType>::is_signed)
-    , ToType > ::type aznumeric_cast(FromType value)
+    AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value &&
+        std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits &&
+        (!std::numeric_limits<FromType>::is_signed || std::numeric_limits<ToType>::is_signed),
+    ToType>::type
+aznumeric_cast(FromType value)
 {
     return static_cast<ToType>(value);
 }
 
 // (B) Not losing digits, but we are losing sign, so make sure we aren't dealing with a negative number
-template <typename ToType, typename FromType>
+template<typename ToType, typename FromType>
 inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value&& AZStd::is_integral<ToType>::value
-    && std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits
-    && std::numeric_limits<FromType>::is_signed&& !std::numeric_limits<ToType>::is_signed
-    , ToType > ::type aznumeric_cast(FromType value)
+    AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value &&
+        std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits && std::numeric_limits<FromType>::is_signed &&
+        !std::numeric_limits<ToType>::is_signed,
+    ToType>::type
+aznumeric_cast(FromType value)
 {
-    AZ_NUMERIC_ASSERT(
-        NumericCastInternal::FitsInToType<ToType>(value),
-        "Attempted cast causes loss of signed value.");
+    AZ_NUMERIC_ASSERT(NumericCastInternal::FitsInToType<ToType>(value), "Attempted cast causes loss of signed value.");
     return static_cast<ToType>(value);
 }
 
-
-// (C) Maybe losing digits from an unsigned type, so make sure we don't exceed the destination max value. No check against zero is necessary.
-template <typename ToType, typename FromType>
+// (C) Maybe losing digits from an unsigned type, so make sure we don't exceed the destination max value. No check against zero is
+// necessary.
+template<typename ToType, typename FromType>
 inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value&& AZStd::is_integral<ToType>::value
-    && !(std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits)
-    && !std::numeric_limits<FromType>::is_signed
-    , ToType > ::type aznumeric_cast(FromType value)
+    AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value &&
+        !(std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits) && !std::numeric_limits<FromType>::is_signed,
+    ToType>::type
+aznumeric_cast(FromType value)
 {
     AZ_NUMERIC_ASSERT(
         NumericCastInternal::FitsInToType<ToType>(value),
@@ -173,12 +106,12 @@ inline constexpr typename AZStd::enable_if<
 }
 
 // (D) Maybe losing digits within signed types, we need to check both the min and max values.
-template <typename ToType, typename FromType>
+template<typename ToType, typename FromType>
 inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value&& AZStd::is_integral<ToType>::value
-    && !(std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits)
-    && std::numeric_limits<FromType>::is_signed
-    , ToType > ::type aznumeric_cast(FromType value)
+    AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value &&
+        !(std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits) && std::numeric_limits<FromType>::is_signed,
+    ToType>::type
+aznumeric_cast(FromType value)
 {
     AZ_NUMERIC_ASSERT(
         NumericCastInternal::FitsInToType<ToType>(value),
@@ -188,10 +121,9 @@ inline constexpr typename AZStd::enable_if<
 
 // ENUMS -> INTEGER
 // (E) handled by changing the enum to its underlying type
-template <typename ToType, typename FromType>
-inline constexpr typename AZStd::enable_if<
-    AZStd::is_enum<FromType>::value&& AZStd::is_integral<ToType>::value
-    , ToType > ::type aznumeric_cast(FromType value)
+template<typename ToType, typename FromType>
+inline constexpr typename AZStd::enable_if<AZStd::is_enum<FromType>::value && AZStd::is_integral<ToType>::value, ToType>::type
+aznumeric_cast(FromType value)
 {
     using UnderlyingFromType = typename AZStd::underlying_type<FromType>::type;
     return aznumeric_cast<ToType>(static_cast<UnderlyingFromType>(value));
@@ -199,23 +131,20 @@ inline constexpr typename AZStd::enable_if<
 
 // FLOATING -> INTEGER
 // (E) We'll accept precision loss as long as it stays in range
-template <typename ToType, typename FromType>
-inline constexpr typename AZStd::enable_if<
-    AZStd::is_floating_point<FromType>::value&& AZStd::is_integral<ToType>::value
-    , ToType > ::type aznumeric_cast(FromType value)
+template<typename ToType, typename FromType>
+inline constexpr typename AZStd::enable_if<AZStd::is_floating_point<FromType>::value && AZStd::is_integral<ToType>::value, ToType>::type
+aznumeric_cast(FromType value)
 {
     AZ_NUMERIC_ASSERT(
-        NumericCastInternal::FitsInToType<ToType>(value),
-        "Attempted cast of floating point value does not fit in the supplied type.");
+        NumericCastInternal::FitsInToType<ToType>(value), "Attempted cast of floating point value does not fit in the supplied type.");
     return static_cast<ToType>(value);
 }
 
 // INTEGER -> ENUM
 // (G) We must cast to an enum so go through the backing type
-template <typename ToType, typename FromType>
-inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value&& AZStd::is_enum<ToType>::value
-    , ToType > ::type aznumeric_cast(FromType value)
+template<typename ToType, typename FromType>
+inline constexpr typename AZStd::enable_if<AZStd::is_integral<FromType>::value && AZStd::is_enum<ToType>::value, ToType>::type
+aznumeric_cast(FromType value)
 {
     using UnderlyingToType = typename AZStd::underlying_type<ToType>::type;
     return static_cast<ToType>(aznumeric_cast<UnderlyingToType>(value));
@@ -223,20 +152,18 @@ inline constexpr typename AZStd::enable_if<
 
 // INTEGER -> FLOATING POINT
 // (H) Perhaps some faster code substitutions could be done here instead of the standard int->float calls
-template <typename ToType, typename FromType>
-inline constexpr typename AZStd::enable_if<
-    AZStd::is_integral<FromType>::value&& AZStd::is_floating_point<ToType>::value
-    , ToType > ::type aznumeric_cast(FromType value)
+template<typename ToType, typename FromType>
+inline constexpr typename AZStd::enable_if<AZStd::is_integral<FromType>::value && AZStd::is_floating_point<ToType>::value, ToType>::type
+aznumeric_cast(FromType value)
 {
     return static_cast<ToType>(value);
 }
 
 // ENUM -> ENUM
 // (I) crossing enums using the underlying type as the transport
-template <typename ToType, typename FromType>
-inline constexpr typename AZStd::enable_if<
-    AZStd::is_enum<FromType>::value&& AZStd::is_enum<ToType>::value
-    , ToType > ::type aznumeric_cast(FromType value)
+template<typename ToType, typename FromType>
+inline constexpr typename AZStd::enable_if<AZStd::is_enum<FromType>::value && AZStd::is_enum<ToType>::value, ToType>::type aznumeric_cast(
+    FromType value)
 {
     using UnderlyingFromType = typename AZStd::underlying_type<FromType>::type;
     using UnderlyingToType = typename AZStd::underlying_type<ToType>::type;
@@ -245,49 +172,59 @@ inline constexpr typename AZStd::enable_if<
 
 // FLOATING POINT -> FLOATING POINT
 // (J) crossing floats with no digit loss
-template <typename ToType, typename FromType>
+template<typename ToType, typename FromType>
 inline constexpr typename AZStd::enable_if<
-    AZStd::is_floating_point<FromType>::value&& AZStd::is_floating_point<ToType>::value
-    && std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits
-    , ToType > ::type aznumeric_cast(FromType value)
+    AZStd::is_floating_point<FromType>::value && AZStd::is_floating_point<ToType>::value &&
+        std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits,
+    ToType>::type
+aznumeric_cast(FromType value)
 {
     return static_cast<ToType>(value);
 }
 
 // (K) crossing floats with digit loss
-template <typename ToType, typename FromType>
+template<typename ToType, typename FromType>
 inline constexpr typename AZStd::enable_if<
-    AZStd::is_floating_point<FromType>::value&& AZStd::is_floating_point<ToType>::value
-    && !(std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits)
-    , ToType > ::type aznumeric_cast(FromType value)
+    AZStd::is_floating_point<FromType>::value && AZStd::is_floating_point<ToType>::value &&
+        !(std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits),
+    ToType>::type
+aznumeric_cast(FromType value)
 {
     AZ_NUMERIC_ASSERT(
-        NumericCastInternal::FitsInToType<ToType>(value),
-        "Attempted cast of floating point value does not fit in the supplied type.");
+        NumericCastInternal::FitsInToType<ToType>(value), "Attempted cast of floating point value does not fit in the supplied type.");
     return static_cast<ToType>(value);
 }
 
 // (L) Support for types that implement a specific conversion operator FromType()
 // This is used to forward the numeric_cast from a class type to arithmetic type
-template <typename ToType, typename FromType>
-inline constexpr auto aznumeric_cast(FromType&& value) ->
-    AZStd::enable_if_t<AZStd::is_class_v<AZStd::remove_cvref_t<FromType>> && AZStd::is_arithmetic_v<ToType> && AZStd::is_convertible_v<AZStd::remove_cvref_t<FromType>, ToType>, ToType>
+template<typename ToType, typename FromType>
+inline constexpr auto aznumeric_cast(FromType&& value) -> AZStd::enable_if_t<
+    AZStd::is_class_v<AZStd::remove_cvref_t<FromType>> && AZStd::is_arithmetic_v<ToType> &&
+        AZStd::is_convertible_v<AZStd::remove_cvref_t<FromType>, ToType>,
+    ToType>
 {
     return static_cast<ToType>(value);
 }
 
+#endif
+
 // This is a helper class that lets us induce the destination type of a numeric cast
-// It should never be directly used by anything other than azlossy_caster.
+// It should never be directly used by anything other than aznumeric_caster.
 namespace AZ
 {
-    template <typename FromType>
+    template<typename FromType>
     class NumericCasted
     {
     public:
         explicit constexpr NumericCasted(FromType value)
-            : m_value(value) { }
-        template <typename ToType>
-        constexpr operator ToType() const { return aznumeric_cast<ToType>(m_value); }
+            : m_value(value)
+        {
+        }
+        template<typename ToType>
+        constexpr operator ToType() const
+        {
+            return aznumeric_cast<ToType>(m_value);
+        }
 
     private:
         NumericCasted() = delete;
@@ -295,14 +232,12 @@ namespace AZ
 
         FromType m_value;
     };
-}
+} // namespace AZ
 
 // This is the primary function we should use when doing numeric casting, since it induces the
 // type we need to cast to from the code rather than requiring an explicit coupling in the source.
-template <typename FromType>
+template<typename FromType>
 inline constexpr AZ::NumericCasted<FromType> aznumeric_caster(FromType value)
 {
     return AZ::NumericCasted<FromType>(value);
 }
-
-#pragma pop_macro("max")

--- a/Code/Framework/AzCore/AzCore/Casting/numeric_cast_internal.h
+++ b/Code/Framework/AzCore/AzCore/Casting/numeric_cast_internal.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/typetraits/conditional.h>
+#include <AzCore/std/typetraits/is_floating_point.h>
+#include <AzCore/std/typetraits/is_integral.h>
+#include <AzCore/std/typetraits/is_signed.h>
+#include <AzCore/std/typetraits/is_unsigned.h>
+#include <limits>
+
+namespace NumericCastInternal
+{
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<!AZStd::is_integral<FromType>::value || !AZStd::is_floating_point<ToType>::value, bool>::type
+    UnderflowsToType(const FromType& value)
+    {
+        return (value < static_cast<FromType>(std::numeric_limits<ToType>::lowest()));
+    }
+
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<AZStd::is_integral<FromType>::value && AZStd::is_floating_point<ToType>::value, bool>::type
+    UnderflowsToType(const FromType& value)
+    {
+        return (static_cast<ToType>(value) < std::numeric_limits<ToType>::lowest());
+    }
+
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<!AZStd::is_integral<FromType>::value || !AZStd::is_floating_point<ToType>::value, bool>::type
+    OverflowsToType(const FromType& value)
+    {
+        return (value > static_cast<FromType>(std::numeric_limits<ToType>::max()));
+    }
+
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<AZStd::is_integral<FromType>::value && AZStd::is_floating_point<ToType>::value, bool>::type
+    OverflowsToType(const FromType& value)
+    {
+        return (static_cast<ToType>(value) > std::numeric_limits<ToType>::max());
+    }
+
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<
+        AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value &&
+            std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits && AZStd::is_signed<FromType>::value &&
+            AZStd::is_unsigned<ToType>::value,
+        bool>::type
+    FitsInToType(const FromType& value)
+    {
+        return !NumericCastInternal::UnderflowsToType<ToType>(value);
+    }
+
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<
+        AZStd::is_integral<FromType>::value && AZStd::is_integral<ToType>::value &&
+            (std::numeric_limits<FromType>::digits > std::numeric_limits<ToType>::digits) && AZStd::is_unsigned<FromType>::value,
+        bool>::type
+    FitsInToType(const FromType& value)
+    {
+        return !NumericCastInternal::OverflowsToType<ToType>(value);
+    }
+
+    template<typename ToType, typename FromType>
+    inline constexpr typename AZStd::enable_if<
+        (!AZStd::is_integral<FromType>::value || !AZStd::is_integral<ToType>::value) ||
+            ((std::numeric_limits<FromType>::digits <= std::numeric_limits<ToType>::digits) &&
+             (AZStd::is_unsigned<FromType>::value || AZStd::is_signed<ToType>::value)) ||
+            ((std::numeric_limits<FromType>::digits > std::numeric_limits<ToType>::digits) && AZStd::is_signed<FromType>::value),
+        bool>::type
+    FitsInToType(const FromType& value)
+    {
+        return !NumericCastInternal::OverflowsToType<ToType>(value) && !NumericCastInternal::UnderflowsToType<ToType>(value);
+    }
+
+}

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/CastingHelpers.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/CastingHelpers.h
@@ -8,14 +8,14 @@
 
 #pragma once
 
-#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/Casting/numeric_cast_internal.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/std/string/string_view.h>
 #include <AzCore/std/string/osstring.h>
 
 namespace AZ
 {
-    //! A helper function to casts between numeric types, and consider the data which is being converted comse from user data.
+    //! A helper function to casts between numeric types, and consider the data which is being converted comes from user data.
     //! If a conversion from FromType to ToType will not cause overflow or underflow, the result is stored in result, and the function returns Success
     //! Otherwise, the target is left untouched.
     template <typename ToType, typename FromType>
@@ -24,9 +24,9 @@ namespace AZ
     {
         using namespace JsonSerializationResult;
 
-        if (NumericCastInternal::FitsInToType<ToType>(value))
+        if (NumericCastInternal::template FitsInToType<ToType>(value))
         {
-            result = aznumeric_cast<ToType>(value);
+            result = static_cast<ToType>(value);
             return reporting("Successfully cast number.", ResultCode(Tasks::Convert, Outcomes::Success), path);
         }
         else

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -34,8 +34,8 @@ set(FILES
     Asset/AssetTypeInfoBus.h
     Asset/AssetInternal/WeakAsset.h
     Casting/lossy_cast.h
-    Casting/numeric_cast_internal.h
     Casting/numeric_cast.h
+    Casting/numeric_cast_internal.h
     Component/Component.cpp
     Component/Component.h
     Component/ComponentApplication.cpp

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -34,6 +34,7 @@ set(FILES
     Asset/AssetTypeInfoBus.h
     Asset/AssetInternal/WeakAsset.h
     Casting/lossy_cast.h
+    Casting/numeric_cast_internal.h
     Casting/numeric_cast.h
     Component/Component.cpp
     Component/Component.h

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/Debug/Trace.h>
 
 #include <AzQtComponents/Components/DockTabBar.h>
 #include <AzQtComponents/Components/FancyDocking.h>

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/GradientSlider.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/GradientSlider.cpp
@@ -114,7 +114,7 @@ void GradientSlider::mouseMoveEvent(QMouseEvent* event)
 {
     int intValue = Slider::valueFromPosition(this, event->pos(), width(), height(), rect().bottom());
 
-    qreal value = (aznumeric_cast<qreal, int>(intValue - minimum()) / aznumeric_cast<qreal, int>(maximum() - minimum()));
+    qreal value = (aznumeric_cast<qreal>(intValue - minimum()) / aznumeric_cast<qreal>(maximum() - minimum()));
 
     const QString toolTipText = m_toolTipFunction(value);
 


### PR DESCRIPTION
before: 872s
after: 824s (5.5% reduction)

Signed-off-by: Esteban Papp <81431996+amznestebanpapp@users.noreply.github.com>