### PR TITLE
Fixed PhysX and Blast creation of default config files

### DIFF
--- a/AutomatedTesting/Registry/physx_overrides/Collider_AddingNewGroupWorks.setreg_override
+++ b/AutomatedTesting/Registry/physx_overrides/Collider_AddingNewGroupWorks.setreg_override
@@ -109,7 +109,7 @@
                     },
                     "MaterialLibrary": {
                         "assetId": {
-                            "guid": "{62446378-67F8-5E49-AC31-761DD5942695}"
+                            "guid": "{7CDF49C3-91A2-5C4E-B642-6D1AEC80E70E}"
                         },
                         "loadBehavior": "QueueLoad",
                         "assetHint": "assets/physics/surfacetypemateriallibrary.physmaterial"

--- a/AutomatedTesting/Registry/physx_overrides/Collider_CollisionGroupsWorkflow.setreg_override
+++ b/AutomatedTesting/Registry/physx_overrides/Collider_CollisionGroupsWorkflow.setreg_override
@@ -121,7 +121,7 @@
                     },
                     "MaterialLibrary": {
                         "assetId": {
-                            "guid": "{62446378-67F8-5E49-AC31-761DD5942695}"
+                            "guid": "{7CDF49C3-91A2-5C4E-B642-6D1AEC80E70E}"
                         },
                         "loadBehavior": "QueueLoad",
                         "assetHint": "assets/physics/surfacetypemateriallibrary.physmaterial"

--- a/AutomatedTesting/Registry/physx_overrides/Collider_DiffCollisionGroupDiffCollidingLayersNotCollide.setreg_override
+++ b/AutomatedTesting/Registry/physx_overrides/Collider_DiffCollisionGroupDiffCollidingLayersNotCollide.setreg_override
@@ -121,7 +121,7 @@
                     },
                     "MaterialLibrary": {
                         "assetId": {
-                            "guid": "{62446378-67F8-5E49-AC31-761DD5942695}"
+                            "guid": "{7CDF49C3-91A2-5C4E-B642-6D1AEC80E70E}"
                         },
                         "loadBehavior": "QueueLoad",
                         "assetHint": "assets/physics/surfacetypemateriallibrary.physmaterial"

--- a/AutomatedTesting/Registry/physx_overrides/Collider_NoneCollisionGroupSameLayerNotCollide.setreg_override
+++ b/AutomatedTesting/Registry/physx_overrides/Collider_NoneCollisionGroupSameLayerNotCollide.setreg_override
@@ -121,7 +121,7 @@
                     },
                     "MaterialLibrary": {
                         "assetId": {
-                            "guid": "{62446378-67F8-5E49-AC31-761DD5942695}"
+                            "guid": "{7CDF49C3-91A2-5C4E-B642-6D1AEC80E70E}"
                         },
                         "loadBehavior": "QueueLoad",
                         "assetHint": "assets/physics/surfacetypemateriallibrary.physmaterial"

--- a/AutomatedTesting/Registry/physx_overrides/Collider_SameCollisionGroupSameCustomLayerCollide.setreg_override
+++ b/AutomatedTesting/Registry/physx_overrides/Collider_SameCollisionGroupSameCustomLayerCollide.setreg_override
@@ -121,7 +121,7 @@
                     },
                     "MaterialLibrary": {
                         "assetId": {
-                            "guid": "{62446378-67F8-5E49-AC31-761DD5942695}"
+                            "guid": "{7CDF49C3-91A2-5C4E-B642-6D1AEC80E70E}"
                         },
                         "loadBehavior": "QueueLoad",
                         "assetHint": "assets/physics/surfacetypemateriallibrary.physmaterial"

--- a/AutomatedTesting/Registry/physxsystemconfiguration.setreg
+++ b/AutomatedTesting/Registry/physxsystemconfiguration.setreg
@@ -103,7 +103,7 @@
                     },
                     "MaterialLibrary": {
                         "assetId": {
-                            "guid": "{62446378-67F8-5E49-AC31-761DD5942695}"
+                            "guid": "{7CDF49C3-91A2-5C4E-B642-6D1AEC80E70E}"
                         },
                         "loadBehavior": "QueueLoad",
                         "assetHint": "assets/physics/surfacetypemateriallibrary.physmaterial"

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -286,8 +286,11 @@ namespace Blast
             DefaultConfigurationPath, globalConfiguration);
         AZ_Warning("Blast", loaded, "Failed to load Blast configuration, initializing with default configs.");
 
-        SetGlobalConfiguration(globalConfiguration);
-        SaveConfiguration();
+        ApplyGlobalConfiguration(globalConfiguration);
+        if (!loaded)
+        {
+            SaveConfiguration();
+        }
     }
 
     void BlastSystemComponent::SaveConfiguration()
@@ -394,8 +397,13 @@ namespace Blast
 
     void BlastSystemComponent::SetGlobalConfiguration(const BlastGlobalConfiguration& globalConfiguration)
     {
-        m_configuration = globalConfiguration;
+        ApplyGlobalConfiguration(globalConfiguration);
         SaveConfiguration();
+    }
+
+    void BlastSystemComponent::ApplyGlobalConfiguration(const BlastGlobalConfiguration& globalConfiguration)
+    {
+        m_configuration = globalConfiguration;
 
         {
             AZ::Data::Asset<Blast::BlastMaterialLibraryAsset>& materialLibrary = m_configuration.m_materialLibrary;

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.h
@@ -93,6 +93,7 @@ namespace Blast
         void InitPhysics();
         void DeactivatePhysics();
 
+        void ApplyGlobalConfiguration(const BlastGlobalConfiguration& materialLibrary);
         void RegisterCommands();
 
         // Internal helper functions & classes

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -23,7 +23,7 @@
 
 namespace PhysX
 {
-    constexpr const char* DefaultAssetFilePath = "Physics/SurfaceTypeMaterialLibrary";
+    constexpr const char* DefaultAssetFilePath = "Assets/Physics/SurfaceTypeMaterialLibrary";
     constexpr const char* TemplateAssetFilename = "PhysX/TemplateMaterialLibrary";
 
     static AZStd::optional<AZ::Data::Asset<AZ::Data::AssetData>> GetMaterialLibraryTemplate()
@@ -67,7 +67,7 @@ namespace PhysX
                 assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, relativePath.c_str(), assetType, true /*autoRegisterIfNotFound*/);
 
             AZ::Data::Asset<AZ::Data::AssetData> newAsset =
-                AZ::Data::AssetManager::Instance().GetAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::Default);
+                AZ::Data::AssetManager::Instance().CreateAsset(assetId, assetType, AZ::Data::AssetLoadBehavior::Default);
 
             if (auto* newMaterialLibraryData = azrtti_cast<Physics::MaterialLibraryAsset*>(newAsset.GetData()))
             {
@@ -138,6 +138,9 @@ namespace PhysX
                     if (auto retrievedMaterialLibrary = RetrieveDefaultMaterialLibrary())
                     {
                         physxSystem->UpdateMaterialLibrary(retrievedMaterialLibrary.value());
+
+                        // After setting the default material library, save the physx configuration.
+                        physxSystem->GetSettingsRegistryManager().SaveSystemConfiguration(physxSystem->GetPhysXConfiguration(), {});
                     }
                 }
             }
@@ -236,9 +239,9 @@ namespace PhysX
             if (!resultAssetId.IsValid())
             {
                 // No file for the default material library, create it
-                const char* assetRoot = AZ::IO::FileIOBase::GetInstance()->GetAlias("@projectsourceassets@");
+                const char* projectRoot = AZ::IO::FileIOBase::GetInstance()->GetAlias("@projectroot@");
                 AZStd::string fullPath;
-                AzFramework::StringFunc::Path::ConstructFull(assetRoot, DefaultAssetFilePath, assetExtension.c_str(), fullPath);
+                AzFramework::StringFunc::Path::ConstructFull(projectRoot, DefaultAssetFilePath, assetExtension.c_str(), fullPath);
 
                 if (auto materialLibraryOpt = CreateMaterialLibrary(fullPath, relativePath))
                 {

--- a/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Components/EditorSystemComponent.cpp
@@ -140,7 +140,12 @@ namespace PhysX
                         physxSystem->UpdateMaterialLibrary(retrievedMaterialLibrary.value());
 
                         // After setting the default material library, save the physx configuration.
-                        physxSystem->GetSettingsRegistryManager().SaveSystemConfiguration(physxSystem->GetPhysXConfiguration(), {});
+                        auto saveCallback = []([[maybe_unused]] const PhysXSystemConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                        {
+                            AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
+                                "Unable to save the PhysX configuration after setting default material library.");
+                        };
+                        physxSystem->GetSettingsRegistryManager().SaveSystemConfiguration(physxSystem->GetPhysXConfiguration(), saveCallback);
                     }
                 }
             }

--- a/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
@@ -511,10 +511,12 @@ namespace PhysX
 
         materialLibrary.BlockUntilLoadComplete();
 
-        AZ_Warning("PhysX", (materialLibrary.GetData() != nullptr),
+        const bool loadedSuccessfully = materialLibrary.GetData() != nullptr && !materialLibrary.IsError();
+
+        AZ_Warning("PhysX", loadedSuccessfully,
             "LoadDefaultMaterialLibrary: Default Material Library asset data is invalid.");
         
-        return materialLibrary.GetData() != nullptr && !materialLibrary.IsError();
+        return loadedSuccessfully;
     }
 
     //TEMP -- until these are fully moved over here

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -459,7 +459,7 @@ namespace PhysX
                 const PhysXSystemConfiguration defaultConfig = PhysXSystemConfiguration::CreateDefault();
                 m_physXSystem->Initialize(&defaultConfig);
 
-                auto saveCallback = []([[maybe_unused]] const PhysXSystemConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                auto saveCallback = []([[maybe_unused]] const PhysXSystemConfiguration& config, [[maybe_unused]] PhysXSettingsRegistryManager::Result result)
                 {
                     AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
                         "Unable to save the default PhysX configuration.");
@@ -478,7 +478,7 @@ namespace PhysX
                 const AzPhysics::SceneConfiguration defaultConfig = AzPhysics::SceneConfiguration::CreateDefault();
                 m_physXSystem->UpdateDefaultSceneConfiguration(defaultConfig);
 
-                auto saveCallback = []([[maybe_unused]] const AzPhysics::SceneConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                auto saveCallback = []([[maybe_unused]] const AzPhysics::SceneConfiguration& config, [[maybe_unused]] PhysXSettingsRegistryManager::Result result)
                 {
                     AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
                         "Unable to save the default Scene configuration.");
@@ -499,7 +499,7 @@ namespace PhysX
                     const Debug::DebugConfiguration defaultConfig = Debug::DebugConfiguration::CreateDefault();
                     debug->Initialize(defaultConfig);
 
-                    auto saveCallback = []([[maybe_unused]] const Debug::DebugConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                    auto saveCallback = []([[maybe_unused]] const Debug::DebugConfiguration& config, [[maybe_unused]] PhysXSettingsRegistryManager::Result result)
                     {
                         AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
                             "Unable to save the default PhysX Debug configuration.");

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -458,7 +458,13 @@ namespace PhysX
             {
                 const PhysXSystemConfiguration defaultConfig = PhysXSystemConfiguration::CreateDefault();
                 m_physXSystem->Initialize(&defaultConfig);
-                registryManager.SaveSystemConfiguration(defaultConfig, {});
+
+                auto saveCallback = []([[maybe_unused]] const PhysXSystemConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                {
+                    AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
+                        "Unable to save the default PhysX configuration.");
+                };
+                registryManager.SaveSystemConfiguration(defaultConfig, saveCallback);
             }
 
             //Load the DefaultSceneConfig
@@ -471,7 +477,13 @@ namespace PhysX
             {
                 const AzPhysics::SceneConfiguration defaultConfig = AzPhysics::SceneConfiguration::CreateDefault();
                 m_physXSystem->UpdateDefaultSceneConfiguration(defaultConfig);
-                registryManager.SaveDefaultSceneConfiguration(defaultConfig, {});
+
+                auto saveCallback = []([[maybe_unused]] const AzPhysics::SceneConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                {
+                    AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
+                        "Unable to save the default Scene configuration.");
+                };
+                registryManager.SaveDefaultSceneConfiguration(defaultConfig, saveCallback);
             }
 
             //load the debug configuration and initialize the PhysX debug interface
@@ -486,7 +498,13 @@ namespace PhysX
                 {
                     const Debug::DebugConfiguration defaultConfig = Debug::DebugConfiguration::CreateDefault();
                     debug->Initialize(defaultConfig);
-                    registryManager.SaveDebugConfiguration(defaultConfig, {});
+
+                    auto saveCallback = []([[maybe_unused]] const Debug::DebugConfiguration& config, PhysXSettingsRegistryManager::Result result)
+                    {
+                        AZ_Warning("PhysX", result == PhysXSettingsRegistryManager::Result::Success,
+                            "Unable to save the default PhysX Debug configuration.");
+                    };
+                    registryManager.SaveDebugConfiguration(defaultConfig, saveCallback);
                 }
             }
         }


### PR DESCRIPTION
- Avoid saving blast global configuration unnecessarily every time the editor is opened.
- Fixed how to obtain the default physics material library. The relative path needs to be from the project folder, not the asset folder inside the project. It was also missing saving the physx configuration after a the default library is assigned to it.
- Fixed asset id for physics material asset 'assets/physics/surfacetypemateriallibrary.physmaterial'

Signed-off-by: moraaar <moraaar@amazon.com>