### PR TITLE
Fixed the Comment component viewport icon.

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Editor/EditorCommentComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Editor/EditorCommentComponent.cpp
@@ -30,7 +30,7 @@ namespace LmbrCentral
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::Category, "Editor")
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Comment.svg")
-                        ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Comment.png")
+                        ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Comment.svg")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZStd::vector<AZ::Crc32>({ AZ_CRC("Level", 0x9aeacc13), AZ_CRC("Game", 0x232b318c), AZ_CRC("Layer", 0xe4db211a) }))
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/comment/")


### PR DESCRIPTION
Fixes #4049 

Tested the repro steps and verified the error message no longer displays, and the Comment component viewport icon now shows as intended.

![CommentViewportIconWorking](https://user-images.githubusercontent.com/7519264/133660636-6bff4a00-7629-4063-ab84-0573561d94bc.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>