### PR TITLE
[ATOM][RHI][Vulkan] - Account for null descriptor for sampler.

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSet.cpp
@@ -466,7 +466,7 @@ namespace AZ
 
         bool DescriptorSet::IsNullDescriptorInfo(const VkDescriptorImageInfo& descriptorInfo)
         {
-            return descriptorInfo.imageView == VK_NULL_HANDLE;
+            return (descriptorInfo.imageView == VK_NULL_HANDLE && descriptorInfo.sampler == VK_NULL_HANDLE);
         }
 
         bool DescriptorSet::IsNullDescriptorInfo(const VkBufferView& descriptorInfo)


### PR DESCRIPTION
Signed-off-by: Peng <tonypeng@amazon.com>