### PR TITLE
EMotion FX: Resetting the anim graph while in the middle of selecting transitions for interruption crashes the Editor

### DIFF
--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphTransitionHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/AnimGraphTransitionHandler.cpp
@@ -24,7 +24,6 @@
 #include <QMessageBox>
 #include <QMouseEvent>
 
-
 namespace EMotionFX
 {
     AZ_CLASS_ALLOCATOR_IMPL(AnimGraphTransitionIdPicker, AZ::SystemAllocator, 0)
@@ -126,8 +125,13 @@ namespace EMotionFX
         }
     }
 
-    void AnimGraphTransitionIdPicker::OnAboutToBeRemoved(const QModelIndex &parent, int first, int last)
+    void AnimGraphTransitionIdPicker::OnAboutToBeRemoved(const QModelIndex& parent, int first, int last)
     {
+        if (!parent.isValid())
+        {
+            return;
+        }
+
         EMStudio::EMStudioPlugin* plugin = EMStudio::GetPluginManager()->FindActivePlugin(EMStudio::AnimGraphPlugin::CLASS_ID);
         EMStudio::AnimGraphPlugin* animGraphPlugin = static_cast<EMStudio::AnimGraphPlugin*>(plugin);
         if (animGraphPlugin)


### PR DESCRIPTION
Resolves #4015

Signed-off-by: Benjamin Jillich <jillich@amazon.com>