### PR TITLE
Remove redundant API calls from EditorViewportWidget and use new WorldToScreen call

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -708,8 +708,6 @@ void EditorViewportWidget::OnBeginPrepareRender()
         return;
     }
 
-    PreWidgetRendering();
-
     RenderAll();
 
     // Draw 2D helpers.
@@ -735,8 +733,6 @@ void EditorViewportWidget::OnBeginPrepareRender()
 
     m_debugDisplay->SetState(prevState);
     m_debugDisplay->DepthTestOn();
-
-    PostWidgetRendering();
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -937,8 +933,6 @@ AZ::Vector3 EditorViewportWidget::PickTerrain(const AzFramework::ScreenPoint& po
 
 AZ::EntityId EditorViewportWidget::PickEntity(const AzFramework::ScreenPoint& point)
 {
-    PreWidgetRendering();
-
     AZ::EntityId entityId;
     HitContext hitInfo;
     hitInfo.view = this;
@@ -950,8 +944,6 @@ AZ::EntityId EditorViewportWidget::PickEntity(const AzFramework::ScreenPoint& po
             entityId = entityObject->GetAssociatedEntityId();
         }
     }
-
-    PostWidgetRendering();
 
     return entityId;
 }

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -295,28 +295,17 @@ void EditorViewportWidget::mousePressEvent(QMouseEvent* event)
     QtViewport::mousePressEvent(event);
 }
 
-AzToolsFramework::ViewportInteraction::MousePick EditorViewportWidget::BuildMousePickInternal(const QPoint& point) const
+AzToolsFramework::ViewportInteraction::MousePick EditorViewportWidget::BuildMousePick(const QPoint& point) const
 {
-    using namespace AzToolsFramework::ViewportInteraction;
-
-    MousePick mousePick;
-    mousePick.m_screenCoordinates = ScreenPointFromQPoint(point);
-    const auto& ray = m_renderViewport->ViewportScreenToWorldRay(mousePick.m_screenCoordinates);
-    if (ray.has_value())
+    AzToolsFramework::ViewportInteraction::MousePick mousePick;
+    mousePick.m_screenCoordinates = AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point);
+    if (const auto& ray = m_renderViewport->ViewportScreenToWorldRay(mousePick.m_screenCoordinates);
+        ray.has_value())
     {
         mousePick.m_rayOrigin = ray.value().origin;
         mousePick.m_rayDirection = ray.value().direction;
     }
-    return mousePick;
-}
 
-AzToolsFramework::ViewportInteraction::MousePick EditorViewportWidget::BuildMousePick(const QPoint& point)
-{
-    using namespace AzToolsFramework::ViewportInteraction;
-
-    PreWidgetRendering();
-    const MousePick mousePick = BuildMousePickInternal(point);
-    PostWidgetRendering();
     return mousePick;
 }
 
@@ -325,9 +314,7 @@ AzToolsFramework::ViewportInteraction::MouseInteraction EditorViewportWidget::Bu
     const AzToolsFramework::ViewportInteraction::KeyboardModifiers modifiers,
     const AzToolsFramework::ViewportInteraction::MousePick& mousePick) const
 {
-    using namespace AzToolsFramework::ViewportInteraction;
-
-    MouseInteraction mouse;
+    AzToolsFramework::ViewportInteraction::MouseInteraction mouse;
     mouse.m_interactionId.m_cameraId = m_viewEntityId;
     mouse.m_interactionId.m_viewportId = GetViewportId();
     mouse.m_mouseButtons = buttons;
@@ -339,11 +326,11 @@ AzToolsFramework::ViewportInteraction::MouseInteraction EditorViewportWidget::Bu
 AzToolsFramework::ViewportInteraction::MouseInteraction EditorViewportWidget::BuildMouseInteraction(
     const Qt::MouseButtons buttons, const Qt::KeyboardModifiers modifiers, const QPoint& point)
 {
-    using namespace AzToolsFramework::ViewportInteraction;
+    namespace AztfVi = AzToolsFramework::ViewportInteraction;
 
     return BuildMouseInteractionInternal(
-        BuildMouseButtons(buttons),
-        BuildKeyboardModifiers(modifiers),
+        AztfVi::BuildMouseButtons(buttons),
+        AztfVi::BuildKeyboardModifiers(modifiers),
         BuildMousePick(WidgetToViewport(point)));
 }
 
@@ -769,15 +756,15 @@ void EditorViewportWidget::RenderAll()
 
     if (m_manipulatorManager != nullptr)
     {
-        using namespace AzToolsFramework::ViewportInteraction;
+        namespace AztfVi = AzToolsFramework::ViewportInteraction;
 
         m_debugDisplay->DepthTestOff();
         m_manipulatorManager->DrawManipulators(
             *m_debugDisplay, GetCameraState(),
             BuildMouseInteractionInternal(
-                MouseButtons(TranslateMouseButtons(QGuiApplication::mouseButtons())),
-                BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers()),
-                BuildMousePickInternal(WidgetToViewport(mapFromGlobal(QCursor::pos())))));
+                AztfVi::MouseButtons(AztfVi::TranslateMouseButtons(QGuiApplication::mouseButtons())),
+                AztfVi::BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers()),
+                BuildMousePick(WidgetToViewport(mapFromGlobal(QCursor::pos())))));
         m_debugDisplay->DepthTestOn();
     }
 }
@@ -999,28 +986,17 @@ QWidget* EditorViewportWidget::GetWidgetForViewportContextMenu()
     return this;
 }
 
-void EditorViewportWidget::BeginWidgetContext()
-{
-    PreWidgetRendering();
-}
-
-void EditorViewportWidget::EndWidgetContext()
-{
-    PostWidgetRendering();
-}
-
 bool EditorViewportWidget::ShowingWorldSpace()
 {
-    using namespace AzToolsFramework::ViewportInteraction;
-    return BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers()).Shift();
+    return AzToolsFramework::ViewportInteraction::BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers()).Shift();
 }
 
 void EditorViewportWidget::SetViewportId(int id)
 {
     CViewport::SetViewportId(id);
 
-    // Clear the cached debugdisplay pointer. we're about to delete that render viewport, and deleting the render
-    // viewport invalidates the debugdisplay.
+    // Clear the cached DebugDisplay pointer. we're about to delete that render viewport, and deleting the render
+    // viewport invalidates the DebugDisplay.
     m_debugDisplay = nullptr;
 
     // First delete any existing layout

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -211,8 +211,6 @@ private:
     float TerrainHeight(const AZ::Vector2& position) override;
     bool ShowingWorldSpace() override;
     QWidget* GetWidgetForViewportContextMenu() override;
-    void BeginWidgetContext() override;
-    void EndWidgetContext() override;
 
     // EditorEntityViewportInteractionRequestBus overrides ...
     void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) override;
@@ -271,7 +269,7 @@ private:
     // note: The argument passed to parameter **point**, originating
     // from a Qt event, must first be passed to WidgetToViewport before being
     // passed to BuildMousePick.
-    AzToolsFramework::ViewportInteraction::MousePick BuildMousePick(const QPoint& point);
+    AzToolsFramework::ViewportInteraction::MousePick BuildMousePick(const QPoint& point) const;
 
     bool CheckRespondToInput() const;
 
@@ -281,7 +279,6 @@ private:
     void PushDisableRendering();
     void PopDisableRendering();
     bool IsRenderingDisabled() const;
-    AzToolsFramework::ViewportInteraction::MousePick BuildMousePickInternal(const QPoint& point) const;
 
     void RestoreViewportAfterGameMode();
 

--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -632,14 +632,7 @@ void CEditorImpl::SetReferenceCoordSys(RefCoordSys refCoords)
     CViewport* pViewport = GetActiveView();
     if (pViewport)
     {
-        //Pre and Post widget rendering calls are made here to make sure that the proper camera state is set.
-        //MakeConstructionPlane will make a call to ViewToWorldRay which needs the correct camera state
-        //in the CRenderViewport to be set.
-        pViewport->PreWidgetRendering();
-
         pViewport->MakeConstructionPlane(GetIEditor()->GetAxisConstrains());
-
-        pViewport->PostWidgetRendering();
     }
 
     Notify(eNotify_OnRefCoordSysChange);

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -43,12 +43,7 @@
 void QtViewport::BuildDragDropContext(AzQtComponents::ViewportDragContext& context, const QPoint& pt)
 {
     context.m_hitLocation = AZ::Vector3::CreateZero();
-
-    PreWidgetRendering(); // required so that the current render cam is set.
-
     context.m_hitLocation = GetHitLocation(pt);
-
-    PostWidgetRendering();
 }
 
 
@@ -1351,28 +1346,6 @@ bool QtViewport::MouseCallback(EMouseEvent event, const QPoint& point, Qt::Keybo
     {
         return true;
     }
-
-    // RAII wrapper for Pre / PostWidgetRendering calls.
-    // It also tracks the times a mouse callback potentially created a new viewport context.
-    struct ScopedProcessingMouseCallback
-    {
-        explicit ScopedProcessingMouseCallback(QtViewport* viewport)
-            : m_viewport(viewport)
-        {
-            m_viewport->m_processingMouseCallbacksCounter++;
-            m_viewport->PreWidgetRendering();
-        }
-
-        ~ScopedProcessingMouseCallback()
-        {
-            m_viewport->PostWidgetRendering();
-            m_viewport->m_processingMouseCallbacksCounter--;
-        }
-
-        QtViewport* m_viewport;
-    };
-
-    ScopedProcessingMouseCallback scopedProcessingMouseCallback(this);
 
     //////////////////////////////////////////////////////////////////////////
     // Hit test gizmo objects.

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -274,12 +274,6 @@ public:
 
     void SetViewPane(CLayoutViewPane* viewPane) { m_viewPane = viewPane; }
 
-    //Child classes can override these to provide extra logic that wraps
-    //widget rendering. Needed by the RenderViewport to handle raycasts
-    //from screen-space to world-space.
-    virtual void PreWidgetRendering() {}
-    virtual void PostWidgetRendering() {}
-
     virtual CViewport *asCViewport() { return this; }
 
 protected:
@@ -289,7 +283,7 @@ protected:
     // Screen Matrix
     Matrix34 m_screenTM;
     int m_nCurViewportID;
-    // Final game view matrix before drpping back to editor
+    // Final game view matrix before dropping back to editor
     Matrix34 m_gameTM;
     AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
@@ -427,7 +421,7 @@ public:
     QRect GetSelectionRectangle() const override { return m_selectedRect; };
     //! Called when dragging selection rectangle.
     void OnDragSelectRectangle(const QRect& rect, bool bNormalizeRect = false) override;
-    //! Get selection procision tolerance.
+    //! Get selection precision tolerance.
     float GetSelectionTolerance() const { return m_selectionTolerance; }
     //! Center viewport on selection.
     void CenterOnSelection() override {}

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -572,12 +572,6 @@ protected:
     void dragLeaveEvent(QDragLeaveEvent* event) override;
     void dropEvent(QDropEvent* event) override;
 
-    //Child classes can override these to provide extra logic that wraps
-    //widget rendering. Needed by the RenderViewport to handle raycasts
-    //from screen-space to world-space.
-    virtual void PreWidgetRendering() {}
-    virtual void PostWidgetRendering() {}
-
     AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
     AzToolsFramework::ViewportUi::ViewportUiManager m_viewportUi;
     AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/EditorVertexSelection.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/VertexContainerInterface.h>
 #include <AzCore/std/sort.h>
+#include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
 #include <AzToolsFramework/Manipulators/LinearManipulator.h>
 #include <AzToolsFramework/Manipulators/ManipulatorSnapping.h>
@@ -363,9 +364,7 @@ namespace AzToolsFramework
             boxSelectData.m_activeSelection = boxSelectData.m_startSelection;
         }
 
-        // set the widget context before calls to ViewportWorldToScreen so we are not
-        // going to constantly be pushing/popping the widget context
-        ViewportInteraction::WidgetContextGuard widgetContextGuard(viewportId);
+        const AzFramework::CameraState cameraState = GetCameraState(viewportId);
 
         // box select active (clicking and dragging)
         if (editorBoxSelect.BoxRegion())
@@ -385,7 +384,7 @@ namespace AzToolsFramework
                     found, fixedVertices, &AZ::FixedVerticesRequestBus<Vertex>::Handler::GetVertex, vertexIndex, localVertex);
 
                 const AZ::Vector3 worldVertex = worldFromLocal.TransformPoint(AZ::AdaptVertexOut<Vertex>(localVertex));
-                const AzFramework::ScreenPoint screenPosition = GetScreenPosition(viewportId, worldVertex);
+                const AzFramework::ScreenPoint screenPosition = AzFramework::WorldToScreen(worldVertex, cameraState);
 
                 // check if a vertex is inside the box select region
                 if (editorBoxSelect.BoxRegion()->contains(ViewportInteraction::QPointFromScreenPoint(screenPosition)))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -254,11 +254,6 @@ namespace AzToolsFramework
             virtual bool ShowingWorldSpace() = 0;
             //! Return the widget to use as the parent for the viewport context menu.
             virtual QWidget* GetWidgetForViewportContextMenu() = 0;
-            //! Set the render context for the viewport.
-            virtual void BeginWidgetContext() = 0;
-            //! End the render context for the viewport.
-            //! Return to previous context before Begin was called.
-            virtual void EndWidgetContext() = 0;
 
         protected:
             ~MainEditorViewportInteractionRequests() = default;
@@ -297,28 +292,6 @@ namespace AzToolsFramework
 
         //! Type to inherit to implement MainEditorViewportInteractionRequests.
         using ViewportMouseCursorRequestBus = AZ::EBus<ViewportMouseCursorRequests, ViewportEBusTraits>;
-
-        //! A helper to wrap Begin/EndWidgetContext.
-        class WidgetContextGuard
-        {
-        public:
-            explicit WidgetContextGuard(const int viewportId)
-                : m_viewportId(viewportId)
-            {
-                MainEditorViewportInteractionRequestBus::Event(
-                    viewportId, &MainEditorViewportInteractionRequestBus::Events::BeginWidgetContext);
-            }
-
-            ~WidgetContextGuard()
-            {
-                MainEditorViewportInteractionRequestBus::Event(
-                    m_viewportId, &MainEditorViewportInteractionRequestBus::Events::EndWidgetContext);
-            }
-
-        private:
-            int m_viewportId; //!< The viewport id the widget context is being set on.
-        };
-
     } // namespace ViewportInteraction
 
     //! Utility function to return EntityContextId.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Console/Console.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Viewport/CameraState.h>
+#include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzFramework/Visibility/BoundsBus.h>
 #include <AzToolsFramework/API/EditorViewportIconDisplayInterface.h>
 #include <AzToolsFramework/ToolsComponents/EditorEntityIconComponentBus.h>
@@ -118,10 +119,6 @@ namespace AzToolsFramework
 
         const int viewportId = mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId;
 
-        // set the widget context before calls to ViewportWorldToScreen so we are not
-        // going to constantly be pushing/popping the widget context
-        ViewportInteraction::WidgetContextGuard widgetContextGuard(viewportId);
-
         const bool helpersVisible = HelpersVisible();
 
         // selecting new entities
@@ -145,7 +142,7 @@ namespace AzToolsFramework
                     const AZ::Vector3& entityPosition = m_entityDataCache->GetVisibleEntityPosition(entityCacheIndex);
 
                     // selecting based on 2d icon - should only do it when visible and not selected
-                    const AzFramework::ScreenPoint screenPosition = GetScreenPosition(viewportId, entityPosition);
+                    const AzFramework::ScreenPoint screenPosition = AzFramework::WorldToScreen(entityPosition, cameraState);
 
                     const float distSqFromCamera = cameraState.m_position.GetDistanceSq(entityPosition);
                     const auto iconRange = static_cast<float>(GetIconScale(distSqFromCamera) * s_iconSize * 0.5f);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
@@ -48,18 +48,6 @@ namespace AzToolsFramework
         return AZ::GetMax(projectedCameraDistance, cameraState.m_nearClip) / apparentDistance;
     }
 
-    AzFramework::ScreenPoint GetScreenPosition(const int viewportId, const AZ::Vector3& worldTranslation)
-    {
-        AZ_PROFILE_FUNCTION(AzToolsFramework);
-
-        auto screenPosition = AzFramework::ScreenPoint(0, 0);
-        ViewportInteraction::ViewportInteractionRequestBus::EventResult(
-            screenPosition, viewportId, &ViewportInteraction::ViewportInteractionRequestBus::Events::ViewportWorldToScreen,
-            worldTranslation);
-
-        return screenPosition;
-    }
-
     bool AabbIntersectRay(const AZ::Vector3& origin, const AZ::Vector3& direction, const AZ::Aabb& aabb, float& distance)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
@@ -39,9 +39,6 @@ namespace AzToolsFramework
     //! Calculate scale factor based on distance from camera
     float CalculateScreenToWorldMultiplier(const AZ::Vector3& worldPosition, const AzFramework::CameraState& cameraState);
 
-    //! Map from world space to screen space.
-    AzFramework::ScreenPoint GetScreenPosition(int viewportId, const AZ::Vector3& worldTranslation);
-
     //! Given a mouse interaction, determine if the pick ray from its position
     //! in screen space intersected an aabb in world space.
     bool AabbIntersectMouseRay(const ViewportInteraction::MouseInteraction& mouseInteraction, const AZ::Aabb& aabb);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -412,10 +412,7 @@ namespace AzToolsFramework
                 potentialSelectedEntityIds.clear();
             }
 
-            // set the widget context before calls to ViewportWorldToScreen so we are not
-            // going to constantly be pushing/popping the widget context
-            ViewportInteraction::WidgetContextGuard widgetContextGuard(viewportId);
-
+            const AzFramework::CameraState cameraState = GetCameraState(viewportId);
             for (size_t entityCacheIndex = 0; entityCacheIndex < entityDataCache.VisibleEntityDataCount(); ++entityCacheIndex)
             {
                 if (entityDataCache.IsVisibleEntityLocked(entityCacheIndex) || !entityDataCache.IsVisibleEntityVisible(entityCacheIndex))
@@ -426,7 +423,7 @@ namespace AzToolsFramework
                 const AZ::EntityId entityId = entityDataCache.GetVisibleEntityId(entityCacheIndex);
                 const AZ::Vector3& entityPosition = entityDataCache.GetVisibleEntityPosition(entityCacheIndex);
 
-                const AzFramework::ScreenPoint screenPosition = GetScreenPosition(viewportId, entityPosition);
+                const AzFramework::ScreenPoint screenPosition = AzFramework::WorldToScreen(entityPosition, cameraState);
 
                 if (currentKeyboardModifiers.Ctrl())
                 {
@@ -1779,13 +1776,7 @@ namespace AzToolsFramework
 
         CheckDirtyEntityIds();
 
-        const int viewportId = mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId;
-
-        const AzFramework::CameraState cameraState = GetCameraState(viewportId);
-
-        // set the widget context before calls to ViewportWorldToScreen so we are not
-        // going to constantly be pushing/popping the widget context
-        ViewportInteraction::WidgetContextGuard widgetContextGuard(viewportId);
+        const AzFramework::CameraState cameraState = GetCameraState(mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId);
 
         m_cachedEntityIdUnderCursor = m_editorHelpers->HandleMouseInteraction(cameraState, mouseInteraction);
 

--- a/Gems/PhysX/Code/Editor/EditorViewportEntityPicker.cpp
+++ b/Gems/PhysX/Code/Editor/EditorViewportEntityPicker.cpp
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include <AzCore/Math/IntersectSegment.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Viewport/CameraState.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.h>
-
 #include <Editor/EditorViewportEntityPicker.h>
 
 namespace PhysX
@@ -28,16 +28,12 @@ namespace PhysX
     }
 
     AZ::EntityId EditorViewportEntityPicker::PickEntity(
-        [[maybe_unused]] const AzFramework::CameraState& cameraState
-        , const AzToolsFramework::ViewportInteraction::MouseInteractionEvent& mouseInteraction
-        , AZ::Vector3& pickPosition
-        , AZ::Aabb& pickAabb)
-    {  
+        [[maybe_unused]] const AzFramework::CameraState& cameraState,
+        const AzToolsFramework::ViewportInteraction::MouseInteractionEvent& mouseInteraction,
+        AZ::Vector3& pickPosition,
+        AZ::Aabb& pickAabb)
+    {
         const int viewportId = mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId;
-
-        // set the widget context before calls to ViewportWorldToScreen so we are not
-        // going to constantly be pushing/popping the widget context
-        AzToolsFramework::ViewportInteraction::WidgetContextGuard widgetContextGuard(viewportId);
 
         // selecting new entities
         AZ::EntityId entityIdUnderCursor;
@@ -48,31 +44,29 @@ namespace PhysX
         {
             const AZ::EntityId entityId = m_entityDataCache->GetVisibleEntityId(entityCacheIndex);
 
-            if (m_entityDataCache->IsVisibleEntityLocked(entityCacheIndex)
-                || !m_entityDataCache->IsVisibleEntityVisible(entityCacheIndex))
+            if (m_entityDataCache->IsVisibleEntityLocked(entityCacheIndex) || !m_entityDataCache->IsVisibleEntityVisible(entityCacheIndex))
             {
                 continue;
             }
 
             // Ignore the case where the mouse hovers over an icon. Proceed to check for intersection with entity's AABB.
-            if (const AZ::Aabb aabb = AzToolsFramework::CalculateEditorEntitySelectionBounds(
-                    entityId, AzFramework::ViewportInfo{viewportId});
+            if (const AZ::Aabb aabb =
+                    AzToolsFramework::CalculateEditorEntitySelectionBounds(entityId, AzFramework::ViewportInfo{ viewportId });
                 aabb.IsValid())
             {
                 const float pickRayLength = 1000.0f;
-                const AZ::Vector3 rayScaledDir =
-                    mouseInteraction.m_mouseInteraction.m_mousePick.m_rayDirection * pickRayLength;
+                const AZ::Vector3 rayScaledDir = mouseInteraction.m_mouseInteraction.m_mousePick.m_rayDirection * pickRayLength;
 
                 AZ::Vector3 startNormal;
                 float t, end;
                 int intersectResult = AZ::Intersect::IntersectRayAABB(
-                    mouseInteraction.m_mouseInteraction.m_mousePick.m_rayOrigin, rayScaledDir,
-                    rayScaledDir.GetReciprocal(), aabb, t, end, startNormal);
+                    mouseInteraction.m_mouseInteraction.m_mousePick.m_rayOrigin, rayScaledDir, rayScaledDir.GetReciprocal(), aabb, t, end,
+                    startNormal);
                 if (intersectResult > 0)
                 {
                     entityIdUnderCursor = entityId;
-                    pickPosition = mouseInteraction.m_mouseInteraction.m_mousePick.m_rayOrigin 
-                        + (mouseInteraction.m_mouseInteraction.m_mousePick.m_rayDirection * pickRayLength * t);
+                    pickPosition = mouseInteraction.m_mouseInteraction.m_mousePick.m_rayOrigin +
+                        (mouseInteraction.m_mouseInteraction.m_mousePick.m_rayDirection * pickRayLength * t);
                     pickAabb = aabb;
                 }
             }
@@ -82,10 +76,8 @@ namespace PhysX
     }
 
     void EditorViewportEntityPicker::DisplayViewport(
-        const AzFramework::ViewportInfo& viewportInfo,
-        AzFramework::DebugDisplayRequests& debugDisplay)
+        const AzFramework::ViewportInfo& viewportInfo, [[maybe_unused]] AzFramework::DebugDisplayRequests& debugDisplay)
     {
-        AZ_UNUSED(debugDisplay);
         m_entityDataCache->CalculateVisibleEntityDatas(viewportInfo);
     }
 } // namespace PhysX


### PR DESCRIPTION
This is a tidy-up PR now we have some more test coverage in-place. It removes some redundant calls that are no longer needed and also performs some more small clean-ups.