### PR TITLE
Fixed creation of the Engine.pak file

### DIFF
--- a/cmake/Platform/Linux/PAL_linux.cmake
+++ b/cmake/Platform/Linux/PAL_linux.cmake
@@ -35,7 +35,7 @@ else()
 endif()
 
 # Set the default asset type for deployment
-set(LY_ASSET_DEPLOY_ASSET_TYPE "pc" CACHE STRING "Set the asset type for deployment.")
+set(LY_ASSET_DEPLOY_ASSET_TYPE "linux" CACHE STRING "Set the asset type for deployment.")
 
 # Set the python cmd tool
 ly_set(LY_PYTHON_CMD ${CMAKE_CURRENT_SOURCE_DIR}/python/python.sh)

--- a/cmake/Projects.cmake
+++ b/cmake/Projects.cmake
@@ -147,14 +147,24 @@ foreach(project ${LY_PROJECTS})
     cmake_path(RELATIVE_PATH CMAKE_RUNTIME_OUTPUT_DIRECTORY BASE_DIRECTORY ${CMAKE_BINARY_DIR} OUTPUT_VARIABLE runtime_output_directory)
     set(install_engine_pak_template [=[
 if("${CMAKE_INSTALL_CONFIG_NAME}" MATCHES "^([Rr][Ee][Ll][Ee][Aa][Ss][Ee])$")
-    set(install_output_folder "${CMAKE_INSTALL_PREFIX}/@runtime_output_directory@/@PAL_PLATFORM_NAME@/${CMAKE_INSTALL_CONFIG_NAME}")
-    message(STATUS "Generating ${install_output_folder}/Engine.pak from @full_directory_path@/Cache")
+    set(install_output_folder "${CMAKE_INSTALL_PREFIX}/@runtime_output_directory@/@PAL_PLATFORM_NAME@/${CMAKE_INSTALL_CONFIG_NAME}/@LY_BUILD_PERMUTATION@")
+    if(NOT DEFINED LY_ASSET_DEPLOY_ASSET_TYPE)
+        set(LY_ASSET_DEPLOY_ASSET_TYPE @LY_ASSET_DEPLOY_ASSET_TYPE@)
+    endif()
+    message(STATUS "Generating ${install_output_folder}/Engine.pak from @full_directory_path@/Cache/${LY_ASSET_DEPLOY_ASSET_TYPE}")
     file(MAKE_DIRECTORY "${install_output_folder}")
-    file(ARCHIVE_CREATE OUTPUT "${install_output_folder}/Engine.pak"
-        PATHS "@full_directory_path@/Cache"
-        FORMAT zip
-    )
-    message(STATUS "${install_output_folder}/Engine.pak generated")
+    cmake_path(SET cache_product_path "@full_directory_path@/Cache/${LY_ASSET_DEPLOY_ASSET_TYPE}")
+    file(GLOB product_assets "${cache_product_path}/*")
+    if(product_assets)
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E tar "cf" "${install_output_folder}/Engine.pak" --format=zip -- ${product_assets}
+            WORKING_DIRECTORY "${cache_product_path}"
+            RESULT_VARIABLE archive_creation_result
+        )
+        if(archive_creation_result EQUAL 0)
+            message(STATUS "${install_output_folder}/Engine.pak generated")
+        endif()
+    endif()
 endif()
 ]=])
     string(CONFIGURE "${install_engine_pak_template}" install_engine_pak_code @ONLY)


### PR DESCRIPTION
First the Cache directory itself was being added to the archive. It has
been updated to query the assets from the asset type folder i.e
Cache/<asset-type>

Second execute_process is being used to invoke CMake `tar` command to
create the zip archive since the CMake `file(ARCHIVE_CREATE)` adds the
files to the archive relative to the current working directory which is
${CMAKE_BINARY_DIR} when invoking the install script.

This was causing the archive to store files with a path of "../../Cache/pc"

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>