### PR TITLE
LYN6729: Fix AzAutoGen to Output to Proper Path

### DIFF
--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -71,10 +71,10 @@ def SearchPaths(filename, paths=[]):
     return None
 
 def ComputeOutputPath(inputFiles, projectDir, outputDir):
-    commonInputPath = os.path.commonprefix(inputFiles) # If we've globbed many source files, this finds the common prefix
+    commonInputPath = os.path.commonpath(inputFiles) # If we've globbed many source files, this finds the common path
     if os.path.isfile(commonInputPath): # If the commonInputPath resolves to an actual file, slice off the filename
         commonInputPath = os.path.dirname(commonInputPath)
-    commonPath = os.path.commonprefix([commonInputPath, projectDir]) # Finds the common path between the data source files and our project directory (//depot/dev/Code/Framework/AzCore/)
+    commonPath = os.path.commonpath([commonInputPath, projectDir]) # Finds the common path between the data source files and our project directory (//depot/dev/Code/Framework/AzCore/)
     inputRelativePath = os.path.relpath(commonInputPath, commonPath) # Computes the relative path for the project source directory (Code/Framework/AzCore/AutoGen/)
     return os.path.join(outputDir, inputRelativePath) # Returns a suitable output directory (//depot/dev/Generated/Code/Framework/AzCore/AutoGen/)
 


### PR DESCRIPTION
Fix AzAutoGen to output to a proper directory.  
Using path.commonpath instead of path.commonprefix.  commonpath, unlike commonprefix, always return a valid path. 
For example, path.commonprefix(["/usr/hello.txt", "/usr/helium.cpp"] would return "/usr/he" where as path.commonpath would return the directory "/usr/".  
If there is only one file in the folder then path.commonpath returns the entire file (not the directory) so I kept the check for os.path.isfile and slice off the filename if needed.

Signed-off-by: Gene Walters <genewalt@amazon.com>