### PR TITLE
remove false error from deserializing BC nodes

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.cpp
@@ -610,7 +610,7 @@ namespace ScriptCanvas
             void EBusEventHandler::OnDeserialize()
             {
                 AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
-                if (!m_ebus)
+                if (!m_ebus && !m_ebusName.empty())
                 {
                     CreateHandler(m_ebusName);
                 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Method.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Method.cpp
@@ -769,27 +769,30 @@ namespace ScriptCanvas
             {
                 AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
 
-                m_warnOnMissingFunction = true;
-                const AZ::BehaviorClass* bcClass{};
-                const AZ::BehaviorMethod* method{};
-                EventType eventType;
+                if (!m_lookupName.empty() || !m_className.empty())
+                {
+                    m_warnOnMissingFunction = true;
+                    const AZ::BehaviorClass* bcClass{};
+                    const AZ::BehaviorMethod* method{};
+                    EventType eventType;
 
-                if (GetBehaviorContextClassMethod(m_lookupName, bcClass, method, eventType))
-                {
-                    m_eventType = eventType;
-                    ConfigureMethod(*method, bcClass);
-                }
-                else
-                {
-                    if (!m_method)
+                    if (GetBehaviorContextClassMethod(m_lookupName, bcClass, method, eventType))
                     {
-                        AZ_Warning("ScriptCanvas", !m_warnOnMissingFunction, "method node failed to deserialize properly");
+                        m_eventType = eventType;
+                        ConfigureMethod(*method, bcClass);
                     }
-                }
+                    else
+                    {
+                        if (!m_method)
+                        {
+                            AZ_Warning("ScriptCanvas", !m_warnOnMissingFunction, "method node failed to deserialize properly");
+                        }
+                    }
 
-                if (m_resultSlotIDs.empty())
-                {
-                    m_resultSlotIDs.emplace_back(SlotId{});
+                    if (m_resultSlotIDs.empty())
+                    {
+                        m_resultSlotIDs.emplace_back(SlotId{});
+                    }
                 }
 
                 Node::OnDeserialize();
@@ -798,6 +801,11 @@ namespace ScriptCanvas
 #if defined(OBJECT_STREAM_EDITOR_ASSET_LOADING_SUPPORT_ENABLED)////
             void Method::OnWriteEnd()
             {
+                if (m_lookupName.empty() && m_className.empty())
+                {
+                    return;
+                }
+
                 OnDeserialize();
             }
 #endif//defined(OBJECT_STREAM_EDITOR_ASSET_LOADING_SUPPORT_ENABLED)


### PR DESCRIPTION
Signed-off-by: chcurran <82187351+carlitosan@users.noreply.github.com>

When nodes were cloned by the object stream, OnWriteEnd() gets called, which was causing ebus nodes and method nodes to falsely warn that they couldn't find their methods in behavior context