### PR TITLE
LYN-7165 | RPE asserts and crashes when using the ChangeValidate attribute with asset members (DRAFT)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h
@@ -160,6 +160,20 @@ namespace AzToolsFramework
             WriteGUIValuesIntoProperty(0, reinterpret_cast<WidgetType*>(widget), tempValue, propertyType);
         }
 
+        virtual bool ValidatePropertyChange_Internal(
+            QWidget* editorGUI,
+            const AZ::SerializeContext::ClassData* classMetaData,
+            AZ::SerializeContext* serializeContext,
+            AZStd::function<bool(void* tempValue, const AZ::Uuid& typeId)> callback) override
+        {
+            (void)editorGUI;
+            (void)classMetaData;
+            (void)serializeContext;
+            (void)callback;
+
+            return false;
+        }
+
         void ReadValuesIntoGUI_Internal(QWidget* widget, InstanceDataNode* node) override
         {
             AZ_PROFILE_FUNCTION(AzToolsFramework);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.cpp
@@ -1403,13 +1403,13 @@ namespace AzToolsFramework
             {
                 if (rowWidget->second->ShouldPreValidatePropertyChange())
                 {
-                    void* tempValue = rowWidget->first->GetClassMetadata()->m_factory->Create("Validate Attribute");
+                    auto validateFunction = [&](void* tempValue, const AZ::Uuid& typeId) -> bool
+                    {
+                        return rowWidget->second->ValidatePropertyChange(tempValue, typeId);
+                    };
 
-                    handler->WriteGUIValuesIntoTempProperty_Internal(editorGUI, tempValue, rowWidget->first->GetClassMetadata()->m_typeId, rowWidget->first->GetSerializeContext());
-
-                    bool validated = rowWidget->second->ValidatePropertyChange(tempValue, rowWidget->first->GetClassMetadata()->m_typeId);
-
-                    rowWidget->first->GetClassMetadata()->m_factory->Destroy(tempValue);
+                    bool validated = handler->ValidatePropertyChange_Internal(
+                        editorGUI, rowWidget->first->GetClassMetadata(), rowWidget->first->GetSerializeContext(), validateFunction);
 
                     // Validate the change to make sure everything is okay before actually modifying the value on anything
                     if (!validated)


### PR DESCRIPTION
Possible solution to the following issue:
_"When an EditContext has a member that is of type Asset<T>, and it has a ChangeValidate attribute on that member, attempting to set the value on the member in the Editor will assert and crash."_

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>