### PR TITLE
Modify CalcOverallHeightRange to not return nil

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_Common.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_Common.azsli
@@ -104,6 +104,7 @@ option bool o_layer3_enabled;
 enum class DebugDrawMode { None, BlendMask, Displacement, FinalBlendWeights };
 option DebugDrawMode o_debugDrawMode;
 
+// If you modify this enum, you must update the BlendSourceUsesDisplacement function in StandardMultilayerPBR_Displacement.lua
 enum class LayerBlendSource { BlendMaskTexture, BlendMaskVertexColors, Displacement, Displacement_With_BlendMaskTexture, Displacement_With_BlendMaskVertexColors, Fallback };
 option LayerBlendSource o_layerBlendSource;
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_Displacement.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_Displacement.lua
@@ -138,7 +138,8 @@ function CalcOverallHeightRange(context)
         if(enableLayer3) then GetMergedHeightRange(heightMinMax, offsetLayer3, factorLayer3) end
 
     else
-        heightMinMax = {0,0}
+        heightMinMax[0] = 0
+        heightMinMax[1] = 0
     end
 
     return heightMinMax

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_Displacement.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_Displacement.lua
@@ -88,7 +88,7 @@ end
 -- @return a table with two values {min,max}. Negative values are below the surface and positive values are above the surface.
 function CalcOverallHeightRange(context)
     
-    local heightMinMax = {nil, nil}
+    local heightMinMax = {}
 
     local function GetMergedHeightRange(heightMinMax, offset, factor)
         top = offset


### PR DESCRIPTION
The original implementation would interpret the else condition as nil, and lead to an error
argument #2 to 'SetShaderConstant_float' (number expected, got nil)

Tested with an automated hydra test I am working on locally, which led to the issue.

Signed-off-by: amzn-tommy <waltont@amazon.com>