### PR TITLE
Fix 3p path setting to the upper level

### DIFF
--- a/cmake/Tools/Platform/Android/generate_android_project.py
+++ b/cmake/Tools/Platform/Android/generate_android_project.py
@@ -368,7 +368,6 @@ def main(args):
     if not third_party_path.is_dir():
         raise common.LmbrCmdError(f"Invalid --third-party-path '{parsed_args.third_party_path}'.",
                                   common.ERROR_CODE_INVALID_PARAMETER)
-    third_party_path = third_party_path.parent
 
     build_dir = parsed_args.build_dir
 


### PR DESCRIPTION
The android project generate script used to check .../3rdParty/3rdParty.txt, but this step was removed a while ago.
With this step, third_party_path then was reset to its parent, which is .../3rdParty.
But now without this step, third_party_paty will be set to a level above .../3rdParty.

This issue won't cause any building errors, but it will eat up disk spaces because it downloads 3rd party packages to 2 locations.