### PR TITLE
Fix ASV camera assert

### DIFF
--- a/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
+++ b/Gems/Atom/Component/DebugCamera/Code/Source/CameraComponent.cpp
@@ -272,7 +272,10 @@ namespace AZ
             else if (m_componentConfig.m_target)
             {
                 const auto& viewport = m_componentConfig.m_target->GetViewport();
-                m_aspectRatio = viewport.m_maxX / viewport.m_maxY;
+                if (viewport.m_maxX > 0.0f && viewport.m_maxY > 0.0f)
+                {
+                    m_aspectRatio = viewport.m_maxX / viewport.m_maxY;
+                }
             }
         }
 


### PR DESCRIPTION
Adds a sanity check to the debug camera gem to try to avoid setting an invalid aspect ratio - the assert no longer showed up when I ran a build using this change.

Signed-off-by: nvsickle <nvsickle@amazon.com>