### PR TITLE
Add field names, tooltips to AWSClientAuth gem AuthenticationProvider…

### DIFF
--- a/Gems/AWSClientAuth/Code/Source/AWSClientAuthSystemComponent.cpp
+++ b/Gems/AWSClientAuth/Code/Source/AWSClientAuthSystemComponent.cpp
@@ -33,7 +33,7 @@ namespace AWSClientAuth
         AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
         if (serialize)
         {
-            serialize->Class<AWSClientAuthSystemComponent, AZ::Component>()->Version(0);
+            serialize->Class<AWSClientAuthSystemComponent, AZ::Component>()->Version(1);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -55,26 +55,44 @@ namespace AWSClientAuth
                 ->Enum<(int)ProviderNameEnum::AWSCognitoIDP>("ProviderNameEnum_AWSCognitoIDP")
                 ->Enum<(int)ProviderNameEnum::LoginWithAmazon>("ProviderNameEnum_LoginWithAmazon")
                 ->Enum<(int)ProviderNameEnum::Google>("ProviderNameEnum_Google");
-
             behaviorContext->EBus<AuthenticationProviderScriptCanvasRequestBus>("AuthenticationProviderRequestBus")
                 ->Attribute(AZ::Script::Attributes::Category, SerializeComponentName)
                 ->Event("Initialize", &AuthenticationProviderScriptCanvasRequestBus::Events::Initialize)
-                ->Event("IsSignedIn", &AuthenticationProviderScriptCanvasRequestBus::Events::IsSignedIn)
-                ->Event("GetAuthenticationTokens", &AuthenticationProviderScriptCanvasRequestBus::Events::GetAuthenticationTokens)
+                ->Event("IsSignedIn", &AuthenticationProviderScriptCanvasRequestBus::Events::IsSignedIn,
+                    { { { "Provider name", "The identity provider name" } } })
+                ->Event("GetAuthenticationTokens", &AuthenticationProviderScriptCanvasRequestBus::Events::GetAuthenticationTokens,
+                    { { { "Provider name", "The identity provider name" } } })
                 ->Event(
                     "PasswordGrantSingleFactorSignInAsync",
-                    &AuthenticationProviderScriptCanvasRequestBus::Events::PasswordGrantSingleFactorSignInAsync)
+                    &AuthenticationProviderScriptCanvasRequestBus::Events::PasswordGrantSingleFactorSignInAsync,
+                    { { { "Provider name", "The identity provider" }, { "Username", "The client's username" }, { "Password", "The client's password" } } })
                 ->Event(
                     "PasswordGrantMultiFactorSignInAsync",
-                    &AuthenticationProviderScriptCanvasRequestBus::Events::PasswordGrantMultiFactorSignInAsync)
+                    &AuthenticationProviderScriptCanvasRequestBus::Events::PasswordGrantMultiFactorSignInAsync,
+                    { { { "Provider name", "The identity provider name" },
+                        { "Username", "The client's username" },
+                        { "Password", "The client's password" } } })
                 ->Event(
                     "PasswordGrantMultiFactorConfirmSignInAsync",
-                    &AuthenticationProviderScriptCanvasRequestBus::Events::PasswordGrantMultiFactorConfirmSignInAsync)
-                ->Event("DeviceCodeGrantSignInAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::DeviceCodeGrantSignInAsync)
-                ->Event("DeviceCodeGrantConfirmSignInAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::DeviceCodeGrantConfirmSignInAsync)
-                ->Event("RefreshTokensAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::RefreshTokensAsync)
-                ->Event("GetTokensWithRefreshAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::GetTokensWithRefreshAsync)
-                ->Event("SignOut", &AuthenticationProviderScriptCanvasRequestBus::Events::SignOut);
+                    &AuthenticationProviderScriptCanvasRequestBus::Events::PasswordGrantMultiFactorConfirmSignInAsync,
+                    { { { "Provider name", "The identity provider name" },
+                        { "Username", "The client's username" },
+                        { "Confirmation code", "The client's confirmation code" } } })
+                ->Event(
+                    "DeviceCodeGrantSignInAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::DeviceCodeGrantSignInAsync,
+                    { { { "Provider name", "The identity provider name" } } })
+                ->Event(
+                    "DeviceCodeGrantConfirmSignInAsync",
+                    &AuthenticationProviderScriptCanvasRequestBus::Events::DeviceCodeGrantConfirmSignInAsync,
+                    { { { "Provider name", "The identity provider name" } } })
+                ->Event(
+                    "RefreshTokensAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::RefreshTokensAsync,
+                    { { { "Provider name", "The identity provider name" } } })
+                ->Event("GetTokensWithRefreshAsync", &AuthenticationProviderScriptCanvasRequestBus::Events::GetTokensWithRefreshAsync,
+                    { { { "Provider name", "The identity provider name" } } })
+                ->Event(
+                    "SignOut", &AuthenticationProviderScriptCanvasRequestBus::Events::SignOut,
+                    { { { "Provider name", "The identity provider name" } } });
 
             behaviorContext->EBus<AWSCognitoAuthorizationRequestBus>("AWSCognitoAuthorizationRequestBus")
                 ->Attribute(AZ::Script::Attributes::Category, SerializeComponentName)


### PR DESCRIPTION
…ScriptCanvasRequestBus nodes

Field names taken from [AuthenticationProviderManager.cpp](https://github.com/o3de/o3de/blob/development/Gems/AWSClientAuth/Code/Source/Authentication/AuthenticationProviderManager.cpp) params

## testing

* project builds and runs on Windows.
* unit tests pass
![image](https://user-images.githubusercontent.com/34254888/135892321-2316ba16-c381-4144-b33a-9e54ce1a6b9b.png)

* screenshot of old vs. new nodes in script canvas:

![image](https://user-images.githubusercontent.com/34254888/135697693-c3966928-c66b-411c-909a-e84552c05f18.png)


TBD: whether we want to add a version check/prompt 



Signed-off-by: Stanko <stankoa@amazon.com>