### PR TITLE
Restore event listening behavior in EntityOutlinerListModel

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -1337,7 +1337,10 @@ namespace AzToolsFramework
         //add/remove operations trigger selection change signals which assert and break undo/redo operations in progress in inspector etc.
         //so disallow selection updates until change is complete
         emit EnableSelectionUpdates(false);
-        beginResetModel();
+
+        auto parentIndex = GetIndexFromEntity(parentId);
+        auto childIndex = GetIndexFromEntity(childId);
+        beginRemoveRows(parentIndex, childIndex.row(), childIndex.row());
     }
 
     void EntityOutlinerListModel::OnEntityInfoUpdatedRemoveChildEnd(AZ::EntityId parentId, AZ::EntityId childId)
@@ -1345,7 +1348,7 @@ namespace AzToolsFramework
         (void)childId;
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
-        endResetModel();
+        endRemoveRows();
 
         //must refresh partial lock/visibility of parents
         m_isFilterDirty = true;


### PR DESCRIPTION
Disables a problematic child reparenting code path in EditorEntityModel that led to the series of remove -> add -> remove notifications for reparented entities that led to unnecessary updates and a sporadic QSortFilterProxyModel crash

Signed-off-by: nvsickle <nvsickle@amazon.com>