### PR TITLE
[development] Atom CPU profiler include cleanup

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
@@ -9,8 +9,6 @@
 
 #include "AuxGeomDrawQueue.h"
 
-#include <Atom/RHI/CpuProfiler.h>
-
 #include <Atom/RPI.Public/Scene.h>
 
 #include <AzCore/Debug/EventTrace.h>

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomFeatureProcessor.cpp
@@ -12,7 +12,6 @@
 #include "DynamicPrimitiveProcessor.h"
 #include "FixedShapeProcessor.h"
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
 #include <Atom/RPI.Public/View.h>

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/DynamicPrimitiveProcessor.cpp
@@ -9,7 +9,6 @@
 #include "DynamicPrimitiveProcessor.h"
 #include "AuxGeomDrawProcessorShared.h"
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
@@ -20,6 +19,8 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/View.h>
+
+#include <AzCore/Debug/Profiler.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/Debug/EventTrace.h>
 #include <AzCore/std/containers/array.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/CapsuleLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/CapsuleLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/CpuProfiler.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -12,7 +12,6 @@
 #include <CoreLights/Shadow.h>
 #include <Math/GaussianMathFilter.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DiskLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PointLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/CpuProfiler.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/PolygonLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/QuadLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/QuadLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimplePointLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/CpuProfiler.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/SimpleSpotLightFeatureProcessor.cpp
@@ -16,7 +16,6 @@
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/CpuProfiler.h>
 
 #include <Atom/RPI.Public/ColorManagement/TransformColor.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalFeatureProcessor.cpp
@@ -10,7 +10,6 @@
 
 #include <AzCore/Debug/EventTrace.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -15,7 +15,6 @@
 
 #include <AtomCore/Instance/InstanceDatabase.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/CommandList.h>
 
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>

--- a/Gems/Atom/Feature/Common/Code/Source/ImageBasedLights/ImageBasedLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImageBasedLights/ImageBasedLightFeatureProcessor.cpp
@@ -11,8 +11,6 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 
-#include <Atom/RHI/CpuProfiler.h>
-
 #include <AzCore/Debug/EventTrace.h>
 
 namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -8,7 +8,6 @@
 
 #include <RenderCommon.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/Feature/Mesh/MeshFeatureProcessor.h>

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
@@ -8,8 +8,6 @@
 
 #include <PostProcess/PostProcessFeatureProcessor.h>
 
-#include <Atom/RHI/CpuProfiler.h>
-
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SMAAFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/SMAAFeatureProcessor.cpp
@@ -16,8 +16,6 @@
 
 #include <Atom/RHI/Factory.h>
 
-#include <Atom/RHI/CpuProfiler.h>
-
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.cpp
@@ -8,7 +8,6 @@
 
 #include "ProfilingCaptureSystemComponent.h"
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/CpuProfilerImpl.h>
 #include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI/RHISystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ProfilingCaptureSystemComponent.h
@@ -12,7 +12,6 @@
 #include <AzCore/Component/TickBus.h>
 
 #include <Atom/Feature/Utils/ProfilingCaptureBus.h>
-#include <Atom/RHI/CpuProfiler.h>
 
 namespace AZ
 {

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -9,7 +9,6 @@
 #include <RayTracing/RayTracingFeatureProcessor.h>
 #include <AzCore/Debug/EventTrace.h>
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -13,7 +13,6 @@
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/Feature/ReflectionProbe/ReflectionProbeFeatureProcessor.h>
 #include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI/PipelineState.h>

--- a/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Shadows/ProjectedShadowFeatureProcessor.cpp
@@ -11,7 +11,6 @@
 #include <AzCore/Debug/EventTrace.h>
 #include <AzCore/Math/MatrixUtils.h>
 #include <Math/GaussianMathFilter.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshFeatureProcessor.cpp
@@ -22,7 +22,6 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/CommandList.h>
 
 #include <AzCore/Debug/EventTrace.h>

--- a/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkyBox/SkyBoxFeatureProcessor.cpp
@@ -12,7 +12,6 @@
 
 #include <AzFramework/Asset/AssetSystemBus.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI/RHISystemInterface.h>

--- a/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/TransformService/TransformServiceFeatureProcessor.cpp
@@ -8,7 +8,6 @@
 
 #include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 
 #include <Atom/RHI/RHISystemInterface.h>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
@@ -7,7 +7,6 @@
  */
 #pragma once
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FreeListAllocator.h>
 #include <Atom/RHI/PoolAllocator.h>
 #include <Atom/RHI/MemoryAllocation.h>

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ObjectCollector.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ObjectCollector.h
@@ -7,8 +7,9 @@
  */
 #pragma once
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Object.h>
+
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/functional.h>

--- a/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/BufferPool.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <Atom/RHI/BufferPool.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/MemoryStatisticsBuilder.h>
 #include <AzCore/Debug/EventTrace.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI/CommandQueue.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CommandQueue.cpp
@@ -7,8 +7,9 @@
  */
 
 #include <Atom/RHI/CommandQueue.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Device.h>
+
+#include <AzCore/Debug/Profiler.h>
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Device.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/MemoryStatisticsBus.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Fence.cpp
@@ -8,6 +8,8 @@
 
 #include <Atom/RHI/Fence.h>
 
+#include <AzCore/Debug/Profiler.h>
+
 namespace AZ
 {
     namespace RHI

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraph.cpp
@@ -8,7 +8,6 @@
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/BufferPoolBase.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <Atom/RHI/ImageFrameAttachment.h>
 #include <Atom/RHI/ImagePoolBase.h>

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameGraphCompiler.h>
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/BufferScopeAttachment.h>

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameGraphExecuter.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameGraphExecuter.cpp
@@ -6,7 +6,6 @@
  *
  */
 #include <Atom/RHI/Buffer.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameGraphExecuteGroup.h>
 #include <Atom/RHI/FrameGraphExecuter.h>
 #include <Atom/RHI/FrameGraph.h>

--- a/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/FrameScheduler.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameEventBus.h>

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -6,9 +6,10 @@
  *
  */
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/PipelineStateCache.h>
 #include <Atom/RHI/Factory.h>
+
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/std/parallel/exponential_backoff.h>
 

--- a/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHISystem.cpp
@@ -6,12 +6,12 @@
  *
  */
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/RHISystem.h>
 #include <Atom/RHI/RHIUtils.h>
 
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/Interface/Interface.h>
 
 #include <AzFramework/API/ApplicationAPI.h>

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListPool.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListPool.cpp
@@ -9,7 +9,6 @@
 #include <RHI/CommandList.h>
 #include <RHI/Conversions.h>
 #include <RHI/DescriptorContext.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <AzCore/Debug/EventTrace.h>
 
 namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueueContext.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandQueueContext.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom/RHI/CpuProfiler.h>
+
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI.Reflect/CpuTimingStatistics.h>
 #include <AzCore/Debug/EventTraceDrillerBus.h>

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/DescriptorContext.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/DescriptorContext.cpp
@@ -10,7 +10,6 @@
 #include <RHI/Conversions.h>
 #include <RHI/Device.h>
 #include <RHI/Image.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h>
 
 namespace AZ

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -15,7 +15,6 @@
 #include <RHI/Device.h>
 #include <RHI/Image.h>
 #include <RHI/Scope.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ScopeAttachment.h>

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueueContext.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/CommandQueueContext.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AzCore/Debug/EventTrace.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/CommandQueue.h>
 #include <Atom/RHI.Reflect/CpuTimingStatistics.h>
 #include <RHI/Device.h>

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom/RHI/CpuProfiler.h>
+
 #include <Atom/RHI/FrameGraph.h>
 #include <AzCore/Debug/EventTrace.h>
 #include <RHI/Device.h>

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/Scope.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#include <Atom/RHI/CpuProfiler.h>
+
 #include <Atom/RHI/ImageScopeAttachment.h>
 #include <Atom/RHI/ResolveScopeAttachment.h>
 #include <AzCore/Debug/EventTrace.h>

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.cpp
@@ -6,10 +6,10 @@
  *
  */
 
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/std/string/conversions.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Windowing/WindowBus.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <RHI/Device.h>
 #include <RHI/Image.h>
 #include <RHI/SwapChain.h>

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueueContext.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandQueueContext.cpp
@@ -8,7 +8,6 @@
 #include <AzCore/std/algorithm.h>
 #include <AzCore/std/sort.h>
 #include <AzCore/Debug/EventTrace.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <RHI/CommandQueueContext.h>
 #include <RHI/Device.h>
 #include <RHI/Semaphore.h>

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphCompiler.cpp
@@ -9,7 +9,6 @@
 #include <Atom/RHI/BufferFrameAttachment.h>
 #include <Atom/RHI/BufferScopeAttachment.h>
 #include <Atom/RHI/BufferView.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameGraphAttachmentDatabase.h>
 #include <Atom/RHI/FrameGraph.h>
 #include <Atom/RHI/ImageScopeAttachment.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -14,8 +14,6 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 
-#include <Atom/RHI/CpuProfiler.h>
-
 #include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Math/ShapeIntersection.h>
 #include <AzCore/Casting/numeric_cast.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuQuerySystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/GpuQuery/GpuQuerySystem.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameGraphInterface.h>
 #include <Atom/RHI/RHISystemInterface.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/ImageSystem.cpp
@@ -23,7 +23,6 @@
 #include <Atom/RHI.Reflect/ImagePoolDescriptor.h>
 #include <Atom/RHI/ImagePool.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
 #include <AtomCore/Instance/InstanceDatabase.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -19,7 +19,6 @@
 
 #include <AzCore/Serialization/Json/JsonUtils.h>
 
-#include <Atom/RHI/CpuProfiler.h>
 #include <Atom/RHI/FrameGraphBuilder.h>
 
 #include <Atom/RPI.Public/Pass/FullscreenTrianglePass.h>

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -6,8 +6,6 @@
  *
  */
 
-#include <Atom/RHI/CpuProfiler.h>
-
 #include <Atom/RPI.Public/Culling.h>
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawSystem.h>
 #include <Atom/RPI.Public/FeatureProcessorFactory.h>


### PR DESCRIPTION
- Removed all unnecessary includes to Atom CpuProfiler.h
- Added includes to AzCore Profiler.h where necessary

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>