### PR TITLE
ATOM-16079 [RHI][Vulkan] - Linux Swapchain rendering issue on the first frame

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/SwapChain.h
@@ -81,15 +81,6 @@ namespace AZ
 
             AZ_RTTI(SwapChain, "{888B64A5-D956-406F-9C33-CF6A54FC41B0}", Object);
 
-#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
-            // On Linux platforms that uses XCB, a resize may occur in the swap chain but the command queue may still
-            // reference the original surface. This flag is a temporary fix to make sure the swap chain is ready to present
-            // We need to remove this work around with
-
-            // [GFX TODO][GHI - 2678]
-            AZStd::atomic_bool m_readyToPresent { false };
-#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
-
         protected:
             SwapChain();
 

--- a/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/SwapChain.cpp
@@ -164,12 +164,6 @@ namespace AZ
                 m_currentImageIndex = 0;
             }
 
-#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
-            // If we are presenting through the editor, the resize is triggered through the editor's window, which
-            // won't happen until after the surface is ready to present
-            m_readyToPresent.store(true);
-#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
-
             return resultCode;
         }
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueue.cpp
@@ -42,15 +42,6 @@ namespace AZ
 
         void CommandQueue::ExecuteWork(const RHI::ExecuteWorkRequest& rhiRequest)
         {
-#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
-            for (RHI::SwapChain* swapChain : rhiRequest.m_swapChainsToPresent)
-            {
-                if (!swapChain->m_readyToPresent)
-                {
-                    return;
-                }
-            }
-#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
             const ExecuteWorkRequest& request = static_cast<const ExecuteWorkRequest&>(rhiRequest);
             QueueCommand([=](void* queue) 
             {

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -128,17 +128,6 @@ namespace AZ
                 nativeDimensions->m_imageFormat = ConvertFormat(m_surfaceFormat.format);
             }
 
-#if defined(PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB)
-            // When launching in game mode, the surface will be ready at this point, meaning that after
-            // intialization, this swap chain is ready to present
-            AZ::ApplicationTypeQuery appType;
-            ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
-            if (appType.IsGame())
-            {
-                m_readyToPresent.store(true);
-            }
-#endif // PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
-
             SetName(GetName());
             return result;
         }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -159,8 +159,6 @@ namespace AtomToolsFramework
         AZ::RPI::ViewPtr m_defaultCamera;
         // Our viewport-local aux geom pipeline for supplemental rendering.
         AZ::RPI::AuxGeomDrawPtr m_auxGeom;
-        // Used to keep track of a pending resize event to avoid initialization before window activate.
-        bool m_windowResizedEvent = false;
         // Tracks whether the cursor is currently over our viewport, used for mouse input event book-keeping.
         bool m_mouseOver = false;
         // The last recorded mouse position, in local viewport screen coordinates.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -254,28 +254,11 @@ namespace AtomToolsFramework
 
     void RenderViewportWidget::resizeEvent([[maybe_unused]] QResizeEvent* event)
     {
-        // We need to wait until the window is activated, so the underlying surface
-        // has been created and has the correct size.
-        if (windowHandle()->isActive())
-        {
-            SendWindowResizeEvent();
-        }
-        else
-        {
-            m_windowResizedEvent = true;
-        }
+        SendWindowResizeEvent();
     }
 
     bool RenderViewportWidget::event(QEvent* event)
     {
-        // Check if we have a pending resize event.
-        // At this point the surface has been created and has
-        // the proper dimensions.
-        if (event->type() == QEvent::WindowActivate && m_windowResizedEvent)
-        {
-            SendWindowResizeEvent();
-        }
-
         return QWidget::event(event);
     }
 
@@ -372,7 +355,6 @@ namespace AtomToolsFramework
 
         AzFramework::WindowNotificationBus::Event(
             GetNativeWindowHandle(), &AzFramework::WindowNotifications::OnWindowResized, windowSize.width(), windowSize.height());
-        m_windowResizedEvent = false;
     }
 
     void RenderViewportWidget::NotifyUpdateRefreshRate()


### PR DESCRIPTION
Changes:
Removed the hack that blocks presenting swapchain until window resizing happens.
Applied reasonable fixes.

Cause:
The cause is that the resizing event is blocked intentionally by the viewport widget, which proves to be unnecessary because RHI handles that pretty well, and assumes resizing happens immediately (see comments in Vulkan::SwapChain::AcquireNewImage and Vulkan::SwapChain::PresentInternal).

When the resizing event is suspended, then the surface and swapchain mismatch, while presenting is still happening every frame in a different thread. Thus, in Vulkan, it always gives VK_ERROR_OUT_OF_DATE_KHR when presenting swapchain and acquiring the new image (vkQueuePresentKHR, vkAcquireNextImageKHR). And it can further cause deadlock even when resizing is done afterwards.

Note the issues actually happens on Windows Vulkan as well. Solution is to simply remove the blocker to the resizing event.

Tests:
Tested in Windows Vulkan, Windows DX12, Linux Vulkan, Mac Metal.