### PR TITLE
Additional test support for Manipulator Ditto commands

### DIFF
--- a/Code/Editor/EditorToolsApplication.cpp
+++ b/Code/Editor/EditorToolsApplication.cpp
@@ -34,10 +34,14 @@ namespace EditorInternal
         : ToolsApplication(argc, argv)
     {
         EditorToolsApplicationRequests::Bus::Handler::BusConnect();
+        AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusConnect();
+        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusConnect();
     }
 
     EditorToolsApplication::~EditorToolsApplication()
     {
+        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusDisconnect();
+        AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusDisconnect();
         EditorToolsApplicationRequests::Bus::Handler::BusDisconnect();
         Stop();
     }
@@ -274,5 +278,14 @@ namespace EditorInternal
         Exit();
     }
 
-}
+    AzToolsFramework::ViewportInteraction::KeyboardModifiers EditorToolsApplication::QueryKeyboardModifiers()
+    {
+        return AzToolsFramework::ViewportInteraction::BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers());
+    }
 
+    std::chrono::milliseconds EditorToolsApplication::EditorViewportTimeNow()
+    {
+        auto now = std::chrono::steady_clock::now();
+        return std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch();
+    }
+} // namespace EditorInternal

--- a/Code/Editor/EditorToolsApplication.cpp
+++ b/Code/Editor/EditorToolsApplication.cpp
@@ -35,12 +35,12 @@ namespace EditorInternal
     {
         EditorToolsApplicationRequests::Bus::Handler::BusConnect();
         AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusConnect();
-        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusConnect();
+        AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Handler::BusConnect();
     }
 
     EditorToolsApplication::~EditorToolsApplication()
     {
-        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusDisconnect();
+        AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusDisconnect();
         EditorToolsApplicationRequests::Bus::Handler::BusDisconnect();
         Stop();
@@ -51,7 +51,6 @@ namespace EditorInternal
     {
         return m_StartupAborted;
     }
-
 
     void EditorToolsApplication::RegisterCoreComponents()
     {
@@ -283,9 +282,9 @@ namespace EditorInternal
         return AzToolsFramework::ViewportInteraction::BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers());
     }
 
-    std::chrono::milliseconds EditorToolsApplication::EditorViewportTimeNow()
+    AZStd::chrono::milliseconds EditorToolsApplication::EditorViewportInputTimeNow()
     {
-        auto now = std::chrono::steady_clock::now();
-        return std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch();
+        const auto now = AZStd::chrono::high_resolution_clock::now();
+        return AZStd::chrono::time_point_cast<AZStd::chrono::milliseconds>(now).time_since_epoch();
     }
 } // namespace EditorInternal

--- a/Code/Editor/EditorToolsApplication.h
+++ b/Code/Editor/EditorToolsApplication.h
@@ -20,7 +20,7 @@ namespace EditorInternal
         : public AzToolsFramework::ToolsApplication
         , public EditorToolsApplicationRequests::Bus::Handler
         , public AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler
-        , public AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler
+        , public AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Handler
     {
     public:
         EditorToolsApplication(int* argc, char*** argv);
@@ -49,8 +49,8 @@ namespace EditorInternal
         // EditorModifierKeyRequestBus overrides ...
         AzToolsFramework::ViewportInteraction::KeyboardModifiers QueryKeyboardModifiers() override;
 
-        // EditorViewportTimeNowRequestBus overrides ...
-        std::chrono::milliseconds EditorViewportTimeNow() override;
+        // EditorViewportInputTimeNowRequestBus overrides ...
+        AZStd::chrono::milliseconds EditorViewportInputTimeNow() override;
 
     protected:
         // From EditorToolsApplicationRequests

--- a/Code/Editor/EditorToolsApplication.h
+++ b/Code/Editor/EditorToolsApplication.h
@@ -19,6 +19,8 @@ namespace EditorInternal
     class EditorToolsApplication
         : public AzToolsFramework::ToolsApplication
         , public EditorToolsApplicationRequests::Bus::Handler
+        , public AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler
+        , public AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler
     {
     public:
         EditorToolsApplication(int* argc, char*** argv);
@@ -43,6 +45,12 @@ namespace EditorInternal
         // From AzToolsFramework::ToolsApplication
         void CreateReflectionManager() override;
         void Reflect(AZ::ReflectContext* context) override;
+
+        // EditorModifierKeyRequestBus overrides ...
+        AzToolsFramework::ViewportInteraction::KeyboardModifiers QueryKeyboardModifiers() override;
+
+        // EditorViewportTimeNowRequestBus overrides ...
+        std::chrono::milliseconds EditorViewportTimeNow() override;
 
     protected:
         // From EditorToolsApplicationRequests

--- a/Code/Editor/EditorToolsApplication.h
+++ b/Code/Editor/EditorToolsApplication.h
@@ -7,7 +7,9 @@
  */
 
 #pragma once
+
 #include <AzToolsFramework/Application/ToolsApplication.h>
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 #include "Core/EditorMetricsPlainTextNameRegistration.h"
 #include "EditorToolsApplicationAPI.h"

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -744,11 +744,15 @@ void EditorViewportWidget::RenderAll()
     {
         namespace AztfVi = AzToolsFramework::ViewportInteraction;
 
+        AztfVi::KeyboardModifiers keyboardModifiers;
+        AztfVi::EditorModifierKeyRequestBus::BroadcastResult(
+            keyboardModifiers, &AztfVi::EditorModifierKeyRequestBus::Events::QueryKeyboardModifiers);
+
         m_debugDisplay->DepthTestOff();
         m_manipulatorManager->DrawManipulators(
             *m_debugDisplay, GetCameraState(),
             BuildMouseInteractionInternal(
-                AztfVi::MouseButtons(AztfVi::TranslateMouseButtons(QGuiApplication::mouseButtons())), QueryKeyboardModifiers(),
+                AztfVi::MouseButtons(AztfVi::TranslateMouseButtons(QGuiApplication::mouseButtons())), keyboardModifiers,
                 BuildMousePick(WidgetToViewport(mapFromGlobal(QCursor::pos())))));
         m_debugDisplay->DepthTestOn();
     }
@@ -959,12 +963,13 @@ QWidget* EditorViewportWidget::GetWidgetForViewportContextMenu()
 
 bool EditorViewportWidget::ShowingWorldSpace()
 {
-    return QueryKeyboardModifiers().Shift();
-}
+    namespace AztfVi = AzToolsFramework::ViewportInteraction;
 
-AzToolsFramework::ViewportInteraction::KeyboardModifiers EditorViewportWidget::QueryKeyboardModifiers()
-{
-    return AzToolsFramework::ViewportInteraction::BuildKeyboardModifiers(QGuiApplication::queryKeyboardModifiers());
+    AztfVi::KeyboardModifiers keyboardModifiers;
+    AztfVi::EditorModifierKeyRequestBus::BroadcastResult(
+        keyboardModifiers, &AztfVi::EditorModifierKeyRequestBus::Events::QueryKeyboardModifiers);
+
+    return keyboardModifiers.Shift();
 }
 
 void EditorViewportWidget::SetViewportId(int id)
@@ -1039,7 +1044,6 @@ void EditorViewportWidget::ConnectViewportInteractionRequestBus()
 {
     AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler::BusConnect(GetViewportId());
     AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusConnect(GetViewportId());
-    AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusConnect();
     m_viewportUi.ConnectViewportUiBus(GetViewportId());
 
     AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusConnect();
@@ -1050,7 +1054,6 @@ void EditorViewportWidget::DisconnectViewportInteractionRequestBus()
     AzFramework::InputSystemCursorConstraintRequestBus::Handler::BusDisconnect();
 
     m_viewportUi.DisconnectViewportUiBus();
-    AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusDisconnect();
     AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler::BusDisconnect();
     AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler::BusDisconnect();
 }

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -92,7 +92,6 @@ class SANDBOX_API EditorViewportWidget final
     , private AzFramework::InputSystemCursorConstraintRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::MainEditorViewportInteractionRequestBus::Handler
     , private AzToolsFramework::ViewportInteraction::EditorEntityViewportInteractionRequestBus::Handler
-    , private AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler
     , private AzFramework::AssetCatalogEventBus::Handler
     , private AZ::RPI::SceneNotificationBus::Handler
 {
@@ -211,9 +210,6 @@ private:
 
     // EditorEntityViewportInteractionRequestBus overrides ...
     void FindVisibleEntities(AZStd::vector<AZ::EntityId>& visibleEntities) override;
-
-    // EditorModifierKeyRequestBus overrides ...
-    AzToolsFramework::ViewportInteraction::KeyboardModifiers QueryKeyboardModifiers() override;
 
     // Camera::EditorCameraRequestBus overrides ...
     void SetViewFromEntityPerspective(const AZ::EntityId& entityId) override;

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.cpp
@@ -9,8 +9,7 @@
 #include <AzFramework/Viewport/ClickDetector.h>
 #include <AzFramework/Viewport/ScreenGeometry.h>
 
-#pragma optimize("", off)
-#pragma inline_depth(0)
+#include <AzCore/std/chrono/clocks.h>
 
 namespace AzFramework
 {
@@ -18,8 +17,8 @@ namespace AzFramework
     {
         m_timeNowFn = []
         {
-            auto now = std::chrono::steady_clock::now();
-            return std::chrono::time_point_cast<std::chrono::milliseconds>(now).time_since_epoch();
+            const auto now = AZStd::chrono::high_resolution_clock::now();
+            return AZStd::chrono::time_point_cast<AZStd::chrono::milliseconds>(now).time_since_epoch();
         };
     }
 
@@ -41,7 +40,7 @@ namespace AzFramework
             const auto now = m_timeNowFn();
             if (m_tryBeginTime)
             {
-                using FloatingPointSeconds = std::chrono::duration<float, std::chrono::seconds::period>;
+                using FloatingPointSeconds = AZStd::chrono::duration<float, AZStd::chrono::seconds::period>;
 
                 const auto diff = now - m_tryBeginTime.value();
                 if (FloatingPointSeconds(diff).count() < m_doubleClickInterval)
@@ -82,11 +81,8 @@ namespace AzFramework
         return ClickOutcome::Nil;
     }
 
-    void ClickDetector::OverrideTimeNowFn(AZStd::function<std::chrono::milliseconds()> timeNowFn)
+    void ClickDetector::OverrideTimeNowFn(AZStd::function<AZStd::chrono::milliseconds()> timeNowFn)
     {
         m_timeNowFn = AZStd::move(timeNowFn);
     }
 } // namespace AzFramework
-
-#pragma optimize("", on)
-#pragma inline_depth()

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <AzCore/std/optional.h>
 #include <AzCore/std/functional.h>
+#include <AzCore/std/optional.h>
 
 #include <chrono>
 
@@ -54,7 +54,7 @@ namespace AzFramework
         //! Override how the current time is retrieved.
         //! This is helpful to override when it comes to simulating different passages of
         //! time to avoid double click issues in tests for example.
-        void OverrideTimeNowFn(AZStd::function<std::chrono::milliseconds()> timeNowFn);
+        void OverrideTimeNowFn(AZStd::function<AZStd::chrono::milliseconds()> timeNowFn);
 
     private:
         //! Internal state of ClickDetector based on incoming events.
@@ -69,8 +69,9 @@ namespace AzFramework
         float m_deadZone = 2.0f; //!< How far to move before a click is cancelled (when Move will fire).
         float m_doubleClickInterval = 0.4f; //!< Default double click interval, can be overridden.
         DetectionState m_detectionState; //!< Internal state of ClickDetector.
-        AZStd::optional<std::chrono::milliseconds> m_tryBeginTime; //!< Mouse down time (happens each mouse down, helps with double click handling).
-        AZStd::function<std::chrono::milliseconds()> m_timeNowFn; //!< Interface to query the current time.
+        //! Mouse down time (happens each mouse down, helps with double click handling).
+        AZStd::optional<AZStd::chrono::milliseconds> m_tryBeginTime;
+        AZStd::function<AZStd::chrono::milliseconds()> m_timeNowFn; //!< Interface to query the current time.
     };
 
     inline void ClickDetector::SetDoubleClickInterval(const float doubleClickInterval)

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ClickDetector.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/std/optional.h>
+#include <AzCore/std/functional.h>
 
 #include <chrono>
 
@@ -21,10 +22,9 @@ namespace AzFramework
     //! (mouse down with movement and then mouse up).
     class ClickDetector
     {
-        //! Alias for recording time of mouse down events
-        using Time = std::chrono::time_point<std::chrono::steady_clock>;
-
     public:
+        ClickDetector();
+
         //! Internal representation of click event (map from external event for this when
         //! calling DetectClick).
         enum class ClickEvent
@@ -51,6 +51,10 @@ namespace AzFramework
         void SetDoubleClickInterval(float doubleClickInterval);
         //! Override the dead zone before a 'move' outcome will be triggered.
         void SetDeadZone(float deadZone);
+        //! Override how the current time is retrieved.
+        //! This is helpful to override when it comes to simulating different passages of
+        //! time to avoid double click issues in tests for example.
+        void OverrideTimeNowFn(AZStd::function<std::chrono::milliseconds()> timeNowFn);
 
     private:
         //! Internal state of ClickDetector based on incoming events.
@@ -65,7 +69,8 @@ namespace AzFramework
         float m_deadZone = 2.0f; //!< How far to move before a click is cancelled (when Move will fire).
         float m_doubleClickInterval = 0.4f; //!< Default double click interval, can be overridden.
         DetectionState m_detectionState; //!< Internal state of ClickDetector.
-        AZStd::optional<Time> m_tryBeginTime; //!< Mouse down time (happens each mouse down, helps with double click handling).
+        AZStd::optional<std::chrono::milliseconds> m_tryBeginTime; //!< Mouse down time (happens each mouse down, helps with double click handling).
+        AZStd::function<std::chrono::milliseconds()> m_timeNowFn; //!< Interface to query the current time.
     };
 
     inline void ClickDetector::SetDoubleClickInterval(const float doubleClickInterval)

--- a/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ImmediateModeActionDispatcher.h
+++ b/Code/Framework/AzManipulatorTestFramework/Include/AzManipulatorTestFramework/ImmediateModeActionDispatcher.h
@@ -18,7 +18,7 @@ namespace AzManipulatorTestFramework
     class ImmediateModeActionDispatcher
         : public ActionDispatcher<ImmediateModeActionDispatcher>
         , public AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler
-        , public AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler
+        , public AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Handler
     {
         using KeyboardModifier = AzToolsFramework::ViewportInteraction::KeyboardModifier;
         using KeyboardModifiers = AzToolsFramework::ViewportInteraction::KeyboardModifiers;
@@ -51,8 +51,8 @@ namespace AzManipulatorTestFramework
         // EditorModifierKeyRequestBus overrides ...
         KeyboardModifiers QueryKeyboardModifiers() override;
 
-        // EditorViewportTimeNowRequestBus overrides ...
-        std::chrono::milliseconds EditorViewportTimeNow() override;
+        // EditorViewportInputTimeNowRequestBus overrides ...
+        AZStd::chrono::milliseconds EditorViewportInputTimeNow() override;
 
     protected:
         // ActionDispatcher ...
@@ -84,7 +84,8 @@ namespace AzManipulatorTestFramework
         mutable AZStd::unique_ptr<MouseInteractionEvent> m_event;
         ManipulatorViewportInteraction& m_viewportManipulatorInteraction;
 
-        std::chrono::milliseconds m_timeNow = std::chrono::milliseconds(0); //!< Current time that ticks up after each call to EditorViewportTimeNow.
+        //! Current time that ticks up after each call to EditorViewportInputTimeNow.
+        AZStd::chrono::milliseconds m_timeNow = AZStd::chrono::milliseconds(0);
     };
 
     template<typename ActualT, typename ExpectedT>
@@ -113,11 +114,12 @@ namespace AzManipulatorTestFramework
         return GetMouseInteractionEvent()->m_mouseInteraction.m_keyboardModifiers;
     }
 
-    inline std::chrono::milliseconds ImmediateModeActionDispatcher::EditorViewportTimeNow()
+    inline AZStd::chrono::milliseconds ImmediateModeActionDispatcher::EditorViewportInputTimeNow()
     {
-        // step the time for each call to be greater than the minimum time
-        // required for a double click to register
-        m_timeNow += std::chrono::milliseconds(10000);
+        // step the time for each call to be greater than the minimum time required for a double click to register
+        // note: the time increment is very high to ensure any potential system changes to settings such as double
+        // click interval will not be impacted
+        m_timeNow += AZStd::chrono::milliseconds(10000);
         return m_timeNow;
     }
 } // namespace AzManipulatorTestFramework

--- a/Code/Framework/AzManipulatorTestFramework/Source/ImmediateModeActionDispatcher.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ImmediateModeActionDispatcher.cpp
@@ -33,10 +33,12 @@ namespace AzManipulatorTestFramework
         : m_viewportManipulatorInteraction(viewportManipulatorInteraction)
     {
         AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusConnect();
+        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusConnect();
     }
 
     ImmediateModeActionDispatcher::~ImmediateModeActionDispatcher()
     {
+        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusDisconnect();
     }
 

--- a/Code/Framework/AzManipulatorTestFramework/Source/ImmediateModeActionDispatcher.cpp
+++ b/Code/Framework/AzManipulatorTestFramework/Source/ImmediateModeActionDispatcher.cpp
@@ -33,12 +33,12 @@ namespace AzManipulatorTestFramework
         : m_viewportManipulatorInteraction(viewportManipulatorInteraction)
     {
         AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusConnect();
-        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusConnect();
+        AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Handler::BusConnect();
     }
 
     ImmediateModeActionDispatcher::~ImmediateModeActionDispatcher()
     {
-        AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Handler::BusDisconnect();
+        AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::EditorModifierKeyRequestBus::Handler::BusDisconnect();
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -282,6 +282,22 @@ namespace AzToolsFramework
             return keyboardModifiers;
         }
 
+        //!
+        class EditorViewportTimeNowRequests : public AZ::EBusTraits
+        {
+        public:
+            static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+            static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+
+            //!
+            virtual std::chrono::milliseconds EditorViewportTimeNow() = 0;
+
+        protected:
+            ~EditorViewportTimeNowRequests() = default;
+        };
+
+        using EditorViewportTimeNowRequestBus = AZ::EBus<EditorViewportTimeNowRequests>;
+
         //! Viewport requests for managing the viewport cursor state.
         class ViewportMouseCursorRequests
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -282,21 +282,23 @@ namespace AzToolsFramework
             return keyboardModifiers;
         }
 
-        //!
-        class EditorViewportTimeNowRequests : public AZ::EBusTraits
+        //! An interface to deal with time requests relating to viewports.
+        //! @note The bus is global and not per viewport.
+        class EditorViewportInputTimeNowRequests : public AZ::EBusTraits
         {
         public:
             static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
             static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
 
-            //!
-            virtual std::chrono::milliseconds EditorViewportTimeNow() = 0;
+            //! Returns the current time in seconds.
+            //! This interface can be overridden for the purposes of testing to simplify viewport input requests.
+            virtual AZStd::chrono::milliseconds EditorViewportInputTimeNow() = 0;
 
         protected:
-            ~EditorViewportTimeNowRequests() = default;
+            ~EditorViewportInputTimeNowRequests() = default;
         };
 
-        using EditorViewportTimeNowRequestBus = AZ::EBus<EditorViewportTimeNowRequests>;
+        using EditorViewportInputTimeNowRequestBus = AZ::EBus<EditorViewportInputTimeNowRequests>;
 
         //! Viewport requests for managing the viewport cursor state.
         class ViewportMouseCursorRequests

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -253,10 +253,10 @@ namespace AzToolsFramework
                  mouseInteraction.m_mouseInteraction.m_keyboardModifiers.Ctrl());
         }
 
-        static bool ManipulatorDitto(const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
+        static bool ManipulatorDitto(
+            const AzFramework::ClickDetector::ClickOutcome clickOutcome, const ViewportInteraction::MouseInteractionEvent& mouseInteraction)
         {
-            return mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::Down &&
-                mouseInteraction.m_mouseInteraction.m_mouseButtons.Left() &&
+            return clickOutcome == AzFramework::ClickDetector::ClickOutcome::Click &&
                 mouseInteraction.m_mouseInteraction.m_keyboardModifiers.Ctrl() &&
                 mouseInteraction.m_mouseInteraction.m_keyboardModifiers.Alt();
         }
@@ -1054,6 +1054,15 @@ namespace AzToolsFramework
         RegisterActions();
         SetupBoxSelect();
         RefreshSelectedEntityIdsAndRegenerateManipulators();
+
+        m_clickDetector.OverrideTimeNowFn(
+            []
+            {
+                std::chrono::milliseconds timeNow;
+                AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::BroadcastResult(
+                    timeNow, &AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Events::EditorViewportTimeNow);
+                return timeNow;
+            });
     }
 
     EditorTransformComponentSelection::~EditorTransformComponentSelection()
@@ -1883,7 +1892,7 @@ namespace AzToolsFramework
             }
 
             // set manipulator pivot override translation or orientation (update manipulators)
-            if (Input::ManipulatorDitto(mouseInteraction))
+            if (Input::ManipulatorDitto(clickOutcome, mouseInteraction))
             {
                 PerformManipulatorDitto(entityIdUnderCursor);
                 return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1055,12 +1055,14 @@ namespace AzToolsFramework
         SetupBoxSelect();
         RefreshSelectedEntityIdsAndRegenerateManipulators();
 
+        // ensure the click detector uses the EditorViewportInputTimeNowRequests interface to retrieve elapsed time
+        // note: this is to facilitate overriding this functionality for purposes such as testing
         m_clickDetector.OverrideTimeNowFn(
             []
             {
-                std::chrono::milliseconds timeNow;
-                AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::BroadcastResult(
-                    timeNow, &AzToolsFramework::ViewportInteraction::EditorViewportTimeNowRequestBus::Events::EditorViewportTimeNow);
+                AZStd::chrono::milliseconds timeNow;
+                AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::BroadcastResult(
+                    timeNow, &AzToolsFramework::ViewportInteraction::EditorViewportInputTimeNowRequestBus::Events::EditorViewportInputTimeNow);
                 return timeNow;
             });
     }


### PR DESCRIPTION
This test adds some final coverage for Manipulator ditto commands (that were not working 100% correctly with the updated click changes (https://github.com/o3de/o3de/pull/4094 and https://github.com/o3de/o3de/pull/4149).

To make testing mouse inputs more reliable in the tests a new time interface was introduced that can be overridden at test time for the `ClickDetector`.

One way to solve this would have been to simply add a delay into the test, but this needlessly extends the running time and could add up if we start having to do it more often. 

I discussed the options at some length with @greerdv and we decided this is the best option (instead of providing an API to override the double click interval itself that could lead to further issues or insert a new ClickDetector).

In a perfect world the test environment would set up more of these pieces itself as opposed to relying on ToolsApplication but that change is unfortunately out of scope for this PR.

I also moved the global QueryKeyboardModifiers to EditorToolsApplication (in EditorLib) instead of EditorViewportWidget as in future there may be more than one EditorViewportWidget having it implement a global bus would have made future work more difficult.

One last thing I should point out is I was going to use `steady_clock` but this currently isn't provided in `AZStd` and adding it or even exposing it through `using std::chrono::steady_clock` all started getting a bit complicated so I opted to use `system_clock` instead - in practice it should really make no difference.

```
[==========] Running 7 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 7 tests from ClickDetectorFixture
[ RUN      ] ClickDetectorFixture.ClickIsDetectedWithNoMouseMovementOnMouseUp
[       OK ] ClickDetectorFixture.ClickIsDetectedWithNoMouseMovementOnMouseUp (0 ms)
[ RUN      ] ClickDetectorFixture.MoveIsDetectedWithMouseMovementAfterMouseDown
[       OK ] ClickDetectorFixture.MoveIsDetectedWithMouseMovementAfterMouseDown (0 ms)
[ RUN      ] ClickDetectorFixture.ReleaseIsDetectedAfterMouseMovementOnMouseUp
[       OK ] ClickDetectorFixture.ReleaseIsDetectedAfterMouseMovementOnMouseUp (0 ms)
[ RUN      ] ClickDetectorFixture.MoveIsReturnedOnlyAfterFirstMouseMove
[       OK ] ClickDetectorFixture.MoveIsReturnedOnlyAfterFirstMouseMove (0 ms)
[ RUN      ] ClickDetectorFixture.ClickIsNotRegisteredAfterDoubleClick
[       OK ] ClickDetectorFixture.ClickIsNotRegisteredAfterDoubleClick (0 ms)
[ RUN      ] ClickDetectorFixture.ClickIsNotRegisteredAfterIgnoredDoubleClick
[       OK ] ClickDetectorFixture.ClickIsNotRegisteredAfterIgnoredDoubleClick (0 ms)
[ RUN      ] ClickDetectorFixture.ClickIsNotRegisteredAfterIgnoringMouseMovesBeforeMouseUpWithLargeDelta
[       OK ] ClickDetectorFixture.ClickIsNotRegisteredAfterIgnoringMouseMovesBeforeMouseUpWithLargeDelta (0 ms)
[----------] 7 tests from ClickDetectorFixture (2 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test case ran. (3 ms total)
[  PASSED  ] 7 tests.
```

```
[==========] Running 19 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 15 tests from EditorTransformComponentSelectionViewportPickingManipulatorTestFixture
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickWithNoSelectionWillSelectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickWithNoSelectionWillSelectEntity (145 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickWithNoSelectionWillSelectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickWithNoSelectionWillSelectEntity (124 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOffEntityWithSelectionWillNotDeselectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOffEntityWithSelectionWillNotDeselectEntity (126 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOffEntityWithSelectionWillDeselectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOffEntityWithSelectionWillDeselectEntity (123 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity (126 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOnNewEntityWithSelectionWillChangeSelectedEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOnNewEntityWithSelectionWillChangeSelectedEntity (126 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection (127 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection (125 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection (123 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection (123 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithNoInitialSelectionAddsEntitiesToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithNoInitialSelectionAddsEntitiesToSelection (127 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithSelectionAppendsEntitiesToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithSelectionAppendsEntitiesToSelection (125 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectHoldingCtrlWithSelectionRemovesEntitiesFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectHoldingCtrlWithSelectionRemovesEntitiesFromSelection (127 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyDoubleClickWithSelectionWillDeselectEntities
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyDoubleClickWithSelectionWillDeselectEntities (122 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyUndoOperationForChangeInSelectionIsAtomic
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyUndoOperationForChangeInSelectionIsAtomic (127 ms)
[----------] 15 tests from EditorTransformComponentSelectionViewportPickingManipulatorTestFixture (1908 ms total)

[----------] 4 tests from All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/0
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/0 (124 ms)
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/1
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/1 (127 ms)
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/0
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/0 (124 ms)
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/1
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/1 (122 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam (499 ms total)

[----------] Global test environment tear-down
[==========] 19 tests from 2 test cases ran. (2410 ms total)
[  PASSED  ] 19 tests.
```