### PR TITLE
Add support for marking 3rdParty libraries as supplied by the host system

### DIFF
--- a/cmake/3rdParty.cmake
+++ b/cmake/3rdParty.cmake
@@ -6,6 +6,17 @@
 #
 #
 
+define_property(TARGET PROPERTY LY_SYSTEM_LIBRARY
+    BRIEF_DOCS "Defines a 3rdParty library as a system library"
+    FULL_DOCS [[
+        Property which is set on third party targets that should be considered
+        as provided by the system. Such targets are excluded from the runtime
+        dependencies considerations, and are not distributed as part of the
+        O3DE SDK package. Instead, users of the SDK are expected to install
+        such a third party library themselves.
+    ]]
+)
+
 # Do not overcomplicate searching for the 3rdParty path, if it is not easy to find,
 # the user should define it.
 
@@ -79,9 +90,10 @@ endfunction()
 #                             "fileA\nMy/Output/Subfolder/lib"
 #                             "fileB\nMy/Output/Subfolder/bin"
 #
+# \arg:SYSTEM           If specified, the library is considered a system library, and is not copied to the build output directory
 function(ly_add_external_target)
 
-    set(options)
+    set(options SYSTEM)
     set(oneValueArgs NAME VERSION 3RDPARTY_DIRECTORY PACKAGE 3RDPARTY_ROOT_DIRECTORY OUTPUT_SUBDIRECTORY)
     set(multiValueArgs HEADER_CHECK COMPILE_DEFINITIONS INCLUDE_DIRECTORIES BUILD_DEPENDENCIES RUNTIME_DEPENDENCIES)
 
@@ -298,6 +310,10 @@ function(ly_add_external_target)
                 INTERFACE
                     ${ly_add_external_target_BUILD_DEPENDENCIES}
             )
+        endif()
+
+        if(ly_add_external_target_SYSTEM)
+            set_target_properties(3rdParty::${NAME_WITH_NAMESPACE} PROPERTIES LY_SYSTEM_LIBRARY TRUE)
         endif()
 
     endif()

--- a/cmake/Platform/Common/RuntimeDependencies_common.cmake
+++ b/cmake/Platform/Common/RuntimeDependencies_common.cmake
@@ -70,12 +70,23 @@ function(ly_get_runtime_dependencies ly_RUNTIME_DEPENDENCIES ly_TARGET)
 
     # link dependencies are not runtime dependencies (we dont have anything to copy) however, we need to traverse
     # them since them or some dependency downstream could have something to copy over
-    foreach(link_dependency ${link_dependencies})
-        if(NOT ${link_dependency} MATCHES "^::@") # Skip wraping produced when targets are not created in the same directory (https://cmake.org/cmake/help/latest/prop_tgt/LINK_LIBRARIES.html)
-            unset(dependencies)
-            ly_get_runtime_dependencies(dependencies ${link_dependency})
-            list(APPEND all_runtime_dependencies ${dependencies})
+    foreach(link_dependency IN LISTS link_dependencies)
+        if(${link_dependency} MATCHES "^::@")
+            # Skip wraping produced when targets are not created in the same directory
+            # (https://cmake.org/cmake/help/latest/prop_tgt/LINK_LIBRARIES.html)
+            continue()
         endif()
+
+        if(TARGET ${link_dependency} AND link_dependency MATCHES "^3rdParty::")
+            get_target_property(is_system_library ${link_dependency} LY_SYSTEM_LIBRARY)
+            if(is_system_library)
+                continue()
+            endif()
+        endif()
+
+        unset(dependencies)
+        ly_get_runtime_dependencies(dependencies ${link_dependency})
+        list(APPEND all_runtime_dependencies ${dependencies})
     endforeach()
 
     # For manual dependencies, we want to copy over the dependency and traverse them


### PR DESCRIPTION
This allows 3rdParty libraries to be marked as "system" libraries. These libraries are considered to be part of the host system, and are not copied to the build output directory.