### PR TITLE
Switch job dependency type to OrderOnce for material assets when property names are present.

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -47,7 +47,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
-            materialBuilderDescriptor.m_version = 108;
+            materialBuilderDescriptor.m_version = 108; // Set materialtype dependency to OrderOnce
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();
@@ -223,8 +223,11 @@ namespace AZ
                         parentMaterialPath = materialTypePath;
                     }
 
-                    // If includeMaterialPropertyNames is true, then we need materials to depend on materialtype only once in order to get
-                    // the property names. After the initial processing, materials will no longer be dependent on materialtype files.
+                    // If includeMaterialPropertyNames is false, then a job dependency is needed so the material builder can validate MaterialAsset properties
+                    // against the MaterialTypeAsset at asset build time.
+                    // If includeMaterialPropertyNames is true, the material properties will be validated at runtime when the material is loaded, so the job dependency
+                    // is needed only for first-time processing to set up the initial MaterialAsset. This speeds up AP processing time when a materialtype file
+                    // is edited (e.g. 10s when editing StandardPBR.materialtype on AtomTest project from 45s).
                     bool includeMaterialPropertyNames = true;
                     if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
                     {

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -9,7 +9,6 @@
 #include "MaterialBuilder.h"
 #include <Atom/RPI.Edit/Material/MaterialSourceData.h>
 #include <Atom/RPI.Edit/Material/MaterialTypeSourceData.h>
-#include <Atom/RPI.Edit/Material/MaterialConverterBus.h>
 #include <Atom/RPI.Edit/Material/MaterialUtils.h>
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <Atom/RPI.Edit/Common/JsonFileLoadContext.h>
@@ -31,6 +30,7 @@
 #include <AzCore/IO/IOUtils.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 namespace AZ
 {
@@ -47,7 +47,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
-            materialBuilderDescriptor.m_version = 107; // ATOM-14918
+            materialBuilderDescriptor.m_version = 108; // ATOM-14918
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();
@@ -67,21 +67,19 @@ namespace AZ
         //! Adds all relevant dependencies for a referenced source file, considering that the path might be relative to the original file location or a full asset path.
         //! This will usually include multiple source dependencies and a single job dependency, but will include only source dependencies if the file is not found.
         //! Note the AssetBuilderSDK::JobDependency::m_platformIdentifier will not be set by this function. The calling code must set this value before passing back
-        //! to the AssetBuilderSDK::CreateJobsResponse.
-        void AddPossibleDependencies(
-            AZStd::string_view currentFilePath, AZStd::string_view referencedParentPath,
-            AZStd::vector<AssetBuilderSDK::SourceFileDependency>& sourceFileDependencies,
-            const char* jobKey, AZStd::vector<AssetBuilderSDK::JobDependency>& jobDependencies)
+        //! to the AssetBuilderSDK::CreateJobsResponse. If isOrderedOnceForMaterialTypes is true and the dependency is a materialtype file, the job dependency type
+        //! will be set to JobDependencyType::OrderOnce.
+        void AddPossibleDependencies(AZStd::string_view currentFilePath,
+            AZStd::string_view referencedParentPath,
+            const char* jobKey,
+            AZStd::vector<AssetBuilderSDK::JobDependency>& jobDependencies,
+            bool isOrderedOnceForMaterialTypes = false)
         {
             bool dependencyFileFound = false;
 
             AZStd::vector<AZStd::string> possibleDependencies = RPI::AssetUtils::GetPossibleDepenencyPaths(currentFilePath, referencedParentPath);
             for (auto& file : possibleDependencies)
             {
-                AssetBuilderSDK::SourceFileDependency sourceFileDependency;
-                sourceFileDependency.m_sourceFileDependencyPath = file;
-                sourceFileDependencies.push_back(sourceFileDependency);
-
                 // The first path found is the highest priority, and will have a job dependency, as this is the one
                 // the builder will actually use
                 if (!dependencyFileFound)
@@ -96,9 +94,8 @@ namespace AZ
                         jobDependency.m_jobKey = jobKey;
                         jobDependency.m_sourceFile.m_sourceFileDependencyPath = file;
 
-                        bool includeMaterialPropertyNames = true;
-                        RPI::MaterialConverterBus::BroadcastResult(includeMaterialPropertyNames, &RPI::MaterialConverterBus::Events::ShouldIncludeMaterialPropertyNames);
-                        jobDependency.m_type = includeMaterialPropertyNames ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order;
+                        const bool isMaterialTypeFile = AzFramework::StringFunc::Path::IsExtension(file.c_str(), MaterialTypeSourceData::Extension);
+                        jobDependency.m_type = (isMaterialTypeFile && isOrderedOnceForMaterialTypes) ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order;
 
                         jobDependencies.push_back(jobDependency);
                     }
@@ -178,8 +175,9 @@ namespace AZ
 
                     for (auto& shader : materialTypeSourceData.GetValue().m_shaderCollection)
                     {
-                        AddPossibleDependencies(request.m_sourceFile, shader.m_shaderFilePath,
-                            response.m_sourceFileDependencyList, "Shader Asset",
+                        AddPossibleDependencies(request.m_sourceFile,
+                            shader.m_shaderFilePath,
+                            "Shader Asset",
                             outputJobDescriptor.m_jobDependencyList);
                     }
 
@@ -189,9 +187,10 @@ namespace AZ
 
                         for (const MaterialFunctorSourceData::AssetDependency& dependency : dependencies)
                         {
-                            AddPossibleDependencies(request.m_sourceFile, dependency.m_sourceFilePath,
-                                response.m_sourceFileDependencyList,
-                                dependency.m_jobKey.c_str(), outputJobDescriptor.m_jobDependencyList);
+                            AddPossibleDependencies(request.m_sourceFile,
+                                dependency.m_sourceFilePath,
+                                dependency.m_jobKey.c_str(),
+                                outputJobDescriptor.m_jobDependencyList);
                         }
                     }
                 }
@@ -224,11 +223,21 @@ namespace AZ
                         parentMaterialPath = materialTypePath;
                     }
 
+                    // If includeMaterialPropertyNames is true, then we need materials to depend on materialtype only once in order to get
+                    // the property names. After the initial processing, materials will no longer be dependent on materialtype files.
+                    bool includeMaterialPropertyNames = true;
+                    if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+                    {
+                        settingsRegistry->Get(includeMaterialPropertyNames, "/O3DE/Atom/RPI/MaterialBuilder/IncludeMaterialPropertyNames");
+                    }
+
                     // Register dependency on the parent material source file so we can load it and use it's data to build this variant material.
                     // Note, we don't need a direct dependency on the material type because the parent material will depend on it.
-                    AddPossibleDependencies(request.m_sourceFile, parentMaterialPath,
-                        response.m_sourceFileDependencyList,
-                        JobKey, outputJobDescriptor.m_jobDependencyList);
+                    AddPossibleDependencies(request.m_sourceFile,
+                        parentMaterialPath,
+                        JobKey,
+                        outputJobDescriptor.m_jobDependencyList,
+                        includeMaterialPropertyNames);
                 }
             }
             

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -47,7 +47,7 @@ namespace AZ
         {
             AssetBuilderSDK::AssetBuilderDesc materialBuilderDescriptor;
             materialBuilderDescriptor.m_name = JobKey;
-            materialBuilderDescriptor.m_version = 108; // ATOM-14918
+            materialBuilderDescriptor.m_version = 108;
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.material", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern("*.materialtype", AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             materialBuilderDescriptor.m_busId = azrtti_typeid<MaterialBuilder>();

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Material/MaterialBuilder.cpp
@@ -9,6 +9,7 @@
 #include "MaterialBuilder.h"
 #include <Atom/RPI.Edit/Material/MaterialSourceData.h>
 #include <Atom/RPI.Edit/Material/MaterialTypeSourceData.h>
+#include <Atom/RPI.Edit/Material/MaterialConverterBus.h>
 #include <Atom/RPI.Edit/Material/MaterialUtils.h>
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <Atom/RPI.Edit/Common/JsonFileLoadContext.h>
@@ -93,8 +94,12 @@ namespace AZ
                     {
                         AssetBuilderSDK::JobDependency jobDependency;
                         jobDependency.m_jobKey = jobKey;
-                        jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
                         jobDependency.m_sourceFile.m_sourceFileDependencyPath = file;
+
+                        bool includeMaterialPropertyNames = true;
+                        RPI::MaterialConverterBus::BroadcastResult(includeMaterialPropertyNames, &RPI::MaterialConverterBus::Events::ShouldIncludeMaterialPropertyNames);
+                        jobDependency.m_type = includeMaterialPropertyNames ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order;
+
                         jobDependencies.push_back(jobDependency);
                     }
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
@@ -44,7 +44,7 @@ namespace AZ
             if (auto* serialize = azrtti_cast<SerializeContext*>(context))
             {
                 serialize->Class<MaterialAssetDependenciesComponent, Component>()
-                    ->Version(4)
+                    ->Version(5)
                     ->Attribute(Edit::Attributes::SystemComponentTags, AZStd::vector<Crc32>({ AssetBuilderSDK::ComponentTags::AssetBuilder }));
             }
         }
@@ -88,6 +88,8 @@ namespace AZ
                 jobDependency.m_sourceFile = materialTypeSource;
                 jobDependency.m_platformIdentifier = platformIdentifier;
 
+                // If includeMaterialPropertyNames is true, then we need materials to depend on materialtype only once in order to get
+                // the property names. After the initial processing, materials will no longer be dependent on materialtype files.
                 bool includeMaterialPropertyNames = true;
                 RPI::MaterialConverterBus::BroadcastResult(includeMaterialPropertyNames, &RPI::MaterialConverterBus::Events::ShouldIncludeMaterialPropertyNames);
                 jobDependency.m_type = includeMaterialPropertyNames ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MaterialAssetBuilderComponent.cpp
@@ -78,10 +78,7 @@ namespace AZ
             AZStd::string materialTypePath;
             RPI::MaterialConverterBus::BroadcastResult(materialTypePath, &RPI::MaterialConverterBus::Events::GetMaterialTypePath);
 
-            bool includeMaterialPropertyNames = true;
-            RPI::MaterialConverterBus::BroadcastResult(includeMaterialPropertyNames, &RPI::MaterialConverterBus::Events::ShouldIncludeMaterialPropertyNames);
-            // TODO: Use includeMaterialPropertyNames to break materialtype dependency on fbx files. Materialasset's dependency on materialtypeasset will need to be decoupled first
-            if (conversionEnabled && !materialTypePath.empty() /*&& !includeMaterialPropertyNames*/)
+            if (conversionEnabled && !materialTypePath.empty())
             {
                 AssetBuilderSDK::SourceFileDependency materialTypeSource;
                 materialTypeSource.m_sourceFileDependencyPath = materialTypePath;
@@ -90,7 +87,10 @@ namespace AZ
                 jobDependency.m_jobKey = "Atom Material Builder";
                 jobDependency.m_sourceFile = materialTypeSource;
                 jobDependency.m_platformIdentifier = platformIdentifier;
-                jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
+
+                bool includeMaterialPropertyNames = true;
+                RPI::MaterialConverterBus::BroadcastResult(includeMaterialPropertyNames, &RPI::MaterialConverterBus::Events::ShouldIncludeMaterialPropertyNames);
+                jobDependency.m_type = includeMaterialPropertyNames ? AssetBuilderSDK::JobDependencyType::OrderOnce : AssetBuilderSDK::JobDependencyType::Order;
 
                 jobDependencyList.push_back(jobDependency);
             }


### PR DESCRIPTION
Notes:
- When includeMaterialPropertyNames is enabled, job dependency types for all material files can be set to process only once. Then if the materialtype file is changed in the future, we can rely on the newly implemented load-time mechanism to add the new properties. 
- Remove source dependency in MaterialBuilder. We only need the job dependency. 
- AP load time when adding a dummy property in StandardPBR.materialtype is down from 45s to 10s. 

Testing:
- Observed that adding a dummy property in StandardPBR.materialtype does not cause fbx and standalone material asset rebuild.
- Added a dummy property in StandardPBR.materialtype then reprocessed the fbx and standalone material asset. Observed that removing the dummy property does not cause a rebuild of the fbx and standalone material asset. 