### PR TITLE
Fixed crash in Atom Vulkan RHI when physical device limits timestampComputeAndGraphics is false

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -235,8 +235,6 @@ namespace AZ
 
             //Load device features now that we have loaded all extension info
             physicalDevice.LoadSupportedFeatures();
-
-            InitFeaturesAndLimits(physicalDevice);
             return RHI::ResultCode::Success;
         }
 
@@ -246,6 +244,8 @@ namespace AZ
             commandQueueContextDescriptor.m_frameCountMax = RHI::Limits::Device::FrameCountMax;
             RHI::ResultCode result = m_commandQueueContext.Init(*this, commandQueueContextDescriptor);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
+
+            InitFeaturesAndLimits(static_cast<const Vulkan::PhysicalDevice&>(GetPhysicalDevice()));
 
             // Initialize member variables.
             ReleaseQueue::Descriptor releaseQueueDescriptor;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -691,26 +691,14 @@ namespace AZ
             }
             else
             {
-                // Temporarily initialize a CommandQueueContext in order to query the timestampValidBits of each queue family 
-                CommandQueueContext commandQueueContext;
-                CommandQueueContext::Descriptor commandQueueContextDescriptor;
-                commandQueueContextDescriptor.m_frameCountMax = RHI::Limits::Device::FrameCountMax;
-
-                RHI::ResultCode result = commandQueueContext.Init(*this, commandQueueContextDescriptor);
-
-                AZ_Assert(result == RHI::ResultCode::Success, "Failed to create command queues %s", physicalDevice.GetName().GetCStr());
-
                 for (uint32_t i = 0; i < RHI::HardwareQueueClassCount; ++i)
                 {
-                    QueueId id = commandQueueContext.GetCommandQueue(static_cast<RHI::HardwareQueueClass>(i)).GetId();
+                    QueueId id = m_commandQueueContext.GetCommandQueue(static_cast<RHI::HardwareQueueClass>(i)).GetId();
                     if (m_queueFamilyProperties[id.m_familyIndex].timestampValidBits)
                     {
                         m_features.m_queryTypesMask[i] |= RHI::QueryTypeFlags::Timestamp;
                     }
                 }
-
-                // Delete afterwards
-                commandQueueContext.Shutdown();
             }
 
             m_features.m_occlusionQueryPrecise = m_enabledDeviceFeatures.occlusionQueryPrecise == VK_TRUE;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Device.cpp
@@ -691,14 +691,26 @@ namespace AZ
             }
             else
             {
+                // Temporarily initialize a CommandQueueContext in order to query the timestampValidBits of each queue family 
+                CommandQueueContext commandQueueContext;
+                CommandQueueContext::Descriptor commandQueueContextDescriptor;
+                commandQueueContextDescriptor.m_frameCountMax = RHI::Limits::Device::FrameCountMax;
+
+                RHI::ResultCode result = commandQueueContext.Init(*this, commandQueueContextDescriptor);
+
+                AZ_Assert(result == RHI::ResultCode::Success, "Failed to create command queues %s", physicalDevice.GetName().GetCStr());
+
                 for (uint32_t i = 0; i < RHI::HardwareQueueClassCount; ++i)
                 {
-                    QueueId id = m_commandQueueContext.GetCommandQueue(static_cast<RHI::HardwareQueueClass>(i)).GetId();
+                    QueueId id = commandQueueContext.GetCommandQueue(static_cast<RHI::HardwareQueueClass>(i)).GetId();
                     if (m_queueFamilyProperties[id.m_familyIndex].timestampValidBits)
                     {
                         m_features.m_queryTypesMask[i] |= RHI::QueryTypeFlags::Timestamp;
                     }
                 }
+
+                // Delete afterwards
+                commandQueueContext.Shutdown();
             }
 
             m_features.m_occlusionQueryPrecise = m_enabledDeviceFeatures.occlusionQueryPrecise == VK_TRUE;


### PR DESCRIPTION
Atom Sample Viewer would hit an assert when indexing an AZstd::vector on an Android build running on devices with PowerVR GPUs.

The issue was traced to the Vulkan RHI's Device::InitFeaturesAndLimits() method. On GPUs where the timestampComputeAndGraphics flag in the physical device limits is false, it iterates over the Queue families to check if any of them have timestampValidBits > 0 in order to add RHI::QueryTypeFlags::Timestamp support.

The assert hits because at that point the m_commandQueueContext is not initialized meaning the AZstd::vector that it is trying to index into is empty.

Moving the Device::InitFeaturesAndLimits() method inside Device::InitializeLimits() after the m_commandQueueContext is initialized fixes the issue and is confirmed working on multiple devices with PowerVR GPUs.