### PR TITLE
Prism/open cmake

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -53,7 +53,7 @@ namespace O3DE::ProjectManager
 
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)
         {
-            return AZ::Failure(QObject::tr("This functionality has not been implemented yet on this platform.");
+            return AZ::Failure(QObject::tr("This functionality has not been implemented yet on this platform."));
         }
         
     } // namespace ProjectUtils

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -49,6 +49,12 @@ namespace O3DE::ProjectManager
                 "Make sure that the clang is installed and available from the command prompt. "
                 "Refer to the <a href='https://o3de.org/docs/welcome-guide/setup/requirements/#cmake'>O3DE requirements</a> page for more information."));
         }
+
+
+        AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)
+        {
+            return AZ::Failure(QObject::tr("This functionality has not been implemented yet on this platform.");
+        }
         
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -19,7 +19,10 @@ namespace O3DE::ProjectManager
 
         AZ::Outcome<QProcessEnvironment, QString> GetCommandLineProcessEnvironment()
         {
-            return AZ::Success(QProcessEnvironment(QProcessEnvironment::systemEnvironment()));
+            QProcessEnvironment currentEnvironment(QProcessEnvironment::systemEnvironment());
+            currentEnvironment.insert("CC", "clang-12");
+            currentEnvironment.insert("CXX", "clang++-12");
+            return AZ::Success(currentEnvironment);
         }
 
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform()

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -8,6 +8,7 @@
 #include <ProjectUtils.h>
 #include <ProjectManagerDefs.h>
 #include <QProcessEnvironment>
+#include <QDir>
 
 namespace O3DE::ProjectManager
 {

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -71,7 +71,7 @@ namespace O3DE::ProjectManager
             QString cmakeAppPath = QStandardPaths::locate(QStandardPaths::ApplicationsLocation, "CMake.app", QStandardPaths::LocateDirectory);
             if (cmakeAppPath.isEmpty())
             {
-                return AZ::Failure(QObject::tr("CMake.app not found. ") + cmakeHelp);
+                return AZ::Failure(QObject::tr("CMake.app not found.") + cmakeHelp);
             }
 
             QString projectBuildPath = QDir(projectPath).filePath(ProjectBuildPathPostfix);
@@ -86,10 +86,10 @@ namespace O3DE::ProjectManager
             // if the project build path is relative, it should be relative to the project path 
             process.setWorkingDirectory(projectPath);
             process.setProgram("open");
-            process.setArguments({ "-a","CMake","--args","-S", projectPath, "-B", projectBuildPath });
+            process.setArguments({"-a", "CMake", "--args", "-S", projectPath, "-B", projectBuildPath});
             if(!process.startDetached())
             {
-                return AZ::Failure(QObject::tr("CMake.app failed to open. ") + cmakeHelp);
+                return AZ::Failure(QObject::tr("CMake.app failed to open.") + cmakeHelp);
             }
 
             return AZ::Success();

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -101,21 +101,21 @@ namespace O3DE::ProjectManager
         
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)
         {
-            auto cmakeProcessEnvResult = GetCommandLineProcessEnvironment();
-            if (!cmakeProcessEnvResult.IsSuccess())
+            AZ::Outcome processEnvResult = GetCommandLineProcessEnvironment();
+            if (!processEnvResult.IsSuccess())
             {
-                return AZ::Failure(cmakeProcessEnvResult.GetError());
+                return AZ::Failure(processEnvResult.GetError());
             }
 
             QString projectBuildPath = QDir(projectPath).filePath(ProjectBuildPathPostfix);
-            AZ::Outcome result = GetProjectBuildPath(projectPath);
-            if (result.IsSuccess())
+            AZ::Outcome projectBuildPathResult = GetProjectBuildPath(projectPath);
+            if (projectBuildPathResult.IsSuccess())
             {
-                projectBuildPath = result.GetValue();
+                projectBuildPath = projectBuildPathResult.GetValue();
             }
 
             QProcess process;
-            process.setProcessEnvironment(cmakeProcessEnvResult.GetValue());
+            process.setProcessEnvironment(processEnvResult.GetValue());
 
             // if the project build path is relative, it should be relative to the project path 
             process.setWorkingDirectory(projectPath);

--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -438,6 +438,11 @@ QTabBar::tab:focus {
     max-height:26px;
 }
 
+#projectActionButton, #openEditorButton {
+    min-height:26px;
+    max-height:26px;
+}
+
 #labelButtonOverlay {
     background-color: rgba(50,50,50,200);
     min-width:210px;

--- a/Code/Tools/ProjectManager/Resources/Warning.svg
+++ b/Code/Tools/ProjectManager/Resources/Warning.svg
@@ -1,5 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="24" height="24" fill="#444444"/>
 <rect x="10" y="6" width="4" height="15" fill="black"/>
 <path fill-rule="evenodd" clip-rule="evenodd" d="M12 2L22 22H2L12 2ZM13 20V18H11V20H13ZM13 7H11V16.0862H13V7Z" fill="#F0C32D"/>
 </svg>

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -88,6 +88,7 @@ namespace O3DE::ProjectManager
         QHBoxLayout* horizontalButtonLayout = new QHBoxLayout();
         horizontalButtonLayout->addSpacing(34);
         m_actionButton = new QPushButton(tr("Project Action"), this);
+        m_actionButton->setObjectName("projectActionButton");
         m_actionButton->setVisible(false);
         horizontalButtonLayout->addWidget(m_actionButton);
         horizontalButtonLayout->addSpacing(34);
@@ -197,7 +198,8 @@ namespace O3DE::ProjectManager
 
             QMenu* menu = new QMenu(this);
             menu->addAction(tr("Edit Project Settings..."), this, [this]() { emit EditProject(m_projectInfo.m_path); });
-            menu->addAction(tr("Build"), this, [this]() { emit BuildProject(m_projectInfo); });
+            menu->addAction(tr("Auto-build"), this, [this]() { emit BuildProject(m_projectInfo); });
+            menu->addAction(tr("Open CMake..."), this, [this]() { emit OpenCMake(m_projectInfo); });
             menu->addSeparator();
             menu->addAction(tr("Open Project folder..."), this, [this]()
             { 
@@ -259,15 +261,39 @@ namespace O3DE::ProjectManager
         }
 
         projectActionButton->setText(text);
+        projectActionButton->setMenu(nullptr);
         m_actionButtonConnection = connect(projectActionButton, &QPushButton::clicked, lambda);
     }
 
-    void ProjectButton::SetProjectBuildButtonAction()
+    void ProjectButton::ShowDefaultBuildButton()
     {
-        m_projectImageLabel->GetWarningLabel()->setText(tr("Building project required."));
-        m_projectImageLabel->GetWarningIcon()->setVisible(true);
-        m_projectImageLabel->GetWarningLabel()->setVisible(true);
-        SetProjectButtonAction(tr("Build Project"), [this]() { emit BuildProject(m_projectInfo); });
+        QPushButton* projectActionButton = m_projectImageLabel->GetActionButton();
+        projectActionButton->setVisible(true);
+        projectActionButton->setText(tr("Build Project"));
+        disconnect(m_actionButtonConnection);
+
+        QMenu* menu = new QMenu(this);
+        QAction* autoBuildAction = menu->addAction(tr("Auto-build"));
+        connect( autoBuildAction, &QAction::triggered, this, [this](){ emit BuildProject(m_projectInfo); });
+
+        QAction* openCMakeAction = menu->addAction(tr("Open CMake..."));
+        connect( openCMakeAction, &QAction::triggered, this, [this](){ emit OpenCMake(m_projectInfo); });
+
+        projectActionButton->setMenu(menu);
+    }
+
+    void ProjectButton::ShowBuildRequired()
+    {
+        ShowWarning(true, tr("Building project required"));
+        ShowDefaultBuildButton();
+    }
+
+    void ProjectButton::ShowWarning(bool show, const QString& warning)
+    {
+        m_projectImageLabel->GetWarningLabel()->setTextInteractionFlags(Qt::LinksAccessibleByMouse);
+        m_projectImageLabel->GetWarningLabel()->setText(warning);
+        m_projectImageLabel->GetWarningLabel()->setVisible(show);
+        m_projectImageLabel->GetWarningIcon()->setVisible(show);
     }
 
     void ProjectButton::SetBuildLogsLink(const QUrl& logUrl)
@@ -279,18 +305,15 @@ namespace O3DE::ProjectManager
     {
         if (!logUrl.isEmpty())
         {
-            m_projectImageLabel->GetWarningLabel()->setText(tr("Failed to build. Click to <a href=\"logs\">view logs</a>."));
+            ShowWarning(show, tr("Failed to build. Click to <a href=\"logs\">view logs</a>."));
         }
         else
         {
-            m_projectImageLabel->GetWarningLabel()->setText(tr("Project failed to build."));
+            ShowWarning(show, tr("Project failed to build."));
         }
 
-        m_projectImageLabel->GetWarningLabel()->setTextInteractionFlags(Qt::LinksAccessibleByMouse);
-        m_projectImageLabel->GetWarningIcon()->setVisible(show);
-        m_projectImageLabel->GetWarningLabel()->setVisible(show);
-        m_projectImageLabel->SetLogUrl(logUrl);
-        SetProjectButtonAction(tr("Build Project"), [this]() { emit BuildProject(m_projectInfo); });
+        SetBuildLogsLink(logUrl);
+        ShowDefaultBuildButton();
     }
 
     void ProjectButton::SetProjectBuilding()

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -198,7 +198,7 @@ namespace O3DE::ProjectManager
 
             QMenu* menu = new QMenu(this);
             menu->addAction(tr("Edit Project Settings..."), this, [this]() { emit EditProject(m_projectInfo.m_path); });
-            menu->addAction(tr("Auto-build"), this, [this]() { emit BuildProject(m_projectInfo); });
+            menu->addAction(tr("Build"), this, [this]() { emit BuildProject(m_projectInfo); });
             menu->addAction(tr("Open CMake GUI..."), this, [this]() { emit OpenCMakeGUI(m_projectInfo); });
             menu->addSeparator();
             menu->addAction(tr("Open Project folder..."), this, [this]()
@@ -273,7 +273,7 @@ namespace O3DE::ProjectManager
         disconnect(m_actionButtonConnection);
 
         QMenu* menu = new QMenu(this);
-        QAction* autoBuildAction = menu->addAction(tr("Auto-build"));
+        QAction* autoBuildAction = menu->addAction(tr("Build Now"));
         connect( autoBuildAction, &QAction::triggered, this, [this](){ emit BuildProject(m_projectInfo); });
 
         QAction* openCMakeAction = menu->addAction(tr("Open CMake GUI..."));

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.cpp
@@ -199,7 +199,7 @@ namespace O3DE::ProjectManager
             QMenu* menu = new QMenu(this);
             menu->addAction(tr("Edit Project Settings..."), this, [this]() { emit EditProject(m_projectInfo.m_path); });
             menu->addAction(tr("Auto-build"), this, [this]() { emit BuildProject(m_projectInfo); });
-            menu->addAction(tr("Open CMake..."), this, [this]() { emit OpenCMake(m_projectInfo); });
+            menu->addAction(tr("Open CMake GUI..."), this, [this]() { emit OpenCMakeGUI(m_projectInfo); });
             menu->addSeparator();
             menu->addAction(tr("Open Project folder..."), this, [this]()
             { 
@@ -276,8 +276,8 @@ namespace O3DE::ProjectManager
         QAction* autoBuildAction = menu->addAction(tr("Auto-build"));
         connect( autoBuildAction, &QAction::triggered, this, [this](){ emit BuildProject(m_projectInfo); });
 
-        QAction* openCMakeAction = menu->addAction(tr("Open CMake..."));
-        connect( openCMakeAction, &QAction::triggered, this, [this](){ emit OpenCMake(m_projectInfo); });
+        QAction* openCMakeAction = menu->addAction(tr("Open CMake GUI..."));
+        connect( openCMakeAction, &QAction::triggered, this, [this](){ emit OpenCMakeGUI(m_projectInfo); });
 
         projectActionButton->setMenu(menu);
     }

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
@@ -82,9 +82,9 @@ namespace O3DE::ProjectManager
         void RestoreDefaultState();
 
         void SetProjectButtonAction(const QString& text, AZStd::function<void()> lambda);
-        void SetProjectBuildButtonAction();
         void SetBuildLogsLink(const QUrl& logUrl);
         void ShowBuildFailed(bool show, const QUrl& logUrl);
+        void ShowBuildRequired();
         void SetProjectBuilding();
 
         void SetLaunchButtonEnabled(bool enabled);
@@ -99,10 +99,13 @@ namespace O3DE::ProjectManager
         void RemoveProject(const QString& projectName);
         void DeleteProject(const QString& projectName);
         void BuildProject(const ProjectInfo& projectInfo);
+        void OpenCMake(const ProjectInfo& projectInfo);
 
     private:
         void enterEvent(QEvent* event) override;
         void leaveEvent(QEvent* event) override;
+        void ShowWarning(bool show, const QString& warning);
+        void ShowDefaultBuildButton();
 
         ProjectInfo m_projectInfo;
 

--- a/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
+++ b/Code/Tools/ProjectManager/Source/ProjectButtonWidget.h
@@ -99,7 +99,7 @@ namespace O3DE::ProjectManager
         void RemoveProject(const QString& projectName);
         void DeleteProject(const QString& projectName);
         void BuildProject(const ProjectInfo& projectInfo);
-        void OpenCMake(const ProjectInfo& projectInfo);
+        void OpenCMakeGUI(const ProjectInfo& projectInfo);
 
     private:
         void enterEvent(QEvent* event) override;

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -9,6 +9,8 @@
 #include <ProjectUtils.h>
 #include <ProjectManagerDefs.h>
 #include <PythonBindingsInterface.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/IO/Path/Path.h>
 
 #include <QFileDialog>
 #include <QDir>
@@ -537,5 +539,33 @@ namespace O3DE::ProjectManager
             QString resultOutput = execProcess.readAllStandardOutput();
             return AZ::Success(resultOutput);
         }
+
+        AZ::Outcome<QString, QString> GetProjectBuildPath(const QString& projectPath)
+        {
+            auto registry = AZ::SettingsRegistry::Get();
+
+            // the project_build_path should be in the user settings registry inside the project folder
+            AZ::IO::FixedMaxPath projectUserPath(projectPath.toStdString().c_str());
+            projectUserPath /= AZ::SettingsRegistryInterface::DevUserRegistryFolder;
+            if (!QDir(projectUserPath.c_str()).exists())
+            {
+                return AZ::Failure(QObject::tr("Failed to find the user registry folder %1").arg(projectUserPath.c_str()));
+            }
+
+            AZ::SettingsRegistryInterface::Specializations specializations;
+            if(!registry->MergeSettingsFolder(projectUserPath.Native(), specializations, AZ_TRAIT_OS_PLATFORM_CODENAME))
+            {
+                return AZ::Failure(QObject::tr("Failed to merge registry settings in user registry folder %1").arg(projectUserPath.c_str()));
+            }
+
+            AZ::IO::FixedMaxPath projectBuildPath;
+            if (!registry->Get(projectBuildPath.Native(), AZ::SettingsRegistryMergeUtils::ProjectBuildPath))
+            {
+                return AZ::Failure(QObject::tr("No project build path setting was found in the user registry folder %1").arg(projectUserPath.c_str()));
+            }
+
+            return AZ::Success(QString(projectBuildPath.c_str()));
+        }
+
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -545,7 +545,7 @@ namespace O3DE::ProjectManager
             auto registry = AZ::SettingsRegistry::Get();
 
             // the project_build_path should be in the user settings registry inside the project folder
-            AZ::IO::FixedMaxPath projectUserPath(projectPath.toStdString().c_str());
+            AZ::IO::FixedMaxPath projectUserPath(projectPath.toUtf8().constData());
             projectUserPath /= AZ::SettingsRegistryInterface::DevUserRegistryFolder;
             if (!QDir(projectUserPath.c_str()).exists())
             {

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -42,6 +42,8 @@ namespace O3DE::ProjectManager
             int commandTimeoutSeconds = ProjectCommandLineTimeoutSeconds);
 
         AZ::Outcome<QProcessEnvironment, QString> GetCommandLineProcessEnvironment();
+        AZ::Outcome<QString, QString> GetProjectBuildPath(const QString& projectPath);
+        AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath);
 
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -185,7 +185,7 @@ namespace O3DE::ProjectManager
         connect(projectButton, &ProjectButton::RemoveProject, this, &ProjectsScreen::HandleRemoveProject);
         connect(projectButton, &ProjectButton::DeleteProject, this, &ProjectsScreen::HandleDeleteProject);
         connect(projectButton, &ProjectButton::BuildProject, this, &ProjectsScreen::QueueBuildProject);
-        connect(projectButton, &ProjectButton::OpenCMake, this, 
+        connect(projectButton, &ProjectButton::OpenCMakeGUI, this, 
             [this](const ProjectInfo& projectInfo)
             {
                 AZ::Outcome result = ProjectUtils::OpenCMakeGUI(projectInfo.m_path);

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -185,7 +185,7 @@ namespace O3DE::ProjectManager
         connect(projectButton, &ProjectButton::RemoveProject, this, &ProjectsScreen::HandleRemoveProject);
         connect(projectButton, &ProjectButton::DeleteProject, this, &ProjectsScreen::HandleDeleteProject);
         connect(projectButton, &ProjectButton::BuildProject, this, &ProjectsScreen::QueueBuildProject);
-        connect( projectButton, &ProjectButton::OpenCMake, this, 
+        connect(projectButton, &ProjectButton::OpenCMake, this, 
             [this](const ProjectInfo& projectInfo)
             {
                 AZ::Outcome result = ProjectUtils::OpenCMakeGUI(projectInfo.m_path);

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -185,6 +185,15 @@ namespace O3DE::ProjectManager
         connect(projectButton, &ProjectButton::RemoveProject, this, &ProjectsScreen::HandleRemoveProject);
         connect(projectButton, &ProjectButton::DeleteProject, this, &ProjectsScreen::HandleDeleteProject);
         connect(projectButton, &ProjectButton::BuildProject, this, &ProjectsScreen::QueueBuildProject);
+        connect( projectButton, &ProjectButton::OpenCMake, this, 
+            [this](const ProjectInfo& projectInfo)
+            {
+                AZ::Outcome result = ProjectUtils::OpenCMakeGUI(projectInfo.m_path);
+                if (!result)
+                {
+                    QMessageBox::critical(this, tr("Failed to open CMake GUI"), result.GetError(), QMessageBox::Ok);
+                }
+            });
 
         return projectButton;
     }
@@ -308,7 +317,7 @@ namespace O3DE::ProjectManager
                     }
                     else
                     {
-                        projectIter.value()->SetProjectBuildButtonAction();
+                        projectIter.value()->ShowBuildRequired();
                     }
                 }
             }


### PR DESCRIPTION
Adds the option to open CMake in addition to the existing auto-build option.   This provides a fast way for engineers who want to configure -> generate -> open project in IDE -> build & run can do so without waiting for a potentially lengthy auto-build.
Though not the final design, it also provides a way to access information about the project like
- project build folder
- configuration settings/active generator


![Q5rNXgkIhV](https://user-images.githubusercontent.com/26804013/135005602-2338dfa5-2e8b-404a-898f-a469d9260358.gif)


Tests:
- ran on Windows, Mac and Linux
- ran auto-build and verified cancel button shows and works