### PR TITLE
Avoid redefining `PRI` macros on Linux

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/PlatformIncl_UnixLike.h
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/PlatformIncl_UnixLike.h
@@ -9,16 +9,3 @@
 #pragma once
 
 #include <unistd.h>
-
-#define __STDC_FORMAT_MACROS
-#include <inttypes.h>
-
-// types like AZ::u64 require an usigned long long, but inttypes.h has it as unsigned long
-#undef PRIX64
-#undef PRIx64
-#undef PRId64
-#undef PRIu64
-#define PRIX64 "llX"
-#define PRIx64 "llx"
-#define PRId64 "lld"
-#define PRIu64 "llu"

--- a/Code/Legacy/CryCommon/platform.h
+++ b/Code/Legacy/CryCommon/platform.h
@@ -51,20 +51,9 @@
 #undef AZ_RESTRICTED_SECTION_IMPLEMENTED
 #elif defined(LINUX) || defined(APPLE)
     #define __STDC_FORMAT_MACROS
-    #include <inttypes.h>
-    #if defined(APPLE) || defined(LINUX64)
-    // int64 is not the same type as the operating system's int64_t
-        #undef PRIX64
-        #undef PRIx64
-        #undef PRId64
-        #undef PRIu64
-        #define PRIX64 "llX"
-        #define PRIx64 "llx"
-        #define PRId64 "lld"
-        #define PRIu64 "llu"
-    #endif
+    #include <cinttypes>
 #else
-    #include <inttypes.h>
+    #include <cinttypes>
 #endif
 
 #if !defined(PRISIZE_T)

--- a/Code/Legacy/CrySystem/XML/XMLBinaryNode.cpp
+++ b/Code/Legacy/CrySystem/XML/XMLBinaryNode.cpp
@@ -125,7 +125,7 @@ bool CBinaryXmlNode::getAttr(const char* key, int64& value) const
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        azsscanf(svalue, "%" PRId64, &value);
+        value = strtoll(svalue, nullptr, 10);
         return true;
     }
     return false;
@@ -137,14 +137,7 @@ bool CBinaryXmlNode::getAttr(const char* key, uint64& value, bool useHexFormat) 
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        if (useHexFormat)
-        {
-            azsscanf(svalue, "%" PRIX64, &value);
-        }
-        else
-        {
-            azsscanf(svalue, "%" PRIu64, &value);
-        }
+        value = strtoull(svalue, nullptr, useHexFormat ? 16 : 10);
         return true;
     }
     return false;

--- a/Code/Legacy/CrySystem/XML/xml.cpp
+++ b/Code/Legacy/CrySystem/XML/xml.cpp
@@ -400,7 +400,7 @@ bool CXmlNode::getAttr(const char* key, int64& value) const
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        azsscanf(svalue, "%" PRId64, &value);
+        value = strtoll(key, nullptr, 10);
         return true;
     }
     return false;
@@ -412,14 +412,7 @@ bool CXmlNode::getAttr(const char* key, uint64& value, bool useHexFormat) const
     const char* svalue = GetValue(key);
     if (svalue)
     {
-        if (useHexFormat)
-        {
-            azsscanf(svalue, "%" PRIX64, &value);
-        }
-        else
-        {
-            azsscanf(svalue, "%" PRIu64, &value);
-        }
+        value = strtoull(key, nullptr, useHexFormat ? 16 : 10);
         return true;
     }
     return false;

--- a/Code/Tools/AssetProcessor/native/AssetManager/SourceFileRelocator.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/SourceFileRelocator.cpp
@@ -699,7 +699,7 @@ Please note that only those seed files will get updated that are active for your
                 if (isMove)
                 {
                     report.append(AZStd::string::format(
-                        "SOURCEID: %" PRId64 ", CURRENT PATH: %s, NEW PATH: %s, CURRENT GUID: %s, NEW GUID: %s\n",
+                        "SOURCEID: %lld, CURRENT PATH: %s, NEW PATH: %s, CURRENT GUID: %s, NEW GUID: %s\n",
                         relocationInfo.m_sourceEntry.m_sourceID,
                         relocationInfo.m_oldRelativePath.c_str(),
                         relocationInfo.m_newRelativePath.c_str(),
@@ -709,7 +709,7 @@ Please note that only those seed files will get updated that are active for your
                 else
                 {
                     report.append(AZStd::string::format(
-                        "SOURCEID: %" PRId64 ", CURRENT PATH: %s, CURRENT GUID: %s\n",
+                        "SOURCEID: %lld, CURRENT PATH: %s, CURRENT GUID: %s\n",
                         relocationInfo.m_sourceEntry.m_sourceID,
                         relocationInfo.m_oldRelativePath.c_str(),
                         relocationInfo.m_sourceEntry.m_sourceGuid.ToString<AZStd::string>().c_str()));

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -1018,7 +1018,7 @@ namespace AssetUtilities
 
     AZStd::string ComputeJobLogFileName(const AzToolsFramework::AssetSystem::JobInfo& jobInfo)
     {
-        return AZStd::string::format("%s-%u-%" PRIu64 ".log", jobInfo.m_sourceFile.c_str(), jobInfo.GetHash(), jobInfo.m_jobRunKey);
+        return AZStd::string::format("%s-%u-%llu.log", jobInfo.m_sourceFile.c_str(), jobInfo.GetHash(), jobInfo.m_jobRunKey);
     }
 
     AZStd::string ComputeJobLogFileName(const AssetBuilderSDK::CreateJobsRequest& createJobsRequest)
@@ -1287,13 +1287,13 @@ namespace AssetUtilities
             // so we add the size of it too.
             // its also possible that it moved to a different file with the same modtime/hash AND size,
             // but with a different name.  So we add that too.
-            return AZStd::string::format("%" PRIX64 ":%" PRIu64 ":%s", fileIdentifier, fileStateInfo.m_fileSize, nameToUse.c_str());
+            return AZStd::string::format("%llX:%llu:%s", fileIdentifier, fileStateInfo.m_fileSize, nameToUse.c_str());
         }
     }
 
     AZStd::string ComputeJobLogFileName(const AssetProcessor::JobEntry& jobEntry)
     {
-        return AZStd::string::format("%s-%u-%" PRIu64 ".log", jobEntry.m_databaseSourceName.toUtf8().constData(), jobEntry.GetHash(), jobEntry.m_jobRunKey);
+        return AZStd::string::format("%s-%u-%llu.log", jobEntry.m_databaseSourceName.toUtf8().constData(), jobEntry.GetHash(), jobEntry.m_jobRunKey);
     }
 
     bool CreateTempRootFolder(QString startFolder, QDir& tempRoot)

--- a/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATL.cpp
@@ -2144,7 +2144,7 @@ namespace Audio
     {
         if (bytes < (1 << 10))
         {
-            azsnprintf(buffer, bufLength, "%" PRIu64 " B", bytes);
+            azsnprintf(buffer, bufLength, "%llu B", bytes);
         }
         else if (bytes < (1 << 20))
         {
@@ -2261,10 +2261,10 @@ namespace Audio
             auxGeom.Draw2dLabel(fPosX + xTablePositions[4], posY + lineHeight, textSize, color, false, "%s", buffer);
 
             auxGeom.Draw2dLabel(fPosX + xTablePositions[5], posY, textSize, color, false, "Total Allocs");
-            auxGeom.Draw2dLabel(fPosX + xTablePositions[5], posY + lineHeight, textSize, color, false, "%" PRIu64, totalAllocs);
+            auxGeom.Draw2dLabel(fPosX + xTablePositions[5], posY + lineHeight, textSize, color, false, "%llu", totalAllocs);
 
             auxGeom.Draw2dLabel(fPosX + xTablePositions[6], posY, textSize, color, false, "Total Frees");
-            auxGeom.Draw2dLabel(fPosX + xTablePositions[6], posY + lineHeight, textSize, color, false, "%" PRIu64, totalFrees);
+            auxGeom.Draw2dLabel(fPosX + xTablePositions[6], posY + lineHeight, textSize, color, false, "%llu", totalFrees);
         }
         else
         {

--- a/Gems/AudioSystem/Code/Source/Engine/ATLAudioObject.cpp
+++ b/Gems/AudioSystem/Code/Source/Engine/ATLAudioObject.cpp
@@ -762,7 +762,7 @@ namespace Audio
         AZStd::string eventsString;
         for (auto activeEvent : m_cActiveEvents)
         {
-            eventsString = AZStd::string::format("%s%" PRIu64 "%s", eventsString.c_str(), activeEvent, sSeparator);
+            eventsString = AZStd::string::format("%s%llu%s", eventsString.c_str(), activeEvent, sSeparator);
         }
 
         return eventsString;

--- a/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
+++ b/Gems/LmbrCentral/Code/Source/Builders/SliceBuilder/SliceBuilderWorker.cpp
@@ -211,7 +211,7 @@ namespace SliceBuilder
 
             jobDescriptor.SetPlatformIdentifier(info.m_identifier.c_str());
             jobDescriptor.m_additionalFingerprintInfo = AZStd::string(compilerVersion)
-                .append(AZStd::string::format("|%" PRIu64, static_cast<AZ::u64>(sourceSliceTypeFingerprint)));
+                .append(AZStd::string::format("|%zu", sourceSliceTypeFingerprint));
 
             for (const auto& sourceDependency : sourceFileDependencies)
             {

--- a/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
+++ b/Gems/Vegetation/Code/Source/AreaSystemComponent.cpp
@@ -211,7 +211,7 @@ namespace Vegetation
         {
             return AZ::Failure(
                 AZStd::string::format("The combination of View Area Grid Size and Sector Point Density will create %" PRId64 " instances.  Only a max of %" PRId64 " instances is allowed.",
-                static_cast<AZ::u64>(totalInstances), static_cast<AZ::u64>(s_maxVegetationInstances)));
+                totalInstances, s_maxVegetationInstances));
         }
 
         return AZ::Success();
@@ -235,7 +235,7 @@ namespace Vegetation
         {
             return AZ::Failure(
                 AZStd::string::format("The combination of View Area Grid Size and Sector Point Density will create %" PRId64 " instances.  Only a max of %" PRId64 " instances is allowed.",
-                static_cast<AZ::u64>(totalInstances), static_cast<AZ::u64>(s_maxVegetationInstances)));
+                totalInstances, s_maxVegetationInstances));
         }
 
         const float instancesPerMeter = static_cast<float>(sectorDensity) / static_cast<float>(m_sectorSizeInMeters);


### PR DESCRIPTION
The fixed width 64-bit integer types are defined differently per platform.
Some platforms define it as "long", others define it as "long long". For
consistency, `AZ::u64` or `AZ::s64` is always defined to "long long".
However, this causes problems for formatting those types, because on
platforms where `uint64_t` is a `long`, `PRIu64` gives the wrong format
string for `AZ::u64`. Previously this was fixed by redefining the `PRI`
macros so that they work for `AZ::u64`, but that breaks the ability to
format `uint64_t`.

We could add an AZ-specific version of the `PRI` macros for 64-bit integer
types, but we don't really need to, since they are `long long` on every
platform we support.

 * Use `%ll` for `AZ::u64`
 * Use `PRIu64` for `uint64_t`

Signed-off-by: Chris Burel <burelc@amazon.com>