### PR TITLE
Adding missing pragma header guards to _xcb.h header files

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Application/Application_Linux_xcb.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Application/Application_Linux_xcb.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#pragma once
 
 #include <AzFramework/API/ApplicationAPI_Platform.h>
 #include <AzFramework/Application/Application.h>

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Windowing/NativeWindow_Linux_xcb.h
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Windowing/NativeWindow_Linux_xcb.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#pragma once
 
 #include <AzFramework/API/ApplicationAPI_Platform.h>
 #include <AzFramework/Application/Application.h>


### PR DESCRIPTION
Signed-off-by: Steve Pham <spham@amazon.com>