### PR TITLE
Fix Entity id consistency issue & refactor prefab workflows/tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/prefab/Prefab.py
+++ b/AutomatedTesting/Gem/PythonTests/prefab/Prefab.py
@@ -25,28 +25,39 @@ import prefab.Prefab_Test_Utils as prefab_test_utils
 # This is a helper class which contains some of the useful information about a prefab instance.
 class PrefabInstance:
 
-    def __init__(self, name: str=None, prefab_file_name: str=None, container_entity: EditorEntity=EntityId()):
-        self.name = name
+    def __init__(self, prefab_file_name: str=None, container_entity: EditorEntity=EntityId()):
         self.prefab_file_name: str = prefab_file_name
         self.container_entity: EditorEntity = container_entity
+
+    def __eq__(self, other):
+        return other and self.container_entity.id == other.container_entity.id
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(self.container_entity.id)
 
     """
     See if this instance is valid to be used with other prefab operations. 
     :return: Whether the target instance is valid or not.
     """
     def is_valid() -> bool:
-        return self.container_entity.id.IsValid() and self.name is not None and self.prefab_file_name in Prefab.existing_prefabs
+        return self.container_entity.id.IsValid() and self.prefab_file_name in Prefab.existing_prefabs
 
-    
     """
     Reparent this instance to target parent entity. 
     The function will also check pop up dialog ui in editor to see if there's prefab cyclical dependency error while reparenting prefabs.
     :param parent_entity_id: The id of the entity this instance should be a child of in the transform hierarchy next.
     """
     async def ui_reparent_prefab_instance(self, parent_entity_id: EntityId):
-        container_entity_name = self.container_entity.get_name()
-        current_children_entity_ids_having_prefab_name = prefab_test_utils.get_children_ids_by_name(parent_entity_id, container_entity_name)
-        Report.info(f'current_children_entity_ids_having_prefab_name: {current_children_entity_ids_having_prefab_name}')
+        container_entity_id_before_reparent = self.container_entity.id
+
+        original_parent = EditorEntity(self.container_entity.get_parent_id())
+        original_parent_before_reparent_children_ids = set(original_parent.get_children_ids())
+
+        new_parent = EditorEntity(parent_entity_id)
+        new_parent_before_reparent_children_ids = set(new_parent.get_children_ids())
 
         pyside_utils.run_soon(lambda: self.container_entity.set_parent_entity(parent_entity_id))
         pyside_utils.run_soon(lambda: prefab_test_utils.wait_for_propagation())
@@ -60,18 +71,23 @@ class PrefabInstance:
         except pyside_utils.EventLoopTimeoutException:
             pass
 
-        updated_children_entity_ids_having_prefab_name = prefab_test_utils.get_children_ids_by_name(parent_entity_id, container_entity_name)
-        Report.info(f'updated_children_entity_ids_having_prefab_name: {updated_children_entity_ids_having_prefab_name}')
-        new_child_with_reparented_prefab_name_added = len(updated_children_entity_ids_having_prefab_name) == len(current_children_entity_ids_having_prefab_name) + 1
-        assert new_child_with_reparented_prefab_name_added, "No entity with reparented prefab name become a child of target parent entity"
+        original_parent_after_reparent_children_ids = set(original_parent.get_children_ids())
+        assert len(original_parent_after_reparent_children_ids) == len(original_parent_before_reparent_children_ids) - 1, \
+            "The children count of the Prefab Instance's original parent should be decreased by 1."
+        assert not container_entity_id_before_reparent in original_parent_after_reparent_children_ids, \
+            "This Prefab Instance is still a child entity of its original parent entity."
+       
+        new_parent_after_reparent_children_ids = set(new_parent.get_children_ids())
+        assert len(new_parent_after_reparent_children_ids) == len(new_parent_before_reparent_children_ids) + 1, \
+            "The children count of the Prefab Instance's new parent should be increased by 1."
 
-        updated_container_entity_id = set(updated_children_entity_ids_having_prefab_name).difference(current_children_entity_ids_having_prefab_name).pop()
-        updated_container_entity = EditorEntity(updated_container_entity_id)
-        updated_container_entity_parent_id = updated_container_entity.get_parent_id()
-        has_correct_parent = updated_container_entity_parent_id.ToString() == parent_entity_id.ToString()
-        assert has_correct_parent, "Prefab reparented is *not* under the expected parent entity"
+        container_entity_id_after_reparent = set(new_parent_after_reparent_children_ids).difference(new_parent_before_reparent_children_ids).pop()
+        reparented_container_entity = EditorEntity(container_entity_id_after_reparent)
+        reparented_container_entity_parent_id = reparented_container_entity.get_parent_id()
+        has_correct_parent = reparented_container_entity_parent_id.ToString() == parent_entity_id.ToString()
+        assert has_correct_parent, "Prefab Instance reparented is *not* under the expected parent entity"
 
-        self.container_entity = EditorEntity(updated_container_entity_id)
+        self.container_entity = reparented_container_entity
 
 # This is a helper class which contains some of the useful information about a prefab template.
 class Prefab:
@@ -81,7 +97,7 @@ class Prefab:
     def __init__(self, file_name: str):
         self.file_name:str = file_name
         self.file_path: str = prefab_test_utils.get_prefab_file_path(file_name)
-        self.instances: dict = {}
+        self.instances: set[PrefabInstance] = set()
 
     """
     Check if a prefab is ready to be used to generate its instances.
@@ -122,10 +138,10 @@ class Prefab:
     :param entities: The entities that should form the new prefab (along with their descendants).
     :param file_name: A unique file name of new prefab.
     :param prefab_instance_name: A name for the very first instance generated while prefab creation. The default instance name is the same as file_name.
-    :return: An outcome object with an entityId of the new prefab's container entity; on failure, it comes with an error message detailing the cause of the error.
+    :return: Created Prefab object and the very first PrefabInstance object owned by the prefab.
     """
     @classmethod
-    def create_prefab(cls, entities: list[EditorEntity], file_name: str, prefab_instance_name: str=None) -> Prefab:
+    def create_prefab(cls, entities: list[EditorEntity], file_name: str, prefab_instance_name: str=None) -> (Prefab, PrefabInstance):
         assert not Prefab.is_prefab_loaded(file_name), f"Can't create Prefab '{file_name}' since the prefab already exists"
 
         new_prefab = Prefab(file_name)
@@ -133,18 +149,18 @@ class Prefab:
         create_prefab_result = prefab.PrefabPublicRequestBus(bus.Broadcast, 'CreatePrefabInMemory', entity_ids, new_prefab.file_path)
         assert create_prefab_result.IsSuccess(), f"Prefab operation 'CreatePrefab' failed. Error: {create_prefab_result.GetError()}"
 
-        container_entity = EditorEntity(create_prefab_result.GetValue())
+        container_entity_id = create_prefab_result.GetValue()
+        container_entity = EditorEntity(container_entity_id)
 
         if prefab_instance_name:
             container_entity.set_name(prefab_instance_name)
-        else:
-            prefab_instance_name = file_name
 
         prefab_test_utils.wait_for_propagation()
-        container_entity_id = prefab_test_utils.find_entity_by_unique_name(prefab_instance_name)
-        new_prefab.instances[prefab_instance_name] = PrefabInstance(prefab_instance_name, file_name, EditorEntity(container_entity_id))
+
+        new_prefab_instance = PrefabInstance(file_name, EditorEntity(container_entity_id))
+        new_prefab.instances.add(new_prefab_instance)
         Prefab.existing_prefabs[file_name] = new_prefab
-        return new_prefab
+        return new_prefab, new_prefab_instance
 
     """
     Remove target prefab instances.
@@ -152,22 +168,15 @@ class Prefab:
     """
     @classmethod
     def remove_prefabs(cls, prefab_instances: list[PrefabInstance]):
-        instances_to_remove_name_counts = Counter()
-        instances_removed_expected_name_counts = Counter()
-
-        entities_to_remove = [prefab_instance.container_entity for prefab_instance in prefab_instances]
-        while entities_to_remove:
-            entity = entities_to_remove.pop(-1)
-            entity_name = entity.get_name()
-            instances_to_remove_name_counts[entity_name] += 1
-
+        entity_ids_to_remove = []
+        entity_id_queue = [prefab_instance.container_entity for prefab_instance in prefab_instances]
+        while entity_id_queue:
+            entity = entity_id_queue.pop(0)
             children_entity_ids = entity.get_children_ids()
             for child_entity_id in children_entity_ids:
-                entities_to_remove.append(EditorEntity(child_entity_id))
+                entity_id_queue.append(EditorEntity(child_entity_id))
 
-        for entity_name, entity_count in instances_to_remove_name_counts.items():
-            entities = prefab_test_utils.find_entities_by_name(entity_name)
-            instances_removed_expected_name_counts[entity_name] = len(entities) - entity_count
+            entity_ids_to_remove.append(entity.id)
 
         container_entity_ids = [prefab_instance.container_entity.id for prefab_instance in prefab_instances]
         delete_prefab_result = prefab.PrefabPublicRequestBus(bus.Broadcast, 'DeleteEntitiesAndAllDescendantsInInstance', container_entity_ids)
@@ -175,28 +184,24 @@ class Prefab:
 
         prefab_test_utils.wait_for_propagation()
 
-        prefab_entities_deleted = True
-        for entity_name, expected_entity_count in instances_removed_expected_name_counts.items():
-            actual_entity_count = len(prefab_test_utils.find_entities_by_name(entity_name))
-            if actual_entity_count is not expected_entity_count:
-                prefab_entities_deleted = False
-                break
-
-        assert prefab_entities_deleted, "Not all entities and descendants in target prefabs are deleted."
+        entity_ids_after_delete = set(prefab_test_utils.get_all_entities())
+        for entity_id_removed in entity_ids_to_remove:
+            if entity_id_removed in entity_ids_after_delete:
+                assert prefab_entities_deleted, "Not all entities and descendants in target prefabs are deleted."
 
         for instance in prefab_instances:
             instance_deleted_prefab = Prefab.get_prefab(instance.prefab_file_name)
-            instance_deleted_prefab.instances.pop(instance.name)
+            instance_deleted_prefab.instances.remove(instance)
             instance = PrefabInstance()
         
     """
     Instantiate an instance of this prefab.
-    :param name: A name for newly instantiated prefab instance. The default instance name is the same as this prefab's file name.
     :param parent_entity: The entity the prefab should be a child of in the transform hierarchy.
+    :param name: A name for newly instantiated prefab instance. The default instance name is the same as this prefab's file name.
     :param prefab_position: The position in world space the prefab should be instantiated in.
-    :return: An outcome object with an entityId of the new prefab's container entity; on failure, it comes with an error message detailing the cause of the error.
+    :return: Instantiated PrefabInstance object owned by this prefab.
     """
-    def instantiate(self, name: str=None, parent_entity: EditorEntity=None, prefab_position: Vector3=Vector3()) -> PrefabInstance:
+    def instantiate(self, parent_entity: EditorEntity=None, name: str=None, prefab_position: Vector3=Vector3()) -> PrefabInstance:
         parent_entity_id = parent_entity.id if parent_entity is not None else EntityId()
 
         instantiate_prefab_result = prefab.PrefabPublicRequestBus(
@@ -209,13 +214,13 @@ class Prefab:
 
         if name:
             container_entity.set_name(name)
-        else:
-            name = self.file_name
 
         prefab_test_utils.wait_for_propagation()
-        container_entity_id = prefab_test_utils.find_entity_by_unique_name(name)
-        self.instances[name] = PrefabInstance(name, self.file_name, EditorEntity(container_entity_id)) 
+
+        new_prefab_instance = PrefabInstance(self.file_name, EditorEntity(container_entity_id))
+        assert not new_prefab_instance in self.instances, "This prefab instance is already existed before this instantiation."
+        self.instances.add(new_prefab_instance)
 
         prefab_test_utils.check_entity_at_position(container_entity_id, prefab_position)
 
-        return container_entity_id
+        return new_prefab_instance

--- a/AutomatedTesting/Gem/PythonTests/prefab/Prefab_BasicWorkflow_CreateAndDeletePrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/prefab/Prefab_BasicWorkflow_CreateAndDeletePrefab.py
@@ -22,11 +22,10 @@ def Prefab_BasicWorkflow_CreateAndDeletePrefab():
     car_prefab_entities = [car_entity]
 
     # Checks for prefab creation passed or not 
-    car_prefab = Prefab.create_prefab(
+    _, car = Prefab.create_prefab(
         car_prefab_entities, CAR_PREFAB_FILE_NAME)
 
     # Checks for prefab deletion passed or not 
-    car = car_prefab.instances[CAR_PREFAB_FILE_NAME]
     Prefab.remove_prefabs([car])
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/prefab/Prefab_BasicWorkflow_CreateAndReparentPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/prefab/Prefab_BasicWorkflow_CreateAndReparentPrefab.py
@@ -28,7 +28,7 @@ def Prefab_BasicWorkflow_CreateAndReparentPrefab():
         car_prefab_entities = [car_entity]
 
         # Checks for prefab creation passed or not 
-        car_prefab = Prefab.create_prefab(
+        _, car = Prefab.create_prefab(
             car_prefab_entities, CAR_PREFAB_FILE_NAME)
 
         # Creates another new Entity at the root level
@@ -36,12 +36,10 @@ def Prefab_BasicWorkflow_CreateAndReparentPrefab():
         wheel_prefab_entities = [wheel_entity]
 
         # Checks for wheel prefab creation passed or not 
-        wheel_prefab = Prefab.create_prefab(
+        _, wheel = Prefab.create_prefab(
             wheel_prefab_entities, WHEEL_PREFAB_FILE_NAME)
 
         # Checks for prefab reparenting passed or not 
-        car = car_prefab.instances[CAR_PREFAB_FILE_NAME]
-        wheel = wheel_prefab.instances[WHEEL_PREFAB_FILE_NAME]
         await wheel.ui_reparent_prefab_instance(car.container_entity.id)
 
     run_test()

--- a/AutomatedTesting/Gem/PythonTests/prefab/Prefab_BasicWorkflow_InstantiatePrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/prefab/Prefab_BasicWorkflow_InstantiatePrefab.py
@@ -22,11 +22,11 @@ def Prefab_BasicWorkflow_InstantiatePrefab():
     # Checks for prefab instantiation passed or not 
     test_prefab = Prefab.get_prefab(EXISTING_TEST_PREFAB_FILE_NAME)
 
-    instantiated_test_container_entity_id = test_prefab.instantiate( 
+    test_instance = test_prefab.instantiate( 
         prefab_position=INSTANTIATED_TEST_PREFAB_POSITION)
     
     prefab_test_utils.check_entity_children_count(
-        instantiated_test_container_entity_id, 
+        test_instance.container_entity.id, 
         EXPECTED_TEST_PREFAB_CHILDREN_COUNT)
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/prefab/Prefab_Test_Utils.py
+++ b/AutomatedTesting/Gem/PythonTests/prefab/Prefab_Test_Utils.py
@@ -29,20 +29,8 @@ def find_entities_by_name(entity_name):
     searchFilter.names = [entity_name]
     return entity.SearchBus(bus.Broadcast, 'SearchEntities', searchFilter)
 
-def find_entity_by_unique_name(entity_name):
-    unique_name_entity_found_result =  (
-        "Entity with a unique name found",
-        "Entity with a unique name *not* found")
-
-    entities = find_entities_by_name(entity_name)
-    unique_name_entity_found = len(entities) == 1
-    Report.result(unique_name_entity_found_result, unique_name_entity_found)
-
-    if unique_name_entity_found:
-        return entities[0]
-    else:
-        Report.info(f"{len(entities)} entities with name '{entity_name}' found")
-        return EntityId()
+def get_all_entities():
+    return entity.SearchBus(bus.Broadcast, 'SearchEntities', entity.SearchFilter())
 
 def check_entity_at_position(entity_id, expected_entity_position):
     entity_at_expected_position_result = (

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -314,13 +314,13 @@ namespace AzToolsFramework
             instanceToParentUnderReference = *m_rootInstance;
         }
 
-        AZStd::unique_ptr<Prefab::Instance> createdPrefabInstance = m_prefabSystemComponent->CreatePrefabUnderParent(
-            entities, AZStd::move(nestedPrefabInstances), filePath, instanceToParentUnderReference);
+        AZStd::unique_ptr<Prefab::Instance> createdPrefabInstance = m_prefabSystemComponent->CreatePrefab(
+            entities, AZStd::move(nestedPrefabInstances), filePath, nullptr, instanceToParentUnderReference, false);
 
         if (createdPrefabInstance)
         {
-            Prefab::Instance& instanceToParentUnder = instanceToParentUnderReference->get();
-            Prefab::Instance& addedInstance = instanceToParentUnder.AddInstance(AZStd::move(createdPrefabInstance));
+            Prefab::Instance& addedInstance = instanceToParentUnderReference->get().AddInstance(
+                AZStd::move(createdPrefabInstance));
             AZ::Entity* containerEntity = addedInstance.m_containerEntity.get();
             containerEntity->AddComponent(aznew Prefab::EditorPrefabComponent());
             HandleEntitiesAdded({containerEntity});
@@ -344,8 +344,7 @@ namespace AzToolsFramework
 
         if (instantiatedPrefabInstance)
         {
-            Prefab::Instance& instanceToParentUnder = instanceToParentUnderReference->get();
-            Prefab::Instance& addedInstance = instanceToParentUnder.AddInstance(
+            Prefab::Instance& addedInstance = instanceToParentUnderReference->get().AddInstance(
                 AZStd::move(instantiatedPrefabInstance));
             HandleEntitiesAdded({addedInstance.m_containerEntity.get()});
             return addedInstance;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -307,19 +307,19 @@ namespace AzToolsFramework
 
     Prefab::InstanceOptionalReference PrefabEditorEntityOwnershipService::CreatePrefab(
         const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Prefab::Instance>>&& nestedPrefabInstances,
-        AZ::IO::PathView filePath, Prefab::InstanceOptionalReference instanceToParentUnderReference)
+        AZ::IO::PathView filePath, Prefab::InstanceOptionalReference instanceToParentUnder)
     {
-        if (!instanceToParentUnderReference)
+        if (!instanceToParentUnder)
         {
-            instanceToParentUnderReference = *m_rootInstance;
+            instanceToParentUnder = *m_rootInstance;
         }
 
         AZStd::unique_ptr<Prefab::Instance> createdPrefabInstance = m_prefabSystemComponent->CreatePrefab(
-            entities, AZStd::move(nestedPrefabInstances), filePath, nullptr, instanceToParentUnderReference, false);
+            entities, AZStd::move(nestedPrefabInstances), filePath, nullptr, instanceToParentUnder, false);
 
         if (createdPrefabInstance)
         {
-            Prefab::Instance& addedInstance = instanceToParentUnderReference->get().AddInstance(
+            Prefab::Instance& addedInstance = instanceToParentUnder->get().AddInstance(
                 AZStd::move(createdPrefabInstance));
             AZ::Entity* containerEntity = addedInstance.m_containerEntity.get();
             containerEntity->AddComponent(aznew Prefab::EditorPrefabComponent());
@@ -332,19 +332,19 @@ namespace AzToolsFramework
     }
 
     Prefab::InstanceOptionalReference PrefabEditorEntityOwnershipService::InstantiatePrefab(
-        AZ::IO::PathView filePath, Prefab::InstanceOptionalReference instanceToParentUnderReference)
+        AZ::IO::PathView filePath, Prefab::InstanceOptionalReference instanceToParentUnder)
     {
-        if (!instanceToParentUnderReference)
+        if (!instanceToParentUnder)
         {
-            instanceToParentUnderReference = *m_rootInstance;
+            instanceToParentUnder = *m_rootInstance;
         }
 
         AZStd::unique_ptr<Prefab::Instance> instantiatedPrefabInstance =
-            m_prefabSystemComponent->InstantiatePrefab(filePath, instanceToParentUnderReference);
+            m_prefabSystemComponent->InstantiatePrefab(filePath, instanceToParentUnder);
 
         if (instantiatedPrefabInstance)
         {
-            Prefab::Instance& addedInstance = instanceToParentUnderReference->get().AddInstance(
+            Prefab::Instance& addedInstance = instanceToParentUnder->get().AddInstance(
                 AZStd::move(instantiatedPrefabInstance));
             HandleEntitiesAdded({addedInstance.m_containerEntity.get()});
             return addedInstance;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -31,6 +31,7 @@ namespace AzToolsFramework
         Instance::Instance(AZStd::unique_ptr<AZ::Entity> containerEntity)
             : m_parent(nullptr)
             , m_alias(GenerateInstanceAlias())
+            , m_containerEntity(containerEntity ? AZStd::move(containerEntity) : AZStd::make_unique<AZ::Entity>())
             , m_instanceEntityMapper(AZ::Interface<InstanceEntityMapperInterface>::Get())
             , m_templateInstanceMapper(AZ::Interface<TemplateInstanceMapperInterface>::Get())
         {
@@ -44,9 +45,6 @@ namespace AzToolsFramework
                 "It is a requirement for the Prefab Instance class. "
                 "Check that it is being correctly initialized.");
 
-            m_containerEntity = containerEntity ? AZStd::move(containerEntity)
-                                                : AZStd::make_unique<AZ::Entity>();
-
             RegisterEntity(m_containerEntity->GetId(), PrefabDomUtils::ContainerEntityName);
         }
 
@@ -56,7 +54,7 @@ namespace AzToolsFramework
         }
 
         Instance::Instance(InstanceOptionalReference parent)
-            : Instance(parent.has_value()? &parent->get() : nullptr, GenerateInstanceAlias())
+            : Instance(parent.has_value() ? &parent->get() : nullptr, GenerateInstanceAlias())
         {
         }
 
@@ -113,12 +111,12 @@ namespace AzToolsFramework
             }
         }
 
-        const TemplateId& Instance::GetTemplateId() const
+        TemplateId Instance::GetTemplateId() const
         {
             return m_templateId;
         }
 
-        void Instance::SetTemplateId(const TemplateId& templateId)
+        void Instance::SetTemplateId(TemplateId templateId)
         {
             // If we aren't changing the template Id, there's no need to unregister / re-register
             if (templateId == m_templateId)
@@ -353,7 +351,7 @@ namespace AzToolsFramework
 
             instance->m_parent = this;
             auto& alias = instance->GetInstanceAlias();
-            return *(m_nestedInstances[alias] = std::move(instance));
+            return *(m_nestedInstances[alias] = AZStd::move(instance));
         }
 
         void Instance::DetachNestedInstances(const AZStd::function<void(AZStd::unique_ptr<Instance>)>& callback)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -78,49 +78,6 @@ namespace AzToolsFramework
             RegisterEntity(m_containerEntity->GetId(), PrefabDomUtils::ContainerEntityName);
         }
 
-        /*Instance::Instance(InstanceAlias alias)
-            : Instance(nullptr, AZStd::move(alias))
-        {
-        }
-
-        Instance::Instance(InstanceOptionalReference parent)
-            : Instance(parent.has_value() ? &parent->get() : nullptr, GenerateInstanceAlias())
-        {
-        }
-
-        Instance::Instance(Instance* parent, InstanceAlias alias)
-            : m_parent(parent)
-            , m_alias(alias)
-            , m_instanceEntityMapper(AZ::Interface<InstanceEntityMapperInterface>::Get())
-            , m_templateInstanceMapper(AZ::Interface<TemplateInstanceMapperInterface>::Get())
-        {
-            AZ_Assert(m_instanceEntityMapper,
-                "Instance Entity Mapper Interface could not be found. "
-                "It is a requirement for the Prefab Instance class. "
-                "Check that it is being correctly initialized.");
-
-            AZ_Assert(m_templateInstanceMapper,
-                "Template Instance Mapper Interface could not be found. "
-                "It is a requirement for the Prefab Instance class. "
-                "Check that it is being correctly initialized.");
-
-            if (parent)
-            {
-                AliasPath absoluteInstancePath = m_parent->GetAbsoluteInstanceAliasPath();
-                absoluteInstancePath.Append(m_alias);
-                absoluteInstancePath.Append(PrefabDomUtils::ContainerEntityName);
-
-                AZ::EntityId newContainerEntityId = InstanceEntityIdMapper::GenerateEntityIdForAliasPath(absoluteInstancePath);
-                m_containerEntity = AZStd::make_unique<AZ::Entity>(newContainerEntityId);
-            }
-            else
-            {
-                m_containerEntity = AZStd::make_unique<AZ::Entity>();
-            }
-            
-            RegisterEntity(m_containerEntity->GetId(), PrefabDomUtils::ContainerEntityName);
-        }*/
-
         Instance::~Instance()
         {
             Reset();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -44,20 +44,9 @@ namespace AzToolsFramework
                 "It is a requirement for the Prefab Instance class. "
                 "Check that it is being correctly initialized.");
 
-            if (containerEntity)
-            {
-                m_containerEntity = AZStd::move(containerEntity);
-            }
-            else
-            {
-                AliasPath absoluteInstancePath;
-                absoluteInstancePath.Append(m_alias);
-                absoluteInstancePath.Append(PrefabDomUtils::ContainerEntityName);
+            m_containerEntity = containerEntity ? AZStd::move(containerEntity)
+                                                : AZStd::make_unique<AZ::Entity>();
 
-                AZ::EntityId containerEntityId = InstanceEntityIdMapper::GenerateEntityIdForAliasPath(absoluteInstancePath);
-                m_containerEntity = AZStd::make_unique<AZ::Entity>(containerEntityId);
-            }
-            
             RegisterEntity(m_containerEntity->GetId(), PrefabDomUtils::ContainerEntityName);
         }
 
@@ -87,13 +76,20 @@ namespace AzToolsFramework
                 "It is a requirement for the Prefab Instance class. "
                 "Check that it is being correctly initialized.");
 
-            AliasPath absoluteInstancePath = m_parent? m_parent->GetAbsoluteInstanceAliasPath() : AliasPath();
-            absoluteInstancePath.Append(m_alias);
-            absoluteInstancePath.Append(PrefabDomUtils::ContainerEntityName);
+            if (parent)
+            {
+                AliasPath absoluteInstancePath = m_parent->GetAbsoluteInstanceAliasPath();
+                absoluteInstancePath.Append(m_alias);
+                absoluteInstancePath.Append(PrefabDomUtils::ContainerEntityName);
 
-            AZ::EntityId newContainerEntityId = InstanceEntityIdMapper::GenerateEntityIdForAliasPath(absoluteInstancePath);
-            m_containerEntity = AZStd::make_unique<AZ::Entity>(newContainerEntityId);
-
+                AZ::EntityId newContainerEntityId = InstanceEntityIdMapper::GenerateEntityIdForAliasPath(absoluteInstancePath);
+                m_containerEntity = AZStd::make_unique<AZ::Entity>(newContainerEntityId);
+            }
+            else
+            {
+                m_containerEntity = AZStd::make_unique<AZ::Entity>();
+            }
+            
             RegisterEntity(m_containerEntity->GetId(), PrefabDomUtils::ContainerEntityName);
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
@@ -66,6 +66,7 @@ namespace AzToolsFramework
             Instance();
             explicit Instance(AZStd::unique_ptr<AZ::Entity> containerEntity);
             explicit Instance(InstanceOptionalReference parent);
+            explicit Instance(AZStd::unique_ptr<AZ::Entity> containerEntity, InstanceOptionalReference parent);
             explicit Instance(InstanceAlias alias);
             virtual ~Instance();
 
@@ -185,7 +186,7 @@ namespace AzToolsFramework
         private:
             static constexpr const char s_aliasPathSeparator = '/';
 
-            Instance(Instance* parent, InstanceAlias alias);
+            Instance(AZStd::unique_ptr<AZ::Entity> containerEntity, InstanceOptionalReference parent, InstanceAlias alias);
 
             void ClearEntities();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
@@ -65,6 +65,8 @@ namespace AzToolsFramework
 
             Instance();
             explicit Instance(AZStd::unique_ptr<AZ::Entity> containerEntity);
+            explicit Instance(InstanceOptionalReference parent);
+            explicit Instance(InstanceAlias alias);
             virtual ~Instance();
 
             Instance(const Instance& rhs) = delete;
@@ -97,7 +99,6 @@ namespace AzToolsFramework
             void Reset();
 
             Instance& AddInstance(AZStd::unique_ptr<Instance> instance);
-            Instance& AddInstance(AZStd::unique_ptr<Instance> instance, InstanceAlias instanceAlias);
             AZStd::unique_ptr<Instance> DetachNestedInstance(const InstanceAlias& instanceAlias);
             void DetachNestedInstances(const AZStd::function<void(AZStd::unique_ptr<Instance>)>& callback);
 
@@ -183,6 +184,8 @@ namespace AzToolsFramework
 
         private:
             static constexpr const char s_aliasPathSeparator = '/';
+
+            explicit Instance(Instance* parent, InstanceAlias alias);
 
             void ClearEntities();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.h
@@ -74,8 +74,8 @@ namespace AzToolsFramework
 
             static void Reflect(AZ::ReflectContext* context);
 
-            const TemplateId& GetTemplateId() const;
-            void SetTemplateId(const TemplateId& templateId);
+            TemplateId GetTemplateId() const;
+            void SetTemplateId(TemplateId templateId);
 
             const AZ::IO::Path& GetTemplateSourcePath() const;
             void SetTemplateSourcePath(AZ::IO::PathView sourcePath);
@@ -185,7 +185,7 @@ namespace AzToolsFramework
         private:
             static constexpr const char s_aliasPathSeparator = '/';
 
-            explicit Instance(Instance* parent, InstanceAlias alias);
+            Instance(Instance* parent, InstanceAlias alias);
 
             void ClearEntities();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/TemplateInstanceMapper.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/TemplateInstanceMapper.cpp
@@ -27,7 +27,7 @@ namespace AzToolsFramework
         }
 
 
-        bool TemplateInstanceMapper::RegisterTemplate(const TemplateId& templateId)
+        bool TemplateInstanceMapper::RegisterTemplate(TemplateId templateId)
         {
             const bool result = m_templateIdToInstancesMap.emplace(templateId, InstanceSet()).second;
             AZ_Assert(result,
@@ -39,7 +39,7 @@ namespace AzToolsFramework
             return result;
         }
 
-        bool TemplateInstanceMapper::UnregisterTemplate(const TemplateId& templateId)
+        bool TemplateInstanceMapper::UnregisterTemplate(TemplateId templateId)
         {
             const bool result = m_templateIdToInstancesMap.erase(templateId) != 0;
             AZ_Assert(result,
@@ -53,7 +53,7 @@ namespace AzToolsFramework
 
         bool TemplateInstanceMapper::RegisterInstanceToTemplate(Instance& instance)
         {
-            const TemplateId& templateId = instance.GetTemplateId();
+            TemplateId templateId = instance.GetTemplateId();
             if (templateId == InvalidTemplateId)
             {
                 return false; 
@@ -79,7 +79,7 @@ namespace AzToolsFramework
                 found->second.erase(&instance) != 0;
         }
 
-        InstanceSetConstReference TemplateInstanceMapper::FindInstancesOwnedByTemplate(const TemplateId& templateId) const
+        InstanceSetConstReference TemplateInstanceMapper::FindInstancesOwnedByTemplate(TemplateId templateId) const
         {
             auto found = m_templateIdToInstancesMap.find(templateId);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/TemplateInstanceMapper.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/TemplateInstanceMapper.h
@@ -26,10 +26,10 @@ namespace AzToolsFramework
             TemplateInstanceMapper();
             ~TemplateInstanceMapper() override;
 
-            InstanceSetConstReference FindInstancesOwnedByTemplate(const TemplateId& templateId) const override;
+            InstanceSetConstReference FindInstancesOwnedByTemplate(TemplateId templateId) const override;
 
-            bool RegisterTemplate(const TemplateId& templateId);
-            bool UnregisterTemplate(const TemplateId& templateId);
+            bool RegisterTemplate(TemplateId templateId);
+            bool UnregisterTemplate(TemplateId templateId);
 
         protected:
             bool RegisterInstanceToTemplate(Instance& instance) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/TemplateInstanceMapperInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/TemplateInstanceMapperInterface.h
@@ -24,7 +24,7 @@ namespace AzToolsFramework
             AZ_RTTI(TemplateInstanceMapperInterface, "{5DCCCDAA-3441-4266-9670-B349386E0129}");
 
             virtual ~TemplateInstanceMapperInterface() = default;
-            virtual InstanceSetConstReference FindInstancesOwnedByTemplate(const TemplateId& templateId) const = 0;
+            virtual InstanceSetConstReference FindInstancesOwnedByTemplate(TemplateId templateId) const = 0;
 
         protected:
             // Only the Instance class is allowed to register and unregister Instances.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -122,12 +122,12 @@ namespace AzToolsFramework
                 !m_instanceName.empty();
         }
 
-        const TemplateId& Link::GetSourceTemplateId() const
+        TemplateId Link::GetSourceTemplateId() const
         {
             return m_sourceTemplateId;
         }
 
-        const TemplateId& Link::GetTargetTemplateId() const
+        TemplateId Link::GetTargetTemplateId() const
         {
             return m_targetTemplateId;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
@@ -48,8 +48,8 @@ namespace AzToolsFramework
 
             bool IsValid() const;
 
-            const TemplateId& GetSourceTemplateId() const;
-            const TemplateId& GetTargetTemplateId() const;
+            TemplateId GetSourceTemplateId() const;
+            TemplateId GetTargetTemplateId() const;
 
             LinkId GetId() const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -95,10 +95,7 @@ namespace AzToolsFramework
             AZ::IO::PathView filePath, AZStd::unique_ptr<AZ::Entity> containerEntity, InstanceOptionalReference parent,
             bool shouldCreateLinks)
         {
-
-            AZStd::unique_ptr<Instance> newInstance = parent.has_value() ? AZStd::make_unique<Instance>(parent)
-                                                                         : AZStd::make_unique<Instance>(AZStd::move(containerEntity));
-
+            AZStd::unique_ptr<Instance> newInstance = AZStd::make_unique<Instance>(AZStd::move(containerEntity), parent);
             CreatePrefab(entities, AZStd::move(instancesToConsume), filePath, newInstance, shouldCreateLinks);
             return newInstance;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -96,16 +96,8 @@ namespace AzToolsFramework
             bool shouldCreateLinks)
         {
 
-            AZStd::unique_ptr<Instance> newInstance;
-
-            if (parent.has_value())
-            {
-                newInstance = AZStd::make_unique<Instance>(parent);
-            }
-            else
-            {
-                newInstance = AZStd::make_unique<Instance>(AZStd::move(containerEntity));
-            }
+            AZStd::unique_ptr<Instance> newInstance = parent.has_value() ? AZStd::make_unique<Instance>(parent)
+                                                                         : AZStd::make_unique<Instance>(AZStd::move(containerEntity));
 
             CreatePrefab(entities, AZStd::move(instancesToConsume), filePath, newInstance, shouldCreateLinks);
             return newInstance;
@@ -188,7 +180,7 @@ namespace AzToolsFramework
             }
         }
 
-        void PrefabSystemComponent::UpdatePrefabInstances(const TemplateId& templateId, InstanceOptionalReference instanceToExclude)
+        void PrefabSystemComponent::UpdatePrefabInstances(TemplateId templateId, InstanceOptionalReference instanceToExclude)
         {
             m_instanceUpdateExecutor.AddTemplateInstancesToQueue(templateId, instanceToExclude);
         }
@@ -298,7 +290,7 @@ namespace AzToolsFramework
         }
 
         AZStd::unique_ptr<Instance> PrefabSystemComponent::InstantiatePrefab(
-            const TemplateId& templateId, InstanceOptionalReference parent)
+            TemplateId templateId, InstanceOptionalReference parent)
         {
             TemplateReference instantiatingTemplate = FindTemplate(templateId);
 
@@ -373,7 +365,7 @@ namespace AzToolsFramework
             return newTemplateId;
         }
 
-        TemplateReference PrefabSystemComponent::FindTemplate(const TemplateId& id)
+        TemplateReference PrefabSystemComponent::FindTemplate(TemplateId id)
         {
             auto found = m_templateIdMap.find(id);
             if (found != m_templateIdMap.end())
@@ -485,7 +477,7 @@ namespace AzToolsFramework
             templateToChange.SetFilePath(filePath);
         }
 
-        void PrefabSystemComponent::RemoveTemplate(const TemplateId& templateId)
+        void PrefabSystemComponent::RemoveTemplate(TemplateId templateId)
         {
             auto findTemplateResult = FindTemplate(templateId);
             if (!findTemplateResult.has_value())
@@ -572,8 +564,8 @@ namespace AzToolsFramework
         }
 
         LinkId PrefabSystemComponent::AddLink(
-            const TemplateId& sourceTemplateId,
-            const TemplateId& targetTemplateId,
+            TemplateId sourceTemplateId,
+            TemplateId targetTemplateId,
             PrefabDomValue::MemberIterator& instanceIterator,
             InstanceOptionalReference instance)
         {
@@ -635,8 +627,8 @@ namespace AzToolsFramework
         }
 
         LinkId PrefabSystemComponent::CreateLink(
-            const TemplateId& linkTargetId,
-            const TemplateId& linkSourceId,
+            TemplateId linkTargetId,
+            TemplateId linkSourceId,
             const InstanceAlias& instanceAlias,
             const PrefabDomConstReference linkPatches,
             const LinkId& linkId)
@@ -793,7 +785,7 @@ namespace AzToolsFramework
             }
         }
 
-        bool PrefabSystemComponent::IsTemplateDirty(const TemplateId& templateId)
+        bool PrefabSystemComponent::IsTemplateDirty(TemplateId templateId)
         {
             auto templateRef = FindTemplate(templateId);
 
@@ -805,7 +797,7 @@ namespace AzToolsFramework
             return false;
         }
 
-        void PrefabSystemComponent::SetTemplateDirtyFlag(const TemplateId& templateId, bool dirty)
+        void PrefabSystemComponent::SetTemplateDirtyFlag(TemplateId templateId, bool dirty)
         {
             auto templateRef = FindTemplate(templateId);
 
@@ -952,7 +944,7 @@ namespace AzToolsFramework
             return true;
         }
 
-        bool PrefabSystemComponent::GenerateLinksForNewTemplate(const TemplateId& newTemplateId, Instance& instance)
+        bool PrefabSystemComponent::GenerateLinksForNewTemplate(TemplateId newTemplateId, Instance& instance)
         {
             TemplateReference newTemplateReference = FindTemplate(newTemplateId);
             if (!newTemplateReference.has_value())
@@ -992,7 +984,7 @@ namespace AzToolsFramework
                 }
 
                 const PrefabDomValue& source = instanceSourceReference->get();
-                const TemplateId& nestedTemplateId = GetTemplateIdFromFilePath(source.GetString());
+                TemplateId nestedTemplateId = GetTemplateIdFromFilePath(source.GetString());
                 if (nestedTemplateId == InvalidTemplateId)
                 {
                     AZ_Error("Prefab", false,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -84,7 +84,7 @@ namespace AzToolsFramework
              * @param id A unique id of a Template.
              * @return Reference of Template if the Template exists.
              */
-            TemplateReference FindTemplate(const TemplateId& id) override;
+            TemplateReference FindTemplate(TemplateId id) override;
 
             /**
              * Find Link with given Link id from Prefab System Component.
@@ -112,7 +112,7 @@ namespace AzToolsFramework
             * Remove the Template associated with the given id from Prefab System Component.
             * @param templateId A unique id of a Template.
             */
-            void RemoveTemplate(const TemplateId& templateId) override;
+            void RemoveTemplate(TemplateId templateId) override;
 
             /**
              * Remove all Templates from the Prefab System Component.
@@ -135,7 +135,7 @@ namespace AzToolsFramework
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
             AZStd::unique_ptr<Instance> InstantiatePrefab(
-                const TemplateId& templateId, InstanceOptionalReference parent = AZStd::nullopt) override;
+                TemplateId templateId, InstanceOptionalReference parent = AZStd::nullopt) override;
 
             /**
             * Add a new Link into Prefab System Component and create a unique id for it.
@@ -146,8 +146,8 @@ namespace AzToolsFramework
             * @return A unique id for the new Link.
             */
             LinkId AddLink(
-                const TemplateId& sourceTemplateId,
-                const TemplateId& targetTemplateId,
+                TemplateId sourceTemplateId,
+                TemplateId targetTemplateId,
                 PrefabDomValue::MemberIterator& instanceIterator,
                 InstanceOptionalReference instance) override;
 
@@ -161,8 +161,8 @@ namespace AzToolsFramework
             * @return A unique id for the new Link.
             */
             LinkId CreateLink(
-                const TemplateId& linkTargetId,
-                const TemplateId& linkSourceId,
+                TemplateId linkTargetId,
+                TemplateId linkSourceId,
                 const InstanceAlias& instanceAlias,
                 const PrefabDomConstReference linkPatches,
                 const LinkId& linkId = InvalidLinkId) override;
@@ -185,14 +185,14 @@ namespace AzToolsFramework
              * @param templateId The id of the template to query.
              * @return The value of the dirty flag on the template.
              */
-            bool IsTemplateDirty(const TemplateId& templateId) override;
+            bool IsTemplateDirty(TemplateId templateId) override;
 
             /**
              * Sets the dirty flag of the template to the value provided.
              * @param templateId The id of the template to flag.
              * @param dirty The new value of the dirty flag.
              */
-            void SetTemplateDirtyFlag(const TemplateId& templateId, bool dirty) override;
+            void SetTemplateDirtyFlag(TemplateId templateId, bool dirty) override;
 
             bool AreDirtyTemplatesPresent(TemplateId rootTemplateId) override;
 
@@ -237,7 +237,7 @@ namespace AzToolsFramework
              *
              * @param templateId The id of the Template owning Instances to update.
              */
-            void UpdatePrefabInstances(const TemplateId& templateId, InstanceOptionalReference instanceToExclude = AZStd::nullopt);
+            void UpdatePrefabInstances(TemplateId templateId, InstanceOptionalReference instanceToExclude = AZStd::nullopt);
 
         private:
             AZ_DISABLE_COPY_MOVE(PrefabSystemComponent);
@@ -330,7 +330,7 @@ namespace AzToolsFramework
             * @param instance The instance that the template was created from. This needs to be editable for inserting linkId into it.
             * @return bool on whether the operation succeeded
             */
-            bool GenerateLinksForNewTemplate(const TemplateId& newTemplateId, Instance& instance);
+            bool GenerateLinksForNewTemplate(TemplateId newTemplateId, Instance& instance);
 
             /**
              * Create a unique Template id for newly created Template.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -124,14 +124,16 @@ namespace AzToolsFramework
             * @param filePath the path to the prefab source file containing the template being instantiated.
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
-            AZStd::unique_ptr<Instance> InstantiatePrefab(AZ::IO::PathView filePath) override;
+            AZStd::unique_ptr<Instance> InstantiatePrefab(
+                AZ::IO::PathView filePath, InstanceOptionalReference parent = AZStd::nullopt) override;
 
             /**
             * Generates a new Prefab Instance based on the Template referenced by templateId
             * @param templateId the id of the template being instantiated.
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
-            AZStd::unique_ptr<Instance> InstantiatePrefab(const TemplateId& templateId) override;
+            AZStd::unique_ptr<Instance> InstantiatePrefab(
+                const TemplateId& templateId, InstanceOptionalReference parent = AZStd::nullopt) override;
 
             /**
             * Add a new Link into Prefab System Component and create a unique id for it.
@@ -212,8 +214,11 @@ namespace AzToolsFramework
             */
             AZStd::unique_ptr<Instance> CreatePrefab(
                 const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume,
-                AZ::IO::PathView filePath, AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr,
-                bool ShouldCreateLinks = true) override;
+                AZ::IO::PathView filePath, AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr) override;
+
+            AZStd::unique_ptr<Instance> CreatePrefabUnderParent(
+                const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume,
+                AZ::IO::PathView filePath, InstanceOptionalReference parent) override;
 
             PrefabDom& FindTemplateDom(TemplateId templateId) override;
 
@@ -236,6 +241,10 @@ namespace AzToolsFramework
 
         private:
             AZ_DISABLE_COPY_MOVE(PrefabSystemComponent);
+
+            AZStd::unique_ptr<Instance> CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
+                AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
+                AZStd::unique_ptr<Instance> instance, bool shouldCreateLinks);
 
             /**
              * Updates all the linked Instances corresponding to the linkIds in the provided queue.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -122,7 +122,7 @@ namespace AzToolsFramework
             /**
             * Generates a new Prefab Instance based on the Template whose source is stored in filepath.
             * @param filePath The path to the prefab source file containing the template being instantiated.
-            * @param parent Reference the the target instance the instantiated instance will be placed under.
+            * @param parent Reference of the target instance the instantiated instance will be placed under.
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
             AZStd::unique_ptr<Instance> InstantiatePrefab(
@@ -131,7 +131,7 @@ namespace AzToolsFramework
             /**
             * Generates a new Prefab Instance based on the Template referenced by templateId.
             * @param templateId The id of the template being instantiated.
-            * @param parent Reference the the target instance the instantiated instance will be placed under.
+            * @param parent Reference of the target instance the instantiated instance will be placed under.
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
             AZStd::unique_ptr<Instance> InstantiatePrefab(
@@ -210,25 +210,15 @@ namespace AzToolsFramework
             *                  May be empty.
             * @param filePath The path to associate the template of the new instance to.
             * @param containerEntity The container entity for the prefab to be created. It will be created if a nullptr is provided.
+            * @param parent Reference of an instance the created instance will be placed under, if given.
+            * @param shouldCreateLinks The flag indicating if links should be created between the templates of the instance
+            *        and its nested instances.
             * @return A pointer to the newly created instance. nullptr on failure.
             */
             AZStd::unique_ptr<Instance> CreatePrefab(
                 const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume,
-                AZ::IO::PathView filePath, AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr) override;
-
-            /**
-            * Builds a new Prefab Template out of entities and instances and returns the first instance under a parent instance comprised of
-            * these entities and instances.
-            * @param entities A vector of entities that will be used in the new instance. May be empty.
-            * @param instances A vector of Prefab Instances that will be nested in the new instance, will be consumed and moved.
-            *                  May be empty.
-            * @param filePath the path to associate the template of the new instance to.
-            * @param parent A reference of an instance the created instance will be placed under.
-            * @return A pointer to the newly created instance. nullptr on failure.
-            */
-            AZStd::unique_ptr<Instance> CreatePrefabUnderParent(
-                const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume,
-                AZ::IO::PathView filePath, InstanceOptionalReference parent) override;
+                AZ::IO::PathView filePath, AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr,
+                InstanceOptionalReference parent = AZStd::nullopt, bool shouldCreateLinks = true) override;
 
             PrefabDom& FindTemplateDom(TemplateId templateId) override;
 
@@ -259,14 +249,13 @@ namespace AzToolsFramework
             * @param instances A vector of Prefab Instances that will be nested in the new instance, will be consumed and moved.
             *                  May be empty.
             * @param filePath The path to associate the template of the new instance to.
-            * @param instance A pointer to the newly created instance which needs initiation.
+            * @param instance Reference of a pointer to the newly created instance which needs initiation.
             * @param shouldCreateLinks The flag indicating if links should be created between the templates of the instance
             *        and its nested instances.
-            * @return A pointer to the newly created instance. nullptr on failure.
             */
-            AZStd::unique_ptr<Instance> CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
+            void CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
                 AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
-                AZStd::unique_ptr<Instance> instance, bool shouldCreateLinks);
+                AZStd::unique_ptr<Instance>& instance, bool shouldCreateLinks);
 
             /**
              * Updates all the linked Instances corresponding to the linkIds in the provided queue.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.h
@@ -121,15 +121,17 @@ namespace AzToolsFramework
 
             /**
             * Generates a new Prefab Instance based on the Template whose source is stored in filepath.
-            * @param filePath the path to the prefab source file containing the template being instantiated.
+            * @param filePath The path to the prefab source file containing the template being instantiated.
+            * @param parent Reference the the target instance the instantiated instance will be placed under.
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
             AZStd::unique_ptr<Instance> InstantiatePrefab(
                 AZ::IO::PathView filePath, InstanceOptionalReference parent = AZStd::nullopt) override;
 
             /**
-            * Generates a new Prefab Instance based on the Template referenced by templateId
-            * @param templateId the id of the template being instantiated.
+            * Generates a new Prefab Instance based on the Template referenced by templateId.
+            * @param templateId The id of the template being instantiated.
+            * @param parent Reference the the target instance the instantiated instance will be placed under.
             * @return A unique_ptr to the newly instantiated instance. Null if operation failed.
             */
             AZStd::unique_ptr<Instance> InstantiatePrefab(
@@ -202,20 +204,28 @@ namespace AzToolsFramework
 
             /**
             * Builds a new Prefab Template out of entities and instances and returns the first instance comprised of
-            * these entities and instances
-            * @param entities A vector of entities that will be used in the new instance. May be empty
+            * these entities and instances.
+            * @param entities A vector of entities that will be used in the new instance. May be empty.
             * @param instances A vector of Prefab Instances that will be nested in the new instance, will be consumed and moved.
-            *                  May be empty
-            * @param filePath the path to associate the template of the new instance to.
+            *                  May be empty.
+            * @param filePath The path to associate the template of the new instance to.
             * @param containerEntity The container entity for the prefab to be created. It will be created if a nullptr is provided.
-            * @param shouldCreateLinks The flag indicating if links should be created between the templates of the instance
-            *        and its nested instances.
-            * @return A pointer to the newly created instance. nullptr on failure
+            * @return A pointer to the newly created instance. nullptr on failure.
             */
             AZStd::unique_ptr<Instance> CreatePrefab(
                 const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume,
                 AZ::IO::PathView filePath, AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr) override;
 
+            /**
+            * Builds a new Prefab Template out of entities and instances and returns the first instance under a parent instance comprised of
+            * these entities and instances.
+            * @param entities A vector of entities that will be used in the new instance. May be empty.
+            * @param instances A vector of Prefab Instances that will be nested in the new instance, will be consumed and moved.
+            *                  May be empty.
+            * @param filePath the path to associate the template of the new instance to.
+            * @param parent A reference of an instance the created instance will be placed under.
+            * @return A pointer to the newly created instance. nullptr on failure.
+            */
             AZStd::unique_ptr<Instance> CreatePrefabUnderParent(
                 const AZStd::vector<AZ::Entity*>& entities, AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume,
                 AZ::IO::PathView filePath, InstanceOptionalReference parent) override;
@@ -242,6 +252,18 @@ namespace AzToolsFramework
         private:
             AZ_DISABLE_COPY_MOVE(PrefabSystemComponent);
 
+            /**
+            * Builds a new Prefab Template out of entities and instances and returns the first instance comprised of
+            * these entities and instances.
+            * @param entities A vector of entities that will be used in the new instance. May be empty.
+            * @param instances A vector of Prefab Instances that will be nested in the new instance, will be consumed and moved.
+            *                  May be empty.
+            * @param filePath The path to associate the template of the new instance to.
+            * @param instance A pointer to the newly created instance which needs initiation.
+            * @param shouldCreateLinks The flag indicating if links should be created between the templates of the instance
+            *        and its nested instances.
+            * @return A pointer to the newly created instance. nullptr on failure.
+            */
             AZStd::unique_ptr<Instance> CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
                 AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
                 AZStd::unique_ptr<Instance> instance, bool shouldCreateLinks);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
@@ -69,11 +69,16 @@ namespace AzToolsFramework
             virtual void UpdatePrefabTemplate(TemplateId templateId, const PrefabDom& updatedDom) = 0;
             virtual void PropagateTemplateChanges(TemplateId templateId, InstanceOptionalReference instanceToExclude = AZStd::nullopt) = 0;
 
-            virtual AZStd::unique_ptr<Instance> InstantiatePrefab(AZ::IO::PathView filePath) = 0;
-            virtual AZStd::unique_ptr<Instance> InstantiatePrefab(const TemplateId& templateId) = 0;
+            virtual AZStd::unique_ptr<Instance> InstantiatePrefab(
+                AZ::IO::PathView filePath, InstanceOptionalReference parent = AZStd::nullopt) = 0;
+            virtual AZStd::unique_ptr<Instance> InstantiatePrefab(
+                const TemplateId& templateId, InstanceOptionalReference parent = AZStd::nullopt) = 0;
             virtual AZStd::unique_ptr<Instance> CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
                 AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
-                AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr, bool ShouldCreateLinks = true) = 0;
+                AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr) = 0;
+            virtual AZStd::unique_ptr<Instance> CreatePrefabUnderParent(const AZStd::vector<AZ::Entity*>& entities,
+                AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
+                InstanceOptionalReference parent) = 0;
         };
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
@@ -75,10 +75,8 @@ namespace AzToolsFramework
                 const TemplateId& templateId, InstanceOptionalReference parent = AZStd::nullopt) = 0;
             virtual AZStd::unique_ptr<Instance> CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
                 AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
-                AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr) = 0;
-            virtual AZStd::unique_ptr<Instance> CreatePrefabUnderParent(const AZStd::vector<AZ::Entity*>& entities,
-                AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
-                InstanceOptionalReference parent) = 0;
+                AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr, InstanceOptionalReference parent = AZStd::nullopt,
+                bool shouldCreateLinks = true) = 0;
         };
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponentInterface.h
@@ -29,28 +29,28 @@ namespace AzToolsFramework
         public:
             AZ_RTTI(PrefabSystemComponentInterface, "{8E95A029-67F9-4F74-895F-DDBFE29516A0}");
 
-            virtual TemplateReference FindTemplate(const TemplateId& id) = 0;
+            virtual TemplateReference FindTemplate(TemplateId id) = 0;
             virtual LinkReference FindLink(const LinkId& id) = 0;
 
             virtual TemplateId AddTemplate(const AZ::IO::Path& filePath, PrefabDom prefabDom) = 0;
             virtual void UpdateTemplateFilePath(TemplateId templateId, const AZ::IO::PathView& filePath) = 0;
-            virtual void RemoveTemplate(const TemplateId& templateId) = 0;
+            virtual void RemoveTemplate(TemplateId templateId) = 0;
             virtual void RemoveAllTemplates() = 0;
 
-            virtual LinkId AddLink(const TemplateId& sourceTemplateId, const TemplateId& targetTemplateId,
+            virtual LinkId AddLink(TemplateId sourceTemplateId, TemplateId targetTemplateId,
                 PrefabDomValue::MemberIterator& instanceIterator, InstanceOptionalReference instance) = 0;
 
             //creates a new Link
             virtual LinkId CreateLink(
-                const TemplateId& linkTargetId, const TemplateId& linkSourceId, const InstanceAlias& instanceAlias,
+                TemplateId linkTargetId, TemplateId linkSourceId, const InstanceAlias& instanceAlias,
                 const PrefabDomConstReference linkPatches, const LinkId& linkId = InvalidLinkId) = 0;
 
             virtual void RemoveLink(const LinkId& linkId) = 0;
 
             virtual TemplateId GetTemplateIdFromFilePath(AZ::IO::PathView filePath) const = 0;
 
-            virtual bool IsTemplateDirty(const TemplateId& templateId) = 0;
-            virtual void SetTemplateDirtyFlag(const TemplateId& templateId, bool dirty) = 0;
+            virtual bool IsTemplateDirty(TemplateId templateId) = 0;
+            virtual void SetTemplateDirtyFlag(TemplateId templateId, bool dirty) = 0;
 
             //! Recursive function to check if the template is dirty or if any dirty templates are presents in the links of the template.
             //! @param rootTemplateId The id of the template provided as the beginning template to check the outgoing links.
@@ -72,7 +72,7 @@ namespace AzToolsFramework
             virtual AZStd::unique_ptr<Instance> InstantiatePrefab(
                 AZ::IO::PathView filePath, InstanceOptionalReference parent = AZStd::nullopt) = 0;
             virtual AZStd::unique_ptr<Instance> InstantiatePrefab(
-                const TemplateId& templateId, InstanceOptionalReference parent = AZStd::nullopt) = 0;
+                TemplateId templateId, InstanceOptionalReference parent = AZStd::nullopt) = 0;
             virtual AZStd::unique_ptr<Instance> CreatePrefab(const AZStd::vector<AZ::Entity*>& entities,
                 AZStd::vector<AZStd::unique_ptr<Instance>>&& instancesToConsume, AZ::IO::PathView filePath,
                 AZStd::unique_ptr<AZ::Entity> containerEntity = nullptr, InstanceOptionalReference parent = AZStd::nullopt,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.cpp
@@ -33,7 +33,7 @@ namespace AzToolsFramework
         void PrefabUndoInstance::Capture(
             const PrefabDom& initialState,
             const PrefabDom& endState,
-            const TemplateId& templateId)
+            TemplateId templateId)
         {
             m_templateId = templateId;
 
@@ -136,8 +136,8 @@ namespace AzToolsFramework
         }
 
         void PrefabUndoInstanceLink::Capture(
-            const TemplateId& targetId,
-            const TemplateId& sourceId,
+            TemplateId targetId,
+            TemplateId sourceId,
             const InstanceAlias& instanceAlias,
             PrefabDom linkPatches,
             const LinkId linkId)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.h
@@ -49,7 +49,7 @@ namespace AzToolsFramework
             void Capture(
                 const PrefabDom& initialState,
                 const PrefabDom& endState,
-                const TemplateId& templateId);
+                TemplateId templateId);
 
             void Undo() override;
             void Redo() override;
@@ -95,8 +95,8 @@ namespace AzToolsFramework
 
             //capture for add/remove
             void Capture(
-                const TemplateId& targetId,
-                const TemplateId& sourceId,
+                TemplateId targetId,
+                TemplateId sourceId,
                 const InstanceAlias& instanceAlias,
                 PrefabDom linkPatches = PrefabDom(),
                 const LinkId linkId = InvalidLinkId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabCreateBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabCreateBenchmarks.cpp
@@ -165,7 +165,7 @@ namespace Benchmark
             {
                 nestedInstanceRoot = m_prefabSystemComponent->CreatePrefab(
                     {},
-                    MakeInstanceList( AZStd::move(nestedInstanceRoot) ),
+                    MakeInstanceList(AZStd::move(nestedInstanceRoot)),
                     m_paths[instanceCounter]);
             }
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabCreateBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabCreateBenchmarks.cpp
@@ -72,7 +72,7 @@ namespace Benchmark
             AZStd::unique_ptr<Instance> instance = m_prefabSystemComponent->CreatePrefab(
                 entities
                 , {}
-            , m_pathString);
+                , m_pathString);
 
             state.PauseTiming();
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
@@ -36,7 +36,7 @@ namespace Benchmark
 
             AZStd::unique_ptr<Instance> enclosingInstance = m_prefabSystemComponent->CreatePrefab(
                 {},
-                MakeInstanceList( AZStd::move(nestedInstance) ),
+                MakeInstanceList(AZStd::move(nestedInstance)),
                 enclosingTemplatePath);
 
             TemplateId templateToInstantiateId = enclosingInstance->GetTemplateId();
@@ -99,7 +99,7 @@ namespace Benchmark
             {
                 currentInstanceRoot = m_prefabSystemComponent->CreatePrefab(
                     {},
-                    MakeInstanceList( AZStd::move(currentInstanceRoot) ),
+                    MakeInstanceList(AZStd::move(currentInstanceRoot)),
                     m_paths[currentDepth - 1]);
             }
 
@@ -151,7 +151,7 @@ namespace Benchmark
             {
                 currentInstanceRoot = m_prefabSystemComponent->CreatePrefab(
                     {},
-                    MakeInstanceList( AZStd::move(currentInstanceRoot) ),
+                    MakeInstanceList(AZStd::move(currentInstanceRoot)),
                     m_paths[currentDepth]);
             }
 
@@ -214,7 +214,7 @@ namespace Benchmark
 
                 currentInstanceRoot = m_prefabSystemComponent->CreatePrefab(
                     {},
-                    MakeInstanceList( AZStd::move(currentInstanceRoot), AZStd::move(extraNestedInstance) ),
+                    MakeInstanceList(AZStd::move(currentInstanceRoot), AZStd::move(extraNestedInstance)),
                     m_paths[currentDepth]);
             }
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabFocus/PrefabFocusTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabFocus/PrefabFocusTests.cpp
@@ -49,7 +49,7 @@ namespace UnitTest
             m_instanceMap["sportsCar"] = sportsCarInstance.get();
 
             AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> streetInstance =
-                m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList( AZStd::move(carInstance), AZStd::move(sportsCarInstance) ), "test/street");
+                m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList(AZStd::move(carInstance), AZStd::move(sportsCarInstance)), "test/street");
             ASSERT_TRUE(streetInstance);
             m_instanceMap["street"] = streetInstance.get();
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceToTemplatePropagatorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstanceToTemplatePropagatorTests.cpp
@@ -320,7 +320,7 @@ namespace UnitTest
         Instance& addedInstance = *addedInstancePtr;
 
         //create a first instance where the instance will be removed
-        AZStd::unique_ptr<Instance> firstInstance = m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList( AZStd::move(addedInstancePtr) ), "test/path");
+        AZStd::unique_ptr<Instance> firstInstance = m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList(AZStd::move(addedInstancePtr)), "test/path");
         ASSERT_TRUE(firstInstance);
 
         //get added instance alias

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstantiateTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabInstantiateTests.cpp
@@ -44,11 +44,11 @@ namespace UnitTest
         ASSERT_TRUE(firstInstance);
 
         AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> secondInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(firstInstance) ), "test/path2");
+            MakeInstanceList(AZStd::move(firstInstance)), "test/path2");
         ASSERT_TRUE(secondInstance);
 
         AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> thirdInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(secondInstance) ), "test/path3");
+            MakeInstanceList(AZStd::move(secondInstance)), "test/path3");
         ASSERT_TRUE(thirdInstance);
 
         //Instantiate it

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.cpp
@@ -21,8 +21,8 @@ namespace UnitTest
         using namespace AzToolsFramework::Prefab;
         LinkData CreateLinkData(
             const InstanceData& instanceData,
-            const TemplateId& sourceTemplateId,
-            const TemplateId& targetTemplateId)
+            TemplateId sourceTemplateId,
+            TemplateId targetTemplateId)
         {
             LinkData newLinkData;
             newLinkData.m_instanceData = instanceData;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDataUtils.h
@@ -17,8 +17,8 @@ namespace UnitTest
     {
         LinkData CreateLinkData(
             const InstanceData& instanceData,
-            const AzToolsFramework::Prefab::TemplateId& sourceTemplateId,
-            const AzToolsFramework::Prefab::TemplateId& targetTemplateId);
+            AzToolsFramework::Prefab::TemplateId sourceTemplateId,
+            AzToolsFramework::Prefab::TemplateId targetTemplateId);
 
         InstanceData CreateInstanceDataWithNoPatches(
             const AZStd::string& name,

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDomUtils.cpp
@@ -56,7 +56,7 @@ namespace UnitTest
         }
 
         void ValidateInstances(
-            const TemplateId& templateId,
+            TemplateId templateId,
             const PrefabDomValue& expectedContent,
             const PrefabDomPath& contentPath,
             bool isContentAnInstance,
@@ -204,7 +204,7 @@ namespace UnitTest
         }
 
         void ValidateEntitiesOfInstances(
-            const AzToolsFramework::Prefab::TemplateId& templateId,
+            AzToolsFramework::Prefab::TemplateId templateId,
             const AzToolsFramework::Prefab::PrefabDom& expectedPrefabDom,
             const AZStd::vector<EntityAlias>& entityAliases)
         {
@@ -219,7 +219,7 @@ namespace UnitTest
         }
 
         void ValidateNestedInstancesOfInstances(
-            const AzToolsFramework::Prefab::TemplateId& templateId,
+            AzToolsFramework::Prefab::TemplateId templateId,
             const AzToolsFramework::Prefab::PrefabDom& expectedPrefabDom,
             const AZStd::vector<InstanceAlias>& nestedInstanceAliases)
         {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDomUtils.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestDomUtils.h
@@ -118,7 +118,7 @@ namespace UnitTest
             const PrefabDomValue& patches);
 
         void ValidateInstances(
-            const TemplateId& templateId,
+            TemplateId templateId,
             const PrefabDomValue& expectedContent,
             const PrefabDomPath& contentPath,
             bool isContentAnInstance = false,
@@ -147,12 +147,12 @@ namespace UnitTest
         void ComparePrefabDomValues(PrefabDomValueConstReference valueA, PrefabDomValueConstReference valueB);
 
         void ValidateEntitiesOfInstances(
-            const AzToolsFramework::Prefab::TemplateId& templateId,
+            AzToolsFramework::Prefab::TemplateId templateId,
             const AzToolsFramework::Prefab::PrefabDom& expectedPrefabDom,
             const AZStd::vector<EntityAlias>& entityAliases);
 
         void ValidateNestedInstancesOfInstances(
-            const AzToolsFramework::Prefab::TemplateId& templateId,
+            AzToolsFramework::Prefab::TemplateId templateId,
             const AzToolsFramework::Prefab::PrefabDom& expectedPrefabDom,
             const AZStd::vector<InstanceAlias>& nestedInstanceAliases);
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestUndoFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabTestUndoFixture.cpp
@@ -18,14 +18,14 @@ namespace UnitTest
     {
         //create two prefabs for test
         //create prefab 1
-        firstInstance = AZStd::move(m_prefabSystemComponent->CreatePrefab({ }, {}, "test/path0"));
+        firstInstance = AZStd::move(m_prefabSystemComponent->CreatePrefab({}, {}, "test/path0"));
         ASSERT_TRUE(firstInstance);
 
         //get template id
         ownerId = firstInstance->GetTemplateId();
 
         //create prefab 2
-        secondInstance = AZStd::move(m_prefabSystemComponent->CreatePrefab({ }, {}, "test/path1"));
+        secondInstance = AZStd::move(m_prefabSystemComponent->CreatePrefab({}, {}, "test/path1"));
         ASSERT_TRUE(secondInstance);
 
         //get template id

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateInstancesTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateInstancesTests.cpp
@@ -120,7 +120,7 @@ namespace UnitTest
 
         // Create an enclosing Template with 0 entities and 1 nested Instance.
         AZStd::unique_ptr<Instance> nestedInstance1 = m_prefabSystemComponent->InstantiatePrefab(newNestedTemplateId);
-        AZStd::unique_ptr<Instance> newEnclosingInstance = m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList( AZStd::move(nestedInstance1) ), PrefabMockFilePath);
+        AZStd::unique_ptr<Instance> newEnclosingInstance = m_prefabSystemComponent->CreatePrefab({}, MakeInstanceList(AZStd::move(nestedInstance1)), PrefabMockFilePath);
         TemplateId newEnclosingTemplateId = newEnclosingInstance->GetTemplateId();
         EXPECT_TRUE(newEnclosingTemplateId != InvalidTemplateId);
         PrefabDom& newEnclosingTemplateDom = m_prefabSystemComponent->FindTemplateDom(newEnclosingTemplateId);
@@ -284,7 +284,7 @@ namespace UnitTest
         AZStd::unique_ptr<Instance> nestedInstance2 = m_prefabSystemComponent->InstantiatePrefab(newNestedTemplateId);
         AZStd::unique_ptr<Instance> newEnclosingInstance = m_prefabSystemComponent->CreatePrefab(
             {},
-            MakeInstanceList( AZStd::move(nestedInstance1), AZStd::move(nestedInstance2) ),
+            MakeInstanceList(AZStd::move(nestedInstance1), AZStd::move(nestedInstance2)),
             PrefabMockFilePath);
         TemplateId newEnclosingTemplateId = newEnclosingInstance->GetTemplateId();
         EXPECT_TRUE(newEnclosingTemplateId != InvalidTemplateId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateTemplateTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateTemplateTests.cpp
@@ -51,7 +51,7 @@ namespace UnitTest
         AZStd::unique_ptr<Instance> axle2UnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> spareWheelUnderCar = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axle1UnderCar), AZStd::move(axle2UnderCar), AZStd::move(spareWheelUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axle1UnderCar), AZStd::move(axle2UnderCar), AZStd::move(spareWheelUnderCar) ), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -253,7 +253,7 @@ namespace UnitTest
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> wheel2UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle), AZStd::move(wheel2UnderAxle) ),
+            MakeInstanceList(AZStd::move(wheel1UnderAxle), AZStd::move(wheel2UnderAxle) ),
             AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
@@ -265,7 +265,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axle1UnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axle1UnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axle1UnderCar) ), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);
@@ -381,7 +381,7 @@ namespace UnitTest
         // Create an axle with 0 entities and 1 wheel instance.
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -389,7 +389,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axleUnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateTemplateTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateTemplateTests.cpp
@@ -41,7 +41,7 @@ namespace UnitTest
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> wheel2UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle), AZStd::move(wheel2UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle), AZStd::move(wheel2UnderAxle)), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
@@ -51,7 +51,7 @@ namespace UnitTest
         AZStd::unique_ptr<Instance> axle2UnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> spareWheelUnderCar = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList(AZStd::move(axle1UnderCar), AZStd::move(axle2UnderCar), AZStd::move(spareWheelUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axle1UnderCar), AZStd::move(axle2UnderCar), AZStd::move(spareWheelUnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -93,7 +93,7 @@ namespace UnitTest
         // Create an axle with 0 entities and 1 wheel instance.
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle)), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
         AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -105,7 +105,7 @@ namespace UnitTest
         AZStd::unique_ptr<Instance> axle1UnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> axle2UnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance>  carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axle1UnderCar), AZStd::move(axle2UnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axle1UnderCar), AZStd::move(axle2UnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);
@@ -151,7 +151,7 @@ namespace UnitTest
         // Create an axle with 0 entities and 1 wheel instance.
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle)), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -159,7 +159,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axleUnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance>  carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axleUnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);
@@ -205,7 +205,7 @@ namespace UnitTest
         // Create an axle with 0 entities and 1 wheel instance.
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle)), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -213,7 +213,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axleUnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axleUnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);
@@ -265,7 +265,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axle1UnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList(AZStd::move(axle1UnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axle1UnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);
@@ -320,7 +320,7 @@ namespace UnitTest
         // Create an axle with 0 entities and 1 wheel instance.
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle)), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -328,7 +328,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axleUnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axleUnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);
@@ -381,7 +381,7 @@ namespace UnitTest
         // Create an axle with 0 entities and 1 wheel instance.
         AZStd::unique_ptr<Instance> wheel1UnderAxle = m_prefabSystemComponent->InstantiatePrefab(wheelTemplateId);
         AZStd::unique_ptr<Instance> axleInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList(AZStd::move(wheel1UnderAxle) ), AxlePrefabMockFilePath);
+            MakeInstanceList(AZStd::move(wheel1UnderAxle)), AxlePrefabMockFilePath);
         const TemplateId axleTemplateId = axleInstance->GetTemplateId();
         PrefabDom& axleTemplateDom = m_prefabSystemComponent->FindTemplateDom(axleTemplateId);
         const AZStd::vector<InstanceAlias> wheelInstanceAliasesUnderAxle = axleInstance->GetNestedInstanceAliases(wheelTemplateId);
@@ -389,7 +389,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axleUnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList(AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axleUnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateWithPatchesTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/PrefabUpdateWithPatchesTests.cpp
@@ -68,7 +68,7 @@ namespace UnitTest
         // Create a car with 0 entities and 1 axle instance.
         AZStd::unique_ptr<Instance> axleUnderCar = m_prefabSystemComponent->InstantiatePrefab(axleTemplateId);
         AZStd::unique_ptr<Instance> carInstance = m_prefabSystemComponent->CreatePrefab({},
-            MakeInstanceList( AZStd::move(axleUnderCar) ), CarPrefabMockFilePath);
+            MakeInstanceList(AZStd::move(axleUnderCar)), CarPrefabMockFilePath);
         const TemplateId carTemplateId = carInstance->GetTemplateId();
         const AZStd::vector<InstanceAlias> axleInstanceAliasesUnderCar = carInstance->GetNestedInstanceAliases(axleTemplateId);
         PrefabDom& carTemplateDom = m_prefabSystemComponent->FindTemplateDom(carTemplateId);

--- a/Code/Tools/SerializeContextTools/SliceConverter.cpp
+++ b/Code/Tools/SerializeContextTools/SliceConverter.cpp
@@ -558,7 +558,7 @@ namespace AZ
             AZStd::string instanceAlias = GetInstanceAlias(instance);
 
             // Create a new unmodified prefab Instance for the nested slice instance.
-            auto nestedInstance = AZStd::make_unique<AzToolsFramework::Prefab::Instance>();
+            auto nestedInstance = AZStd::make_unique<AzToolsFramework::Prefab::Instance>(AZStd::move(instanceAlias));
             AzToolsFramework::Prefab::Instance::EntityList newEntities;
             if (!AzToolsFramework::Prefab::PrefabDomUtils::LoadInstanceFromPrefabDom(
                     *nestedInstance, newEntities, nestedTemplate->get().GetPrefabDom()))
@@ -742,7 +742,7 @@ namespace AZ
             instanceToTemplateInterface->GenerateDomForInstance(topLevelInstanceDomBefore, *topLevelInstance);
 
             // Use the deterministic instance alias for this new instance
-            AzToolsFramework::Prefab::Instance& addedInstance = topLevelInstance->AddInstance(AZStd::move(nestedInstance), instanceAlias);
+            AzToolsFramework::Prefab::Instance& addedInstance = topLevelInstance->AddInstance(AZStd::move(nestedInstance));
 
             AzToolsFramework::Prefab::PrefabDom topLevelInstanceDomAfter;
             instanceToTemplateInterface->GenerateDomForInstance(topLevelInstanceDomAfter, *topLevelInstance);


### PR DESCRIPTION
- Fixed entity id consistency issue. Right now we can get consistent container entity id from Create/InstantiatePrefab workflows.
- Refactored python automated test scripts related to prefab. Removed unnecessary container entity name checks.
- Refactored Create/InstantiatePrefab workflows on C++.
- Fixed some python automated  tests by fixing indention.

Tested prefab automated tests and passed by running the following command:
`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\prefab\TestSuite_Main.py::TestAutomation --build-directory windows_vs2019\bin\debug`

Builds and all tests succeeded on local branch.

Signed-off-by: chiyteng <chiyteng@amazon.com>