### PR TITLE
- Optimize SRG compilation to not update the whole SRG if not needed …

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -507,8 +507,13 @@ namespace AZ
                     }
                 }
 
-                RHI::ShaderInputBufferUnboundedArrayIndex bufferUnboundedArrayIndex = srgLayout->FindShaderInputBufferUnboundedArrayIndex(AZ::Name("m_meshBuffers"));
-                m_rayTracingSceneSrg->SetBufferViewUnboundedArray(bufferUnboundedArrayIndex, meshBuffers);
+                //Check if buffer view data changed from previous frame. 
+                if (m_meshBuffers.size() != meshBuffers.size() || m_meshBuffers != meshBuffers)
+                {
+                    m_meshBuffers = meshBuffers;
+                    RHI::ShaderInputBufferUnboundedArrayIndex bufferUnboundedArrayIndex = srgLayout->FindShaderInputBufferUnboundedArrayIndex(AZ::Name("m_meshBuffers"));
+                    m_rayTracingSceneSrg->SetBufferViewUnboundedArray(bufferUnboundedArrayIndex, m_meshBuffers);
+                }
             }
 
             m_rayTracingSceneSrg->Compile();
@@ -554,8 +559,13 @@ namespace AZ
                     }
                 }
 
-                RHI::ShaderInputImageUnboundedArrayIndex textureUnboundedArrayIndex = srgLayout->FindShaderInputImageUnboundedArrayIndex(AZ::Name("m_materialTextures"));
-                m_rayTracingMaterialSrg->SetImageViewUnboundedArray(textureUnboundedArrayIndex, materialTextures);
+                // Check if image view data changed from previous frame. 
+                if (m_materialTextures.size() != materialTextures.size() || m_materialTextures != materialTextures)
+                {
+                    m_materialTextures = materialTextures;
+                    RHI::ShaderInputImageUnboundedArrayIndex textureUnboundedArrayIndex = srgLayout->FindShaderInputImageUnboundedArrayIndex(AZ::Name("m_materialTextures"));
+                    m_rayTracingMaterialSrg->SetImageViewUnboundedArray(textureUnboundedArrayIndex, materialTextures);
+                }
             }
 
             m_rayTracingMaterialSrg->Compile();

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.h
@@ -281,6 +281,10 @@ namespace AZ
 
             using BlasInstanceMap = AZStd::unordered_map<AZ::Data::AssetId, MeshBlasInstance>;
             BlasInstanceMap m_blasInstanceMap;
+
+            // Cache view pointers so we dont need to update them if none changed from frame to frame.
+            AZStd::vector<const RHI::BufferView*> m_meshBuffers;
+            AZStd::vector<const RHI::ImageView*> m_materialTextures;
         };
     }
 }

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/ShaderResourceGroupData.h
@@ -179,6 +179,42 @@ namespace AZ
             //! Returns the shader resource layout for this group.
             const ShaderResourceGroupLayout* GetLayout() const;
 
+            enum class ResourceType : uint32_t
+            {
+                ConstantData,
+                BufferView,
+                ImageView,
+                BufferViewUnboundedArray,
+                ImageViewUnboundedArray,
+                Sampler,
+                Count
+            };
+
+            enum class ResourceTypeMask : uint32_t
+            {
+                None = 0,
+                ConstantDataMask = AZ_BIT(static_cast<uint32_t>(ResourceType::ConstantData)),
+                BufferViewMask = AZ_BIT(static_cast<uint32_t>(ResourceType::BufferView)),
+                ImageViewMask = AZ_BIT(static_cast<uint32_t>(ResourceType::ImageView)),
+                BufferViewUnboundedArrayMask = AZ_BIT(static_cast<uint32_t>(ResourceType::BufferViewUnboundedArray)),
+                ImageViewUnboundedArrayMask = AZ_BIT(static_cast<uint32_t>(ResourceType::ImageViewUnboundedArray)),
+                SamplerMask = AZ_BIT(static_cast<uint32_t>(ResourceType::Sampler))
+            };
+
+            //! Returns true if a resource type specified by resourceTypeMask is enabled for compilation
+            bool IsResourceTypeEnabledForCompilation(uint32_t resourceTypeMask) const;
+
+            //! Disables all resource types for compilation after m_updateMaskResetLatency number of compiles
+            //! This allows higher level code to ensure that if SRG is multi-buffered it can compile multiple
+            //! times in order to ensure all SRG buffers are updated.
+            void DisableCompilationForAllResourceTypes();
+
+            //! Returns true if any of the resource type has been enabled for compilation. 
+            bool IsAnyResourceTypeUpdated() const;
+
+            //! Enable compilation for a resourceType specified by resourceType/resourceTypeMask
+            void EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask, ResourceType resourceType);
+
         private:
             static const ConstPtr<ImageView> s_nullImageView;
             static const ConstPtr<BufferView> s_nullBufferView;
@@ -203,23 +239,43 @@ namespace AZ
 
             //! The backing data store of constants for the shader resource group.
             ConstantsData m_constantsData;
+
+            //! Mask used to check whether to compile a specific resource type
+            uint32_t m_updateMask = 0;
+
+            //! Track iteration for each resource type in order to keep compiling it for m_updateMaskResetLatency number of times
+            uint32_t m_resourceTypeIteration[static_cast<uint32_t>(ResourceType::Count)] = { 0 };
+            uint32_t m_updateMaskResetLatency = RHI::Limits::Device::FrameCountMax;
         };
 
         template <typename T>
         bool ShaderResourceGroupData::SetConstant(ShaderInputConstantIndex inputIndex, const T& value)
         {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
             return m_constantsData.SetConstant(inputIndex, value);
         }
 
         template <typename T>
         bool ShaderResourceGroupData::SetConstant(ShaderInputConstantIndex inputIndex, const T& value, uint32_t arrayIndex)
         {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
             return m_constantsData.SetConstant(inputIndex, value, arrayIndex);
+        }
+        
+        template<typename T>
+        bool ShaderResourceGroupData::SetConstantMatrixRows(ShaderInputConstantIndex inputIndex, const T& value, uint32_t rowCount)
+        {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
+            return m_constantsData.SetConstantMatrixRows(inputIndex, value, rowCount);
         }
 
         template <typename T>
         bool ShaderResourceGroupData::SetConstantArray(ShaderInputConstantIndex inputIndex, AZStd::array_view<T> values)
         {
+            if (!values.empty())
+            {
+                EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
+            }
             return m_constantsData.SetConstantArray(inputIndex, values);
         }
 
@@ -239,12 +295,6 @@ namespace AZ
         T ShaderResourceGroupData::GetConstant(ShaderInputConstantIndex inputIndex, uint32_t arrayIndex) const
         {
             return m_constantsData.GetConstant<T>(inputIndex, arrayIndex);
-        }
-
-        template <typename T>
-        bool ShaderResourceGroupData::SetConstantMatrixRows(ShaderInputConstantIndex inputIndex, const T& value, uint32_t rowCount)
-        {
-            return m_constantsData.SetConstantMatrixRows(inputIndex, value, rowCount);
         }
 
         template<typename TShaderInput, typename TShaderInputDescriptor>

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupData.cpp
@@ -7,6 +7,7 @@
  */
 #include <Atom/RHI/ShaderResourceGroupData.h>
 #include <Atom/RHI/ShaderResourceGroupPool.h>
+#include <Atom/RHI.Reflect/Bits.h>
 
 namespace AZ
 {
@@ -126,6 +127,12 @@ namespace AZ
                     }
                     isValidAll &= isValid;
                 }
+
+                if(!imageViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::ImageViewMask, ResourceType::ImageView);
+                }
+                
                 return isValidAll;
             }
             return false;
@@ -145,6 +152,11 @@ namespace AZ
                         m_imageViewsUnboundedArray.push_back(imageViews[i]);
                     }
                     isValidAll &= isValid;
+                }
+
+                if (!imageViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::ImageViewUnboundedArrayMask, ResourceType::ImageViewUnboundedArray);
                 }
                 return isValidAll;
             }
@@ -172,6 +184,11 @@ namespace AZ
                     }
                     isValidAll &= isValid;
                 }
+
+                if (!bufferViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::BufferViewMask, ResourceType::BufferView);
+                }
                 return isValidAll;
             }
             return false;
@@ -192,6 +209,11 @@ namespace AZ
                     }
                     isValidAll &= isValid;
                 }
+
+                if (!bufferViews.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::BufferViewUnboundedArrayMask, ResourceType::BufferViewUnboundedArray);
+                }
                 return isValidAll;
             }
             return false;
@@ -211,6 +233,11 @@ namespace AZ
                 {
                     m_samplers[interval.m_min + arrayIndex + i] = samplers[i];
                 }
+
+                if (!samplers.empty())
+                {
+                    EnableResourceTypeCompilation(ResourceTypeMask::SamplerMask, ResourceType::Sampler);
+                }
                 return true;
             }
             return false;
@@ -223,16 +250,19 @@ namespace AZ
 
         bool ShaderResourceGroupData::SetConstantRaw(ShaderInputConstantIndex inputIndex, const void* bytes, uint32_t byteOffset, uint32_t byteCount)
         {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
             return m_constantsData.SetConstantRaw(inputIndex, bytes, byteOffset, byteCount);
         }
 
         bool ShaderResourceGroupData::SetConstantData(const void* bytes, uint32_t byteCount)
         {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
             return m_constantsData.SetConstantData(bytes, byteCount);
         }
 
         bool ShaderResourceGroupData::SetConstantData(const void* bytes, uint32_t byteOffset, uint32_t byteCount)
         {
+            EnableResourceTypeCompilation(ResourceTypeMask::ConstantDataMask, ResourceType::ConstantData);
             return m_constantsData.SetConstantData(bytes, byteOffset, byteCount);
         }
         
@@ -340,5 +370,33 @@ namespace AZ
             return m_constantsData;
         }
 
+        bool ShaderResourceGroupData::IsResourceTypeEnabledForCompilation(uint32_t resourceTypeMask) const
+        {
+            return RHI::CheckBitsAny(m_updateMask, resourceTypeMask);
+        }
+
+        bool ShaderResourceGroupData::IsAnyResourceTypeUpdated() const
+        {
+            return m_updateMask != 0;
+        }
+
+        void ShaderResourceGroupData::EnableResourceTypeCompilation(ResourceTypeMask resourceTypeMask, ResourceType resourceType)
+        {
+            AZ_Assert(static_cast<uint32_t>(resourceTypeMask) == AZ_BIT(static_cast<uint32_t>(resourceType)), "resourceType and resourceTypeMask should point to the same ResourceType");
+            m_updateMask = RHI::SetBits(m_updateMask, static_cast<uint32_t>(resourceTypeMask));
+            m_resourceTypeIteration[static_cast<uint32_t>(resourceType)] = 0;
+        }
+
+        void ShaderResourceGroupData::DisableCompilationForAllResourceTypes()
+        {
+            for (uint32_t i = 0; i < static_cast<uint32_t>(ResourceType::Count); i++)
+            {
+                if (m_resourceTypeIteration[i] == m_updateMaskResetLatency)
+                {
+                    m_updateMask = RHI::ResetBits(m_updateMask, AZ_BIT(i));
+                }
+                m_resourceTypeIteration[i]++;
+            }
+        }
     } // namespace RHI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -114,6 +114,10 @@ namespace AZ
         void ShaderResourceGroup::Compile()
         {
             m_shaderResourceGroup->Compile(m_data);
+
+            //Disable compilation for all resource types as a performance optimization
+            //No need to re-update SRG data on GPU timeline if nothing was updated.
+            m_data.DisableCompilationForAllResourceTypes();
         }
 
         bool ShaderResourceGroup::IsQueuedForCompile() const


### PR DESCRIPTION
…across all backends

- Each resource type is tracked and updated separately
- Added caching ability for Raytracing srg to save ~2ms for a scene containing 100 x 50 vegetation patch

Signed-off-by: moudgils <moudgils@amazon.com>