### PR TITLE
Fix issue that gives wrong results for running debugger

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -38,11 +38,11 @@ namespace AZ
                 {
                     return false;
                 }
-                for (size_t i = tracerPidOffset; i < numRead; ++i)
+                for (size_t i = tracerPidOffset + tracerPidString.length(); i < numRead; ++i)
                 {
                     if (!::isspace(processStatusView[i]))
                     {
-                        return processStatusView[i] != '0';
+                        return (::isdigit(processStatusView[i]) != 0) && processStatusView[i] != '0';
                     }
                 }
                 return false;

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/Debug/Trace_UnixLike.cpp
@@ -42,7 +42,7 @@ namespace AZ
                 {
                     if (!::isspace(processStatusView[i]))
                     {
-                        return (::isdigit(processStatusView[i]) != 0) && processStatusView[i] != '0';
+                        return processStatusView[i] != '0';
                     }
                 }
                 return false;


### PR DESCRIPTION
Hi O3DE Team

The current implementation for performDebuggerDetection is giving wrong results. processStatusView.find(tracerPidString) will return the starting location of that string.  If I am not wrong continuing in the logic, checking the first letter "t" is not a whitespace and neither "0" it will return always true.

Signed-off-by: Yaakuro <y1@codeposer.net>