### PR TITLE
Allow for `AZCoreLogSink::Disconnect()` to be called more than once

### DIFF
--- a/Code/Legacy/CrySystem/AZCoreLogSink.h
+++ b/Code/Legacy/CrySystem/AZCoreLogSink.h
@@ -46,6 +46,7 @@ public:
     {
         GetInstance().BusDisconnect();
         delete GetInstance().m_ignoredAsserts;
+        GetInstance().m_ignoredAsserts = nullptr;
     }
 
     static AZCoreLogSink& GetInstance()


### PR DESCRIPTION
Fix up for b53bf52e0dc0a2af6886b35478a9c65eb64e03ba:

For `Disconnect()` to be able to be called more than once, the pointer that `Disconnect()` calls `delete` on needs to be set to `nullptr`. Calling `delete` on a `nullptr` does nothing, so the next time `Disconnect()` is called, it does not attempt to re-delete the same pointer.

Signed-off-by: Chris Burel <burelc@amazon.com>