### PR TITLE
Update to how entity space is treated in the viewport

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
@@ -8,11 +8,11 @@
 
 #pragma once
 
-#include <AzCore/base.h>
+#include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
-#include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/base.h>
 
 namespace AZ
 {
@@ -27,7 +27,11 @@ namespace AzFramework
         AZ_TYPE_INFO(ScreenPoint, "{8472B6C2-527F-44FC-87F8-C226B1A57A97}");
         ScreenPoint() = default;
 
-        ScreenPoint(int x, int y) : m_x(x), m_y(y) {}
+        ScreenPoint(int x, int y)
+            : m_x(x)
+            , m_y(y)
+        {
+        }
 
         int m_x; //!< X screen position.
         int m_y; //!< Y screen position.
@@ -42,7 +46,11 @@ namespace AzFramework
         AZ_TYPE_INFO(ScreenVector, "{1EAA2C62-8FDB-4A28-9FE3-1FA4F1418894}");
         ScreenVector() = default;
 
-        ScreenVector(int x, int y) : m_x(x), m_y(y) {}
+        ScreenVector(int x, int y)
+            : m_x(x)
+            , m_y(y)
+        {
+        }
 
         int m_x; //!< X screen delta.
         int m_y; //!< Y screen delta.
@@ -71,14 +79,14 @@ namespace AzFramework
 
     inline const ScreenPoint operator+(const ScreenPoint& lhs, const ScreenVector& rhs)
     {
-        ScreenPoint result{lhs};
+        ScreenPoint result{ lhs };
         result += rhs;
         return result;
     }
 
     inline const ScreenPoint operator-(const ScreenPoint& lhs, const ScreenVector& rhs)
     {
-        ScreenPoint result{lhs};
+        ScreenPoint result{ lhs };
         result -= rhs;
         return result;
     }
@@ -99,14 +107,14 @@ namespace AzFramework
 
     inline const ScreenVector operator+(const ScreenVector& lhs, const ScreenVector& rhs)
     {
-        ScreenVector result{lhs};
+        ScreenVector result{ lhs };
         result += rhs;
         return result;
     }
 
     inline const ScreenVector operator-(const ScreenVector& lhs, const ScreenVector& rhs)
     {
-        ScreenVector result{lhs};
+        ScreenVector result{ lhs };
         result -= rhs;
         return result;
     }
@@ -131,21 +139,35 @@ namespace AzFramework
         return !operator==(lhs, rhs);
     }
 
+    inline ScreenVector& operator*=(ScreenVector& lhs, const float rhs)
+    {
+        lhs.m_x = aznumeric_cast<int>(AZStd::llround(aznumeric_cast<float>(lhs.m_x) * rhs));
+        lhs.m_y = aznumeric_cast<int>(AZStd::llround(aznumeric_cast<float>(lhs.m_y) * rhs));
+        return lhs;
+    }
+
+    inline const ScreenVector operator*(const ScreenVector& lhs, const float rhs)
+    {
+        ScreenVector result{ lhs };
+        result *= rhs;
+        return result;
+    }
+
     inline float ScreenVectorLength(const ScreenVector& screenVector)
     {
         return aznumeric_cast<float>(AZStd::sqrt(screenVector.m_x * screenVector.m_x + screenVector.m_y * screenVector.m_y));
     }
 
-    inline ScreenPoint ScreenPointFromNDC(const AZ::Vector3& screenNDC, const AZ::Vector2& viewportSize)
+    inline ScreenPoint ScreenPointFromNdc(const AZ::Vector3& screenNDC, const AZ::Vector2& viewportSize)
     {
         return ScreenPoint(
-            aznumeric_caster(AZStd::round(screenNDC.GetX() * viewportSize.GetX())),
-            aznumeric_caster(AZStd::round((1.0f - screenNDC.GetY()) * viewportSize.GetY())));
+            AZStd::lround(screenNDC.GetX() * viewportSize.GetX()), AZStd::lround((1.0f - screenNDC.GetY()) * viewportSize.GetY()));
     }
 
-    inline AZ::Vector2 NDCFromScreenPoint(const ScreenPoint& screenPoint, const AZ::Vector2& viewportSize)
+    inline AZ::Vector2 NdcFromScreenPoint(const ScreenPoint& screenPoint, const AZ::Vector2& viewportSize)
     {
-        return AZ::Vector2(aznumeric_cast<float>(screenPoint.m_x), viewportSize.GetY() - aznumeric_cast<float>(screenPoint.m_y)) / viewportSize;
+        return AZ::Vector2(aznumeric_cast<float>(screenPoint.m_x), viewportSize.GetY() - aznumeric_cast<float>(screenPoint.m_y)) /
+            viewportSize;
     }
 
     //! Return an AZ::Vector2 from a ScreenPoint.

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
@@ -141,8 +141,8 @@ namespace AzFramework
 
     inline ScreenVector& operator*=(ScreenVector& lhs, const float rhs)
     {
-        lhs.m_x = aznumeric_cast<int>(AZStd::llround(aznumeric_cast<float>(lhs.m_x) * rhs));
-        lhs.m_y = aznumeric_cast<int>(AZStd::llround(aznumeric_cast<float>(lhs.m_y) * rhs));
+        lhs.m_x = AZStd::lround(aznumeric_cast<float>(lhs.m_x) * rhs);
+        lhs.m_y = AZStd::lround(aznumeric_cast<float>(lhs.m_y) * rhs);
         return lhs;
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
@@ -141,8 +141,8 @@ namespace AzFramework
 
     inline ScreenVector& operator*=(ScreenVector& lhs, const float rhs)
     {
-        lhs.m_x = AZStd::lround(aznumeric_cast<float>(lhs.m_x) * rhs);
-        lhs.m_y = AZStd::lround(aznumeric_cast<float>(lhs.m_y) * rhs);
+        lhs.m_x = aznumeric_cast<int>(AZStd::lround(aznumeric_cast<float>(lhs.m_x) * rhs));
+        lhs.m_y = aznumeric_cast<int>(AZStd::lround(aznumeric_cast<float>(lhs.m_y) * rhs));
         return lhs;
     }
 
@@ -156,18 +156,6 @@ namespace AzFramework
     inline float ScreenVectorLength(const ScreenVector& screenVector)
     {
         return aznumeric_cast<float>(AZStd::sqrt(screenVector.m_x * screenVector.m_x + screenVector.m_y * screenVector.m_y));
-    }
-
-    inline ScreenPoint ScreenPointFromNdc(const AZ::Vector3& screenNDC, const AZ::Vector2& viewportSize)
-    {
-        return ScreenPoint(
-            AZStd::lround(screenNDC.GetX() * viewportSize.GetX()), AZStd::lround((1.0f - screenNDC.GetY()) * viewportSize.GetY()));
-    }
-
-    inline AZ::Vector2 NdcFromScreenPoint(const ScreenPoint& screenPoint, const AZ::Vector2& viewportSize)
-    {
-        return AZ::Vector2(aznumeric_cast<float>(screenPoint.m_x), viewportSize.GetY() - aznumeric_cast<float>(screenPoint.m_y)) /
-            viewportSize;
     }
 
     //! Return an AZ::Vector2 from a ScreenPoint.

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ScreenGeometry.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Math/Vector2.h>
-#include <AzCore/Math/Vector3.h>
 #include <AzCore/RTTI/TypeInfoSimple.h>
 #include <AzCore/base.h>
 

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
@@ -23,7 +23,7 @@ namespace AzFramework
     // y-up, z into the screen, x-left
     //
     // x -> -x
-    // y ->  z 
+    // y ->  z
     // z ->  y
     //
     // the same transform can be used to go to/from z-up - the only difference is the order of
@@ -37,15 +37,15 @@ namespace AzFramework
         //      yaw = AZ::Matrix4x4::CreateRotationZ(AZ::DegToRad(180.0f));
         //      conversion = pitch * yaw
         return AZ::Matrix4x4::CreateFromColumns(
-            AZ::Vector4(-1.0f, 0.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 1.0f, .0f),
-            AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f));
+            AZ::Vector4(-1.0f, 0.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 1.0f, .0f), AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f),
+            AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f));
     }
 
     AZ::Matrix4x4 CameraTransform(const CameraState& cameraState)
     {
         return AZ::Matrix4x4::CreateFromColumns(
-            AZ::Vector3ToVector4(cameraState.m_side), AZ::Vector3ToVector4(cameraState.m_forward),
-            AZ::Vector3ToVector4(cameraState.m_up), AZ::Vector3ToVector4(cameraState.m_position, 1.0f));
+            AZ::Vector3ToVector4(cameraState.m_side), AZ::Vector3ToVector4(cameraState.m_forward), AZ::Vector3ToVector4(cameraState.m_up),
+            AZ::Vector3ToVector4(cameraState.m_position, 1.0f));
     }
 
     AZ::Matrix4x4 CameraView(const CameraState& cameraState)
@@ -63,8 +63,7 @@ namespace AzFramework
     AZ::Matrix4x4 CameraProjection(const CameraState& cameraState)
     {
         return AZ::Matrix4x4::CreateProjection(
-            cameraState.VerticalFovRadian(), AspectRatio(cameraState.m_viewportSize), cameraState.m_nearClip,
-            cameraState.m_farClip);
+            cameraState.VerticalFovRadian(), AspectRatio(cameraState.m_viewportSize), cameraState.m_nearClip, cameraState.m_farClip);
     }
 
     AZ::Matrix4x4 InverseCameraProjection(const CameraState& cameraState)
@@ -93,12 +92,11 @@ namespace AzFramework
         const auto cameraWorldTransform = AZ::Transform::CreateFromMatrix3x3AndTranslation(
             AZ::Matrix3x3::CreateFromMatrix4x4(worldFromView), worldFromView.GetTranslation());
         return AZ::ViewFrustumAttributes(
-            cameraWorldTransform, AspectRatio(cameraState.m_viewportSize), cameraState.m_fovOrZoom,
-            cameraState.m_nearClip, cameraState.m_farClip);
+            cameraWorldTransform, AspectRatio(cameraState.m_viewportSize), cameraState.m_fovOrZoom, cameraState.m_nearClip,
+            cameraState.m_farClip);
     }
 
-    AZ::Vector3 WorldToScreenNDC(
-        const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection)
+    AZ::Vector3 WorldToScreenNdc(const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection)
     {
         // transform the world space position to clip space
         const auto clipSpacePosition = cameraProjection * cameraView * AZ::Vector3ToVector4(worldPosition, 1.0f);
@@ -108,25 +106,24 @@ namespace AzFramework
         return (AZ::Vector4ToVector3(ndcPosition) + AZ::Vector3::CreateOne()) * 0.5f;
     }
 
-
     ScreenPoint WorldToScreen(
-        const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection,
+        const AZ::Vector3& worldPosition,
+        const AZ::Matrix4x4& cameraView,
+        const AZ::Matrix4x4& cameraProjection,
         const AZ::Vector2& viewportSize)
     {
-        const auto ndcNormalizedPosition = WorldToScreenNDC(worldPosition, cameraView, cameraProjection);
+        const auto ndcNormalizedPosition = WorldToScreenNdc(worldPosition, cameraView, cameraProjection);
         // scale ndc position by screen dimensions to return screen position
         return ScreenPointFromNdc(ndcNormalizedPosition, viewportSize);
     }
 
     ScreenPoint WorldToScreen(const AZ::Vector3& worldPosition, const CameraState& cameraState)
     {
-        return WorldToScreen(
-            worldPosition, CameraView(cameraState), CameraProjection(cameraState), cameraState.m_viewportSize);
+        return WorldToScreen(worldPosition, CameraView(cameraState), CameraProjection(cameraState), cameraState.m_viewportSize);
     }
 
-    AZ::Vector3 ScreenNDCToWorld(
-        const AZ::Vector2& normalizedScreenPosition, const AZ::Matrix4x4& inverseCameraView,
-        const AZ::Matrix4x4& inverseCameraProjection)
+    AZ::Vector3 ScreenNdcToWorld(
+        const AZ::Vector2& normalizedScreenPosition, const AZ::Matrix4x4& inverseCameraView, const AZ::Matrix4x4& inverseCameraProjection)
     {
         // convert screen space coordinates from <0, 1> to <-1,1> range
         const auto ndcPosition = normalizedScreenPosition * 2.0f - AZ::Vector2::CreateOne();
@@ -142,18 +139,19 @@ namespace AzFramework
     }
 
     AZ::Vector3 ScreenToWorld(
-        const ScreenPoint& screenPosition, const AZ::Matrix4x4& inverseCameraView,
-        const AZ::Matrix4x4& inverseCameraProjection, const AZ::Vector2& viewportSize)
+        const ScreenPoint& screenPosition,
+        const AZ::Matrix4x4& inverseCameraView,
+        const AZ::Matrix4x4& inverseCameraProjection,
+        const AZ::Vector2& viewportSize)
     {
         const auto normalizedScreenPosition = NdcFromScreenPoint(screenPosition, viewportSize);
 
-        return ScreenNDCToWorld(normalizedScreenPosition, inverseCameraView, inverseCameraProjection);
+        return ScreenNdcToWorld(normalizedScreenPosition, inverseCameraView, inverseCameraProjection);
     }
 
     AZ::Vector3 ScreenToWorld(const ScreenPoint& screenPosition, const CameraState& cameraState)
     {
         return ScreenToWorld(
-            screenPosition, InverseCameraView(cameraState), InverseCameraProjection(cameraState),
-            cameraState.m_viewportSize);
+            screenPosition, InverseCameraView(cameraState), InverseCameraProjection(cameraState), cameraState.m_viewportSize);
     }
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
@@ -115,7 +115,7 @@ namespace AzFramework
     {
         const auto ndcNormalizedPosition = WorldToScreenNDC(worldPosition, cameraView, cameraProjection);
         // scale ndc position by screen dimensions to return screen position
-        return ScreenPointFromNDC(ndcNormalizedPosition, viewportSize);
+        return ScreenPointFromNdc(ndcNormalizedPosition, viewportSize);
     }
 
     ScreenPoint WorldToScreen(const AZ::Vector3& worldPosition, const CameraState& cameraState)
@@ -145,7 +145,7 @@ namespace AzFramework
         const ScreenPoint& screenPosition, const AZ::Matrix4x4& inverseCameraView,
         const AZ::Matrix4x4& inverseCameraProjection, const AZ::Vector2& viewportSize)
     {
-        const auto normalizedScreenPosition = NDCFromScreenPoint(screenPosition, viewportSize);
+        const auto normalizedScreenPosition = NdcFromScreenPoint(screenPosition, viewportSize);
 
         return ScreenNDCToWorld(normalizedScreenPosition, inverseCameraView, inverseCameraProjection);
     }

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
@@ -37,7 +37,7 @@ namespace AzFramework
         //      yaw = AZ::Matrix4x4::CreateRotationZ(AZ::DegToRad(180.0f));
         //      conversion = pitch * yaw
         return AZ::Matrix4x4::CreateFromColumns(
-            AZ::Vector4(-1.0f, 0.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 1.0f, .0f), AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f),
+            AZ::Vector4(-1.0f, 0.0f, 0.0f, 0.0f), AZ::Vector4(0.0f, 0.0f, 1.0f, 0.0f), AZ::Vector4(0.0f, 1.0f, 0.0f, 0.0f),
             AZ::Vector4(0.0f, 0.0f, 0.0f, 1.0f));
     }
 

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.cpp
@@ -114,7 +114,7 @@ namespace AzFramework
     {
         const auto ndcNormalizedPosition = WorldToScreenNdc(worldPosition, cameraView, cameraProjection);
         // scale ndc position by screen dimensions to return screen position
-        return ScreenPointFromNdc(ndcNormalizedPosition, viewportSize);
+        return ScreenPointFromNdc(AZ::Vector3ToVector2(ndcNormalizedPosition), viewportSize);
     }
 
     ScreenPoint WorldToScreen(const AZ::Vector3& worldPosition, const CameraState& cameraState)

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.h
@@ -25,9 +25,7 @@ namespace AzFramework
     struct ViewportInfo;
 
     //! Projects a position in world space to screen space normalized device coordinates for the given camera.
-    AZ::Vector3 WorldToScreenNDC(
-        const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection);
-
+    AZ::Vector3 WorldToScreenNdc(const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection);
 
     //! Projects a position in world space to screen space for the given camera.
     ScreenPoint WorldToScreen(const AZ::Vector3& worldPosition, const CameraState& cameraState);
@@ -35,7 +33,9 @@ namespace AzFramework
     //! Overload of WorldToScreen that accepts camera values that can be precomputed if this function
     //! is called many times in a loop.
     ScreenPoint WorldToScreen(
-        const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection,
+        const AZ::Vector3& worldPosition,
+        const AZ::Matrix4x4& cameraView,
+        const AZ::Matrix4x4& cameraProjection,
         const AZ::Vector2& viewportSize);
 
     //! Unprojects a position in screen space pixel coordinates to world space.
@@ -45,14 +45,15 @@ namespace AzFramework
     //! Overload of ScreenToWorld that accepts camera values that can be precomputed if this function
     //! is called many times in a loop.
     AZ::Vector3 ScreenToWorld(
-        const ScreenPoint& screenPosition, const AZ::Matrix4x4& inverseCameraView,
-        const AZ::Matrix4x4& inverseCameraProjection, const AZ::Vector2& viewportSize);
+        const ScreenPoint& screenPosition,
+        const AZ::Matrix4x4& inverseCameraView,
+        const AZ::Matrix4x4& inverseCameraProjection,
+        const AZ::Vector2& viewportSize);
 
     //! Unprojects a position in screen space normalized device coordinates to world space.
     //! Note: The position returned will be on the near clip plane of the camera in world space.
-    AZ::Vector3 ScreenNDCToWorld(
-        const AZ::Vector2& ndcPosition, const AZ::Matrix4x4& inverseCameraView,
-        const AZ::Matrix4x4& inverseCameraProjection);
+    AZ::Vector3 ScreenNdcToWorld(
+        const AZ::Vector2& ndcPosition, const AZ::Matrix4x4& inverseCameraView, const AZ::Matrix4x4& inverseCameraProjection);
 
     //! Returns the camera projection for the current camera state.
     AZ::Matrix4x4 CameraProjection(const CameraState& cameraState);

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.h
@@ -27,11 +27,11 @@ namespace AzFramework
 
     //! Returns a position in screen space (in the range [0-viewportSize.x, 0-viewportSize.y]) from normalized device
     //! coordinates (in the range 0.0-1.0).
-    inline ScreenPoint ScreenPointFromNdc(const AZ::Vector3& screenNDC, const AZ::Vector2& viewportSize)
+    inline ScreenPoint ScreenPointFromNdc(const AZ::Vector2& screenNdc, const AZ::Vector2& viewportSize)
     {
         return ScreenPoint(
-            aznumeric_cast<int>(AZStd::lround(screenNDC.GetX() * viewportSize.GetX())),
-            aznumeric_cast<int>(AZStd::lround((1.0f - screenNDC.GetY()) * viewportSize.GetY())));
+            aznumeric_cast<int>(AZStd::lround(screenNdc.GetX() * viewportSize.GetX())),
+            aznumeric_cast<int>(AZStd::lround((1.0f - screenNdc.GetY()) * viewportSize.GetY())));
     }
 
     //! Returns a position in normalized device coordinates (in the range [0.0-1.0, 0.0-1.0]) from a

--- a/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/ViewportScreen.h
@@ -8,21 +8,39 @@
 
 #pragma once
 
+#include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Math/Vector2.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzFramework/Viewport/ScreenGeometry.h>
 
 namespace AZ
 {
     class Frustum;
     class Matrix4x4;
-    class Vector3;
     struct ViewFrustumAttributes;
 } // namespace AZ
 
 namespace AzFramework
 {
     struct CameraState;
-    struct ScreenPoint;
     struct ViewportInfo;
+
+    //! Returns a position in screen space (in the range [0-viewportSize.x, 0-viewportSize.y]) from normalized device
+    //! coordinates (in the range 0.0-1.0).
+    inline ScreenPoint ScreenPointFromNdc(const AZ::Vector3& screenNDC, const AZ::Vector2& viewportSize)
+    {
+        return ScreenPoint(
+            aznumeric_cast<int>(AZStd::lround(screenNDC.GetX() * viewportSize.GetX())),
+            aznumeric_cast<int>(AZStd::lround((1.0f - screenNDC.GetY()) * viewportSize.GetY())));
+    }
+
+    //! Returns a position in normalized device coordinates (in the range [0.0-1.0, 0.0-1.0]) from a
+    //! screen space position (in the range [0-viewportSize.x, 0-viewportSize.y]).
+    inline AZ::Vector2 NdcFromScreenPoint(const ScreenPoint& screenPoint, const AZ::Vector2& viewportSize)
+    {
+        return AZ::Vector2(aznumeric_cast<float>(screenPoint.m_x), viewportSize.GetY() - aznumeric_cast<float>(screenPoint.m_y)) /
+            viewportSize;
+    }
 
     //! Projects a position in world space to screen space normalized device coordinates for the given camera.
     AZ::Vector3 WorldToScreenNdc(const AZ::Vector3& worldPosition, const AZ::Matrix4x4& cameraView, const AZ::Matrix4x4& cameraProjection);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ScaleManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ScaleManipulators.cpp
@@ -71,6 +71,7 @@ namespace AzToolsFramework
         }
 
         m_uniformScaleManipulator->SetVisualOrientationOverride(QuaternionFromTransformNoScaling(localTransform));
+        m_uniformScaleManipulator->SetLocalPosition(localTransform.GetTranslation());
         m_uniformScaleManipulator->SetLocalOrientation(AZ::Quaternion::CreateIdentity());
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
@@ -13,9 +13,9 @@
 
 namespace AzToolsFramework
 {
-    static const float s_surfaceManipulatorTransparency = 0.75f;
-    static const float s_axisLength = 2.0f;
-    static const float s_surfaceManipulatorRadius = 0.1f;
+    static const float SurfaceManipulatorTransparency = 0.75f;
+    static const float LinearManipulatorAxisLength = 2.0f;
+    static const float SurfaceManipulatorRadius = 0.1f;
 
     static const AZ::Color s_xAxisColor = AZ::Color(1.0f, 0.0f, 0.0f, 1.0f);
     static const AZ::Color s_yAxisColor = AZ::Color(0.0f, 1.0f, 0.0f, 1.0f);
@@ -291,7 +291,7 @@ namespace AzToolsFramework
                 {
                     const AZ::Color color[2] = {
                         defaultColor,
-                        Vector3ToVector4(BaseManipulator::s_defaultMouseOverColor.GetAsVector3(), s_surfaceManipulatorTransparency)
+                        Vector3ToVector4(BaseManipulator::s_defaultMouseOverColor.GetAsVector3(), SurfaceManipulatorTransparency)
                     };
 
                     return color[mouseOver];
@@ -326,14 +326,14 @@ namespace AzToolsFramework
     {
         translationManipulators->SetAxes(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY(), AZ::Vector3::CreateAxisZ());
         translationManipulators->ConfigurePlanarView(s_xAxisColor, s_yAxisColor, s_zAxisColor);
-        translationManipulators->ConfigureLinearView(s_axisLength, s_xAxisColor, s_yAxisColor, s_zAxisColor);
-        translationManipulators->ConfigureSurfaceView(s_surfaceManipulatorRadius, s_surfaceManipulatorColor);
+        translationManipulators->ConfigureLinearView(LinearManipulatorAxisLength, s_xAxisColor, s_yAxisColor, s_zAxisColor);
+        translationManipulators->ConfigureSurfaceView(SurfaceManipulatorRadius, s_surfaceManipulatorColor);
     }
 
     void ConfigureTranslationManipulatorAppearance2d(TranslationManipulators* translationManipulators)
     {
         translationManipulators->SetAxes(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY());
         translationManipulators->ConfigurePlanarView(s_xAxisColor);
-        translationManipulators->ConfigureLinearView(s_axisLength, s_xAxisColor, s_yAxisColor);
+        translationManipulators->ConfigureLinearView(LinearManipulatorAxisLength, s_xAxisColor, s_yAxisColor);
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/TranslationManipulators.cpp
@@ -17,10 +17,10 @@ namespace AzToolsFramework
     static const float LinearManipulatorAxisLength = 2.0f;
     static const float SurfaceManipulatorRadius = 0.1f;
 
-    static const AZ::Color s_xAxisColor = AZ::Color(1.0f, 0.0f, 0.0f, 1.0f);
-    static const AZ::Color s_yAxisColor = AZ::Color(0.0f, 1.0f, 0.0f, 1.0f);
-    static const AZ::Color s_zAxisColor = AZ::Color(0.0f, 0.0f, 1.0f, 1.0f);
-    static const AZ::Color s_surfaceManipulatorColor = AZ::Color(1.0f, 1.0f, 0.0f, 0.5f);
+    static const AZ::Color LinearManipulatorXAxisColor = AZ::Color(1.0f, 0.0f, 0.0f, 1.0f);
+    static const AZ::Color LinearManipulatorYAxisColor = AZ::Color(0.0f, 1.0f, 0.0f, 1.0f);
+    static const AZ::Color LinearManipulatorZAxisColor = AZ::Color(0.0f, 0.0f, 1.0f, 1.0f);
+    static const AZ::Color SurfaceManipulatorColor = AZ::Color(1.0f, 1.0f, 0.0f, 0.5f);
 
     TranslationManipulators::TranslationManipulators(
         const Dimensions dimensions, const AZ::Transform& worldFromLocal, const AZ::Vector3& nonUniformScale)
@@ -325,15 +325,16 @@ namespace AzToolsFramework
     void ConfigureTranslationManipulatorAppearance3d(TranslationManipulators* translationManipulators)
     {
         translationManipulators->SetAxes(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY(), AZ::Vector3::CreateAxisZ());
-        translationManipulators->ConfigurePlanarView(s_xAxisColor, s_yAxisColor, s_zAxisColor);
-        translationManipulators->ConfigureLinearView(LinearManipulatorAxisLength, s_xAxisColor, s_yAxisColor, s_zAxisColor);
-        translationManipulators->ConfigureSurfaceView(SurfaceManipulatorRadius, s_surfaceManipulatorColor);
+        translationManipulators->ConfigurePlanarView(LinearManipulatorXAxisColor, LinearManipulatorYAxisColor, LinearManipulatorZAxisColor);
+        translationManipulators->ConfigureLinearView(
+            LinearManipulatorAxisLength, LinearManipulatorXAxisColor, LinearManipulatorYAxisColor, LinearManipulatorZAxisColor);
+        translationManipulators->ConfigureSurfaceView(SurfaceManipulatorRadius, SurfaceManipulatorColor);
     }
 
     void ConfigureTranslationManipulatorAppearance2d(TranslationManipulators* translationManipulators)
     {
         translationManipulators->SetAxes(AZ::Vector3::CreateAxisX(), AZ::Vector3::CreateAxisY());
-        translationManipulators->ConfigurePlanarView(s_xAxisColor);
-        translationManipulators->ConfigureLinearView(LinearManipulatorAxisLength, s_xAxisColor, s_yAxisColor);
+        translationManipulators->ConfigurePlanarView(LinearManipulatorXAxisColor);
+        translationManipulators->ConfigureLinearView(LinearManipulatorAxisLength, LinearManipulatorXAxisColor, LinearManipulatorYAxisColor);
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1252,7 +1252,7 @@ namespace AzToolsFramework
 
         AZStd::unique_ptr<TranslationManipulators> translationManipulators = AZStd::make_unique<TranslationManipulators>(
             TranslationManipulators::Dimensions::Three, AZ::Transform::CreateIdentity(), AZ::Vector3::CreateOne());
-        translationManipulators->SetLineBoundWidth(ManipulatorLineBoundWidth(ViewportUi::DefaultViewportId));
+        translationManipulators->SetLineBoundWidth(ManipulatorLineBoundWidth());
 
         InitializeManipulators(*translationManipulators);
 
@@ -1380,7 +1380,7 @@ namespace AzToolsFramework
 
         AZStd::unique_ptr<RotationManipulators> rotationManipulators =
             AZStd::make_unique<RotationManipulators>(AZ::Transform::CreateIdentity());
-        rotationManipulators->SetCircleBoundWidth(ManipulatorCicleBoundWidth(ViewportUi::DefaultViewportId));
+        rotationManipulators->SetCircleBoundWidth(ManipulatorCicleBoundWidth());
 
         InitializeManipulators(*rotationManipulators);
 
@@ -1541,7 +1541,7 @@ namespace AzToolsFramework
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
         AZStd::unique_ptr<ScaleManipulators> scaleManipulators = AZStd::make_unique<ScaleManipulators>(AZ::Transform::CreateIdentity());
-        scaleManipulators->SetLineBoundWidth(ManipulatorLineBoundWidth(ViewportUi::DefaultViewportId));
+        scaleManipulators->SetLineBoundWidth(ManipulatorLineBoundWidth());
 
         InitializeManipulators(*scaleManipulators);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1471,7 +1471,8 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    // only update the pivot override if the orientation is being modified in local space
+                    // only update the pivot override if the orientation is being modified in local space and we have
+                    // more than one entity selected (so rotating a single entity does not set the orientation override)
                     if (referenceFrame == ReferenceFrame::Local && sharedRotationState->m_entityIds.size() > 1)
                     {
                         m_pivotOverrideFrame.m_orientationOverride = manipulatorOrientation;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1471,6 +1471,12 @@ namespace AzToolsFramework
                 }
                 else
                 {
+                    // only update the pivot override if the orientation is being modified in local space
+                    if (referenceFrame == ReferenceFrame::Local && sharedRotationState->m_entityIds.size() > 1)
+                    {
+                        m_pivotOverrideFrame.m_orientationOverride = manipulatorOrientation;
+                    }
+
                     // note: must use sorted entityIds based on hierarchy order when updating transforms
                     for (AZ::EntityId entityId : sharedRotationState->m_entityIds)
                     {
@@ -1505,18 +1511,8 @@ namespace AzToolsFramework
                             break;
                         case Influence::Group:
                             {
-                                // only update the pivot override if the orientation is being modified in local space
-                                if (referenceFrame == ReferenceFrame::Local && sharedRotationState->m_entityIds.size() != 1)
-                                {
-                                    m_pivotOverrideFrame.m_orientationOverride = manipulatorOrientation;
-                                }
-
-                                const auto pivotOrientation = ETCS::CalculateSelectionPivotOrientation(
-                                    m_entityIdManipulators.m_lookups, m_pivotOverrideFrame, referenceFrame);
-
                                 const AZ::Transform pivotTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
-                                    pivotOrientation.m_worldOrientation,
-                                    m_entityIdManipulators.m_manipulators->GetLocalTransform().GetTranslation());
+                                    manipulatorOrientation, m_entityIdManipulators.m_manipulators->GetLocalTransform().GetTranslation());
                                 const AZ::Transform transformInPivotSpace =
                                     pivotTransform.GetInverse() * entityIdLookupIt->second.m_initial;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -77,13 +77,6 @@ namespace AzToolsFramework
         nullptr,
         AZ::ConsoleFunctorFlags::Null,
         "The screen position of the gizmo in normalized (0-1) ndc space");
-    AZ_CVAR(
-        bool,
-        ed_preferredWorldOuterSpace,
-        true,
-        nullptr,
-        AZ::ConsoleFunctorFlags::Null,
-        "Which space is prefered to move to when using the outer space modifier");
 
     // strings related to new viewport interaction model (EditorTransformComponentSelection)
     static const char* const TogglePivotTitleRightClick = "Toggle pivot";
@@ -804,20 +797,14 @@ namespace AzToolsFramework
         }
     }
 
-    // utility function to immediately return the current reference frame
-    // based on the state of the modifiers
+    // utility function to immediately return the current reference frame based on the state of the modifiers
     static ReferenceFrame ReferenceFrameFromModifiers(const ViewportInteraction::KeyboardModifiers modifiers)
     {
-        if (modifiers.Shift())
-        {
-            return ed_preferredWorldOuterSpace ? ReferenceFrame::World : ReferenceFrame::Parent;
-        }
-        else
-        {
-            return ReferenceFrame::Local;
-        }
+        return modifiers.Shift() ? ReferenceFrame::World : ReferenceFrame::Local;
     }
 
+    // utility function to immediately return the current sphere of influence of the manipulators based on the
+    // state of the modifiers
     static Influence InfluenceFromModifiers(const ViewportInteraction::KeyboardModifiers modifiers)
     {
         return modifiers.Alt() ? Influence::Individual : Influence::Group;
@@ -1519,7 +1506,7 @@ namespace AzToolsFramework
                         case Influence::Group:
                             {
                                 // only update the pivot override if the orientation is being modified in local space
-                                if (referenceFrame == ReferenceFrame::Local)
+                                if (referenceFrame == ReferenceFrame::Local && sharedRotationState->m_entityIds.size() != 1)
                                 {
                                     m_pivotOverrideFrame.m_orientationOverride = manipulatorOrientation;
                                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -700,13 +700,6 @@ namespace AzToolsFramework
                 switch (referenceFrame)
                 {
                 case ReferenceFrame::Local:
-                    // if we have a group selection, always use the pivot override if one
-                    // is set when moving to local space (can't pick individual local space)
-                    if (entityIdMap.size() > 1)
-                    {
-                        pivot.m_worldOrientation = pivotOverrideFrame.m_orientationOverride.value();
-                    }
-                    break;
                 case ReferenceFrame::Parent:
                     pivot.m_worldOrientation = pivotOverrideFrame.m_orientationOverride.value();
                     break;
@@ -2736,8 +2729,7 @@ namespace AzToolsFramework
 
         if (m_pivotOverrideFrame.m_orientationOverride && m_entityIdManipulators.m_manipulators)
         {
-            m_pivotOverrideFrame.m_orientationOverride =
-                QuaternionFromTransformNoScaling(m_entityIdManipulators.m_manipulators->GetLocalTransform());
+            m_pivotOverrideFrame.m_orientationOverride = m_entityIdManipulators.m_manipulators->GetLocalTransform().GetRotation();
         }
 
         if (m_pivotOverrideFrame.m_translationOverride && m_entityIdManipulators.m_manipulators)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1590,6 +1590,12 @@ namespace AzToolsFramework
         auto uniformLeftMouseMoveCallback = [this, sharedScaleState, prevModifiers = ViewportInteraction::KeyboardModifiers()](
                                                 const LinearManipulator::Action& action) mutable
         {
+            // do nothing to modify the manipulator
+            if (action.m_modifiers.Ctrl())
+            {
+                return;
+            }
+
             if (prevModifiers != action.m_modifiers)
             {
                 UpdateInitialTransform(m_entityIdManipulators);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -3559,7 +3559,7 @@ namespace AzToolsFramework
         // screen space
         const auto calculateGizmoAxis = [&cameraView, &cameraProjection, &screenOffset](const AZ::Vector3& axis)
         {
-            auto result = AZ::Vector2(AzFramework::WorldToScreenNDC(axis, cameraView, cameraProjection));
+            auto result = AZ::Vector2(AzFramework::WorldToScreenNdc(axis, cameraView, cameraProjection));
             result.SetY(1.0f - result.GetY());
             return result + screenOffset;
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1568,6 +1568,7 @@ namespace AzToolsFramework
 
         auto uniformLeftMouseDownCallback = [this, sharedScaleState]([[maybe_unused]] const LinearManipulator::Action& action)
         {
+            sharedScaleState->m_savedScale = AZ::Vector3::CreateZero();
             // important to sort entityIds based on hierarchy order when updating transforms
             BuildSortedEntityIdVectorFromEntityIdMap(m_entityIdManipulators.m_lookups, sharedScaleState->m_entityIds);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1553,7 +1553,7 @@ namespace AzToolsFramework
 
         struct SharedScaleState
         {
-            AZ::Vector3 m_savedScale = AZ::Vector3::CreateZero();
+            AZ::Vector3 m_savedScaleOffset = AZ::Vector3::CreateZero();
             EntityIdList m_entityIds;
         };
 
@@ -1562,7 +1562,7 @@ namespace AzToolsFramework
 
         auto uniformLeftMouseDownCallback = [this, sharedScaleState]([[maybe_unused]] const LinearManipulator::Action& action)
         {
-            sharedScaleState->m_savedScale = AZ::Vector3::CreateZero();
+            sharedScaleState->m_savedScaleOffset = AZ::Vector3::CreateZero();
             // important to sort entityIds based on hierarchy order when updating transforms
             BuildSortedEntityIdVectorFromEntityIdMap(m_entityIdManipulators.m_lookups, sharedScaleState->m_entityIds);
 
@@ -1599,7 +1599,7 @@ namespace AzToolsFramework
             if (prevModifiers != action.m_modifiers)
             {
                 UpdateInitialTransform(m_entityIdManipulators);
-                sharedScaleState->m_savedScale = action.LocalScaleOffset();
+                sharedScaleState->m_savedScaleOffset = action.LocalScaleOffset();
             }
 
             // note: must use sorted entityIds based on hierarchy order when updating transforms
@@ -1620,11 +1620,11 @@ namespace AzToolsFramework
                 };
 
                 const float uniformScale =
-                    action.m_start.m_sign * sumVectorElements(action.LocalScaleOffset() - sharedScaleState->m_savedScale);
+                    action.m_start.m_sign * sumVectorElements(action.LocalScaleOffset() - sharedScaleState->m_savedScaleOffset);
                 const float scale = AZ::GetClamp(1.0f + uniformScale / initialScale, AZ::MinTransformScale, AZ::MaxTransformScale);
                 const AZ::Transform scaleTransform = AZ::Transform::CreateUniformScale(scale);
 
-                switch (const Influence influence = InfluenceFromModifiers(action.m_modifiers); influence)
+                switch (InfluenceFromModifiers(action.m_modifiers))
                 {
                 case Influence::Individual:
                     {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -96,6 +96,14 @@ namespace AzToolsFramework
         AZ::u8 m_pickTypes = PickType::None; //!< What mode(s) were we in when picking an EntityId override.
     };
 
+    //! How a manipulator should treat an adjustment.
+    //! @note Determines if a transform is applied to an individual entity or the whole group.
+    enum class Influence
+    {
+        Group,
+        Individual
+    };
+
     //! What frame/space is the manipulator currently operating in.
     enum class ReferenceFrame
     {
@@ -328,7 +336,8 @@ namespace AzToolsFramework
         OptionalFrame m_pivotOverrideFrame; //!< Has a pivot override been set.
         Mode m_mode = Mode::Translation; //!< Manipulator mode - default to translation.
         Pivot m_pivotMode = Pivot::Object; //!< Entity pivot mode - default to object (authored root).
-        ReferenceFrame m_referenceFrame = ReferenceFrame::Parent; //!< What reference frame is the Manipulator currently operating in.
+        ReferenceFrame m_referenceFrame = ReferenceFrame::Local; //!< What reference frame is the Manipulator currently operating in.
+        Influence m_influence = Influence::Group; //!< What sphere of influence does the Manipulator have.
         Frame m_axisPreview; //!< Axes of entity at the time of mouse down to indicate delta of translation.
         bool m_triedToRefresh = false; //!< Did a refresh event occur to recalculate the current Manipulator transform.
         //! Was EditorTransformComponentSelection responsible for the most recent entity selection change.

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -371,16 +371,16 @@ namespace UnitTest
         // Given
         AzToolsFramework::SelectEntity(m_entityId1);
 
-        ArrangeIndividualRotatedEntitySelection(m_entityIds, AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)));
+        const auto entityTransform = AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(AZ::DegToRad(90.0f)));
+        ArrangeIndividualRotatedEntitySelection(m_entityIds, entityTransform.GetRotation());
         RefreshManipulators(EditorTransformComponentSelectionRequestBus::Events::RefreshType::All);
 
         SetTransformMode(EditorTransformComponentSelectionRequestBus::Events::Mode::Rotation);
 
         const AZ::Transform manipulatorTransformBefore = GetManipulatorTransform().value_or(AZ::Transform::CreateIdentity());
 
-        // check preconditions - manipulator transform matches parent/world transform (identity)
-        EXPECT_THAT(manipulatorTransformBefore.GetBasisY(), IsClose(AZ::Vector3::CreateAxisY()));
-        EXPECT_THAT(manipulatorTransformBefore.GetBasisZ(), IsClose(AZ::Vector3::CreateAxisZ()));
+        // check preconditions - manipulator transform matches the entity transform
+        EXPECT_THAT(manipulatorTransformBefore, IsClose(entityTransform));
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1661,7 +1661,7 @@ namespace UnitTest
         All,
         EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture,
         testing::Values(
-            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, ChildExpectedPivotLocalOrientationInWorldSpace },
+            ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Local, PivotOverrideLocalOrientationInWorldSpace },
             ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::Parent, PivotOverrideLocalOrientationInWorldSpace },
             ReferenceFrameWithOrientation{ AzToolsFramework::ReferenceFrame::World, AZ::Quaternion::CreateIdentity() }));
 

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -242,11 +242,11 @@ namespace UnitTest
         {
             // the initial starting position of the entities
             AZ::TransformBus::Event(
-                m_entityId1, &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(m_entity1WorldTranslation));
+                m_entityId1, &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(Entity1WorldTranslation));
             AZ::TransformBus::Event(
-                m_entityId2, &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(m_entity2WorldTranslation));
+                m_entityId2, &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(Entity2WorldTranslation));
             AZ::TransformBus::Event(
-                m_entityId3, &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(m_entity3WorldTranslation));
+                m_entityId3, &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateTranslation(Entity3WorldTranslation));
         }
 
         static void PositionCamera(AzFramework::CameraState& cameraState)
@@ -261,10 +261,15 @@ namespace UnitTest
         AZ::EntityId m_entityId1;
         AZ::EntityId m_entityId2;
         AZ::EntityId m_entityId3;
-        AZ::Vector3 m_entity1WorldTranslation = AZ::Vector3(5.0f, 15.0f, 10.0f);
-        AZ::Vector3 m_entity2WorldTranslation = AZ::Vector3(5.0f, 14.0f, 10.0f);
-        AZ::Vector3 m_entity3WorldTranslation = AZ::Vector3(5.0f, 16.0f, 10.0f);
+
+        static const AZ::Vector3 Entity1WorldTranslation;
+        static const AZ::Vector3 Entity2WorldTranslation;
+        static const AZ::Vector3 Entity3WorldTranslation;
     };
+
+    const AZ::Vector3 EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation = AZ::Vector3(5.0f, 15.0f, 10.0f);
+    const AZ::Vector3 EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation = AZ::Vector3(5.0f, 14.0f, 10.0f);
+    const AZ::Vector3 EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation = AZ::Vector3(5.0f, 16.0f, 10.0f);
 
     void ArrangeIndividualRotatedEntitySelection(const AzToolsFramework::EntityIdList& entityIds, const AZ::Quaternion& orientation)
     {
@@ -624,7 +629,7 @@ namespace UnitTest
         EXPECT_TRUE(selectedEntitiesBefore.empty());
 
         // calculate the position in screen space of the initial entity position
-        const auto entity1ScreenPosition = AzFramework::WorldToScreen(m_entity1WorldTranslation, m_cameraState);
+        const auto entity1ScreenPosition = AzFramework::WorldToScreen(Entity1WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(true)
@@ -649,7 +654,7 @@ namespace UnitTest
         EXPECT_TRUE(selectedEntitiesBefore.empty());
 
         // calculate the position in screen space of the initial entity position
-        const auto entity1ScreenPosition = AzFramework::WorldToScreen(m_entity1WorldTranslation, m_cameraState);
+        const auto entity1ScreenPosition = AzFramework::WorldToScreen(Entity1WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(false)
@@ -728,7 +733,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(true)
@@ -754,7 +759,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(false)
@@ -780,7 +785,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(true)
@@ -806,7 +811,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(false)
@@ -832,7 +837,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntities({ m_entityId1, m_entityId2 });
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(true)
@@ -858,7 +863,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntities({ m_entityId1, m_entityId2 });
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // click the entity in the viewport
         m_actionDispatcher->SetStickySelect(false)
@@ -1001,7 +1006,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // single click select entity2
         m_actionDispatcher->SetStickySelect(false)
@@ -1035,7 +1040,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // single click select entity2
         m_actionDispatcher->SetStickySelect(GetParam())
@@ -1056,7 +1061,7 @@ namespace UnitTest
             manipulatorTransform, AzToolsFramework::GetEntityContextId(),
             &AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::GetManipulatorTransform);
 
-        EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(m_entity2WorldTranslation));
+        EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(Entity2WorldTranslation));
     }
 
     TEST_P(
@@ -1069,7 +1074,7 @@ namespace UnitTest
         AzToolsFramework::SelectEntity(m_entityId1);
 
         // calculate the position in screen space of the second entity
-        const auto entity2ScreenPosition = AzFramework::WorldToScreen(m_entity2WorldTranslation, m_cameraState);
+        const auto entity2ScreenPosition = AzFramework::WorldToScreen(Entity2WorldTranslation, m_cameraState);
 
         // position in space above the entities
         const auto clickOffPositionWorld = AZ::Vector3(5.0f, 15.0f, 12.0f);
@@ -1096,7 +1101,7 @@ namespace UnitTest
                         manipulatorTransform, AzToolsFramework::GetEntityContextId(),
                         &AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::GetManipulatorTransform);
 
-                    EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(m_entity2WorldTranslation));
+                    EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(Entity2WorldTranslation));
                 })
             ->MousePosition(clickOffPositionScreen)
             ->KeyboardModifierDown(AzToolsFramework::ViewportInteraction::KeyboardModifier::Control)
@@ -1113,7 +1118,7 @@ namespace UnitTest
             &AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::GetManipulatorTransform);
 
         // manipulator transform is reset
-        EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(m_entity1WorldTranslation));
+        EXPECT_THAT(manipulatorTransform->GetTranslation(), IsClose(Entity1WorldTranslation));
     }
 
     INSTANTIATE_TEST_CASE_P(All, EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam, testing::Values(true, false));
@@ -1122,10 +1127,22 @@ namespace UnitTest
     using EditorTransformComponentSelectionManipulatorInteractionTestFixture =
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture;
 
-    // note: this replicates rotating an entity in local space with no modifiers held (local space)
-    TEST_F(
-        EditorTransformComponentSelectionManipulatorInteractionTestFixture,
-        RotatingASingleEntityInLocalSpaceWillRotateBothTheEntityAndTheManipulator)
+    struct ManipulatorOptionsSingle
+    {
+        AzToolsFramework::ViewportInteraction::KeyboardModifier m_keyboardModifier;
+        AZ::Transform m_expectedManipulatorTransformAfter;
+        AZ::Transform m_expectedEntityTransformAfter;
+    };
+
+    class EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam
+        : public EditorTransformComponentSelectionManipulatorInteractionTestFixture
+        , public ::testing::WithParamInterface<ManipulatorOptionsSingle>
+    {
+    };
+
+    TEST_P(
+        EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam,
+        RotatingASingleEntityWithDifferentModifierCombinations)
     {
         using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
 
@@ -1136,12 +1153,12 @@ namespace UnitTest
 
         AzToolsFramework::SelectEntity(m_entityId1);
 
-        const float screenToWorldMultiplier = AzToolsFramework::CalculateScreenToWorldMultiplier(m_entity1WorldTranslation, m_cameraState);
+        const float screenToWorldMultiplier = AzToolsFramework::CalculateScreenToWorldMultiplier(Entity1WorldTranslation, m_cameraState);
         const float manipulatorRadius = 2.0f * screenToWorldMultiplier;
 
-        const auto rotationManipulatorStartHoldWorldPosition = m_entity1WorldTranslation +
+        const auto rotationManipulatorStartHoldWorldPosition = Entity1WorldTranslation +
             AZ::Quaternion::CreateRotationX(AZ::DegToRad(-45.0f)).TransformVector(AZ::Vector3::CreateAxisY(-manipulatorRadius));
-        const auto rotationManipulatorEndHoldWorldPosition = m_entity1WorldTranslation +
+        const auto rotationManipulatorEndHoldWorldPosition = Entity1WorldTranslation +
             AZ::Quaternion::CreateRotationX(AZ::DegToRad(-135.0f)).TransformVector(AZ::Vector3::CreateAxisY(-manipulatorRadius));
 
         // calculate the position in screen space of the second entity
@@ -1152,19 +1169,163 @@ namespace UnitTest
 
         m_actionDispatcher->CameraState(m_cameraState)
             ->MousePosition(rotationManipulatorHoldScreenPosition)
+            ->KeyboardModifierDown(GetParam().m_keyboardModifier)
             ->MouseLButtonDown()
             ->MousePosition(rotationManipulatorEndHoldScreenPosition)
             ->MouseLButtonUp();
 
-        const auto expectedTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
-            AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f)), m_entity1WorldTranslation);
+        const auto expectedEntityTransform = GetParam().m_expectedEntityTransformAfter;
+        const auto expectedManipulatorTransform = GetParam().m_expectedManipulatorTransformAfter;
 
         const auto manipulatorTransform = GetManipulatorTransform();
         const auto entityTransform = AzToolsFramework::GetWorldTransform(m_entityId1);
 
-        EXPECT_THAT(*manipulatorTransform, IsClose(expectedTransform));
-        EXPECT_THAT(entityTransform, IsClose(expectedTransform));
+        EXPECT_THAT(*manipulatorTransform, IsClose(expectedManipulatorTransform));
+        EXPECT_THAT(entityTransform, IsClose(expectedEntityTransform));
     }
+
+    static const AZ::Transform ExpectedTransformAfterLocalRotationManipulatorMotion = AZ::Transform::CreateFromQuaternionAndTranslation(
+        AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f)),
+        EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation);
+
+    INSTANTIATE_TEST_CASE_P(
+        All,
+        EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam,
+        testing::Values(
+            // this replicates rotating an entity in local space with no modifiers held
+            // manipulator and entity rotate
+            ManipulatorOptionsSingle{ AzToolsFramework::ViewportInteraction::KeyboardModifier::None,
+                                              ExpectedTransformAfterLocalRotationManipulatorMotion,
+                                              ExpectedTransformAfterLocalRotationManipulatorMotion },
+            // this replicates rotating an entity in local space with the alt modifier held
+            // manipulator and entity rotate
+            ManipulatorOptionsSingle{ AzToolsFramework::ViewportInteraction::KeyboardModifier::Alt,
+                                              ExpectedTransformAfterLocalRotationManipulatorMotion,
+                                              ExpectedTransformAfterLocalRotationManipulatorMotion },
+            // this replicates rotating an entity in world space with the shift modifier held
+            // entity rotates, manipulator remains aligned to world
+            ManipulatorOptionsSingle{
+                AzToolsFramework::ViewportInteraction::KeyboardModifier::Shift,
+                AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation),
+                ExpectedTransformAfterLocalRotationManipulatorMotion },
+            // this replicates rotating the manipulator in local space with the ctrl modifier held (entity is unchanged)
+            ManipulatorOptionsSingle{
+                AzToolsFramework::ViewportInteraction::KeyboardModifier::Ctrl, ExpectedTransformAfterLocalRotationManipulatorMotion,
+                AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation) }));
+
+    struct ManipulatorOptionsMultiple
+    {
+        AzToolsFramework::ViewportInteraction::KeyboardModifier m_keyboardModifier;
+        AZ::Transform m_expectedManipulatorTransformAfter;
+        AZ::Transform m_firstExpectedEntityTransformAfter;
+        AZ::Transform m_secondExpectedEntityTransformAfter;
+    };
+
+    class EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam
+        : public EditorTransformComponentSelectionManipulatorInteractionTestFixture
+        , public ::testing::WithParamInterface<ManipulatorOptionsMultiple>
+    {
+    };
+
+    TEST_P(
+        EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam,
+        RotatingMultipleEntitiesWithDifferentModifierCombinations)
+    {
+        using AzToolsFramework::EditorTransformComponentSelectionRequestBus;
+
+        PositionEntities();
+        PositionCamera(m_cameraState);
+
+        SetTransformMode(EditorTransformComponentSelectionRequestBus::Events::Mode::Rotation);
+
+        AzToolsFramework::SelectEntities({ m_entityId2, m_entityId3 });
+
+        // manipulator should be centered between the two entities
+        const auto initialManipulatorTransform = GetManipulatorTransform();
+
+        const float screenToWorldMultiplier =
+            AzToolsFramework::CalculateScreenToWorldMultiplier(initialManipulatorTransform->GetTranslation(), m_cameraState);
+        const float manipulatorRadius = 2.0f * screenToWorldMultiplier;
+
+        const auto rotationManipulatorStartHoldWorldPosition = initialManipulatorTransform->GetTranslation() +
+            AZ::Quaternion::CreateRotationX(AZ::DegToRad(-45.0f)).TransformVector(AZ::Vector3::CreateAxisY(-manipulatorRadius));
+        const auto rotationManipulatorEndHoldWorldPosition = initialManipulatorTransform->GetTranslation() +
+            AZ::Quaternion::CreateRotationX(AZ::DegToRad(-135.0f)).TransformVector(AZ::Vector3::CreateAxisY(-manipulatorRadius));
+
+        // calculate the position in screen space of the second entity
+        const auto rotationManipulatorHoldScreenPosition =
+            AzFramework::WorldToScreen(rotationManipulatorStartHoldWorldPosition, m_cameraState);
+        const auto rotationManipulatorEndHoldScreenPosition =
+            AzFramework::WorldToScreen(rotationManipulatorEndHoldWorldPosition, m_cameraState);
+
+        m_actionDispatcher->CameraState(m_cameraState)
+            ->MousePosition(rotationManipulatorHoldScreenPosition)
+            ->KeyboardModifierDown(GetParam().m_keyboardModifier)
+            ->MouseLButtonDown()
+            ->MousePosition(rotationManipulatorEndHoldScreenPosition)
+            ->MouseLButtonUp();
+
+        const auto expectedEntity2Transform = GetParam().m_firstExpectedEntityTransformAfter;
+        const auto expectedEntity3Transform = GetParam().m_secondExpectedEntityTransformAfter;
+        const auto expectedManipulatorTransform = GetParam().m_expectedManipulatorTransformAfter;
+
+        const auto manipulatorTransformAfter = GetManipulatorTransform();
+        const auto entity2Transform = AzToolsFramework::GetWorldTransform(m_entityId2);
+        const auto entity3Transform = AzToolsFramework::GetWorldTransform(m_entityId3);
+
+        EXPECT_THAT(*manipulatorTransformAfter, IsClose(expectedManipulatorTransform));
+        EXPECT_THAT(entity2Transform, IsClose(expectedEntity2Transform));
+        EXPECT_THAT(entity3Transform, IsClose(expectedEntity3Transform));
+    }
+
+    // note: The aggregate manipulator position will be the average of entity 2 and 3 combined which
+    // winds up being the same as entity 1
+    static const AZ::Vector3 AggregateManipulatorPositionWithEntity2and3Selected =
+        EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation;
+
+    static const AZ::Transform ExpectedEntity2TransformAfterLocalGroupRotationManipulatorMotion =
+        AZ::Transform::CreateTranslation(AggregateManipulatorPositionWithEntity2and3Selected) *
+        AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f))) *
+        AZ::Transform::CreateTranslation(AZ::Vector3::CreateAxisY(-1.0f));
+    static const AZ::Transform ExpectedEntity3TransformAfterLocalGroupRotationManipulatorMotion =
+        AZ::Transform::CreateTranslation(AggregateManipulatorPositionWithEntity2and3Selected) *
+        AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f))) *
+        AZ::Transform::CreateTranslation(AZ::Vector3::CreateAxisY(1.0f));
+    static const AZ::Transform ExpectedEntity2TransformAfterLocalIndividualRotationManipulatorMotion =
+        AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation) *
+        AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f)));
+    static const AZ::Transform ExpectedEntity3TransformAfterLocalIndividualRotationManipulatorMotion =
+        AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) *
+        AZ::Transform::CreateFromQuaternion(AZ::Quaternion::CreateRotationX(AZ::DegToRad(-90.0f)));
+
+    INSTANTIATE_TEST_CASE_P(
+        All,
+        EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam,
+        testing::Values(
+            // this replicates rotating an entity in local space with no modifiers held
+            // manipulator and entity rotate
+            ManipulatorOptionsMultiple{ AzToolsFramework::ViewportInteraction::KeyboardModifier::None,
+                                                ExpectedTransformAfterLocalRotationManipulatorMotion,
+                                                ExpectedEntity2TransformAfterLocalGroupRotationManipulatorMotion,
+                                                ExpectedEntity3TransformAfterLocalGroupRotationManipulatorMotion },
+            // this replicates rotating an entity in local space with the alt modifier held
+            // manipulator and entity rotate
+            ManipulatorOptionsMultiple{ AzToolsFramework::ViewportInteraction::KeyboardModifier::Alt,
+                                                ExpectedTransformAfterLocalRotationManipulatorMotion,
+                                                ExpectedEntity2TransformAfterLocalIndividualRotationManipulatorMotion,
+                                                ExpectedEntity3TransformAfterLocalIndividualRotationManipulatorMotion },
+            // this replicates rotating an entity in world space with the shift modifier held
+            // entity rotates, manipulator remains aligned to world
+            ManipulatorOptionsMultiple{
+                AzToolsFramework::ViewportInteraction::KeyboardModifier::Shift,
+                AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation),
+                ExpectedEntity2TransformAfterLocalGroupRotationManipulatorMotion,
+                ExpectedEntity3TransformAfterLocalGroupRotationManipulatorMotion },
+            // this replicates rotating the manipulator in local space with the ctrl modifier held (entity is unchanged)
+            ManipulatorOptionsMultiple{
+                AzToolsFramework::ViewportInteraction::KeyboardModifier::Ctrl, ExpectedTransformAfterLocalRotationManipulatorMotion,
+                AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation),
+                AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) }));
 
     using EditorTransformComponentSelectionManipulatorTestFixture =
         IndirectCallManipulatorViewportInteractionFixtureMixin<EditorTransformComponentSelectionFixture>;

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -1127,6 +1127,7 @@ namespace UnitTest
     using EditorTransformComponentSelectionManipulatorInteractionTestFixture =
         EditorTransformComponentSelectionViewportPickingManipulatorTestFixture;
 
+    // type to group related inputs and outcomes for parameterized tests (single entity)
     struct ManipulatorOptionsSingle
     {
         AzToolsFramework::ViewportInteraction::KeyboardModifier m_keyboardModifier;
@@ -1213,6 +1214,7 @@ namespace UnitTest
                 AzToolsFramework::ViewportInteraction::KeyboardModifier::Ctrl, ExpectedTransformAfterLocalRotationManipulatorMotion,
                 AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation) }));
 
+    // type to group related inputs and outcomes for parameterized tests (two entities)
     struct ManipulatorOptionsMultiple
     {
         AzToolsFramework::ViewportInteraction::KeyboardModifier m_keyboardModifier;

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -262,14 +262,10 @@ namespace UnitTest
         AZ::EntityId m_entityId2;
         AZ::EntityId m_entityId3;
 
-        static const AZ::Vector3 Entity1WorldTranslation;
-        static const AZ::Vector3 Entity2WorldTranslation;
-        static const AZ::Vector3 Entity3WorldTranslation;
+        static inline const AZ::Vector3 Entity1WorldTranslation = AZ::Vector3(5.0f, 15.0f, 10.0f);;
+        static inline const AZ::Vector3 Entity2WorldTranslation = AZ::Vector3(5.0f, 14.0f, 10.0f);
+        static inline const AZ::Vector3 Entity3WorldTranslation= AZ::Vector3(5.0f, 16.0f, 10.0f);
     };
-
-    const AZ::Vector3 EditorTransformComponentSelectionViewportPickingFixture::Entity1WorldTranslation = AZ::Vector3(5.0f, 15.0f, 10.0f);
-    const AZ::Vector3 EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation = AZ::Vector3(5.0f, 14.0f, 10.0f);
-    const AZ::Vector3 EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation = AZ::Vector3(5.0f, 16.0f, 10.0f);
 
     void ArrangeIndividualRotatedEntitySelection(const AzToolsFramework::EntityIdList& entityIds, const AZ::Quaternion& orientation)
     {

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -262,9 +262,9 @@ namespace UnitTest
         AZ::EntityId m_entityId2;
         AZ::EntityId m_entityId3;
 
-        static inline const AZ::Vector3 Entity1WorldTranslation = AZ::Vector3(5.0f, 15.0f, 10.0f);;
+        static inline const AZ::Vector3 Entity1WorldTranslation = AZ::Vector3(5.0f, 15.0f, 10.0f);
         static inline const AZ::Vector3 Entity2WorldTranslation = AZ::Vector3(5.0f, 14.0f, 10.0f);
-        static inline const AZ::Vector3 Entity3WorldTranslation= AZ::Vector3(5.0f, 16.0f, 10.0f);
+        static inline const AZ::Vector3 Entity3WorldTranslation = AZ::Vector3(5.0f, 16.0f, 10.0f);
     };
 
     void ArrangeIndividualRotatedEntitySelection(const AzToolsFramework::EntityIdList& entityIds, const AZ::Quaternion& orientation)
@@ -1631,8 +1631,7 @@ namespace UnitTest
         AZ::Transform::CreateUniformScale(LinearManipulatorZAxisMovement);
     static const AZ::Transform ExpectedEntity3TransformAfterLocalGroupScaleManipulatorMotion =
         AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity3WorldTranslation) *
-        AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 1.0f, 0.0f)) *
-        AZ::Transform::CreateUniformScale(LinearManipulatorZAxisMovement);
+        AZ::Transform::CreateTranslation(AZ::Vector3(0.0f, 1.0f, 0.0f)) * AZ::Transform::CreateUniformScale(LinearManipulatorZAxisMovement);
     static const AZ::Transform ExpectedEntity2TransformAfterLocalIndividualScaleManipulatorMotion =
         AZ::Transform::CreateTranslation(EditorTransformComponentSelectionViewportPickingFixture::Entity2WorldTranslation) *
         AZ::Transform::CreateUniformScale(LinearManipulatorZAxisMovement);

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
@@ -21,11 +21,11 @@
 namespace UnitTest
 {
     // transform a point from normalized device coordinates to world space, and then from world space back to normalized device coordinates
-    AZ::Vector2 ScreenNDCToWorldToScreenNDC(const AZ::Vector2& ndcPoint, const AzFramework::CameraState& cameraState)
+    AZ::Vector2 ScreenNdcToWorldToScreenNdc(const AZ::Vector2& ndcPoint, const AzFramework::CameraState& cameraState)
     {
         const auto worldResult =
-            AzFramework::ScreenNDCToWorld(ndcPoint, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
-        const auto ndcResult = AzFramework::WorldToScreenNDC(worldResult, CameraView(cameraState), CameraProjection(cameraState));
+            AzFramework::ScreenNdcToWorld(ndcPoint, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
+        const auto ndcResult = AzFramework::WorldToScreenNdc(worldResult, CameraView(cameraState), CameraProjection(cameraState));
         return AZ::Vector3ToVector2(ndcResult);
     }
 
@@ -113,25 +113,25 @@ namespace UnitTest
         const auto cameraState = AzFramework::CreateIdentityDefaultCamera(cameraPosition, screenDimensions);
         {
             const auto expectedNdcPoint = NdcPoint{ 0.75f, 0.75f };
-            const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
+            const auto resultNdcPoint = ScreenNdcToWorldToScreenNdc(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
 
         {
             const auto expectedNdcPoint = NdcPoint{ 0.5f, 0.5f };
-            const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
+            const auto resultNdcPoint = ScreenNdcToWorldToScreenNdc(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
 
         {
             const auto expectedNdcPoint = NdcPoint{ 0.0f, 0.0f };
-            const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
+            const auto resultNdcPoint = ScreenNdcToWorldToScreenNdc(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
 
         {
             const auto expectedNdcPoint = NdcPoint{ 1.0f, 1.0f };
-            const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
+            const auto resultNdcPoint = ScreenNdcToWorldToScreenNdc(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
     }
@@ -147,7 +147,7 @@ namespace UnitTest
         const auto cameraState = AzFramework::CreateDefaultCamera(cameraTransform, screenDimensions);
 
         const auto expectedNdcPoint = NdcPoint{ 0.25f, 0.5f };
-        const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
+        const auto resultNdcPoint = ScreenNdcToWorldToScreenNdc(expectedNdcPoint, cameraState);
         EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
     }
 
@@ -164,7 +164,7 @@ namespace UnitTest
         const auto cameraState = AzFramework::CreateDefaultCamera(cameraTransform, screenDimensions);
 
         const auto worldResult =
-            AzFramework::ScreenNDCToWorld(NdcPoint{ 0.5f, 0.5f }, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
+            AzFramework::ScreenNdcToWorld(NdcPoint{ 0.5f, 0.5f }, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
         EXPECT_THAT(worldResult, IsClose(AZ::Vector3(10.1f, 0.0f, 0.0f)));
     }
 

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix3x3.h>
+#include <AzCore/Math/Matrix3x4.h>
 #include <AzCore/Math/Matrix4x4.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/VectorConversions.h>
@@ -20,18 +20,17 @@
 
 namespace UnitTest
 {
-     // transform a point from normalized device coordinates to world space, and then from world space back to normalized device coordinates
-    AZ::Vector2 ScreenNDCToWorldToScreenNDC(
-        const AZ::Vector2& ndcPoint, const AzFramework::CameraState& cameraState)
+    // transform a point from normalized device coordinates to world space, and then from world space back to normalized device coordinates
+    AZ::Vector2 ScreenNDCToWorldToScreenNDC(const AZ::Vector2& ndcPoint, const AzFramework::CameraState& cameraState)
     {
-        const auto worldResult = AzFramework::ScreenNDCToWorld(ndcPoint, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
+        const auto worldResult =
+            AzFramework::ScreenNDCToWorld(ndcPoint, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
         const auto ndcResult = AzFramework::WorldToScreenNDC(worldResult, CameraView(cameraState), CameraProjection(cameraState));
         return AZ::Vector3ToVector2(ndcResult);
     }
 
     // transform a point from screen space to world space, and then from world space back to screen space
-    AzFramework::ScreenPoint ScreenToWorldToScreen(
-        const AzFramework::ScreenPoint& screenPoint, const AzFramework::CameraState& cameraState)
+    AzFramework::ScreenPoint ScreenToWorldToScreen(const AzFramework::ScreenPoint& screenPoint, const AzFramework::CameraState& cameraState)
     {
         const auto worldResult = AzFramework::ScreenToWorld(screenPoint, cameraState);
         return AzFramework::WorldToScreen(worldResult, cameraState);
@@ -47,25 +46,25 @@ namespace UnitTest
 
         const auto cameraState = AzFramework::CreateIdentityDefaultCamera(cameraPosition, screenDimensions);
         {
-            const auto expectedScreenPoint = ScreenPoint{600, 450};
+            const auto expectedScreenPoint = ScreenPoint{ 600, 450 };
             const auto resultScreenPoint = ScreenToWorldToScreen(expectedScreenPoint, cameraState);
             EXPECT_EQ(resultScreenPoint, expectedScreenPoint);
         }
 
         {
-            const auto expectedScreenPoint = ScreenPoint{400, 300};
+            const auto expectedScreenPoint = ScreenPoint{ 400, 300 };
             const auto resultScreenPoint = ScreenToWorldToScreen(expectedScreenPoint, cameraState);
             EXPECT_EQ(resultScreenPoint, expectedScreenPoint);
         }
 
         {
-            const auto expectedScreenPoint = ScreenPoint{0, 0};
+            const auto expectedScreenPoint = ScreenPoint{ 0, 0 };
             const auto resultScreenPoint = ScreenToWorldToScreen(expectedScreenPoint, cameraState);
             EXPECT_EQ(resultScreenPoint, expectedScreenPoint);
         }
 
         {
-            const auto expectedScreenPoint = ScreenPoint{800, 600};
+            const auto expectedScreenPoint = ScreenPoint{ 800, 600 };
             const auto resultScreenPoint = ScreenToWorldToScreen(expectedScreenPoint, cameraState);
             EXPECT_EQ(resultScreenPoint, expectedScreenPoint);
         }
@@ -81,7 +80,7 @@ namespace UnitTest
 
         const auto cameraState = AzFramework::CreateDefaultCamera(cameraTransform, screenDimensions);
 
-        const auto expectedScreenPoint = ScreenPoint{200, 300};
+        const auto expectedScreenPoint = ScreenPoint{ 200, 300 };
         const auto resultScreenPoint = ScreenToWorldToScreen(expectedScreenPoint, cameraState);
         EXPECT_EQ(resultScreenPoint, expectedScreenPoint);
     }
@@ -93,45 +92,45 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
 
         const auto screenDimensions = AZ::Vector2(800.0f, 600.0f);
-        const auto cameraTransform = AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 0.0f, 0.0f)) *
-            AZ::Transform::CreateRotationZ(AZ::DegToRad(-90.0f));
+        const auto cameraTransform =
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 0.0f, 0.0f)) * AZ::Transform::CreateRotationZ(AZ::DegToRad(-90.0f));
 
         const auto cameraState = AzFramework::CreateDefaultCamera(cameraTransform, screenDimensions);
 
-        const auto worldResult = AzFramework::ScreenToWorld(ScreenPoint{400, 300}, cameraState);
+        const auto worldResult = AzFramework::ScreenToWorld(ScreenPoint{ 400, 300 }, cameraState);
         EXPECT_THAT(worldResult, IsClose(AZ::Vector3(10.1f, 0.0f, 0.0f)));
     }
-    
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     // NDC tests
     TEST(ViewportScreen, WorldToScreenNDCAndScreenNDCToWorldReturnsTheSameValueIdentityCameraOffsetFromOrigin)
     {
         using NdcPoint = AZ::Vector2;
-        
+
         const auto screenDimensions = AZ::Vector2(800.0f, 600.0f);
         const auto cameraPosition = AZ::Vector3::CreateAxisY(-10.0f);
 
         const auto cameraState = AzFramework::CreateIdentityDefaultCamera(cameraPosition, screenDimensions);
         {
-            const auto expectedNdcPoint = NdcPoint{0.75f, 0.75f};
+            const auto expectedNdcPoint = NdcPoint{ 0.75f, 0.75f };
             const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
 
         {
-            const auto expectedNdcPoint = NdcPoint{0.5f, 0.5f};
+            const auto expectedNdcPoint = NdcPoint{ 0.5f, 0.5f };
             const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
 
         {
-            const auto expectedNdcPoint = NdcPoint{0.0f, 0.0f};
+            const auto expectedNdcPoint = NdcPoint{ 0.0f, 0.0f };
             const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
 
         {
-            const auto expectedNdcPoint = NdcPoint{1.0f, 1.0f};
+            const auto expectedNdcPoint = NdcPoint{ 1.0f, 1.0f };
             const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
             EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
         }
@@ -147,7 +146,7 @@ namespace UnitTest
 
         const auto cameraState = AzFramework::CreateDefaultCamera(cameraTransform, screenDimensions);
 
-        const auto expectedNdcPoint = NdcPoint{0.25f, 0.5f};
+        const auto expectedNdcPoint = NdcPoint{ 0.25f, 0.5f };
         const auto resultNdcPoint = ScreenNDCToWorldToScreenNDC(expectedNdcPoint, cameraState);
         EXPECT_THAT(resultNdcPoint, IsClose(expectedNdcPoint));
     }
@@ -159,12 +158,13 @@ namespace UnitTest
         using NdcPoint = AZ::Vector2;
 
         const auto screenDimensions = AZ::Vector2(800.0f, 600.0f);
-        const auto cameraTransform = AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 0.0f, 0.0f)) *
-            AZ::Transform::CreateRotationZ(AZ::DegToRad(-90.0f));
+        const auto cameraTransform =
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 0.0f, 0.0f)) * AZ::Transform::CreateRotationZ(AZ::DegToRad(-90.0f));
 
         const auto cameraState = AzFramework::CreateDefaultCamera(cameraTransform, screenDimensions);
 
-        const auto worldResult = AzFramework::ScreenNDCToWorld(NdcPoint{0.5f, 0.5f}, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
+        const auto worldResult =
+            AzFramework::ScreenNDCToWorld(NdcPoint{ 0.5f, 0.5f }, InverseCameraView(cameraState), InverseCameraProjection(cameraState));
         EXPECT_THAT(worldResult, IsClose(AZ::Vector3(10.1f, 0.0f, 0.0f)));
     }
 
@@ -175,7 +175,7 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
         using AzFramework::ScreenVector;
 
-        const ScreenVector screenVector = ScreenPoint{100, 200} - ScreenPoint{10, 20};
+        const ScreenVector screenVector = ScreenPoint{ 100, 200 } - ScreenPoint{ 10, 20 };
         EXPECT_EQ(screenVector, ScreenVector(90, 180));
     }
 
@@ -184,7 +184,7 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
         using AzFramework::ScreenVector;
 
-        const ScreenPoint screenPoint = ScreenPoint{100, 200} + ScreenVector{50, 25};
+        const ScreenPoint screenPoint = ScreenPoint{ 100, 200 } + ScreenVector{ 50, 25 };
         EXPECT_EQ(screenPoint, ScreenPoint(150, 225));
     }
 
@@ -193,7 +193,7 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
         using AzFramework::ScreenVector;
 
-        const ScreenPoint screenPoint = ScreenPoint{120, 200} - ScreenVector{50, 20};
+        const ScreenPoint screenPoint = ScreenPoint{ 120, 200 } - ScreenVector{ 50, 20 };
         EXPECT_EQ(screenPoint, ScreenPoint(70, 180));
     }
 
@@ -202,7 +202,7 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
         using AzFramework::ScreenVector;
 
-        const ScreenVector screenVector = ScreenVector{100, 200} + ScreenVector{50, 25};
+        const ScreenVector screenVector = ScreenVector{ 100, 200 } + ScreenVector{ 50, 25 };
         EXPECT_EQ(screenVector, ScreenVector(150, 225));
     }
 
@@ -211,7 +211,7 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
         using AzFramework::ScreenVector;
 
-        const ScreenVector screenVector = ScreenVector{100, 200} - ScreenVector{50, 25};
+        const ScreenVector screenVector = ScreenVector{ 100, 200 } - ScreenVector{ 50, 25 };
         EXPECT_EQ(screenVector, ScreenVector(50, 175));
     }
 
@@ -220,8 +220,8 @@ namespace UnitTest
         using AzFramework::ScreenPoint;
         using AzFramework::ScreenVector;
 
-        const ScreenPoint screenPoint = ScreenPoint{100, 200};
-        const ScreenVector screenVector = ScreenVector{50, 25};
+        const ScreenPoint screenPoint = ScreenPoint{ 100, 200 };
+        const ScreenVector screenVector = ScreenVector{ 50, 25 };
 
         const AZ::Vector2 fromScreenPoint = AzFramework::Vector2FromScreenPoint(screenPoint);
         const AZ::Vector2 fromScreenVector = AzFramework::Vector2FromScreenVector(screenVector);
@@ -293,6 +293,36 @@ namespace UnitTest
         EXPECT_NEAR(AzFramework::ScreenVectorLength(ScreenVector(1, 1)), 1.41421f, 0.001f);
         EXPECT_NEAR(AzFramework::ScreenVectorLength(ScreenVector(3, 4)), 5.0f, 0.001f);
         EXPECT_NEAR(AzFramework::ScreenVectorLength(ScreenVector(12, 15)), 19.20937f, 0.001f);
+    }
+
+    TEST(ViewportScreen, ScreenVectorTransformedByScalarUpwards)
+    {
+        using AzFramework::ScreenVector;
+
+        auto screenVector = ScreenVector(5, 10);
+        auto scaledScreenVector = screenVector * 2.0f;
+
+        EXPECT_EQ(scaledScreenVector, ScreenVector(10, 20));
+    }
+
+    TEST(ViewportScreen, ScreenVectorTransformedByScalarDownwards)
+    {
+        using AzFramework::ScreenVector;
+
+        auto screenVector = ScreenVector(6, 12);
+        auto scaledScreenVector = screenVector * 0.5f;
+
+        EXPECT_EQ(scaledScreenVector, ScreenVector(3, 6));
+    }
+
+    TEST(ViewportScreen, ScreenVectorTransformedByScalarInplace)
+    {
+        using AzFramework::ScreenVector;
+
+        auto screenVector = ScreenVector(13, 37);
+        screenVector *= 10.0f;
+
+        EXPECT_EQ(screenVector, ScreenVector(130, 370));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportScreenTests.cpp
@@ -305,6 +305,28 @@ namespace UnitTest
         EXPECT_EQ(scaledScreenVector, ScreenVector(10, 20));
     }
 
+    TEST(ViewportScreen, ScreenVectorTransformedByScalarWithRounding)
+    {
+        using AzFramework::ScreenVector;
+
+        auto screenVector = ScreenVector(1, 6);
+        auto scaledScreenVector = screenVector * 0.1f;
+
+        // value less than 0.5 rounds down, greater than or equal to 0.5 rounds up
+        EXPECT_EQ(scaledScreenVector, ScreenVector(0, 1));
+    }
+
+    TEST(ViewportScreen, ScreenVectorTransformedByScalarWithRoundingAtHalfwayBoundary)
+    {
+        using AzFramework::ScreenVector;
+
+        auto screenVector = ScreenVector(5, 10);
+        auto scaledScreenVector = screenVector * 0.1f;
+
+        // value less than 0.5 rounds down, greater than or equal to 0.5 rounds up
+        EXPECT_EQ(scaledScreenVector, ScreenVector(1, 1));
+    }
+
     TEST(ViewportScreen, ScreenVectorTransformedByScalarDownwards)
     {
         using AzFramework::ScreenVector;

--- a/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Source/FFont.cpp
@@ -1726,7 +1726,7 @@ void AZ::FFont::DrawScreenAlignedText3d(
     {
         return;
     }
-    AZ::Vector3 positionNDC = AzFramework::WorldToScreenNDC(
+    AZ::Vector3 positionNDC = AzFramework::WorldToScreenNdc(
         params.m_position,
         currentView->GetWorldToViewMatrix(),
         currentView->GetViewToClipMatrix()


### PR DESCRIPTION
This is a fairly significant behavior change to make the way entity space is handled in the viewport more standard while also retaining some of the interesting features we developed while building the new Viewport Interaction Model.

## Headlines

### Local space is now the default

In the Editor today we default to parent space, which while useful in certain situations, is used far less widely than local space. Selecting an entity will now show the entities local transform.

It's still possible to quickly switch to world space by holding Shift. To access Parent or World space permanently, the Viewport UI toggles in the top right of the viewport can be used.

### Separation of Group and Individual manipulation

Before this change, reference space (local/parent/world) was not only used for the reference frame orientation, but also to determine how to move entities in a group (manipulating a selection of entities in local space would move all entities relative to their own local space, making group edits in local space difficult).

This concept has been split to now introduce the concept of 'Influence'. This can be `Group` (the default) or `Individual` (activated by holding Alt). For example, when using a rotation manipulator, a selection can be rotated as a group, about the manipulators pivot point (the median position or custom if the manipulator has been moved) but also if Alt is held, entities will rotate about their own pivot (spinning on the spot). This is useful for scale and translation as well as rotation.

--- 

There are a couple of other small fixes (switching between Individual and Group scale while moving a manipulator no longer snaps awkwardly, and the scale manipulator central manipulator now draws in the right place). There are a few other minor tidy-up changes as well.

~~### Incoming...

To better support this change some more integration tests will be created to help guard against regressions (the coverage won't be exhaustive but should attempt to cover a number of the most common operations).~~

### Arrived

A number of parameterized tests have been added to verify the behavior of Translation, Rotation and Scale manipulators in the viewport with different modifiers held. The Viewport is a complex beast, so writing tests to minimize duplication while also being readable is a challenge. I've gone with parameterized tests for the new tests and have tried to add comments to aid with understanding. It's not perfect but hopefully this is a good source of protection against future breakages.

**Demo of changes**

https://user-images.githubusercontent.com/82228511/134354951-e27f0f2c-4dec-4096-8cae-53fc5ed397ec.mp4

Related Tests for Viewport Interaction Model

```
[==========] Running 78 tests from 18 test cases.
[----------] Global test environment set-up.
[----------] 10 tests from EditorTransformComponentSelectionFixture
[ RUN      ] EditorTransformComponentSelectionFixture.FocusIsNotChangedWhileSwitchingViewportInteractionRequestInstance
[       OK ] EditorTransformComponentSelectionFixture.FocusIsNotChangedWhileSwitchingViewportInteractionRequestInstance (135 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.ManipulatorOrientationIsResetWhenEntityOrientationIsReset
[       OK ] EditorTransformComponentSelectionFixture.ManipulatorOrientationIsResetWhenEntityOrientationIsReset (111 ms)[ RUN      ] EditorTransformComponentSelectionFixture.EntityOrientationRemainsConstantWhenOnlyManipulatorOrientationIsReset
[       OK ] EditorTransformComponentSelectionFixture.EntityOrientationRemainsConstantWhenOnlyManipulatorOrientationIsReset (127 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.TestComponentPropertyNotificationIsSentAfterModifyingSlice
[       OK ] EditorTransformComponentSelectionFixture.TestComponentPropertyNotificationIsSentAfterModifyingSlice (124 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.CopyOrientationToSelectedEntitiesIndividualDoesNotAffectScale
[       OK ] EditorTransformComponentSelectionFixture.CopyOrientationToSelectedEntitiesIndividualDoesNotAffectScale (141 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.InvertSelectionIgnoresLockedAndHiddenEntities
[       OK ] EditorTransformComponentSelectionFixture.InvertSelectionIgnoresLockedAndHiddenEntities (191 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.SelectAllIgnoresLockedAndHiddenEntities
[       OK ] EditorTransformComponentSelectionFixture.SelectAllIgnoresLockedAndHiddenEntities (125 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.MouseScrollWheelSwitchesTransformMode
[       OK ] EditorTransformComponentSelectionFixture.MouseScrollWheelSwitchesTransformMode (125 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.EntityPositionsCanBeSnappedToGrid
[       OK ] EditorTransformComponentSelectionFixture.EntityPositionsCanBeSnappedToGrid (125 ms)
[ RUN      ] EditorTransformComponentSelectionFixture.ManipulatorStaysAlignedToEntityTranslationAfterSnap
[       OK ] EditorTransformComponentSelectionFixture.ManipulatorStaysAlignedToEntityTranslationAfterSnap (123 ms)
[----------] 10 tests from EditorTransformComponentSelectionFixture (1337 ms total)

[----------] 15 tests from EditorTransformComponentSelectionViewportPickingManipulatorTestFixture
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickWithNoSelectionWillSelectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickWithNoSelectionWillSelectEntity (123 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickWithNoSelectionWillSelectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickWithNoSelectionWillSelectEntity (121 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOffEntityWithSelectionWillNotDeselectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOffEntityWithSelectionWillNotDeselectEntity (120 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOffEntityWithSelectionWillDeselectEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOffEntityWithSelectionWillDeselectEntity (137 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickySingleClickOnNewEntityWithSelectionWillNotChangeSelectedEntity (125 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOnNewEntityWithSelectionWillChangeSelectedEntity
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickySingleClickOnNewEntityWithSelectionWillChangeSelectedEntity (123 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection (136 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnNewEntityWithSelectionWillAppendSelectedEntityToSelection (121 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection (123 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyCtrlSingleClickOnEntityInSelectionWillRemoveEntityFromSelection (127 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithNoInitialSelectionAddsEntitiesToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithNoInitialSelectionAddsEntitiesToSelection (136 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithSelectionAppendsEntitiesToSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectWithSelectionAppendsEntitiesToSelection (135 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectHoldingCtrlWithSelectionRemovesEntitiesFromSelection
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.BoxSelectHoldingCtrlWithSelectionRemovesEntitiesFromSelection (138 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyDoubleClickWithSelectionWillDeselectEntities
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.StickyDoubleClickWithSelectionWillDeselectEntities (136 ms)
[ RUN      ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyUndoOperationForChangeInSelectionIsAtomic
[       OK ] EditorTransformComponentSelectionViewportPickingManipulatorTestFixture.UnstickyUndoOperationForChangeInSelectionIsAtomic (125 ms)
[----------] 15 tests from EditorTransformComponentSelectionViewportPickingManipulatorTestFixture (1992 ms total)

[----------] 2 tests from EditorTransformComponentSelectionManipulatorTestFixture
[ RUN      ] EditorTransformComponentSelectionManipulatorTestFixture.CanMoveEntityUsingManipulatorMouseMovement
[       OK ] EditorTransformComponentSelectionManipulatorTestFixture.CanMoveEntityUsingManipulatorMouseMovement (119 ms)[ RUN      ] EditorTransformComponentSelectionManipulatorTestFixture.TranslatingEntityWithLinearManipulatorNotifiesOnEntityTransformChanged
[       OK ] EditorTransformComponentSelectionManipulatorTestFixture.TranslatingEntityWithLinearManipulatorNotifiesOnEntityTransformChanged (125 ms)
[----------] 2 tests from EditorTransformComponentSelectionManipulatorTestFixture (251 ms total)

[----------] 4 tests from All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/0
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/0 (124 ms)
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/1
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndDoesNotChangeSelection/1 (122 ms)
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/0
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/0 (135 ms)
[ RUN      ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/1
[       OK ] All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam.StickyAndUnstickyDittoManipulatorToOtherEntityChangesManipulatorAndClickOffResetsManipulator/1 (120 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionViewportPickingManipulatorTestFixtureParam (518 ms total)
[----------] 4 tests from All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/0
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/0 (120 ms)
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/1
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/1 (123 ms)
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/2
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/2 (124 ms)
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/3
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam.RotatingASingleEntityWithDifferentModifierCombinations/3 (123 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionRotationManipulatorSingleEntityTestFixtureParam (506 ms total)

[----------] 4 tests from All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/0
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/0 (134 ms)
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/1
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/1 (140 ms)
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/2
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/2 (125 ms)
[ RUN      ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/3
[       OK ] All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam.RotatingMultipleEntitiesWithDifferentModifierCombinations/3 (125 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionRotationManipulatorMultipleEntityTestFixtureParam (536 ms total)

[----------] 4 tests from All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/0
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/0 (119 ms)
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/1
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/1 (124 ms)
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/2
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/2 (122 ms)
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/3
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam.TranslatingASingleEntityWithDifferentModifierCombinations/3 (120 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionTranslationManipulatorSingleEntityTestFixtureParam (496 ms total)

[----------] 4 tests from All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/0
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/0 (132 ms)
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/1
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/1 (126 ms)
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/2
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/2 (122 ms)
[ RUN      ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/3
[       OK ] All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam.TranslatingMultipleEntitiesWithDifferentModifierCombinations/3 (121 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionTranslationManipulatorMultipleEntityTestFixtureParam (513 ms total)

[----------] 4 tests from All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam
[ RUN      ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/0
[       OK ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/0 (135 ms)
[ RUN      ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/1
[       OK ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/1 (141 ms)
[ RUN      ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/2
[       OK ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/2 (122 ms)
[ RUN      ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/3
[       OK ] All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam.ScalingMultipleEntitiesWithDifferentModifierCombinations/3 (124 ms)
[----------] 4 tests from All/EditorTransformComponentSelectionScaleManipulatorMultipleEntityTestFixtureParam (527 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionSingleEntityPivotFixture
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityPivotFixture.PivotOrientationMatchesReferenceFrameSingleEntity/0
[       OK ] All/EditorTransformComponentSelectionSingleEntityPivotFixture.PivotOrientationMatchesReferenceFrameSingleEntity/0 (126 ms)
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityPivotFixture.PivotOrientationMatchesReferenceFrameSingleEntity/1
[       OK ] All/EditorTransformComponentSelectionSingleEntityPivotFixture.PivotOrientationMatchesReferenceFrameSingleEntity/1 (125 ms)
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityPivotFixture.PivotOrientationMatchesReferenceFrameSingleEntity/2
[       OK ] All/EditorTransformComponentSelectionSingleEntityPivotFixture.PivotOrientationMatchesReferenceFrameSingleEntity/2 (125 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionSingleEntityPivotFixture (378 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture.PivotOrientationMatchesReferenceFrameEntityWithParent/0
[       OK ] All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture.PivotOrientationMatchesReferenceFrameEntityWithParent/0 (125 ms)
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture.PivotOrientationMatchesReferenceFrameEntityWithParent/1
[       OK ] All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture.PivotOrientationMatchesReferenceFrameEntityWithParent/1 (112 ms)
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture.PivotOrientationMatchesReferenceFrameEntityWithParent/2
[       OK ] All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture.PivotOrientationMatchesReferenceFrameEntityWithParent/2 (127 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionSingleEntityWithParentPivotFixture (367 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntities/0
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntities/0 (126 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntities/1
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntities/1 (125 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntities/2
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntities/2 (125 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesPivotFixture (379 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent/0
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent/0 (123 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent/1
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent/1 (124 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent/2
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParent/2 (124 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesWithSameParentPivotFixture (377 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent/0
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent/0 (121 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent/1
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent/1 (126 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent/2
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesDifferentParent/2 (121 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesWithDifferentParentPivotFixture (374 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride/0
[       OK ] All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride/0 (107 ms)
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride/1
[       OK ] All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride/1 (127 ms)
[ RUN      ] All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride/2
[       OK ] All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameSingleEntityOptionalOverride/2 (125 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionSingleEntityPivotAndOverrideFixture (365 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride/0
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride/0 (123 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride/1
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride/1 (125 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride/2
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesOptionalOverride/2 (122 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesPivotAndOverrideFixture (376 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride/0
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride/0 (118 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride/1
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride/1 (111 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride/2
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesNoOptionalOverride/2 (123 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesPivotAndNoOverrideFixture (359 ms total)

[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride/0
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride/0 (122 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride/1
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride/1 (122 ms)
[ RUN      ] All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride/2
[       OK ] All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture.PivotOrientationMatchesReferenceFrameMultipleEntitiesSameParentNoOptionalOverride/2 (124 ms)
[----------] 3 tests from All/EditorTransformComponentSelectionMultipleEntitiesSameParentPivotAndNoOverrideFixture (376 ms total)

[----------] Global test environment tear-down
[==========] 78 tests from 18 test cases ran. (10067 ms total)
[  PASSED  ] 78 tests.
```
