### PR TITLE
Network Hierarchy optimizations for rebuilding hierarchies

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkHierarchyChildComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkHierarchyChildComponent.h
@@ -64,10 +64,8 @@ namespace Multiplayer
 
     private:
         AZ::ChildChangedEvent::Handler m_childChangedHandler;
-        AZ::ParentChangedEvent::Handler m_parentChangedHandler;
 
         void OnChildChanged(AZ::ChildChangeType type, AZ::EntityId child);
-        void OnParentChanged(AZ::EntityId oldParent, AZ::EntityId parent);
 
         //! Points to the top level root.
         AZ::Entity* m_rootEntity = nullptr;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkHierarchyRootComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/NetworkHierarchyRootComponent.h
@@ -78,22 +78,12 @@ namespace Multiplayer
         //! Rebuilds hierarchy starting from this root component's entity.
         void RebuildHierarchy();
         
-        //! @param underEntity Walk the child entities that belong to @underEntity and consider adding them to the hierarchy
-        //! @param currentEntityCount The total number of entities in the hierarchy prior to calling this method,
-        //!            used to avoid adding too many entities to the hierarchy while walking recursively the relevant entities.
-        //!            @currentEntityCount will be modified to reflect the total entity count upon completion of this method.
-        //! @returns false if an attempt was made to go beyond the maximum supported hierarchy size, true otherwise
-        bool RecursiveAttachHierarchicalEntities(AZ::EntityId underEntity, uint32_t& currentEntityCount);
-
-        //! @param entity Add the child entity and any of its relevant children to the hierarchy
-        //! @param currentEntityCount The total number of entities in the hierarchy prior to calling this method,
-        //!            used to avoid adding too many entities to the hierarchy while walking recursively the relevant entities.
-        //!            @currentEntityCount will be modified to reflect the total entity count upon completion of this method.
-        //! @returns false if an attempt was made to go beyond the maximum supported hierarchy size, true otherwise
-        bool RecursiveAttachHierarchicalChild(AZ::EntityId entity, uint32_t& currentEntityCount);
+        //! @param underEntity Walk the child entities that belong to @underEntity and consider adding them to the hierarchy.
+        //! Builds the hierarchy using breadth-first iterative method.
+        void InternalBuildHierarchyList(AZ::Entity* underEntity);
 
         void SetRootForEntity(AZ::Entity* root, const AZ::Entity* childEntity);
-        
+
         //! Set to false when deactivating or otherwise not to be included in hierarchy considerations.
         bool m_isHierarchyEnabled = true;
 

--- a/Gems/Multiplayer/Code/Source/Components/NetworkHierarchyChildComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetworkHierarchyChildComponent.cpp
@@ -201,16 +201,13 @@ namespace Multiplayer
         {
             if (const AZ::Entity* childEntity = componentApplication->FindEntity(childEntityId))
             {
-                for (Component* component : childEntity->GetComponents())
+                if (auto* hierarchyChildComponent = childEntity->FindComponent<NetworkHierarchyChildComponent>())
                 {
-                    if (component->GetUnderlyingComponentType() == NetworkHierarchyChildComponent::TYPEINFO_Uuid())
-                    {
-                        static_cast<NetworkHierarchyChildComponent*>(component)->SetTopLevelHierarchyRootEntity(nullptr);
-                    }
-                    else if (component->GetUnderlyingComponentType() == NetworkHierarchyRootComponent::TYPEINFO_Uuid())
-                    {
-                        static_cast<NetworkHierarchyRootComponent*>(component)->SetTopLevelHierarchyRootEntity(nullptr);
-                    }
+                    hierarchyChildComponent->SetTopLevelHierarchyRootEntity(nullptr);
+                }
+                else if (auto* hierarchyRootComponent = childEntity->FindComponent<NetworkHierarchyRootComponent>())
+                {
+                    hierarchyRootComponent->SetTopLevelHierarchyRootEntity(nullptr);
                 }
             }
         }


### PR DESCRIPTION
**Before**

```
Benchmark                                                                     Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------
ServerDeepHierarchyBenchmark/RebuildHierarchy                              43.7 us         43.9 us        16000
ServerDeepHierarchyBenchmark/RebuildHierarchyRemoveAndAddLastChild          133 us          134 us         5600
ServerDeepHierarchyBenchmark/RebuildHierarchyRemoveAndAddMiddleChild        167 us          165 us         4073
ServerDeepHierarchyBenchmark/RebuildHierarchyRemoveAndAddFirstChild         231 us          225 us         2987
```

**After**

```
Benchmark                                                                     Time             CPU   Iterations
---------------------------------------------------------------------------------------------------------------
ServerDeepHierarchyBenchmark/RebuildHierarchy                              30.5 us         30.7 us        22400
ServerDeepHierarchyBenchmark/RebuildHierarchyRemoveAndAddLastChild         67.9 us         68.0 us         8960
ServerDeepHierarchyBenchmark/RebuildHierarchyRemoveAndAddMiddleChild       70.6 us         69.8 us        11200
ServerDeepHierarchyBenchmark/RebuildHierarchyRemoveAndAddFirstChild        72.0 us         73.2 us         8960
```

+ reworked recursive rebuilding to iterative breadth first method
+ some minor optimization here and there

Note: the biggest item now is TransformBus::GetChildren

![image](https://user-images.githubusercontent.com/5432499/136090908-358c92d5-1a09-40b0-af04-3daab07212a0.png)

