### PR TITLE
Animation Editor: Move real-time plugin updates from SystemComponent to the main window

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/MainWindow.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <AzCore/Component/TickBus.h>
 #include <EMotionStudio/EMStudioSDK/Source/EMStudioConfig.h>
 #include <EMotionStudio/EMStudioSDK/Source/GUIOptions.h>
 #include <EMotionStudio/EMStudioSDK/Source/PluginOptionsBus.h>
@@ -99,8 +100,9 @@ namespace EMStudio
         : public AzQtComponents::DockMainWindow
         , private PluginOptionsNotificationsBus::Router
         , public EMotionFX::ActorEditorRequestBus::Handler
+        , private AZ::TickBus::Handler
     {
-        Q_OBJECT
+        Q_OBJECT // AUTOMOC
         MCORE_MEMORYOBJECTCATEGORY(MainWindow, MCore::MCORE_DEFAULT_ALIGNMENT, MEMCATEGORY_EMSTUDIOSDK)
 
     public:
@@ -303,6 +305,16 @@ namespace EMStudio
         };
 
         MainWindowCommandManagerCallback m_mainWindowCommandManagerCallback;
+
+    private:
+        // AZ::TickBus::Handler overrides
+        void OnTick(float delta, AZ::ScriptTimePoint timePoint) override;
+        int GetTickOrder() override;
+
+        void UpdatePlugins(float timeDelta);
+
+        void EnableUpdatingPlugins();
+        void DisableUpdatingPlugins();
 
     public slots:
         void OnFileOpenActor();

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.h
@@ -108,7 +108,6 @@ namespace EMotionFX
             void SetMediaRoot(const char* alias);
 
 #if defined (EMOTIONFXANIMATION_EDITOR)
-            void UpdateAnimationEditorPlugins(float delta);
             void NotifyRegisterViews() override;
             bool IsSystemActive(EditorAnimationSystemRequests::AnimationSystem systemType) override;
 


### PR DESCRIPTION
Untangled the system component from editor ticking dependencies and moved it to the main window which is the more logical place for it.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>