### PR TITLE
Updated LmbrCentral gem.json documentation_url field. This doc is being moved 

### DIFF
--- a/Gems/LmbrCentral/gem.json
+++ b/Gems/LmbrCentral/gem.json
@@ -15,6 +15,6 @@
     ],
     "icon_path": "preview.png",
     "requirements": "",
-    "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/core/lmbr-central/",
+    "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/o3de-core/",
     "dependencies": []
 }


### PR DESCRIPTION
per: https://github.com/o3de/o3de.org/pull/993

Signed-off-by: Mike Cronin <58789750+micronAMZN@users.noreply.github.com>