### PR TITLE
Clean up benign errors that occur when a Reflection Probe is baked

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapForwardMSAA.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EnvironmentCubeMapForwardMSAA.pass
@@ -147,22 +147,6 @@
                         },
                         "LoadAction": "Clear"
                     }
-                },
-                {
-                    "Name": "ScatterDistanceOutput",
-                    "SlotType": "Output",
-                    "ScopeAttachmentUsage": "RenderTarget",
-                    "LoadStoreAction": {
-                        "ClearValue": {
-                            "Value": [
-                                0.0,
-                                0.0,
-                                0.0,
-                                0.0
-                            ]
-                        },
-                        "LoadAction": "Clear"
-                    }
                 }
             ],
             "ImageAttachments": [
@@ -257,23 +241,6 @@
                     "AssetRef": {
                         "FilePath": "Textures/BRDFTexture.attimage"
                     }
-                },
-                {
-                    "Name": "ScatterDistanceImage",
-                    "SizeSource": {
-                        "Source": {
-                            "Pass": "Parent",
-                            "Attachment": "Output"
-                        }
-                    },
-                    "MultisampleSource": {
-                        "Pass": "This",
-                        "Attachment": "DepthStencilInputOutput"
-                    },    
-                    "ImageDescriptor": {
-                        "Format": "R11G11B10_FLOAT",
-                        "SharedQueueMask": "Graphics"
-                    }
                 }
             ],
             "Connections": [
@@ -317,13 +284,6 @@
                     "AttachmentRef": {
                         "Pass": "This",
                         "Attachment": "BRDFTexture"
-                    }
-                },
-                {
-                    "LocalSlot": "ScatterDistanceOutput",
-                    "AttachmentRef": {
-                        "Pass": "This",
-                        "Attachment": "ScatterDistanceImage"
                     }
                 }
             ]

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionComposite.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionComposite.azsl
@@ -15,7 +15,6 @@
 // box-filtered from the MSAA sub-pixels of the reflection texture.
 
 #include <scenesrg.srgi>
-#include <viewsrg.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>
@@ -25,8 +24,6 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 {
     Texture2DMS<float4>  m_reflection;
 }
-
-#include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 
 // Vertex Shader
 VSOutput MainVS(VSInput input)


### PR DESCRIPTION
Removed the ScatterDistanceOutput texture from the EnvironmentCubeMapForwardMSAAPass.
Removed unused Srgs from the ReflectionCompositePass.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>