### PR TITLE
Remove camera LookAtAfterInterpolation

### DIFF
--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -175,27 +175,15 @@ namespace SandboxEditor
         m_pivotCamera = AZStd::make_shared<AzFramework::PivotCameraInput>(SandboxEditor::CameraPivotChannelId());
 
         m_pivotCamera->SetPivotFn(
-            [viewportId = m_viewportId]([[maybe_unused]] const AZ::Vector3& position, [[maybe_unused]] const AZ::Vector3& direction)
+            []([[maybe_unused]] const AZ::Vector3& position, [[maybe_unused]] const AZ::Vector3& direction)
             {
-                AZStd::optional<AZ::Vector3> lookAtAfterInterpolation;
-                AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
-                    lookAtAfterInterpolation, viewportId,
-                    &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::LookAtAfterInterpolation);
-
-                // initially attempt to use the last set look at point after an interpolation has finished
-                // note: ignore this if it is the same location as the camera (e.g. after go to position)
-                if (lookAtAfterInterpolation.has_value() && !lookAtAfterInterpolation->IsClose(position))
-                {
-                    return *lookAtAfterInterpolation;
-                }
-
-                // otherwise fall back to the selected entity pivot
+                // use the manipulator transform as the pivot point
                 AZStd::optional<AZ::Transform> entityPivot;
                 AzToolsFramework::EditorTransformComponentSelectionRequestBus::EventResult(
                     entityPivot, AzToolsFramework::GetEntityContextId(),
                     &AzToolsFramework::EditorTransformComponentSelectionRequestBus::Events::GetManipulatorTransform);
 
-                // finally just use the identity
+                // otherwise just use the identity
                 return entityPivot.value_or(AZ::Transform::CreateIdentity()).GetTranslation();
             });
 

--- a/Code/Editor/EditorViewportCamera.cpp
+++ b/Code/Editor/EditorViewportCamera.cpp
@@ -48,7 +48,7 @@ namespace SandboxEditor
         {
             AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
                 viewportContext->GetId(), &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
-                AZ::Transform::CreateFromQuaternionAndTranslation(CameraRotation(pitch, yaw), position), 0.0f);
+                AZ::Transform::CreateFromQuaternionAndTranslation(CameraRotation(pitch, yaw), position));
         }
     }
 

--- a/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
+++ b/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
@@ -167,7 +167,7 @@ namespace UnitTest
             AZ::Quaternion::CreateRotationZ(AZ::DegToRad(90.0f)), AZ::Vector3(20.0f, 40.0f, 60.0f));
         AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
             TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
-            transformToInterpolateTo, 0.0f);
+            transformToInterpolateTo);
 
         // simulate interpolation
         m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
@@ -193,7 +193,7 @@ namespace UnitTest
         // When
         AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
             TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
-            transformToInterpolateTo, 0.0f);
+            transformToInterpolateTo);
 
         // simulate interpolation
         m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1739,8 +1739,7 @@ void SandboxIntegrationManager::GoToEntitiesInViewports(const AzToolsFramework::
 
             AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
                 viewportContext->GetId(),
-                &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform, nextCameraTransform,
-                distanceToLookAt);
+                &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform, nextCameraTransform);
         }
     }
 }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -112,8 +112,7 @@ namespace AtomToolsFramework
         void UpdateViewport(const AzFramework::ViewportControllerUpdateEvent& event) override;
 
         // ModularViewportCameraControllerRequestBus overrides ...
-        void InterpolateToTransform(const AZ::Transform& worldFromLocal, float lookAtDistance) override;
-        AZStd::optional<AZ::Vector3> LookAtAfterInterpolation() const override;
+        void InterpolateToTransform(const AZ::Transform& worldFromLocal) override;
         AZ::Transform GetReferenceFrame() const override;
         void SetReferenceFrame(const AZ::Transform& worldFromLocal) override;
         void ClearReferenceFrame() override;
@@ -149,9 +148,8 @@ namespace AtomToolsFramework
 
         CameraAnimation m_cameraAnimation; //!< Camera animation state (used during CameraMode::Animation).
         CameraMode m_cameraMode = CameraMode::Control; //!< The current mode the camera is operating in.
-        AZStd::optional<AZ::Vector3> m_lookAtAfterInterpolation; //!< The look at point after an interpolation has finished.
-                                                                 //!< Will be cleared when the view changes (camera looks away).
-        AZ::Transform m_referenceFrameOverride = AZ::Transform::CreateIdentity(); //!<
+        //! An additional reference frame the camera can operate in (identity has no effect).
+        AZ::Transform m_referenceFrameOverride = AZ::Transform::CreateIdentity();
         //! Flag to prevent circular updates of the camera transform (while the viewport transform is being updated internally).
         bool m_updatingTransformInternally = false;
         //! Listen for camera view changes outside of the camera controller.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
@@ -29,11 +29,7 @@ namespace AtomToolsFramework
 
         //! Begin a smooth transition of the camera to the requested transform.
         //! @param worldFromLocal The transform of where the camera should end up.
-        //! @param lookAtDistance The distance between the camera transform and the imagined look at point.
-        virtual void InterpolateToTransform(const AZ::Transform& worldFromLocal, float lookAtDistance) = 0;
-
-        //! Look at point after an interpolation has finished and no translation has occurred.
-        virtual AZStd::optional<AZ::Vector3> LookAtAfterInterpolation() const = 0;
+        virtual void InterpolateToTransform(const AZ::Transform& worldFromLocal) = 0;
 
         //! Return the current reference frame.
         //! @note If a reference frame has not been set or a frame has been cleared, this is just the identity.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -227,19 +227,6 @@ namespace AtomToolsFramework
         {
             m_targetCamera = m_cameraSystem.StepCamera(m_targetCamera, event.m_deltaTime.count());
             m_camera = AzFramework::SmoothCamera(m_camera, m_targetCamera, m_cameraProps, event.m_deltaTime.count());
-
-            // if there has been an interpolation, only clear the look at point if it is no longer
-            // centered in the view (the camera has looked away from it)
-            if (m_lookAtAfterInterpolation.has_value())
-            {
-                if (const float lookDirection =
-                        (*m_lookAtAfterInterpolation - m_camera.Translation()).GetNormalized().Dot(m_camera.Transform().GetBasisY());
-                    !AZ::IsCloseMag(lookDirection, 1.0f, 0.001f))
-                {
-                    m_lookAtAfterInterpolation = {};
-                }
-            }
-
             m_modularCameraViewportContext->SetCameraTransform(m_referenceFrameOverride * m_camera.Transform());
         }
         else if (m_cameraMode == CameraMode::Animation)
@@ -277,16 +264,10 @@ namespace AtomToolsFramework
         m_updatingTransformInternally = false;
     }
 
-    void ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal, const float lookAtDistance)
+    void ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal)
     {
         m_cameraMode = CameraMode::Animation;
         m_cameraAnimation = CameraAnimation{ m_referenceFrameOverride * m_camera.Transform(), worldFromLocal, 0.0f };
-        m_lookAtAfterInterpolation = worldFromLocal.GetTranslation() + worldFromLocal.GetBasisY() * lookAtDistance;
-    }
-
-    AZStd::optional<AZ::Vector3> ModularViewportCameraControllerInstance::LookAtAfterInterpolation() const
-    {
-        return m_lookAtAfterInterpolation;
     }
 
     AZ::Transform ModularViewportCameraControllerInstance::GetReferenceFrame() const


### PR DESCRIPTION
This functionality is no longer required and winds up just making things more complicated, removing for simplicity sake 🙂 