### PR TITLE
Editor crashes after changing the layout when the Prefab system is enabled

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -82,6 +82,8 @@ namespace AzToolsFramework
         , m_entityExpansionState()
         , m_entityFilteredState()
     {
+        m_focusModeInterface = AZ::Interface<FocusModeInterface>::Get();
+        AZ_Assert(m_focusModeInterface != nullptr, "EntityOutlinerListModel requires a FocusModeInterface instance on construction.");
     }
 
     EntityOutlinerListModel::~EntityOutlinerListModel()
@@ -106,11 +108,6 @@ namespace AzToolsFramework
         m_editorEntityUiInterface = AZ::Interface<AzToolsFramework::EditorEntityUiInterface>::Get();
         AZ_Assert(m_editorEntityUiInterface != nullptr,
             "EntityOutlinerListModel requires a EditorEntityUiInterface instance on Initialize.");
-
-        m_focusModeInterface = AZ::Interface<FocusModeInterface>::Get();
-        AZ_Assert(
-            m_focusModeInterface != nullptr,
-            "EntityOutlinerListModel requires a FocusModeInterface instance on Initialize.");
     }
 
     int EntityOutlinerListModel::rowCount(const QModelIndex& parent) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -232,6 +232,9 @@ namespace AzToolsFramework
         m_gui->m_objectTree->header()->setSortIndicatorShown(false);
         m_gui->m_objectTree->header()->setStretchLastSection(false);
 
+        // Always expand root entity (level entity) - needed if the widget is re-created while a level is already open.
+        m_gui->m_objectTree->expand(m_proxyModel->index(0, 0));
+
         // resize the icon columns so that the Visibility and Lock toggle icon columns stay right-justified
         m_gui->m_objectTree->header()->setStretchLastSection(false);
         m_gui->m_objectTree->header()->setMinimumSectionSize(0);


### PR DESCRIPTION
Fixes an issue with the order of operations on Entity Outliner construction that would cause a crash on layout refresh.
This would only occur in situations where the Entity Outliner is constructed while a level is already loaded.

Also added an additional fix to make sure the root entity is expanded on construction and not just on prefab propagation end.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>