### PR TITLE
{LYN6482} Fix warning as error in Editor Python Bindings

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
@@ -293,7 +293,7 @@ namespace EditorPythonBindings
                     handler->m_ebus->m_name.c_str(), eventName);
             }
 
-            void OnEventGenericHook(const char* eventName, pybind11::function callback, [[maybe_unused]] int eventIndex, AZ::BehaviorValueParameter* result, int numParameters, AZ::BehaviorValueParameter* parameters)
+            void OnEventGenericHook([[maybe_unused]] const char* eventName, pybind11::function callback, [[maybe_unused]] int eventIndex, AZ::BehaviorValueParameter* result, int numParameters, AZ::BehaviorValueParameter* parameters)
             {
                 // build the parameters to send to callback
                 Convert::StackVariableAllocator stackVariableAllocator;


### PR DESCRIPTION
{LYN6482} Fix warning as error in Editor Python Bindings
Signed-off-by: Jackson <23512001+jackalbe@users.noreply.github.com>