### PR TITLE
Limits configuration types a project sees when using an engine SDK

### DIFF
--- a/cmake/ConfigurationTypes.cmake
+++ b/cmake/ConfigurationTypes.cmake
@@ -1,0 +1,14 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+include_guard(GLOBAL)
+
+# By default, CMAKE_CONFIGURATION_TYPES = LY_CONFIGURATION_TYPES, but in installed SDKs, this
+# file will be replaced with cmake/install/ConfigurationTypes.cmake and discover configurations
+# that are available from the SDK
+set(CMAKE_CONFIGURATION_TYPES ${LY_CONFIGURATION_TYPES} CACHE STRING "" FORCE)

--- a/cmake/Platform/Common/Install_common.cmake
+++ b/cmake/Platform/Common/Install_common.cmake
@@ -350,8 +350,26 @@ function(ly_setup_cmake_install)
         DESTINATION .
         COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
         PATTERN "__pycache__" EXCLUDE
-        REGEX "Findo3de.cmake" EXCLUDE
-        REGEX "Platform\/.*\/BuiltInPackages_.*\.cmake" EXCLUDE
+        PATTERN "Findo3de.cmake" EXCLUDE
+        PATTERN "ConfigurationTypes.cmake" EXCLUDE
+        REGEX "3rdParty/Platform\/.*\/BuiltInPackages_.*\.cmake" EXCLUDE
+    )
+    # Connect configuration types
+    install(FILES "${LY_ROOT_FOLDER}/cmake/install/ConfigurationTypes.cmake"
+        DESTINATION cmake
+        COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
+    )
+    # Inject code that will generate each ConfigurationType_<CONFIG>.cmake file
+    set(install_configuration_type_template [=[
+        configure_file(@LY_ROOT_FOLDER@/cmake/install/ConfigurationType_config.cmake.in
+            ${CMAKE_INSTALL_PREFIX}/cmake/ConfigurationTypes_${CMAKE_INSTALL_CONFIG_NAME}.cmake
+            @ONLY
+        )
+        message(STATUS "Generated ${CMAKE_INSTALL_PREFIX}/cmake/ConfigurationTypes_${CMAKE_INSTALL_CONFIG_NAME}.cmake")
+    ]=])
+    string(CONFIGURE "${install_configuration_type_template}" install_configuration_type @ONLY)
+    install(CODE "${install_configuration_type}"
+        COMPONENT ${CMAKE_INSTALL_DEFAULT_COMPONENT_NAME}
     )
 
     # Transform the LY_EXTERNAL_SUBDIRS list into a json array

--- a/cmake/install/ConfigurationType_config.cmake.in
+++ b/cmake/install/ConfigurationType_config.cmake.in
@@ -1,0 +1,11 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+include_guard(GLOBAL)
+
+list(APPEND CMAKE_CONFIGURATION_TYPES @CMAKE_INSTALL_CONFIG_NAME@)

--- a/cmake/install/ConfigurationTypes.cmake
+++ b/cmake/install/ConfigurationTypes.cmake
@@ -1,0 +1,22 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+include_guard(GLOBAL)
+
+
+# In SDK builds CMAKE_CONFIGURATION_TYPES will be filled by entries generated per configuration build.
+# At install time we generate `cmake/ConfigurationTypes_<config>.cmake` files that append the configuration
+# to CMAKE_CONFIGURATION_TYPES
+set(CMAKE_CONFIGURATION_TYPES "" CACHE STRING "" FORCE)
+
+# For the SDK case, we want to only define the confiuguration types that have been added to the SDK
+file(GLOB configuration_type_files "cmake/ConfigurationTypes_*.cmake")
+foreach(configuration_type_file ${configuration_type_files})
+    include(${configuration_type_file})
+endforeach()
+ly_set(CMAKE_CONFIGURATION_TYPES ${CMAKE_CONFIGURATION_TYPES}) # propagate to parent


### PR DESCRIPTION
In a project-centric / engine SDK was used, we were using the same configuration types that we defined for the engine. However, that doesnt mean that the SDK contains all those configuration types.
This change tweaks the SDK CMake's file to only expose the configuration types that the SDK was generated for.

To achieve it, we generate a file that appends the configuration during the install step of that configuration. The install step is per configuration.

Closes #2526