### PR TITLE
Added a ThreadDispatch Policy to the EBus code

### DIFF
--- a/Code/Framework/AzCore/AzCore/EBus/DispatchPolicies.h
+++ b/Code/Framework/AzCore/AzCore/EBus/DispatchPolicies.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+namespace AZ::EBusPolicies
+{
+    struct PostDispatchTagType {};
+    inline constexpr PostDispatchTagType PostDispatchTag;
+    /**
+    * Default EBus Policy used to indicate the EBus Event/Broadcast/Enumerate*
+    * functions should perform no actions before and after finishing
+    * dispatching on a thread
+    * Any EBus which desires to have a function invoked after an EBus eventing operation
+    * has completely finished on a thread dispatching should implement a struct with a
+    * <ret-type> operator()(PostDispatchTagType) function override the `ThreadDispatchPolicy` type alias
+    * in their EBusTraits derived class during Bus Configuration
+    */
+    struct ThreadDispatch
+    {
+        constexpr void operator()(PostDispatchTagType) = delete;
+    };
+}

--- a/Code/Framework/AzCore/AzCore/EBus/Internal/BusContainer.h
+++ b/Code/Framework/AzCore/AzCore/EBus/Internal/BusContainer.h
@@ -115,7 +115,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -158,7 +158,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -201,7 +201,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -230,7 +230,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -261,7 +261,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, false);
 
@@ -297,7 +297,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, false);
 
@@ -333,7 +333,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, true);
 
@@ -355,7 +355,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, true);
 
@@ -377,7 +377,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -423,7 +423,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -469,7 +469,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -527,7 +527,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -587,7 +587,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         auto& addresses = context->m_buses.m_addresses;
                         auto addressIt = addresses.begin();
@@ -606,7 +606,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         auto& addresses = context->m_buses.m_addresses;
                         auto addressIt = addresses.find(id);
@@ -621,7 +621,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         if (ptr)
                         {
@@ -795,7 +795,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -812,7 +812,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -829,7 +829,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -846,7 +846,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, &id, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -865,7 +865,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, false);
 
@@ -883,7 +883,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, false);
 
@@ -901,7 +901,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, true);
 
@@ -919,7 +919,7 @@ namespace AZ
                     {
                         auto* context = Bus::GetContext();
                         EBUS_ASSERT(context, "Internal error: context deleted with bind ptr outstanding.");
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         EBUS_DO_ROUTING(*context, &busPtr->m_busId, false, true);
 
@@ -937,7 +937,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -975,7 +975,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -1013,7 +1013,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -1069,7 +1069,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, true);
 
                         auto& addresses = context->m_buses.m_addresses;
@@ -1127,7 +1127,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         auto& addresses = context->m_buses.m_addresses;
                         auto addressIt = addresses.begin();
@@ -1167,7 +1167,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         auto& addresses = context->m_buses.m_addresses;
                         auto addressIt = addresses.find(id);
@@ -1191,7 +1191,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         if (ptr)
                         {
@@ -1336,7 +1336,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto& handlers = context->m_buses.m_handlers;
@@ -1371,7 +1371,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto& handlers = context->m_buses.m_handlers;
@@ -1406,7 +1406,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, true);
 
                         auto& handlers = context->m_buses.m_handlers;
@@ -1427,7 +1427,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, true);
 
                         auto& handlers = context->m_buses.m_handlers;
@@ -1450,7 +1450,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         auto& handlers = context->m_buses.m_handlers;
                         auto handlerIt = handlers.begin();
@@ -1530,7 +1530,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto handler = context->m_buses.m_handler;
@@ -1546,7 +1546,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto handler = context->m_buses.m_handler;
@@ -1562,7 +1562,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto handler = context->m_buses.m_handler;
@@ -1578,7 +1578,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
                         EBUS_DO_ROUTING(*context, nullptr, false, false);
 
                         auto handler = context->m_buses.m_handler;
@@ -1596,7 +1596,7 @@ namespace AZ
                 {
                     if (auto* context = Bus::GetContext())
                     {
-                        typename Bus::Context::DispatchLockGuard lock(context->m_contextMutex);
+                        typename Bus::Context::DispatchLockGuard lock(*context, context->m_contextMutex);
 
                         auto handler = context->m_buses.m_handler;
                         if (handler)

--- a/Code/Framework/AzCore/AzCore/azcore_files.cmake
+++ b/Code/Framework/AzCore/AzCore/azcore_files.cmake
@@ -130,6 +130,7 @@ set(FILES
     Driller/Stream.cpp
     Driller/Stream.h
     EBus/BusImpl.h
+    EBus/DispatchPolicies.h
     EBus/EBus.h
     EBus/EBusEnvironment.cpp
     EBus/Environment.h

--- a/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
@@ -117,7 +117,7 @@ namespace GradientSignal
             // (One case where this was previously able to occur was in rapid updating of the Preview widget on the GradientSurfaceDataComponent
             // in the Editor when moving the threshold sliders back and forth rapidly)
             auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-            typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
+            typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext, surfaceDataContext.m_contextMutex);
 
             if (m_isRequestInProgress)
             {

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -499,7 +499,7 @@ void TerrainSystem::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/)
         // (One case where this was previously able to occur was in rapid updating of the Preview widget on the
         // GradientSurfaceDataComponent in the Editor when moving the threshold sliders back and forth rapidly)
         auto& surfaceDataContext = SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext(false);
-        typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext.m_contextMutex);
+        typename SurfaceData::SurfaceDataSystemRequestBus::Context::DispatchLockGuard scopeLock(surfaceDataContext, surfaceDataContext.m_contextMutex);
 
         AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask changeMask =
             AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None;


### PR DESCRIPTION
The ThreadDispatch Policy can be configured by authors of an EBusTraits to
invoke a callback function after an EBus has finished it's dispatching
mechanism on a specific thread.

It takes into account recursive calls as well and will only invoke the
PostDispatch callback after all callstack entries for the current thread
are cleared.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>