### PR TITLE
[LY-111998] Surface Tags didn't refresh immediately.

### DIFF
--- a/Gems/SurfaceData/Code/Source/Editor/EditorSurfaceDataSystemComponent.h
+++ b/Gems/SurfaceData/Code/Source/Editor/EditorSurfaceDataSystemComponent.h
@@ -48,6 +48,7 @@ namespace SurfaceData
 
     private:
 
+        void LoadAsset(const AZ::Data::AssetId& assetId);
         void AddAsset(AZ::Data::Asset<AZ::Data::AssetData>& asset);
 
         ////////////////////////////////////////////////////////////////////////
@@ -63,7 +64,6 @@ namespace SurfaceData
         ////////////////////////////////////////////////////////////////////////
         // AzFramework::AssetCatalogEventBus
         void OnCatalogLoaded(const char* /*catalogFile*/) override;
-        void OnCatalogAssetChanged(const AZ::Data::AssetId& assetId) override;
         void OnCatalogAssetAdded(const AZ::Data::AssetId& assetId) override;
         void OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo) override;
 


### PR DESCRIPTION
When adding or modifying surface tags to a surface tag list asset, the surface tag lists didn't immediately refresh in the Editor.  There were a couple of bugs in the way the tag assets were getting loaded and monitored that are now fixed.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>