### PR TITLE
Expose sticky select option to the SettingsRegistry

### DIFF
--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -24,8 +24,8 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         ->Field("Sync2DViews", &General::m_sync2DViews)
         ->Field("DefaultFOV", &General::m_defaultFOV)
         ->Field("DefaultAspectRatio", &General::m_defaultAspectRatio)
-        ->Field("EnableContextMenu", &General::m_enableContextMenu)
-        ->Field("StickySelect", &General::m_stickySelect);
+        ->Field("EnableContextMenu", &General::m_contextMenuEnabled)
+        ->Field("StickySelect", &General::m_stickySelectEnabled);
 
     serialize.Class<Display>()
         ->Version(1)
@@ -48,7 +48,12 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         ->Field("ShowGridGuide", &Display::m_showGridGuide)
         ->Field("DisplayDimensions", &Display::m_displayDimension);
 
-    serialize.Class<MapViewport>()->Version(1)->Field("SwapXY", &MapViewport::m_swapXY)->Field("Resolution", &MapViewport::m_resolution);
+    // clang-format off
+    serialize.Class<MapViewport>()
+        ->Version(1)
+        ->Field("SwapXY", &MapViewport::m_swapXY)
+        ->Field("Resolution", &MapViewport::m_resolution);
+    // clang-format on
 
     serialize.Class<TextLabels>()
         ->Version(1)
@@ -86,9 +91,9 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
                 AZ::Edit::UIHandlers::SpinBox, &General::m_defaultAspectRatio, "Perspective View Aspect Ratio",
                 "Perspective View Aspect Ratio")
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &General::m_enableContextMenu, "Enable Right-Click Context Menu",
+                AZ::Edit::UIHandlers::CheckBox, &General::m_contextMenuEnabled, "Enable Right-Click Context Menu",
                 "Enable Right-Click Context Menu")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_stickySelect, "Enable Sticky Select", "Enable Sticky Select");
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_stickySelectEnabled, "Enable Sticky Select", "Enable Sticky Select");
 
         editContext->Class<Display>("Viewport Display Settings", "")
             ->DataElement(
@@ -216,9 +221,9 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
 
     gSettings.viewports.fDefaultAspectRatio = m_general.m_defaultAspectRatio;
     gSettings.viewports.fDefaultFov = m_general.m_defaultFOV;
-    gSettings.viewports.bEnableContextMenu = m_general.m_enableContextMenu;
+    gSettings.viewports.bEnableContextMenu = m_general.m_contextMenuEnabled;
     gSettings.viewports.bSync2DViews = m_general.m_sync2DViews;
-    SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelect);
+    SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelectEnabled);
 
     gSettings.viewports.bShowSafeFrame = m_display.m_showSafeFrame;
     gSettings.viewports.bHighlightSelectedGeometry = m_display.m_highlightSelGeom;
@@ -279,9 +284,9 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
 
     m_general.m_defaultAspectRatio = gSettings.viewports.fDefaultAspectRatio;
     m_general.m_defaultFOV = gSettings.viewports.fDefaultFov;
-    m_general.m_enableContextMenu = gSettings.viewports.bEnableContextMenu;
+    m_general.m_contextMenuEnabled = gSettings.viewports.bEnableContextMenu;
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;
-    m_general.m_stickySelect = SandboxEditor::StickySelectEnabled();
+    m_general.m_stickySelectEnabled = SandboxEditor::StickySelectEnabled();
 
     m_display.m_showSafeFrame = gSettings.viewports.bShowSafeFrame;
     m_display.m_highlightSelGeom = gSettings.viewports.bHighlightSelectedGeometry;

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.cpp
@@ -5,16 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #include "EditorDefs.h"
 
 #include "EditorPreferencesPageViewportGeneral.h"
+#include "EditorViewportSettings.h"
 
 #include <AzQtComponents/Components/StyleManager.h>
 
 // Editor
 #include "DisplaySettings.h"
 #include "Settings.h"
-
 
 void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& serialize)
 {
@@ -23,7 +24,8 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         ->Field("Sync2DViews", &General::m_sync2DViews)
         ->Field("DefaultFOV", &General::m_defaultFOV)
         ->Field("DefaultAspectRatio", &General::m_defaultAspectRatio)
-        ->Field("EnableContextMenu", &General::m_enableContextMenu);
+        ->Field("EnableContextMenu", &General::m_enableContextMenu)
+        ->Field("StickySelect", &General::m_stickySelect);
 
     serialize.Class<Display>()
         ->Version(1)
@@ -46,10 +48,7 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         ->Field("ShowGridGuide", &Display::m_showGridGuide)
         ->Field("DisplayDimensions", &Display::m_displayDimension);
 
-    serialize.Class<MapViewport>()
-        ->Version(1)
-        ->Field("SwapXY", &MapViewport::m_swapXY)
-        ->Field("Resolution", &MapViewport::m_resolution);
+    serialize.Class<MapViewport>()->Version(1)->Field("SwapXY", &MapViewport::m_swapXY)->Field("Resolution", &MapViewport::m_resolution);
 
     serialize.Class<TextLabels>()
         ->Version(1)
@@ -80,31 +79,51 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         editContext->Class<General>("General Viewport Settings", "")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_sync2DViews, "Synchronize 2D Viewports", "Synchronize 2D Viewports")
             ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultFOV, "Perspective View FOV", "Perspective View FOV")
-                ->Attribute("Multiplier", RAD2DEG(1))
-                ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
-                ->Attribute(AZ::Edit::Attributes::Max, 120.0f)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &General::m_defaultAspectRatio, "Perspective View Aspect Ratio", "Perspective View Aspect Ratio")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_enableContextMenu, "Enable Right-Click Context Menu", "Enable Right-Click Context Menu");
+            ->Attribute("Multiplier", RAD2DEG(1))
+            ->Attribute(AZ::Edit::Attributes::Min, 1.0f)
+            ->Attribute(AZ::Edit::Attributes::Max, 120.0f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &General::m_defaultAspectRatio, "Perspective View Aspect Ratio",
+                "Perspective View Aspect Ratio")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &General::m_enableContextMenu, "Enable Right-Click Context Menu",
+                "Enable Right-Click Context Menu")
+            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &General::m_stickySelect, "Enable Sticky Select", "Enable Sticky Select");
 
         editContext->Class<Display>("Viewport Display Settings", "")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showSafeFrame, "Show 4:3 Aspect Ratio Frame", "Show 4:3 Aspect Ratio Frame")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelGeom, "Highlight Selected Geometry", "Highlight Selected Geometry")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelVegetation, "Highlight Selected Vegetation", "Highlight Selected Vegetation")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightOnMouseOver, "Highlight Geometry On Mouse Over", "Highlight Geometry On Mouse Over")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_hideMouseCursorWhenCaptured, "Hide Cursor When Captured", "Hide Mouse Cursor When Captured")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_showSafeFrame, "Show 4:3 Aspect Ratio Frame", "Show 4:3 Aspect Ratio Frame")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelGeom, "Highlight Selected Geometry", "Highlight Selected Geometry")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightSelVegetation, "Highlight Selected Vegetation",
+                "Highlight Selected Vegetation")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_highlightOnMouseOver, "Highlight Geometry On Mouse Over",
+                "Highlight Geometry On Mouse Over")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_hideMouseCursorWhenCaptured, "Hide Cursor When Captured",
+                "Hide Mouse Cursor When Captured")
             ->DataElement(AZ::Edit::UIHandlers::SpinBox, &Display::m_dragSquareSize, "Drag Square Size", "Drag Square Size")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayLinks, "Display Object Links", "Display Object Links")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayTracks, "Display Animation Tracks", "Display Animation Tracks")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_alwaysShowRadii, "Always Show Radii", "Always Show Radii")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showBBoxes, "Show Bounding Boxes", "Show Bounding Boxes")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_drawEntityLabels, "Always Draw Entity Labels", "Always Draw Entity Labels")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showTriggerBounds, "Always Show Trigger Bounds", "Always Show Trigger Bounds")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_drawEntityLabels, "Always Draw Entity Labels", "Always Draw Entity Labels")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_showTriggerBounds, "Always Show Trigger Bounds", "Always Show Trigger Bounds")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showIcons, "Show Object Icons", "Show Object Icons")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_distanceScaleIcons, "Scale Object Icons with Distance", "Scale Object Icons with Distance")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showFrozenHelpers, "Show Helpers of Frozen Objects", "Show Helpers of Frozen Objects")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_distanceScaleIcons, "Scale Object Icons with Distance",
+                "Scale Object Icons with Distance")
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_showFrozenHelpers, "Show Helpers of Frozen Objects",
+                "Show Helpers of Frozen Objects")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_fillSelectedShapes, "Fill Selected Shapes", "Fill Selected Shapes")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_showGridGuide, "Show Snapping Grid Guide", "Show Snapping Grid Guide")
-            ->DataElement(AZ::Edit::UIHandlers::CheckBox, &Display::m_displayDimension, "Display Dimension Figures", "Display Dimension Figures");
+            ->DataElement(
+                AZ::Edit::UIHandlers::CheckBox, &Display::m_displayDimension, "Display Dimension Figures", "Display Dimension Figures");
 
         editContext->Class<MapViewport>("Map Viewport Settings", "")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &MapViewport::m_swapXY, "Swap X/Y Axis", "Swap X/Y Axis")
@@ -113,40 +132,62 @@ void CEditorPreferencesPage_ViewportGeneral::Reflect(AZ::SerializeContext& seria
         editContext->Class<TextLabels>("Text Label Settings", "")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &TextLabels::m_labelsOn, "Enabled", "Enabled")
             ->DataElement(AZ::Edit::UIHandlers::CheckBox, &TextLabels::m_labelsDistance, "Distance", "Distance")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.f)
-                ->Attribute(AZ::Edit::Attributes::Max, 100000.f);
+            ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+            ->Attribute(AZ::Edit::Attributes::Max, 100000.f);
 
         editContext->Class<SelectionPreviewColor>("Selection Preview Color Settings", "")
             ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorGroupBBox, "Group Bounding Box", "Group Bounding Box")
-            ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorEntityBBox, "Entity Bounding Box", "Entity Bounding Box")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fBBoxAlpha, "Bounding Box Highlight Alpha", "Bounding Box Highlight Alpha")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_colorEntityBBox, "Entity Bounding Box", "Entity Bounding Box")
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fBBoxAlpha, "Bounding Box Highlight Alpha",
+                "Bounding Box Highlight Alpha")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+            ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
             ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_geometryHighlightColor, "Geometry Color", "Geometry Color")
-            ->DataElement(AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_solidBrushGeometryColor, "Solid Brush Geometry Color", "Solid Brush Geometry Color")
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fgeomAlpha, "Geometry Highlight Alpha", "Geometry Highlight Alpha")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
-            ->DataElement(AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_childObjectGeomAlpha, "Child Geometry Highlight Alpha", "Child Geometry Highlight Alpha")
-                ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                ->Attribute(AZ::Edit::Attributes::Max, 1.0f);
+            ->DataElement(
+                AZ::Edit::UIHandlers::Color, &SelectionPreviewColor::m_solidBrushGeometryColor, "Solid Brush Geometry Color",
+                "Solid Brush Geometry Color")
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_fgeomAlpha, "Geometry Highlight Alpha", "Geometry Highlight Alpha")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+            ->Attribute(AZ::Edit::Attributes::Max, 1.0f)
+            ->DataElement(
+                AZ::Edit::UIHandlers::SpinBox, &SelectionPreviewColor::m_childObjectGeomAlpha, "Child Geometry Highlight Alpha",
+                "Child Geometry Highlight Alpha")
+            ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+            ->Attribute(AZ::Edit::Attributes::Max, 1.0f);
 
         editContext->Class<CEditorPreferencesPage_ViewportGeneral>("General Viewport Preferences", "General Viewport Preferences")
             ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
             ->Attribute(AZ::Edit::Attributes::Visibility, AZ_CRC("PropertyVisibility_ShowChildrenOnly", 0xef428f20))
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_general, "General Viewport Settings", "General Viewport Settings")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_display, "Viewport Display Settings", "Viewport Display Settings")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_map, "Map Viewport Settings", "Map Viewport Settings")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_textLabels, "Text Label Settings", "Text Label Settings")
-            ->DataElement(AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_selectionPreviewColor, "Selection Preview Color Settings", "Selection Preview Color Settings");
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_general, "General Viewport Settings",
+                "General Viewport Settings")
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_display, "Viewport Display Settings",
+                "Viewport Display Settings")
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_map, "Map Viewport Settings",
+                "Map Viewport Settings")
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_textLabels, "Text Label Settings",
+                "Text Label Settings")
+            ->DataElement(
+                AZ::Edit::UIHandlers::Default, &CEditorPreferencesPage_ViewportGeneral::m_selectionPreviewColor,
+                "Selection Preview Color Settings", "Selection Preview Color Settings");
     }
 }
-
 
 CEditorPreferencesPage_ViewportGeneral::CEditorPreferencesPage_ViewportGeneral()
 {
     InitializeSettings();
     m_icon = QIcon(":/res/Viewport.svg");
+}
+
+const char* CEditorPreferencesPage_ViewportGeneral::GetCategory()
+{
+    return "Viewports";
 }
 
 const char* CEditorPreferencesPage_ViewportGeneral::GetTitle()
@@ -159,6 +200,16 @@ QIcon& CEditorPreferencesPage_ViewportGeneral::GetIcon()
     return m_icon;
 }
 
+void CEditorPreferencesPage_ViewportGeneral::OnCancel()
+{
+    // noop
+}
+
+bool CEditorPreferencesPage_ViewportGeneral::OnQueryCancel()
+{
+    return true;
+}
+
 void CEditorPreferencesPage_ViewportGeneral::OnApply()
 {
     CDisplaySettings* ds = GetIEditor()->GetDisplaySettings();
@@ -167,6 +218,7 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
     gSettings.viewports.fDefaultFov = m_general.m_defaultFOV;
     gSettings.viewports.bEnableContextMenu = m_general.m_enableContextMenu;
     gSettings.viewports.bSync2DViews = m_general.m_sync2DViews;
+    SandboxEditor::SetStickySelectEnabled(m_general.m_stickySelect);
 
     gSettings.viewports.bShowSafeFrame = m_display.m_showSafeFrame;
     gSettings.viewports.bHighlightSelectedGeometry = m_display.m_highlightSelGeom;
@@ -202,19 +254,19 @@ void CEditorPreferencesPage_ViewportGeneral::OnApply()
 
     gSettings.objectColorSettings.fChildGeomAlpha = m_selectionPreviewColor.m_childObjectGeomAlpha;
     gSettings.objectColorSettings.entityHighlight = QColor(
-            static_cast<int>(m_selectionPreviewColor.m_colorEntityBBox.GetR() * 255.0f),
-            static_cast<int>(m_selectionPreviewColor.m_colorEntityBBox.GetG() * 255.0f),
-            static_cast<int>(m_selectionPreviewColor.m_colorEntityBBox.GetB() * 255.0f));
+        static_cast<int>(m_selectionPreviewColor.m_colorEntityBBox.GetR() * 255.0f),
+        static_cast<int>(m_selectionPreviewColor.m_colorEntityBBox.GetG() * 255.0f),
+        static_cast<int>(m_selectionPreviewColor.m_colorEntityBBox.GetB() * 255.0f));
     gSettings.objectColorSettings.groupHighlight = QColor(
-            static_cast<int>(m_selectionPreviewColor.m_colorGroupBBox.GetR() * 255.0f),
-            static_cast<int>(m_selectionPreviewColor.m_colorGroupBBox.GetG() * 255.0f),
-            static_cast<int>(m_selectionPreviewColor.m_colorGroupBBox.GetB() * 255.0f));
+        static_cast<int>(m_selectionPreviewColor.m_colorGroupBBox.GetR() * 255.0f),
+        static_cast<int>(m_selectionPreviewColor.m_colorGroupBBox.GetG() * 255.0f),
+        static_cast<int>(m_selectionPreviewColor.m_colorGroupBBox.GetB() * 255.0f));
     gSettings.objectColorSettings.fBBoxAlpha = m_selectionPreviewColor.m_fBBoxAlpha;
     gSettings.objectColorSettings.fGeomAlpha = m_selectionPreviewColor.m_fgeomAlpha;
     gSettings.objectColorSettings.geometryHighlightColor = QColor(
-            static_cast<int>(m_selectionPreviewColor.m_geometryHighlightColor.GetR() * 255.0f),
-            static_cast<int>(m_selectionPreviewColor.m_geometryHighlightColor.GetG() * 255.0f),
-            static_cast<int>(m_selectionPreviewColor.m_geometryHighlightColor.GetB() * 255.0f));
+        static_cast<int>(m_selectionPreviewColor.m_geometryHighlightColor.GetR() * 255.0f),
+        static_cast<int>(m_selectionPreviewColor.m_geometryHighlightColor.GetG() * 255.0f),
+        static_cast<int>(m_selectionPreviewColor.m_geometryHighlightColor.GetB() * 255.0f));
     gSettings.objectColorSettings.solidBrushGeometryColor = QColor(
         static_cast<int>(m_selectionPreviewColor.m_solidBrushGeometryColor.GetR() * 255.0f),
         static_cast<int>(m_selectionPreviewColor.m_solidBrushGeometryColor.GetG() * 255.0f),
@@ -229,6 +281,7 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
     m_general.m_defaultFOV = gSettings.viewports.fDefaultFov;
     m_general.m_enableContextMenu = gSettings.viewports.bEnableContextMenu;
     m_general.m_sync2DViews = gSettings.viewports.bSync2DViews;
+    m_general.m_stickySelect = SandboxEditor::StickySelectEnabled();
 
     m_display.m_showSafeFrame = gSettings.viewports.bShowSafeFrame;
     m_display.m_highlightSelGeom = gSettings.viewports.bHighlightSelectedGeometry;
@@ -256,10 +309,22 @@ void CEditorPreferencesPage_ViewportGeneral::InitializeSettings()
     m_textLabels.m_labelsDistance = ds->GetLabelsDistance();
 
     m_selectionPreviewColor.m_childObjectGeomAlpha = gSettings.objectColorSettings.fChildGeomAlpha;
-    m_selectionPreviewColor.m_colorEntityBBox.Set(static_cast<float>(gSettings.objectColorSettings.entityHighlight.redF()), static_cast<float>(gSettings.objectColorSettings.entityHighlight.greenF()), static_cast<float>(gSettings.objectColorSettings.entityHighlight.blueF()), 1.0f);
-    m_selectionPreviewColor.m_colorGroupBBox.Set(static_cast<float>(gSettings.objectColorSettings.groupHighlight.redF()), static_cast<float>(gSettings.objectColorSettings.groupHighlight.greenF()), static_cast<float>(gSettings.objectColorSettings.groupHighlight.blueF()), 1.0f);
+    m_selectionPreviewColor.m_colorEntityBBox.Set(
+        static_cast<float>(gSettings.objectColorSettings.entityHighlight.redF()),
+        static_cast<float>(gSettings.objectColorSettings.entityHighlight.greenF()),
+        static_cast<float>(gSettings.objectColorSettings.entityHighlight.blueF()), 1.0f);
+    m_selectionPreviewColor.m_colorGroupBBox.Set(
+        static_cast<float>(gSettings.objectColorSettings.groupHighlight.redF()),
+        static_cast<float>(gSettings.objectColorSettings.groupHighlight.greenF()),
+        static_cast<float>(gSettings.objectColorSettings.groupHighlight.blueF()), 1.0f);
     m_selectionPreviewColor.m_fBBoxAlpha = gSettings.objectColorSettings.fBBoxAlpha;
     m_selectionPreviewColor.m_fgeomAlpha = gSettings.objectColorSettings.fGeomAlpha;
-    m_selectionPreviewColor.m_geometryHighlightColor.Set(static_cast<float>(gSettings.objectColorSettings.geometryHighlightColor.redF()), static_cast<float>(gSettings.objectColorSettings.geometryHighlightColor.greenF()), static_cast<float>(gSettings.objectColorSettings.geometryHighlightColor.blueF()), 1.0f);
-    m_selectionPreviewColor.m_solidBrushGeometryColor.Set(static_cast<float>(gSettings.objectColorSettings.solidBrushGeometryColor.redF()), static_cast<float>(gSettings.objectColorSettings.solidBrushGeometryColor.greenF()), static_cast<float>(gSettings.objectColorSettings.solidBrushGeometryColor.blueF()), 1.0f);
+    m_selectionPreviewColor.m_geometryHighlightColor.Set(
+        static_cast<float>(gSettings.objectColorSettings.geometryHighlightColor.redF()),
+        static_cast<float>(gSettings.objectColorSettings.geometryHighlightColor.greenF()),
+        static_cast<float>(gSettings.objectColorSettings.geometryHighlightColor.blueF()), 1.0f);
+    m_selectionPreviewColor.m_solidBrushGeometryColor.Set(
+        static_cast<float>(gSettings.objectColorSettings.solidBrushGeometryColor.redF()),
+        static_cast<float>(gSettings.objectColorSettings.solidBrushGeometryColor.greenF()),
+        static_cast<float>(gSettings.objectColorSettings.solidBrushGeometryColor.blueF()), 1.0f);
 }

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.h
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.h
@@ -42,8 +42,8 @@ private:
         bool m_sync2DViews;
         float m_defaultFOV;
         float m_defaultAspectRatio;
-        bool m_enableContextMenu;
-        bool m_stickySelect;
+        bool m_contextMenuEnabled;
+        bool m_stickySelectEnabled;
     };
 
     struct Display

--- a/Code/Editor/EditorPreferencesPageViewportGeneral.h
+++ b/Code/Editor/EditorPreferencesPageViewportGeneral.h
@@ -5,18 +5,17 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+
 #pragma once
 
 #include "Include/IPreferencesPage.h"
-#include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Math/Color.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <QIcon>
 
-
-class CEditorPreferencesPage_ViewportGeneral
-    : public IPreferencesPage
+class CEditorPreferencesPage_ViewportGeneral : public IPreferencesPage
 {
 public:
     AZ_RTTI(CEditorPreferencesPage_ViewportGeneral, "{8511FF7F-F774-47E1-A99B-3DE3A867E403}", IPreferencesPage)
@@ -26,12 +25,12 @@ public:
     CEditorPreferencesPage_ViewportGeneral();
     virtual ~CEditorPreferencesPage_ViewportGeneral() = default;
 
-    virtual const char* GetCategory() override { return "Viewports"; }
+    virtual const char* GetCategory() override;
     virtual const char* GetTitle() override;
     virtual QIcon& GetIcon() override;
     virtual void OnApply() override;
-    virtual void OnCancel() override {}
-    virtual bool OnQueryCancel() override { return true; }
+    virtual void OnCancel() override;
+    virtual bool OnQueryCancel() override;
 
 private:
     void InitializeSettings();
@@ -44,6 +43,7 @@ private:
         float m_defaultFOV;
         float m_defaultAspectRatio;
         bool m_enableContextMenu;
+        bool m_stickySelect;
     };
 
     struct Display
@@ -106,5 +106,3 @@ private:
     SelectionPreviewColor m_selectionPreviewColor;
     QIcon m_icon;
 };
-
-

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -20,6 +20,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view AngleSnappingSetting = "/Amazon/Preferences/Editor/AngleSnapping";
     constexpr AZStd::string_view AngleSizeSetting = "/Amazon/Preferences/Editor/AngleSize";
     constexpr AZStd::string_view ShowGridSetting = "/Amazon/Preferences/Editor/ShowGrid";
+    constexpr AZStd::string_view StickySelectSetting = "/Amazon/Preferences/Editor/StickySelect";
     constexpr AZStd::string_view ManipulatorLineBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/LineBoundWidth";
     constexpr AZStd::string_view ManipulatorCircleBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/CircleBoundWidth";
     constexpr AZStd::string_view CameraTranslateSpeedSetting = "/Amazon/Preferences/Editor/Camera/TranslateSpeed";
@@ -156,6 +157,16 @@ namespace SandboxEditor
     void SetShowingGrid(const bool showing)
     {
         SetRegistry(ShowGridSetting, showing);
+    }
+
+    bool StickySelectEnabled()
+    {
+        return GetRegistry(StickySelectSetting, false);
+    }
+
+    void SetStickySelectEnabled(const bool enabled)
+    {
+        SetRegistry(StickySelectSetting, enabled);
     }
 
     float ManipulatorLineBoundWidth()

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -47,6 +47,9 @@ namespace SandboxEditor
     SANDBOX_API bool ShowingGrid();
     SANDBOX_API void SetShowingGrid(bool showing);
 
+    SANDBOX_API bool StickySelectEnabled();
+    SANDBOX_API void SetStickySelectEnabled(bool enabled);
+
     SANDBOX_API float ManipulatorLineBoundWidth();
     SANDBOX_API void SetManipulatorLineBoundWidth(float lineBoundWidth);
 

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2522,6 +2522,11 @@ float EditorViewportSettings::ManipulatorCircleBoundWidth() const
     return SandboxEditor::ManipulatorCircleBoundWidth();
 }
 
+bool EditorViewportSettings::StickySelectEnabled() const
+{
+    return SandboxEditor::StickySelectEnabled();
+}
+
 AZ_CVAR_EXTERNED(bool, ed_previewGameInFullscreen_once);
 
 bool EditorViewportWidget::ShouldPreviewFullscreen() const

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -77,6 +77,7 @@ struct EditorViewportSettings : public AzToolsFramework::ViewportInteraction::Vi
     float AngleStep() const override;
     float ManipulatorLineBoundWidth() const override;
     float ManipulatorCircleBoundWidth() const override;
+    bool StickySelectEnabled() const override;
 };
 
 // EditorViewportWidget window

--- a/Code/Editor/ViewportTitleDlg.cpp
+++ b/Code/Editor/ViewportTitleDlg.cpp
@@ -154,6 +154,8 @@ void CViewportTitleDlg::SetupCameraDropdownMenu()
     cameraMenu->addMenu(GetFovMenu());
     m_ui->m_cameraMenu->setMenu(cameraMenu);
     m_ui->m_cameraMenu->setPopupMode(QToolButton::InstantPopup);
+    QObject::connect(cameraMenu, &QMenu::aboutToShow, this, &CViewportTitleDlg::CheckForCameraSpeedUpdate);
+
     QAction* gotoPositionAction = new QAction("Go to position", cameraMenu);
     connect(gotoPositionAction, &QAction::triggered, this, &CViewportTitleDlg::OnBnClickedGotoPosition);
     cameraMenu->addAction(gotoPositionAction);

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ActionDispatcher.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ActionDispatcher.h
@@ -15,19 +15,19 @@
 
 namespace AzManipulatorTestFramework
 {
-    //! Base class for derived immediate and retained action dispatchers.
+    //! Base class for derived immediate action dispatchers.
     template<typename DerivedDispatcherT>
     class ActionDispatcher
     {
     public:
         virtual ~ActionDispatcher() = default;
 
-        //! Enable grid snapping.
-        DerivedDispatcherT* EnableSnapToGrid();
-        //! Disable grid snapping.
-        DerivedDispatcherT* DisableSnapToGrid();
+        //! Enable/disable grid snapping.
+        DerivedDispatcherT* SetSnapToGrid(bool enabled);
         //! Set the grid size.
         DerivedDispatcherT* GridSize(float size);
+        //! Enable/disable sticky select.
+        DerivedDispatcherT* SetStickySelect(bool enabled);
         //! Enable/disable action logging.
         DerivedDispatcherT* LogActions(bool logging);
         //! Output a trace debug message.
@@ -66,9 +66,9 @@ namespace AzManipulatorTestFramework
         DerivedDispatcherT* EnterComponentMode();
 
     protected:
-        // Actions to be implemented by derived immediate and retained action dispatchers.
-        virtual void EnableSnapToGridImpl() = 0;
-        virtual void DisableSnapToGridImpl() = 0;
+        // Actions to be implemented by derived immediate action dispatcher.
+        virtual void SetSnapToGridImpl(bool enabled) = 0;
+        virtual void SetStickySelectImpl(bool enabled) = 0;
         virtual void GridSizeImpl(float size) = 0;
         virtual void CameraStateImpl(const AzFramework::CameraState& cameraState) = 0;
         virtual void MouseLButtonDownImpl() = 0;
@@ -127,18 +127,18 @@ namespace AzManipulatorTestFramework
     }
 
     template<typename DerivedDispatcherT>
-    DerivedDispatcherT* ActionDispatcher<DerivedDispatcherT>::EnableSnapToGrid()
+    DerivedDispatcherT* ActionDispatcher<DerivedDispatcherT>::SetSnapToGrid(const bool enabled)
     {
-        Log("Enabling SnapToGrid");
-        EnableSnapToGridImpl();
+        Log("SnapToGrid %s", enabled ? "on" : "off");
+        SetSnapToGridImpl(enabled);
         return static_cast<DerivedDispatcherT*>(this);
     }
 
     template<typename DerivedDispatcherT>
-    DerivedDispatcherT* ActionDispatcher<DerivedDispatcherT>::DisableSnapToGrid()
+    DerivedDispatcherT* ActionDispatcher<DerivedDispatcherT>::SetStickySelect(bool enabled)
     {
-        Log("Disabling SnapToGrid");
-        DisableSnapToGridImpl();
+        Log("StickySelect %s", enabled ? "on" : "off");
+        SetStickySelectImpl(enabled);
         return static_cast<DerivedDispatcherT*>(this);
     }
 

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/AzManipulatorTestFramework.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/AzManipulatorTestFramework.h
@@ -16,7 +16,7 @@ namespace AzFramework
 {
     class DebugDisplayRequests;
     struct CameraState;
-}
+} // namespace AzFramework
 
 namespace AzManipulatorTestFramework
 {
@@ -31,14 +31,10 @@ namespace AzManipulatorTestFramework
         virtual void SetCameraState(const AzFramework::CameraState& cameraState) = 0;
         //! Retrieve the debug display.
         virtual AzFramework::DebugDisplayRequests& GetDebugDisplay() = 0;
-        //! Enable grid snapping.
-        virtual void EnableGridSnaping() = 0;
-        //! Disable grid snapping.
-        virtual void DisableGridSnaping() = 0;
-        //! Enable grid snapping.
-        virtual void EnableAngularSnaping() = 0;
-        //! Disable grid snapping.
-        virtual void DisableAngularSnaping() = 0;
+        //! Set if grid snapping is enabled or not.
+        virtual void SetGridSnapping(bool enabled) = 0;
+        //! Set if angular snapping is enabled or not.
+        virtual void SetAngularSnapping(bool enabled) = 0;
         //! Set the grid size.
         virtual void SetGridSize(float size) = 0;
         //! Set the angular step.
@@ -48,6 +44,8 @@ namespace AzManipulatorTestFramework
         //! Updates the visibility state.
         //! Updates which entities are currently visible given the current camera state.
         virtual void UpdateVisibility() = 0;
+        //! Set if sticky select is enabled or not.
+        virtual void SetStickySelect(bool enabled) = 0;
     };
 
     //! This interface is used to simulate the manipulator manager while the manipulators are under test.
@@ -82,15 +80,15 @@ namespace AzManipulatorTestFramework
         //! Return the representation of the viewport interaction model.
         ViewportInteractionInterface& GetViewportInteraction()
         {
-            return const_cast<
-                ViewportInteractionInterface&>(const_cast<const ManipulatorViewportInteraction*>(this)->GetViewportInteraction());
+            return const_cast<ViewportInteractionInterface&>(
+                const_cast<const ManipulatorViewportInteraction*>(this)->GetViewportInteraction());
         }
 
         //! Return the const representation of the manipulator manager.
         ManipulatorManagerInterface& GetManipulatorManager()
         {
-            return const_cast<
-                ManipulatorManagerInterface&>(const_cast<const ManipulatorViewportInteraction*>(this)->GetManipulatorManager());
+            return const_cast<ManipulatorManagerInterface&>(
+                const_cast<const ManipulatorViewportInteraction*>(this)->GetManipulatorManager());
         }
     };
 } // namespace AzManipulatorTestFramework

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ImmediateModeActionDispatcher.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ImmediateModeActionDispatcher.h
@@ -52,8 +52,8 @@ namespace AzManipulatorTestFramework
 
     protected:
         // ActionDispatcher ...
-        void EnableSnapToGridImpl() override;
-        void DisableSnapToGridImpl() override;
+        void SetSnapToGridImpl(bool enabled) override;
+        void SetStickySelectImpl(bool enabled) override;
         void GridSizeImpl(float size) override;
         void CameraStateImpl(const AzFramework::CameraState& cameraState) override;
         void MouseLButtonDownImpl() override;

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ViewportInteraction.h
@@ -29,14 +29,13 @@ namespace AzManipulatorTestFramework
         // ViewportInteractionInterface overrides ...
         void SetCameraState(const AzFramework::CameraState& cameraState) override;
         AzFramework::DebugDisplayRequests& GetDebugDisplay() override;
-        void EnableGridSnaping() override;
-        void DisableGridSnaping() override;
-        void EnableAngularSnaping() override;
-        void DisableAngularSnaping() override;
+        void SetGridSnapping(bool enabled) override;
+        void SetAngularSnapping(bool enabled) override;
         void SetGridSize(float size) override;
         void SetAngularStep(float step) override;
         int GetViewportId() const override;
         void UpdateVisibility() override;
+        void SetStickySelect(bool enabled) override;
 
         // ViewportInteractionRequestBus overrides ...
         AzFramework::CameraState GetCameraState() override;
@@ -54,6 +53,7 @@ namespace AzManipulatorTestFramework
         float AngleStep() const override;
         float ManipulatorLineBoundWidth() const override;
         float ManipulatorCircleBoundWidth() const override;
+        bool StickySelectEnabled() const override;
 
         // EditorEntityViewportInteractionRequestBus overrides ...
         void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) override;
@@ -65,6 +65,7 @@ namespace AzManipulatorTestFramework
         AzFramework::CameraState m_cameraState;
         bool m_gridSnapping = false;
         bool m_angularSnapping = false;
+        bool m_stickySelect = true;
         float m_gridSize = 1.0f;
         float m_angularStep = 0.0f;
     };

--- a/Code/Framework/AzManipulatorTestFramework/Source/ImmediateModeActionDispatcher.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ImmediateModeActionDispatcher.cpp
@@ -49,17 +49,17 @@ namespace AzManipulatorTestFramework
         m_viewportManipulatorInteraction.GetManipulatorManager().ConsumeMouseInteractionEvent(*m_event);
     }
 
-    void ImmediateModeActionDispatcher::EnableSnapToGridImpl()
+    void ImmediateModeActionDispatcher::SetSnapToGridImpl(const bool enabled)
     {
-        m_viewportManipulatorInteraction.GetViewportInteraction().EnableGridSnaping();
+        m_viewportManipulatorInteraction.GetViewportInteraction().SetGridSnapping(enabled);
     }
 
-    void ImmediateModeActionDispatcher::DisableSnapToGridImpl()
+    void ImmediateModeActionDispatcher::SetStickySelectImpl(const bool enabled)
     {
-        m_viewportManipulatorInteraction.GetViewportInteraction().DisableGridSnaping();
+        m_viewportManipulatorInteraction.GetViewportInteraction().SetStickySelect(enabled);
     }
 
-    void ImmediateModeActionDispatcher::GridSizeImpl(float size)
+    void ImmediateModeActionDispatcher::GridSizeImpl(const float size)
     {
         m_viewportManipulatorInteraction.GetViewportInteraction().SetGridSize(size);
     }

--- a/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ViewportInteraction.cpp
@@ -6,16 +6,15 @@
  *
  */
 
-#include <AzManipulatorTestFramework/ViewportInteraction.h>
-#include <AzFramework/Viewport/ViewportScreen.h>
 #include <AzFramework/Viewport/CameraState.h>
+#include <AzFramework/Viewport/ViewportScreen.h>
+#include <AzManipulatorTestFramework/ViewportInteraction.h>
 #include <AzToolsFramework/Manipulators/ManipulatorBus.h>
 
 namespace AzManipulatorTestFramework
 {
     // Null debug display for dummy draw calls
-    class NullDebugDisplayRequests
-        : public AzFramework::DebugDisplayRequests
+    class NullDebugDisplayRequests : public AzFramework::DebugDisplayRequests
     {
     public:
         virtual ~NullDebugDisplayRequests() = default;
@@ -76,6 +75,11 @@ namespace AzManipulatorTestFramework
         return 0.1f;
     }
 
+    bool ViewportInteraction::StickySelectEnabled() const
+    {
+        return m_stickySelect;
+    }
+
     void ViewportInteraction::FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntitiesOut)
     {
         visibleEntitiesOut.assign(m_entityVisibilityQuery.Begin(), m_entityVisibilityQuery.End());
@@ -101,24 +105,19 @@ namespace AzManipulatorTestFramework
         return *m_nullDebugDisplayRequests;
     }
 
-    void ViewportInteraction::EnableGridSnaping()
+    void ViewportInteraction::SetGridSnapping(const bool enabled)
     {
-        m_gridSnapping = true;
+        m_gridSnapping = enabled;
     }
 
-    void ViewportInteraction::DisableGridSnaping()
+    void ViewportInteraction::SetAngularSnapping(const bool enabled)
     {
-        m_gridSnapping = false;
+        m_angularSnapping = enabled;
     }
 
-    void ViewportInteraction::EnableAngularSnaping()
+    void ViewportInteraction::SetStickySelect(const bool enabled)
     {
-        m_angularSnapping = true;
-    }
-
-    void ViewportInteraction::DisableAngularSnaping()
-    {
-        m_angularSnapping = false;
+        m_stickySelect = enabled;
     }
 
     void ViewportInteraction::SetGridSize(float size)
@@ -152,4 +151,4 @@ namespace AzManipulatorTestFramework
     {
         return 1.0f;
     }
-}// namespace AzManipulatorTestFramework
+} // namespace AzManipulatorTestFramework

--- a/Code/Framework/AzManipulatorTestFramework/Tests/GridSnappingTest.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Tests/GridSnappingTest.cpp
@@ -76,7 +76,7 @@ namespace UnitTest
                 linearManipulator->SetLocalPosition(action.LocalPosition());
             });
 
-        m_actionDispatcher->EnableSnapToGrid()
+        m_actionDispatcher->SetSnapToGrid(true)
             ->GridSize(5.0f)
             ->CameraState(m_cameraState)
             ->MousePosition(initialPositionScreen)
@@ -114,7 +114,7 @@ namespace UnitTest
                 manipulator->SetLocalPosition(action.LocalPosition());
             });
 
-        actionDispatcher->EnableSnapToGrid()
+        actionDispatcher->SetSnapToGrid(true)
             ->GridSize(1.0f)
             ->CameraState(cameraState)
             ->MousePosition(initialPositionScreen)

--- a/Code/Framework/AzManipulatorTestFramework/Tests/ViewportInteractionTest.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Tests/ViewportInteractionTest.cpp
@@ -48,7 +48,7 @@ namespace UnitTest
     {
         bool snapping = false;
 
-        m_viewportInteraction->EnableGridSnaping();
+        m_viewportInteraction->SetGridSnapping(true);
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
             &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::GridSnappingEnabled);
@@ -60,7 +60,7 @@ namespace UnitTest
     {
         bool snapping = true;
 
-        m_viewportInteraction->DisableGridSnaping();
+        m_viewportInteraction->SetGridSnapping(false);
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
             &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::GridSnappingEnabled);
@@ -75,7 +75,7 @@ namespace UnitTest
 
         m_viewportInteraction->SetGridSize(expectedGridSize);
 
-        m_viewportInteraction->DisableGridSnaping();
+        m_viewportInteraction->SetGridSnapping(false);
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             gridSize, m_viewportInteraction->GetViewportId(),
             &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::GridSize);
@@ -87,7 +87,7 @@ namespace UnitTest
     {
         bool snapping = false;
 
-        m_viewportInteraction->EnableAngularSnaping();
+        m_viewportInteraction->SetAngularSnapping(true);
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
             &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::AngleSnappingEnabled);
@@ -99,7 +99,7 @@ namespace UnitTest
     {
         bool snapping = true;
 
-        m_viewportInteraction->DisableAngularSnaping();
+        m_viewportInteraction->SetAngularSnapping(false);
         AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::EventResult(
             snapping, m_viewportInteraction->GetViewportId(),
             &AzToolsFramework::ViewportInteraction::ViewportSettingsRequestBus::Events::AngleSnappingEnabled);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -196,6 +196,8 @@ namespace AzToolsFramework
             virtual float ManipulatorLineBoundWidth() const = 0;
             //! Returns the current circle (torus) bound width for manipulators.
             virtual float ManipulatorCircleBoundWidth() const = 0;
+            //! Returns if sticky select is enabled or not.
+            virtual bool StickySelectEnabled() const = 0;
 
         protected:
             ~ViewportSettingsRequests() = default;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -77,13 +77,6 @@ namespace AzToolsFramework
         nullptr,
         AZ::ConsoleFunctorFlags::Null,
         "The screen position of the gizmo in normalized (0-1) ndc space");
-    AZ_CVAR(
-        bool,
-        ed_viewportStickySelect,
-        true,
-        nullptr,
-        AZ::ConsoleFunctorFlags::Null,
-        "Sticky select implies a single click will not change selection with an entity already selected");
 
     // strings related to new viewport interaction model (EditorTransformComponentSelection)
     static const char* const TogglePivotTitleRightClick = "Toggle pivot";
@@ -1790,7 +1783,8 @@ namespace AzToolsFramework
 
         CheckDirtyEntityIds();
 
-        const AzFramework::CameraState cameraState = GetCameraState(mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId);
+        const AzFramework::ViewportId viewportId = mouseInteraction.m_mouseInteraction.m_interactionId.m_viewportId;
+        const AzFramework::CameraState cameraState = GetCameraState(viewportId);
 
         m_cachedEntityIdUnderCursor = m_editorHelpers->HandleMouseInteraction(cameraState, mouseInteraction);
 
@@ -1835,7 +1829,11 @@ namespace AzToolsFramework
             return true;
         }
 
-        if (ed_viewportStickySelect)
+        bool stickySelect = false;
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            stickySelect, viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::StickySelectEnabled);
+
+        if (stickySelect)
         {
             // double click to deselect all
             if (Input::DeselectAll(mouseInteraction))
@@ -1891,7 +1889,7 @@ namespace AzToolsFramework
                 return false;
             }
 
-            if (ed_viewportStickySelect)
+            if (stickySelect)
             {
                 return false;
             }
@@ -1900,7 +1898,7 @@ namespace AzToolsFramework
         // standard toggle selection
         if (Input::IndividualSelect(clickOutcome))
         {
-            if (!ed_viewportStickySelect)
+            if (!stickySelect)
             {
                 ChangeSelectedEntity(entityIdUnderCursor);
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -33,8 +33,6 @@
 
 namespace AzToolsFramework
 {
-    AZ_CVAR_EXTERNED(bool, ed_viewportStickySelect);
-
     class EditorVisibleEntityDataCache;
 
     using EntityIdSet = AZStd::unordered_set<AZ::EntityId>; //!< Alias for unordered_set of EntityIds.

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -616,8 +616,6 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, StickySingleClickWithNoSelectionWillSelectEntity)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -629,7 +627,11 @@ namespace UnitTest
         const auto entity1ScreenPosition = AzFramework::WorldToScreen(m_entity1WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(entity1ScreenPosition)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
+            ->MousePosition(entity1ScreenPosition)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // entity is selected
         auto selectedEntitiesAfter = SelectedEntities();
@@ -639,8 +641,6 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, UnstickySingleClickWithNoSelectionWillSelectEntity)
     {
-        AzToolsFramework::ed_viewportStickySelect = false;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -652,7 +652,11 @@ namespace UnitTest
         const auto entity1ScreenPosition = AzFramework::WorldToScreen(m_entity1WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(entity1ScreenPosition)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(false)
+            ->CameraState(m_cameraState)
+            ->MousePosition(entity1ScreenPosition)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // entity is selected
         auto selectedEntitiesAfter = SelectedEntities();
@@ -664,8 +668,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         StickySingleClickOffEntityWithSelectionWillNotDeselectEntity)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -678,7 +680,11 @@ namespace UnitTest
         const auto clickOffPositionScreen = AzFramework::WorldToScreen(clickOffPositionWorld, m_cameraState);
 
         // click the empty space in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(clickOffPositionScreen)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
+            ->MousePosition(clickOffPositionScreen)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // entity was not deselected
         using ::testing::Eq;
@@ -690,8 +696,6 @@ namespace UnitTest
     TEST_F(
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, UnstickySingleClickOffEntityWithSelectionWillDeselectEntity)
     {
-        AzToolsFramework::ed_viewportStickySelect = false;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -703,7 +707,11 @@ namespace UnitTest
         const auto clickOffPositionScreen = AzFramework::WorldToScreen(clickOffPositionWorld, m_cameraState);
 
         // click the empty space in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(clickOffPositionScreen)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(false)
+            ->CameraState(m_cameraState)
+            ->MousePosition(clickOffPositionScreen)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // entity was deselected
         auto selectedEntitiesAfter = SelectedEntities();
@@ -714,8 +722,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         StickySingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -725,7 +731,11 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(entity2ScreenPosition)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
+            ->MousePosition(entity2ScreenPosition)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // entity selection was not changed
         using ::testing::Eq;
@@ -738,8 +748,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         UnstickySingleClickOnNewEntityWithSelectionWillChangeSelectedEntity)
     {
-        AzToolsFramework::ed_viewportStickySelect = false;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -749,7 +757,11 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(entity2ScreenPosition)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(false)
+            ->CameraState(m_cameraState)
+            ->MousePosition(entity2ScreenPosition)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // entity selection was changed
         using ::testing::Eq;
@@ -762,8 +774,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         StickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -773,7 +783,7 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(true)->CameraState(m_cameraState)
             ->MousePosition(entity2ScreenPosition)
             ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
             ->MouseLButtonDown()
@@ -789,8 +799,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         UnstickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = false;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -800,7 +808,8 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(false)
+            ->CameraState(m_cameraState)
             ->MousePosition(entity2ScreenPosition)
             ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
             ->MouseLButtonDown()
@@ -816,8 +825,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         StickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -827,7 +834,8 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
             ->MousePosition(entity2ScreenPosition)
             ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
             ->MouseLButtonDown()
@@ -843,8 +851,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         UnstickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = false;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -854,7 +860,8 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(false)
+            ->CameraState(m_cameraState)
             ->MousePosition(entity2ScreenPosition)
             ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
             ->MouseLButtonDown()
@@ -868,8 +875,6 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, BoxSelectWithNoInitialSelectionAddsEntitiesToSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -882,7 +887,8 @@ namespace UnitTest
         const auto endingPositionWorldBoxSelect = AzFramework::WorldToScreen(AZ::Vector3(5.0f, 16.5f, 9.5f), m_cameraState);
 
         // perform a box select in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
             ->MousePosition(beginningPositionWorldBoxSelect)
             ->MouseLButtonDown()
             ->MousePosition(endingPositionWorldBoxSelect)
@@ -896,8 +902,6 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, BoxSelectWithSelectionAppendsEntitiesToSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -914,7 +918,8 @@ namespace UnitTest
         const auto endingPositionWorldBoxSelect2 = AzFramework::WorldToScreen(AZ::Vector3(5.0f, 16.5f, 9.5f), m_cameraState);
 
         // perform a box select in the viewport (going left and right)
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
             ->MousePosition(beginningPositionWorldBoxSelect1)
             ->MouseLButtonDown()
             ->MousePosition(endingPositionWorldBoxSelect1)
@@ -933,8 +938,6 @@ namespace UnitTest
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture,
         BoxSelectHoldingCtrlWithSelectionRemovesEntitiesFromSelection)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -949,7 +952,8 @@ namespace UnitTest
         const auto endingPositionWorldBoxSelect = AzFramework::WorldToScreen(AZ::Vector3(5.0f, 16.5f, 9.5f), m_cameraState);
 
         // perform a box select in the viewport
-        m_actionDispatcher->CameraState(m_cameraState)
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
             ->MousePosition(beginningPositionWorldBoxSelect)
             ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
             ->MouseLButtonDown()
@@ -963,8 +967,6 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, StickyDoubleClickWithSelectionWillDeselectEntities)
     {
-        AzToolsFramework::ed_viewportStickySelect = true;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -980,7 +982,10 @@ namespace UnitTest
         const auto clickOffPositionScreen = AzFramework::WorldToScreen(clickOffPositionWorld, m_cameraState);
 
         // double click to deselect entities
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(clickOffPositionScreen)->MouseLButtonDoubleClick();
+        m_actionDispatcher->SetStickySelect(true)
+            ->CameraState(m_cameraState)
+            ->MousePosition(clickOffPositionScreen)
+            ->MouseLButtonDoubleClick();
 
         // no entities are selected
         auto selectedEntitiesAfter = SelectedEntities();
@@ -989,8 +994,6 @@ namespace UnitTest
 
     TEST_F(EditorTransformComponentSelectionViewportPickingManipulatorTestFixture, UnstickyUndoOperationForChangeInSelectionIsAtomic)
     {
-        AzToolsFramework::ed_viewportStickySelect = false;
-
         PositionEntities();
         PositionCamera(m_cameraState);
 
@@ -1000,7 +1003,11 @@ namespace UnitTest
         const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
 
         // single click select entity2
-        m_actionDispatcher->CameraState(m_cameraState)->MousePosition(entity2ScreenPosition)->MouseLButtonDown()->MouseLButtonUp();
+        m_actionDispatcher->SetStickySelect(false)
+            ->CameraState(m_cameraState)
+            ->MousePosition(entity2ScreenPosition)
+            ->MouseLButtonDown()
+            ->MouseLButtonUp();
 
         // undo action
         AzToolsFramework::ToolsApplicationRequestBus::Broadcast(&AzToolsFramework::ToolsApplicationRequestBus::Events::UndoPressed);


### PR DESCRIPTION
This PR moves the AZ_CVAR to the SettingsRegistry.

It also includes some tidy-up changes to the manipulator test framework as well