### PR TITLE
Added array index operators to Spawnable(Const)EntityContainerView.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
@@ -73,6 +73,11 @@ namespace AzFramework
         return AZStd::distance(m_begin, m_end);
     }
 
+    bool SpawnableEntityContainerView::empty() const
+    {
+        return m_begin == m_end;
+    }
+
 
     //
     // SpawnableConstEntityContainerView
@@ -135,6 +140,11 @@ namespace AzFramework
     size_t SpawnableConstEntityContainerView::size() const
     {
         return AZStd::distance(m_begin, m_end);
+    }
+
+    bool SpawnableConstEntityContainerView::empty() const
+    {
+        return m_begin == m_end;
     }
 
 

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
@@ -58,13 +58,13 @@ namespace AzFramework
 
     AZ::Entity* SpawnableEntityContainerView::operator[](size_t n)
     {
-        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
+        AZ_Assert(n < size(), "Index %zu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
         return *(m_begin + n);
     }
 
     const AZ::Entity* SpawnableEntityContainerView::operator[](size_t n) const
     {
-        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
+        AZ_Assert(n < size(), "Index %zu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
         return *(m_begin + n);
     }
 
@@ -122,13 +122,13 @@ namespace AzFramework
 
     const AZ::Entity* SpawnableConstEntityContainerView::operator[](size_t n)
     {
-        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Const Entity Container View", n, size());
+        AZ_Assert(n < size(), "Index %zu is out of bounds (size: %llu) for Spawnable Const Entity Container View", n, size());
         return *(m_begin + n);
     }
 
     const AZ::Entity* SpawnableConstEntityContainerView::operator[](size_t n) const
     {
-        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
+        AZ_Assert(n < size(), "Index %zu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
         return *(m_begin + n);
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
@@ -36,6 +36,16 @@ namespace AzFramework
         return m_end;
     }
 
+    const AZ::Entity* const* SpawnableEntityContainerView::begin() const
+    {
+        return m_begin;
+    }
+
+    const AZ::Entity* const* SpawnableEntityContainerView::end() const
+    {
+        return m_end;
+    }
+
     const AZ::Entity* const* SpawnableEntityContainerView::cbegin()
     {
         return m_begin;
@@ -46,7 +56,19 @@ namespace AzFramework
         return m_end;
     }
 
-    size_t SpawnableEntityContainerView::size()
+    AZ::Entity* SpawnableEntityContainerView::operator[](size_t n)
+    {
+        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
+        return *(m_begin + n);
+    }
+
+    const AZ::Entity* SpawnableEntityContainerView::operator[](size_t n) const
+    {
+        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
+        return *(m_begin + n);
+    }
+
+    size_t SpawnableEntityContainerView::size() const
     {
         return AZStd::distance(m_begin, m_end);
     }
@@ -78,6 +100,16 @@ namespace AzFramework
         return m_end;
     }
 
+    const AZ::Entity* const* SpawnableConstEntityContainerView::begin() const
+    {
+        return m_begin;
+    }
+
+    const AZ::Entity* const* SpawnableConstEntityContainerView::end() const
+    {
+        return m_end;
+    }
+
     const AZ::Entity* const* SpawnableConstEntityContainerView::cbegin()
     {
         return m_begin;
@@ -88,7 +120,19 @@ namespace AzFramework
         return m_end;
     }
 
-    size_t SpawnableConstEntityContainerView::size()
+    const AZ::Entity* SpawnableConstEntityContainerView::operator[](size_t n)
+    {
+        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Const Entity Container View", n, size());
+        return *(m_begin + n);
+    }
+
+    const AZ::Entity* SpawnableConstEntityContainerView::operator[](size_t n) const
+    {
+        AZ_Assert(n <= size(), "Index %llu is out of bounds (size: %llu) for Spawnable Entity Container View", n, size());
+        return *(m_begin + n);
+    }
+
+    size_t SpawnableConstEntityContainerView::size() const
     {
         return AZStd::distance(m_begin, m_end);
     }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -36,17 +36,18 @@ namespace AzFramework
         SpawnableEntityContainerView(AZ::Entity** begin, size_t length);
         SpawnableEntityContainerView(AZ::Entity** begin, AZ::Entity** end);
 
-        AZ::Entity** begin();
-        AZ::Entity** end();
-        const AZ::Entity* const* begin() const;
-        const AZ::Entity* const* end() const;
-        const AZ::Entity* const* cbegin();
-        const AZ::Entity* const* cend();
+        [[nodiscard]] AZ::Entity** begin();
+        [[nodiscard]] AZ::Entity** end();
+        [[nodiscard]] const AZ::Entity* const* begin() const;
+        [[nodiscard]] const AZ::Entity* const* end() const;
+        [[nodiscard]] const AZ::Entity* const* cbegin();
+        [[nodiscard]] const AZ::Entity* const* cend();
 
-        AZ::Entity* operator[](size_t n);
-        const AZ::Entity* operator[](size_t n) const;
+        [[nodiscard]] AZ::Entity* operator[](size_t n);
+        [[nodiscard]] const AZ::Entity* operator[](size_t n) const;
 
-        size_t size() const;
+        [[nodiscard]] size_t size() const;
+        [[nodiscard]] bool empty() const;
 
     private:
         AZ::Entity** m_begin;
@@ -59,17 +60,18 @@ namespace AzFramework
         SpawnableConstEntityContainerView(AZ::Entity** begin, size_t length);
         SpawnableConstEntityContainerView(AZ::Entity** begin, AZ::Entity** end);
 
-        const AZ::Entity* const* begin();
-        const AZ::Entity* const* end();
-        const AZ::Entity* const* begin() const;
-        const AZ::Entity* const* end() const;
-        const AZ::Entity* const* cbegin();
-        const AZ::Entity* const* cend();
+        [[nodiscard]] const AZ::Entity* const* begin();
+        [[nodiscard]] const AZ::Entity* const* end();
+        [[nodiscard]] const AZ::Entity* const* begin() const;
+        [[nodiscard]] const AZ::Entity* const* end() const;
+        [[nodiscard]] const AZ::Entity* const* cbegin();
+        [[nodiscard]] const AZ::Entity* const* cend();
 
-        const AZ::Entity* operator[](size_t n);
-        const AZ::Entity* operator[](size_t n) const;
+        [[nodiscard]] const AZ::Entity* operator[](size_t n);
+        [[nodiscard]] const AZ::Entity* operator[](size_t n) const;
 
-        size_t size() const;
+        [[nodiscard]] size_t size() const;
+        [[nodiscard]] bool empty() const;
 
     private:
         AZ::Entity** m_begin;

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -38,9 +38,15 @@ namespace AzFramework
 
         AZ::Entity** begin();
         AZ::Entity** end();
+        const AZ::Entity* const* begin() const;
+        const AZ::Entity* const* end() const;
         const AZ::Entity* const* cbegin();
         const AZ::Entity* const* cend();
-        size_t size();
+
+        AZ::Entity* operator[](size_t n);
+        const AZ::Entity* operator[](size_t n) const;
+
+        size_t size() const;
 
     private:
         AZ::Entity** m_begin;
@@ -55,9 +61,15 @@ namespace AzFramework
 
         const AZ::Entity* const* begin();
         const AZ::Entity* const* end();
+        const AZ::Entity* const* begin() const;
+        const AZ::Entity* const* end() const;
         const AZ::Entity* const* cbegin();
         const AZ::Entity* const* cend();
-        size_t size();
+
+        const AZ::Entity* operator[](size_t n);
+        const AZ::Entity* operator[](size_t n) const;
+
+        size_t size() const;
 
     private:
         AZ::Entity** m_begin;

--- a/Code/Framework/AzFramework/Tests/Spawnable/SpawnableEntitiesInterfaceTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Spawnable/SpawnableEntitiesInterfaceTests.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/std/containers/array.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <AzTest/AzTest.h>
+
+namespace UnitTest
+{
+    //
+    // SpawnableEntityContainerView
+    //
+
+    class SpawnableEntityContainerViewTest : public ::testing::Test
+    {
+    protected:
+        AZStd::array<AZ::Entity*, 4> m_values{ reinterpret_cast<AZ::Entity*>(1), reinterpret_cast<AZ::Entity*>(2),
+                                               reinterpret_cast<AZ::Entity*>(3), reinterpret_cast<AZ::Entity*>(4) };
+        AzFramework::SpawnableEntityContainerView m_view{ m_values.begin(), m_values.end() };
+    };
+
+    TEST_F(SpawnableEntityContainerViewTest, begin_Get_MatchesBeginOfArray)
+    {
+        EXPECT_EQ(m_view.begin(), m_values.begin());
+    }
+
+    TEST_F(SpawnableEntityContainerViewTest, end_Get_MatchesEndOfArray)
+    {
+        EXPECT_EQ(m_view.end(), m_values.end());
+    }
+
+    TEST_F(SpawnableEntityContainerViewTest, cbegin_Get_MatchesBeginOfArray)
+    {
+        EXPECT_EQ(m_view.cbegin(), m_values.cbegin());
+    }
+
+    TEST_F(SpawnableEntityContainerViewTest, cend_Get_MatchesEndOfArray)
+    {
+        EXPECT_EQ(m_view.cend(), m_values.cend());
+    }
+
+    TEST_F(SpawnableEntityContainerViewTest, IndexOperator_Get_MatchesThirdElement)
+    {
+        EXPECT_EQ(m_view[2], m_values[2]);
+    }
+
+    TEST_F(SpawnableEntityContainerViewTest, Size_Get_MatchesSizeOfArray)
+    {
+        EXPECT_EQ(m_view.size(), m_values.size());
+    }
+
+
+
+    //
+    // SpawnableConstEntityContainerView
+    //
+
+    class SpawnableConstEntityContainerViewTest : public ::testing::Test
+    {
+    protected:
+        AZStd::array<AZ::Entity*, 4> m_values{ reinterpret_cast<AZ::Entity*>(1), reinterpret_cast<AZ::Entity*>(2),
+                                               reinterpret_cast<AZ::Entity*>(3), reinterpret_cast<AZ::Entity*>(4) };
+        AzFramework::SpawnableConstEntityContainerView m_view{ m_values.begin(), m_values.end() };
+    };
+
+    TEST_F(SpawnableConstEntityContainerViewTest, begin_Get_MatchesBeginOfArray)
+    {
+        EXPECT_EQ(m_view.begin(), m_values.begin());
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, end_Get_MatchesEndOfArray)
+    {
+        EXPECT_EQ(m_view.end(), m_values.end());
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, cbegin_Get_MatchesBeginOfArray)
+    {
+        EXPECT_EQ(m_view.cbegin(), m_values.cbegin());
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, cend_Get_MatchesEndOfArray)
+    {
+        EXPECT_EQ(m_view.cend(), m_values.cend());
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, IndexOperator_Get_MatchesThirdElement)
+    {
+        EXPECT_EQ(m_view[2], m_values[2]);
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, Size_Get_MatchesSizeOfArray)
+    {
+        EXPECT_EQ(m_view.size(), m_values.size());
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzFramework/Tests/Spawnable/SpawnableEntitiesInterfaceTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Spawnable/SpawnableEntitiesInterfaceTests.cpp
@@ -55,6 +55,16 @@ namespace UnitTest
         EXPECT_EQ(m_view.size(), m_values.size());
     }
 
+    TEST_F(SpawnableEntityContainerViewTest, empty_GetFromFilledArray_ReturnsFalse)
+    {
+        EXPECT_FALSE(m_view.empty());
+    }
+
+    TEST_F(SpawnableEntityContainerViewTest, empty_GetFromEmtpyView_ReturnsTrue)
+    {
+        AzFramework::SpawnableEntityContainerView view{ nullptr, nullptr };
+        EXPECT_TRUE(view.empty());
+    }
 
 
     //
@@ -94,8 +104,19 @@ namespace UnitTest
         EXPECT_EQ(m_view[2], m_values[2]);
     }
 
-    TEST_F(SpawnableConstEntityContainerViewTest, Size_Get_MatchesSizeOfArray)
+    TEST_F(SpawnableConstEntityContainerViewTest, size_Get_MatchesSizeOfArray)
     {
         EXPECT_EQ(m_view.size(), m_values.size());
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, empty_GetFromFilledArray_ReturnsFalse)
+    {
+        EXPECT_FALSE(m_view.empty());
+    }
+
+    TEST_F(SpawnableConstEntityContainerViewTest, empty_GetFromEmtpyView_ReturnsTrue)
+    {
+        AzFramework::SpawnableConstEntityContainerView view{ nullptr, nullptr };
+        EXPECT_TRUE(view.empty());
     }
 } // namespace UnitTest

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -8,6 +8,7 @@
 
 set(FILES
     ../../AzCore/Tests/Main.cpp
+    Spawnable/SpawnableEntitiesInterfaceTests.cpp
     Spawnable/SpawnableEntitiesManagerTests.cpp
     ArchiveCompressionTests.cpp
     ArchiveTests.cpp


### PR DESCRIPTION
This commit also includes some tweaks to the begin/end functions and unit tests.

Ticket: https://github.com/o3de/o3de/issues/4110

Signed-off-by: AMZN-koppersr <82230785+AMZN-koppersr@users.noreply.github.com>