### PR TITLE
EMotion FX: Simple LOD Component to use Atom LOD override

### DIFF
--- a/Gems/EMotionFX/Code/CMakeLists.txt
+++ b/Gems/EMotionFX/Code/CMakeLists.txt
@@ -36,6 +36,7 @@ ly_add_target(
         PUBLIC
             AZ::AtomCore
             Gem::Atom_RPI.Public
+            Gem::AtomLyIntegration_CommonFeatures.Static
             Gem::LmbrCentral
     COMPILE_DEFINITIONS
         PUBLIC

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.h
@@ -17,7 +17,7 @@
 
 #include <Integration/Assets/MotionAsset.h>
 #include <Integration/ActorComponentBus.h>
-
+#include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h>
 
 namespace EMotionFX
 {
@@ -93,6 +93,9 @@ namespace EMotionFX
 
             Configuration                               m_configuration;        // Component configuration.
             EMotionFX::ActorInstance*                   m_actorInstance;        // Associated actor instance (retrieved from Actor Component).
+
+            AZ::RPI::Cullable::LodType m_previousLodType = AZ::RPI::Cullable::LodType::Default;
+            size_t m_previousLodLevel = 0;
         };
 
     } // namespace Integration


### PR DESCRIPTION
The LOD level for skinned meshes is determined in the render phase, which is after the animation update and is also specific to the camera/target Atom renders to, which means that different render targets could end up using different LOD levels depending on how much screen space the character's bounding box takes.

In order to make sure that all transformations are calculated by EMotion FX that the skinned mesh Atom wants to render are available, the Simple LOD Component takes ownership of the LOD level and uses the Atom LOD override. That way Atom adapts to the LOD level determined by the Simple LOD component and makes sure the skeletal matches with the geometry LOD levels.

![LODOverride](https://user-images.githubusercontent.com/43751992/135853446-e3bd1e9c-c91a-4755-9e7e-482638e45215.gif)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>