### PR TITLE
Moving run Physx Benchmarks behind a cmake flag

### DIFF
--- a/Gems/PhysX/Code/CMakeLists.txt
+++ b/Gems/PhysX/Code/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(NumericalMethods)
 ly_get_list_relative_pal_filename(pal_source_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME})
 
 include(${pal_source_dir}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake) # for PAL_TRAIT_PHYSX_SUPPORTED
+set(PHYSX_ENABLE_RUNNING_BENCHMARKS OFF CACHE BOOL "Adds a target to allow running of the physx benchmarks.")
 
 if(PAL_TRAIT_PHYSX_SUPPORTED)
     set(physx_dependency 3rdParty::PhysX)
@@ -150,9 +151,6 @@ endif()
 # Tests
 ################################################################################
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
-
-    
-
     ly_add_target(
         NAME PhysX.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
         NAMESPACE Gem
@@ -183,10 +181,16 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     ly_add_googletest(
         NAME Gem::PhysX.Tests
     )
-    ly_add_googlebenchmark(
-        NAME Gem::PhysX.Benchmarks
-        TARGET Gem::PhysX.Tests
-    )
+
+    # Only add the physx benchmarks if this flag is set. The benchmark code is still built, as it is part of the PhysX.Tests project.
+    # Currently jenkins has a 1500sec(25min) timeout, our benchmarks can sometimes take over 1500sec and cause a build failure for timeout.
+    # Jenkins currently doesn't upload the results of the benchmarks, so this is ok.
+    if(PHYSX_ENABLE_RUNNING_BENCHMARKS)
+        ly_add_googlebenchmark(
+            NAME Gem::PhysX.Benchmarks
+            TARGET Gem::PhysX.Tests
+        )
+    endif()
 
     list(APPEND testTargets PhysX.Tests)
     


### PR DESCRIPTION
The benchmark code is still built, as it is part of the PhysX.Tests project.
Currently jenkins has a 1500sec(25min) timeout, the benchmarks can sometimes take over 1500sec and cause a build failure for timeout.
Jenkins currently doesn't upload the results of the benchmarks, so this is ok.

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>