### PR TITLE
Fix EditorServer Connection

### DIFF
--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -146,7 +146,6 @@ namespace Multiplayer
                     {
                         // Connect the Editor to the editor server for Multiplayer simulation
                         AZ::Interface<IMultiplayer>::Get()->Connect(remoteAddress.c_str(), remotePort);
-                        AZ::Interface<IMultiplayer>::Get()->SendReadyForEntityUpdates(true);
                     }
             }
         }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -142,8 +142,14 @@ namespace Multiplayer
         }
 
         // Start the configured server if it's available
+        AZStd::string projectPath(AZ::Utils::GetProjectPath().c_str());
+        AZStd::replace(projectPath.begin(), projectPath.end(), AZ::IO::WindowsPathSeparator, AZ::IO::PosixPathSeparator);
         AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
-        processLaunchInfo.m_commandlineParameters = AZStd::string::format("\"%s\" --editorsv_isDedicated true", serverPath.c_str());
+        processLaunchInfo.m_commandlineParameters = AZStd::string::format(
+            R"("%s" --project-path "%s" --editorsv_isDedicated true --sv_defaultPlayerSpawnAsset "%s")",
+            serverPath.c_str(),
+            projectPath.c_str(),
+            static_cast<AZ::CVarFixedString>(sv_defaultPlayerSpawnAsset).c_str());
         processLaunchInfo.m_showWindow = true;
         processLaunchInfo.m_processPriority = AzFramework::ProcessPriority::PROCESSPRIORITY_NORMAL;
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -37,6 +37,8 @@ namespace AzNetworking
 
 namespace Multiplayer
 {
+    AZ_CVAR_EXTERNED(AZ::CVarFixedString, sv_defaultPlayerSpawnAsset);
+
     //! Multiplayer system component wraps the bridging logic between the game and transport layer.
     class MultiplayerSystemComponent final
         : public AZ::Component


### PR DESCRIPTION
1. Fix EditorServer Connection by ensuring that SendReadyForEntityUpdates is only called after a handshake is finished and the editor has accepted the editorserver's connection. 
2. Allow engine-centric projects to use editor-server by passing in the project-path when launching the editor-server. 
3. Allow devs to set sv_defaultPlayerSpawnAsset from inside the editor via console and it'll be used by the editor-server.

Signed-off-by: Gene Walters <genewalt@amazon.com>