### PR TITLE
Fix a minor spelling mistake

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonProxyBus.cpp
@@ -195,7 +195,7 @@ namespace EditorPythonBindings
 
                 if (!m_handler)
                 {
-                    AZ_Error("python", false, "No EBus connection deteced; missing call or failed call to connect()?");
+                    AZ_Error("python", false, "No EBus connection detected; missing call or failed call to connect()?");
                     return false;
                 }
 


### PR DESCRIPTION
Came across this error while writing a test. Updating the error message.

Signed-off-by: amzn-tommy <waltont@amazon.com>