### PR TITLE
Simplify viewport interaction model reset functionality

### DIFF
--- a/Code/Editor/Core/LevelEditorMenuHandler.cpp
+++ b/Code/Editor/Core/LevelEditorMenuHandler.cpp
@@ -487,8 +487,6 @@ void LevelEditorMenuHandler::PopulateEditMenu(ActionManager::MenuWrapper& editMe
     editMenu.AddAction(AzToolsFramework::EditPivot);
     editMenu.AddAction(AzToolsFramework::EditReset);
     editMenu.AddAction(AzToolsFramework::EditResetManipulator);
-    editMenu.AddAction(AzToolsFramework::EditResetLocal);
-    editMenu.AddAction(AzToolsFramework::EditResetWorld);
 
     // Hide Selection
     editMenu.AddAction(AzToolsFramework::HideSelection);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -103,10 +103,6 @@ namespace AzToolsFramework
     static const char* const ResetEntityTransformDesc = "Reset transform based on manipulator mode";
     static const char* const ResetManipulatorTitle = "Reset Manipulator";
     static const char* const ResetManipulatorDesc = "Reset the manipulator to recenter it on the selected entity";
-    static const char* const ResetTransformLocalTitle = "Reset Transform (Local)";
-    static const char* const ResetTransformLocalDesc = "Reset transform to local space";
-    static const char* const ResetTransformWorldTitle = "Reset Transform (World)";
-    static const char* const ResetTransformWorldDesc = "Reset transform to world space";
 
     static const char* const EntityBoxSelectUndoRedoDesc = "Box Select Entities";
     static const char* const EntityDeselectUndoRedoDesc = "Deselect Entity";
@@ -2424,45 +2420,9 @@ namespace AzToolsFramework
 
         AddAction(
             m_actions, { QKeySequence(Qt::CTRL + Qt::Key_R) }, EditResetManipulator, ResetManipulatorTitle, ResetManipulatorDesc,
-            AZStd::bind(AZStd::mem_fn(&EditorTransformComponentSelection::DelegateClearManipulatorOverride), this));
-
-        AddAction(
-            m_actions, { QKeySequence(Qt::ALT + Qt::Key_R) }, EditResetLocal, ResetTransformLocalTitle, ResetTransformLocalDesc,
-            [this]()
+            [this]
             {
-                switch (m_mode)
-                {
-                case Mode::Rotation:
-                    ResetOrientationForSelectedEntitiesLocal();
-                    break;
-                case Mode::Scale:
-                    CopyScaleToSelectedEntitiesIndividualWorld(1.0f);
-                    break;
-                case Mode::Translation:
-                    // do nothing
-                    break;
-                }
-            });
-
-        AddAction(
-            m_actions, { QKeySequence(Qt::SHIFT + Qt::Key_R) }, EditResetWorld, ResetTransformWorldTitle, ResetTransformWorldDesc,
-            [this]()
-            {
-                switch (m_mode)
-                {
-                case Mode::Rotation:
-                    {
-                        // begin an undo batch so operations inside CopyOrientation... and
-                        // DelegateClear... are grouped into a single undo/redo
-                        ScopedUndoBatch undoBatch{ ResetTransformWorldTitle };
-                        CopyOrientationToSelectedEntitiesIndividual(AZ::Quaternion::CreateIdentity());
-                        ClearManipulatorOrientationOverride();
-                    }
-                    break;
-                case Mode::Scale:
-                case Mode::Translation:
-                    break;
-                }
+                DelegateClearManipulatorOverride();
             });
 
         AddAction(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelectionRequestBus.h
@@ -31,8 +31,6 @@ namespace AzToolsFramework
     constexpr inline AZ::Crc32 EditPivot = AZ_CRC_CE("com.o3de.action.editortransform.editpivot");
     constexpr inline AZ::Crc32 EditReset = AZ_CRC_CE("com.o3de.action.editortransform.editreset");
     constexpr inline AZ::Crc32 EditResetManipulator = AZ_CRC_CE("com.o3de.action.editortransform.editresetmanipulator");
-    constexpr inline AZ::Crc32 EditResetLocal = AZ_CRC_CE("com.o3de.action.editortransform.editresetlocal");
-    constexpr inline AZ::Crc32 EditResetWorld = AZ_CRC_CE("com.o3de.action.editortransform.editresetworld");
     constexpr inline AZ::Crc32 ViewportUiVisible = AZ_CRC_CE("com.o3de.action.editortransform.viewportuivisible");
     //@}
 


### PR DESCRIPTION
Resolves #3581 (LYN-580)

This simplifies the available reset options so holding Alt/Shift makes no difference when pressing 'R' - the options were not used often and added extra confusion more than anything. We just default to simple reset which is equivalent to resetting the transform data on the entity.