### PR TITLE
Disable TIAF Jenkins job

### DIFF
--- a/scripts/build/Platform/Windows/build_config.json
+++ b/scripts/build/Platform/Windows/build_config.json
@@ -31,7 +31,6 @@
     ],
     "steps": [
       "profile_vs2019",
-      "test_impact_analysis_profile_vs2019",
       "asset_profile_vs2019",
       "test_cpu_profile_vs2019"
     ]


### PR DESCRIPTION
The TIAF job is not successfully writing to its persistant storage location, causing all jobs to run TIAF on a change list generated between `c9a3b51fa934af1ae316a787571111e23bcf9ec9` and the commit for the PR build. As the current focus of development is on integrating Python tests into TIAF, the job will be disabled and this issue fixed once the Python tests integration is complete.

Signed-off-by: John <jonawals@amazon.com>