### PR TITLE
LYN-6793 [iOS] [asset_profile] 4 assets fail to process for iOS

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/PixelOperation.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/PixelOperation.cpp
@@ -333,8 +333,8 @@ namespace ImageProcessingAtom
         {
             const uint16* data = (uint16*)(buf);
             r = U16ToF32(data[0]);
-            g = 0.f;
-            b = 0.f;
+            g = r;
+            b = r;
             a = 1.f;
         }
 
@@ -418,8 +418,8 @@ namespace ImageProcessingAtom
         {
             const float* data = (float*)(buf);
             r = data[0];
-            g = 0.f;
-            b = 0.f;
+            g = r;
+            b = r;
             a = 1.f;
         }
 
@@ -485,8 +485,8 @@ namespace ImageProcessingAtom
         {
             const SHalf* data = (SHalf*)(buf);
             r = data[0];
-            g = 0.f;
-            b = 0.f;
+            g = r;
+            b = r;
             a = 1.f;
         }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/PixelOperation.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Converters/PixelOperation.cpp
@@ -248,8 +248,8 @@ namespace ImageProcessingAtom
         {
             const uint8* data = buf;
             r = U8ToF32(data[0]);
-            g = 0.f;
-            b = 0.f;
+            g = r;
+            b = r;
             a = 1.f;
         }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Albedo.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Albedo.preset
@@ -39,7 +39,7 @@
                     "_bc",
                     "_diffuse"
                 ],
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/AlbedoWithCoverage.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/AlbedoWithCoverage.preset
@@ -36,7 +36,7 @@
                     "_bc",
                     "_diffuse"
                 ],
-                "PixelFormat": "ETC2a1",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/AlbedoWithGenericAlpha.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/AlbedoWithGenericAlpha.preset
@@ -36,7 +36,7 @@
                     "_bc",
                     "_diffuse"
                 ],
-                "PixelFormat": "ETC2a",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/AlbedoWithOpacity.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/AlbedoWithOpacity.preset
@@ -36,7 +36,7 @@
                     "_bc",
                     "_diffuse"
                 ],
-                "PixelFormat": "ETC2a",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/AmbientOcclusion.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/AmbientOcclusion.preset
@@ -28,7 +28,7 @@
                     "_amb",
                     "_ambientocclusion"
                 ],
-                "PixelFormat": "EAC_R11"
+                "PixelFormat": "ASTC_4x4"
             },
             "ios": {
                 "UUID": "{02ED0ECE-B198-49D9-85BC-CEBA6C28546C}",
@@ -41,7 +41,7 @@
                     "_amb",
                     "_ambientocclusion"
                 ],
-                "PixelFormat": "EAC_R11"
+                "PixelFormat": "ASTC_4x4"
             },
             "mac": {
                 "UUID": "{02ED0ECE-B198-49D9-85BC-CEBA6C28546C}",

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/CloudShadows.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/CloudShadows.preset
@@ -15,14 +15,14 @@
                 "UUID": "{884B5F7C-44AC-4E9E-8B8A-559D098BE2C7}",
                 "Name": "CloudShadows",
                 "DestColor": "Linear",
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true
             },
             "ios": {
                 "UUID": "{884B5F7C-44AC-4E9E-8B8A-559D098BE2C7}",
                 "Name": "CloudShadows",
                 "DestColor": "Linear",
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true
             },
             "mac": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Decal_AlbedoWithOpacity.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Decal_AlbedoWithOpacity.preset
@@ -24,13 +24,13 @@
                 "FileMasks": [
                     "_decal"
                 ],
-                "PixelFormat": "ETC2a",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
                 },
                 // Decal Texture Arrays need all mips available immediately for packing. 
-                "NumberResidentMips": 255              
+                "NumberResidentMips": 255
             },
             "ios": {
                 "UUID": "{E06B5087-2640-49B6-B9BA-D40048162B90}",

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Detail_MergedAlbedoNormalsSmoothness.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Detail_MergedAlbedoNormalsSmoothness.preset
@@ -26,7 +26,7 @@
                 "FileMasks": [
                     "_detail"
                 ],
-                "PixelFormat": "ETC2a",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Displacement.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Displacement.preset
@@ -45,7 +45,7 @@
                     "_ht",
                     "_h"
                 ],
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "SizeReduceLevel": 3,
@@ -70,7 +70,7 @@
                     "_ht",
                     "_h"
                 ],
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Emissive.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Emissive.preset
@@ -29,7 +29,7 @@
                     "_em",
                     "_emit"
                 ],
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "DiscardAlpha": true
             },
             "ios": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Greyscale.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Greyscale.preset
@@ -26,7 +26,7 @@
                 "FileMasks": [
                     "_mask"
                 ],
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -40,7 +40,7 @@
                 "FileMasks": [
                     "_mask"
                 ],
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/LensOptics.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/LensOptics.preset
@@ -12,7 +12,7 @@
             "android": {
                 "UUID": "{3000A993-0A04-4E08-A813-DFB1A47A0980}",
                 "Name": "LensOptics",
-                "PixelFormat": "ETC2"
+                "PixelFormat": "ASTC_4x4"
             },
             "ios": {
                 "UUID": "{3000A993-0A04-4E08-A813-DFB1A47A0980}",

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/LightProjector.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/LightProjector.preset
@@ -18,7 +18,7 @@
                 "UUID": "{1DFEF41A-D97F-40FB-99D3-C142A3E5225E}",
                 "Name": "LightProjector",
                 "DestColor": "Linear",
-                "PixelFormat": "EAC_RG11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -28,7 +28,7 @@
                 "UUID": "{1DFEF41A-D97F-40FB-99D3-C142A3E5225E}",
                 "Name": "LightProjector",
                 "DestColor": "Linear",
-                "PixelFormat": "EAC_RG11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Minimap.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Minimap.preset
@@ -19,7 +19,7 @@
                 "UUID": "{0D2F4C31-A665-4862-9C63-9E49A58E9A37}",
                 "Name": "Minimap",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "SizeReduceLevel": 1,
                 "MipMapSetting": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/MuzzleFlash.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/MuzzleFlash.preset
@@ -18,7 +18,7 @@
                 "UUID": "{8BCC23A5-D08E-458E-B0B3-087C65FA1D31}",
                 "Name": "MuzzleFlash",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Opacity.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Opacity.preset
@@ -44,7 +44,7 @@
                     "_msk",
                     "_blend"
                 ],
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -67,7 +67,7 @@
                     "_msk",
                     "_blend"
                 ],
-                "PixelFormat": "EAC_R11",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Reflectance.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Reflectance.preset
@@ -57,7 +57,7 @@
                     "_roughness",
                     "_rough"
                 ],
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/ReflectanceWithSmoothness_Legacy.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/ReflectanceWithSmoothness_Legacy.preset
@@ -22,7 +22,7 @@
                 "FileMasks": [
                     "_spec"
                 ],
-                "PixelFormat": "ETC2a",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Reflectance_Linear.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Reflectance_Linear.preset
@@ -26,7 +26,7 @@
                     "_spec",
                     "_refl"
                 ],
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/SF_Image.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/SF_Image.preset
@@ -19,7 +19,7 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true
             },
             "ios": {
@@ -28,7 +28,7 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "PVRTC4",
+                "PixelFormat": "ASTC_4x4",
                 "IsPowerOf2": true
             },
             "mac": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/SF_Image_nonpower2.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/SF_Image_nonpower2.preset
@@ -18,7 +18,7 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "ETC2"
+                "PixelFormat": "ASTC_4x4"
             },
             "ios": {
                 "UUID": "{C456B8AB-C360-4822-BCDD-225252D0E697}",
@@ -26,7 +26,7 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "PVRTC4"
+                "PixelFormat": "ASTC_4x4"
             },
             "mac": {
                 "UUID": "{C456B8AB-C360-4822-BCDD-225252D0E697}",

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Terrain_Albedo.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Terrain_Albedo.preset
@@ -21,7 +21,7 @@
                 "Name": "Terrain_Albedo",
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "HighPassMip": 5,
                 "MipMapSetting": {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/Terrain_Albedo_HighPassed.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/Terrain_Albedo_HighPassed.preset
@@ -20,7 +20,7 @@
                 "Name": "Terrain_Albedo_HighPassed",
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
-                "PixelFormat": "ETC2",
+                "PixelFormat": "ASTC_6x6",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Config/UserInterface_Compressed.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Config/UserInterface_Compressed.preset
@@ -17,7 +17,7 @@
                 "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",
                 "Name": "UserInterface_Compressed",
                 "SuppressEngineReduce": true,
-                "PixelFormat": "ETC2"
+                "PixelFormat": "ASTC_6x6"
             },
             "ios": {
                 "UUID": "{2828FBFE-BDF9-45A7-9370-F93822719CCF}",


### PR DESCRIPTION
The issue was because the compression of ETC formats took too long.
Replaced all ETC and PVRTC formats with ASTC formats.

Signed-off-by: Qing Tao <qingtao@amazon.com>