### PR TITLE
Adding a temporary Orphan function to the InstanceDatabase

### DIFF
--- a/Code/Framework/AtomCore/AtomCore/Instance/InstanceData.h
+++ b/Code/Framework/AtomCore/AtomCore/Instance/InstanceData.h
@@ -89,6 +89,9 @@ namespace AZ
 
             // Tracks the asset type used to create the instance.
             AssetType m_assetType;
+            
+            // Boolean to indicate if the instance has been orphaned from the instance database
+            bool m_isOrphaned = false;
         };
 
         /// @cond EXCLUDE_DOCS


### PR DESCRIPTION
TEMPOrphan will remove an instance from the database so it will not be found using Find or FindOrCreate. The instance will still persist until its use-count drops to 0, at which point it will be deleted. This is to enable the model asset to remove existing buffer/modellod/model instances and replace them with new instances that have the up to date data. 

Added unit tests for testing. Expanded the parallel tests. In addtion to Creating and immediately letting the refcount drop to 0, I added a mode to hold on to a reference, and added a mode to orphan an instance, and a mode that does both.

Changed the duration for the parallel tests to a float so that small times can be used when needing to run the tests to repro issues locally

Signed-off-by: amzn-tommy <waltont@amazon.com>