### PR TITLE
Fix path to the correct location of 'user.cfg' in the Cache

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/ComponentApplication.cpp
@@ -672,7 +672,7 @@ namespace AZ
         // Execute user.cfg after modules have been loaded but before processing any command-line overrides
         AZ::IO::FixedMaxPath platformCachePath;
         m_settingsRegistry->Get(platformCachePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder);
-        m_console->ExecuteConfigFile((platformCachePath / "user.cfg").Native());
+        m_console->ExecuteConfigFile((platformCachePath / "config" / "user.cfg").Native());
 
         // Parse the command line parameters for console commands after modules have loaded
         m_console->ExecuteCommandLine(m_commandLine);


### PR DESCRIPTION
The path to user.cfg is located in a 'config' subfolder. However, its looking in the root of the platform Cache instead.

Fixes the following error:

```
    SettingsRegistryMergeUtils: Unable to open file "/home/XXXXXX/github/o3de/AutomatedTesting/Cache/linux/user.cfg"
```
Signed-off-by: Steve Pham <spham@amazon.com>