### PR TITLE
Fix missing include for AZStd::unordered_set in AssetEditorBus.h

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorBus.h
@@ -10,7 +10,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Outcome/Outcome.h>
 #include <AzCore/UserSettings/UserSettings.h>
-#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/unordered_set.h>
 
 namespace AZ::Data
 {


### PR DESCRIPTION
Fix for:

```
[2021-09-30T00:27:55.672Z] In file included from ../../Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorBus.cpp:9:
[2021-09-30T00:27:55.672Z] ../../Code/Framework/AzToolsFramework/AzToolsFramework/AssetEditor/AssetEditorBus.h:46:20: error: too few template arguments for class template 'unordered_set'
[2021-09-30T00:27:55.672Z]             AZStd::unordered_set<AZ::Data::Asset<AZ::Data::AssetData>> m_openAssets;
```
in non-unity builds

Signed-off-by: Steve Pham <spham@amazon.com>