### PR TITLE
LYN-6874 : Restore viewport setting causes error when exiting game mode

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2428,7 +2428,7 @@ void EditorViewportWidget::RestoreViewportAfterGameMode()
     }
     else
     {
-        AZ_Error("CryLegacy", false, "Not restoring the editor viewport camera is currently unsupported");
+        AZ_Warning("CryLegacy", false, "Not restoring the editor viewport camera is currently unsupported");
         SetViewTM(preGameModeViewTM);
     }
 }


### PR DESCRIPTION
when editor preferences > general preferences > restore viewport camera on game mode exit
This will be properly fixed when the Editor Camera Location Storage is supported.