### PR TITLE
LYN6808: Fix Compiler Error Due to EntityPreRenderEvent

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkHitVolumesComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkHitVolumesComponent.h
@@ -64,7 +64,7 @@ namespace Multiplayer
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
 
     private:
-        void OnPreRender(float deltaTime, float blendFactor);
+        void OnPreRender(float deltaTime);
         void OnTransformUpdate(const AZ::Transform& transform);
         void OnSyncRewind();
 

--- a/Gems/Multiplayer/Code/Source/Components/NetworkHitVolumesComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkHitVolumesComponent.cpp
@@ -109,7 +109,7 @@ namespace Multiplayer
 
     NetworkHitVolumesComponent::NetworkHitVolumesComponent()
         : m_syncRewindHandler([this]() { OnSyncRewind(); })
-        , m_preRenderHandler([this](float deltaTime, float blendFactor) { OnPreRender(deltaTime, blendFactor); })
+        , m_preRenderHandler([this](float deltaTime) { OnPreRender(deltaTime); })
         , m_transformChangedHandler([this](const AZ::Transform&, const AZ::Transform& worldTm) { OnTransformUpdate(worldTm); })
     {
         ;
@@ -135,7 +135,7 @@ namespace Multiplayer
         EMotionFX::Integration::ActorComponentNotificationBus::Handler::BusDisconnect();
     }
 
-    void NetworkHitVolumesComponent::OnPreRender([[maybe_unused]] float deltaTime, [[maybe_unused]] float blendFactor)
+    void NetworkHitVolumesComponent::OnPreRender([[maybe_unused]] float deltaTime)
     {
         if (m_animatedHitVolumes.size() <= 0)
         {


### PR DESCRIPTION
Fix compiler error.  EntityPreRenderEvent went from accept 2 parameters to 1.  Updated to properly take the one float for deltaTime.
Signed-off-by: Gene Walters <genewalt@amazon.com>