### PR TITLE
Update MaterialEditor launcher to use platform traits for executable extensions

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -137,7 +137,7 @@ namespace AZ
                 arguments.append(QString("--project-path=%1").arg(projectPath.c_str()));
             }
 
-            AtomToolsFramework::LaunchTool("MaterialEditor", ".exe", arguments);
+            AtomToolsFramework::LaunchTool("MaterialEditor", AZ_TRAIT_OS_EXECUTABLE_EXTENSION, arguments);
         }
 
         void EditorMaterialSystemComponent::OpenMaterialInspector(


### PR DESCRIPTION
'MaterialEditor' on Linux/Mac does not have an '.exe' extension

Signed-off-by: Steve Pham <spham@amazon.com>