### PR TITLE
EMotion FX: Resetting the Motion extraction joint when the Anim Graph is active crashes the Editor

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/Actor.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Actor.cpp
@@ -1245,7 +1245,7 @@ namespace EMotionFX
         }
         else
         {
-            SetMotionExtractionNodeIndex(MCORE_INVALIDINDEX32);
+            SetMotionExtractionNodeIndex(InvalidIndex);
         }
     }
 

--- a/Gems/EMotionFX/Code/Source/Editor/ActorJointBrowseEdit.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ActorJointBrowseEdit.cpp
@@ -66,6 +66,7 @@ namespace EMStudio
         m_jointSelectionWindow = new NodeSelectionWindow(this, m_singleJointSelection);
         connect(m_jointSelectionWindow, &NodeSelectionWindow::rejected, this, &ActorJointBrowseEdit::OnSelectionRejected);
         connect(m_jointSelectionWindow->GetNodeHierarchyWidget()->GetTreeWidget(), &QTreeWidget::itemSelectionChanged, this, &ActorJointBrowseEdit::OnSelectionChanged);
+        connect(m_jointSelectionWindow->GetNodeHierarchyWidget(), &NodeHierarchyWidget::OnSelectionDone, this, &ActorJointBrowseEdit::OnSelectionDone);
 
         NodeSelectionWindow::connect(m_jointSelectionWindow, &QDialog::finished, [=]([[maybe_unused]] int resultCode)
             {


### PR DESCRIPTION
Wrong invalid index type caused the crash. Selecting another joint was broken as well and got fixed directly, too. The selection done event was never received due to not being connected to the node hierarchy widget.

Resolves #4108

Signed-off-by: Benjamin Jillich <jillich@amazon.com>