### PR TITLE
Account for WKPDID_D3DDebugObjectNameW not being defined.

### DIFF
--- a/Code/Framework/AzTest/AzTest/Platform/Common/Unimplemented/Platform_Unimplemented.cpp
+++ b/Code/Framework/AzTest/AzTest/Platform/Common/Unimplemented/Platform_Unimplemented.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include "Platform.h"
+#include <AzTest/Platform.h>
 #include <iostream>
 
 class ModuleHandle

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
@@ -96,8 +96,12 @@ namespace AZ
             {
                 AZStd::wstring wname;
                 AZStd::to_wstring(wname, name);
+            #if defined(WKPDID_D3DDebugObjectNameW)
                 m_memoryAllocation.m_memory->SetPrivateData(
                     WKPDID_D3DDebugObjectNameW, aznumeric_cast<unsigned int>(wname.size() * sizeof(wchar_t)), wname.data());
+            #else
+                m_memoryAllocation.m_memory->SetName(wname.data());
+            #endif
             }
         }
 
@@ -105,8 +109,12 @@ namespace AZ
         {
             if (m_memoryAllocation.m_memory)
             {
+            #if defined(WKPDID_D3DDebugObjectNameW)
                 m_memoryAllocation.m_memory->SetPrivateData(
                     WKPDID_D3DDebugObjectNameW, aznumeric_cast<unsigned int>(name.size() * sizeof(wchar_t)), name.data());
+            #else
+                m_memoryAllocation.m_memory->SetName(name.data());
+            #endif
             }
         }
 


### PR DESCRIPTION
Account for WKPDID_D3DDebugObjectNameW not being defined by reverting to the old behavior, and fix an (unrelated) invalid #include path. Related to https://github.com/o3de/o3de/pull/4052

Signed-off-by: bosnichd <bosnichd@amazon.com>