### PR TITLE
Add support for NVMe volumes to mounting script

### DIFF
--- a/scripts/build/bootstrap/incremental_build_util.py
+++ b/scripts/build/bootstrap/incremental_build_util.py
@@ -320,10 +320,14 @@ def mount_volume_to_device(created):
         time.sleep(1)
 
     else:
-        subprocess.call(['file', '-s', '/dev/xvdf'])
+        device_name = '/dev/xvdf'
+        nvme_device_name = '/dev/nvme1n1'
+        if os.path.exists(nvme_device_name):
+            device_name = nvme_device_name
+        subprocess.call(['file', '-s', device_name])
         if created:
-            subprocess.call(['mkfs', '-t', 'ext4', '/dev/xvdf'])
-        subprocess.call(['mount', '/dev/xvdf', MOUNT_PATH])
+            subprocess.call(['mkfs', '-t', 'ext4', device_name])
+        subprocess.call(['mount', device_name, MOUNT_PATH])
 
 
 def attach_volume_to_ec2_instance(volume, volume_id, instance_id, timeout_duration=DEFAULT_TIMEOUT):


### PR DESCRIPTION
This PR updates the inc_build_util script to support build nodes that utilize NVMe-based storage. Required when we migrate all our linux nodes from C4 to to C5. Nodes that still use the current device setup will continue operating normally. 

Tested in our fork:
- Running linux build on c5.9xlarge prior to update: build failed
- Running linux build on c5.9xlarge after update: build succeeds
- Running linux build on c4.8xlarge after update: build succeeds