### PR TITLE
Edit URL: Lua Editor > Help Menu > Lua Documentation

### DIFF
--- a/Code/Tools/Standalone/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/Standalone/Source/LUA/LUAEditorMainWindow.cpp
@@ -395,7 +395,7 @@ namespace LUAEditor
 
     void LUAEditorMainWindow::OnLuaDocumentation()
     {
-        QDesktopServices::openUrl(QUrl("http://docs.aws.amazon.com/lumberyard/latest/developerguide/lua-scripting-intro.html"));
+        QDesktopServices::openUrl(QUrl("https://o3de.org/docs/user-guide/scripting/lua/"));
     }
 
     void LUAEditorMainWindow::OnMenuCloseCurrentWindow()


### PR DESCRIPTION
The **Help** menu item, `Lua Documentation` in **Lua Editor** now links to https://o3de.org/docs/user-guide/scripting/lua/.

Fix #4518 