### PR TITLE
Fixes debug console autocomplete issues

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -236,7 +236,12 @@ namespace AZ
             if (StringFunc::StartsWith(curr->m_name, command, false))
             {
                 AZLOG_INFO("- %s : %s\n", curr->m_name, curr->m_desc);
-                commandSubset.push_back(curr->m_name);
+
+                if (commandSubset.size() < MaxConsoleCommandPlusArgsLength)
+                {
+                    commandSubset.push_back(curr->m_name);
+                }
+
                 if (matches)
                 {
                     matches->push_back(curr->m_name);

--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -225,8 +225,11 @@ namespace AZ
 
         ConsoleCommandContainer commandSubset;
 
-        for (ConsoleFunctorBase* curr = m_head; curr != nullptr; curr = curr->m_next)
+        for (const auto& functor : m_commands)
         {
+            // Filter functors registered with the same name
+            ConsoleFunctorBase* curr = functor.second.front();
+
             if ((curr->GetFlags() & ConsoleFunctorFlags::IsInvisible) == ConsoleFunctorFlags::IsInvisible)
             {
                 // Filter functors marked as invisible
@@ -340,6 +343,11 @@ namespace AZ
             if (iter2 != iter->second.end())
             {
                 iter->second.erase(iter2);
+            }
+
+            if (iter->second.empty())
+            {
+                m_commands.erase(iter);
             }
         }
         functor->Unlink(m_head);


### PR DESCRIPTION
- Debug console no longer crashes when printing large autocomplete results.
- It also no longer needlessly prints duplicate autocomplete results. 

![before](https://user-images.githubusercontent.com/90814386/134064424-e3680d67-871f-47d0-b57f-1a0200d8b562.gif)
![after](https://user-images.githubusercontent.com/90814386/134064527-84df9a9f-9f61-4c63-862d-613835072e2f.gif)



