### PR TITLE
Perform global deinitialization when exiting the game launcher

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -2185,7 +2185,7 @@ namespace AZ::IO
         AZStd::unique_lock lock(m_archiveMutex);
         if (pArchive)
         {
-            AZ_TracePrintf("Archive", "Closing Archive file: %s", pArchive->GetFullPath());
+            AZ_TracePrintf("Archive", "Closing Archive file: %s\n", pArchive->GetFullPath());
         }
         ArchiveArray::iterator it;
         if (m_arrArchives.size() < 16)

--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -232,12 +232,16 @@ namespace
         // our frame time to be managed by AzGameFramework::GameApplication
         // instead, which probably isn't going to happen anytime soon given
         // how many things depend on the ITimer interface).
-        bool continueRunning = true;
         ISystem* system = gEnv ? gEnv->pSystem : nullptr;
-        while (continueRunning)
+        while (!gameApplication.WasExitMainLoopRequested())
         {
             // Pump the system event loop
             gameApplication.PumpSystemEventLoopUntilEmpty();
+
+            if (gameApplication.WasExitMainLoopRequested())
+            {
+                break;
+            }
 
             // Update the AzFramework system tick bus
             gameApplication.TickSystem();
@@ -256,9 +260,6 @@ namespace
             {
                 system->UpdatePostTickBus();
             }
-
-            // Check for quit requests
-            continueRunning = !gameApplication.WasExitMainLoopRequested() && continueRunning;
         }
     }
 }

--- a/Code/Legacy/CrySystem/AZCoreLogSink.h
+++ b/Code/Legacy/CrySystem/AZCoreLogSink.h
@@ -31,6 +31,11 @@ class AZCoreLogSink
     : public AZ::Debug::TraceMessageBus::Handler
 {
 public:
+    ~AZCoreLogSink()
+    {
+        Disconnect();
+    }
+
     inline static void Connect()
     {
         GetInstance().m_ignoredAsserts = new IgnoredAssertMap();

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -233,6 +233,7 @@ CLevelSystem::CLevelSystem(ISystem* pSystem, const char* levelsFolder)
 //------------------------------------------------------------------------
 CLevelSystem::~CLevelSystem()
 {
+    UnloadLevel();
 }
 
 //------------------------------------------------------------------------

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -548,29 +548,6 @@ void CSystem::Quit()
         logger->Flush();
     }
 
-    /*
-    * TODO: This call to _exit, _Exit, TerminateProcess etc. needs to
-    * eventually be removed. This causes an extremely early exit before we
-    * actually perform cleanup. When this gets called most managers are
-    * simply never deleted and we leave it to the OS to clean up our mess
-    * which is just really bad practice. However there are LOTS of issues
-    * with shutdown at the moment. Removing this will simply cause
-    * a crash when either the Editor or Launcher initiate shutdown. Both
-    * applications crash differently too. Bugs will be logged about those
-    * issues.
-    */
-#if defined(AZ_RESTRICTED_PLATFORM)
-#define AZ_RESTRICTED_SECTION SYSTEM_CPP_SECTION_4
-#include AZ_RESTRICTED_FILE(System_cpp)
-#endif
-#if defined(AZ_RESTRICTED_SECTION_IMPLEMENTED)
-#undef AZ_RESTRICTED_SECTION_IMPLEMENTED
-#elif defined(WIN32) || defined(WIN64)
-    TerminateProcess(GetCurrentProcess(), m_env.retCode);
-#else
-    exit(m_env.retCode);
-#endif
-
 #ifdef WIN32
     //Post a WM_QUIT message to the Win32 api which causes the message loop to END
     //This is not the same as handling a WM_DESTROY event which destroys a window

--- a/Code/Tools/RemoteConsole/Core/RemoteConsoleCore.cpp
+++ b/Code/Tools/RemoteConsole/Core/RemoteConsoleCore.cpp
@@ -239,6 +239,11 @@ void SRemoteServer::Run()
 
     while (m_bAcceptClients)
     {
+        AZTIMEVAL timeout { 1, 0 };
+        if (!AZ::AzSock::IsRecvPending(m_socket, &timeout))
+        {
+            continue;
+        }
         AZ::AzSock::AzSocketAddress clientAddress;
         sClient = AZ::AzSock::Accept(m_socket, clientAddress);
         if (!m_bAcceptClients || !AZ::AzSock::IsAzSocketValid(sClient))

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -386,7 +386,7 @@ namespace AZ
                     // Unbind m_defaultScene to the GameEntityContext's AzFramework::Scene
                     if (m_defaultFrameworkScene)
                     {
-                        m_defaultFrameworkScene->UnsetSubsystem<RPI::Scene>();
+                        m_defaultFrameworkScene->UnsetSubsystem(m_defaultScene);
                     }
 
                     m_defaultScene = nullptr;

--- a/Gems/HttpRequestor/Code/Source/HttpRequestManager.cpp
+++ b/Gems/HttpRequestor/Code/Source/HttpRequestManager.cpp
@@ -35,7 +35,6 @@ namespace HttpRequestor
         desc.m_name = s_loggingName;
         desc.m_cpuId = AFFINITY_MASK_USERTHREADS;
         m_runThread = true;
-        // Shutdown will be handled by the InitializationManager - no need to call in the destructor
         AWSNativeSDKInit::InitializationManager::InitAwsApi();
         auto function = AZStd::bind(&Manager::ThreadFunction, this);
         m_thread = AZStd::thread(function, &desc);
@@ -43,7 +42,7 @@ namespace HttpRequestor
 
     Manager::~Manager()
     {
-        // NativeSDK Shutdown does not need to be called here - will be taken care of by the InitializationManager
+        AWSNativeSDKInit::InitializationManager::Shutdown();
         m_runThread = false;
         m_requestConditionVar.notify_all();
         if (m_thread.joinable())


### PR DESCRIPTION
This removes the `TerminateProcess()` / `exit()` calls from `CSystem::Quit`, and fixes all the crashes and leaks that were occurring as a result of the atexit code now running.