### PR TITLE
Remove legacy Cry dependencies from the Camera Gem

### DIFF
--- a/Gems/Camera/Code/CMakeLists.txt
+++ b/Gems/Camera/Code/CMakeLists.txt
@@ -18,8 +18,8 @@ ly_add_target(
         PUBLIC
             Gem::Atom_RPI.Public
             AZ::AtomCore
-        PRIVATE
-            Legacy::CryCommon
+            AZ::AzCore
+            AZ::AzFramework
 )
 
 ly_add_target(
@@ -32,7 +32,6 @@ ly_add_target(
             Source
     BUILD_DEPENDENCIES
         PRIVATE
-            Legacy::CryCommon
             Gem::Camera.Static
 )
 
@@ -56,9 +55,6 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 Source
         BUILD_DEPENDENCIES
             PRIVATE
-                Legacy::CryCommon
-                Legacy::Editor.Headers
-                Legacy::EditorCommon
                 AZ::AzToolsFramework
                 Gem::Camera.Static
     )

--- a/Gems/Camera/Code/Source/CameraComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraComponent.cpp
@@ -14,9 +14,7 @@
 
 #include "CameraComponent.h"
 
-#include <MathConversion.h>
 #include <AzCore/Math/MatrixUtils.h>
-#include <IRenderer.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 
 namespace Camera

--- a/Gems/Camera/Code/Source/CameraComponent.h
+++ b/Gems/Camera/Code/Source/CameraComponent.h
@@ -11,9 +11,6 @@
 #include <AzFramework/Components/ComponentAdapter.h>
 
 #include <AzFramework/Components/CameraBus.h>
-#include <IViewSystem.h>
-#include <ISystem.h>
-#include <Cry_Camera.h>
 #include <CameraComponentController.h>
 
 #include <Atom/RPI.Public/Base.h>

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -9,7 +9,6 @@
 #include "CameraComponentController.h"
 #include "CameraViewRegistrationBus.h"
 
-#include <MathConversion.h>
 #include <AzCore/Math/MatrixUtils.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
@@ -53,7 +52,7 @@ namespace Camera
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_fov, "Field of view", "Vertical field of view in degrees")
-                        ->Attribute(AZ::Edit::Attributes::Min, MIN_FOV)
+                        ->Attribute(AZ::Edit::Attributes::Min, MinFoV)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " degrees")
                         ->Attribute(AZ::Edit::Attributes::Step, 1.f)
                         ->Attribute(AZ::Edit::Attributes::Max, AZ::RadToDeg(AZ::Constants::Pi) - 0.0001f)       //We assert at fovs >= Pi so set the max for this field to be just under that
@@ -61,7 +60,7 @@ namespace Camera
                         ->Attribute(AZ::Edit::Attributes::Visibility, &CameraComponentConfig::GetPerspectiveParameterVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CameraComponentConfig::m_nearClipDistance, "Near clip distance",
                         "Distance to the near clip plane of the view Frustum")
-                        ->Attribute(AZ::Edit::Attributes::Min, CAMERA_MIN_NEAR)
+                        ->Attribute(AZ::Edit::Attributes::Min, MinimumNearPlaneDistance)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " m")
                         ->Attribute(AZ::Edit::Attributes::Step, 0.1f)
                         ->Attribute(AZ::Edit::Attributes::Max, &CameraComponentConfig::GetFarClipDistance)
@@ -150,6 +149,11 @@ namespace Camera
         }
     }
 
+    void CameraComponentController::SetShouldActivateFunction(AZStd::function<bool()> shouldActivateFunction)
+    {
+        m_shouldActivateFn = shouldActivateFunction;
+    }
+
     void CameraComponentController::Reflect(AZ::ReflectContext* context)
     {
         CameraComponentConfig::Reflect(context);
@@ -202,36 +206,6 @@ namespace Camera
     {
         m_entityId = entityId;
 
-        if ((!m_viewSystem)||(!m_system))
-        {
-            // perform first-time init
-            if (gEnv)
-            {
-                m_system = gEnv->pSystem;
-            }
-            if (m_system)
-            {
-                // Initialize local view.
-                m_viewSystem = m_system->GetIViewSystem();
-                if (!m_viewSystem)
-                {
-                    AZ_Error("CameraComponent", m_viewSystem != nullptr, "The CameraComponent shouldn't be used without a local view system");
-                }
-            }
-        }
-
-        if (m_viewSystem)
-        {
-            if (m_view == nullptr)
-            {
-                m_view = m_viewSystem->CreateView();
-
-                AZ::Entity* entity = nullptr;
-                AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, m_entityId);
-                m_view->LinkTo(entity);
-            }
-        }
-
         auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
         if (atomViewportRequests)
         {
@@ -270,9 +244,8 @@ namespace Camera
         CameraBus::Handler::BusConnect();
         CameraNotificationBus::Broadcast(&CameraNotificationBus::Events::OnCameraAdded, m_entityId);
 
-        // Activate our camera if we're running from the launcher or Editor game mode
-        // Otherwise, let the Editor keep managing the active camera
-        if (m_config.m_makeActiveViewOnActivation && (!gEnv || !gEnv->IsEditor() || gEnv->IsEditorGameMode()))
+        // Only activate if we're configured to do so, and our activation call back indicates that we should
+        if (m_config.m_makeActiveViewOnActivation && (!m_shouldActivateFn || m_shouldActivateFn()))
         {
             MakeActiveView();
         }
@@ -284,20 +257,6 @@ namespace Camera
         CameraBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect(m_entityId);
         CameraRequestBus::Handler::BusDisconnect(m_entityId);
-        if (m_viewSystem)
-        {
-            if (m_view != nullptr && m_viewSystem->GetViewId(m_view) != 0)
-            {
-                m_view->Unlink();
-            }
-            if (m_viewSystem->GetActiveView() == m_view)
-            {
-                m_viewSystem->SetActiveView(m_prevViewId);
-            }
-            m_viewSystem->RemoveView(m_view);
-            m_prevViewId = 0;
-            m_view = nullptr;
-        }
 
         auto atomViewportRequests = AZ::Interface<AZ::RPI::ViewportContextRequestsInterface>::Get();
         if (atomViewportRequests)
@@ -429,13 +388,6 @@ namespace Camera
             return;
         }
 
-        // Set Legacy Cry view, if it exists
-        if (m_viewSystem)
-        {
-            m_prevViewId = AZ::u32(m_viewSystem->GetActiveViewId());
-            m_viewSystem->SetActiveView(m_view);
-        }
-
         // Set Atom camera, if it exists
         if (m_atomCamera)
         {
@@ -459,12 +411,6 @@ namespace Camera
         if (m_updatingTransformFromEntity)
         {
             return;
-        }
-
-        if (m_view)
-        {
-            CCamera& camera = m_view->GetCamera();
-            camera.SetMatrix(AZTransformToLYTransform(world.GetOrthogonalized()));
         }
 
         if (m_atomCamera)
@@ -495,25 +441,15 @@ namespace Camera
 
     void CameraComponentController::UpdateCamera()
     {
-        if (m_view)
-        {
-            auto viewParams = *m_view->GetCurrentParams();
-            viewParams.fov = AZ::DegToRad(m_config.m_fov);
-            viewParams.nearplane = m_config.m_nearClipDistance;
-            viewParams.farplane = m_config.m_farClipDistance;
-            m_view->SetCurrentParams(viewParams);
-        }
-
         if (auto viewportContext = GetViewportContext())
         {
             AZ::Matrix4x4 viewToClipMatrix;
-            float aspectRatio = m_view ? m_view->GetCamera().GetPixelAspectRatio() : 1.f;
             if (!m_atomAuxGeom)
             {
                 SetupAtomAuxGeom(viewportContext);
             }
             auto windowSize = viewportContext->GetViewportSize();
-            aspectRatio = aznumeric_cast<float>(windowSize.m_width) / aznumeric_cast<float>(windowSize.m_height);
+            const float aspectRatio = aznumeric_cast<float>(windowSize.m_width) / aznumeric_cast<float>(windowSize.m_height);
 
             // This assumes a reversed depth buffer, in line with other LY Atom integration
             if (m_config.m_orthographic)

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -16,15 +16,12 @@
 #include <Atom/RPI.Public/ViewProviderBus.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 
-#include <IViewSystem.h>
-#include <ISystem.h>
-#include <Cry_Camera.h>
-
 namespace Camera
 {
     static constexpr float DefaultFoV = 75.0f;
     static constexpr float MinFoV = std::numeric_limits<float>::epsilon();
     static constexpr float MaxFoV = AZ::RadToDeg(AZ::Constants::Pi);
+    static constexpr float MinimumNearPlaneDistance = 0.001f;
     static constexpr float DefaultNearPlaneDistance = 0.2f;
     static constexpr float DefaultFarClipPlaneDistance = 1024.0f;
     static constexpr float DefaultFrustumDimension = 256.f;
@@ -68,6 +65,10 @@ namespace Camera
 
         CameraComponentController() = default;
         explicit CameraComponentController(const CameraComponentConfig& config);
+
+        //! Defines a callback for determining whether this camera should push itself to the top of the Atom camera stack.
+        //! Used by the Editor to disable undesirable camera changes in edit mode.
+        void SetShouldActivateFunction(AZStd::function<bool()> shouldActivateFunction);
 
         // Controller interface
         static void Reflect(AZ::ReflectContext* context);
@@ -134,10 +135,6 @@ namespace Camera
         bool m_updatingTransformFromEntity = false;
         bool m_isActiveView = false;
 
-        // Cry view integration
-        IView* m_view = nullptr;
-        AZ::u32 m_prevViewId = 0;
-        IViewSystem* m_viewSystem = nullptr;
-        ISystem* m_system = nullptr;
+        AZStd::function<bool()> m_shouldActivateFn;
     };
 } // namespace Camera

--- a/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
+++ b/Gems/Camera/Code/Source/CameraEditorSystemComponent.cpp
@@ -21,16 +21,11 @@
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 
-#include <IEditor.h>
-#include <ViewManager.h>
-#include <GameEngine.h>
-#include <Objects/BaseObject.h>
-#include <Include/IObjectManager.h>
-
-#include <Cry_Geo.h>
-#include <MathConversion.h>
 #include <AzToolsFramework/API/EditorCameraBus.h>
 #include "ViewportCameraSelectorWindow.h"
+
+#include <QAction>
+#include <QMenu>
 
 namespace Camera
 {
@@ -72,15 +67,6 @@ namespace Camera
 
     void CameraEditorSystemComponent::PopulateEditorGlobalContextMenu(QMenu* menu, const AZ::Vector2&, int flags)
     {
-        IEditor* editor;
-        AzToolsFramework::EditorRequests::Bus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::GetEditor);
-
-        CGameEngine* gameEngine = editor->GetGameEngine();
-        if (!gameEngine || !gameEngine->IsLevelLoaded())
-        {
-            return;
-        }
-
         if (!(flags & AzToolsFramework::EditorEvents::eECMF_HIDE_ENTITY_CREATION))
         {
             QAction* action = menu->addAction(QObject::tr("Create camera entity from view"));
@@ -90,9 +76,6 @@ namespace Camera
 
     void CameraEditorSystemComponent::CreateCameraEntityFromViewport()
     {
-        IEditor* editor = nullptr;
-        AzToolsFramework::EditorRequests::Bus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::GetEditor);
-
         AzFramework::CameraState cameraState{};
         AZ::EBusReduceResult<bool, AZStd::logical_or<bool>> aggregator;
         Camera::EditorCameraRequestBus::BroadcastResult(

--- a/Gems/Camera/Code/Source/CameraGem.cpp
+++ b/Gems/Camera/Code/Source/CameraGem.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AzCore/Module/Module.h>
-#include <IGem.h>
 
 #include "CameraComponent.h"
 #include "CameraSystemComponent.h"
@@ -22,13 +21,13 @@
 namespace Camera
 {
     class CameraModule
-        : public CryHooksModule
+        : public AZ::Module
     {
     public:
         AZ_RTTI(CameraModule, "{C2E72B0D-BCEF-452A-9BFA-03833015258C}", AZ::Module);
 
         CameraModule()
-            : CryHooksModule()
+            : AZ::Module()
         {
             m_descriptors.insert(m_descriptors.end(), {
                 Camera::CameraComponent::CreateDescriptor(),

--- a/Gems/Camera/Code/Source/EditorCameraComponent.cpp
+++ b/Gems/Camera/Code/Source/EditorCameraComponent.cpp
@@ -12,10 +12,9 @@
 #include "EditorCameraComponent.h"
 #include "ViewportCameraSelectorWindow.h"
 
-#include <MathConversion.h>
-#include <IRenderer.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 
 #include <Atom/RPI.Public/ViewportContext.h>
 #include <Atom/RPI.Public/View.h>
@@ -33,6 +32,14 @@ namespace Camera
         CameraComponentConfig controllerConfig = m_controller.GetConfiguration();
         controllerConfig.m_editorEntityId = GetEntityId().operator AZ::u64();
         m_controller.SetConfiguration(controllerConfig);
+        // Only allow our camera to activate with the component if we're currently in game mode.
+        m_controller.SetShouldActivateFunction([]()
+            {
+                bool isInGameMode = true;
+                AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+                    isInGameMode, &AzToolsFramework::EditorEntityContextRequestBus::Events::IsEditorRunningGame);
+                return isInGameMode;
+            });
 
         // Call base class activate, which in turn calls Activate on our controller.
         EditorCameraComponentBase::Activate();

--- a/Gems/Camera/Code/Source/EditorCameraComponent.h
+++ b/Gems/Camera/Code/Source/EditorCameraComponent.h
@@ -21,8 +21,6 @@
 #include <AzFramework/Components/EditorEntityEvents.h>
 #include "CameraComponent.h"
 #include "CameraComponentController.h"
-#include <IViewSystem.h>
-#include <Cry_Camera.h>
 
 #include <Atom/RPI.Public/Base.h>
 

--- a/Gems/Camera/Code/Source/ViewportCameraSelectorWindow.cpp
+++ b/Gems/Camera/Code/Source/ViewportCameraSelectorWindow.cpp
@@ -7,17 +7,14 @@
  */
 #include "ViewportCameraSelectorWindow.h"
 #include "ViewportCameraSelectorWindow_Internals.h"
-#include <IEditor.h>
 #include <qmetatype.h>
 #include <QScopedValueRollback>
 #include <QListView>
 #include <QSortFilterProxyModel>
 #include <QVBoxLayout>
 #include <QLabel>
-#include <ViewManager.h>
-#include <Maestro/Bus/EditorSequenceBus.h>
-#include <Maestro/Bus/SequenceComponentBus.h>
 #include <AzToolsFramework/API/EditorCameraBus.h>
+#include <AzToolsFramework/API/ViewPaneOptions.h>
 
 namespace Qt
 {
@@ -308,7 +305,7 @@ namespace Camera
 
     void RegisterViewportCameraSelectorWindow()
     {
-        QtViewOptions viewOptions;
+        AzToolsFramework::ViewPaneOptions viewOptions;
         viewOptions.isPreview = true;
         viewOptions.showInMenu = true;
         viewOptions.preferedDockingArea = Qt::DockWidgetArea::LeftDockWidgetArea;


### PR DESCRIPTION
This fixes the camera crash outlined in https://github.com/o3de/o3de/issues/4170 by removing the component's view reference.

Signed-off-by: nvsickle <nvsickle@amazon.com>