### PR TITLE
Change editor viewport mode tracker id from viewport to entity context.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerInterface.h
@@ -22,22 +22,22 @@ namespace AzToolsFramework
 
         virtual ~ViewportEditorModeTrackerInterface() = default;
 
-        //! Activates the specified editor mode for the specified viewport.
+        //! Activates the specified editor mode for the specified viewport editor mode tracker.
         virtual AZ::Outcome<void, AZStd::string> ActivateMode(
-            const ViewportEditorModeInfo& viewportEditorModeInfo, ViewportEditorMode mode) = 0;
+            const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo, ViewportEditorMode mode) = 0;
        
-        //! Deactivates the specified editor mode for the specified viewport.
+        //! Deactivates the specified editor mode for the specified viewport editor mode tracker.
         virtual AZ::Outcome<void, AZStd::string> DeactivateMode(
-            const ViewportEditorModeInfo& viewportEditorModeInfo, ViewportEditorMode mode) = 0;
+            const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo, ViewportEditorMode mode) = 0;
 
-        //! Attempts to retrieve the editor mode state for the specified viewport, otherwise returns nullptr.
-        virtual const ViewportEditorModesInterface* GetViewportEditorModes(const ViewportEditorModeInfo& viewportEditorModeInfo) const = 0;
+        //! Attempts to retrieve the editor mode state for the specified viewport editor mode tracker, otherwise returns nullptr.
+        virtual const ViewportEditorModesInterface* GetViewportEditorModes(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo) const = 0;
 
-        //! Returns the number of viewports currently being tracked.
+        //! Returns the number of viewport editor mode trackers.
         virtual size_t GetTrackedViewportCount() const = 0;
 
-        //! Returns true if the specified viewport is being tracked, otherwise false.
-        virtual bool IsViewportModeTracked(const ViewportEditorModeInfo& viewportEditorModeInfo) const = 0;
+        //! Returns true if viewport editor modes are being tracked for the specified od, otherwise false.
+        virtual bool IsViewportModeTracked(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo) const = 0;
     };
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h
@@ -24,7 +24,7 @@ namespace AzToolsFramework
     };
 
     //! Viewport editor mode tracker identifier and other relevant data.
-    struct ViewportEditorModeInfo
+    struct ViewportEditorModeTrackerInfo
     {
         using IdType = AzFramework::EntityContextId;
         IdType m_id = AzFramework::EntityContextId::CreateNull(); //!< The unique identifier for a given viewport editor mode tracker.
@@ -49,7 +49,7 @@ namespace AzToolsFramework
         // EBusTraits overrides
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
-        using BusIdType = ViewportEditorModeInfo::IdType;
+        using BusIdType = ViewportEditorModeTrackerInfo::IdType;
         //////////////////////////////////////////////////////////////////////////
 
         //! Notifies subscribers of the a given viewport to the activation of the specified editor mode.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <AzCore/EBus/Event.h>
-#include <AzFramework/Viewport/ViewportId.h>
+#include <AzFramework/Entity/EntityContextBus.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiRequestBus.h>
 
 namespace AzToolsFramework
@@ -23,11 +23,11 @@ namespace AzToolsFramework
         Pick
     };
 
-    //! Viewport identifier and other relevant viewport data.
+    //! Viewport editor mode tracker identifier and other relevant data.
     struct ViewportEditorModeInfo
     {
-        using IdType = AzFramework::ViewportId;
-        IdType m_id = ViewportUi::DefaultViewportId; //!< The unique identifier for a given viewport.
+        using IdType = AzFramework::EntityContextId;
+        IdType m_id = AzFramework::EntityContextId::CreateNull(); //!< The unique identifier for a given viewport editor mode tracker.
     };
 
     //! Interface for the editor modes of a given viewport.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
@@ -218,7 +218,7 @@ namespace AzToolsFramework
             // this call to activate the component mode editor state should eventually replace the bus call in
             // ComponentModeCollection::BeginComponentMode() to EditorComponentModeNotifications::EnteredComponentMode
             // such that all of the notifications for activating/deactivating the different editor modes are in a central location
-            m_viewportEditorModeTracker->ActivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Component);
+            m_viewportEditorModeTracker->ActivateMode({ GetEntityContextId() }, ViewportEditorMode::Component);
 
             // enable actions for the first/primary ComponentMode
             // note: if multiple ComponentModes are activated at the same time, actions
@@ -296,7 +296,7 @@ namespace AzToolsFramework
             // this call to deactivate the component mode editor state should eventually replace the bus call in
             // ComponentModeCollection::EndComponentMode() to EditorComponentModeNotifications::LeftComponentMode
             // such that all of the notifications for activating/deactivating the different editor modes are in a central location
-            m_viewportEditorModeTracker->DeactivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Component);
+            m_viewportEditorModeTracker->DeactivateMode({ GetEntityContextId() }, ViewportEditorMode::Component);
 
             // clear stored modes and builders for this ComponentMode
             // TLDR: avoid 'use after free' error

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeSystemComponent.cpp
@@ -10,7 +10,7 @@
 
 #include <AzToolsFramework/API/ViewportEditorModeTrackerInterface.h>
 #include <AzToolsFramework/FocusMode/FocusModeSystemComponent.h>
-#include <AzToolsFramework/API/ViewportEditorModeTrackerInterface.h>
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 namespace AzToolsFramework
 {
@@ -72,11 +72,11 @@ namespace AzToolsFramework
         {
             if (!m_focusRoot.IsValid() && entityId.IsValid())
             {
-                tracker->ActivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Focus);
+                tracker->ActivateMode({ GetEntityContextId() }, ViewportEditorMode::Focus);
             }
             else if (m_focusRoot.IsValid() && !entityId.IsValid())
             {
-                tracker->DeactivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Focus);
+                tracker->DeactivateMode({ GetEntityContextId() }, ViewportEditorMode::Focus);
             }
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.cpp
@@ -32,14 +32,14 @@ namespace AzToolsFramework
 
         m_manipulatorManager = AZStd::make_shared<AzToolsFramework::ManipulatorManager>(AzToolsFramework::g_mainManipulatorManagerId);
         m_transformComponentSelection = AZStd::make_unique<EditorTransformComponentSelection>(entityDataCache);
-        m_viewportEditorModeTracker->ActivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Default);
+        m_viewportEditorModeTracker->ActivateMode({ GetEntityContextId() }, ViewportEditorMode::Default);
     }
 
     EditorDefaultSelection::~EditorDefaultSelection()
     {
         ComponentModeFramework::ComponentModeSystemRequestBus::Handler::BusDisconnect();
         ActionOverrideRequestBus::Handler::BusDisconnect();
-        m_viewportEditorModeTracker->DeactivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Default);
+        m_viewportEditorModeTracker->DeactivateMode({ GetEntityContextId() }, ViewportEditorMode::Default);
     }
 
     void EditorDefaultSelection::SetOverridePhantomWidget(QWidget* phantomOverrideWidget)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
@@ -21,7 +21,7 @@ namespace AzToolsFramework
         : m_editorHelpers(AZStd::make_unique<EditorHelpers>(entityDataCache))
         , m_viewportEditorModeTracker(viewportEditorModeTracker)
     {
-        m_viewportEditorModeTracker->ActivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Pick);
+        m_viewportEditorModeTracker->ActivateMode({ GetEntityContextId() }, ViewportEditorMode::Pick);
     }
 
     EditorPickEntitySelection::~EditorPickEntitySelection()
@@ -31,7 +31,7 @@ namespace AzToolsFramework
             ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetEntityHighlighted, m_hoveredEntityId, false);
         }
 
-        m_viewportEditorModeTracker->DeactivateMode({ /* DefaultViewportId */ }, ViewportEditorMode::Pick);
+        m_viewportEditorModeTracker->DeactivateMode({ GetEntityContextId() }, ViewportEditorMode::Pick);
     }
 
     // note: entityIdUnderCursor is the authoritative entityId we get each frame by querying

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.cpp
@@ -52,7 +52,8 @@ namespace AzToolsFramework
         if (editorModes.IsModeActive(mode))
         {
             return AZ::Failure(AZStd::string::format(
-                "Duplicate call to ActivateMode for mode '%u' on id '%i'", static_cast<AZ::u32>(mode), viewportEditorModeInfo.m_id));
+                "Duplicate call to ActivateMode for mode '%u' on id '%s'", static_cast<AZ::u32>(mode),
+                viewportEditorModeInfo.m_id.ToString<AZStd::string>().c_str()));
         }
         
         if (const auto result = editorModes.ActivateMode(mode);
@@ -78,7 +79,8 @@ namespace AzToolsFramework
             if (!editorModes->IsModeActive(mode))
             {
                 return AZ::Failure(AZStd::string::format(
-                    "Duplicate call to DeactivateMode for mode '%u' on id '%i'", static_cast<AZ::u32>(mode), viewportEditorModeInfo.m_id));
+                    "Duplicate call to DeactivateMode for mode '%u' on id '%s'", static_cast<AZ::u32>(mode),
+                    viewportEditorModeInfo.m_id.ToString<AZStd::string>().c_str()));
             }
         }
         else
@@ -103,8 +105,8 @@ namespace AzToolsFramework
         else
         {
             return AZ::Failure(AZStd::string::format(
-                "Call to DeactivateMode for mode '%u' on id '%i' without precursor call to ActivateMode", static_cast<AZ::u32>(mode),
-                viewportEditorModeInfo.m_id));
+                "Call to DeactivateMode for mode '%u' on id '%s' without precursor call to ActivateMode", static_cast<AZ::u32>(mode),
+                viewportEditorModeInfo.m_id.ToString<AZStd::string>().c_str()));
         }
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.cpp
@@ -46,14 +46,14 @@ namespace AzToolsFramework
     }
 
     AZ::Outcome<void, AZStd::string> ViewportEditorModeTracker::ActivateMode(
-        const ViewportEditorModeInfo& viewportEditorModeInfo, ViewportEditorMode mode)
+        const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo, ViewportEditorMode mode)
     {
-        auto& editorModes = m_viewportEditorModesMap[viewportEditorModeInfo.m_id];
+        auto& editorModes = m_viewportEditorModesMap[ViewportEditorModeTrackerInfo.m_id];
         if (editorModes.IsModeActive(mode))
         {
             return AZ::Failure(AZStd::string::format(
                 "Duplicate call to ActivateMode for mode '%u' on id '%s'", static_cast<AZ::u32>(mode),
-                viewportEditorModeInfo.m_id.ToString<AZStd::string>().c_str()));
+                ViewportEditorModeTrackerInfo.m_id.ToString<AZStd::string>().c_str()));
         }
         
         if (const auto result = editorModes.ActivateMode(mode);
@@ -63,30 +63,30 @@ namespace AzToolsFramework
         }
 
         ViewportEditorModeNotificationsBus::Event(
-            viewportEditorModeInfo.m_id, &ViewportEditorModeNotificationsBus::Events::OnEditorModeActivated, editorModes, mode);
+            ViewportEditorModeTrackerInfo.m_id, &ViewportEditorModeNotificationsBus::Events::OnEditorModeActivated, editorModes, mode);
 
         return AZ::Success();
     }
 
     AZ::Outcome<void, AZStd::string> ViewportEditorModeTracker::DeactivateMode(
-        const ViewportEditorModeInfo& viewportEditorModeInfo, ViewportEditorMode mode)
+        const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo, ViewportEditorMode mode)
     {
         ViewportEditorModes* editorModes = nullptr;
         bool modeWasActive = true;
-        if (m_viewportEditorModesMap.count(viewportEditorModeInfo.m_id))
+        if (m_viewportEditorModesMap.count(ViewportEditorModeTrackerInfo.m_id))
         {
-            editorModes = &m_viewportEditorModesMap.at(viewportEditorModeInfo.m_id);
+            editorModes = &m_viewportEditorModesMap.at(ViewportEditorModeTrackerInfo.m_id);
             if (!editorModes->IsModeActive(mode))
             {
                 return AZ::Failure(AZStd::string::format(
                     "Duplicate call to DeactivateMode for mode '%u' on id '%s'", static_cast<AZ::u32>(mode),
-                    viewportEditorModeInfo.m_id.ToString<AZStd::string>().c_str()));
+                    ViewportEditorModeTrackerInfo.m_id.ToString<AZStd::string>().c_str()));
             }
         }
         else
         {
             modeWasActive = false;
-            editorModes = &m_viewportEditorModesMap[viewportEditorModeInfo.m_id];
+            editorModes = &m_viewportEditorModesMap[ViewportEditorModeTrackerInfo.m_id];
         }
 
         if(const auto result = editorModes->DeactivateMode(mode);
@@ -96,7 +96,7 @@ namespace AzToolsFramework
         }
 
         ViewportEditorModeNotificationsBus::Event(
-            viewportEditorModeInfo.m_id, &ViewportEditorModeNotificationsBus::Events::OnEditorModeDeactivated, *editorModes, mode);
+            ViewportEditorModeTrackerInfo.m_id, &ViewportEditorModeNotificationsBus::Events::OnEditorModeDeactivated, *editorModes, mode);
 
         if (modeWasActive)
         {
@@ -106,13 +106,13 @@ namespace AzToolsFramework
         {
             return AZ::Failure(AZStd::string::format(
                 "Call to DeactivateMode for mode '%u' on id '%s' without precursor call to ActivateMode", static_cast<AZ::u32>(mode),
-                viewportEditorModeInfo.m_id.ToString<AZStd::string>().c_str()));
+                ViewportEditorModeTrackerInfo.m_id.ToString<AZStd::string>().c_str()));
         }
     }
 
-    const ViewportEditorModesInterface* ViewportEditorModeTracker::GetViewportEditorModes(const ViewportEditorModeInfo& viewportEditorModeInfo) const
+    const ViewportEditorModesInterface* ViewportEditorModeTracker::GetViewportEditorModes(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo) const
     {
-        if (auto editorModes = m_viewportEditorModesMap.find(viewportEditorModeInfo.m_id);
+        if (auto editorModes = m_viewportEditorModesMap.find(ViewportEditorModeTrackerInfo.m_id);
             editorModes != m_viewportEditorModesMap.end())
         {
             return &editorModes->second;
@@ -128,8 +128,8 @@ namespace AzToolsFramework
         return m_viewportEditorModesMap.size();
     }
 
-    bool ViewportEditorModeTracker::IsViewportModeTracked(const ViewportEditorModeInfo& viewportEditorModeInfo) const
+    bool ViewportEditorModeTracker::IsViewportModeTracked(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo) const
     {
-        return m_viewportEditorModesMap.count(viewportEditorModeInfo.m_id) > 0;
+        return m_viewportEditorModesMap.count(ViewportEditorModeTrackerInfo.m_id) > 0;
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.h
@@ -42,14 +42,14 @@ namespace AzToolsFramework
     {
     public:
         // ViewportEditorModeTrackerInterface overrides ...
-        AZ::Outcome<void, AZStd::string> ActivateMode(const ViewportEditorModeInfo& viewportEditorModeInfo, ViewportEditorMode mode) override;
-        AZ::Outcome<void, AZStd::string> DeactivateMode(const ViewportEditorModeInfo& viewportEditorModeInfo, ViewportEditorMode mode) override;
-        const ViewportEditorModesInterface* GetViewportEditorModes(const ViewportEditorModeInfo& viewportEditorModeInfo) const override;
+        AZ::Outcome<void, AZStd::string> ActivateMode(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo, ViewportEditorMode mode) override;
+        AZ::Outcome<void, AZStd::string> DeactivateMode(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo, ViewportEditorMode mode) override;
+        const ViewportEditorModesInterface* GetViewportEditorModes(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo) const override;
         size_t GetTrackedViewportCount() const override;
-        bool IsViewportModeTracked(const ViewportEditorModeInfo& viewportEditorModeInfo) const override;
+        bool IsViewportModeTracked(const ViewportEditorModeTrackerInfo& ViewportEditorModeTrackerInfo) const override;
 
     private:
-        using ViewportEditorModesMap = AZStd::unordered_map<typename ViewportEditorModeInfo::IdType, ViewportEditorModes>;
-        ViewportEditorModesMap m_viewportEditorModesMap; //!< Editor mode state per viewport.
+        using ViewportEditorModesMap = AZStd::unordered_map<typename ViewportEditorModeTrackerInfo::IdType, ViewportEditorModes>;
+        ViewportEditorModesMap m_viewportEditorModesMap; //!< Editor mode states per tracker.
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
@@ -9,6 +9,7 @@
 #include <AzTest/AzTest.h>
 #include <AzToolsFramework/ComponentMode/EditorComponentModeBus.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/ViewportSelection/EditorPickEntitySelection.h>
 #include <AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.h>
 
@@ -18,7 +19,7 @@ namespace UnitTest
     using ViewportEditorModes = AzToolsFramework::ViewportEditorModes;
     using ViewportEditorModeTracker = AzToolsFramework::ViewportEditorModeTracker;
     using ViewportEditorModeInfo = AzToolsFramework::ViewportEditorModeInfo;
-    using ViewportId = ViewportEditorModeInfo::IdType;
+    using TrackerId = ViewportEditorModeInfo::IdType;
     using ViewportEditorModesInterface = AzToolsFramework::ViewportEditorModesInterface;
     using ViewportEditorModeTrackerInterface = AzToolsFramework::ViewportEditorModeTrackerInterface;
 
@@ -113,20 +114,15 @@ namespace UnitTest
 
         using EditModeTracker = AZStd::unordered_map<ViewportEditorMode, ReceivedEvents>;
 
-        ViewportEditorModeNotificationsBusHandler(ViewportId viewportId)
-             : m_viewportSubscription(viewportId)
+        ViewportEditorModeNotificationsBusHandler(TrackerId id)
+             : m_trackerSubscription(id)
         {
-            AzToolsFramework::ViewportEditorModeNotificationsBus::Handler::BusConnect(m_viewportSubscription);
+            AzToolsFramework::ViewportEditorModeNotificationsBus::Handler::BusConnect(m_trackerSubscription);
         }
 
         ~ViewportEditorModeNotificationsBusHandler()
         {
             AzToolsFramework::ViewportEditorModeNotificationsBus::Handler::BusDisconnect();
-        }
-
-        ViewportId GetViewportSubscription() const
-        {
-            return m_viewportSubscription;
         }
 
         const EditModeTracker& GetEditorModes() const
@@ -145,7 +141,7 @@ namespace UnitTest
         }
 
      private:
-         ViewportId m_viewportSubscription;
+        TrackerId m_trackerSubscription;
          EditModeTracker m_editorModes;
 
     };
@@ -158,10 +154,13 @@ namespace UnitTest
 
         void SetUpEditorFixtureImpl() override
         {
+            m_handlerIds.resize(ViewportEditorModes::NumEditorModes);
             for (auto mode = 0; mode < ViewportEditorModes::NumEditorModes; mode++)
             {
-                m_editorModeHandlers[mode] = AZStd::make_unique<ViewportEditorModeNotificationsBusHandler>(mode);
+                m_handlerIds[mode] = TrackerId::CreateRandom();
+                m_editorModeHandlers[mode] = AZStd::make_unique<ViewportEditorModeNotificationsBusHandler>(m_handlerIds[mode]);
             }
+
         }
 
         void TearDownEditorFixtureImpl() override
@@ -173,6 +172,7 @@ namespace UnitTest
         }
 
         AZStd::array<AZStd::unique_ptr<ViewportEditorModeNotificationsBusHandler>, ViewportEditorModes::NumEditorModes> m_editorModeHandlers;
+        AZStd::vector<TrackerId> m_handlerIds;
     };
 
     // Fixture for testing the integration of viewport editor mode state tracker
@@ -184,7 +184,8 @@ namespace UnitTest
         {
             m_viewportEditorModeTracker = AZ::Interface<ViewportEditorModeTrackerInterface>::Get();
             ASSERT_NE(m_viewportEditorModeTracker, nullptr);
-            m_viewportEditorModes = m_viewportEditorModeTracker->GetViewportEditorModes({});
+            m_viewportEditorModes = m_viewportEditorModeTracker->GetViewportEditorModes({AzToolsFramework::GetEntityContextId()});
+            ASSERT_NE(m_viewportEditorModes, nullptr);
         }
 
         ViewportEditorModeTrackerInterface* m_viewportEditorModeTracker = nullptr;
@@ -316,17 +317,17 @@ namespace UnitTest
     TEST_F(ViewportEditorModeTrackerTestFixture, ActivatingViewportEditorModeForNonExistentIdCreatesViewportEditorModesForThatId)
     {
         // Given a viewport not currently being tracked
-        const ViewportId viewportid = 0;
-        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
-        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid }), nullptr);
+        const TrackerId id = 0;
+        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
+        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ id }), nullptr);
 
         // When a mode is activated for that viewport
         const auto editorMode = ViewportEditorMode::Default;
-        m_viewportEditorModeTracker.ActivateMode({ viewportid }, editorMode);
-        const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid });
+        m_viewportEditorModeTracker.ActivateMode({ id }, editorMode);
+        const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ id });
 
         // Expect that viewport to now be tracked
-        EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
+        EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
         EXPECT_NE(viewportEditorModeState, nullptr);
 
         // Expect the mode for that viewport to be active
@@ -336,23 +337,24 @@ namespace UnitTest
     TEST_F(ViewportEditorModeTrackerTestFixture, DeactivatingViewportEditorModeForNonExistentIdCreatesViewportEditorModesForThatIdButReturnsError)
     {
         // Given a viewport not currently being tracked
-        const ViewportId viewportid = 0;
-        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
-        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid }), nullptr);
+        const TrackerId id = 0;
+        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
+        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ id }), nullptr);
 
         // When a mode is deactivated for that viewport
         const auto editorMode = ViewportEditorMode::Default;
         const auto expectedErrorMsg = AZStd::string::format(
-            "Call to DeactivateMode for mode '%u' on id '%i' without precursor call to ActivateMode", static_cast<AZ::u32>(editorMode), viewportid);
-        const auto result = m_viewportEditorModeTracker.DeactivateMode({ viewportid }, editorMode);
+            "Call to DeactivateMode for mode '%u' on id '%s' without precursor call to ActivateMode", static_cast<AZ::u32>(editorMode),
+            id.ToString<AZStd::string>().c_str());
+        const auto result = m_viewportEditorModeTracker.DeactivateMode({ id }, editorMode);
 
         // Expect an error due to no precursor activation of that mode
         EXPECT_FALSE(result.IsSuccess());
         EXPECT_EQ(result.GetError(), expectedErrorMsg);
 
         // Expect that viewport to now be tracked
-        const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid });
-        EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
+        const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ id });
+        EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
 
         // Expect the mode for that viewport to be inactive
         EXPECT_NE(viewportEditorModeState, nullptr);
@@ -361,45 +363,46 @@ namespace UnitTest
 
     TEST_F(ViewportEditorModeTrackerTestFixture, GettingNonExistentViewportEditorModesForIdReturnsNull)
     {
-        const ViewportId viewportid = 0;
-        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
-        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid }), nullptr);
+        const TrackerId id = 0;
+        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
+        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ id }), nullptr);
     }
 
     TEST_F(ViewportEditorModeTrackerTestFixture, ActivatingViewportEditorModesForExistingIdInThatStateReturnsError)
     {
         // Given a viewport not currently tracked
-        const ViewportId viewportid = 0;
-        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
-        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid }), nullptr);
+        const TrackerId id = 0;
+        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
+        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ id }), nullptr);
 
         const auto editorMode = ViewportEditorMode::Default;
         {
             // When the mode is activated for the viewport
-            const auto result = m_viewportEditorModeTracker.ActivateMode({ viewportid }, editorMode);
+            const auto result = m_viewportEditorModeTracker.ActivateMode({ id }, editorMode);
 
             // Expect no error as there is no duplicate activation
             EXPECT_TRUE(result.IsSuccess());
 
             // Expect the mode to be active for the viewport
-            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid });
-            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
+            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ id });
+            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
             EXPECT_NE(viewportEditorModeState, nullptr);
             EXPECT_TRUE(viewportEditorModeState->IsModeActive(editorMode));
         }
         {
             // When the mode is activated again for the viewport
-            const auto result = m_viewportEditorModeTracker.ActivateMode({ viewportid }, editorMode);
+            const auto result = m_viewportEditorModeTracker.ActivateMode({ id }, editorMode);
 
             // Expect an error for the duplicate activation
             const auto expectedErrorMsg = AZStd::string::format(
-                "Duplicate call to ActivateMode for mode '%u' on id '%i'", static_cast<AZ::u32>(editorMode), viewportid);
+                "Duplicate call to ActivateMode for mode '%u' on id '%s'", static_cast<AZ::u32>(editorMode),
+                id.ToString<AZStd::string>().c_str());
             EXPECT_FALSE(result.IsSuccess());
             EXPECT_EQ(result.GetError(), expectedErrorMsg);
 
             // Expect the mode to still be active for the viewport
-            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid });
-            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
+            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ id });
+            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
             EXPECT_NE(viewportEditorModeState, nullptr);
             EXPECT_TRUE(viewportEditorModeState->IsModeActive(editorMode));
         }
@@ -408,38 +411,39 @@ namespace UnitTest
     TEST_F(ViewportEditorModeTrackerTestFixture, DeactivatingViewportEditorModesForExistingIdNotInThatStateReturnssError)
     {
         // Given a viewport not currently tracked
-        const ViewportId viewportid = 0;
-        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
-        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid }), nullptr);
+        const TrackerId id = 0;
+        EXPECT_FALSE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
+        EXPECT_EQ(m_viewportEditorModeTracker.GetViewportEditorModes({ id }), nullptr);
 
         const auto editorMode = ViewportEditorMode::Default;
         {
             // When the mode is activated and then deactivated for the viewport
-            m_viewportEditorModeTracker.ActivateMode({ viewportid }, editorMode);
-            const auto result = m_viewportEditorModeTracker.DeactivateMode({ viewportid }, editorMode);
+            m_viewportEditorModeTracker.ActivateMode({ id }, editorMode);
+            const auto result = m_viewportEditorModeTracker.DeactivateMode({ id }, editorMode);
 
             // Expect no error as there is no duplicate deactivation
             EXPECT_TRUE(result.IsSuccess());
 
             // Expect the mode to be inctive for the viewport
-            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid });
-            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
+            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ id });
+            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
             EXPECT_NE(viewportEditorModeState, nullptr);
             EXPECT_FALSE(viewportEditorModeState->IsModeActive(editorMode));
         }
         {
             // When the mode is deactivated again for the viewport
-            const auto result = m_viewportEditorModeTracker.DeactivateMode({ viewportid }, editorMode);
+            const auto result = m_viewportEditorModeTracker.DeactivateMode({ id }, editorMode);
 
             // Expect an error for the duplicate deactivation
             const auto expectedErrorMsg = AZStd::string::format(
-                "Duplicate call to DeactivateMode for mode '%u' on id '%i'", static_cast<AZ::u32>(editorMode), viewportid);
+                "Duplicate call to DeactivateMode for mode '%u' on id '%s'", static_cast<AZ::u32>(editorMode),
+                id.ToString<AZStd::string>().c_str());
             EXPECT_FALSE(result.IsSuccess());
             EXPECT_EQ(result.GetError(), expectedErrorMsg);
 
             // Expect the mode to still be inactive for the viewport
-            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ viewportid });
-            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ viewportid }));
+            const auto* viewportEditorModeState = m_viewportEditorModeTracker.GetViewportEditorModes({ id });
+            EXPECT_TRUE(m_viewportEditorModeTracker.IsViewportModeTracked({ id }));
             EXPECT_NE(viewportEditorModeState, nullptr);
             EXPECT_FALSE(viewportEditorModeState->IsModeActive(editorMode));
         }
@@ -459,9 +463,9 @@ namespace UnitTest
         // When each editor mode is activated by the state tracker for a specific viewport
         for (auto mode = 0; mode < ViewportEditorModes::NumEditorModes; mode++)
         {
-            const ViewportId viewportId = mode;
+            const TrackerId id = m_handlerIds[mode];
             const ViewportEditorMode editorMode = static_cast<ViewportEditorMode>(mode);
-            m_viewportEditorModeTracker.ActivateMode({ viewportId }, editorMode);
+            m_viewportEditorModeTracker.ActivateMode({ id }, editorMode);
         }
 
         for (auto mode = 0; mode < ViewportEditorModes::NumEditorModes; mode++)
@@ -491,10 +495,10 @@ namespace UnitTest
         // When each editor mode is activated deactivated by the state tracker for a specific viewport
         for (auto mode = 0; mode < ViewportEditorModes::NumEditorModes; mode++)
         {
-            const ViewportId viewportId = mode;
+            const TrackerId id = m_handlerIds[mode];
             const ViewportEditorMode editorMode = static_cast<ViewportEditorMode>(mode);
-            m_viewportEditorModeTracker.ActivateMode({ viewportId }, editorMode);
-            m_viewportEditorModeTracker.DeactivateMode({ viewportId }, editorMode);
+            m_viewportEditorModeTracker.ActivateMode({ id }, editorMode);
+            m_viewportEditorModeTracker.DeactivateMode({ id }, editorMode);
         }
 
         for (auto mode = 0; mode < ViewportEditorModes::NumEditorModes; mode++)

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
@@ -18,8 +18,8 @@ namespace UnitTest
     using ViewportEditorMode = AzToolsFramework::ViewportEditorMode;
     using ViewportEditorModes = AzToolsFramework::ViewportEditorModes;
     using ViewportEditorModeTracker = AzToolsFramework::ViewportEditorModeTracker;
-    using ViewportEditorModeInfo = AzToolsFramework::ViewportEditorModeInfo;
-    using TrackerId = ViewportEditorModeInfo::IdType;
+    using ViewportEditorModeTrackerInfo = AzToolsFramework::ViewportEditorModeTrackerInfo;
+    using TrackerId = ViewportEditorModeTrackerInfo::IdType;
     using ViewportEditorModesInterface = AzToolsFramework::ViewportEditorModesInterface;
     using ViewportEditorModeTrackerInterface = AzToolsFramework::ViewportEditorModeTrackerInterface;
 

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
@@ -157,6 +157,7 @@ namespace UnitTest
             m_handlerIds.resize(ViewportEditorModes::NumEditorModes);
             for (auto mode = 0; mode < ViewportEditorModes::NumEditorModes; mode++)
             {
+                // Create a random GUID for each handler and associate that GUID with an index derived from one of the possible editor modes
                 m_handlerIds[mode] = TrackerId::CreateRandom();
                 m_editorModeHandlers[mode] = AZStd::make_unique<ViewportEditorModeNotificationsBusHandler>(m_handlerIds[mode]);
             }


### PR DESCRIPTION
**Overview**

This PR changes the id associated with each `ViewportEditorModeTracker` from `ViewportId` to `EntityContxtId`. The implication here is that trackers are now organized by entity context and not viewport.

**Testing**

```
[==========] Running 31 tests from 5 test cases.
[----------] Global test environment set-up.
[----------] 4 tests from ViewportEditorModesTestsFixture
[ RUN      ] ViewportEditorModesTestsFixture.NumberOfEditorModesIsEqualTo4
[       OK ] ViewportEditorModesTestsFixture.NumberOfEditorModesIsEqualTo4 (0 ms)
[ RUN      ] ViewportEditorModesTestsFixture.InitialEditorModeStateHasAllInactiveModes
[       OK ] ViewportEditorModesTestsFixture.InitialEditorModeStateHasAllInactiveModes (1 ms)
[ RUN      ] ViewportEditorModesTestsFixture.SettingOutOfBoundsModeActiveReturnsError
[       OK ] ViewportEditorModesTestsFixture.SettingOutOfBoundsModeActiveReturnsError (0 ms)
[ RUN      ] ViewportEditorModesTestsFixture.SettingOutOfBoundsModeInactiveReturnsError
[       OK ] ViewportEditorModesTestsFixture.SettingOutOfBoundsModeInactiveReturnsError (0 ms)
[----------] 4 tests from ViewportEditorModesTestsFixture (1 ms total)

[----------] 6 tests from ViewportEditorModeTrackerTestFixture
[ RUN      ] ViewportEditorModeTrackerTestFixture.InitialCentralStateTrackerHasNoViewportEditorModess
[       OK ] ViewportEditorModeTrackerTestFixture.InitialCentralStateTrackerHasNoViewportEditorModess (480 ms)
[ RUN      ] ViewportEditorModeTrackerTestFixture.ActivatingViewportEditorModeForNonExistentIdCreatesViewportEditorModesForThatId
[       OK ] ViewportEditorModeTrackerTestFixture.ActivatingViewportEditorModeForNonExistentIdCreatesViewportEditorModesForThatId (292 ms)
[ RUN      ] ViewportEditorModeTrackerTestFixture.DeactivatingViewportEditorModeForNonExistentIdCreatesViewportEditorModesForThatIdButReturnsError
[       OK ] ViewportEditorModeTrackerTestFixture.DeactivatingViewportEditorModeForNonExistentIdCreatesViewportEditorModesForThatIdButReturnsError (298 ms)
[ RUN      ] ViewportEditorModeTrackerTestFixture.GettingNonExistentViewportEditorModesForIdReturnsNull
[       OK ] ViewportEditorModeTrackerTestFixture.GettingNonExistentViewportEditorModesForIdReturnsNull (265 ms)
[ RUN      ] ViewportEditorModeTrackerTestFixture.ActivatingViewportEditorModesForExistingIdInThatStateReturnsError
[       OK ] ViewportEditorModeTrackerTestFixture.ActivatingViewportEditorModesForExistingIdInThatStateReturnsError (251 ms)
[ RUN      ] ViewportEditorModeTrackerTestFixture.DeactivatingViewportEditorModesForExistingIdNotInThatStateReturnssError
[       OK ] ViewportEditorModeTrackerTestFixture.DeactivatingViewportEditorModesForExistingIdNotInThatStateReturnssError (296 ms)
[----------] 6 tests from ViewportEditorModeTrackerTestFixture (1892 ms total)

[----------] 2 tests from ViewportEditorModePublisherTestFixture
[ RUN      ] ViewportEditorModePublisherTestFixture.ActivatingViewportEditorModesForExistingIdPublishesOnViewportEditorModeActivateEventForAllSubscribers
[       OK ] ViewportEditorModePublisherTestFixture.ActivatingViewportEditorModesForExistingIdPublishesOnViewportEditorModeActivateEventForAllSubscribers (248 ms)
[ RUN      ] ViewportEditorModePublisherTestFixture.DeactivatingViewportEditorModesForExistingIdPublishesOnViewportEditorModeDeactivatingEventForAllSubscribers
[       OK ] ViewportEditorModePublisherTestFixture.DeactivatingViewportEditorModesForExistingIdPublishesOnViewportEditorModeDeactivatingEventForAllSubscribers (250 ms)
[----------] 2 tests from ViewportEditorModePublisherTestFixture (503 ms total)

[----------] 3 tests from ViewportEditorModeTrackerIntegrationTestFixture
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.InitialViewportEditorModeIsDefault
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.InitialViewportEditorModeIsDefault (250 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringComponentModeAfterInitialStateHasViewportEditorModesDefaultAndComponentModeActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringComponentModeAfterInitialStateHasViewportEditorModesDefaultAndComponentModeActive (243 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringEditorPickEntitySelectionAfterInitialStateHasOnlyViewportEditorModePickModeActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringEditorPickEntitySelectionAfterInitialStateHasOnlyViewportEditorModePickModeActive (251 ms)
[----------] 3 tests from ViewportEditorModeTrackerIntegrationTestFixture (750 ms total)

[----------] 16 tests from AllEditorModes/ViewportEditorModesTestsFixtureWithParams
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/0
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/0 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/1
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/1 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/2
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/2 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/3
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeActiveActivatesOnlyThatMode/3 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/0
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/0 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/1
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/1 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/2
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/2 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/3
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingModeInactiveInactivatesOnlyThatMode/3 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/0
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/0 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/1
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/1 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/2
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/2 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/3
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesActiveActivatesAllThoseModesNonMutuallyExclusively/3 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/0
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/0 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/1
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/1 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/2
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/2 (0 ms)
[ RUN      ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/3
[       OK ] AllEditorModes/ViewportEditorModesTestsFixtureWithParams.SettingMultipleModesInactiveInactivatesAllThoseModesNonMutuallyExclusively/3 (0 ms)
[----------] 16 tests from AllEditorModes/ViewportEditorModesTestsFixtureWithParams (29 ms total)

[----------] Global test environment tear-down
[==========] 31 tests from 5 test cases ran. (3186 ms total)
[  PASSED  ] 31 tests.
```

Signed-off-by: John <jonawals@amazon.com>