### PR TITLE
Fix LuaIDE crash at startup caused by missing System Allocator Initialization

### DIFF
--- a/Code/Tools/Standalone/Source/Editor/LuaEditor.cpp
+++ b/Code/Tools/Standalone/Source/Editor/LuaEditor.cpp
@@ -35,6 +35,10 @@ int main(int argc, char* argv[])
         {
             AZ::AllocatorInstance<AZ::OSAllocator>::Create();
         }
+        if (!AZ::AllocatorInstance<AZ::SystemAllocator>::IsReady())
+        {
+            AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
+        }
 
         AZStd::unique_ptr<AZ::IO::LocalFileIO> fileIO = AZStd::unique_ptr<AZ::IO::LocalFileIO>(aznew AZ::IO::LocalFileIO());
         AZ::IO::FileIOBase::SetInstance(fileIO.get());

--- a/Code/Tools/Standalone/Source/Editor/LuaEditor.cpp
+++ b/Code/Tools/Standalone/Source/Editor/LuaEditor.cpp
@@ -74,6 +74,10 @@ int main(int argc, char* argv[])
         // if its in GUI mode or not.
     }
 
+    if (AZ::AllocatorInstance<AZ::SystemAllocator>::IsReady())
+    {
+        AZ::AllocatorInstance<AZ::SystemAllocator>::Destroy();
+    }
     if (AZ::AllocatorInstance<AZ::OSAllocator>::IsReady())
     {
         AZ::AllocatorInstance<AZ::OSAllocator>::Destroy();


### PR DESCRIPTION
Fixes the following crash

```
System: Trace::Assert
 /home/ANT.AMAZON.COM/spham/github/o3de/Code/Framework/AzCore/./AzCore/Memory/Memory.h(582): (140737286531712) 'static AZ::IAllocator &AZ::AllocatorStorage::EnvironmentStoragePolicy<AZ::SystemAllocator>::GetAllocator() [Allocator = AZ::SystemAllocator]'
System: Allocator 'SystemAllocator' NOT ready for use! Call Create first!
System: ------------------------------------------------
System: AZ::AllocatorStorage::EnvironmentStoragePolicy<AZ::SystemAllocator>::GetAllocator() (+0x102) [0x4d1492]
System: AZ::Internal::AllocatorInstanceBase<AZ::SystemAllocator, AZ::AllocatorStorage::EnvironmentStoragePolicy<AZ::SystemAllocator> >::GetAllocator() (+0x9) [0x4d1369]
System: AZ::Internal::AllocatorInstanceBase<AZ::SystemAllocator, AZ::AllocatorStorage::EnvironmentStoragePolicy<AZ::SystemAllocator> >::Get() (+0x9) [0x4d1349]
System: AZ::IO::LocalFileIO::operator new(unsigned long, char const*, int, char const*) (+0x79) [0x557179]
System: main (+0x78) [0x556df8]
System: __libc_start_main (+0xf3) [0x7ffff428f0b3]
System: _start (+0x2e) [0x4c042e]
System: ==================================================================
System: 
```

Signed-off-by: Steve Pham <spham@amazon.com>