### PR TITLE
Fix Vulkan RHI test failure by increasing timeout

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -226,9 +226,9 @@ class TestMaterialEditor(object):
             self, request, workspace, project, launcher_platform, generic_launcher, exe_file_name, cfg_args):
         """
         Tests each valid RHI option (Null RHI excluded) can be launched with the MaterialEditor.
-        Checks for the "Finished loading viewport configurtions." success message post lounch.
+        Checks for the "Finished loading viewport configurations." success message post launch.
         """
-        expected_lines = ["Finished loading viewport configurtions."]
+        expected_lines = ["Finished loading viewport configurations."]
         unexpected_lines = [
             # "Trace::Assert",
             # "Trace::Error",
@@ -241,7 +241,7 @@ class TestMaterialEditor(object):
             generic_launcher,
             editor_script="",
             run_python="--runpython",
-            timeout=30,
+            timeout=60,
             expected_lines=expected_lines,
             unexpected_lines=unexpected_lines,
             halt_on_unexpected=False,

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportComponent.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportComponent.cpp
@@ -271,7 +271,7 @@ namespace MaterialEditor
 
         MaterialViewportNotificationBus::Broadcast(&MaterialViewportNotificationBus::Events::OnEndReloadContent);
 
-        AZ_TracePrintf("Material Editor", "Finished loading viewport configurtions.\n");
+        AZ_TracePrintf("Material Editor", "Finished loading viewport configurations.\n");
     }
 
     AZ::Render::LightingPresetPtr MaterialViewportComponent::AddLightingPreset(const AZ::Render::LightingPreset& preset)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportComponent.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportComponent.cpp
@@ -190,7 +190,7 @@ namespace MaterialEditor
 
     void MaterialViewportComponent::ReloadContent()
     {
-        AZ_TracePrintf("Material Editor", "Started loading viewport configurtions.\n");
+        AZ_TracePrintf("Material Editor", "Started loading viewport configurations.\n");
 
         MaterialViewportNotificationBus::Broadcast(&MaterialViewportNotificationBus::Events::OnBeginReloadContent);
 
@@ -239,7 +239,7 @@ namespace MaterialEditor
                     {
                         auto presetPtr = AddLightingPreset(*preset);
                         m_lightingPresetLastSavePathMap[presetPtr] = AZ::RPI::AssetUtils::GetSourcePathByAssetId(info.m_assetId);
-                        AZ_TracePrintf("Material Editor", "Loaded viewport configurtion: %s.\n", info.m_relativePath.c_str());
+                        AZ_TracePrintf("Material Editor", "Loaded viewport configuration: %s.\n", info.m_relativePath.c_str());
                     }
                 }
             }
@@ -258,7 +258,7 @@ namespace MaterialEditor
                     {
                         auto presetPtr = AddModelPreset(*preset);
                         m_modelPresetLastSavePathMap[presetPtr] = AZ::RPI::AssetUtils::GetSourcePathByAssetId(info.m_assetId);
-                        AZ_TracePrintf("Material Editor", "Loaded viewport configurtion: %s.\n", info.m_relativePath.c_str());
+                        AZ_TracePrintf("Material Editor", "Loaded viewport configuration: %s.\n", info.m_relativePath.c_str());
                     }
                 }
             }


### PR DESCRIPTION
- Passes locally and I got it to fail locally before by making the test take longer.  The original failure appears timeout related.
- Also fixed the spelling of "configurtion" to be "configuration".
- Sample output below:
```
C:\git\o3de>C:\git\o3de\python\runtime\python-3.7.10-rev1-windows\python\python.exe -m pytest -vv -s --build-directory=".\build\bin\profile" AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py -k test_MaterialEditorLaunch_AllRHIOptionsSucceed
#
# Skipping to end of log
#
|MaterialEditor.log| 2021-09-30T19:02:34{0000000000005290}[Material Editor]     Loaded viewport configuration: materialeditor/viewportmodels/beveledcylinder.modelpreset.azasset.
|MaterialEditor.log| 2021-09-30T19:02:34{0000000000005290}[Material Editor]     Finished loading viewport configurations.
|MaterialEditor.log| 2021-09-30T19:02:51{0000000000005290}[   PhysXSystem]
|MaterialEditor.log| ==================================================================
|MaterialEditor.log| 2021-09-30T19:02:51{0000000000005290}[   PhysXSystem]     Trace::Warning
|MaterialEditor.log|  C:/git/o3de/Gems/PhysX/Code/Source/System/PhysXSystem.cpp(167): 'void __cdecl PhysX::PhysXSystem::Simulate(float)'
|MaterialEditor.log| 2021-09-30T19:02:51{0000000000005290}[   PhysXSystem]     [3] of [1000] frames had a deltatime over the Max physics timestep[0.100000]. Physx timestep was clamped on those frames, losing [12.111090] seconds.
|MaterialEditor.log| 2021-09-30T19:02:51{0000000000005290}[   PhysXSystem]     ==================================================================

156554.19850349426 - INFO - [MainThread] - ly_test_tools.log.log_monitor - Finished log monitoring for '60' seconds, validating results.
expected_lines_not_found: []
 unexpected_lines_found: []
156555.19819259644 - INFO - [MainThread] - ly_test_tools.log.log_monitor - LogMonitor Result:
--- Expected lines ---
[ FOUND ] Finished loading viewport configurations.
Found 1/1 expected lines
157556.71381950378 - INFO - [MainThread] - ly_test_tools.environment.file_system - Restoring backup of C:\git\o3de\system_windows_pc.cfg from C:\Users\jromnoa\AppData\Local\Temp\tmpuhya83uk\system_windows_pc.cfg.bak
157559.69095230103 - WARNING - [MainThread] - ly_test_tools.environment.file_system - Backup file C:\Users\jromnoa\AppData\Local\Temp\tmpuhya83uk\config.ini.bak does not exist, aborting backup restoration.
157561.72060966492 - INFO - [MainThread] - ly_test_tools.o3de.asset_processor - Sent input quit
PASSED158623.20828437805 - INFO - [MainThread] - ly_test_tools.environment.process_utils - Killing all processes named ['AssetProcessor.exe']
159201.89571380615 - INFO - [crash_log_watchdog] - ly_test_tools.environment.watchdog - Shutting down watchdog: crash_log_watchdog


=========================================================================================================== warnings summary ===========================================================================================================
python\runtime\python-3.7.10-rev1-windows\python\lib\site-packages\_pytest\mark\structures.py:327
  C:\git\o3de\python\runtime\python-3.7.10-rev1-windows\python\lib\site-packages\_pytest\mark\structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.system - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================================================== 2 passed, 4 deselected, 1 warning in 158.85s (0:02:38) ========================================================================================
```