### PR TITLE
Fix missing virtual destructor causing debug build failure

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/EBus.h
+++ b/Code/Framework/AzCore/AzCore/EBus/EBus.h
@@ -1717,6 +1717,7 @@ AZ_POP_DISABLE_WARNING
         {
             EBusRouterNode<typename EBus::InterfaceType> m_routerNode;
         public:
+            virtual ~EBusNestedVersionRouter() = default;
             template<class Container>
             void BusRouterConnect(Container& container, int order = 0);
 


### PR DESCRIPTION
Fixes the following:

```
[2021-09-16T05:41:47.746Z] D:\workspace\o3de\Code\Framework\AzCore\AzCore/EBus/EBus.h(1731,1): error C4265: 'AZ::Internal::EBusNestedVersionRouter<AZ::EBus<UnitTest::EBusInterfaceV2,Interface>>': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly [D:\workspace\o3de\build\windows_vs2019\Code\Framework\AzCore\AzCore.Tests.vcxproj]
[2021-09-16T05:41:47.746Z]           with
[2021-09-16T05:41:47.746Z]           [
[2021-09-16T05:41:47.746Z]               Interface=UnitTest::EBusInterfaceV2
[2021-09-16T05:41:47.746Z]           ]
[2021-09-16T05:41:47.746Z]           };
[2021-09-16T05:41:47.746Z]   ^
[2021-09-16T05:41:47.746Z]   D:/workspace/o3de/Code/Framework/AzCore/Tests/EBus.cpp(2439): note: see reference to class template instantiation 'AZ::Internal::EBusNestedVersionRouter<AZ::EBus<UnitTest::EBusInterfaceV2,Interface>>' being compiled
[2021-09-16T05:41:47.746Z]           with
[2021-09-16T05:41:47.746Z]           [
[2021-09-16T05:41:47.746Z]               Interface=UnitTest::EBusInterfaceV2
[2021-09-16T05:41:47.746Z]           ]
[2021-09-16T05:41:47.746Z]               {
[2021-09-16T05:41:47.746Z]   D:/workspace/o3de/Code/Framework/AzCore/Tests/EBus.cpp(2492): note: see reference to class template instantiation 'UnitTest::EBusInterfaceV2::RouterPolicy<AZ::EBus<UnitTest::EBusInterfaceV2,Interface>>::V2toV1Router' being compiled
[2021-09-16T05:41:47.746Z]           with
[2021-09-16T05:41:47.746Z]           [
[2021-09-16T05:41:47.746Z]               Interface=UnitTest::EBusInterfaceV2
[2021-09-16T05:41:47.746Z]           ]
[2021-09-16T05:41:47.746Z]               V2toV1Router m_v2toV1Router;
[2021-09-16T05:41:47.746Z]   D:\workspace\o3de\Code\Framework\AzCore\AzCore/EBus/EBus.h(495): note: see reference to class template instantiation 'UnitTest::EBusInterfaceV2::RouterPolicy<AZ::EBus<UnitTest::EBusInterfaceV2,Interface>>' being compiled
[2021-09-16T05:41:47.746Z]           with
[2021-09-16T05:41:47.746Z]           [
[2021-09-16T05:41:47.746Z]               Interface=UnitTest::EBusInterfaceV2
[2021-09-16T05:41:47.746Z]           ]
[2021-09-16T05:41:47.746Z]           using RouterProcessingState = typename RouterPolicy::EventProcessingState;
[2021-09-16T05:41:47.746Z]   D:/workspace/o3de/Code/Framework/AzCore/Tests/EBus.cpp(2542): note: see reference to class template instantiation 'AZ::EBus<UnitTest::EBusInterfaceV2,Interface>' being compiled
[2021-09-16T05:41:47.746Z]           with
[2021-09-16T05:41:47.746Z]           [
[2021-09-16T05:41:47.746Z]               Interface=UnitTest::EBusInterfaceV2
[2021-09-16T05:41:47.746Z]           ]
[2021-09-16T05:41:47.746Z]           {
[2021-09-16T05:41:47.746Z] D:/workspace/o3de/Code/Framework/AzCore/Tests/EBus.cpp(2451,1): error C4265: 'UnitTest::EBusInterfaceV2::RouterPolicy<AZ::EBus<UnitTest::EBusInterfaceV2,Interface>>::V2toV1Router': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly [D:\workspace\o3de\build\windows_vs2019\Code\Framework\AzCore\AzCore.Tests.vcxproj]
[2021-09-16T05:41:47.746Z]           with
[2021-09-16T05:41:47.746Z]           [
[2021-09-16T05:41:47.746Z]               Interface=UnitTest::EBusInterfaceV2
[2021-09-16T05:41:47.746Z]           ]
[2021-09-16T05:41:47.746Z]               };
[2021-09-16T05:41:47.746Z]   ^
```

Signed-off-by: Steve Pham <spham@amazon.com>