### PR TITLE
Add deserialization to sequence reports.

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReport.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReport.h
@@ -126,7 +126,7 @@ namespace TestImpact
         class SequenceReportBase
         {
         public:
-            static constexpr SequenceReportType m_type = Type;
+            static constexpr SequenceReportType ReportType = Type;
             using PolicyState = PolicyStateType;
 
             //! Constructs the report for a sequence of selected tests.
@@ -139,41 +139,43 @@ namespace TestImpact
             //! @param selectedTestRunReport The report for the set of selected test runs.
             SequenceReportBase(
                 size_t maxConcurrency,
-                const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-                const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-                const PolicyStateType& policyState,
+                AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
+                AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+                PolicyStateType policyState,
                 SuiteType suiteType,
-                const TestRunSelection& selectedTestRuns,
-                TestRunReport&& selectedTestRunReport)
+                TestRunSelection selectedTestRuns,
+                TestRunReport selectedTestRunReport)
                 : m_maxConcurrency(maxConcurrency)
-                , m_testTargetTimeout(testTargetTimeout)
-                , m_globalTimeout(globalTimeout)
-                , m_policyState(policyState)
+                , m_testTargetTimeout(AZStd::move(testTargetTimeout))
+                , m_globalTimeout(AZStd::move(globalTimeout))
+                , m_policyState(AZStd::move(policyState))
                 , m_suite(suiteType)
-                , m_selectedTestRuns(selectedTestRuns)
+                , m_selectedTestRuns(AZStd::move(selectedTestRuns))
                 , m_selectedTestRunReport(AZStd::move(selectedTestRunReport))
             {
             }
 
             SequenceReportBase(SequenceReportBase&& report)
-                : m_maxConcurrency(AZStd::move(report.m_maxConcurrency))
-                , m_testTargetTimeout(AZStd::move(report.m_testTargetTimeout))
-                , m_globalTimeout(AZStd::move(report.m_globalTimeout))
-                , m_policyState(AZStd::move(report.m_policyState))
-                , m_suite(AZStd::move(report.m_suite))
-                , m_selectedTestRuns(AZStd::move(report.m_selectedTestRuns))
-                , m_selectedTestRunReport(AZStd::move(report.m_selectedTestRunReport))
+                : SequenceReportBase(
+                    AZStd::move(report.m_maxConcurrency),
+                    AZStd::move(report.m_testTargetTimeout),
+                    AZStd::move(report.m_globalTimeout),
+                    AZStd::move(report.m_policyState),
+                    AZStd::move(report.m_suite),
+                    AZStd::move(report.m_selectedTestRuns),
+                    AZStd::move(report.m_selectedTestRunReport))
             {
             }
 
             SequenceReportBase(const SequenceReportBase& report)
-                : m_maxConcurrency(report.m_maxConcurrency)
-                , m_testTargetTimeout(report.m_testTargetTimeout)
-                , m_globalTimeout(report.m_globalTimeout)
-                , m_policyState(report.m_policyState)
-                , m_suite(report.m_suite)
-                , m_selectedTestRuns(report.m_selectedTestRuns)
-                , m_selectedTestRunReport(report.m_selectedTestRunReport)
+                : SequenceReportBase(
+                    report.m_maxConcurrency,
+                    report.m_testTargetTimeout,
+                    report.m_globalTimeout,
+                    report.m_policyState,
+                    report.m_suite,
+                    report.m_selectedTestRuns,
+                    report.m_selectedTestRunReport)
             {
             }
 
@@ -182,7 +184,7 @@ namespace TestImpact
             //! Returns the identifying type for this sequence report.
             SequenceReportType GetType() const
             {
-                return m_type;
+                return ReportType;
             }
 
             //! Returns the maximum concurrency for this sequence.
@@ -349,12 +351,12 @@ namespace TestImpact
             //! @param draftedTestRunReport The report for the set of drafted test runs.
             DraftingSequenceReportBase(
                 size_t maxConcurrency,
-                const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-                const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-                const PolicyStateType& policyState,
+                AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
+                AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+                PolicyStateType policyState,
                 SuiteType suiteType,
-                const TestRunSelection& selectedTestRuns,
-                const AZStd::vector<AZStd::string>& draftedTestRuns,
+                TestRunSelection selectedTestRuns,
+                AZStd::vector<AZStd::string> draftedTestRuns,
                 TestRunReport&& selectedTestRunReport,
                 TestRunReport&& draftedTestRunReport)
                 : SequenceReportBase<Type, PolicyStateType>(
@@ -365,17 +367,17 @@ namespace TestImpact
                     suiteType,
                     selectedTestRuns,
                     AZStd::move(selectedTestRunReport))
-                , m_draftedTestRuns(draftedTestRuns)
+                , m_draftedTestRuns(AZStd::move(draftedTestRuns))
                 , m_draftedTestRunReport(AZStd::move(draftedTestRunReport))
             {
             }
 
             DraftingSequenceReportBase(
                 SequenceReportBase<Type, PolicyStateType>&& report,
-                const AZStd::vector<AZStd::string>& draftedTestRuns,
+                AZStd::vector<AZStd::string> draftedTestRuns,
                 TestRunReport&& draftedTestRunReport)
                 : SequenceReportBase<Type, PolicyStateType>(AZStd::move(report))
-                , m_draftedTestRuns(draftedTestRuns)
+                , m_draftedTestRuns(AZStd::move(draftedTestRuns))
                 , m_draftedTestRunReport(AZStd::move(draftedTestRunReport))
             {
             }
@@ -469,17 +471,17 @@ namespace TestImpact
             //! @param draftedTestRunReport The report for the set of drafted test runs.
             ImpactAnalysisSequenceReport(
                 size_t maxConcurrency,
-                const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-                const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-                const ImpactAnalysisSequencePolicyState& policyState,
+                AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
+                AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+                ImpactAnalysisSequencePolicyState policyState,
                 SuiteType suiteType,
-                const TestRunSelection& selectedTestRuns,
-                const AZStd::vector<AZStd::string>& discardedTestRuns,
-                const AZStd::vector<AZStd::string>& draftedTestRuns,
+                TestRunSelection selectedTestRuns,
+                AZStd::vector<AZStd::string> discardedTestRuns,
+                AZStd::vector<AZStd::string> draftedTestRuns,
                 TestRunReport&& selectedTestRunReport,
                 TestRunReport&& draftedTestRunReport);
 
-            ImpactAnalysisSequenceReport(DraftingSequenceReportBase&& report, const AZStd::vector<AZStd::string>& discardedTestRuns);
+            ImpactAnalysisSequenceReport(DraftingSequenceReportBase&& report, AZStd::vector<AZStd::string> discardedTestRuns);
 
             //! Returns the test runs discarded from running in the sequence.
             const AZStd::vector<AZStd::string>& GetDiscardedTestRuns() const;
@@ -506,19 +508,19 @@ namespace TestImpact
             //! @param draftedTestRunReport The report for the set of drafted test runs.
             SafeImpactAnalysisSequenceReport(
                 size_t maxConcurrency,
-                const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-                const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-                const SafeImpactAnalysisSequencePolicyState& policyState,
+                AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
+                AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+                SafeImpactAnalysisSequencePolicyState policyState,
                 SuiteType suiteType,
-                const TestRunSelection& selectedTestRuns,
-                const TestRunSelection& discardedTestRuns,
-                const AZStd::vector<AZStd::string>& draftedTestRuns,
+                TestRunSelection selectedTestRuns,
+                TestRunSelection discardedTestRuns,
+                AZStd::vector<AZStd::string> draftedTestRuns,
                 TestRunReport&& selectedTestRunReport,
                 TestRunReport&& discardedTestRunReport,
                 TestRunReport&& draftedTestRunReport);
 
             SafeImpactAnalysisSequenceReport(
-                DraftingSequenceReportBase&& report, const TestRunSelection& discardedTestRuns, TestRunReport&& discardedTestRunReport);
+                DraftingSequenceReportBase&& report, TestRunSelection discardedTestRuns, TestRunReport&& discardedTestRunReport);
 
             // SequenceReport overrides ...
             AZStd::chrono::milliseconds GetDuration() const override;

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReport.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReport.h
@@ -181,12 +181,6 @@ namespace TestImpact
 
             virtual ~SequenceReportBase() = default;
 
-            //! Returns the identifying type for this sequence report.
-            SequenceReportType GetType() const
-            {
-                return ReportType;
-            }
-
             //! Returns the maximum concurrency for this sequence.
             size_t GetMaxConcurrency() const
             {

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReportSerializer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReportSerializer.h
@@ -14,27 +14,27 @@
 
 namespace TestImpact
 {
-    //! Serializes a regular sequence report to JSON format.
+    //! Serializes a regular sequence report to Json format.
     AZStd::string SerializeSequenceReport(const Client::RegularSequenceReport& sequenceReport);
 
-    //! Serializes a seed sequence report to JSON format.
+    //! Serializes a seed sequence report to Json format.
     AZStd::string SerializeSequenceReport(const Client::SeedSequenceReport& sequenceReport);
 
-    //! Serializes an impact analysis sequence report to JSON format.
+    //! Serializes an impact analysis sequence report to Json format.
     AZStd::string SerializeSequenceReport(const Client::ImpactAnalysisSequenceReport& sequenceReport);
 
-    //! Serializes a safe impact analysis sequence report to JSON format.
+    //! Serializes a safe impact analysis sequence report to Json format.
     AZStd::string SerializeSequenceReport(const Client::SafeImpactAnalysisSequenceReport& sequenceReport);
 
-    //! Deserialize a regular sequence report from JSON format.
-    Client::RegularSequenceReport DeserializeRegularSequenceReport(const AZStd::string& sequenceReportJSON);
+    //! Deserialize a regular sequence report from Json format.
+    Client::RegularSequenceReport DeserializeRegularSequenceReport(const AZStd::string& sequenceReportJson);
 
-    //! Deserialize a seed sequence report from JSON format.
-    Client::SeedSequenceReport DeserializeSeedSequenceReport(const AZStd::string& sequenceReportJSON);
+    //! Deserialize a seed sequence report from Json format.
+    Client::SeedSequenceReport DeserializeSeedSequenceReport(const AZStd::string& sequenceReportJson);
 
-    //! Deserialize an impact analysis sequence report from JSON format.
-    Client::ImpactAnalysisSequenceReport DeserializeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON);
+    //! Deserialize an impact analysis sequence report from Json format.
+    Client::ImpactAnalysisSequenceReport DeserializeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJson);
 
-    //! Deserialize a safe impact analysis sequence report from JSON format.
-    Client::SafeImpactAnalysisSequenceReport DeserializeSafeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON);
+    //! Deserialize a safe impact analysis sequence report from Json format.
+    Client::SafeImpactAnalysisSequenceReport DeserializeSafeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJson);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReportSerializer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactClientSequenceReportSerializer.h
@@ -25,4 +25,16 @@ namespace TestImpact
 
     //! Serializes a safe impact analysis sequence report to JSON format.
     AZStd::string SerializeSequenceReport(const Client::SafeImpactAnalysisSequenceReport& sequenceReport);
+
+    //! Deserialize a regular sequence report from JSON format.
+    Client::RegularSequenceReport DeserializeRegularSequenceReport(const AZStd::string& sequenceReportJSON);
+
+    //! Deserialize a seed sequence report from JSON format.
+    Client::SeedSequenceReport DeserializeSeedSequenceReport(const AZStd::string& sequenceReportJSON);
+
+    //! Deserialize an impact analysis sequence report from JSON format.
+    Client::ImpactAnalysisSequenceReport DeserializeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON);
+
+    //! Deserialize a safe impact analysis sequence report from JSON format.
+    Client::SafeImpactAnalysisSequenceReport DeserializeSafeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactUtils.h
@@ -103,4 +103,42 @@ namespace TestImpact
 
     //! User-friendly names for the client test result types.
     AZStd::string ClientTestResultAsString(Client::TestResult result);
+
+    SuiteType SuiteTypeFromString(const AZStd::string& suiteType);
+
+    //! Returns the sequence report type for the specified string.
+    Client::SequenceReportType SequenceReportTypeFromString(const AZStd::string& type);
+
+    //! Returns the test run result for the specified string.
+    Client::TestRunResult TestRunResultFromString(const AZStd::string& result);
+
+    //! Returns the test result for the specified string.
+    Client::TestResult TestResultFromString(const AZStd::string& result);
+
+    //! Returns the test sequence result for the specified string.
+    TestSequenceResult TestSequenceResultFromString(const AZStd::string& result);
+
+    //! Returns the execution failure policy for the specified string.
+    Policy::ExecutionFailure ExecutionFailurePolicyFromString(const AZStd::string& executionFailurePolicy);
+
+    //! Returns the failed test coverage policy for the specified string.
+    Policy::FailedTestCoverage FailedTestCoveragePolicyFromString(const AZStd::string& failedTestCoveragePolicy);
+
+    //! Returns the test prioritization policy for the specified string.
+    Policy::TestPrioritization TestPrioritizationPolicyFromString(const AZStd::string& testPrioritizationPolicy);
+
+    //! Returns the test failure policy for the specified string.
+    Policy::TestFailure TestFailurePolicyFromString(const AZStd::string& testFailurePolicy);
+
+    //! Returns the integrity failure policy for the specified string.
+    Policy::IntegrityFailure IntegrityFailurePolicyFromString(const AZStd::string& integrityFailurePolicy);
+
+    //! Returns the dynamic dependency map policy for the specified string.
+    Policy::DynamicDependencyMap DynamicDependencyMapPolicyFromString(const AZStd::string& dynamicDependencyMapPolicy);
+
+    //! Returns the test sharding policy for the specified string.
+    Policy::TestSharding TestShardingPolicyFromString(const AZStd::string& testShardingPolicy);
+
+    //! Returns the target output capture policy for the specified string.
+    Policy::TargetOutputCapture TargetOutputCapturePolicyFromString(const AZStd::string& targetOutputCapturePolicy);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactUtils.h
@@ -104,6 +104,7 @@ namespace TestImpact
     //! User-friendly names for the client test result types.
     AZStd::string ClientTestResultAsString(Client::TestResult result);
 
+    //! User-friendly names for the suite types.
     SuiteType SuiteTypeFromString(const AZStd::string& suiteType);
 
     //! Returns the sequence report type for the specified string.

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
@@ -161,23 +161,23 @@ namespace TestImpact
 
         ImpactAnalysisSequenceReport::ImpactAnalysisSequenceReport(
             size_t maxConcurrency,
-            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-            const ImpactAnalysisSequencePolicyState& policyState,
+            AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
+            AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+            ImpactAnalysisSequencePolicyState policyState,
             SuiteType suiteType,
-            const TestRunSelection& selectedTestRuns,
-            const AZStd::vector<AZStd::string>& discardedTestRuns,
-            const AZStd::vector<AZStd::string>& draftedTestRuns,
+            TestRunSelection selectedTestRuns,
+            AZStd::vector<AZStd::string> discardedTestRuns,
+            AZStd::vector<AZStd::string> draftedTestRuns,
             TestRunReport&& selectedTestRunReport,
             TestRunReport&& draftedTestRunReport)
             : DraftingSequenceReportBase(
                 maxConcurrency,
-                testTargetTimeout,
-                globalTimeout,
-                policyState,
+                AZStd::move(testTargetTimeout),
+                AZStd::move(globalTimeout),
+                AZStd::move(policyState),
                 suiteType,
-                selectedTestRuns,
-                draftedTestRuns,
+                AZStd::move(selectedTestRuns),
+                AZStd::move(draftedTestRuns),
                 AZStd::move(selectedTestRunReport),
                 AZStd::move(draftedTestRunReport))
             , m_discardedTestRuns(discardedTestRuns)
@@ -185,9 +185,9 @@ namespace TestImpact
         }
 
         ImpactAnalysisSequenceReport::ImpactAnalysisSequenceReport(
-            DraftingSequenceReportBase&& report, const AZStd::vector<AZStd::string>& discardedTestRuns)
+            DraftingSequenceReportBase&& report, AZStd::vector<AZStd::string> discardedTestRuns)
             : DraftingSequenceReportBase(AZStd::move(report))
-            , m_discardedTestRuns(discardedTestRuns)
+            , m_discardedTestRuns(AZStd::move(discardedTestRuns))
         {
         }
 
@@ -198,24 +198,24 @@ namespace TestImpact
 
         SafeImpactAnalysisSequenceReport::SafeImpactAnalysisSequenceReport(
             size_t maxConcurrency,
-            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-            const SafeImpactAnalysisSequencePolicyState& policyState,
+            AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
+            AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+            SafeImpactAnalysisSequencePolicyState policyState,
             SuiteType suiteType,
-            const TestRunSelection& selectedTestRuns,
-            const TestRunSelection& discardedTestRuns,
-            const AZStd::vector<AZStd::string>& draftedTestRuns,
+            TestRunSelection selectedTestRuns,
+            TestRunSelection discardedTestRuns,
+            AZStd::vector<AZStd::string> draftedTestRuns,
             TestRunReport&& selectedTestRunReport,
             TestRunReport&& discardedTestRunReport,
             TestRunReport&& draftedTestRunReport)
             : DraftingSequenceReportBase(
                 maxConcurrency,
-                testTargetTimeout,
-                globalTimeout,
-                policyState,
+                AZStd::move(testTargetTimeout),
+                AZStd::move(globalTimeout),
+                AZStd::move(policyState),
                 suiteType,
-                selectedTestRuns,
-                draftedTestRuns,
+                AZStd::move(selectedTestRuns),
+                AZStd::move(draftedTestRuns),
                 AZStd::move(selectedTestRunReport),
                 AZStd::move(draftedTestRunReport))
             , m_discardedTestRuns(discardedTestRuns)
@@ -224,9 +224,9 @@ namespace TestImpact
         }
 
         SafeImpactAnalysisSequenceReport::SafeImpactAnalysisSequenceReport(
-            DraftingSequenceReportBase&& report, const TestRunSelection& discardedTestRuns, TestRunReport&& discardedTestRunReport)
+            DraftingSequenceReportBase&& report, TestRunSelection discardedTestRuns, TestRunReport&& discardedTestRunReport)
             : DraftingSequenceReportBase(AZStd::move(report))
-            , m_discardedTestRuns(discardedTestRuns)
+            , m_discardedTestRuns(AZStd::move(discardedTestRuns))
             , m_discardedTestRunReport(AZStd::move(discardedTestRunReport))
         {
         }

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
@@ -159,46 +159,6 @@ namespace TestImpact
             return m_totalNumDisabledTests;
         }
 
-        RegularSequenceReport::RegularSequenceReport(
-            size_t maxConcurrency,
-            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-            const SequencePolicyState& policyState,
-            SuiteType suiteType,
-            const TestRunSelection& selectedTestRuns,
-            TestRunReport&& selectedTestRunReport)
-            : SequenceReportBase(
-                  SequenceReportType::RegularSequence,
-                  maxConcurrency,
-                  testTargetTimeout,
-                  globalTimeout,
-                  policyState,
-                  suiteType,
-                  selectedTestRuns,
-                  AZStd::move(selectedTestRunReport))
-        {
-        }
-
-        SeedSequenceReport::SeedSequenceReport(
-            size_t maxConcurrency,
-            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
-            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
-            const SequencePolicyState& policyState,
-            SuiteType suiteType,
-            const TestRunSelection& selectedTestRuns,
-            TestRunReport&& selectedTestRunReport)
-            : SequenceReportBase(
-                  SequenceReportType::SeedSequence,
-                  maxConcurrency,
-                  testTargetTimeout,
-                  globalTimeout,
-                  policyState,
-                  suiteType,
-                  selectedTestRuns,
-                  AZStd::move(selectedTestRunReport))
-        {
-        }
-
         ImpactAnalysisSequenceReport::ImpactAnalysisSequenceReport(
             size_t maxConcurrency,
             const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
@@ -211,7 +171,6 @@ namespace TestImpact
             TestRunReport&& selectedTestRunReport,
             TestRunReport&& draftedTestRunReport)
             : DraftingSequenceReportBase(
-                SequenceReportType::ImpactAnalysisSequence,
                 maxConcurrency,
                 testTargetTimeout,
                 globalTimeout,
@@ -221,6 +180,13 @@ namespace TestImpact
                 draftedTestRuns,
                 AZStd::move(selectedTestRunReport),
                 AZStd::move(draftedTestRunReport))
+            , m_discardedTestRuns(discardedTestRuns)
+        {
+        }
+
+        ImpactAnalysisSequenceReport::ImpactAnalysisSequenceReport(
+            DraftingSequenceReportBase&& report, const AZStd::vector<AZStd::string>& discardedTestRuns)
+            : DraftingSequenceReportBase(AZStd::move(report))
             , m_discardedTestRuns(discardedTestRuns)
         {
         }
@@ -243,7 +209,6 @@ namespace TestImpact
             TestRunReport&& discardedTestRunReport,
             TestRunReport&& draftedTestRunReport)
             : DraftingSequenceReportBase(
-                SequenceReportType::SafeImpactAnalysisSequence,
                 maxConcurrency,
                 testTargetTimeout,
                 globalTimeout,
@@ -253,6 +218,14 @@ namespace TestImpact
                 draftedTestRuns,
                 AZStd::move(selectedTestRunReport),
                 AZStd::move(draftedTestRunReport))
+            , m_discardedTestRuns(discardedTestRuns)
+            , m_discardedTestRunReport(AZStd::move(discardedTestRunReport))
+        {
+        }
+
+        SafeImpactAnalysisSequenceReport::SafeImpactAnalysisSequenceReport(
+            DraftingSequenceReportBase&& report, const TestRunSelection& discardedTestRuns, TestRunReport&& discardedTestRunReport)
+            : DraftingSequenceReportBase(AZStd::move(report))
             , m_discardedTestRuns(discardedTestRuns)
             , m_discardedTestRunReport(AZStd::move(discardedTestRunReport))
         {

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -423,7 +423,7 @@ namespace TestImpact
         {
             // Type
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::Type]);
-            writer.String(SequenceReportTypeAsString(sequenceReport.ReportType).c_str());
+            writer.String(SequenceReportTypeAsString(sequenceReport::ReportType).c_str());
 
             // Test target timeout
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestTargetTimeout]);

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -423,7 +423,7 @@ namespace TestImpact
         {
             // Type
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::Type]);
-            writer.String(SequenceReportTypeAsString(sequenceReport::ReportType).c_str());
+            writer.String(SequenceReportTypeAsString(sequenceReport.ReportType).c_str());
 
             // Test target timeout
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestTargetTimeout]);

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -21,7 +21,7 @@ namespace TestImpact
     {
         namespace SequenceReportFields
         {
-            // Keys for pertinent JSON node and attribute names
+            // Keys for pertinent Json node and attribute names
             constexpr const char* Keys[] =
             {
                 "name",
@@ -640,7 +640,7 @@ namespace TestImpact
         testRuns.reserve(serialTestRuns.GetArray().Size());
         for (const auto& testRun : serialTestRuns.GetArray())
         {
-            testRuns.push_back(TestRunType(DeserializeTestRunBase(testRun)));
+            testRuns.emplace_back(TestRunType(DeserializeTestRunBase(testRun)));
         }
 
         return testRuns;
@@ -653,7 +653,7 @@ namespace TestImpact
         testRuns.reserve(serialCompletedTestRuns.GetArray().Size());
         for (const auto& testRun : serialCompletedTestRuns.GetArray())
         {
-            testRuns.push_back(CompletedTestRunType(
+            testRuns.emplace_back(CompletedTestRunType(
                 DeserializeTestRunBase(testRun), DeserializeTests(testRun[SequenceReportFields::Keys[SequenceReportFields::Tests]])));
         }
 
@@ -686,7 +686,7 @@ namespace TestImpact
             testTargets.reserve(serialTestTargets.GetArray().Size());
             for (const auto& testTarget : serialTestTargets.GetArray())
             {
-                testTargets.push_back(testTarget.GetString());
+                testTargets.emplace_back(testTarget.GetString());
             }
 
             return testTargets;
@@ -761,7 +761,7 @@ namespace TestImpact
     {
         const auto type = SequenceReportTypeFromString(serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::Type]].GetString());
         AZ_TestImpact_Eval(
-            type == SequenceReportBaseType::m_type,
+            type == SequenceReportBaseType::ReportType,
             SequenceReportException, AZStd::string::format(
                 "The JSON sequence report type '%s' does not match the constructed report type",
                 serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::Type]].GetString()));
@@ -782,8 +782,8 @@ namespace TestImpact
     }
 
     template<typename DerivedDraftingSequenceReportType>
-    Client::DraftingSequenceReportBase<DerivedDraftingSequenceReportType::m_type, typename DerivedDraftingSequenceReportType::PolicyState>
-        DeserializeDraftingSequenceReportType(const rapidjson::Value& serialDraftingSequenceReportBase)
+    Client::DraftingSequenceReportBase<DerivedDraftingSequenceReportType::ReportType, typename DerivedDraftingSequenceReportType::PolicyState>
+        DeserializeDraftingSequenceReportBase(const rapidjson::Value& serialDraftingSequenceReportBase)
     {
         AZStd::vector<AZStd::string> draftingTestRuns;
         draftingTestRuns.reserve(
@@ -791,13 +791,13 @@ namespace TestImpact
         for (const auto& testRun :
              serialDraftingSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::DraftedTestRuns]].GetArray())
         {
-            draftingTestRuns.push_back(testRun.GetString());
+            draftingTestRuns.emplace_back(testRun.GetString());
         }
 
         using SequenceBase =
-            Client::SequenceReportBase<DerivedDraftingSequenceReportType::m_type, typename DerivedDraftingSequenceReportType::PolicyState>;
+            Client::SequenceReportBase<DerivedDraftingSequenceReportType::ReportType, typename DerivedDraftingSequenceReportType::PolicyState>;
         using DraftingSequenceBase =
-            Client::DraftingSequenceReportBase<DerivedDraftingSequenceReportType::m_type, typename DerivedDraftingSequenceReportType::PolicyState>;
+            Client::DraftingSequenceReportBase<DerivedDraftingSequenceReportType::ReportType, typename DerivedDraftingSequenceReportType::PolicyState>;
 
         return DraftingSequenceBase(
             DeserialiseSequenceReportBase<SequenceBase>(serialDraftingSequenceReportBase),
@@ -805,11 +805,11 @@ namespace TestImpact
             DeserializeTestRunReport(serialDraftingSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::DraftedTestRunReport]]));
     }
 
-    rapidjson::Document OpenSequenceReportJSON(const AZStd::string& sequenceReportJSON)
+    rapidjson::Document OpenSequenceReportJson(const AZStd::string& sequenceReportJson)
     {
         rapidjson::Document doc;
 
-        if (doc.Parse<0>(sequenceReportJSON.c_str()).HasParseError())
+        if (doc.Parse<0>(sequenceReportJson.c_str()).HasParseError())
         {
             throw SequenceReportException("Could not parse sequence report data");
         }
@@ -817,39 +817,39 @@ namespace TestImpact
         return doc;
     }
 
-    Client::RegularSequenceReport DeserializeRegularSequenceReport(const AZStd::string& sequenceReportJSON)
+    Client::RegularSequenceReport DeserializeRegularSequenceReport(const AZStd::string& sequenceReportJson)
     {
-        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+        const auto doc = OpenSequenceReportJson(sequenceReportJson);
         return DeserialiseSequenceReportBase<Client::RegularSequenceReport>(doc);
     }
 
-    Client::SeedSequenceReport DeserializeSeedSequenceReport(const AZStd::string& sequenceReportJSON)
+    Client::SeedSequenceReport DeserializeSeedSequenceReport(const AZStd::string& sequenceReportJson)
     {
-        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+        const auto doc = OpenSequenceReportJson(sequenceReportJson);
         return DeserialiseSequenceReportBase<Client::SeedSequenceReport>(doc);
     }
 
-    Client::ImpactAnalysisSequenceReport DeserializeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON)
+    Client::ImpactAnalysisSequenceReport DeserializeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJson)
     {
-        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+        const auto doc = OpenSequenceReportJson(sequenceReportJson);
 
         AZStd::vector<AZStd::string> discardedTestRuns;
         discardedTestRuns.reserve(doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]].GetArray().Size());
         for (const auto& testRun : doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]].GetArray())
         {
-            discardedTestRuns.push_back(testRun.GetString());
+            discardedTestRuns.emplace_back(testRun.GetString());
         }
 
         return Client::ImpactAnalysisSequenceReport(
-            DeserializeDraftingSequenceReportType<Client::ImpactAnalysisSequenceReport>(doc), AZStd::move(discardedTestRuns));
+            DeserializeDraftingSequenceReportBase<Client::ImpactAnalysisSequenceReport>(doc), AZStd::move(discardedTestRuns));
     }
 
-    Client::SafeImpactAnalysisSequenceReport DeserializeSafeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON)
+    Client::SafeImpactAnalysisSequenceReport DeserializeSafeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJson)
     {
-        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+        const auto doc = OpenSequenceReportJson(sequenceReportJson);
 
         return Client::SafeImpactAnalysisSequenceReport(
-            DeserializeDraftingSequenceReportType<Client::SafeImpactAnalysisSequenceReport>(doc),
+            DeserializeDraftingSequenceReportBase<Client::SafeImpactAnalysisSequenceReport>(doc),
             DeserializeTestSelection(doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]]),
             DeserializeTestRunReport(doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRunReport]]));
     }

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -417,9 +417,9 @@ namespace TestImpact
             writer.String(DynamicDependencyMapPolicyAsString(policyState.m_dynamicDependencyMap).c_str());
         }
 
-        template<typename PolicyStateType>
+        template<typename SequenceReportBaseType>
         void SerializeSequenceReportBaseMembers(
-            const Client::SequenceReportBase<PolicyStateType>& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+            const SequenceReportBaseType& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             // Type
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::Type]);
@@ -510,9 +510,9 @@ namespace TestImpact
             writer.Uint64(sequenceReport.GetTotalNumDisabledTests());
         }
 
-        template<typename PolicyStateType>
+        template<typename DraftingSequenceReportBaseType>
         void SerializeDraftingSequenceReportMembers(
-            const Client::DraftingSequenceReportBase<PolicyStateType>& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+            const DraftingSequenceReportBaseType& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             SerializeSequenceReportBaseMembers(sequenceReport, writer);
 
@@ -602,5 +602,255 @@ namespace TestImpact
         writer.EndObject();
 
         return stringBuffer.GetString();
+    }
+
+    AZStd::chrono::high_resolution_clock::time_point TimePointFromMsInt64(AZ::s64 ms)
+    {
+        return AZStd::chrono::high_resolution_clock::time_point(AZStd::chrono::milliseconds(ms));
+    }
+
+    AZStd::vector<Client::Test> DeserializeTests(const rapidjson::Value& serialTests)
+    {
+        AZStd::vector<Client::Test> tests;
+        tests.reserve(serialTests[SequenceReportFields::Keys[SequenceReportFields::Tests]].GetArray().Size());
+        for (const auto& test : serialTests[SequenceReportFields::Keys[SequenceReportFields::Tests]].GetArray())
+        {
+            const AZStd::string name = test[SequenceReportFields::Keys[SequenceReportFields::Name]].GetString();
+            const auto result = TestResultFromString(test[SequenceReportFields::Keys[SequenceReportFields::Result]].GetString());
+            tests.emplace_back(name, result);
+        }
+
+        return tests;
+    }
+
+    Client::TestRunBase DeserializeTestRunBase(const rapidjson::Value& serialTestRun)
+    {
+        return Client::TestRunBase(
+            serialTestRun[SequenceReportFields::Keys[SequenceReportFields::Name]].GetString(),
+            serialTestRun[SequenceReportFields::Keys[SequenceReportFields::CommandArgs]].GetString(),
+            TimePointFromMsInt64(serialTestRun[SequenceReportFields::Keys[SequenceReportFields::StartTime]].GetInt64()),
+            AZStd::chrono::milliseconds(serialTestRun[SequenceReportFields::Keys[SequenceReportFields::Duration]].GetInt64()),
+            TestRunResultFromString(serialTestRun[SequenceReportFields::Keys[SequenceReportFields::Result]].GetString()));
+    }
+
+    template<typename TestRunType>
+    AZStd::vector<TestRunType> DeserializeTestRuns(const rapidjson::Value& serialTestRuns)
+    {
+        AZStd::vector<TestRunType> testRuns;
+        testRuns.reserve(serialTestRuns.GetArray().Size());
+        for (const auto& testRun : serialTestRuns.GetArray())
+        {
+            testRuns.push_back(TestRunType(DeserializeTestRunBase(testRun)));
+        }
+
+        return testRuns;
+    }
+
+    template<typename CompletedTestRunType>
+    AZStd::vector<CompletedTestRunType> DeserializeCompletedTestRuns(const rapidjson::Value& serialCompletedTestRuns)
+    {
+        AZStd::vector<CompletedTestRunType> testRuns;
+        testRuns.reserve(serialCompletedTestRuns.GetArray().Size());
+        for (const auto& testRun : serialCompletedTestRuns.GetArray())
+        {
+            testRuns.push_back(CompletedTestRunType(
+                DeserializeTestRunBase(testRun), DeserializeTests(testRun[SequenceReportFields::Keys[SequenceReportFields::Tests]])));
+        }
+
+        return testRuns;
+    }
+
+    Client::TestRunReport DeserializeTestRunReport(const rapidjson::Value& serialTestRunReport)
+    {
+        return Client::TestRunReport(
+            TestSequenceResultFromString(serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::Result]].GetString()),
+            TimePointFromMsInt64(serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::StartTime]].GetInt64()),
+            AZStd::chrono::milliseconds(serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::Duration]].GetInt64()),
+            DeserializeCompletedTestRuns<Client::PassingTestRun>(
+                serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::PassingTestRuns]]),
+            DeserializeCompletedTestRuns<Client::FailingTestRun>(
+                serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::FailingTestRuns]]),
+            DeserializeTestRuns<Client::TestRunWithExecutionFailure>(
+                serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::ExecutionFailureTestRuns]]),
+            DeserializeTestRuns<Client::TimedOutTestRun>(
+                serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::TimedOutTestRuns]]),
+            DeserializeTestRuns<Client::UnexecutedTestRun>(
+                serialTestRunReport[SequenceReportFields::Keys[SequenceReportFields::UnexecutedTestRuns]]));
+    }
+
+    Client::TestRunSelection DeserializeTestSelection(const rapidjson::Value& serialTestRunSelection)
+    {
+        const auto extractTestTargetNames = [](const rapidjson::Value& serialTestTargets)
+        {
+            AZStd::vector<AZStd::string> testTargets;
+            testTargets.reserve(serialTestTargets.GetArray().Size());
+            for (const auto& testTarget : serialTestTargets.GetArray())
+            {
+                testTargets.push_back(testTarget.GetString());
+            }
+
+            return testTargets;
+        };
+
+        return Client::TestRunSelection(
+            extractTestTargetNames(serialTestRunSelection[SequenceReportFields::Keys[SequenceReportFields::IncludedTestRuns]]),
+            extractTestTargetNames(serialTestRunSelection[SequenceReportFields::Keys[SequenceReportFields::ExcludedTestRuns]]));
+    }
+
+    PolicyStateBase DeserializePolicyStateBaseMembers(const rapidjson::Value& serialPolicyState)
+    {
+        return
+        {
+            ExecutionFailurePolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::ExecutionFailure]].GetString()),
+            FailedTestCoveragePolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::CoverageFailure]].GetString()),
+            TestFailurePolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::TestFailure]].GetString()),
+            IntegrityFailurePolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::IntegrityFailure]].GetString()),
+            TestShardingPolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::TestSharding]].GetString()),
+            TargetOutputCapturePolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::TargetOutputCapture]].GetString())
+        };
+    }
+
+    SequencePolicyState DeserializePolicyStateMembers(const rapidjson::Value& serialPolicyState)
+    {
+        return { DeserializePolicyStateBaseMembers(serialPolicyState) };
+    }
+
+    SafeImpactAnalysisSequencePolicyState DeserializeSafeImpactAnalysisPolicyStateMembers(const rapidjson::Value& serialPolicyState)
+    {
+        return
+        {
+            DeserializePolicyStateBaseMembers(serialPolicyState),
+            TestPrioritizationPolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::TestPrioritization]].GetString())
+        };
+    }
+
+    ImpactAnalysisSequencePolicyState DeserializeImpactAnalysisSequencePolicyStateMembers(const rapidjson::Value& serialPolicyState)
+    {
+        return
+        {
+            DeserializePolicyStateBaseMembers(serialPolicyState),
+            TestPrioritizationPolicyFromString(serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::TestPrioritization]].GetString()),
+            DynamicDependencyMapPolicyFromString(
+                serialPolicyState[SequenceReportFields::Keys[SequenceReportFields::DynamicDependencyMap]].GetString())
+        };
+    }
+
+    template<typename PolicyStateType>
+    PolicyStateType DeserializePolicyStateType(const rapidjson::Value& serialPolicyStateType)
+    {
+        if constexpr (AZStd::is_same_v<PolicyStateType, SequencePolicyState>)
+        {
+            return DeserializePolicyStateMembers(serialPolicyStateType);
+        }
+        else if constexpr (AZStd::is_same_v<PolicyStateType, SafeImpactAnalysisSequencePolicyState>)
+        {
+            return DeserializeSafeImpactAnalysisPolicyStateMembers(serialPolicyStateType);
+        }
+        else if constexpr (AZStd::is_same_v<PolicyStateType, ImpactAnalysisSequencePolicyState>)
+        {
+            return DeserializeImpactAnalysisSequencePolicyStateMembers(serialPolicyStateType);
+        }
+        else
+        {
+            static_assert(false, "Template paramater must be a valid policy state type");
+        }
+    }
+
+    template<typename SequenceReportBaseType>
+    SequenceReportBaseType DeserialiseSequenceReportBase(const rapidjson::Value& serialSequenceReportBase)
+    {
+        const auto type = SequenceReportTypeFromString(serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::Type]].GetString());
+        AZ_TestImpact_Eval(
+            type == SequenceReportBaseType::m_type,
+            SequenceReportException, AZStd::string::format(
+                "The JSON sequence report type '%s' does not match the constructed report type",
+                serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::Type]].GetString()));
+
+        const auto testTargetTimeout =
+            serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::TestTargetTimeout]].GetUint64();
+        const auto globalTimeout =
+            serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::GlobalTimeout]].GetUint64();
+
+        return SequenceReportBaseType(
+            serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::MaxConcurrency]].GetUint64(),
+            testTargetTimeout ? AZStd::optional<AZStd::chrono::milliseconds>{ testTargetTimeout } : AZStd::nullopt,
+            globalTimeout ? AZStd::optional<AZStd::chrono::milliseconds>{ globalTimeout } : AZStd::nullopt,
+            DeserializePolicyStateType<SequenceReportBaseType::PolicyState>(serialSequenceReportBase),
+            SuiteTypeFromString(serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::Suite]].GetString()),
+            DeserializeTestSelection(serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::SelectedTestRuns]]),
+            DeserializeTestRunReport(serialSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::SelectedTestRunReport]]));
+    }
+
+    template<typename DerivedDraftingSequenceReportType>
+    Client::DraftingSequenceReportBase<DerivedDraftingSequenceReportType::m_type, typename DerivedDraftingSequenceReportType::PolicyState>
+        DeserializeDraftingSequenceReportType(const rapidjson::Value& serialDraftingSequenceReportBase)
+    {
+        AZStd::vector<AZStd::string> draftingTestRuns;
+        draftingTestRuns.reserve(
+            serialDraftingSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::DraftedTestRuns]].GetArray().Size());
+        for (const auto& testRun :
+             serialDraftingSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::DraftedTestRuns]].GetArray())
+        {
+            draftingTestRuns.push_back(testRun.GetString());
+        }
+
+        using SequenceBase =
+            Client::SequenceReportBase<DerivedDraftingSequenceReportType::m_type, typename DerivedDraftingSequenceReportType::PolicyState>;
+        using DraftingSequenceBase =
+            Client::DraftingSequenceReportBase<DerivedDraftingSequenceReportType::m_type, typename DerivedDraftingSequenceReportType::PolicyState>;
+
+        return DraftingSequenceBase(
+            DeserialiseSequenceReportBase<SequenceBase>(serialDraftingSequenceReportBase),
+            AZStd::move(draftingTestRuns),
+            DeserializeTestRunReport(serialDraftingSequenceReportBase[SequenceReportFields::Keys[SequenceReportFields::DraftedTestRunReport]]));
+    }
+
+    rapidjson::Document OpenSequenceReportJSON(const AZStd::string& sequenceReportJSON)
+    {
+        rapidjson::Document doc;
+
+        if (doc.Parse<0>(sequenceReportJSON.c_str()).HasParseError())
+        {
+            throw SequenceReportException("Could not parse sequence report data");
+        }
+
+        return doc;
+    }
+
+    Client::RegularSequenceReport DeserializeRegularSequenceReport(const AZStd::string& sequenceReportJSON)
+    {
+        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+        return DeserialiseSequenceReportBase<Client::RegularSequenceReport>(doc);
+    }
+
+    Client::SeedSequenceReport DeserializeSeedSequenceReport(const AZStd::string& sequenceReportJSON)
+    {
+        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+        return DeserialiseSequenceReportBase<Client::SeedSequenceReport>(doc);
+    }
+
+    Client::ImpactAnalysisSequenceReport DeserializeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON)
+    {
+        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+
+        AZStd::vector<AZStd::string> discardedTestRuns;
+        discardedTestRuns.reserve(doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]].GetArray().Size());
+        for (const auto& testRun : doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]].GetArray())
+        {
+            discardedTestRuns.push_back(testRun.GetString());
+        }
+
+        return Client::ImpactAnalysisSequenceReport(
+            DeserializeDraftingSequenceReportType<Client::ImpactAnalysisSequenceReport>(doc), AZStd::move(discardedTestRuns));
+    }
+
+    Client::SafeImpactAnalysisSequenceReport DeserializeSafeImpactAnalysisSequenceReport(const AZStd::string& sequenceReportJSON)
+    {
+        const auto doc = OpenSequenceReportJSON(sequenceReportJSON);
+
+        return Client::SafeImpactAnalysisSequenceReport(
+            DeserializeDraftingSequenceReportType<Client::SafeImpactAnalysisSequenceReport>(doc),
+            DeserializeTestSelection(doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]]),
+            DeserializeTestRunReport(doc[SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRunReport]]));
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -423,7 +423,7 @@ namespace TestImpact
         {
             // Type
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::Type]);
-            writer.String(SequenceReportTypeAsString(sequenceReport.GetType()).c_str());
+            writer.String(SequenceReportTypeAsString(sequenceReport.ReportType).c_str());
 
             // Test target timeout
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestTargetTimeout]);
@@ -640,7 +640,7 @@ namespace TestImpact
         testRuns.reserve(serialTestRuns.GetArray().Size());
         for (const auto& testRun : serialTestRuns.GetArray())
         {
-            testRuns.emplace_back(TestRunType(DeserializeTestRunBase(testRun)));
+            testRuns.emplace_back(DeserializeTestRunBase(testRun));
         }
 
         return testRuns;
@@ -653,8 +653,8 @@ namespace TestImpact
         testRuns.reserve(serialCompletedTestRuns.GetArray().Size());
         for (const auto& testRun : serialCompletedTestRuns.GetArray())
         {
-            testRuns.emplace_back(CompletedTestRunType(
-                DeserializeTestRunBase(testRun), DeserializeTests(testRun[SequenceReportFields::Keys[SequenceReportFields::Tests]])));
+            testRuns.emplace_back(
+                DeserializeTestRunBase(testRun), DeserializeTests(testRun[SequenceReportFields::Keys[SequenceReportFields::Tests]]));
         }
 
         return testRuns;

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
@@ -243,4 +243,256 @@ namespace TestImpact
             throw(Exception(AZStd::string::format("Unexpected client test case result: %u", aznumeric_cast<AZ::u32>(result))));
         }
     }
+
+    SuiteType SuiteTypeFromString(const AZStd::string& suiteType)
+    {
+        if (suiteType == SuiteTypeAsString(SuiteType::Main))
+        {
+            return SuiteType::Main;
+        }
+        else if (suiteType == SuiteTypeAsString(SuiteType::Periodic))
+        {
+            return SuiteType::Periodic;
+        }
+        else if (suiteType == SuiteTypeAsString(SuiteType::Sandbox))
+        {
+            return SuiteType::Sandbox;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected suite type: '%s'", suiteType.c_str()));
+        }
+    }
+
+    Client::SequenceReportType SequenceReportTypeFromString(const AZStd::string& type)
+    {
+        if (type == SequenceReportTypeAsString(Client::SequenceReportType::ImpactAnalysisSequence))
+        {
+            return Client::SequenceReportType::ImpactAnalysisSequence;
+        }
+        else if (type == SequenceReportTypeAsString(Client::SequenceReportType::RegularSequence))
+        {
+            return Client::SequenceReportType::RegularSequence;
+        }
+        else if (type == SequenceReportTypeAsString(Client::SequenceReportType::SafeImpactAnalysisSequence))
+        {
+            return Client::SequenceReportType::SafeImpactAnalysisSequence;
+        }
+        else if (type == SequenceReportTypeAsString(Client::SequenceReportType::SeedSequence))
+        {
+            return Client::SequenceReportType::SeedSequence;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected sequence report type: '%s'", type.c_str()));
+        }
+    }
+
+    Client::TestRunResult TestRunResultFromString(const AZStd::string& result)
+    {
+        if (result == TestRunResultAsString(Client::TestRunResult::AllTestsPass))
+        {
+            return Client::TestRunResult::AllTestsPass;
+        }
+        else if (result == TestRunResultAsString(Client::TestRunResult::FailedToExecute))
+        {
+            return Client::TestRunResult::FailedToExecute;
+        }
+        else if (result == TestRunResultAsString(Client::TestRunResult::NotRun))
+        {
+            return Client::TestRunResult::NotRun;
+        }
+        else if (result == TestRunResultAsString(Client::TestRunResult::TestFailures))
+        {
+            return Client::TestRunResult::TestFailures;
+        }
+        else if (result == TestRunResultAsString(Client::TestRunResult::Timeout))
+        {
+            return Client::TestRunResult::Timeout;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected client test run result: '%s'", result.c_str()));
+        }
+    }
+
+    Client::TestResult TestResultFromString(const AZStd::string& result)
+    {
+        if (result == ClientTestResultAsString(Client::TestResult::Failed))
+        {
+            return Client::TestResult::Failed;
+        }
+        else if (result == ClientTestResultAsString(Client::TestResult::NotRun))
+        {
+            return Client::TestResult::NotRun;
+        }
+        else if (result == ClientTestResultAsString(Client::TestResult::Passed))
+        {
+            return Client::TestResult::Passed;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected client test result: '%s'", result.c_str()));
+        }
+    }
+
+    TestSequenceResult TestSequenceResultFromString(const AZStd::string& result)
+    {
+        if (result == TestSequenceResultAsString(TestSequenceResult::Failure))
+        {
+            return TestSequenceResult::Failure;
+        }
+        else if (result == TestSequenceResultAsString(TestSequenceResult::Success))
+        {
+            return TestSequenceResult::Success;
+        }
+        else if (result == TestSequenceResultAsString(TestSequenceResult::Timeout))
+        {
+            return TestSequenceResult::Timeout;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected test sequence result: '%s'", result.c_str()));
+        }
+    }
+
+    Policy::ExecutionFailure ExecutionFailurePolicyFromString(const AZStd::string& executionFailurePolicy)
+    {
+        if (executionFailurePolicy == ExecutionFailurePolicyAsString(Policy::ExecutionFailure::Abort))
+        {
+            return Policy::ExecutionFailure::Abort;
+        }
+        else if (executionFailurePolicy == ExecutionFailurePolicyAsString(Policy::ExecutionFailure::Continue))
+        {
+            return Policy::ExecutionFailure::Continue;
+        }
+        else if (executionFailurePolicy == ExecutionFailurePolicyAsString(Policy::ExecutionFailure::Ignore))
+        {
+            return Policy::ExecutionFailure::Ignore;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected execution failure policy: '%s'", executionFailurePolicy.c_str()));
+        }
+    }
+
+    Policy::FailedTestCoverage FailedTestCoveragePolicyFromString(const AZStd::string& failedTestCoveragePolicy)
+    {
+        if (failedTestCoveragePolicy == FailedTestCoveragePolicyAsString(Policy::FailedTestCoverage::Discard))
+        {
+            return Policy::FailedTestCoverage::Discard;
+        }
+        else if (failedTestCoveragePolicy == FailedTestCoveragePolicyAsString(Policy::FailedTestCoverage::Keep))
+        {
+            return Policy::FailedTestCoverage::Keep;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected failed test coverage policy: '%s'", failedTestCoveragePolicy.c_str()));
+        }
+    }
+
+    Policy::TestPrioritization TestPrioritizationPolicyFromString(const AZStd::string& testPrioritizationPolicy)
+    {
+        if (testPrioritizationPolicy == TestPrioritizationPolicyAsString(Policy::TestPrioritization::DependencyLocality))
+        {
+            return Policy::TestPrioritization::DependencyLocality;
+        }
+        else if (testPrioritizationPolicy == TestPrioritizationPolicyAsString(Policy::TestPrioritization::None))
+        {
+            return Policy::TestPrioritization::None;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected test prioritization policy: '%s'", testPrioritizationPolicy.c_str()));
+        }
+    }
+
+    Policy::TestFailure TestFailurePolicyFromString(const AZStd::string& testFailurePolicy)
+    {
+        if (testFailurePolicy == TestFailurePolicyAsString(Policy::TestFailure::Abort))
+        {
+            return Policy::TestFailure::Abort;
+        }
+        else if (testFailurePolicy == TestFailurePolicyAsString(Policy::TestFailure::Continue))
+        {
+            return Policy::TestFailure::Continue;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected test failure policy: '%s'", testFailurePolicy.c_str()));
+        }
+    }
+
+    Policy::IntegrityFailure IntegrityFailurePolicyFromString(const AZStd::string& integrityFailurePolicy)
+    {
+        if (integrityFailurePolicy == IntegrityFailurePolicyAsString(Policy::IntegrityFailure::Abort))
+        {
+            return Policy::IntegrityFailure::Abort;
+        }
+        else if (integrityFailurePolicy == IntegrityFailurePolicyAsString(Policy::IntegrityFailure::Continue))
+        {
+            return Policy::IntegrityFailure::Continue;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected integration failure policy: '%s'", integrityFailurePolicy.c_str()));
+        }
+    }
+
+    Policy::DynamicDependencyMap DynamicDependencyMapPolicyFromString(const AZStd::string& dynamicDependencyMapPolicy)
+    {
+        if (dynamicDependencyMapPolicy == DynamicDependencyMapPolicyAsString(Policy::DynamicDependencyMap::Discard))
+        {
+            return Policy::DynamicDependencyMap::Discard;
+        }
+        else if (dynamicDependencyMapPolicy == DynamicDependencyMapPolicyAsString(Policy::DynamicDependencyMap::Update))
+        {
+            return Policy::DynamicDependencyMap::Update;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected dynamic dependency map policy: '%s'", dynamicDependencyMapPolicy.c_str()));
+        }
+    }
+
+    Policy::TestSharding TestShardingPolicyFromString(const AZStd::string& testShardingPolicy)
+    {
+        if (testShardingPolicy == TestShardingPolicyAsString(Policy::TestSharding::Always))
+        {
+            return Policy::TestSharding::Always;
+        }
+        else if (testShardingPolicy == TestShardingPolicyAsString(Policy::TestSharding::Never))
+        {
+            return Policy::TestSharding::Never;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected test sharding policy: '%s'", testShardingPolicy.c_str()));
+        }
+    }
+
+    Policy::TargetOutputCapture TargetOutputCapturePolicyFromString(const AZStd::string& targetOutputCapturePolicy)
+    {
+        if (targetOutputCapturePolicy == TargetOutputCapturePolicyAsString(Policy::TargetOutputCapture::File))
+        {
+            return Policy::TargetOutputCapture::File;
+        }
+        else if (targetOutputCapturePolicy == TargetOutputCapturePolicyAsString(Policy::TargetOutputCapture::None))
+        {
+            return Policy::TargetOutputCapture::None;
+        }
+        else if (targetOutputCapturePolicy == TargetOutputCapturePolicyAsString(Policy::TargetOutputCapture::StdOut))
+        {
+            return Policy::TargetOutputCapture::StdOut;
+        }
+        else if (targetOutputCapturePolicy == TargetOutputCapturePolicyAsString(Policy::TargetOutputCapture::StdOutAndFile))
+        {
+            return Policy::TargetOutputCapture::StdOutAndFile;
+        }
+        else
+        {
+            throw Exception(AZStd::string::format("Unexpected target output capture policy: '%s'", targetOutputCapturePolicy.c_str()));
+        }
+    }
 } // namespace TestImpact


### PR DESCRIPTION
This PR adds sequence report serialization. This functionality is necessary for various future features and optimizations including the Python test selection and prioritization.

Signed-off-by: John <jonawals@amazon.com>