### PR TITLE
Prevent crash in Landscape Canvas when creating a prefab from an open graph.

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -2512,6 +2512,25 @@ namespace LandscapeCanvasEditor
     {
         // See comment above in OnPrefabInstancePropagationBegin
         m_prefabPropagationInProgress = false;
+
+        // After prefab propagation is complete, the entity tied to one of our open
+        // graphs might have been deleted (e.g. if a prefab was created from that entity),
+        // so we need to close that graph to be safe. We need to close them in a separate
+        // iterator because the CloseEditor API will end up modifying m_dockWidgetsByEntity.
+        AZStd::vector<GraphCanvas::DockWidgetId> dockWidgetsToDelete;
+        for (auto [entityId, dockWidgetId] : m_dockWidgetsByEntity)
+        {
+            AZ::Entity* entity = nullptr;
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
+            if (!entity)
+            {
+                dockWidgetsToDelete.push_back(dockWidgetId);
+            }
+        }
+        for (auto dockWidgetId : dockWidgetsToDelete)
+        {
+            CloseEditor(dockWidgetId);
+        }
     }
 
     void MainWindow::OnCryEditorEndCreate()

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -2514,9 +2514,10 @@ namespace LandscapeCanvasEditor
         m_prefabPropagationInProgress = false;
 
         // After prefab propagation is complete, the entity tied to one of our open
-        // graphs might have been deleted (e.g. if a prefab was created from that entity),
-        // so we need to close that graph to be safe. We need to close them in a separate
-        // iterator because the CloseEditor API will end up modifying m_dockWidgetsByEntity.
+        // graphs might have been deleted (e.g. if a prefab was created from that entity).
+        // Any open graphs tied to an entity that no longer exists will need to be closed.
+        // We need to close them in a separate iterator because the CloseEditor API will
+        // end up modifying m_dockWidgetsByEntity.
         AZStd::vector<GraphCanvas::DockWidgetId> dockWidgetsToDelete;
         for (auto [entityId, dockWidgetId] : m_dockWidgetsByEntity)
         {


### PR DESCRIPTION
Fixes #4169 

Prevent crash in Landscape Canvas by closing any open graphs after prefab propagation completes to ensure the corresponding Entity still exists. There are some edge cases that could cause the entity to be deleted during prefab propagation that aren't being caught currently (e.g. if you create a prefab out of that Entity), so this prevents the user from getting into a bad state where they'd be attempting to modify data on an Entity that no longer exists.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>