### PR TITLE
Adds unused calls to Trace functions to prevent constant failures in release builds

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.cpp
@@ -213,7 +213,7 @@ namespace AZ
 
         void AssetData::Acquire()
         {
-            AZ_Assert(m_useCount >= 0, "AssetData has been deleted")
+            AZ_Assert(m_useCount >= 0, "AssetData has been deleted");
 
             AcquireWeak();
             ++m_useCount;

--- a/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetCommon.h
@@ -990,7 +990,7 @@ namespace AZ
         template<class T>
         u8 Asset<T>::GetFlags() const
         {
-            AZ_Warning("Asset", false, "Deprecated - replaced by GetAutoLoadBehavior")
+            AZ_Warning("Asset", false, "Deprecated - replaced by GetAutoLoadBehavior");
             return static_cast<u8>(m_loadBehavior);
         }
 
@@ -1012,7 +1012,7 @@ namespace AZ
         template<class T>
         bool Asset<T>::SetFlags(u8 flags)
         {
-            AZ_Warning("Asset", false, "Deprecated - replaced by SetAutoLoadBehavior")
+            AZ_Warning("Asset", false, "Deprecated - replaced by SetAutoLoadBehavior");
             if (!m_assetData)
             {
                 AZ_Assert(flags < static_cast<u8>(AssetLoadBehavior::Count), "Flags value is out of range");

--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -2132,7 +2132,7 @@ namespace AZ
             }
             else
             {
-                AZ_Warning("AssetManager", false, "Couldn't find handler for asset %s (%s)", asset.GetId().ToString<AZStd::string>().c_str(), asset.GetHint().c_str())
+                AZ_Warning("AssetManager", false, "Couldn't find handler for asset %s (%s)", asset.GetId().ToString<AZStd::string>().c_str(), asset.GetHint().c_str());
             }
 
             // Notify any dependent jobs.

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.h
@@ -262,17 +262,17 @@ namespace AZ
 
 #else // !AZ_ENABLE_TRACING
 
-    #define AZ_Assert(...)          AZ_UNUSED(__VA_ARGS__)
-    #define AZ_Error(...)           AZ_UNUSED(__VA_ARGS__)
-    #define AZ_ErrorOnce(...)       AZ_UNUSED(__VA_ARGS__)
-    #define AZ_Warning(...)         AZ_UNUSED(__VA_ARGS__)
-    #define AZ_WarningOnce(...)     AZ_UNUSED(__VA_ARGS__)
-    #define AZ_TracePrintf(...)     AZ_UNUSED(__VA_ARGS__)
-    #define AZ_TracePrintfOnce(...) AZ_UNUSED(__VA_ARGS__)
+    #define AZ_Assert(...)               AZ_UNUSED(__VA_ARGS__);
+    #define AZ_Error(...)                AZ_UNUSED(__VA_ARGS__);
+    #define AZ_ErrorOnce(...)            AZ_UNUSED(__VA_ARGS__);
+    #define AZ_Warning(...)              AZ_UNUSED(__VA_ARGS__);
+    #define AZ_WarningOnce(...)          AZ_UNUSED(__VA_ARGS__);
+    #define AZ_TracePrintf(...)          AZ_UNUSED(__VA_ARGS__);
+    #define AZ_TracePrintfOnce(...)      AZ_UNUSED(__VA_ARGS__);
 
-    #define AZ_Verify(...)          AZ_UNUSED(__VA_ARGS__)
-    #define AZ_VerifyError(...)     AZ_UNUSED(__VA_ARGS__)
-    #define AZ_VerifyWarning(...)   AZ_UNUSED(__VA_ARGS__)
+    #define AZ_Verify(...)               AZ_UNUSED(__VA_ARGS__);
+    #define AZ_VerifyError(...)          AZ_UNUSED(__VA_ARGS__);
+    #define AZ_VerifyWarning(...)        AZ_UNUSED(__VA_ARGS__);
 
 #endif  // AZ_ENABLE_TRACING
 

--- a/Code/Framework/AzCore/AzCore/Debug/Trace.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.h
@@ -8,8 +8,7 @@
 #pragma once
 
 #include <AzCore/PlatformDef.h>
-#define AZ_VA_HAS_ARGS(...) ""#__VA_ARGS__[0] != 0
-
+#include <AzCore/base.h>
 
 namespace AZ
 {
@@ -262,17 +261,18 @@ namespace AZ
     #define AZ_VerifyWarning(window, expression, ...) AZ_Warning(window, 0 != (expression), __VA_ARGS__)
 
 #else // !AZ_ENABLE_TRACING
-    #define AZ_Assert(expression, ...)
-    #define AZ_Error(window, expression, ...)
-    #define AZ_ErrorOnce(window, expression, ...)
-    #define AZ_Warning(window, expression, ...)
-    #define AZ_WarningOnce(window, expression, ...)
-    #define AZ_TracePrintf(window, ...)
-    #define AZ_TracePrintfOnce(window, ...)
 
-    #define AZ_Verify(expression, ...) (void)(expression)
-    #define AZ_VerifyError(window, expression, ...) (void)(expression)
-    #define AZ_VerifyWarning(window, expression, ...) (void)(expression)
+    #define AZ_Assert(...)          AZ_UNUSED(__VA_ARGS__)
+    #define AZ_Error(...)           AZ_UNUSED(__VA_ARGS__)
+    #define AZ_ErrorOnce(...)       AZ_UNUSED(__VA_ARGS__)
+    #define AZ_Warning(...)         AZ_UNUSED(__VA_ARGS__)
+    #define AZ_WarningOnce(...)     AZ_UNUSED(__VA_ARGS__)
+    #define AZ_TracePrintf(...)     AZ_UNUSED(__VA_ARGS__)
+    #define AZ_TracePrintfOnce(...) AZ_UNUSED(__VA_ARGS__)
+
+    #define AZ_Verify(...)          AZ_UNUSED(__VA_ARGS__)
+    #define AZ_VerifyError(...)     AZ_UNUSED(__VA_ARGS__)
+    #define AZ_VerifyWarning(...)   AZ_UNUSED(__VA_ARGS__)
 
 #endif  // AZ_ENABLE_TRACING
 

--- a/Code/Framework/AzCore/AzCore/Driller/Stream.cpp
+++ b/Code/Framework/AzCore/AzCore/Driller/Stream.cpp
@@ -693,7 +693,7 @@ namespace AZ
             }
             else
             {
-                AZ_Assert(m_isPooledString == false && m_isPooledStringCrc32 == false, "This stream requires using of a string pool as the string is send only once and afterwards only the Crc32 is used!")
+                AZ_Assert(m_isPooledString == false && m_isPooledStringCrc32 == false, "This stream requires using of a string pool as the string is send only once and afterwards only the Crc32 is used!");
             }
             return srcData;
         }

--- a/Code/Framework/AzCore/AzCore/IO/IStreamerTypes.h
+++ b/Code/Framework/AzCore/AzCore/IO/IStreamerTypes.h
@@ -150,9 +150,7 @@ namespace AZ::IO::IStreamerTypes
 
     private:
         AZStd::atomic_int m_lockCounter{ 0 };
-#ifdef AZ_ENABLE_TRACING
         AZStd::atomic_int m_allocationCounter{ 0 };
-#endif
         AZ::IAllocatorAllocate& m_allocator;
     };
 

--- a/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Script/ScriptContext.cpp
@@ -222,7 +222,7 @@ namespace AZ
 
         int AddRefCount(int value)
         {
-            AZ_Assert(value == 1 || value == -1, "ModRefCount is only for incrementing or decrementing on copy or destruction of ExposedLambda")
+            AZ_Assert(value == 1 || value == -1, "ModRefCount is only for incrementing or decrementing on copy or destruction of ExposedLambda");
             lua_rawgeti(m_lua, LUA_REGISTRYINDEX, m_refCountRegistryIndex);
             // Lua: refCount-old
             const int refCount = Internal::azlua_tointeger(m_lua, -1) + value;

--- a/Code/Framework/AzCore/AzCore/Serialization/Json/MapSerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/MapSerializer.cpp
@@ -293,7 +293,7 @@ namespace AZ
             }
 
             AZ_Assert(!keyValues.Empty(), "Intermediate array for associative container can't be empty "
-                "because an empty array would be stored as an empty default object.")
+                "because an empty array would be stored as an empty default object.");
             
             if (CanBeConvertedToObject(keyValues))
             {

--- a/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
+++ b/Code/Framework/AzCore/AzCore/Serialization/SerializeContext.cpp
@@ -2300,7 +2300,7 @@ namespace AZ
         {
             if (classData->m_converter)
             {
-                AZ_Assert(false, "A deprecated element with a data converter was passed to CloneObject, this is not supported.")
+                AZ_Assert(false, "A deprecated element with a data converter was passed to CloneObject, this is not supported.");
             }
             // push a dummy node in the stack
             cloneData->m_parentStack.push_back();

--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryMergeUtils.cpp
@@ -109,12 +109,12 @@ namespace AZ::Internal
                     {
                         FixedValueString engineName;
                         settingsRegistry.Get(engineName, engineMonikerKey);
-                        AZ_Warning("SettingsRegistryMergeUtils",engineInfo.m_moniker == engineName,
+                        AZ_Warning("SettingsRegistryMergeUtils", engineInfo.m_moniker == engineName,
                             R"(The engine name key "%s" mapped to engine path "%s" within the global manifest of "%s")"
                             R"( does not match the "engine_name" field "%s" in the engine.json)" "\n"
                             "This engine should be re-registered.",
                             engineInfo.m_moniker.c_str(), engineInfo.m_path.c_str(), engineManifestPath.c_str(),
-                            engineName.c_str())
+                            engineName.c_str());
                         engineInfo.m_moniker = engineName;
                     }
                 }

--- a/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Slice/SliceComponent.cpp
@@ -3464,7 +3464,7 @@ namespace AZ
     const SliceComponent::DataFlagsPerEntity* SliceComponent::GetCorrectBundleOfDataFlags(EntityId entityId) const
     {
         // It would be possible to search non-instantiated slices by crawling over lists, but we haven't needed the capability yet.
-        AZ_Assert(IsInstantiated(), "Data flag access is only permitted after slice is instantiated.")
+        AZ_Assert(IsInstantiated(), "Data flag access is only permitted after slice is instantiated.");
 
         if (IsInstantiated())
         {

--- a/Code/Framework/AzCore/AzCore/base.h
+++ b/Code/Framework/AzCore/AzCore/base.h
@@ -143,6 +143,9 @@
  * example. AZ_VA_NUM_ARGS(x,y,z) -> expands to 3
  */
 #ifndef AZ_VA_NUM_ARGS
+
+#   define AZ_VA_HAS_ARGS(...) ""#__VA_ARGS__[0] != 0
+
 // we add the zero to avoid the case when we require at least 1 param at the end...
 #   define AZ_VA_NUM_ARGS(...) AZ_VA_NUM_ARGS_IMPL_((__VA_ARGS__, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))
 #   define AZ_VA_NUM_ARGS_IMPL_(tuple) AZ_VA_NUM_ARGS_IMPL tuple
@@ -170,15 +173,15 @@
 // This is a pain they we use macros to call functions (with no params).
 
 // we implement functions for up to 10 params
-#define AZ_FUNCTION_CALL_1(_1)                                  _1()
-#define AZ_FUNCTION_CALL_2(_1, _2)                               _1(_2)
-#define AZ_FUNCTION_CALL_3(_1, _2, _3)                           _1(_2, _3)
-#define AZ_FUNCTION_CALL_4(_1, _2, _3, _4)                        _1(_2, _3, _4)
-#define AZ_FUNCTION_CALL_5(_1, _2, _3, _4, _5)                     _1(_2, _3, _4, _5)
-#define AZ_FUNCTION_CALL_6(_1, _2, _3, _4, _5, _6)                  _1(_2, _3, _4, _5, _6)
-#define AZ_FUNCTION_CALL_7(_1, _2, _3, _4, _5, _6, _7)               _1(_2, _3, _4, _5, _6, _7)
-#define AZ_FUNCTION_CALL_8(_1, _2, _3, _4, _5, _6, _7, _8)            _1(_2, _3, _4, _5, _6, _7, _8)
-#define AZ_FUNCTION_CALL_9(_1, _2, _3, _4, _5, _6, _7, _8, _9)         _1(_2, _3, _4, _5, _6, _7, _8, _9)
+#define AZ_FUNCTION_CALL_1(_1)                                          _1()
+#define AZ_FUNCTION_CALL_2(_1, _2)                                      _1(_2)
+#define AZ_FUNCTION_CALL_3(_1, _2, _3)                                  _1(_2, _3)
+#define AZ_FUNCTION_CALL_4(_1, _2, _3, _4)                              _1(_2, _3, _4)
+#define AZ_FUNCTION_CALL_5(_1, _2, _3, _4, _5)                          _1(_2, _3, _4, _5)
+#define AZ_FUNCTION_CALL_6(_1, _2, _3, _4, _5, _6)                      _1(_2, _3, _4, _5, _6)
+#define AZ_FUNCTION_CALL_7(_1, _2, _3, _4, _5, _6, _7)                  _1(_2, _3, _4, _5, _6, _7)
+#define AZ_FUNCTION_CALL_8(_1, _2, _3, _4, _5, _6, _7, _8)              _1(_2, _3, _4, _5, _6, _7, _8)
+#define AZ_FUNCTION_CALL_9(_1, _2, _3, _4, _5, _6, _7, _8, _9)          _1(_2, _3, _4, _5, _6, _7, _8, _9)
 #define AZ_FUNCTION_CALL_10(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10)    _1(_2, _3, _4, _5, _6, _7, _8, _9, _10)
 
 // We require at least 1 param FunctionName
@@ -293,7 +296,20 @@ namespace AZ
 #define AZ_DEFAULT_COPY_MOVE(_Class) AZ_DEFAULT_COPY(_Class) AZ_DEFAULT_MOVE(_Class)
 
 // Macro that can be used to avoid unreferenced variable warnings
-#define AZ_UNUSED(x) (void)x
+#define AZ_UNUSED_1(x)                                          (void)(x);
+#define AZ_UNUSED_2(x1, x2)                                     AZ_UNUSED_1(x1)                     AZ_UNUSED_1(x2)
+#define AZ_UNUSED_3(x1, x2, x3)                                 AZ_UNUSED_1(x1)                     AZ_UNUSED_2(x2, x3)
+#define AZ_UNUSED_4(x1, x2, x3, x4)                             AZ_UNUSED_2(x1, x2)                 AZ_UNUSED_2(x3, x4)
+#define AZ_UNUSED_5(x1, x2, x3, x4, x5)                         AZ_UNUSED_2(x1, x2)                 AZ_UNUSED_3(x3, x4, x5)
+#define AZ_UNUSED_6(x1, x2, x3, x4, x5, x6)                     AZ_UNUSED_3(x1, x2, x3)             AZ_UNUSED_3(x4, x5, x6)
+#define AZ_UNUSED_7(x1, x2, x3, x4, x5, x6, x7)                 AZ_UNUSED_3(x1, x2, x3)             AZ_UNUSED_4(x4, x5, x6, x7)
+#define AZ_UNUSED_8(x1, x2, x3, x4, x5, x6, x7, x8)             AZ_UNUSED_4(x1, x2, x3, x4)         AZ_UNUSED_4(x5, x6, x7, x8)
+#define AZ_UNUSED_9(x1, x2, x3, x4, x5, x6, x7, x8, x9)         AZ_UNUSED_4(x1, x2, x3, x4)         AZ_UNUSED_5(x5, x6, x7, x8, x9)
+#define AZ_UNUSED_10(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)   AZ_UNUSED_5(x1, x2, x3, x4, x5)     AZ_UNUSED_5(x6, x7, x8, x9, x10)
+#define AZ_UNUSED_11(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)   AZ_UNUSED_5(x1, x2, x3, x4, x5)     AZ_UNUSED_6(x6, x7, x8, x9, x10, x11)
+#define AZ_UNUSED_12(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)   AZ_UNUSED_6(x1, x2, x3, x4, x5, x6)     AZ_UNUSED_6(x7, x8, x9, x10, x11, x12)
+
+#define AZ_UNUSED(...) AZ_MACRO_SPECIALIZE(AZ_UNUSED_, AZ_VA_NUM_ARGS(__VA_ARGS__), (__VA_ARGS__))
 
 #define AZ_DEFINE_ENUM_BITWISE_OPERATORS(EnumType) \
 inline constexpr EnumType operator | (EnumType a, EnumType b) \

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/Platform_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/Platform_Windows.cpp
@@ -42,7 +42,7 @@ namespace AZ
                 }
                 else
                 {
-                    AZ_Error("System", false, "Failed to open HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\MachineGuid!")
+                    AZ_Error("System", false, "Failed to open HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\MachineGuid!");
                 }
 
                 wchar_t* hostname = machineInfo + wcslen(machineInfo);

--- a/Code/Framework/AzCore/Tests/Patching.cpp
+++ b/Code/Framework/AzCore/Tests/Patching.cpp
@@ -2651,7 +2651,7 @@ namespace UnitTest
                         if (!rootElement.GetChildData(AZ_CRC("InnerBaseStringField"), stringField))
                         {
                             AZ_Error("PatchingTest", false, "Unable to retrieve 'InnerBaseStringField' data for %u version of the InnerObjectFieldConverterClass",
-                                rootElement.GetVersion())
+                                rootElement.GetVersion());
                             return false;
                         }
 

--- a/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/RemoteStorageDrive.cpp
@@ -281,7 +281,7 @@ namespace AzFramework
         AZ_PROFILE_FUNCTION(AzCore);
             
         auto data = AZStd::get_if<FileRequest::ReadData>(&request->GetCommand());
-        AZ_Assert(data, "Request doing reading in the RemoteStorageDrive didn't contain read data.")
+        AZ_Assert(data, "Request doing reading in the RemoteStorageDrive didn't contain read data.");
 
         HandleType file = InvalidHandle;
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/VectorInput.cpp
@@ -303,7 +303,7 @@ VectorInput::~VectorInput()
 void VectorInput::setLabel(int index, const QString& label)
 {
     AZ_Warning("PropertyGrid", index < m_elementCount,
-        "This control handles only %i controls", m_elementCount)
+        "This control handles only %i controls", m_elementCount);
     if (index < m_elementCount)
     {
         m_elements[index]->setLabel(label);
@@ -313,7 +313,7 @@ void VectorInput::setLabel(int index, const QString& label)
 void VectorInput::setLabelStyle(int index, const QString& qss)
 {
     AZ_Warning("PropertyGrid", index < m_elementCount,
-        "This control handles only %i controls", m_elementCount)
+        "This control handles only %i controls", m_elementCount);
     if (index < m_elementCount)
     {
         m_elements[index]->getLabelWidget()->setStyleSheet(qss);
@@ -323,7 +323,7 @@ void VectorInput::setLabelStyle(int index, const QString& qss)
 void VectorInput::setValuebyIndex(double value, int elementIndex)
 {
     AZ_Warning("PropertyGrid", elementIndex < m_elementCount,
-        "This control handles only %i controls", m_elementCount)
+        "This control handles only %i controls", m_elementCount);
     if (elementIndex < m_elementCount)
     {
         m_elements[elementIndex]->setValue(value);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -526,12 +526,10 @@ namespace AzToolsFramework
 
             Template& targetTemplate = targetTemplateReference->get();
 
-#if defined(AZ_ENABLE_TRACING)
             Template& sourceTemplate = sourceTemplateReference->get();
             AZStd::string_view instanceName(instanceIterator->name.GetString(), instanceIterator->name.GetStringLength());
             const AZStd::string& targetTemplateFilePath = targetTemplate.GetFilePath().Native();
             const AZStd::string& sourceTemplateFilePath = sourceTemplate.GetFilePath().Native();
-#endif
 
             LinkId newLinkId = CreateUniqueLinkId();
             Link newLink(newLinkId);
@@ -770,10 +768,8 @@ namespace AzToolsFramework
                 return false;
             }
 
-#if defined(AZ_ENABLE_TRACING)
             Template& sourceTemplate = sourceTemplateReference->get();
             Template& targetTemplate = targetTemplateReference->get();
-#endif
 
             AZStd::string_view instanceName(instanceIterator->name.GetString(), instanceIterator->name.GetStringLength());
 
@@ -783,10 +779,9 @@ namespace AzToolsFramework
 
             PrefabDomValue& instance = instanceIterator->value;
             AZ_Assert(instance.IsObject(), "Nested instance DOM provided is not a valid JSON object.");
-            [[maybe_unused]] PrefabDomValueReference sourceTemplateName = PrefabDomUtils::FindPrefabDomValue(instance, PrefabDomUtils::SourceName);
+            PrefabDomValueReference sourceTemplateName = PrefabDomUtils::FindPrefabDomValue(instance, PrefabDomUtils::SourceName);
             AZ_Assert(sourceTemplateName, "Couldn't find source template name in the DOM of the nested instance while creating a link.");
-            AZ_Assert(
-                sourceTemplateName->get() == sourceTemplate.GetFilePath().c_str(),
+            AZ_Assert(sourceTemplateName->get() == sourceTemplate.GetFilePath().c_str(),
                 "The name of the source template in the nested instance DOM does not match the name of the source template already loaded");
 
             PrefabDomValueReference patchesReference = PrefabDomUtils::FindPrefabDomValue(instance, PrefabDomUtils::PatchesName);

--- a/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
+++ b/Code/Framework/GFxFramework/GFxFramework/MaterialIO/Material.cpp
@@ -236,7 +236,7 @@ namespace AZ
                 case TextureMapType::Bump:
                     return m_normalMap;
                 default:
-                    AZ_Assert(false, "Invalid Texture map requested.")
+                    AZ_Assert(false, "Invalid Texture map requested.");
                     return m_empty;
             }
         }
@@ -255,7 +255,7 @@ namespace AZ
                 m_normalMap = texture;
                 break;
             default:
-                AZ_Assert(false, "Invalid Texture map requested.")
+                AZ_Assert(false, "Invalid Texture map requested.");
                 break;
             }
         }
@@ -599,7 +599,7 @@ namespace AZ
 
             if (!materialNode)
             {
-                AZ_Assert(false, "Attempted to add material to invalid xml document.")
+                AZ_Assert(false, "Attempted to add material to invalid xml document.");
                 return false;
             }
 

--- a/Code/Framework/GridMate/GridMate/Replica/ReplicaChunk.cpp
+++ b/Code/Framework/GridMate/GridMate/Replica/ReplicaChunk.cpp
@@ -351,7 +351,7 @@ namespace GridMate
                 DataSetBase* dataset = descriptor->GetDataSet(this, i);
                 if (!dataset)
                 {
-                    AZ_Assert(false, "How can we have a dirty dataset that doesn't exist?")
+                    AZ_Assert(false, "How can we have a dirty dataset that doesn't exist?");
                     continue;
                 }
 

--- a/Code/Framework/GridMate/GridMate/Replica/ReplicaTarget.h
+++ b/Code/Framework/GridMate/GridMate/Replica/ReplicaTarget.h
@@ -64,7 +64,7 @@ namespace GridMate
         // Create Callback
         AZStd::weak_ptr<TargetCallbackBase> CreateCallback(AZ::u64 revision)
         {
-            AZ_Assert(IsAckEnabled(), "ACK disabled.")  //Shouldn't happen
+            AZ_Assert(IsAckEnabled(), "ACK disabled.");  //Shouldn't happen
             AZ_Assert(m_replicaRevision <= revision, "Cannot decrease replica revision");
 
             if(!m_callback || m_callback->m_revision != revision)

--- a/Code/Framework/GridMate/GridMate/Session/Session.cpp
+++ b/Code/Framework/GridMate/GridMate/Session/Session.cpp
@@ -1583,7 +1583,7 @@ GridSession::OnStateCreate(HSM& sm, const HSM::Event& e)
 
             // Bind member replica
             bool isAdded = AddMember(m_myMember);
-            AZ_Error("GridMate", isAdded, "Failed to add my replica, check the number of open slots!")
+            AZ_Error("GridMate", isAdded, "Failed to add my replica, check the number of open slots!");
             if (!isAdded)
             {
                 sm.Transition(SS_DELETE);

--- a/Code/Framework/GridMate/GridMate/Session/Session.h
+++ b/Code/Framework/GridMate/GridMate/Session/Session.h
@@ -698,7 +698,7 @@ namespace GridMate
         static void* UserDataCopier(const void* sourceData, unsigned int sourceDataSize)
         {
             (void)sourceDataSize;
-            AZ_Assert(sizeof(T) == sourceDataSize, "Data size %d doesn't match the type size %d", sourceDataSize, sizeof(T))
+            AZ_Assert(sizeof(T) == sourceDataSize, "Data size %d doesn't match the type size %d", sourceDataSize, sizeof(T));
             return azcreate(T, (*static_cast<const T*>(sourceData)), GridMateAllocatorMP, "UserDataCopier");
         }
         template<class T>

--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -626,11 +626,8 @@ namespace O3DELauncher
             AZ_TracePrintf("Launcher", "Application is configured for VFS");
             AZ_TracePrintf("Launcher", "Log and cache files will be written to the Cache directory on your host PC");
 
-#if defined(AZ_ENABLE_TRACING)
-            const char* message = "If your game does not run, check any of the following:\n"
-                                  "\t- Verify the remote_ip address is correct in bootstrap.cfg";
-#endif
-
+            constexpr const char* message = "If your game does not run, check any of the following:\n"
+                                            "\t- Verify the remote_ip address is correct in bootstrap.cfg";
             if (mainInfo.m_additionalVfsResolution)
             {
                 AZ_TracePrintf("Launcher", "%s\n%s", message, mainInfo.m_additionalVfsResolution)

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/AssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/AssetCreator.h
@@ -150,18 +150,22 @@ namespace AZ
 
         template<typename AssetDataT>
         template<typename ... Args>
-        void AssetCreator<AssetDataT>::ReportError(const char* format, Args... args)
+        void AssetCreator<AssetDataT>::ReportError([[maybe_unused]] const char* format, [[maybe_unused]] Args... args)
         {
             ++m_errorCount;
+#if defined(AZ_ENABLE_TRACING) // disabling since it requires argument expansion in this context
             AZ_Error(m_assetClassName, false, format, args...);
+#endif
         }
 
         template<typename AssetDataT>
         template<typename ... Args>
-        void AssetCreator<AssetDataT>::ReportWarning(const char* format, Args... args)
+        void AssetCreator<AssetDataT>::ReportWarning([[maybe_unused]] const char* format, [[maybe_unused]] Args... args)
         {
             ++m_warningCount;
+#if defined(AZ_ENABLE_TRACING) // disabling since it requires argument expansion in this context
             AZ_Warning(m_assetClassName, false, format, args...);
+#endif
         }
 
         template<typename AssetDataT>

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/AssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/AssetCreator.h
@@ -150,7 +150,7 @@ namespace AZ
 
         template<typename AssetDataT>
         template<typename ... Args>
-        void AssetCreator<AssetDataT>::ReportError([[maybe_unused]] const char* format, [[maybe_unused]] Args... args)
+        void AssetCreator<AssetDataT>::ReportError(const char* format, Args... args)
         {
             ++m_errorCount;
             AZ_Error(m_assetClassName, false, format, args...);
@@ -158,7 +158,7 @@ namespace AZ
 
         template<typename AssetDataT>
         template<typename ... Args>
-        void AssetCreator<AssetDataT>::ReportWarning([[maybe_unused]] const char* format, [[maybe_unused]] Args... args)
+        void AssetCreator<AssetDataT>::ReportWarning(const char* format, Args... args)
         {
             ++m_warningCount;
             AZ_Warning(m_assetClassName, false, format, args...);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -1078,9 +1078,7 @@ namespace AZ
         template<typename T>
         void ModelAssetBuilderComponent::ValidateStreamSize([[maybe_unused]] size_t expectedVertexCount, [[maybe_unused]] const AZStd::vector<T>& bufferData, [[maybe_unused]] AZ::RHI::Format format, [[maybe_unused]] const char* streamName) const
         {
-#if defined(AZ_ENABLE_TRACING)
             size_t actualVertexCount = (bufferData.size() * sizeof(T)) / RHI::GetFormatSize(format);
-#endif
             AZ_Error(s_builderName, expectedVertexCount == actualVertexCount, "VertexStream '%s' does not match the expected vertex count. This typically means multiple sub-meshes have mis-matched vertex stream layouts (such as one having more uv sets than the other) but are assigned the same material in the dcc tool so they were merged.", streamName);
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
@@ -70,11 +70,9 @@ namespace AZ::RPI
     {
         const Containers::SceneGraph& sceneGraph = scene.GetGraph();
 
-#if defined(AZ_ENABLE_TRACING)
         const auto baseMeshIt = AZStd::find(sceneGraph.GetContentStorage().cbegin(), sceneGraph.GetContentStorage().cend(), sourceMesh.m_meshData);
         const Containers::SceneGraph::NodeIndex baseMeshIndex = sceneGraph.ConvertToNodeIndex(baseMeshIt);
         const AZStd::string_view baseMeshName{sceneGraph.GetNodeName(baseMeshIndex).GetName(), sceneGraph.GetNodeName(baseMeshIndex).GetNameLength()};
-#endif
 
         // Get the blend shapes for the given mesh
         AZStd::unordered_map<AZStd::string, SourceBlendShapeInfo> blendShapeInfos = GetBlendShapeInfos(scene, sourceMesh.m_meshData.get());
@@ -90,10 +88,8 @@ namespace AZ::RPI
                 AZ_Assert(blendShapeData, "Node is expected to be a blend shape.");
                 if (blendShapeData)
                 {
-#if defined(AZ_ENABLE_TRACING)
                     const Containers::SceneGraph::NodeIndex morphMeshParentIndex = sceneGraph.GetNodeParent(sceneNodeIndex);
                     const AZStd::string_view sourceMeshName{sceneGraph.GetNodeName(morphMeshParentIndex).GetName(), sceneGraph.GetNodeName(morphMeshParentIndex).GetNameLength()};
-#endif
 
                     AZ_Assert(AZ::StringFunc::Equal(baseMeshName, sourceMeshName, /*bCaseSensitive=*/true),
                         "Scene graph mesh node (%.*s) has a different name than the product mesh (%.*s).",

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialFunctor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialFunctor.cpp
@@ -419,9 +419,7 @@ namespace AZ
         {
             if (!materialPropertyDependencies.test(index.GetIndex()))
             {
-#if defined(AZ_ENABLE_TRACING)
                 const MaterialPropertyDescriptor* propertyDescriptor = materialPropertiesLayout.GetPropertyDescriptor(index);
-#endif
                 AZ_Error("MaterialFunctor", false, "Material functor accessing an unregistered material property '%s'.",
                     propertyDescriptor ? propertyDescriptor->GetName().GetCStr() : "<unknown>");
             }

--- a/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
@@ -206,10 +206,7 @@ namespace EditorPythonBindings
                     if (eventName == e.m_name)
                     {
                         AZStd::string eventNameValue{ eventName };
-#if defined(AZ_ENABLE_TRACING)
-                        const auto& callbackIt = m_callbackMap.find(eventNameValue);
-#endif
-                        AZ_Warning("python", m_callbackMap.end() == callbackIt, "Replacing callback for eventName:%s", eventNameValue.c_str());
+                        AZ_Warning("python", m_callbackMap.end() == m_callbackMap.find(eventNameValue), "Replacing callback for eventName:%s", eventNameValue.c_str());
                         m_callbackMap[eventNameValue] = callback;
                         return true;
                     }

--- a/Gems/LmbrCentral/Code/Source/Builders/BenchmarkAssetBuilder/BenchmarkAssetBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/BenchmarkAssetBuilder/BenchmarkAssetBuilderWorker.cpp
@@ -253,12 +253,10 @@ namespace BenchmarkAssetBuilder
         // and 2 bytes of storage for text-based formats.
         // This is just an approximate total size because there's a bit of additional overhead
         // for asset headers and the other fields in the generated asset.
-#if defined(AZ_ENABLE_TRACING)
         uint64_t approximateTotalStorageBytes =
             (settingsPtr->m_assetStorageType == AZ::DataStream::StreamType::ST_BINARY)
             ? UINT64_C(1) * totalGeneratedBytes
             : UINT64_C(2) * totalGeneratedBytes;
-#endif
 
         AZ_TracePrintf(AssetBuilderSDK::InfoWindow,
             "Benchmark asset generation will generate %" PRIu64 " assets "

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/ScriptEventsNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/ScriptEventsNodePaletteTreeItemTypes.cpp
@@ -154,9 +154,7 @@ namespace ScriptCanvasEditor
 
             const ScriptEvents::ScriptEvent& definition = data->m_definition;
 
-#if defined(AZ_ENABLE_TRACING)
             bool recategorize = previousDefinition ? definition.GetCategory().compare(previousDefinition->GetCategory()) != 0 : false;
-#endif
             AZ_Warning("ScriptCanvas", !recategorize, "Unable to recategorize ScriptEvents events while open. Please close and re-open the Script Canvas Editor to see the new categorization");
 
             if (definition.GetName().empty())

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
@@ -116,7 +116,7 @@ namespace ScriptCanvas
             return;
         }
 #else
-        AZ_Assert(m_runtimeAsset.Get(), "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+        AZ_Assert(m_runtimeOverrides.m_runtimeAsset.Get(), "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
 #endif
 
         AZ_PROFILE_SCOPE(ScriptCanvas, "RuntimeComponent::InitializeExecution (%s)", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().c_str());
@@ -130,7 +130,7 @@ namespace ScriptCanvas
             return;
         }
 #else
-        AZ_Assert(m_executionState, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run", m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+        AZ_Assert(m_executionState, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
 #endif
 
         AZ::EntityBus::Handler::BusConnect(GetEntityId());

--- a/Gems/WhiteBox/Code/Source/Rendering/Atom/TangentSpaceHelper.cpp
+++ b/Gems/WhiteBox/Code/Source/Rendering/Atom/TangentSpaceHelper.cpp
@@ -73,9 +73,7 @@ namespace WhiteBox
 
             for (AZ::u32 i = 0; i < triangleCount; ++i)
             {
-#if defined(AZ_ENABLE_TRACING)
                 const auto& trianglePositions = trianglesPositions[i];
-#endif
                 const auto& triangleUVs = trianglesUVs[i];
                 const auto& triangleEdges = trianglesEdges[i];
 


### PR DESCRIPTION
We currently hit a lot of release build failures because we dont gate them and trace functions compile out every parameter.
This change redirects the release versions of the trace functions to mark every parameter as UNUSED