### PR TITLE
Updated references to Engine.pak to be lowercase engine.pak

### DIFF
--- a/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
+++ b/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
@@ -33,16 +33,13 @@ namespace AzGameFramework
         // from the Cache folder
         AZ::IO::FixedMaxPath enginePakPath = AZ::Utils::GetExecutableDirectory();
         enginePakPath /= "engine.pak";
-        if (m_archiveFileIO->Exists(enginePakPath.c_str()))
+        if (!m_archive->OpenPack("@assets@", enginePakPath.Native()))
         {
-            m_archive->OpenPack("@assets@", enginePakPath.Native());
-        }
-        else if (enginePakPath.clear(); m_settingsRegistry->Get(enginePakPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder))
-        {
-            // fall back to checking if there is an engine.pak in the Asset Cache
-            enginePakPath /= "engine.pak";
-            if (m_archiveFileIO->Exists(enginePakPath.c_str()))
+            enginePakPath.clear();
+            if (m_settingsRegistry->Get(enginePakPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder))
             {
+                // fall back to checking Project Cache Root.
+                enginePakPath /= "engine.pak";
                 m_archive->OpenPack("@assets@", enginePakPath.Native());
             }
         }

--- a/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
+++ b/Code/Framework/AzGameFramework/AzGameFramework/Application/GameApplication.cpp
@@ -32,15 +32,15 @@ namespace AzGameFramework
         // at the Assets alias, otherwise to attempting to mount the engine pak
         // from the Cache folder
         AZ::IO::FixedMaxPath enginePakPath = AZ::Utils::GetExecutableDirectory();
-        enginePakPath /= "Engine.pak";
+        enginePakPath /= "engine.pak";
         if (m_archiveFileIO->Exists(enginePakPath.c_str()))
         {
             m_archive->OpenPack("@assets@", enginePakPath.Native());
         }
         else if (enginePakPath.clear(); m_settingsRegistry->Get(enginePakPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_CacheRootFolder))
         {
-            // fall back to checking if there is an Engine.pak in the Asset Cache
-            enginePakPath /= "Engine.pak";
+            // fall back to checking if there is an engine.pak in the Asset Cache
+            enginePakPath /= "engine.pak";
             if (m_archiveFileIO->Exists(enginePakPath.c_str()))
             {
                 m_archive->OpenPack("@assets@", enginePakPath.Native());

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -808,7 +808,7 @@ void CSystem::OpenBasicPaks()
     const char* const assetsDir = "@assets@";
 
     // After game paks to have same search order as with files on disk
-    m_env.pCryPak->OpenPack(assetsDir, "Engine.pak");
+    m_env.pCryPak->OpenPack(assetsDir, "engine.pak");
 
 #if defined(AZ_RESTRICTED_PLATFORM)
 #define AZ_RESTRICTED_SECTION SYSTEMINIT_CPP_SECTION_15
@@ -1261,7 +1261,7 @@ AZ_POP_DISABLE_WARNING
         InlineInitializationProcessing("CSystem::Init Create console");
 
         // Need to load the engine.pak that includes the config files needed during initialization
-        m_env.pCryPak->OpenPack("@assets@", "Engine.pak");
+        m_env.pCryPak->OpenPack("@assets@", "engine.pak");
 
         InitFileSystem_LoadEngineFolders(startupParams);
 

--- a/cmake/Projects.cmake
+++ b/cmake/Projects.cmake
@@ -151,18 +151,18 @@ if("${CMAKE_INSTALL_CONFIG_NAME}" MATCHES "^([Rr][Ee][Ll][Ee][Aa][Ss][Ee])$")
     if(NOT DEFINED LY_ASSET_DEPLOY_ASSET_TYPE)
         set(LY_ASSET_DEPLOY_ASSET_TYPE @LY_ASSET_DEPLOY_ASSET_TYPE@)
     endif()
-    message(STATUS "Generating ${install_output_folder}/Engine.pak from @full_directory_path@/Cache/${LY_ASSET_DEPLOY_ASSET_TYPE}")
+    message(STATUS "Generating ${install_output_folder}/engine.pak from @full_directory_path@/Cache/${LY_ASSET_DEPLOY_ASSET_TYPE}")
     file(MAKE_DIRECTORY "${install_output_folder}")
     cmake_path(SET cache_product_path "@full_directory_path@/Cache/${LY_ASSET_DEPLOY_ASSET_TYPE}")
     file(GLOB product_assets "${cache_product_path}/*")
     if(product_assets)
         execute_process(
-            COMMAND ${CMAKE_COMMAND} -E tar "cf" "${install_output_folder}/Engine.pak" --format=zip -- ${product_assets}
+            COMMAND ${CMAKE_COMMAND} -E tar "cf" "${install_output_folder}/engine.pak" --format=zip -- ${product_assets}
             WORKING_DIRECTORY "${cache_product_path}"
             RESULT_VARIABLE archive_creation_result
         )
         if(archive_creation_result EQUAL 0)
-            message(STATUS "${install_output_folder}/Engine.pak generated")
+            message(STATUS "${install_output_folder}/engine.pak generated")
         endif()
     endif()
 endif()


### PR DESCRIPTION
This makes the engine.pak file consistent with naming scheme of other pak files such as assets.pak.

It will also help avoid issues with mounting the file on Linux.

Cherry-picked commit 2a92346e24177d2a0bc7c936b65a98cdfa867196 to fix issue with the Engine.pak file not being mounted in Release builds due to the `m_archiveFileIO::Exists` check only checking for file existence within a Pak.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>