### PR TITLE
Removing the boundary search method. 

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomEditorComponents_LightComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/atom_hydra_scripts/hydra_AtomEditorComponents_LightComponent.py
@@ -31,8 +31,6 @@ SPHERE_AND_SPOT_DISK_LIGHT_PROPERTIES = [
     ("Controller|Configuration|Shadows|Shadow filter method", 1),  # PCF
     ("Controller|Configuration|Shadows|Filtering sample count", 4.0),
     ("Controller|Configuration|Shadows|Filtering sample count", 64.0),
-    ("Controller|Configuration|Shadows|PCF method", 0),  # Bicubic
-    ("Controller|Configuration|Shadows|PCF method", 1),  # Boundary search
     ("Controller|Configuration|Shadows|Shadow filter method", 2),  # ECM
     ("Controller|Configuration|Shadows|ESM exponent", 50),
     ("Controller|Configuration|Shadows|ESM exponent", 5000),

--- a/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
+++ b/AutomatedTesting/Gem/PythonTests/atom_renderer/test_Atom_MainSuite.py
@@ -200,8 +200,6 @@ class TestAtomEditorComponentsMain(object):
             "Controller|Configuration|Shadows|Shadow filter method set to 1",  # PCF
             "Controller|Configuration|Shadows|Filtering sample count set to 4",
             "Controller|Configuration|Shadows|Filtering sample count set to 64",
-            "Controller|Configuration|Shadows|PCF method set to 0",
-            "Controller|Configuration|Shadows|PCF method set to 1",
             "Controller|Configuration|Shadows|Shadow filter method set to 2",  # ESM
             "Controller|Configuration|Shadows|ESM exponent set to 50.0",
             "Controller|Configuration|Shadows|ESM exponent set to 5000.0",

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/DirectionalLightShadow.azsli
@@ -101,7 +101,6 @@ class DirectionalLightShadow
     // This outputs visibility ratio (from 0.0 to 1.0) for ESM+PCF.
     float GetVisibilityFromLightEsmPcf();
 
-    float SamplePcfBicubic();
     float SamplePcfBicubic(float3 shadowCoord, uint indexOfCascade);
 
     uint m_lightIndex;
@@ -278,70 +277,26 @@ float DirectionalLightShadow::GetVisibilityFromLightNoFilter()
 }
 
 float DirectionalLightShadow::GetVisibilityFromLightPcf()
-{
-    const uint predictionCount = ViewSrg::m_directionalLightShadows[m_lightIndex].m_predictionSampleCount;
+{   
+    static const float DepthMargin = 0.01; // avoiding artifact when near depth bounds.
+    static const float PixelMargin = 1.5; // avoiding artifact between cascade levels.
 
-    if (predictionCount <= 1)
+    const uint size = ViewSrg::m_directionalLightShadows[m_lightIndex].m_shadowmapSize;
+    const uint cascadeCount = ViewSrg::m_directionalLightShadows[m_lightIndex].m_cascadeCount;
+    for (uint indexOfCascade = 0; indexOfCascade < cascadeCount; ++indexOfCascade)
     {
-        return GetVisibilityFromLightNoFilter();
-    }
+        const float3 shadowCoord = m_shadowCoords[indexOfCascade];
     
-    if (ViewSrg::m_directionalLightShadows[m_lightIndex].m_pcfFilterMethod == PcfFilterMethod_Bicubic)
-    {
-        return SamplePcfBicubic();
-    }    
-
-    const float3 lightDirection = 
-        normalize(SceneSrg::m_directionalLights[m_lightIndex].m_direction);
-    const float4 jitterUnitVectorDepthDiffBase = 
-        Shadow::GetJitterUnitVectorDepthDiffBase(m_normalVector, lightDirection);
-    const float3 jitterUnit = jitterUnitVectorDepthDiffBase.xyz;
-    const float jitterDepthDiffBase = jitterUnitVectorDepthDiffBase.w;
-
-    uint shadowedCount = 0;
-    uint jitterIndex = 0;
-
-    // Predicting
-    for (; jitterIndex < predictionCount; ++jitterIndex)
-    {
-        if (IsShadowedWithJitter(
-            jitterUnit,
-            jitterDepthDiffBase,
-            jitterIndex))
+        if (shadowCoord.x >= 0. && shadowCoord.x * size < size - PixelMargin &&
+            shadowCoord.y >= 0. && shadowCoord.y * size < size - PixelMargin && 
+            shadowCoord.z < 1. - DepthMargin)
         {
-            ++shadowedCount;
+            m_debugInfo.m_cascadeIndex = indexOfCascade;
+            return SamplePcfBicubic(shadowCoord, indexOfCascade);
         }
     }
-    if (shadowedCount == 0)
-    {
-        return 1.;
-    }
-    else if (shadowedCount == predictionCount)
-    {
-        return 0.;
-    }
-
-    // Filtering
-
-    // When the prediction detects the point on the boundary of shadow,
-    // i.e., both of a lit point and a a shadowed one exists in the jittering area,
-    // we calculate the more precious lit ratio in the area.
-    const uint filteringCount = max(
-        predictionCount,
-        ViewSrg::m_directionalLightShadows[m_lightIndex].m_filteringSampleCount);
-
-    for (; jitterIndex < filteringCount; ++jitterIndex)
-    {
-        if (IsShadowedWithJitter(
-            jitterUnit,
-            jitterDepthDiffBase,
-            jitterIndex))
-        {
-            ++shadowedCount;
-        }
-    }
-
-    return (filteringCount - shadowedCount) * 1. / filteringCount;
+    m_debugInfo.m_cascadeIndex = cascadeCount;
+    return 1.;
 }
 
 float DirectionalLightShadow::GetVisibilityFromLightEsm()
@@ -411,29 +366,6 @@ float DirectionalLightShadow::GetVisibilityFromLightEsmPcf()
     }
 
     m_debugInfo.m_usePcfFallback = false;
-    m_debugInfo.m_cascadeIndex = cascadeCount;
-    return 1.;
-}
-
-float DirectionalLightShadow::SamplePcfBicubic()
-{
-    static const float DepthMargin = 0.01; // avoiding artifact when near depth bounds.
-    static const float PixelMargin = 1.5; // avoiding artifact between cascade levels.
-
-    const uint size = ViewSrg::m_directionalLightShadows[m_lightIndex].m_shadowmapSize;
-    const uint cascadeCount = ViewSrg::m_directionalLightShadows[m_lightIndex].m_cascadeCount;
-    for (uint indexOfCascade = 0; indexOfCascade < cascadeCount; ++indexOfCascade)
-    {
-        const float3 shadowCoord = m_shadowCoords[indexOfCascade];
-    
-        if (shadowCoord.x >= 0. && shadowCoord.x * size < size - PixelMargin &&
-            shadowCoord.y >= 0. && shadowCoord.y * size < size - PixelMargin && 
-            shadowCoord.z < 1. - DepthMargin)
-        {
-            m_debugInfo.m_cascadeIndex = indexOfCascade;
-            return SamplePcfBicubic(shadowCoord, indexOfCascade);
-        }
-    }
     m_debugInfo.m_cascadeIndex = cascadeCount;
     return 1.;
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/Shadow/ProjectedShadow.azsli
@@ -44,8 +44,6 @@ class ProjectedShadow
     float GetVisibilityEsmPcf();
     float GetThickness();
 
-    float SamplePcfBicubic();
-
     bool IsShadowed(float3 shadowPosition);
     bool IsShadowedWithJitter(
         float3 jitterUnitX,
@@ -87,8 +85,7 @@ float ProjectedShadow::GetVisibility(
     shadow.SetShadowPosition();
 
     float visibility = 1.;
-    // Filter method is stored in top 16 bits.
-    uint filterMethod = ViewSrg::m_projectedShadows[shadow.m_shadowIndex].m_shadowFilterMethod & 0x0000FFFF;
+    const uint filterMethod = ViewSrg::m_projectedShadows[shadow.m_shadowIndex].m_shadowFilterMethod;
     switch (filterMethod)
     {
         case ViewSrg::ShadowFilterMethodNone:
@@ -145,72 +142,29 @@ float ProjectedShadow::GetVisibilityNoFilter()
 
 float ProjectedShadow::GetVisibilityPcf()
 {
-    // PCF filter method is stored in bottom 16 bits.
-    const uint pcfFilterMethod = ViewSrg::m_projectedShadows[m_shadowIndex].m_shadowFilterMethod >> 16;
-    if (pcfFilterMethod == PcfFilterMethod_Bicubic)
+    const uint filteringSampleCount = ViewSrg::m_projectedShadows[m_shadowIndex].m_filteringSampleCount;
+    const float3 atlasPosition = GetAtlasPosition(m_shadowPosition.xy);   
+
+    SampleShadowMapBicubicParameters param;
+    param.shadowMap = PassSrg::m_projectedShadowmaps;
+    param.shadowPos = float3(atlasPosition.xy * ViewSrg::m_invShadowmapAtlasSize, atlasPosition.z);
+    param.shadowMapSize = ViewSrg::m_shadowmapAtlasSize;
+    param.invShadowMapSize = ViewSrg::m_invShadowmapAtlasSize;
+    param.comparisonValue = m_shadowPosition.z - m_bias;
+    param.samplerState = SceneSrg::m_hwPcfSampler;
+
+    if (filteringSampleCount <= 4)       
     {
-        return SamplePcfBicubic();
+        return SampleShadowMapBicubic_4Tap(param);
     }
-
-    const uint predictionCount = ViewSrg::m_projectedShadows[m_shadowIndex].m_predictionSampleCount;
-
-    if (predictionCount <= 1)
+    else if (filteringSampleCount <= 9)
     {
-        return GetVisibilityNoFilter();
+        return SampleShadowMapBicubic_9Tap(param);
     }
-
-    const float4 jitterUnitVectorDepthDiffBase =
-        Shadow::GetJitterUnitVectorDepthDiffBase(m_normalVector, m_lightDirection);
-    const float3 jitterUnitY = jitterUnitVectorDepthDiffBase.xyz;
-    const float3 jitterUnitX = cross(jitterUnitY, m_lightDirection);
-    const float jitterDepthDiffBase = jitterUnitVectorDepthDiffBase.w;
-
-    uint shadowedCount = 0;
-    uint jitterIndex = 0;
-
-    // Predicting
-    for (; jitterIndex < predictionCount; ++jitterIndex)
+    else
     {
-        if (IsShadowedWithJitter(
-            jitterUnitX,
-            jitterUnitY,
-            jitterDepthDiffBase,
-            jitterIndex))
-        {
-            ++shadowedCount;
-        }
+        return SampleShadowMapBicubic_16Tap(param);
     }
-    if (shadowedCount == 0)
-    {
-        return 1.;
-    }
-    else if (shadowedCount == predictionCount)
-    {
-        return 0.;
-    }
-
-    // Filtering
-
-    // When the prediction detects the point on the boundary of shadow,
-    // i.e., both of a lit point and a a shadowed one exists in the jittering area,
-    // we calculate the more precious lit ratio in the area.
-    const uint filteringCount = max(
-        predictionCount,
-        ViewSrg::m_projectedShadows[m_shadowIndex].m_filteringSampleCount);
-
-    for (; jitterIndex < filteringCount; ++jitterIndex)
-    {
-        if (IsShadowedWithJitter(
-            jitterUnitX,
-            jitterUnitY,
-            jitterDepthDiffBase,
-            jitterIndex))
-        {
-            ++shadowedCount;
-        }
-    }
-
-    return (filteringCount - shadowedCount) * 1. / filteringCount;
 }
 
 float ProjectedShadow::GetVisibilityEsm()
@@ -335,33 +289,6 @@ float ProjectedShadow::GetThickness()
     }
 
     return 0.;
-}
-
-float ProjectedShadow::SamplePcfBicubic()
-{
-    const uint filteringSampleCount = ViewSrg::m_projectedShadows[m_shadowIndex].m_filteringSampleCount;
-    const float3 atlasPosition = GetAtlasPosition(m_shadowPosition.xy);   
-
-    SampleShadowMapBicubicParameters param;
-    param.shadowMap = PassSrg::m_projectedShadowmaps;
-    param.shadowPos = float3(atlasPosition.xy * ViewSrg::m_invShadowmapAtlasSize, atlasPosition.z);
-    param.shadowMapSize = ViewSrg::m_shadowmapAtlasSize;
-    param.invShadowMapSize = ViewSrg::m_invShadowmapAtlasSize;
-    param.comparisonValue = m_shadowPosition.z - m_bias;
-    param.samplerState = SceneSrg::m_hwPcfSampler;
-
-    if (filteringSampleCount <= 4)       
-    {
-        return SampleShadowMapBicubic_4Tap(param);
-    }
-    else if (filteringSampleCount <= 9)
-    {
-        return SampleShadowMapBicubic_9Tap(param);
-    }
-    else
-    {
-        return SampleShadowMapBicubic_16Tap(param);
-    }
 }
 
 bool ProjectedShadow::IsShadowed(float3 shadowPosition)

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -82,7 +82,7 @@ partial ShaderResourceGroup ViewSrg
     {
         float4x4 m_depthBiasMatrix;
         uint m_shadowmapArraySlice; // array slice who has shadowmap in the atlas.
-        uint m_shadowFilterMethod; // Includes overall filter method in top 16 bits and pcf method in bottom 16 bits.
+        uint m_shadowFilterMethod; 
         float m_boundaryScale;
         uint m_predictionSampleCount;
         uint m_filteringSampleCount;
@@ -117,8 +117,7 @@ partial ShaderResourceGroup ViewSrg
         uint m_debugFlags;
         uint m_shadowFilterMethod;
         float m_far_minus_near;
-        uint m_pcfFilterMethod; // Matches with PcfFilterMethod in ShadowConstants.h
-        uint m_padding[3];
+        uint m_padding[4];
     };
 
     enum ShadowFilterMethod

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/CoreLights/ViewSrg.azsli
@@ -117,7 +117,6 @@ partial ShaderResourceGroup ViewSrg
         uint m_debugFlags;
         uint m_shadowFilterMethod;
         float m_far_minus_near;
-        uint m_padding[4];
     };
 
     enum ShadowFilterMethod

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h
@@ -149,12 +149,6 @@ namespace AZ
             //! @param method filter method.
             virtual void SetShadowFilterMethod(LightHandle handle, ShadowFilterMethod method) = 0;
 
-            //! This sets sample count to predict boundary of shadow.
-            //! @param handle the light handle.
-            //! @param count Sample Count for prediction of whether the pixel is on the boundary (up to 16)
-            //! The value should be less than or equal to m_filteringSampleCount.
-            virtual void SetPredictionSampleCount(LightHandle handle, uint16_t count) = 0;
-
             //! This sets sample count for filtering of shadow boundary.
             //! @param handle the light handle.
             //! @param count Sample Count for filtering (up to 64)
@@ -165,9 +159,6 @@ namespace AZ
             //! @param width Boundary width. The shadow is gradually changed the degree of shadowed.
             //! If width == 0, softening edge is disabled. Units are in meters.
             virtual void SetShadowBoundaryWidth(LightHandle handle, float boundaryWidth) = 0;
-
-            //! Sets the shadowmap Pcf method.
-            virtual void SetPcfMethod(LightHandle handle, PcfMethod method) = 0;
 
             //! Sets whether the directional shadowmap should use receiver plane bias.
             //! This attempts to reduce shadow acne when using large pcf filters.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h
@@ -92,12 +92,8 @@ namespace AZ
             virtual void SetShadowFilterMethod(LightHandle handle, ShadowFilterMethod method) = 0;
             //! Specifies the width of boundary between shadowed area and lit area in radians. The degree ofshadowed gradually changes on the boundary. 0 disables softening.
             virtual void SetSofteningBoundaryWidthAngle(LightHandle handle, float boundaryWidthRadians) = 0;
-            //! Sets sample count to predict boundary of shadow (up to 16). It will be clamped to be less than or equal to the filtering sample count.
-            virtual void SetPredictionSampleCount(LightHandle handle, uint16_t count) = 0;
             //! Sets sample count for filtering of shadow boundary (up to 64)
             virtual void SetFilteringSampleCount(LightHandle handle, uint16_t count) = 0;
-            //! Sets the shadowmap Pcf (percentage closer filtering) method.
-            virtual void SetPcfMethod(LightHandle handle, PcfMethod method) = 0;
             //! Sets the Esm exponent to use. Higher values produce a steeper falloff in the border areas between light and shadow.
             virtual void SetEsmExponent(LightHandle handle, float exponent) = 0;
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PointLightFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/PointLightFeatureProcessorInterface.h
@@ -73,13 +73,8 @@ namespace AZ
             //! Specifies the width of boundary between shadowed area and lit area in radians. The degree ofshadowed gradually changes on
             //! the boundary. 0 disables softening.
             virtual void SetSofteningBoundaryWidthAngle(LightHandle handle, float boundaryWidthRadians) = 0;
-            //! Sets sample count to predict boundary of shadow (up to 16). It will be clamped to be less than or equal to the filtering
-            //! sample count.
-            virtual void SetPredictionSampleCount(LightHandle handle, uint16_t count) = 0;
             //! Sets sample count for filtering of shadow boundary (up to 64)
             virtual void SetFilteringSampleCount(LightHandle handle, uint16_t count) = 0;
-            //! Sets the shadowmap Pcf (percentage closer filtering) method.
-            virtual void SetPcfMethod(LightHandle handle, PcfMethod method) = 0;
             //! Sets the Esm exponent to use. Higher values produce a steeper falloff in the border areas between light and shadow.
             virtual void SetEsmExponent(LightHandle handle, float exponent) = 0;
             //! Sets all of the the point data for the provided LightHandle.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/CoreLights/ShadowConstants.h
@@ -37,14 +37,6 @@ namespace AZ
             Count
         };
 
-        enum class PcfMethod : uint16_t
-        {
-            BoundarySearch = 0, // Performs a variable number of taps, first to determine if we are on a shadow boundary, then the remaining taps are to find the occlusion amount
-            Bicubic,            // Uses a fixed size Pcf kernel with kernel weights set to approximate bicubic filtering
-
-            Count
-        };
-
         namespace Shadow
         {
             // [GFX TODO][ATOM-2408] Make the max number of cascade modifiable at runtime.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Shadows/ProjectedShadowFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Shadows/ProjectedShadowFeatureProcessorInterface.h
@@ -52,14 +52,10 @@ namespace AZ::Render
         virtual void SetShadowmapMaxResolution(ShadowId id, ShadowmapSize size) = 0;
         //! Sets the shadow bias
         virtual void SetShadowBias(ShadowId id, float bias) = 0;
-        //! Sets the shadowmap Pcf method.
-        virtual void SetPcfMethod(ShadowId id, PcfMethod method) = 0;
         //! Sets the shadow filter method
         virtual void SetShadowFilterMethod(ShadowId id, ShadowFilterMethod method) = 0;
         //! Sets the width of boundary between shadowed area and lit area.
         virtual void SetSofteningBoundaryWidthAngle(ShadowId id, float boundaryWidthRadians) = 0;
-        //! Sets the sample count to predict the boundary of the shadow. Max 16, should be less than filtering sample count.
-        virtual void SetPredictionSampleCount(ShadowId id, uint16_t count) = 0;
         //! Sets the sample count for filtering of the shadow boundary, max 64.
         virtual void SetFilteringSampleCount(ShadowId id, uint16_t count) = 0;
         //! Sets all of the shadow properites in one call

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -571,20 +571,6 @@ namespace AZ
             }
         }
 
-        void DirectionalLightFeatureProcessor::SetPredictionSampleCount(LightHandle handle, uint16_t count)
-        {
-            if (count > Shadow::MaxPcfSamplingCount)
-            {
-                AZ_Warning(FeatureProcessorName, false, "Sampling count exceed the limit.");
-                count = Shadow::MaxPcfSamplingCount;
-            }
-            for (auto& it : m_shadowData)
-            {
-                it.second.GetData(handle.GetIndex()).m_predictionSampleCount = count;
-            }
-            m_shadowBufferNeedsUpdate = true;
-        }
-
         void DirectionalLightFeatureProcessor::SetFilteringSampleCount(LightHandle handle, uint16_t count)
         {
             if (count > Shadow::MaxPcfSamplingCount)
@@ -604,15 +590,6 @@ namespace AZ
             for (auto& it : m_shadowData)
             {
                 it.second.GetData(handle.GetIndex()).m_boundaryScale = boundaryWidth / 2.f;
-            }
-            m_shadowBufferNeedsUpdate = true;
-        }
-
-        void DirectionalLightFeatureProcessor::SetPcfMethod(LightHandle handle, PcfMethod method)
-        {
-            for (auto& it : m_shadowData)
-            {
-                it.second.GetData(handle.GetIndex()).m_pcfMethod = method;
             }
             m_shadowBufferNeedsUpdate = true;
         }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -102,7 +102,6 @@ namespace AZ
             uint32_t m_debugFlags = 0;
             uint32_t m_shadowFilterMethod = 0; 
             float m_far_minus_near = 0;
-            uint32_t m_padding[4];
         };
 
         class DirectionalLightFeatureProcessor final

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -102,8 +102,7 @@ namespace AZ
             uint32_t m_debugFlags = 0;
             uint32_t m_shadowFilterMethod = 0; 
             float m_far_minus_near = 0;
-            PcfMethod m_pcfMethod = PcfMethod::BoundarySearch;
-            uint32_t m_padding[3];
+            uint32_t m_padding[4];
         };
 
         class DirectionalLightFeatureProcessor final
@@ -218,10 +217,8 @@ namespace AZ
             void SetViewFrustumCorrectionEnabled(LightHandle handle, bool enabled) override;
             void SetDebugFlags(LightHandle handle, DebugDrawFlags flags) override;
             void SetShadowFilterMethod(LightHandle handle, ShadowFilterMethod method) override;
-            void SetPredictionSampleCount(LightHandle handle, uint16_t count) override;
             void SetFilteringSampleCount(LightHandle handle, uint16_t count) override;
             void SetShadowBoundaryWidth(LightHandle handle, float boundaryWidth) override;
-            void SetPcfMethod(LightHandle handle, PcfMethod method) override;
             void SetShadowReceiverPlaneBiasEnabled(LightHandle handle, bool enable) override;
 
             const Data::Instance<RPI::Buffer> GetLightBuffer() const;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
@@ -329,19 +329,9 @@ namespace AZ
             SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetSofteningBoundaryWidthAngle, boundaryWidthRadians);
         }
         
-        void DiskLightFeatureProcessor::SetPredictionSampleCount(LightHandle handle, uint16_t count)
-        {
-            SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetPredictionSampleCount, count);
-        }
-        
         void DiskLightFeatureProcessor::SetFilteringSampleCount(LightHandle handle, uint16_t count)
         {
             SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetFilteringSampleCount, count);
-        }
-
-        void DiskLightFeatureProcessor::SetPcfMethod(LightHandle handle, PcfMethod method)
-        {
-            SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetPcfMethod, method);
         }
 
         void DiskLightFeatureProcessor::SetEsmExponent(LightHandle handle, float exponent)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.h
@@ -54,9 +54,7 @@ namespace AZ
             void SetShadowmapMaxResolution(LightHandle handle, ShadowmapSize shadowmapSize) override;
             void SetShadowFilterMethod(LightHandle handle, ShadowFilterMethod method) override;
             void SetSofteningBoundaryWidthAngle(LightHandle handle, float boundaryWidthRadians) override;
-            void SetPredictionSampleCount(LightHandle handle, uint16_t count) override;
             void SetFilteringSampleCount(LightHandle handle, uint16_t count) override;
-            void SetPcfMethod(LightHandle handle, PcfMethod method) override;
             void SetEsmExponent(LightHandle handle, float esmExponent) override;
 
             void SetDiskData(LightHandle handle, const DiskLightData& data) override;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.cpp
@@ -298,19 +298,9 @@ namespace AZ
             SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetSofteningBoundaryWidthAngle, boundaryWidthRadians);
         }
 
-        void PointLightFeatureProcessor::SetPredictionSampleCount(LightHandle handle, uint16_t count)
-        {
-            SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetPredictionSampleCount, count);
-        }
-
         void PointLightFeatureProcessor::SetFilteringSampleCount(LightHandle handle, uint16_t count)
         {
             SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetFilteringSampleCount, count);
-        }
-
-        void PointLightFeatureProcessor::SetPcfMethod(LightHandle handle, PcfMethod method)
-        {
-            SetShadowSetting(handle, &ProjectedShadowFeatureProcessor::SetPcfMethod, method);
         }
 
         void PointLightFeatureProcessor::SetEsmExponent(LightHandle handle, float esmExponent)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.h
@@ -51,9 +51,7 @@ namespace AZ
             void SetShadowmapMaxResolution(LightHandle handle, ShadowmapSize shadowmapSize) override;
             void SetShadowFilterMethod(LightHandle handle, ShadowFilterMethod method) override;
             void SetSofteningBoundaryWidthAngle(LightHandle handle, float boundaryWidthRadians) override;
-            void SetPredictionSampleCount(LightHandle handle, uint16_t count) override;
             void SetFilteringSampleCount(LightHandle handle, uint16_t count) override;
-            void SetPcfMethod(LightHandle handle, PcfMethod method) override;
             void SetEsmExponent(LightHandle handle, float esmExponent) override;
             void SetPointData(LightHandle handle, const PointLightData& data) override;
 

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -165,15 +165,6 @@ namespace AZ::Render
         m_filterParameterNeedsUpdate = true;
     }
     
-    void ProjectedShadowFeatureProcessor::SetPcfMethod(ShadowId id, PcfMethod method)
-    {
-        AZ_Assert(id.IsValid(), "Invalid ShadowId passed to ProjectedShadowFeatureProcessor::SetPcfMethod().");
-        ShadowData& shadowData = m_shadowData.GetElement<ShadowDataIndex>(id.GetIndex());
-        shadowData.m_pcfMethod = method;
-
-        m_deviceBufferNeedsUpdate = true;
-    }
-
     void ProjectedShadowFeatureProcessor::SetEsmExponent(ShadowId id, float exponent)
     {
         AZ_Assert(id.IsValid(), "Invalid ShadowId passed to ProjectedShadowFeatureProcessor::SetEsmExponent().");
@@ -188,7 +179,7 @@ namespace AZ::Render
         
         ShadowProperty& shadowProperty = GetShadowPropertyFromShadowId(id);
         ShadowData& shadowData = m_shadowData.GetElement<ShadowDataIndex>(id.GetIndex());
-        shadowData.m_shadowFilterMethod = aznumeric_cast<uint16_t>(method);
+        shadowData.m_shadowFilterMethod = aznumeric_cast<uint32_t>(method);
 
         UpdateShadowView(shadowProperty);
         
@@ -205,19 +196,6 @@ namespace AZ::Render
         
         m_shadowmapPassNeedsUpdate = true;
         m_filterParameterNeedsUpdate = true;
-    }
-    
-    void ProjectedShadowFeatureProcessor::SetPredictionSampleCount(ShadowId id, uint16_t count)
-    {
-        AZ_Assert(id.IsValid(), "Invalid ShadowId passed to ProjectedShadowFeatureProcessor::SetPredictionSampleCount().");
-
-        AZ_Warning("ProjectedShadowFeatureProcessor", count <= Shadow::MaxPcfSamplingCount, "Sampling count exceed the limit.");
-        count = GetMin(count, Shadow::MaxPcfSamplingCount);
-        
-        ShadowData& shadowData = m_shadowData.GetElement<ShadowDataIndex>(id.GetIndex());
-        shadowData.m_predictionSampleCount = count;
-
-        m_deviceBufferNeedsUpdate = true;
     }
     
     void ProjectedShadowFeatureProcessor::SetFilteringSampleCount(ShadowId id, uint16_t count)

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.h
@@ -48,11 +48,9 @@ namespace AZ::Render
         void SetFieldOfViewY(ShadowId id, float fieldOfViewYRadians) override;
         void SetShadowmapMaxResolution(ShadowId id, ShadowmapSize size) override;
         void SetShadowBias(ShadowId id, float bias) override;
-        void SetPcfMethod(ShadowId id, PcfMethod method);
         void SetEsmExponent(ShadowId id, float exponent);
         void SetShadowFilterMethod(ShadowId id, ShadowFilterMethod method) override;
         void SetSofteningBoundaryWidthAngle(ShadowId id, float boundaryWidthRadians) override;
-        void SetPredictionSampleCount(ShadowId id, uint16_t count) override;
         void SetFilteringSampleCount(ShadowId id, uint16_t count) override;
         void SetShadowProperties(ShadowId id, const ProjectedShadowDescriptor& descriptor) override;
         const ProjectedShadowDescriptor& GetShadowProperties(ShadowId id) override;
@@ -64,8 +62,7 @@ namespace AZ::Render
         {
             Matrix4x4 m_depthBiasMatrix = Matrix4x4::CreateIdentity();
             uint32_t m_shadowmapArraySlice = 0; // array slice who has shadowmap in the atlas.
-            uint16_t m_shadowFilterMethod = 0; // filtering method of shadows.
-            PcfMethod m_pcfMethod = PcfMethod::BoundarySearch;  // method for performing Pcf (uint16_t)
+            uint32_t m_shadowFilterMethod = 0; // filtering method of shadows.
             float m_boundaryScale = 0.f; // the half of boundary of lit/shadowed areas. (in degrees)
             uint32_t m_predictionSampleCount = 0; // sample count to judge whether it is on the shadow boundary or not.
             uint32_t m_filteringSampleCount = 0;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightBus.h
@@ -127,25 +127,12 @@ namespace AZ
             //! 0 disables softening.
             virtual void SetSofteningBoundaryWidthAngle(float degrees) = 0;
 
-            //! Gets the sample count to predict boundary of shadow.
-            virtual uint32_t GetPredictionSampleCount() const = 0;
-            
-            //! Sets the sample count to predict boundary of shadow. Maximum 16, and should also be 
-            //! less than the filtering sample count.
-            virtual void SetPredictionSampleCount(uint32_t count) = 0;
-
             //! Gets the sample count for filtering of the shadow boundary.
             virtual uint32_t GetFilteringSampleCount() const = 0;
 
             //! Sets the sample count for filtering of the shadow boundary. Maximum 64.
             virtual void SetFilteringSampleCount(uint32_t count) = 0;
             
-            //! Gets the type of Pcf (percentage-closer filtering) to use.
-            virtual PcfMethod GetPcfMethod() const = 0;
-
-            //! Sets the type of Pcf (percentage-closer filtering) to use.
-            virtual void SetPcfMethod(PcfMethod method) = 0;
-
             //! Gets the Esm exponent. Higher values produce a steeper falloff between light and shadow.
             virtual float GetEsmExponent() const = 0;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/AreaLightComponentConfig.h
@@ -59,9 +59,7 @@ namespace AZ
             float m_bias = 0.1f;
             ShadowmapSize m_shadowmapMaxSize = ShadowmapSize::Size256;
             ShadowFilterMethod m_shadowFilterMethod = ShadowFilterMethod::None;
-            PcfMethod m_pcfMethod = PcfMethod::Bicubic;
             float m_boundaryWidthInDegrees = 0.25f;
-            uint16_t m_predictionSampleCount = 4;
             uint16_t m_filteringSampleCount = 12;
             float m_esmExponent = 87.0f;
 
@@ -119,14 +117,8 @@ namespace AZ
             //! Returns true if pcf shadows are disabled.
             bool IsShadowPcfDisabled() const;
             
-            //! Returns true if pcf boundary search is disabled.
-            bool IsPcfBoundarySearchDisabled() const;
-
             //! Returns true if exponential shadow maps are disabled.
             bool IsEsmDisabled() const;
-
-            //! Returns true if the softening boundary width parameter is disabled. 
-            bool IsSofteningBoundaryWidthDisabled() const;
         };
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightBus.h
@@ -162,15 +162,6 @@ namespace AZ
             //! If width == 0, softening edge is disabled. Units are in meters.
             virtual void SetSofteningBoundaryWidth(float width) = 0;
 
-            //! This gets sample count to predict boundary of shadow.
-            //! @return Sample Count for prediction of whether the pixel is on the boundary (up to 16)
-            virtual uint32_t GetPredictionSampleCount() const = 0;
-
-            //! This sets sample count to predict boundary of shadow.
-            //! @param count Sample Count for prediction of whether the pixel is on the boundary (up to 16)
-            //! The value should be less than or equal to m_filteringSampleCount.
-            virtual void SetPredictionSampleCount(uint32_t count) = 0;
-
             //! This gets the sample count for filtering of the shadow boundary.
             //! @return Sample Count for filtering (up to 64)
             virtual uint32_t GetFilteringSampleCount() const = 0;
@@ -178,13 +169,6 @@ namespace AZ
             //! This sets the sample count for filtering of the shadow boundary.
             //! @param count Sample Count for filtering (up to 64)
             virtual void SetFilteringSampleCount(uint32_t count) = 0;
-
-            //! This gets the type of Pcf (percentage-closer filtering) to use.
-            virtual PcfMethod GetPcfMethod() const = 0;
-
-            //! This sets the type of Pcf (percentage-closer filtering) to use.
-            //! @param method The Pcf method to use.
-            virtual void SetPcfMethod(PcfMethod method) = 0;
 
             //! Gets whether the directional shadowmap should use receiver plane bias.
             //! This attempts to reduce shadow acne when using large pcf filters.

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Include/AtomLyIntegration/CommonFeatures/CoreLights/DirectionalLightComponentConfig.h
@@ -105,15 +105,9 @@ namespace AZ
             //! If this is 0, edge softening is disabled.  Units are in meters.
             float m_boundaryWidth = 0.03f; // 3cm
 
-            //! Sample Count for prediction of whether the pixel is on the boundary (from 4 to 16)
-            //! The value should be less than or equal to m_filteringSampleCount.
-            uint16_t m_predictionSampleCount = 4;
-
             //! Sample Count for filtering (from 4 to 64)
             //! It is used only when the pixel is predicted as on the boundary.
             uint16_t m_filteringSampleCount = 32;
-
-            PcfMethod m_pcfMethod = PcfMethod::Bicubic;
 
             //! Whether not to enable the receiver plane bias.
             //! This uses partial derivatives to reduce shadow acne when using large pcf kernels.
@@ -124,8 +118,6 @@ namespace AZ
             bool IsCascadeCorrectionDisabled() const;
             bool IsShadowFilteringDisabled() const;
             bool IsShadowPcfDisabled() const;
-            bool IsPcfBoundarySearchDisabled() const;
-            bool IsSofteningBoundaryWidthDisabled() const;
             bool IsEsmDisabled() const;
         };
     } // namespace Render

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentConfig.cpp
@@ -37,9 +37,7 @@ namespace AZ
                     ->Field("Shadowmap Max Size", &AreaLightComponentConfig::m_shadowmapMaxSize)
                     ->Field("Shadow Filter Method", &AreaLightComponentConfig::m_shadowFilterMethod)
                     ->Field("Softening Boundary Width", &AreaLightComponentConfig::m_boundaryWidthInDegrees)
-                    ->Field("Prediction Sample Count", &AreaLightComponentConfig::m_predictionSampleCount)
                     ->Field("Filtering Sample Count", &AreaLightComponentConfig::m_filteringSampleCount)
-                    ->Field("Pcf Method", &AreaLightComponentConfig::m_pcfMethod)
                     ->Field("Esm Exponent", &AreaLightComponentConfig::m_esmExponent)
                     ;
             }
@@ -182,31 +180,9 @@ namespace AZ
                 m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
 
-        bool AreaLightComponentConfig::IsPcfBoundarySearchDisabled() const
-        {
-            if (IsShadowPcfDisabled())
-            {
-                return true;
-            }
-
-            return m_pcfMethod != PcfMethod::BoundarySearch;
-        }
-
         bool AreaLightComponentConfig::IsEsmDisabled() const
         {
             return !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
-
-        bool AreaLightComponentConfig::IsSofteningBoundaryWidthDisabled() const
-        {
-            // softening boundary width is always available with ESM. It controls the width of the blur kernel during the ESM gaussian
-            // blur passes
-            if (!IsEsmDisabled())
-                return false;
-
-            // with PCF, softening boundary width is used with the boundary search method and NOT the bicubic pcf methods
-            return IsPcfBoundarySearchDisabled();
-        }
-
     }
 }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
@@ -76,12 +76,8 @@ namespace AZ::Render
                 ->Event("SetShadowFilterMethod", &AreaLightRequestBus::Events::SetShadowFilterMethod)
                 ->Event("GetSofteningBoundaryWidthAngle", &AreaLightRequestBus::Events::GetSofteningBoundaryWidthAngle)
                 ->Event("SetSofteningBoundaryWidthAngle", &AreaLightRequestBus::Events::SetSofteningBoundaryWidthAngle)
-                ->Event("GetPredictionSampleCount", &AreaLightRequestBus::Events::GetPredictionSampleCount)
-                ->Event("SetPredictionSampleCount", &AreaLightRequestBus::Events::SetPredictionSampleCount)
                 ->Event("GetFilteringSampleCount", &AreaLightRequestBus::Events::GetFilteringSampleCount)
                 ->Event("SetFilteringSampleCount", &AreaLightRequestBus::Events::SetFilteringSampleCount)
-                ->Event("GetPcfMethod", &AreaLightRequestBus::Events::GetPcfMethod)
-                ->Event("SetPcfMethod", &AreaLightRequestBus::Events::SetPcfMethod)
                 ->Event("GetEsmExponent", &AreaLightRequestBus::Events::GetEsmExponent)
                 ->Event("SetEsmExponent", &AreaLightRequestBus::Events::SetEsmExponent)
 
@@ -100,9 +96,7 @@ namespace AZ::Render
                 ->VirtualProperty("ShadowmapMaxSize", "GetShadowmapMaxSize", "SetShadowmapMaxSize")
                 ->VirtualProperty("ShadowFilterMethod", "GetShadowFilterMethod", "SetShadowFilterMethod")
                 ->VirtualProperty("SofteningBoundaryWidthAngle", "GetSofteningBoundaryWidthAngle", "SetSofteningBoundaryWidthAngle")
-                ->VirtualProperty("PredictionSampleCount", "GetPredictionSampleCount", "SetPredictionSampleCount")
                 ->VirtualProperty("FilteringSampleCount", "GetFilteringSampleCount", "SetFilteringSampleCount")
-                ->VirtualProperty("PcfMethod", "GetPcfMethod", "SetPcfMethod")
                 ->VirtualProperty("EsmExponent", "GetEsmExponent", "SetEsmExponent");
             ;
         }
@@ -314,9 +308,7 @@ namespace AZ::Render
                 m_lightShapeDelegate->SetShadowmapMaxSize(m_configuration.m_shadowmapMaxSize);
                 m_lightShapeDelegate->SetShadowFilterMethod(m_configuration.m_shadowFilterMethod);
                 m_lightShapeDelegate->SetSofteningBoundaryWidthAngle(m_configuration.m_boundaryWidthInDegrees);
-                m_lightShapeDelegate->SetPredictionSampleCount(m_configuration.m_predictionSampleCount);
                 m_lightShapeDelegate->SetFilteringSampleCount(m_configuration.m_filteringSampleCount);
-                m_lightShapeDelegate->SetPcfMethod(m_configuration.m_pcfMethod);
                 m_lightShapeDelegate->SetEsmExponent(m_configuration.m_esmExponent);
             }
         }
@@ -528,20 +520,6 @@ namespace AZ::Render
         }
     }
 
-    uint32_t AreaLightComponentController::GetPredictionSampleCount() const
-    {
-        return m_configuration.m_predictionSampleCount;
-    }
-
-    void AreaLightComponentController::SetPredictionSampleCount(uint32_t count)
-    {
-        m_configuration.m_predictionSampleCount = static_cast<uint16_t>(count);
-        if (m_lightShapeDelegate)
-        {
-            m_lightShapeDelegate->SetPredictionSampleCount(count);
-        }
-    }
-
     uint32_t AreaLightComponentController::GetFilteringSampleCount() const
     {
         return m_configuration.m_filteringSampleCount;
@@ -566,20 +544,6 @@ namespace AZ::Render
         if (m_lightShapeDelegate)
         {
             m_lightShapeDelegate->DrawDebugDisplay(transform, m_configuration.m_color, debugDisplay, isSelected);
-        }
-    }
-    
-    PcfMethod AreaLightComponentController::GetPcfMethod() const
-    {
-        return m_configuration.m_pcfMethod;
-    }
-
-    void AreaLightComponentController::SetPcfMethod(PcfMethod method)
-    {
-        m_configuration.m_pcfMethod = method;
-        if (m_lightShapeDelegate)
-        {
-            m_lightShapeDelegate->SetPcfMethod(method);
         }
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.h
@@ -84,12 +84,8 @@ namespace AZ
             void SetShadowFilterMethod(ShadowFilterMethod method) override;
             float GetSofteningBoundaryWidthAngle() const override;
             void SetSofteningBoundaryWidthAngle(float width) override;
-            uint32_t GetPredictionSampleCount() const override;
-            void SetPredictionSampleCount(uint32_t count) override;
             uint32_t GetFilteringSampleCount() const override;
             void SetFilteringSampleCount(uint32_t count) override;
-            PcfMethod GetPcfMethod() const override;
-            void SetPcfMethod(PcfMethod method) override;
             float GetEsmExponent() const override;
             void SetEsmExponent(float exponent) override;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentConfig.cpp
@@ -38,9 +38,7 @@ namespace AZ
                     ->Field("IsDebugColoringEnabled", &DirectionalLightComponentConfig::m_isDebugColoringEnabled)
                     ->Field("ShadowFilterMethod", &DirectionalLightComponentConfig::m_shadowFilterMethod)
                     ->Field("SofteningBoundaryWidth", &DirectionalLightComponentConfig::m_boundaryWidth)
-                    ->Field("PcfPredictionSampleCount", &DirectionalLightComponentConfig::m_predictionSampleCount)
                     ->Field("PcfFilteringSampleCount", &DirectionalLightComponentConfig::m_filteringSampleCount)
-                    ->Field("Pcf Method", &DirectionalLightComponentConfig::m_pcfMethod)
                     ->Field("ShadowReceiverPlaneBiasEnabled", &DirectionalLightComponentConfig::m_receiverPlaneBiasEnabled);
             }
         }
@@ -118,31 +116,9 @@ namespace AZ
                 m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
 
-        bool DirectionalLightComponentConfig::IsPcfBoundarySearchDisabled() const
-        {
-            if (IsShadowPcfDisabled())
-            {
-                return true;
-            }
-
-            return m_pcfMethod != PcfMethod::BoundarySearch;
-        }
-
         bool DirectionalLightComponentConfig::IsEsmDisabled() const
         {
             return !(m_shadowFilterMethod == ShadowFilterMethod::Esm || m_shadowFilterMethod == ShadowFilterMethod::EsmPcf);
         }
-
-        bool DirectionalLightComponentConfig::IsSofteningBoundaryWidthDisabled() const
-        {
-            // softening boundary width is always available with ESM. It controls the width of the blur kernel during the ESM gaussian
-            // blur passes
-            if (!IsEsmDisabled())
-                return false;
-
-            // with PCF, softening boundary width is used with the boundary search method and NOT the bicubic pcf methods
-            return IsPcfBoundarySearchDisabled();
-        }
-
     } // namespace Render
 } // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.cpp
@@ -82,12 +82,8 @@ namespace AZ
                     ->Event("SetShadowFilterMethod", &DirectionalLightRequestBus::Events::SetShadowFilterMethod)
                     ->Event("GetSofteningBoundaryWidth", &DirectionalLightRequestBus::Events::GetSofteningBoundaryWidth)
                     ->Event("SetSofteningBoundaryWidth", &DirectionalLightRequestBus::Events::SetSofteningBoundaryWidth)
-                    ->Event("GetPredictionSampleCount", &DirectionalLightRequestBus::Events::GetPredictionSampleCount)
-                    ->Event("SetPredictionSampleCount", &DirectionalLightRequestBus::Events::SetPredictionSampleCount)
                     ->Event("GetFilteringSampleCount", &DirectionalLightRequestBus::Events::GetFilteringSampleCount)
                     ->Event("SetFilteringSampleCount", &DirectionalLightRequestBus::Events::SetFilteringSampleCount)
-                    ->Event("GetPcfMethod", &DirectionalLightRequestBus::Events::GetPcfMethod)
-                    ->Event("SetPcfMethod", &DirectionalLightRequestBus::Events::SetPcfMethod)
                     ->Event("GetShadowReceiverPlaneBiasEnabled", &DirectionalLightRequestBus::Events::GetShadowReceiverPlaneBiasEnabled)
                     ->Event("SetShadowReceiverPlaneBiasEnabled", &DirectionalLightRequestBus::Events::SetShadowReceiverPlaneBiasEnabled)
                     ->VirtualProperty("Color", "GetColor", "SetColor")
@@ -104,9 +100,7 @@ namespace AZ
                     ->VirtualProperty("DebugColoringEnabled", "GetDebugColoringEnabled", "SetDebugColoringEnabled")
                     ->VirtualProperty("ShadowFilterMethod", "GetShadowFilterMethod", "SetShadowFilterMethod")
                     ->VirtualProperty("SofteningBoundaryWidth", "GetSofteningBoundaryWidth", "SetSofteningBoundaryWidth")
-                    ->VirtualProperty("PredictionSampleCount", "GetPredictionSampleCount", "SetPredictionSampleCount")
                     ->VirtualProperty("FilteringSampleCount", "GetFilteringSampleCount", "SetFilteringSampleCount")
-                    ->VirtualProperty("PcfMethod", "GetPcfMethod", "SetPcfMethod")
                     ->VirtualProperty("ShadowReceiverPlaneBiasEnabled", "GetShadowReceiverPlaneBiasEnabled", "SetShadowReceiverPlaneBiasEnabled");
                 ;
             }
@@ -425,21 +419,6 @@ namespace AZ
             }
         }
 
-        uint32_t DirectionalLightComponentController::GetPredictionSampleCount() const
-        {
-            return aznumeric_cast<uint32_t>(m_configuration.m_predictionSampleCount);
-        }
-
-        void DirectionalLightComponentController::SetPredictionSampleCount(uint32_t count)
-        {
-            const uint16_t count16 = GetMin(Shadow::MaxPcfSamplingCount, aznumeric_cast<uint16_t>(count));
-            m_configuration.m_predictionSampleCount = count16;
-            if (m_featureProcessor)
-            {
-                m_featureProcessor->SetPredictionSampleCount(m_lightHandle, count16);
-            }
-        }
-
         uint32_t DirectionalLightComponentController::GetFilteringSampleCount() const
         {
             return aznumeric_cast<uint32_t>(m_configuration.m_filteringSampleCount);
@@ -539,9 +518,7 @@ namespace AZ
             SetDebugColoringEnabled(m_configuration.m_isDebugColoringEnabled);
             SetShadowFilterMethod(m_configuration.m_shadowFilterMethod);
             SetSofteningBoundaryWidth(m_configuration.m_boundaryWidth);
-            SetPredictionSampleCount(m_configuration.m_predictionSampleCount);
             SetFilteringSampleCount(m_configuration.m_filteringSampleCount);
-            SetPcfMethod(m_configuration.m_pcfMethod);
             SetShadowReceiverPlaneBiasEnabled(m_configuration.m_receiverPlaneBiasEnabled);
 
             // [GFX TODO][ATOM-1726] share config for multiple light (e.g., light ID).
@@ -629,17 +606,6 @@ namespace AZ
             {
                 m_featureProcessor->SetRgbIntensity(m_lightHandle, m_photometricValue.GetCombinedRgb<PhotometricUnit::Lux>());
             }
-        }
-
-        PcfMethod DirectionalLightComponentController::GetPcfMethod() const
-        {
-            return m_configuration.m_pcfMethod;
-        }
-
-        void DirectionalLightComponentController::SetPcfMethod(PcfMethod method)
-        {
-            m_configuration.m_pcfMethod = method;
-            m_featureProcessor->SetPcfMethod(m_lightHandle, method);
         }
 
         bool DirectionalLightComponentController::GetShadowReceiverPlaneBiasEnabled() const

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DirectionalLightComponentController.h
@@ -78,12 +78,8 @@ namespace AZ
             void SetShadowFilterMethod(ShadowFilterMethod method) override;
             float GetSofteningBoundaryWidth() const override;
             void SetSofteningBoundaryWidth(float width) override;
-            uint32_t GetPredictionSampleCount() const override;
-            void SetPredictionSampleCount(uint32_t count) override;
             uint32_t GetFilteringSampleCount() const override;
             void SetFilteringSampleCount(uint32_t count) override;
-            PcfMethod GetPcfMethod() const override;
-            void SetPcfMethod(PcfMethod method) override;
             bool GetShadowReceiverPlaneBiasEnabled() const override;
             void SetShadowReceiverPlaneBiasEnabled(bool enable) override;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DiskLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DiskLightDelegate.cpp
@@ -155,27 +155,11 @@ namespace AZ::Render
         }
     }
 
-    void DiskLightDelegate::SetPredictionSampleCount(uint32_t count)
-    {
-        if (GetShadowsEnabled() && GetLightHandle().IsValid())
-        {
-            GetFeatureProcessor()->SetPredictionSampleCount(GetLightHandle(), static_cast<uint16_t>(count));
-        }
-    }
-
     void DiskLightDelegate::SetFilteringSampleCount(uint32_t count)
     {
         if (GetShadowsEnabled() && GetLightHandle().IsValid())
         {
             GetFeatureProcessor()->SetFilteringSampleCount(GetLightHandle(), static_cast<uint16_t>(count));
-        }
-    }
-
-    void DiskLightDelegate::SetPcfMethod(PcfMethod method)
-    {
-        if (GetShadowsEnabled() && GetLightHandle().IsValid())
-        {
-            GetFeatureProcessor()->SetPcfMethod(GetLightHandle(), method);
         }
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DiskLightDelegate.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/DiskLightDelegate.h
@@ -45,9 +45,7 @@ namespace AZ
             void SetShadowmapMaxSize(ShadowmapSize size) override;
             void SetShadowFilterMethod(ShadowFilterMethod method) override;
             void SetSofteningBoundaryWidthAngle(float widthInDegrees) override;
-            void SetPredictionSampleCount(uint32_t count) override;
             void SetFilteringSampleCount(uint32_t count) override;
-            void SetPcfMethod(PcfMethod method) override;
             void SetEsmExponent(float exponent) override;
 
         private:

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -162,27 +162,11 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Max, 1.f)
                             ->Attribute(Edit::Attributes::Suffix, " deg")
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsShadows)
-                            ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsSofteningBoundaryWidthDisabled)
-                        ->DataElement(Edit::UIHandlers::Slider, &AreaLightComponentConfig::m_predictionSampleCount, "Prediction sample count",
-                            "Sample count for prediction of whether the pixel is on the boundary. Specific to PCF and ESM+PCF.")
-                            ->Attribute(Edit::Attributes::Min, 4)
-                            ->Attribute(Edit::Attributes::Max, 16)
-                            ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsShadows)
-                            ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsPcfBoundarySearchDisabled)
+                            ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsEsmDisabled)
                         ->DataElement(Edit::UIHandlers::Slider, &AreaLightComponentConfig::m_filteringSampleCount, "Filtering sample count",
                             "This is only used when the pixel is predicted to be on the boundary. Specific to PCF and ESM+PCF.")
                             ->Attribute(Edit::Attributes::Min, 4)
                             ->Attribute(Edit::Attributes::Max, 64)
-                            ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsShadows)
-                            ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsShadowPcfDisabled)
-                        ->DataElement(
-                            Edit::UIHandlers::ComboBox, &AreaLightComponentConfig::m_pcfMethod, "PCF method",
-                            "Type of PCF to use.\n"
-                            "  Bicubic: a smooth, fixed-size kernel \n"
-                            "  Boundary search: do several taps to first determine if we are on a shadow boundary\n")
-                            ->EnumAttribute(PcfMethod::Bicubic, "Bicubic")
-                            ->EnumAttribute(PcfMethod::BoundarySearch, "Boundary search")
-                            ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::SupportsShadows)
                             ->Attribute(Edit::Attributes::ReadOnly, &AreaLightComponentConfig::IsShadowPcfDisabled)
                         ->DataElement(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -141,28 +141,12 @@ namespace AZ
                             ->Attribute(Edit::Attributes::Max, 0.1f)
                             ->Attribute(Edit::Attributes::Suffix, " m")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-                        ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsSofteningBoundaryWidthDisabled)
-                        ->DataElement(Edit::UIHandlers::Slider, &DirectionalLightComponentConfig::m_predictionSampleCount, "Prediction sample count",
-                            "Sample count for prediction of whether the pixel is on the boundary. "
-                            "Specific to PCF and ESM+PCF.")
-                            ->Attribute(Edit::Attributes::Min, 4)
-                            ->Attribute(Edit::Attributes::Max, 16)
-                            ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-                        ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsPcfBoundarySearchDisabled)
+                        ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsEsmDisabled)
                         ->DataElement(Edit::UIHandlers::Slider, &DirectionalLightComponentConfig::m_filteringSampleCount, "Filtering sample count",
                             "This is used only when the pixel is predicted as on the boundary. "
                             "Specific to PCF and ESM+PCF.")
                             ->Attribute(Edit::Attributes::Min, 4)
                             ->Attribute(Edit::Attributes::Max, 64)
-                            ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-                            ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsShadowPcfDisabled)
-                        ->DataElement(
-                            Edit::UIHandlers::ComboBox, &DirectionalLightComponentConfig::m_pcfMethod, "Pcf method",
-                            "Type of PCF to use.\n"
-                            "  Bicubic: a smooth, fixed-size kernel \n"
-                            "  Boundary search: do several taps to first determine if we are on a shadow boundary\n")
-                            ->EnumAttribute(PcfMethod::Bicubic, "Bicubic")
-                            ->EnumAttribute(PcfMethod::BoundarySearch, "Boundary search")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(Edit::Attributes::ReadOnly, &DirectionalLightComponentConfig::IsShadowPcfDisabled)
                         ->DataElement(

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateBase.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateBase.h
@@ -57,9 +57,7 @@ namespace AZ
             void SetShadowmapMaxSize([[maybe_unused]] ShadowmapSize size) override {};
             void SetShadowFilterMethod([[maybe_unused]] ShadowFilterMethod method) override {};
             void SetSofteningBoundaryWidthAngle([[maybe_unused]] float widthInDegrees) override {};
-            void SetPredictionSampleCount([[maybe_unused]] uint32_t count) override {};
             void SetFilteringSampleCount([[maybe_unused]] uint32_t count) override {};
-            void SetPcfMethod([[maybe_unused]] PcfMethod method) override {};
             void SetEsmExponent([[maybe_unused]] float esmExponent) override{};
 
         protected:

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateInterface.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/LightDelegateInterface.h
@@ -77,12 +77,8 @@ namespace AZ
             virtual void SetShadowFilterMethod(ShadowFilterMethod method) = 0;
             //! Sets the width of boundary between shadowed area and lit area in degrees.
             virtual void SetSofteningBoundaryWidthAngle(float widthInDegrees) = 0;
-            //! Sets the sample count to predict the boundary of the shadow. Max 16, should be less than filtering sample count.
-            virtual void SetPredictionSampleCount(uint32_t count) = 0;
             //! Sets the sample count for filtering of the shadow boundary, max 64.
             virtual void SetFilteringSampleCount(uint32_t count) = 0;
-            //! Sets the Pcf (Percentage closer filtering) method to use.
-            virtual void SetPcfMethod(PcfMethod method) = 0;
             //! Sets the Esm exponent to use. Higher values produce a steeper falloff between light and shadow.
             virtual void SetEsmExponent(float exponent) = 0;
         };

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.cpp
@@ -100,27 +100,11 @@ namespace AZ::Render
         }
     }
 
-    void SphereLightDelegate::SetPredictionSampleCount(uint32_t count)
-    {
-        if (GetShadowsEnabled() && GetLightHandle().IsValid())
-        {
-            GetFeatureProcessor()->SetPredictionSampleCount(GetLightHandle(), static_cast<uint16_t>(count));
-        }
-    }
-
     void SphereLightDelegate::SetFilteringSampleCount(uint32_t count)
     {
         if (GetShadowsEnabled() && GetLightHandle().IsValid())
         {
             GetFeatureProcessor()->SetFilteringSampleCount(GetLightHandle(), static_cast<uint16_t>(count));
-        }
-    }
-
-    void SphereLightDelegate::SetPcfMethod(PcfMethod method)
-    {
-        if (GetShadowsEnabled() && GetLightHandle().IsValid())
-        {
-            GetFeatureProcessor()->SetPcfMethod(GetLightHandle(), method);
         }
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/SphereLightDelegate.h
@@ -35,9 +35,7 @@ namespace AZ
             void SetShadowmapMaxSize(ShadowmapSize size) override;
             void SetShadowFilterMethod(ShadowFilterMethod method) override;
             void SetSofteningBoundaryWidthAngle(float widthInDegrees) override;
-            void SetPredictionSampleCount(uint32_t count) override;
             void SetFilteringSampleCount(uint32_t count) override;
-            void SetPcfMethod(PcfMethod method) override;
             void SetEsmExponent(float esmExponent) override;
 
         private:


### PR DESCRIPTION
(PR only contains deletions)

Bicubic is now the default and only PCF filtering method. Boundary search never looked that great, and had a ton of artifacts. It was generally much slower than bicubic.

Apocalypse was ok with removing this method.

Tested ASV on AMD and Nvidia cards.

ATOM-13741
Signed-off-by: mrieggeramzn <mriegger@amazon.com>