### PR TITLE
Atom Tools: Fixing problems with inspector property group layout and deletion

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorWidget.cpp
@@ -31,20 +31,26 @@ namespace AtomToolsFramework
 
     void InspectorWidget::AddHeading(QWidget* headingWidget)
     {
-        headingWidget->setParent(m_ui->m_headingSection);
-        m_ui->m_headingSectionLayout->addWidget(headingWidget);
+        headingWidget->setParent(this);
+        m_ui->m_headingContentsLayout->addWidget(headingWidget);
     }
 
     void InspectorWidget::ClearHeading()
     {
-        qDeleteAll(m_ui->m_headingSection->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly));
-        qDeleteAll(m_ui->m_headingSectionLayout->children());
+        while (QLayoutItem* child = m_ui->m_headingContentsLayout->takeAt(0))
+        {
+            delete child->widget();
+            delete child;
+        }
     }
 
     void InspectorWidget::Reset()
     {
-        qDeleteAll(m_ui->m_groupContents->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly));
-        qDeleteAll(m_ui->m_groupContentsLayout->children());
+        while (QLayoutItem* child = m_ui->m_groupContentsLayout->takeAt(0))
+        {
+            delete child->widget();
+            delete child;
+        }
         m_groups.clear();
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorWidget.ui
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorWidget.ui
@@ -30,104 +30,85 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QWidget" name="m_sections">
-     <layout class="QVBoxLayout" name="m_sectionsLayout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QWidget" name="m_headingSection" native="true">
-        <layout class="QVBoxLayout" name="m_headingSectionLayout">
-         <property name="spacing">
-          <number>0</number>
+      <layout class="QVBoxLayout" name="m_headingContentsLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="m_groupSectionLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QScrollArea" name="m_groupScrollArea">
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAsNeeded</enum>
          </property>
-         <property name="leftMargin">
-          <number>0</number>
+         <property name="widgetResizable">
+          <bool>true</bool>
          </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="m_groupSection" native="true">
-        <layout class="QVBoxLayout" name="m_groupSectionLayout">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QScrollArea" name="m_groupScrollArea">
-           <property name="verticalScrollBarPolicy">
-            <enum>Qt::ScrollBarAsNeeded</enum>
+         <widget class="QWidget" name="m_groupContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>679</width>
+            <height>767</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QVBoxLayout" name="m_groupContentsLayout">
+           <property name="spacing">
+            <number>0</number>
            </property>
-           <property name="widgetResizable">
-            <bool>true</bool>
+           <property name="leftMargin">
+            <number>0</number>
            </property>
-           <widget class="QWidget" name="m_groupContents">
-            <property name="geometry">
-             <rect>
-              <x>0</x>
-              <y>0</y>
-              <width>683</width>
-              <height>763</height>
-             </rect>
-            </property>
-            <layout class="QVBoxLayout" name="m_groupContentsLayout">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
• A previous change introduced a heading section of the top of the inspector
• The code was incorrectly attempting to delete child widgets and layouts from the layout of each section
• Size policies were also updated to give priority to the section containing the property groups
• Tested material component property editor and material editor to make sure that widgets were laid out correctly at the top of the inspector

Signed-off-by: Guthrie Adams <guthadam@amazon.com>