### PR TITLE
Remove viewport freeze request bus

### DIFF
--- a/Code/Editor/CryEditPy.cpp
+++ b/Code/Editor/CryEditPy.cpp
@@ -77,10 +77,6 @@ namespace
             // This closes the current document (level)
             currentLevel->OnNewDocument();
 
-            // Then we freeze the viewport's input
-            AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Broadcast(
-                &AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Events::FreezeViewportInput, true);
-
             // Then we need to tell the game engine there is no level to render anymore
             if (GetIEditor()->GetGameEngine())
             {

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -669,16 +669,6 @@ void EditorViewportWidget::OnEditorNotifyEvent(EEditorNotifyEvent event)
     case eNotify_OnEndSceneSave:
         PopDisableRendering();
         break;
-
-    case eNotify_OnBeginLoad: // disables viewport input when starting to load an existing level
-    case eNotify_OnBeginCreate: // disables viewport input when starting to create a new level
-        m_freezeViewportInput = true;
-        break;
-
-    case eNotify_OnEndLoad: // enables viewport input when finished loading an existing level
-    case eNotify_OnEndCreate: // enables viewport input when finished creating a new level
-        m_freezeViewportInput = false;
-        break;
     }
 }
 
@@ -962,16 +952,6 @@ AzFramework::ScreenPoint EditorViewportWidget::ViewportWorldToScreen(const AZ::V
     return m_renderViewport->ViewportWorldToScreen(worldPosition);
 }
 
-bool EditorViewportWidget::IsViewportInputFrozen()
-{
-    return m_freezeViewportInput;
-}
-
-void EditorViewportWidget::FreezeViewportInput(bool freeze)
-{
-    m_freezeViewportInput = freeze;
-}
-
 QWidget* EditorViewportWidget::GetWidgetForViewportContextMenu()
 {
     return this;
@@ -1057,7 +1037,6 @@ void EditorViewportWidget::SetViewportId(int id)
 
 void EditorViewportWidget::ConnectViewportInteractionRequestBus()
 {
-    AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Handler::BusConnect(GetViewportId());
     AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler::BusConnect(GetViewportId());
     AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusConnect(GetViewportId());
     m_viewportUi.ConnectViewportUiBus(GetViewportId());
@@ -1072,7 +1051,6 @@ void EditorViewportWidget::DisconnectViewportInteractionRequestBus()
     m_viewportUi.DisconnectViewportUiBus();
     AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusDisconnect();
     AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler::BusDisconnect();
-    AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Handler::BusDisconnect();
 }
 
 namespace AZ::ViewportHelpers

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -89,7 +89,6 @@ class SANDBOX_API EditorViewportWidget final
     , private Camera::EditorCameraRequestBus::Handler
     , private Camera::CameraNotificationBus::Handler
     , private AzFramework::InputSystemCursorConstraintRequestBus::Handler
-    , private AzToolsFramework::ViewportInteraction::ViewportFreezeRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler
@@ -201,10 +200,6 @@ private:
 
     // AzFramework::InputSystemCursorConstraintRequestBus overrides ...
     void* GetSystemCursorConstraintWindow() const override;
-
-    // AzToolsFramework::ViewportFreezeRequestBus overrides ...
-    bool IsViewportInputFrozen() override;
-    void FreezeViewportInput(bool freeze) override;
 
     // AzToolsFramework::MainEditorViewportInteractionRequestBus overrides ...
     AZ::EntityId PickEntity(const AzFramework::ScreenPoint& point) override;
@@ -386,9 +381,6 @@ private:
     // Used for some legacy logic which lets the widget release a grabbed keyboard at the right times
     // Unclear if it's still necessary.
     QSet<int> m_keyDown;
-
-    // State for ViewportFreezeRequestBus, currently does nothing
-    bool m_freezeViewportInput = false;
 
     // This widget holds a reference to the manipulator manage because its responsible for drawing manipulators
     AZStd::shared_ptr<AzToolsFramework::ManipulatorManager> m_manipulatorManager;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -221,24 +221,6 @@ namespace AzToolsFramework
 
         using ViewportSettingsNotificationBus = AZ::EBus<ViewportSettingNotifications, ViewportEBusTraits>;
 
-        //! Requests to freeze the Viewport Input
-        //! Added to prevent a bug with the legacy CryEngine Viewport code that would
-        //! keep doing raycast tests even when no level is loaded, causing a crash.
-        class ViewportFreezeRequests
-        {
-        public:
-            //! Return if Viewport Input is frozen
-            virtual bool IsViewportInputFrozen() = 0;
-            //! Sets the Viewport Input freeze state
-            virtual void FreezeViewportInput(bool freeze) = 0;
-
-        protected:
-            ~ViewportFreezeRequests() = default;
-        };
-
-        //! Type to inherit to implement ViewportFreezeRequests.
-        using ViewportFreezeRequestBus = AZ::EBus<ViewportFreezeRequests, ViewportEBusTraits>;
-
         //! Viewport requests that are only guaranteed to be serviced by the Main Editor viewport.
         class MainEditorViewportInteractionRequests
         {


### PR DESCRIPTION
This bus was needed to fix an issue in the legacy viewport which is no longer used and can be removed