### PR TITLE
Use resize_no_construct when creating a buffer asset, 

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Buffer/BufferAssetCreator.cpp
@@ -57,7 +57,7 @@ namespace AZ
             // Only allocate buffer if initial data is not empty
             if (initialData != nullptr && initialDataSize > 0)
             {
-                bufferAsset->m_buffer.resize(descriptor.m_byteCount);
+                bufferAsset->m_buffer.resize_no_construct(descriptor.m_byteCount);
                 memcpy(bufferAsset->m_buffer.data(), initialData, initialDataSize);
             }
 


### PR DESCRIPTION
since the initial data is going to be memcpy'd anyways.

Tested with the SkinnedMeshExampleComponent in AtomSampleViewer, which creates buffers on the CPU with up to 4billion vertices, and tested with the O3DE Editor.

Signed-off-by: amzn-tommy <waltont@amazon.com>