### PR TITLE
Fixing gestures gem warnings when gEnv/pTimer is null

### DIFF
--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerClickOrTap.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerClickOrTap.inl
@@ -73,12 +73,12 @@ inline Gestures::RecognizerClickOrTap::~RecognizerClickOrTap()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerClickOrTap::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
 
-    const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+    const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
     switch (m_currentState)
     {
     case State::Idle:
@@ -120,7 +120,7 @@ inline bool Gestures::RecognizerClickOrTap::OnPressedEvent(const AZ::Vector2& sc
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerClickOrTap::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -129,7 +129,7 @@ inline bool Gestures::RecognizerClickOrTap::OnDownEvent(const AZ::Vector2& scree
     {
     case State::Pressed:
     {
-        const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+        const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
         if ((currentTime.GetDifferenceInSeconds(m_timeOfLastEvent) > m_config.maxSecondsHeld) ||
             (screenPosition.GetDistance(m_positionOfLastEvent) > m_config.maxPixelsMoved))
         {
@@ -159,7 +159,7 @@ inline bool Gestures::RecognizerClickOrTap::OnDownEvent(const AZ::Vector2& scree
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerClickOrTap::OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -168,7 +168,7 @@ inline bool Gestures::RecognizerClickOrTap::OnReleasedEvent(const AZ::Vector2& s
     {
     case State::Pressed:
     {
-        const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+        const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
         if ((currentTime.GetDifferenceInSeconds(m_timeOfLastEvent) > m_config.maxSecondsHeld) ||
             (screenPosition.GetDistance(m_positionOfLastEvent) > m_config.maxPixelsMoved))
         {

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDrag.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDrag.inl
@@ -59,7 +59,7 @@ inline Gestures::RecognizerDrag::~RecognizerDrag()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerDrag::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -68,7 +68,7 @@ inline bool Gestures::RecognizerDrag::OnPressedEvent(const AZ::Vector2& screenPo
     {
     case State::Idle:
     {
-        m_startTime = gEnv->pTimer->GetFrameStartTime().GetValue();
+        m_startTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime().GetValue() : 0;
         m_startPosition = screenPosition;
         m_currentPosition = screenPosition;
         m_currentState = State::Pressed;
@@ -90,7 +90,7 @@ inline bool Gestures::RecognizerDrag::OnPressedEvent(const AZ::Vector2& screenPo
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerDrag::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -101,7 +101,7 @@ inline bool Gestures::RecognizerDrag::OnDownEvent(const AZ::Vector2& screenPosit
     {
     case State::Pressed:
     {
-        const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+        const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
         if ((currentTime.GetDifferenceInSeconds(m_startTime) >= m_config.minSecondsHeld) &&
             (GetDistance() >= m_config.minPixelsMoved))
         {

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.inl
@@ -59,7 +59,7 @@ inline Gestures::RecognizerHold::~RecognizerHold()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerHold::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -68,7 +68,7 @@ inline bool Gestures::RecognizerHold::OnPressedEvent(const AZ::Vector2& screenPo
     {
     case State::Idle:
     {
-        m_startTime = gEnv->pTimer->GetFrameStartTime().GetValue();
+        m_startTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime().GetValue() : 0;
         m_startPosition = screenPosition;
         m_currentPosition = screenPosition;
         m_currentState = State::Pressed;
@@ -90,7 +90,7 @@ inline bool Gestures::RecognizerHold::OnPressedEvent(const AZ::Vector2& screenPo
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerHold::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -101,7 +101,7 @@ inline bool Gestures::RecognizerHold::OnDownEvent(const AZ::Vector2& screenPosit
     {
     case State::Pressed:
     {
-        const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+        const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
         if (screenPosition.GetDistance(m_startPosition) > m_config.maxPixelsMoved)
         {
             // Hold recognition failed.

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.inl
@@ -106,13 +106,13 @@ inline float AngleInDegreesBetweenVectors(const AZ::Vector2& vec0, const AZ::Vec
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerPinch::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex > s_maxPinchPointerIndex)
+    if (pointerIndex > s_maxPinchPointerIndex)
     {
         return false;
     }
 
     m_currentPositions[pointerIndex] = screenPosition;
-    m_lastUpdateTimes[pointerIndex] = gEnv->pTimer->GetFrameStartTime().GetValue();
+    m_lastUpdateTimes[pointerIndex] = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime().GetValue() : 0;
     if (m_lastUpdateTimes[0] != m_lastUpdateTimes[1])
     {
         // We need to wait until both touches have been updated this frame.

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.inl
@@ -95,13 +95,13 @@ inline bool Gestures::RecognizerRotate::OnPressedEvent(const AZ::Vector2& screen
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerRotate::OnDownEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex > s_maxRotatePointerIndex)
+    if (pointerIndex > s_maxRotatePointerIndex)
     {
         return false;
     }
 
     m_currentPositions[pointerIndex] = screenPosition;
-    m_lastUpdateTimes[pointerIndex] = gEnv->pTimer->GetFrameStartTime().GetValue();
+    m_lastUpdateTimes[pointerIndex] = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime().GetValue() : 0;
     if (m_lastUpdateTimes[0] != m_lastUpdateTimes[1])
     {
         // We need to wait until both touches have been updated this frame.

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerSwipe.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerSwipe.inl
@@ -59,7 +59,7 @@ inline Gestures::RecognizerSwipe::~RecognizerSwipe()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerSwipe::OnPressedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -68,7 +68,7 @@ inline bool Gestures::RecognizerSwipe::OnPressedEvent(const AZ::Vector2& screenP
     {
     case State::Idle:
     {
-        m_startTime = gEnv->pTimer->GetFrameStartTime().GetValue();
+        m_startTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime().GetValue() : 0;
         m_startPosition = screenPosition;
         m_endPosition = screenPosition;
         m_currentState = State::Pressed;
@@ -89,7 +89,7 @@ inline bool Gestures::RecognizerSwipe::OnPressedEvent(const AZ::Vector2& screenP
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerSwipe::OnDownEvent([[maybe_unused]] const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -98,7 +98,7 @@ inline bool Gestures::RecognizerSwipe::OnDownEvent([[maybe_unused]] const AZ::Ve
     {
     case State::Pressed:
     {
-        const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+        const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
         if (currentTime.GetDifferenceInSeconds(m_startTime) > m_config.maxSecondsHeld)
         {
             // Swipe recognition failed because we took too long.
@@ -125,7 +125,7 @@ inline bool Gestures::RecognizerSwipe::OnDownEvent([[maybe_unused]] const AZ::Ve
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline bool Gestures::RecognizerSwipe::OnReleasedEvent(const AZ::Vector2& screenPosition, uint32_t pointerIndex)
 {
-    if (!gEnv || !gEnv->pTimer || pointerIndex != m_config.pointerIndex)
+    if (pointerIndex != m_config.pointerIndex)
     {
         return false;
     }
@@ -134,7 +134,7 @@ inline bool Gestures::RecognizerSwipe::OnReleasedEvent(const AZ::Vector2& screen
     {
     case State::Pressed:
     {
-        const CTimeValue currentTime = gEnv->pTimer->GetFrameStartTime();
+        const CTimeValue currentTime = (gEnv && gEnv->pTimer) ? gEnv->pTimer->GetFrameStartTime() : CTimeValue();
         if ((currentTime.GetDifferenceInSeconds(m_startTime) <= m_config.maxSecondsHeld) &&
             (screenPosition.GetDistance(m_startPosition) >= m_config.minPixelsMoved))
         {


### PR DESCRIPTION
This is an update from a previous change that added early return null checks for the global environment and its timer. Those changes fixed crashes when gestures was activated and running outside of the main editor. But the changes also resulted in warnings that went unnoticed. This round of changes allows gestures to run without warnings, using inline checks and default values instead of returning early.