### PR TITLE
partial fixes for loading level.pak files from within other pak files

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCacheFactory.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirCacheFactory.cpp
@@ -76,7 +76,7 @@ namespace AZ::IO::ZipDir
         // first, try to open the file for reading or reading/writing
         if (m_nFlags & FLAGS_READ_ONLY)
         {
-            AZ::IO::FileIOBase::GetDirectInstance()->Open(szFileName, AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeBinary, m_fileExt.m_fileHandle);
+            m_fileExt.m_fileIOBase->Open(szFileName, AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeBinary, m_fileExt.m_fileHandle);
             pCache->m_nFlags |= Cache::FLAGS_CDR_DIRTY | Cache::FLAGS_READ_ONLY;
 
             if (m_fileExt.m_fileHandle == AZ::IO::InvalidHandle)
@@ -95,7 +95,9 @@ namespace AZ::IO::ZipDir
             m_fileExt.m_fileHandle = AZ::IO::InvalidHandle;
             if (!(m_nFlags & FLAGS_CREATE_NEW))
             {
-                AZ::IO::FileIOBase::GetDirectInstance()->Open(szFileName, AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeUpdate | AZ::IO::OpenMode::ModeBinary, m_fileExt.m_fileHandle);
+                m_fileExt.m_fileIOBase->Open(
+                    szFileName, AZ::IO::OpenMode::ModeRead | AZ::IO::OpenMode::ModeUpdate | AZ::IO::OpenMode::ModeBinary,
+                    m_fileExt.m_fileHandle);
             }
 
             bool bOpenForWriting = true;
@@ -122,11 +124,13 @@ namespace AZ::IO::ZipDir
             {
                 if (m_fileExt.m_fileHandle != AZ::IO::InvalidHandle)
                 {
-                    AZ::IO::FileIOBase::GetDirectInstance()->Close(m_fileExt.m_fileHandle);
+                    m_fileExt.m_fileIOBase->Close(m_fileExt.m_fileHandle);
                     m_fileExt.m_fileHandle = AZ::IO::InvalidHandle;
                 }
 
-                if (AZ::IO::FileIOBase::GetDirectInstance()->Open(szFileName, AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeUpdate | AZ::IO::OpenMode::ModeBinary, m_fileExt.m_fileHandle))
+                if (m_fileExt.m_fileIOBase->Open(
+                        szFileName, AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeUpdate | AZ::IO::OpenMode::ModeBinary,
+                        m_fileExt.m_fileHandle))
                 {
                     // there's no such file, but we'll create one. We'll need to write out the CDR here
                     pCache->m_lCDROffset = 0;

--- a/Code/Framework/AzFramework/AzFramework/Archive/ZipDirStructures.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ZipDirStructures.cpp
@@ -434,7 +434,7 @@ namespace AZ::IO::ZipDir
 
         if (AZ::IO::PathView(filename).IsRelative())
         {
-            AZ::IO::FileIOBase::GetDirectInstance()->ResolvePath(volume, filename);
+            m_fileIOBase->ResolvePath(volume, filename);
         }
         else
         {
@@ -754,7 +754,7 @@ namespace AZ::IO::ZipDir
     // the file must be opened both for reading and writing
     ErrorEnum UpdateLocalHeader(AZ::IO::HandleType fileHandle, FileEntryBase* pFileEntry)
     {
-
+        // This function is writing, so use the direct instance, it won't write to an archive nested in another archive.
         if (!AZ::IO::FileIOBase::GetDirectInstance()->Seek(fileHandle, pFileEntry->nFileHeaderOffset, AZ::IO::SeekType::SeekFromStart))
         {
             return ZD_ERROR_IO_FAILED;
@@ -799,6 +799,7 @@ namespace AZ::IO::ZipDir
         pFileEntry->nFileDataOffset = aznumeric_cast<uint32_t>(pFileEntry->nFileHeaderOffset + nHeaderSize);
         pFileEntry->nEOFOffset = pFileEntry->nFileDataOffset + pFileEntry->desc.lSizeCompressed;
 
+        // This function is writing, so use the direct instance, it won't write to an archive nested in another archive.
         if (!AZ::IO::FileIOBase::GetDirectInstance()->Seek(fileHandle, pFileEntry->nFileHeaderOffset, AZ::IO::SeekType::SeekFromStart))
         {
             return ZD_ERROR_IO_FAILED;
@@ -1031,7 +1032,7 @@ namespace AZ::IO::ZipDir
         }
         else
         {
-            if (AZ::IO::FileIOBase::GetDirectInstance()->Seek(file->m_fileHandle, origin, AZ::IO::GetSeekTypeFromFSeekMode(command)))
+            if (file->m_fileIOBase->Seek(file->m_fileHandle, origin, AZ::IO::GetSeekTypeFromFSeekMode(command)))
             {
                 return 0;
             }
@@ -1061,7 +1062,7 @@ namespace AZ::IO::ZipDir
         {
             AZ::IO::HandleType fileHandle = file->m_fileHandle;
             AZ::u64 bytesRead = 0;
-            AZ::IO::FileIOBase::GetDirectInstance()->Read(fileHandle, data, elementSize * count, false, &bytesRead);
+            file->m_fileIOBase->Read(fileHandle, data, elementSize * count, false, &bytesRead);
             return bytesRead / elementSize;
         }
     }
@@ -1075,7 +1076,7 @@ namespace AZ::IO::ZipDir
         else
         {
             AZ::u64 tellResult = 0;
-            AZ::IO::FileIOBase::GetDirectInstance()->Tell(file->m_fileHandle, tellResult);
+            file->m_fileIOBase->Tell(file->m_fileHandle, tellResult);
             return tellResult;
         }
     }
@@ -1088,7 +1089,7 @@ namespace AZ::IO::ZipDir
         }
         else
         {
-            return AZ::IO::FileIOBase::GetDirectInstance()->Eof(zipFile->m_fileHandle);
+            return zipFile->m_fileIOBase->Eof(zipFile->m_fileHandle);
         }
     }
 }

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -339,7 +339,9 @@ void CLevelSystem::PopulateLevels(
     {
         // allow this find first to actually touch the file system
         // (causes small overhead but with minimal amount of levels this should only be around 150ms on actual DVD Emu)
-        AZ::IO::ArchiveFileIterator handle = pPak->FindFirst(searchPattern.c_str(), AZ::IO::IArchive::eFileSearchType_AllowOnDiskOnly);
+        const AZ::IO::IArchive::EFileSearchType fileSearchType =
+            fromFileSystemOnly ? AZ::IO::IArchive::eFileSearchType_AllowOnDiskOnly : AZ::IO::IArchive::eFileSearchType_AllowInZipsOnly;
+        AZ::IO::ArchiveFileIterator handle = pPak->FindFirst(searchPattern.c_str(), fileSearchType);
 
         if (handle)
         {


### PR DESCRIPTION
Fixed incorrect search for levels with the term levels.pak, replaced with level.pak
Fixed pak file searching to allow for pak files to be found inside of other pak files
Updated ZipDir logic to use m_fileExt.m_fileIOBase instead of hardcoding calls to GetDirectInstance

Signed-off-by: stankowi <4838196+AMZN-stankowi@users.noreply.github.com>