### PR TITLE
Linux fix launch project manager from editor

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2810,7 +2810,9 @@ void CCryEditApp::OpenProjectManager(const AZStd::string& screen)
 {
     // provide the current project path for in case we want to update the project
     AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
-#if !AZ_TRAIT_OS_PLATFORM_APPLE && !AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
+#if defined(AZ_PLATFORM_LINUX)
+    const char* argumentQuoteString = "";
+#elif !AZ_TRAIT_OS_PLATFORM_APPLE && !AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
     const char* argumentQuoteString = R"(")";
 #else
     const char* argumentQuoteString = R"(\")";

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2810,9 +2810,7 @@ void CCryEditApp::OpenProjectManager(const AZStd::string& screen)
 {
     // provide the current project path for in case we want to update the project
     AZ::IO::FixedMaxPathString projectPath = AZ::Utils::GetProjectPath();
-#if defined(AZ_PLATFORM_LINUX)
-    const char* argumentQuoteString = "";
-#elif !AZ_TRAIT_OS_PLATFORM_APPLE && !AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
+#if !AZ_TRAIT_OS_PLATFORM_APPLE && !AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
     const char* argumentQuoteString = R"(")";
 #else
     const char* argumentQuoteString = R"(\")";

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessWatcher_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessWatcher_Linux.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <errno.h>
 #include <signal.h>
-#include <stdio.h>
 #include <sys/ioctl.h>
 #include <sys/resource.h> // for iopolicy
 #include <sys/types.h>

--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessWatcher_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Process/ProcessWatcher_Linux.cpp
@@ -298,15 +298,6 @@ namespace AzFramework
         // Close these handles as they are only to be used by the child process
         processData.m_startupInfo.CloseAllHandles();
 
-        /*if (processLaunchInfo.m_environmentVariables)
-        {
-            for (int i = 0; i < numEnvironmentVars; i++)
-            {
-                delete [] environmentVariables[i];
-            }
-            delete [] environmentVariables;
-        }*/
-
         for (int i = 0; i < commandTokens.size(); i++)
         {
             delete [] commandAndArgs[i];


### PR DESCRIPTION
Fix issue where ProjectManager fails to launch because some of the environment variables that is needed to connect to the xcb display was not carried forward from the Editor process. 