### PR TITLE
Fix "index out of range" error in AssetProcessor

### DIFF
--- a/Code/Editor/UndoDropDown.cpp
+++ b/Code/Editor/UndoDropDown.cpp
@@ -101,13 +101,13 @@ public:
 
         if (fresh.size() < m_stackNames.size())
         {
-            beginRemoveRows(createIndex(-1, -1), static_cast<int>(fresh.size()), static_cast<int>(m_stackNames.size() - 1));
+            beginRemoveRows(QModelIndex(), static_cast<int>(fresh.size()), static_cast<int>(m_stackNames.size() - 1));
             m_stackNames = fresh;
             endRemoveRows();
         }
         else
         {
-            beginInsertRows(createIndex(-1, -1), static_cast<int>(m_stackNames.size()), static_cast<int>(fresh.size() - 1));
+            beginInsertRows(QModelIndex(), static_cast<int>(m_stackNames.size()), static_cast<int>(fresh.size() - 1));
             m_stackNames = fresh;
             endInsertRows();
         }

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeModel.cpp
@@ -168,7 +168,9 @@ namespace AssetProcessor
 
         if (childItem)
         {
-            return createIndex(row, column, childItem);
+            QModelIndex index = createIndex(row, column, childItem);
+            Q_ASSERT(checkIndex(index));
+            return index;
         }
         return QModelIndex();
     }
@@ -197,7 +199,9 @@ namespace AssetProcessor
         {
             return QModelIndex();
         }
-        return createIndex(parentItem->GetRow(), 0, parentItem);
+        QModelIndex parentIndex = createIndex(parentItem->GetRow(), 0, parentItem);
+        Q_ASSERT(checkIndex(parentIndex));
+        return parentIndex;
     }
 
     bool AssetTreeModel::hasChildren(const QModelIndex &parent) const

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
@@ -92,6 +92,7 @@ namespace AssetProcessor
         }
 
         QModelIndex parentIndex = createIndex(parent->GetRow(), 0, parent);
+        Q_ASSERT(checkIndex(parentIndex));
 
         beginRemoveRows(parentIndex, assetToRemove->GetRow(), assetToRemove->GetRow());
 
@@ -179,6 +180,8 @@ namespace AssetProcessor
             
             QModelIndex existingIndexStart = createIndex(existingEntry->second->GetRow(), 0, existingEntry->second);
             QModelIndex existingIndexEnd = createIndex(existingEntry->second->GetRow(), existingEntry->second->GetColumnCount() - 1, existingEntry->second);
+            Q_ASSERT(checkIndex(existingIndexStart));
+            Q_ASSERT(checkIndex(existingIndexEnd));
             dataChanged(existingIndexStart, existingIndexEnd);
             return;
         }
@@ -206,6 +209,7 @@ namespace AssetProcessor
                 if (!modelIsResetting)
                 {
                     QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
+                    Q_ASSERT(checkIndex(parentIndex));
                     beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
                 }
                 nextParent = parentItem->CreateChild(ProductAssetTreeItemData::MakeShared(nullptr, currentFullFolderPath.Native(), currentPath.c_str(), true, AZ::Uuid::CreateNull()));
@@ -232,6 +236,7 @@ namespace AssetProcessor
         if (!modelIsResetting)
         {
             QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
+            Q_ASSERT(checkIndex(parentIndex));
             beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
         }
 

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
@@ -205,7 +205,7 @@ namespace AssetProcessor
             {
                 if (!modelIsResetting)
                 {
-                    QModelIndex parentIndex = createIndex(parentItem->GetRow(), 0, parentItem);
+                    QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
                     beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
                 }
                 nextParent = parentItem->CreateChild(ProductAssetTreeItemData::MakeShared(nullptr, currentFullFolderPath.Native(), currentPath.c_str(), true, AZ::Uuid::CreateNull()));
@@ -231,7 +231,7 @@ namespace AssetProcessor
 
         if (!modelIsResetting)
         {
-            QModelIndex parentIndex = createIndex(parentItem->GetRow(), 0, parentItem);
+            QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
             beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
         }
 

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.cpp
@@ -102,7 +102,7 @@ namespace AssetProcessor
             {
                 if (!modelIsResetting)
                 {
-                    QModelIndex parentIndex = createIndex(parentItem->GetRow(), 0, parentItem);
+                    QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
                     beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
                 }
                 nextParent = parentItem->CreateChild(SourceAssetTreeItemData::MakeShared(nullptr, nullptr, currentFullFolderPath.Native(), currentPath.c_str(), true));
@@ -118,7 +118,7 @@ namespace AssetProcessor
 
         if (!modelIsResetting)
         {
-            QModelIndex parentIndex = createIndex(parentItem->GetRow(), 0, parentItem);
+            QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
             beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
         }
 
@@ -173,7 +173,7 @@ namespace AssetProcessor
             return;
         }
 
-        QModelIndex parentIndex = createIndex(parent->GetRow(), 0, parent);
+        QModelIndex parentIndex = parent == m_root.get() ? QModelIndex() : createIndex(parent->GetRow(), 0, parent);
 
         beginRemoveRows(parentIndex, assetToRemove->GetRow(), assetToRemove->GetRow());
 

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/IO/Path/Path.h>
 #include <native/utilities/assetUtils.h>
 #include <AzCore/Console/IConsole.h>
+#include <QDebug>
 
 namespace AssetProcessor
 {
@@ -103,6 +104,7 @@ namespace AssetProcessor
                 if (!modelIsResetting)
                 {
                     QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
+                    Q_ASSERT(checkIndex(parentIndex));
                     beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
                 }
                 nextParent = parentItem->CreateChild(SourceAssetTreeItemData::MakeShared(nullptr, nullptr, currentFullFolderPath.Native(), currentPath.c_str(), true));
@@ -119,6 +121,7 @@ namespace AssetProcessor
         if (!modelIsResetting)
         {
             QModelIndex parentIndex = parentItem == m_root.get() ? QModelIndex() : createIndex(parentItem->GetRow(), 0, parentItem);
+            Q_ASSERT(checkIndex(parentIndex));
             beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
         }
 
@@ -174,6 +177,7 @@ namespace AssetProcessor
         }
 
         QModelIndex parentIndex = parent == m_root.get() ? QModelIndex() : createIndex(parent->GetRow(), 0, parent);
+        Q_ASSERT(checkIndex(parentIndex));
 
         beginRemoveRows(parentIndex, assetToRemove->GetRow(), assetToRemove->GetRow());
 


### PR DESCRIPTION
When the parent is the tree root element, beginInsertRows must be
called with an invalid (but legal) index. A QModelIndex with a row
index of zero when the parent has no children is an illegal index
and will result in "undefined behavior", like the "index out of
range" one.

Therefore, if our parent is the tree root element, we use QModelIndex()
instead.

Fixes #2343

This PR also contains two other commits which are not strictly necessary, one
makes the code more in line with Qt best practices, the other adds some debugging
asserts.