### PR TITLE
[ATOM][RHI][Vulkan] - Separate out LightCullingTilePrepare MSAA and n…

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/LightCullingParentNoMSAA.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LightCullingParentNoMSAA.pass
@@ -1,0 +1,160 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "LightCullingParentNoMSAATemplate",
+            "PassClass": "ParentPass",
+            "Slots": [
+                // Inputs...
+                {
+                    "Name": "SkinnedMeshes",
+                    "SlotType": "Input"
+                },
+                {
+                    "Name": "Depth",
+                    "SlotType": "Input"
+                },
+                // Outputs...
+                {
+                    "Name": "TileLightData",
+                    "SlotType": "Output"
+                },
+                {
+                    "Name": "LightListRemapped",
+                    "SlotType": "Output"
+                },
+                // SwapChain here is only used to reference the frame height and format
+                {
+                    "Name": "SwapChainOutput",
+                    "SlotType": "InputOutput"
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "TileLightData",
+                    "AttachmentRef": {
+                        "Pass": "LightCullingRemapPass",
+                        "Attachment": "TileLightData"
+                    }
+                },
+                {
+                    "LocalSlot": "LightListRemapped",
+                    "AttachmentRef": {
+                        "Pass": "LightCullingRemapPass",
+                        "Attachment": "LightListRemapped"
+                    }
+                }
+            ],
+            "PassRequests": [
+                // The light culling system can do highly accurate culling of transparent objects but it needs
+                // more depth information than the opaque geometry pass can provide
+                // Specifically the minimum and maximum depth of transparent objects
+                {
+                    "Name": "DepthTransparentMinPass",
+                    "TemplateName": "DepthPassTemplate",
+                    "PassData": {
+                        "$type": "RasterPassData",
+                        "DrawListTag": "depthTransparentMin",
+                        "PipelineViewTag": "MainCamera"
+                    },
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "SkinnedMeshes"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "DepthTransparentMaxPass",
+                    "TemplateName": "DepthMaxPassTemplate",
+                    "PassData": {
+                        "$type": "RasterPassData",
+                        "DrawListTag": "depthTransparentMax",
+                        "PipelineViewTag": "MainCamera"
+                    },
+                    "Connections": [
+                        {
+                            "LocalSlot": "SkinnedMeshes",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "SkinnedMeshes"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightCullingTilePreparePass",
+                    "TemplateName": "LightCullingTilePrepareTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Depth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthTransparentMin",
+                            "AttachmentRef": {
+                                "Pass": "DepthTransparentMinPass",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthTransparentMax",
+                            "AttachmentRef": {
+                                "Pass": "DepthTransparentMaxPass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightCullingPass",
+                    "TemplateName": "LightCullingTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingTilePreparePass",
+                                "Attachment": "TileLightData"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "LightCullingRemapPass",
+                    "TemplateName": "LightCullingRemapTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "TileLightData",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingTilePreparePass",
+                                "Attachment": "TileLightData"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightCount",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightCount"
+                            }
+                        },
+                        {
+                            "LocalSlot": "LightList",
+                            "AttachmentRef": {
+                                "Pass": "LightCullingPass",
+                                "Attachment": "LightList"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/LightCullingTilePrepare.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LightCullingTilePrepare.pass
@@ -1,0 +1,63 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "LightCullingTilePrepareTemplate",
+            "PassClass": "LightCullingTilePreparePass",
+            "Slots": [
+                {
+                    "Name": "TileLightData",
+                    "SlotType": "Output",
+                    "ShaderInputName": "m_tileLightData",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "Depth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_depthBuffer",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "AspectFlags": [
+                            "Depth"
+                        ]
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "TileLightData",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "Depth"
+                        },
+                        "Multipliers": {
+                            "WidthMultiplier": 0.0625,
+                            "HeightMultiplier": 0.0625
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Format": "R32G32B32A32_UINT"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "TileLightData",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "TileLightData"
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "ComputePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/LightCulling/LightCullingTilePrepare.shader"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/LowEndPipeline.pass
@@ -53,7 +53,7 @@
                 },
                 {
                     "Name": "LightCullingPass",
-                    "TemplateName": "LightCullingParentTemplate",
+                    "TemplateName": "LightCullingParentNoMSAATemplate",
                     "Connections": [
                         {
                             "LocalSlot": "SkinnedMeshes",
@@ -63,7 +63,7 @@
                             }
                         },
                         {
-                            "LocalSlot": "DepthMSAA",
+                            "LocalSlot": "Depth",
                             "AttachmentRef": {
                                 "Pass": "DepthPrePass",
                                 "Attachment": "DepthMSAA"

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -213,6 +213,10 @@
                 "Path": "Passes/LightCulling.pass"
             },
             {
+                "Name": "LightCullingTilePrepareTemplate",
+                "Path": "Passes/LightCullingTilePrepare.pass"
+            },
+            {
                 "Name": "LightCullingTilePrepareMSAATemplate",
                 "Path": "Passes/LightCullingTilePrepareMSAA.pass"
             },
@@ -467,6 +471,10 @@
             {
                 "Name": "LightCullingParentTemplate",
                 "Path": "Passes/LightCullingParent.pass"
+            },
+            {
+                "Name": "LightCullingParentNoMSAATemplate",
+                "Path": "Passes/LightCullingParentNoMSAA.pass"
             },
             {
                 "Name": "ShadowParentTemplate",

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingTilePrepare.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingTilePrepare.azsl
@@ -66,6 +66,8 @@ void StoreTransparentMinMaxIntoSharedMemory(float2 data)
 
 ShaderResourceGroup PassSrg : SRG_PerPass
 {
+    // We will use one or the other depending upon if MSAA is enabled or not
+    Texture2D<float4> m_depthBuffer;
     Texture2DMS<float4> m_depthBufferMSAA;
 
     // Depth buffer where we rendered the nearest pixels of transparent objects
@@ -285,7 +287,7 @@ void MainCS(
         float2 opaqueDepthSamples;
         if (o_msaaMode == MsaaMode::None)
         {
-            float depth = PassSrg::m_depthBufferMSAA.Load(dispatchThreadID.xy, 0).x;
+            float depth = PassSrg::m_depthBuffer.Load(uint3(dispatchThreadID.xy, 0)).x;
             opaqueDepthSamples = float2(depth, depth);
         }
         else if (o_msaaMode == MsaaMode::Msaa2x)

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -150,7 +150,9 @@ set(FILES
     Passes/LightCulling.pass
     Passes/LightCullingHeatmap.pass
     Passes/LightCullingParent.pass
+    Passes/LightCullingParentNoMSAA.pass
     Passes/LightCullingRemap.pass
+    Passes/LightCullingTilePrepare.pass
     Passes/LightCullingTilePrepareMSAA.pass
     Passes/LookModificationComposite.pass
     Passes/LookModificationTransform.pass

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -371,17 +371,25 @@ namespace AZ
             // set draw list mask
             m_cullable.m_cullData.m_drawListMask.reset();
 
-            // check for draw packets due certain render pipelines such as lowend render pipeline that might not this feature enabled 
-            if (m_stencilDrawPacket 
-                && m_blendWeightDrawPacket 
-                && m_renderOuterDrawPacket 
-                && m_renderInnerDrawPacket)
+            // check for draw packets due certain render pipelines such as lowend render pipeline that might not have this feature enabled 
+            if (m_stencilDrawPacket)
             {
-                m_cullable.m_cullData.m_drawListMask =
-                    m_stencilDrawPacket->GetDrawListMask() |
-                    m_blendWeightDrawPacket->GetDrawListMask() |
-                    m_renderOuterDrawPacket->GetDrawListMask() |
-                    m_renderInnerDrawPacket->GetDrawListMask();
+                m_cullable.m_cullData.m_drawListMask |= m_stencilDrawPacket->GetDrawListMask();
+            } 
+            
+            if (m_blendWeightDrawPacket)
+            {
+                m_cullable.m_cullData.m_drawListMask |= m_blendWeightDrawPacket->GetDrawListMask();
+            } 
+            
+            if (m_renderOuterDrawPacket)
+            {
+                m_cullable.m_cullData.m_drawListMask |= m_renderOuterDrawPacket->GetDrawListMask();
+            } 
+            
+            if (m_renderInnerDrawPacket)
+            {
+                m_cullable.m_cullData.m_drawListMask |= m_renderInnerDrawPacket->GetDrawListMask();
             }
 
             // setup the Lod entry, using one entry for all four draw packets

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbe.cpp
@@ -370,11 +370,19 @@ namespace AZ
         {
             // set draw list mask
             m_cullable.m_cullData.m_drawListMask.reset();
-            m_cullable.m_cullData.m_drawListMask =
-                m_stencilDrawPacket->GetDrawListMask() |
-                m_blendWeightDrawPacket->GetDrawListMask() |
-                m_renderOuterDrawPacket->GetDrawListMask() |
-                m_renderInnerDrawPacket->GetDrawListMask();
+
+            // check for draw packets due certain render pipelines such as lowend render pipeline that might not this feature enabled 
+            if (m_stencilDrawPacket 
+                && m_blendWeightDrawPacket 
+                && m_renderOuterDrawPacket 
+                && m_renderInnerDrawPacket)
+            {
+                m_cullable.m_cullData.m_drawListMask =
+                    m_stencilDrawPacket->GetDrawListMask() |
+                    m_blendWeightDrawPacket->GetDrawListMask() |
+                    m_renderOuterDrawPacket->GetDrawListMask() |
+                    m_renderInnerDrawPacket->GetDrawListMask();
+            }
 
             // setup the Lod entry, using one entry for all four draw packets
             m_cullable.m_lodData.m_lods.clear();


### PR DESCRIPTION
…on-MSAA pass due to the different texture sampling needed. This ensures that non-MSAA and MSAA option uses the texture Load(int3) and Load(int2, int) respectively. This is necessary on low end pipeline without MSAA. Also check for ReflectionPRobe features that might not be enabled in different render pipelines.

Signed-off-by: Peng <tonypeng@amazon.com>