### PR TITLE
EMotionFX: Basic profile instrumentation for anim graph

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/ActorInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/ActorInstance.cpp
@@ -372,6 +372,8 @@ namespace EMotionFX
     // updates the skinning matrices of all nodes
     void ActorInstance::UpdateSkinningMatrices()
     {
+        AZ_PROFILE_SCOPE(Animation, "ActorInstance::UpdateSkinningMatrices");
+
         AZ::Matrix3x4* skinningMatrices = m_transformData->GetSkinningMatrices();
         const Pose* pose = m_transformData->GetCurrentPose();
 
@@ -596,6 +598,8 @@ namespace EMotionFX
     // update the bounding volume
     void ActorInstance::UpdateBounds(size_t geomLODLevel, EBoundsType boundsType, uint32 itemFrequency)
     {
+        AZ_PROFILE_SCOPE(Animation, "ActorInstance::UpdateBounds");
+
         // depending on the bounding volume update type
         switch (boundsType)
         {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
@@ -218,6 +218,8 @@ namespace EMotionFX
     // output the results into the internal pose object
     void AnimGraphInstance::Output(Pose* outputPose)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphInstance::Output");
+
         // reset max used
         const uint32 threadIndex = m_actorInstance->GetThreadIndex();
         AnimGraphPosePool& posePool = GetEMotionFX().GetThreadData(threadIndex)->GetPosePool();
@@ -854,6 +856,8 @@ namespace EMotionFX
     // synchronize all nodes, based on sync tracks etc
     void AnimGraphInstance::Update(float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphInstance::Update");
+
         // pass 0: (Optional, networking only) When this instance is shared between network, restore the instance using an animgraph snapshot.
         if (m_snapshot)
         {
@@ -940,6 +944,8 @@ namespace EMotionFX
     // reset all node pose ref counts
     void AnimGraphInstance::ResetPoseRefCountsForAllNodes()
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphInstance::ResetPoseRefCountsForAllNodes");
+
         const size_t numNodes = m_animGraph->GetNumNodes();
         for (size_t i = 0; i < numNodes; ++i)
         {
@@ -951,6 +957,8 @@ namespace EMotionFX
     // reset all node pose ref counts
     void AnimGraphInstance::ResetRefDataRefCountsForAllNodes()
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphInstance::ResetRefDataRefCountsForAllNodes");
+
         const size_t numNodes = m_animGraph->GetNumNodes();
         for (size_t i = 0; i < numNodes; ++i)
         {
@@ -962,6 +970,8 @@ namespace EMotionFX
     // reset all node flags
     void AnimGraphInstance::ResetFlagsForAllObjects()
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphInstance::ResetFlagsForAllObjects");
+
         MCore::MemSet(m_objectFlags.data(), 0, sizeof(uint32) * m_objectFlags.size());
 
         for (AnimGraphInstance* childInstance : m_childAnimGraphInstances)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
@@ -394,6 +394,8 @@ namespace EMotionFX
     // the main process method of the final node
     void AnimGraphMotionNode::Output(AnimGraphInstance* animGraphInstance)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphMotionNode::Output");
+
         // if this motion is disabled, output the bind pose
         if (m_disabled)
         {
@@ -537,6 +539,8 @@ namespace EMotionFX
 
     void AnimGraphMotionNode::UniqueData::Update()
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphMotionNode::Update");
+
         AnimGraphMotionNode* motionNode = azdynamic_cast<AnimGraphMotionNode*>(m_object);
         AZ_Assert(motionNode, "Unique data linked to incorrect node type.");
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphStateMachine.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphStateMachine.cpp
@@ -92,6 +92,8 @@ namespace EMotionFX
 
     void AnimGraphStateMachine::Output(AnimGraphInstance* animGraphInstance)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphStateMachine::Update");
+
         ActorInstance* actorInstance = animGraphInstance->GetActorInstance();
         AnimGraphPose* outputPose = nullptr;
 
@@ -476,6 +478,8 @@ namespace EMotionFX
 
     void AnimGraphStateMachine::Update(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphStateMachine::Update");
+
         UniqueData* uniqueData = static_cast<UniqueData*>(FindOrCreateUniqueNodeData(animGraphInstance));
 
         // Defer switch to entry state.
@@ -622,6 +626,8 @@ namespace EMotionFX
 
     void AnimGraphStateMachine::PostUpdate(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphStateMachine::PostUpdate");
+
         RequestRefDatas(animGraphInstance);
         UniqueData* uniqueData = static_cast<UniqueData*>(FindOrCreateUniqueNodeData(animGraphInstance));
         AnimGraphRefCountedData* data = uniqueData->GetRefCountedData();
@@ -1344,6 +1350,8 @@ namespace EMotionFX
 
     void AnimGraphStateMachine::TopDownUpdate(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphStateMachine::TopDownUpdate");
+
         UniqueData* uniqueData = static_cast<UniqueData*>(FindOrCreateUniqueNodeData(animGraphInstance));
 
         if (!IsTransitioning(uniqueData))

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace1DNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace1DNode.cpp
@@ -166,6 +166,8 @@ namespace EMotionFX
 
     void BlendSpace1DNode::Output(AnimGraphInstance* animGraphInstance)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendSpace1DNode::Output");
+
         if (!AnimGraphInstanceExists(animGraphInstance))
         {
             return;
@@ -276,6 +278,8 @@ namespace EMotionFX
 
     void BlendSpace1DNode::Update(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendSpace1DNode::Update");
+
         if (!m_disabled)
         {
             EMotionFX::BlendTreeConnection* paramConnection = GetInputPort(INPUTPORT_VALUE).m_connection;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace2DNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendSpace2DNode.cpp
@@ -282,6 +282,8 @@ namespace EMotionFX
 
     void BlendSpace2DNode::Output(AnimGraphInstance* animGraphInstance)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendSpace2DNode::Output");
+
         if (!AnimGraphInstanceExists(animGraphInstance))
         {
             return;
@@ -402,6 +404,8 @@ namespace EMotionFX
 
     void BlendSpace2DNode::Update(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendSpace2DNode::Update");
+
         if (!AnimGraphInstanceExists(animGraphInstance))
         {
             return;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTree.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTree.cpp
@@ -116,10 +116,11 @@ namespace EMotionFX
         return nullptr;
     }
 
-
     // process the blend tree and calculate its output
     void BlendTree::Output(AnimGraphInstance* animGraphInstance)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendTree::Output");
+
         AZ_Assert(m_finalNode, "There should always be a final node. Something seems to be wrong with the blend tree creation.");
 
         // get the output pose
@@ -164,6 +165,8 @@ namespace EMotionFX
     // post sync update
     void BlendTree::PostUpdate(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "AnimGraphStateMachine::PostUpdate");
+
         // if this node is disabled, exit
         if (m_disabled)
         {
@@ -212,6 +215,8 @@ namespace EMotionFX
     // update all nodes
     void BlendTree::Update(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendTree::Update");
+
         // if this node is disabled, output the bind pose
         if (m_disabled)
         {
@@ -256,6 +261,8 @@ namespace EMotionFX
     // top down update
     void BlendTree::TopDownUpdate(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendTree::TopDownUpdate");
+
         // get the final node
         AnimGraphNode* finalNode = GetRealFinalNode();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeBlend2Node.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeBlend2Node.cpp
@@ -45,6 +45,8 @@ namespace EMotionFX
 
     void BlendTreeBlend2Node::Update(AnimGraphInstance* animGraphInstance, float timePassedInSeconds)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendTreeBlend2Node::Update");
+
         if (m_disabled)
         {
             AnimGraphNodeData* uniqueData = FindOrCreateUniqueNodeData(animGraphInstance);
@@ -88,9 +90,10 @@ namespace EMotionFX
         }
     }
 
-
     void BlendTreeBlend2Node::Output(AnimGraphInstance* animGraphInstance)
     {
+        AZ_PROFILE_SCOPE(Animation, "BlendTreeBlend2Node::Output");
+
         if (m_disabled)
         {
             RequestPoses(animGraphInstance);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionSystem.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionSystem.cpp
@@ -147,6 +147,8 @@ namespace EMotionFX
     // update motion queue and instances
     void MotionSystem::Update(float timePassed, bool updateNodes)
     {
+        AZ_PROFILE_SCOPE(Animation, "MotionSystem::Update");
+
         MCORE_UNUSED(updateNodes);
 
         // update the motion queue


### PR DESCRIPTION
Added some basic profile instrumentation for anim graphs to capture the update phases and the most important anim graph nodes.

![image](https://user-images.githubusercontent.com/43751992/134191096-7026f2b9-dc44-4cdc-a541-1391ba4690f2.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>