### PR TITLE
EMotion FX: Asset Processor generates an Actor for every FBX

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Behaviors/ActorGroupBehavior.cpp
@@ -176,19 +176,10 @@ namespace EMotionFX
                     return AZ::SceneAPI::Events::ProcessingResult::Ignored;
                 }
 
-                const bool hasBoneData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBoneData>(scene, true);
+                // Skip adding the actor group if it doesn't contain any skin and blendshape data.
                 const bool hasSkinData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::ISkinWeightData>(scene, true);
-                const bool hasBlendShapeData =
-                    AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBlendShapeData>(scene, true);
-                // Skip adding the actor group if it doesn't contain any bone, skin and blendshape data.
-                if (!hasBoneData && !hasSkinData && !hasBlendShapeData)
-                {
-                    return AZ::SceneAPI::Events::ProcessingResult::Ignored;
-                }
-                
-                const bool hasAnimationData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IAnimationData>(scene, true);
-                // Skip adding the actor group if it contains animation data but doesn't contain any skin or blendshape data.
-                if (hasAnimationData && !hasSkinData && !hasBlendShapeData)
+                const bool hasBlendShapeData = AZ::SceneAPI::Utilities::DoesSceneGraphContainDataLike<AZ::SceneAPI::DataTypes::IBlendShapeData>(scene, true);
+                if (!hasSkinData && !hasBlendShapeData)
                 {
                     return AZ::SceneAPI::Events::ProcessingResult::Ignored;
                 }
@@ -197,7 +188,7 @@ namespace EMotionFX
                 AZStd::shared_ptr<Group::ActorGroup> group = AZStd::make_shared<Group::ActorGroup>();
 
                 // This is a group that's generated automatically so may not be saved to disk but would need to be recreated
-                //      in the same way again. To guarantee the same uuid, generate a stable one instead.
+                // in the same way again. To guarantee the same uuid, generate a stable one instead.
                 group->OverrideId(AZ::SceneAPI::DataTypes::Utilities::CreateStableUuid(scene, Group::ActorGroup::TYPEINFO_Uuid()));
 
                 EBUS_EVENT(AZ::SceneAPI::Events::ManifestMetaInfoBus, InitializeObject, scene, *group);

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/ActorGroup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Groups/ActorGroup.cpp
@@ -108,7 +108,7 @@ namespace EMotionFX
 
                 serializeContext->Class<IActorGroup, AZ::SceneAPI::DataTypes::IGroup>()->Version(3, IActorGroupVersionConverter);
 
-                serializeContext->Class<ActorGroup, IActorGroup>()->Version(6, ActorVersionConverter)
+                serializeContext->Class<ActorGroup, IActorGroup>()->Version(7, ActorVersionConverter)
                     ->Field("name", &ActorGroup::m_name)
                     ->Field("selectedRootBone", &ActorGroup::m_selectedRootBone)
                     ->Field("id", &ActorGroup::m_id)


### PR DESCRIPTION
Fixing the actor behavior to ignore actor asset generation for files that only contain nodes/bones. We're only checking for blend shapes and skins now. In case neither is present in an FBX, we don't export the actor asset.

This makes a plain skeleton a special case where users manually need to add the actor group for the fbx. The most common use case for these are animation files anyway, where we don't want to export actor assets.

Also increased the version number of the actor group so that they are all getting reprocessed and the unneeded actor assets get removed.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>