### PR TITLE
Update naming to CameraInput types

### DIFF
--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -135,7 +135,7 @@ namespace SandboxEditor
         m_firstPersonRotateCamera->SetActivationEndedFn(showCursor);
 
         m_firstPersonPanCamera = AZStd::make_shared<AzFramework::PanCameraInput>(
-            SandboxEditor::CameraFreePanChannelId(), AzFramework::LookPan, AzFramework::TranslatePivot);
+            SandboxEditor::CameraFreePanChannelId(), AzFramework::LookPan, AzFramework::TranslatePivotLook);
 
         m_firstPersonPanCamera->m_panSpeedFn = []
         {
@@ -155,7 +155,7 @@ namespace SandboxEditor
         const auto translateCameraInputChannelIds = BuildTranslateCameraInputChannelIds();
 
         m_firstPersonTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
-            translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslatePivot);
+            translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslatePivotLook);
 
         m_firstPersonTranslateCamera->m_translateSpeedFn = []
         {
@@ -167,7 +167,7 @@ namespace SandboxEditor
             return SandboxEditor::CameraBoostMultiplier();
         };
 
-        m_firstPersonScrollCamera = AZStd::make_shared<AzFramework::ScrollTranslationCameraInput>();
+        m_firstPersonScrollCamera = AZStd::make_shared<AzFramework::LookScrollTranslationCameraInput>();
 
         m_firstPersonScrollCamera->m_scrollSpeedFn = []
         {
@@ -217,7 +217,7 @@ namespace SandboxEditor
         };
 
         m_orbitTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
-            translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslateOffset);
+            translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslateOffsetOrbit);
 
         m_orbitTranslateCamera->m_translateSpeedFn = []
         {
@@ -244,7 +244,7 @@ namespace SandboxEditor
         };
 
         m_orbitPanCamera = AZStd::make_shared<AzFramework::PanCameraInput>(
-            SandboxEditor::CameraOrbitPanChannelId(), AzFramework::LookPan, AzFramework::TranslateOffset);
+            SandboxEditor::CameraOrbitPanChannelId(), AzFramework::LookPan, AzFramework::TranslateOffsetOrbit);
 
         m_orbitPanCamera->m_panSpeedFn = []
         {

--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -96,7 +96,7 @@ namespace SandboxEditor
                 cameras.AddCamera(m_firstPersonTranslateCamera);
                 cameras.AddCamera(m_firstPersonScrollCamera);
                 cameras.AddCamera(m_firstPersonFocusCamera);
-                cameras.AddCamera(m_pivotCamera);
+                cameras.AddCamera(m_orbitCamera);
             });
 
         return controller;
@@ -196,82 +196,82 @@ namespace SandboxEditor
 
         m_firstPersonFocusCamera->SetPivotFn(pivotFn);
 
-        m_pivotCamera = AZStd::make_shared<AzFramework::PivotCameraInput>(SandboxEditor::CameraPivotChannelId());
+        m_orbitCamera = AZStd::make_shared<AzFramework::OrbitCameraInput>(SandboxEditor::CameraOrbitChannelId());
 
-        m_pivotCamera->SetPivotFn(
+        m_orbitCamera->SetPivotFn(
             [pivotFn]([[maybe_unused]] const AZ::Vector3& position, [[maybe_unused]] const AZ::Vector3& direction)
             {
                 return pivotFn();
             });
 
-        m_pivotRotateCamera = AZStd::make_shared<AzFramework::RotateCameraInput>(SandboxEditor::CameraPivotLookChannelId());
+        m_orbitRotateCamera = AZStd::make_shared<AzFramework::RotateCameraInput>(SandboxEditor::CameraOrbitLookChannelId());
 
-        m_pivotRotateCamera->m_rotateSpeedFn = []
+        m_orbitRotateCamera->m_rotateSpeedFn = []
         {
             return SandboxEditor::CameraRotateSpeed();
         };
 
-        m_pivotRotateCamera->m_invertYawFn = []
+        m_orbitRotateCamera->m_invertYawFn = []
         {
-            return SandboxEditor::CameraPivotYawRotationInverted();
+            return SandboxEditor::CameraOrbitYawRotationInverted();
         };
 
-        m_pivotTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
+        m_orbitTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
             translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslateOffset);
 
-        m_pivotTranslateCamera->m_translateSpeedFn = []
+        m_orbitTranslateCamera->m_translateSpeedFn = []
         {
             return SandboxEditor::CameraTranslateSpeed();
         };
 
-        m_pivotTranslateCamera->m_boostMultiplierFn = []
+        m_orbitTranslateCamera->m_boostMultiplierFn = []
         {
             return SandboxEditor::CameraBoostMultiplier();
         };
 
-        m_pivotDollyScrollCamera = AZStd::make_shared<AzFramework::PivotDollyScrollCameraInput>();
+        m_orbitDollyScrollCamera = AZStd::make_shared<AzFramework::OrbitDollyScrollCameraInput>();
 
-        m_pivotDollyScrollCamera->m_scrollSpeedFn = []
+        m_orbitDollyScrollCamera->m_scrollSpeedFn = []
         {
             return SandboxEditor::CameraScrollSpeed();
         };
 
-        m_pivotDollyMoveCamera = AZStd::make_shared<AzFramework::PivotDollyMotionCameraInput>(SandboxEditor::CameraPivotDollyChannelId());
+        m_orbitDollyMoveCamera = AZStd::make_shared<AzFramework::OrbitDollyMotionCameraInput>(SandboxEditor::CameraOrbitDollyChannelId());
 
-        m_pivotDollyMoveCamera->m_motionSpeedFn = []
+        m_orbitDollyMoveCamera->m_motionSpeedFn = []
         {
             return SandboxEditor::CameraDollyMotionSpeed();
         };
 
-        m_pivotPanCamera = AZStd::make_shared<AzFramework::PanCameraInput>(
-            SandboxEditor::CameraPivotPanChannelId(), AzFramework::LookPan, AzFramework::TranslateOffset);
+        m_orbitPanCamera = AZStd::make_shared<AzFramework::PanCameraInput>(
+            SandboxEditor::CameraOrbitPanChannelId(), AzFramework::LookPan, AzFramework::TranslateOffset);
 
-        m_pivotPanCamera->m_panSpeedFn = []
+        m_orbitPanCamera->m_panSpeedFn = []
         {
             return SandboxEditor::CameraPanSpeed();
         };
 
-        m_pivotPanCamera->m_invertPanXFn = []
+        m_orbitPanCamera->m_invertPanXFn = []
         {
             return SandboxEditor::CameraPanInvertedX();
         };
 
-        m_pivotPanCamera->m_invertPanYFn = []
+        m_orbitPanCamera->m_invertPanYFn = []
         {
             return SandboxEditor::CameraPanInvertedY();
         };
 
-        m_pivotFocusCamera =
-            AZStd::make_shared<AzFramework::FocusCameraInput>(SandboxEditor::CameraFocusChannelId(), AzFramework::FocusPivot);
+        m_orbitFocusCamera =
+            AZStd::make_shared<AzFramework::FocusCameraInput>(SandboxEditor::CameraFocusChannelId(), AzFramework::FocusOrbit);
 
-        m_pivotFocusCamera->SetPivotFn(pivotFn);
+        m_orbitFocusCamera->SetPivotFn(pivotFn);
 
-        m_pivotCamera->m_pivotCameras.AddCamera(m_pivotRotateCamera);
-        m_pivotCamera->m_pivotCameras.AddCamera(m_pivotTranslateCamera);
-        m_pivotCamera->m_pivotCameras.AddCamera(m_pivotDollyScrollCamera);
-        m_pivotCamera->m_pivotCameras.AddCamera(m_pivotDollyMoveCamera);
-        m_pivotCamera->m_pivotCameras.AddCamera(m_pivotPanCamera);
-        m_pivotCamera->m_pivotCameras.AddCamera(m_pivotFocusCamera);
+        m_orbitCamera->m_orbitCameras.AddCamera(m_orbitRotateCamera);
+        m_orbitCamera->m_orbitCameras.AddCamera(m_orbitTranslateCamera);
+        m_orbitCamera->m_orbitCameras.AddCamera(m_orbitDollyScrollCamera);
+        m_orbitCamera->m_orbitCameras.AddCamera(m_orbitDollyMoveCamera);
+        m_orbitCamera->m_orbitCameras.AddCamera(m_orbitPanCamera);
+        m_orbitCamera->m_orbitCameras.AddCamera(m_orbitFocusCamera);
     }
 
     void EditorModularViewportCameraComposer::OnEditorModularViewportCameraComposerSettingsChanged()
@@ -282,12 +282,12 @@ namespace SandboxEditor
         m_firstPersonRotateCamera->SetRotateInputChannelId(SandboxEditor::CameraFreeLookChannelId());
         m_firstPersonFocusCamera->SetFocusInputChannelId(SandboxEditor::CameraFocusChannelId());
 
-        m_pivotCamera->SetPivotInputChannelId(SandboxEditor::CameraPivotChannelId());
-        m_pivotTranslateCamera->SetTranslateCameraInputChannelIds(translateCameraInputChannelIds);
-        m_pivotPanCamera->SetPanInputChannelId(SandboxEditor::CameraPivotPanChannelId());
-        m_pivotRotateCamera->SetRotateInputChannelId(SandboxEditor::CameraPivotLookChannelId());
-        m_pivotDollyMoveCamera->SetDollyInputChannelId(SandboxEditor::CameraPivotDollyChannelId());
-        m_pivotFocusCamera->SetFocusInputChannelId(SandboxEditor::CameraFocusChannelId());
+        m_orbitCamera->SetOrbitInputChannelId(SandboxEditor::CameraOrbitChannelId());
+        m_orbitTranslateCamera->SetTranslateCameraInputChannelIds(translateCameraInputChannelIds);
+        m_orbitPanCamera->SetPanInputChannelId(SandboxEditor::CameraOrbitPanChannelId());
+        m_orbitRotateCamera->SetRotateInputChannelId(SandboxEditor::CameraOrbitLookChannelId());
+        m_orbitDollyMoveCamera->SetDollyInputChannelId(SandboxEditor::CameraOrbitDollyChannelId());
+        m_orbitFocusCamera->SetFocusInputChannelId(SandboxEditor::CameraFocusChannelId());
     }
 
     void EditorModularViewportCameraComposer::OnViewportViewEntityChanged(const AZ::EntityId& viewEntityId)

--- a/Code/Editor/EditorModularViewportCameraComposer.h
+++ b/Code/Editor/EditorModularViewportCameraComposer.h
@@ -41,7 +41,7 @@ namespace SandboxEditor
         AZStd::shared_ptr<AzFramework::RotateCameraInput> m_firstPersonRotateCamera;
         AZStd::shared_ptr<AzFramework::PanCameraInput> m_firstPersonPanCamera;
         AZStd::shared_ptr<AzFramework::TranslateCameraInput> m_firstPersonTranslateCamera;
-        AZStd::shared_ptr<AzFramework::ScrollTranslationCameraInput> m_firstPersonScrollCamera;
+        AZStd::shared_ptr<AzFramework::LookScrollTranslationCameraInput> m_firstPersonScrollCamera;
         AZStd::shared_ptr<AzFramework::FocusCameraInput> m_firstPersonFocusCamera;
         AZStd::shared_ptr<AzFramework::OrbitCameraInput> m_orbitCamera;
         AZStd::shared_ptr<AzFramework::RotateCameraInput> m_orbitRotateCamera;

--- a/Code/Editor/EditorModularViewportCameraComposer.h
+++ b/Code/Editor/EditorModularViewportCameraComposer.h
@@ -43,13 +43,13 @@ namespace SandboxEditor
         AZStd::shared_ptr<AzFramework::TranslateCameraInput> m_firstPersonTranslateCamera;
         AZStd::shared_ptr<AzFramework::ScrollTranslationCameraInput> m_firstPersonScrollCamera;
         AZStd::shared_ptr<AzFramework::FocusCameraInput> m_firstPersonFocusCamera;
-        AZStd::shared_ptr<AzFramework::PivotCameraInput> m_pivotCamera;
-        AZStd::shared_ptr<AzFramework::RotateCameraInput> m_pivotRotateCamera;
-        AZStd::shared_ptr<AzFramework::TranslateCameraInput> m_pivotTranslateCamera;
-        AZStd::shared_ptr<AzFramework::PivotDollyScrollCameraInput> m_pivotDollyScrollCamera;
-        AZStd::shared_ptr<AzFramework::PivotDollyMotionCameraInput> m_pivotDollyMoveCamera;
-        AZStd::shared_ptr<AzFramework::PanCameraInput> m_pivotPanCamera;
-        AZStd::shared_ptr<AzFramework::FocusCameraInput> m_pivotFocusCamera;
+        AZStd::shared_ptr<AzFramework::OrbitCameraInput> m_orbitCamera;
+        AZStd::shared_ptr<AzFramework::RotateCameraInput> m_orbitRotateCamera;
+        AZStd::shared_ptr<AzFramework::TranslateCameraInput> m_orbitTranslateCamera;
+        AZStd::shared_ptr<AzFramework::OrbitDollyScrollCameraInput> m_orbitDollyScrollCamera;
+        AZStd::shared_ptr<AzFramework::OrbitDollyMotionCameraInput> m_orbitDollyMoveCamera;
+        AZStd::shared_ptr<AzFramework::PanCameraInput> m_orbitPanCamera;
+        AZStd::shared_ptr<AzFramework::FocusCameraInput> m_orbitFocusCamera;
 
         AzFramework::ViewportId m_viewportId;
     };

--- a/Code/Editor/EditorPreferencesPageViewportCamera.cpp
+++ b/Code/Editor/EditorPreferencesPageViewportCamera.cpp
@@ -73,7 +73,7 @@ void CEditorPreferencesPage_ViewportCamera::Reflect(AZ::SerializeContext& serial
         ->Field("TranslateSmoothing", &CameraMovementSettings::m_translateSmoothing)
         ->Field("TranslateSmoothness", &CameraMovementSettings::m_translateSmoothness)
         ->Field("CaptureCursorLook", &CameraMovementSettings::m_captureCursorLook)
-        ->Field("PivotYawRotationInverted", &CameraMovementSettings::m_pivotYawRotationInverted)
+        ->Field("OrbitYawRotationInverted", &CameraMovementSettings::m_orbitYawRotationInverted)
         ->Field("PanInvertedX", &CameraMovementSettings::m_panInvertedX)
         ->Field("PanInvertedY", &CameraMovementSettings::m_panInvertedY);
 
@@ -86,12 +86,12 @@ void CEditorPreferencesPage_ViewportCamera::Reflect(AZ::SerializeContext& serial
         ->Field("TranslateUp", &CameraInputSettings::m_translateUpChannelId)
         ->Field("TranslateDown", &CameraInputSettings::m_translateDownChannelId)
         ->Field("Boost", &CameraInputSettings::m_boostChannelId)
-        ->Field("Pivot", &CameraInputSettings::m_pivotChannelId)
+        ->Field("Orbit", &CameraInputSettings::m_orbitChannelId)
         ->Field("FreeLook", &CameraInputSettings::m_freeLookChannelId)
         ->Field("FreePan", &CameraInputSettings::m_freePanChannelId)
-        ->Field("PivotLook", &CameraInputSettings::m_pivotLookChannelId)
-        ->Field("PivotDolly", &CameraInputSettings::m_pivotDollyChannelId)
-        ->Field("PivotPan", &CameraInputSettings::m_pivotPanChannelId)
+        ->Field("OrbitLook", &CameraInputSettings::m_orbitLookChannelId)
+        ->Field("OrbitDolly", &CameraInputSettings::m_orbitDollyChannelId)
+        ->Field("OrbitPan", &CameraInputSettings::m_orbitPanChannelId)
         ->Field("Focus", &CameraInputSettings::m_focusChannelId);
 
     serialize.Class<CEditorPreferencesPage_ViewportCamera>()
@@ -144,8 +144,8 @@ void CEditorPreferencesPage_ViewportCamera::Reflect(AZ::SerializeContext& serial
             ->Attribute(AZ::Edit::Attributes::Min, minValue)
             ->Attribute(AZ::Edit::Attributes::Visibility, &CameraMovementSettings::TranslateSmoothingVisibility)
             ->DataElement(
-                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_pivotYawRotationInverted, "Camera Pivot Yaw Inverted",
-                "Inverted yaw rotation while pivoting")
+                AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_orbitYawRotationInverted, "Camera Orbit Yaw Inverted",
+                "Inverted yaw rotation while orbiting")
             ->DataElement(
                 AZ::Edit::UIHandlers::CheckBox, &CameraMovementSettings::m_panInvertedX, "Invert Pan X",
                 "Invert direction of pan in local X axis")
@@ -186,8 +186,8 @@ void CEditorPreferencesPage_ViewportCamera::Reflect(AZ::SerializeContext& serial
                 "Key/button to move the camera more quickly")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_pivotChannelId, "Pivot",
-                "Key/button to begin the camera pivot behavior")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_orbitChannelId, "Orbit",
+                "Key/button to begin the camera orbit behavior")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
                 AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_freeLookChannelId, "Free Look",
@@ -197,19 +197,19 @@ void CEditorPreferencesPage_ViewportCamera::Reflect(AZ::SerializeContext& serial
                 AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_freePanChannelId, "Free Pan", "Key/button to begin camera free pan")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_pivotLookChannelId, "Pivot Look",
-                "Key/button to begin camera pivot look")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_orbitLookChannelId, "Orbit Look",
+                "Key/button to begin camera orbit look")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_pivotDollyChannelId, "Pivot Dolly",
-                "Key/button to begin camera pivot dolly")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_orbitDollyChannelId, "Orbit Dolly",
+                "Key/button to begin camera orbit dolly")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_pivotPanChannelId, "Pivot Pan",
-                "Key/button to begin camera pivot pan")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_orbitPanChannelId, "Orbit Pan",
+                "Key/button to begin camera orbit pan")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames)
             ->DataElement(
-                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_focusChannelId, "Focus", "Key/button to focus camera pivot")
+                AZ::Edit::UIHandlers::ComboBox, &CameraInputSettings::m_focusChannelId, "Focus", "Key/button to focus camera orbit")
             ->Attribute(AZ::Edit::Attributes::StringList, &GetEditorInputNames);
 
         editContext->Class<CEditorPreferencesPage_ViewportCamera>("Viewport Preferences", "Viewport Preferences")
@@ -268,7 +268,7 @@ void CEditorPreferencesPage_ViewportCamera::OnApply()
     SandboxEditor::SetCameraTranslateSmoothness(m_cameraMovementSettings.m_translateSmoothness);
     SandboxEditor::SetCameraTranslateSmoothingEnabled(m_cameraMovementSettings.m_translateSmoothing);
     SandboxEditor::SetCameraCaptureCursorForLook(m_cameraMovementSettings.m_captureCursorLook);
-    SandboxEditor::SetCameraPivotYawRotationInverted(m_cameraMovementSettings.m_pivotYawRotationInverted);
+    SandboxEditor::SetCameraOrbitYawRotationInverted(m_cameraMovementSettings.m_orbitYawRotationInverted);
     SandboxEditor::SetCameraPanInvertedX(m_cameraMovementSettings.m_panInvertedX);
     SandboxEditor::SetCameraPanInvertedY(m_cameraMovementSettings.m_panInvertedY);
 
@@ -279,12 +279,12 @@ void CEditorPreferencesPage_ViewportCamera::OnApply()
     SandboxEditor::SetCameraTranslateUpChannelId(m_cameraInputSettings.m_translateUpChannelId);
     SandboxEditor::SetCameraTranslateDownChannelId(m_cameraInputSettings.m_translateDownChannelId);
     SandboxEditor::SetCameraTranslateBoostChannelId(m_cameraInputSettings.m_boostChannelId);
-    SandboxEditor::SetCameraPivotChannelId(m_cameraInputSettings.m_pivotChannelId);
+    SandboxEditor::SetCameraOrbitChannelId(m_cameraInputSettings.m_orbitChannelId);
     SandboxEditor::SetCameraFreeLookChannelId(m_cameraInputSettings.m_freeLookChannelId);
     SandboxEditor::SetCameraFreePanChannelId(m_cameraInputSettings.m_freePanChannelId);
-    SandboxEditor::SetCameraPivotLookChannelId(m_cameraInputSettings.m_pivotLookChannelId);
-    SandboxEditor::SetCameraPivotDollyChannelId(m_cameraInputSettings.m_pivotDollyChannelId);
-    SandboxEditor::SetCameraPivotPanChannelId(m_cameraInputSettings.m_pivotPanChannelId);
+    SandboxEditor::SetCameraOrbitLookChannelId(m_cameraInputSettings.m_orbitLookChannelId);
+    SandboxEditor::SetCameraOrbitDollyChannelId(m_cameraInputSettings.m_orbitDollyChannelId);
+    SandboxEditor::SetCameraOrbitPanChannelId(m_cameraInputSettings.m_orbitPanChannelId);
     SandboxEditor::SetCameraFocusChannelId(m_cameraInputSettings.m_focusChannelId);
 
     SandboxEditor::EditorModularViewportCameraComposerNotificationBus::Broadcast(
@@ -304,7 +304,7 @@ void CEditorPreferencesPage_ViewportCamera::InitializeSettings()
     m_cameraMovementSettings.m_translateSmoothness = SandboxEditor::CameraTranslateSmoothness();
     m_cameraMovementSettings.m_translateSmoothing = SandboxEditor::CameraTranslateSmoothingEnabled();
     m_cameraMovementSettings.m_captureCursorLook = SandboxEditor::CameraCaptureCursorForLook();
-    m_cameraMovementSettings.m_pivotYawRotationInverted = SandboxEditor::CameraPivotYawRotationInverted();
+    m_cameraMovementSettings.m_orbitYawRotationInverted = SandboxEditor::CameraOrbitYawRotationInverted();
     m_cameraMovementSettings.m_panInvertedX = SandboxEditor::CameraPanInvertedX();
     m_cameraMovementSettings.m_panInvertedY = SandboxEditor::CameraPanInvertedY();
 
@@ -315,11 +315,11 @@ void CEditorPreferencesPage_ViewportCamera::InitializeSettings()
     m_cameraInputSettings.m_translateUpChannelId = SandboxEditor::CameraTranslateUpChannelId().GetName();
     m_cameraInputSettings.m_translateDownChannelId = SandboxEditor::CameraTranslateDownChannelId().GetName();
     m_cameraInputSettings.m_boostChannelId = SandboxEditor::CameraTranslateBoostChannelId().GetName();
-    m_cameraInputSettings.m_pivotChannelId = SandboxEditor::CameraPivotChannelId().GetName();
+    m_cameraInputSettings.m_orbitChannelId = SandboxEditor::CameraOrbitChannelId().GetName();
     m_cameraInputSettings.m_freeLookChannelId = SandboxEditor::CameraFreeLookChannelId().GetName();
     m_cameraInputSettings.m_freePanChannelId = SandboxEditor::CameraFreePanChannelId().GetName();
-    m_cameraInputSettings.m_pivotLookChannelId = SandboxEditor::CameraPivotLookChannelId().GetName();
-    m_cameraInputSettings.m_pivotDollyChannelId = SandboxEditor::CameraPivotDollyChannelId().GetName();
-    m_cameraInputSettings.m_pivotPanChannelId = SandboxEditor::CameraPivotPanChannelId().GetName();
+    m_cameraInputSettings.m_orbitLookChannelId = SandboxEditor::CameraOrbitLookChannelId().GetName();
+    m_cameraInputSettings.m_orbitDollyChannelId = SandboxEditor::CameraOrbitDollyChannelId().GetName();
+    m_cameraInputSettings.m_orbitPanChannelId = SandboxEditor::CameraOrbitPanChannelId().GetName();
     m_cameraInputSettings.m_focusChannelId = SandboxEditor::CameraFocusChannelId().GetName();
 }

--- a/Code/Editor/EditorPreferencesPageViewportCamera.h
+++ b/Code/Editor/EditorPreferencesPageViewportCamera.h
@@ -54,7 +54,7 @@ private:
         float m_translateSmoothness;
         bool m_translateSmoothing;
         bool m_captureCursorLook;
-        bool m_pivotYawRotationInverted;
+        bool m_orbitYawRotationInverted;
         bool m_panInvertedX;
         bool m_panInvertedY;
 
@@ -80,12 +80,12 @@ private:
         AZStd::string m_translateUpChannelId;
         AZStd::string m_translateDownChannelId;
         AZStd::string m_boostChannelId;
-        AZStd::string m_pivotChannelId;
+        AZStd::string m_orbitChannelId;
         AZStd::string m_freeLookChannelId;
         AZStd::string m_freePanChannelId;
-        AZStd::string m_pivotLookChannelId;
-        AZStd::string m_pivotDollyChannelId;
-        AZStd::string m_pivotPanChannelId;
+        AZStd::string m_orbitLookChannelId;
+        AZStd::string m_orbitDollyChannelId;
+        AZStd::string m_orbitPanChannelId;
         AZStd::string m_focusChannelId;
     };
 

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -28,7 +28,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraRotateSpeedSetting = "/Amazon/Preferences/Editor/Camera/RotateSpeed";
     constexpr AZStd::string_view CameraScrollSpeedSetting = "/Amazon/Preferences/Editor/Camera/DollyScrollSpeed";
     constexpr AZStd::string_view CameraDollyMotionSpeedSetting = "/Amazon/Preferences/Editor/Camera/DollyMotionSpeed";
-    constexpr AZStd::string_view CameraPivotYawRotationInvertedSetting = "/Amazon/Preferences/Editor/Camera/YawRotationInverted";
+    constexpr AZStd::string_view CameraOrbitYawRotationInvertedSetting = "/Amazon/Preferences/Editor/Camera/YawRotationInverted";
     constexpr AZStd::string_view CameraPanInvertedXSetting = "/Amazon/Preferences/Editor/Camera/PanInvertedX";
     constexpr AZStd::string_view CameraPanInvertedYSetting = "/Amazon/Preferences/Editor/Camera/PanInvertedY";
     constexpr AZStd::string_view CameraPanSpeedSetting = "/Amazon/Preferences/Editor/Camera/PanSpeed";
@@ -44,12 +44,12 @@ namespace SandboxEditor
     constexpr AZStd::string_view CameraTranslateUpIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateUpId";
     constexpr AZStd::string_view CameraTranslateDownIdSetting = "/Amazon/Preferences/Editor/Camera/CameraTranslateUpDownId";
     constexpr AZStd::string_view CameraTranslateBoostIdSetting = "/Amazon/Preferences/Editor/Camera/TranslateBoostId";
-    constexpr AZStd::string_view CameraPivotIdSetting = "/Amazon/Preferences/Editor/Camera/PivotId";
+    constexpr AZStd::string_view CameraOrbitIdSetting = "/Amazon/Preferences/Editor/Camera/OrbitId";
     constexpr AZStd::string_view CameraFreeLookIdSetting = "/Amazon/Preferences/Editor/Camera/FreeLookId";
     constexpr AZStd::string_view CameraFreePanIdSetting = "/Amazon/Preferences/Editor/Camera/FreePanId";
-    constexpr AZStd::string_view CameraPivotLookIdSetting = "/Amazon/Preferences/Editor/Camera/PivotLookId";
-    constexpr AZStd::string_view CameraPivotDollyIdSetting = "/Amazon/Preferences/Editor/Camera/PivotDollyId";
-    constexpr AZStd::string_view CameraPivotPanIdSetting = "/Amazon/Preferences/Editor/Camera/PivotPanId";
+    constexpr AZStd::string_view CameraOrbitLookIdSetting = "/Amazon/Preferences/Editor/Camera/OrbitLookId";
+    constexpr AZStd::string_view CameraOrbitDollyIdSetting = "/Amazon/Preferences/Editor/Camera/OrbitDollyId";
+    constexpr AZStd::string_view CameraOrbitPanIdSetting = "/Amazon/Preferences/Editor/Camera/OrbitPanId";
     constexpr AZStd::string_view CameraFocusIdSetting = "/Amazon/Preferences/Editor/Camera/FocusId";
 
     template<typename T>
@@ -240,14 +240,14 @@ namespace SandboxEditor
         SetRegistry(CameraDollyMotionSpeedSetting, speed);
     }
 
-    bool CameraPivotYawRotationInverted()
+    bool CameraOrbitYawRotationInverted()
     {
-        return GetRegistry(CameraPivotYawRotationInvertedSetting, false);
+        return GetRegistry(CameraOrbitYawRotationInvertedSetting, false);
     }
 
-    void SetCameraPivotYawRotationInverted(const bool inverted)
+    void SetCameraOrbitYawRotationInverted(const bool inverted)
     {
-        SetRegistry(CameraPivotYawRotationInvertedSetting, inverted);
+        SetRegistry(CameraOrbitYawRotationInvertedSetting, inverted);
     }
 
     bool CameraPanInvertedX()
@@ -404,14 +404,14 @@ namespace SandboxEditor
         SetRegistry(CameraTranslateBoostIdSetting, cameraTranslateBoostId);
     }
 
-    AzFramework::InputChannelId CameraPivotChannelId()
+    AzFramework::InputChannelId CameraOrbitChannelId()
     {
-        return AzFramework::InputChannelId(GetRegistry(CameraPivotIdSetting, AZStd::string("keyboard_key_modifier_alt_l")).c_str());
+        return AzFramework::InputChannelId(GetRegistry(CameraOrbitIdSetting, AZStd::string("keyboard_key_modifier_alt_l")).c_str());
     }
 
-    void SetCameraPivotChannelId(AZStd::string_view cameraPivotId)
+    void SetCameraOrbitChannelId(AZStd::string_view cameraOrbitId)
     {
-        SetRegistry(CameraPivotIdSetting, cameraPivotId);
+        SetRegistry(CameraOrbitIdSetting, cameraOrbitId);
     }
 
     AzFramework::InputChannelId CameraFreeLookChannelId()
@@ -434,34 +434,34 @@ namespace SandboxEditor
         SetRegistry(CameraFreePanIdSetting, cameraFreePanId);
     }
 
-    AzFramework::InputChannelId CameraPivotLookChannelId()
+    AzFramework::InputChannelId CameraOrbitLookChannelId()
     {
-        return AzFramework::InputChannelId(GetRegistry(CameraPivotLookIdSetting, AZStd::string("mouse_button_left")).c_str());
+        return AzFramework::InputChannelId(GetRegistry(CameraOrbitLookIdSetting, AZStd::string("mouse_button_left")).c_str());
     }
 
-    void SetCameraPivotLookChannelId(AZStd::string_view cameraPivotLookId)
+    void SetCameraOrbitLookChannelId(AZStd::string_view cameraOrbitLookId)
     {
-        SetRegistry(CameraPivotLookIdSetting, cameraPivotLookId);
+        SetRegistry(CameraOrbitLookIdSetting, cameraOrbitLookId);
     }
 
-    AzFramework::InputChannelId CameraPivotDollyChannelId()
+    AzFramework::InputChannelId CameraOrbitDollyChannelId()
     {
-        return AzFramework::InputChannelId(GetRegistry(CameraPivotDollyIdSetting, AZStd::string("mouse_button_right")).c_str());
+        return AzFramework::InputChannelId(GetRegistry(CameraOrbitDollyIdSetting, AZStd::string("mouse_button_right")).c_str());
     }
 
-    void SetCameraPivotDollyChannelId(AZStd::string_view cameraPivotDollyId)
+    void SetCameraOrbitDollyChannelId(AZStd::string_view cameraOrbitDollyId)
     {
-        SetRegistry(CameraPivotDollyIdSetting, cameraPivotDollyId);
+        SetRegistry(CameraOrbitDollyIdSetting, cameraOrbitDollyId);
     }
 
-    AzFramework::InputChannelId CameraPivotPanChannelId()
+    AzFramework::InputChannelId CameraOrbitPanChannelId()
     {
-        return AzFramework::InputChannelId(GetRegistry(CameraPivotPanIdSetting, AZStd::string("mouse_button_middle")).c_str());
+        return AzFramework::InputChannelId(GetRegistry(CameraOrbitPanIdSetting, AZStd::string("mouse_button_middle")).c_str());
     }
 
-    void SetCameraPivotPanChannelId(AZStd::string_view cameraPivotPanId)
+    void SetCameraOrbitPanChannelId(AZStd::string_view cameraOrbitPanId)
     {
-        SetRegistry(CameraPivotPanIdSetting, cameraPivotPanId);
+        SetRegistry(CameraOrbitPanIdSetting, cameraOrbitPanId);
     }
 
     AzFramework::InputChannelId CameraFocusChannelId()

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -71,8 +71,8 @@ namespace SandboxEditor
     SANDBOX_API float CameraDollyMotionSpeed();
     SANDBOX_API void SetCameraDollyMotionSpeed(float speed);
 
-    SANDBOX_API bool CameraPivotYawRotationInverted();
-    SANDBOX_API void SetCameraPivotYawRotationInverted(bool inverted);
+    SANDBOX_API bool CameraOrbitYawRotationInverted();
+    SANDBOX_API void SetCameraOrbitYawRotationInverted(bool inverted);
 
     SANDBOX_API bool CameraPanInvertedX();
     SANDBOX_API void SetCameraPanInvertedX(bool inverted);
@@ -119,8 +119,8 @@ namespace SandboxEditor
     SANDBOX_API AzFramework::InputChannelId CameraTranslateBoostChannelId();
     SANDBOX_API void SetCameraTranslateBoostChannelId(AZStd::string_view cameraTranslateBoostId);
 
-    SANDBOX_API AzFramework::InputChannelId CameraPivotChannelId();
-    SANDBOX_API void SetCameraPivotChannelId(AZStd::string_view cameraPivotId);
+    SANDBOX_API AzFramework::InputChannelId CameraOrbitChannelId();
+    SANDBOX_API void SetCameraOrbitChannelId(AZStd::string_view cameraOrbitId);
 
     SANDBOX_API AzFramework::InputChannelId CameraFreeLookChannelId();
     SANDBOX_API void SetCameraFreeLookChannelId(AZStd::string_view cameraFreeLookId);
@@ -128,14 +128,14 @@ namespace SandboxEditor
     SANDBOX_API AzFramework::InputChannelId CameraFreePanChannelId();
     SANDBOX_API void SetCameraFreePanChannelId(AZStd::string_view cameraFreePanId);
 
-    SANDBOX_API AzFramework::InputChannelId CameraPivotLookChannelId();
-    SANDBOX_API void SetCameraPivotLookChannelId(AZStd::string_view cameraPivotLookId);
+    SANDBOX_API AzFramework::InputChannelId CameraOrbitLookChannelId();
+    SANDBOX_API void SetCameraOrbitLookChannelId(AZStd::string_view cameraOrbitLookId);
 
-    SANDBOX_API AzFramework::InputChannelId CameraPivotDollyChannelId();
-    SANDBOX_API void SetCameraPivotDollyChannelId(AZStd::string_view cameraPivotDollyId);
+    SANDBOX_API AzFramework::InputChannelId CameraOrbitDollyChannelId();
+    SANDBOX_API void SetCameraOrbitDollyChannelId(AZStd::string_view cameraOrbitDollyId);
 
-    SANDBOX_API AzFramework::InputChannelId CameraPivotPanChannelId();
-    SANDBOX_API void SetCameraPivotPanChannelId(AZStd::string_view cameraPivotPanId);
+    SANDBOX_API AzFramework::InputChannelId CameraOrbitPanChannelId();
+    SANDBOX_API void SetCameraOrbitPanChannelId(AZStd::string_view cameraOrbitPanId);
 
     SANDBOX_API AzFramework::InputChannelId CameraFocusChannelId();
     SANDBOX_API void SetCameraFocusChannelId(AZStd::string_view cameraFocusId);

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -687,7 +687,7 @@ namespace AzFramework
         m_dollyChannelId = dollyChannelId;
     }
 
-    ScrollTranslationCameraInput::ScrollTranslationCameraInput()
+    LookScrollTranslationCameraInput::LookScrollTranslationCameraInput()
     {
         m_scrollSpeedFn = []() constexpr
         {
@@ -695,7 +695,7 @@ namespace AzFramework
         };
     }
 
-    bool ScrollTranslationCameraInput::HandleEvents(
+    bool LookScrollTranslationCameraInput::HandleEvents(
         const InputEvent& event, [[maybe_unused]] const ScreenVector& cursorDelta, [[maybe_unused]] const float scrollDelta)
     {
         if (const auto* scroll = AZStd::get_if<ScrollEvent>(&event))
@@ -706,7 +706,7 @@ namespace AzFramework
         return !Idle();
     }
 
-    Camera ScrollTranslationCameraInput::StepCamera(
+    Camera LookScrollTranslationCameraInput::StepCamera(
         const Camera& targetCamera,
         [[maybe_unused]] const ScreenVector& cursorDelta,
         const float scrollDelta,

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.cpp
@@ -533,8 +533,8 @@ namespace AzFramework
         m_translateCameraInputChannelIds = translateCameraInputChannelIds;
     }
 
-    PivotCameraInput::PivotCameraInput(const InputChannelId& pivotChannelId)
-        : m_pivotChannelId(pivotChannelId)
+    OrbitCameraInput::OrbitCameraInput(const InputChannelId& orbitChannelId)
+        : m_orbitChannelId(orbitChannelId)
     {
         m_pivotFn = []([[maybe_unused]] const AZ::Vector3& position, [[maybe_unused]] const AZ::Vector3& direction)
         {
@@ -542,11 +542,11 @@ namespace AzFramework
         };
     }
 
-    bool PivotCameraInput::HandleEvents(const InputEvent& event, const ScreenVector& cursorDelta, const float scrollDelta)
+    bool OrbitCameraInput::HandleEvents(const InputEvent& event, const ScreenVector& cursorDelta, const float scrollDelta)
     {
         if (const auto* input = AZStd::get_if<DiscreteInputEvent>(&event))
         {
-            if (input->m_channelId == m_pivotChannelId)
+            if (input->m_channelId == m_orbitChannelId)
             {
                 if (input->m_state == InputChannel::State::Began)
                 {
@@ -561,13 +561,13 @@ namespace AzFramework
 
         if (Active())
         {
-            return m_pivotCameras.HandleEvents(event, cursorDelta, scrollDelta);
+            return m_orbitCameras.HandleEvents(event, cursorDelta, scrollDelta);
         }
 
         return !Idle();
     }
 
-    Camera PivotCameraInput::StepCamera(
+    Camera OrbitCameraInput::StepCamera(
         const Camera& targetCamera, const ScreenVector& cursorDelta, const float scrollDelta, const float deltaTime)
     {
         Camera nextCamera = targetCamera;
@@ -581,12 +581,12 @@ namespace AzFramework
         if (Active())
         {
             MovePivotDetached(nextCamera, m_pivotFn(targetCamera.Translation(), targetCamera.Rotation().GetBasisY()));
-            nextCamera = m_pivotCameras.StepCamera(nextCamera, cursorDelta, scrollDelta, deltaTime);
+            nextCamera = m_orbitCameras.StepCamera(nextCamera, cursorDelta, scrollDelta, deltaTime);
         }
 
         if (Ending())
         {
-            m_pivotCameras.Reset();
+            m_orbitCameras.Reset();
 
             nextCamera.m_pivot = nextCamera.Translation();
             nextCamera.m_offset = AZ::Vector3::CreateZero();
@@ -595,12 +595,12 @@ namespace AzFramework
         return nextCamera;
     }
 
-    void PivotCameraInput::SetPivotInputChannelId(const InputChannelId& pivotChanneId)
+    void OrbitCameraInput::SetOrbitInputChannelId(const InputChannelId& orbitChanneId)
     {
-        m_pivotChannelId = pivotChanneId;
+        m_orbitChannelId = orbitChanneId;
     }
 
-    PivotDollyScrollCameraInput::PivotDollyScrollCameraInput()
+    OrbitDollyScrollCameraInput::OrbitDollyScrollCameraInput()
     {
         m_scrollSpeedFn = []() constexpr
         {
@@ -608,7 +608,7 @@ namespace AzFramework
         };
     }
 
-    bool PivotDollyScrollCameraInput::HandleEvents(
+    bool OrbitDollyScrollCameraInput::HandleEvents(
         const InputEvent& event, [[maybe_unused]] const ScreenVector& cursorDelta, [[maybe_unused]] const float scrollDelta)
     {
         if (const auto* scroll = AZStd::get_if<ScrollEvent>(&event))
@@ -619,7 +619,7 @@ namespace AzFramework
         return !Idle();
     }
 
-    static Camera PivotDolly(const Camera& targetCamera, const float delta)
+    static Camera OrbitDolly(const Camera& targetCamera, const float delta)
     {
         Camera nextCamera = targetCamera;
 
@@ -646,18 +646,18 @@ namespace AzFramework
         return nextCamera;
     }
 
-    Camera PivotDollyScrollCameraInput::StepCamera(
+    Camera OrbitDollyScrollCameraInput::StepCamera(
         const Camera& targetCamera,
         [[maybe_unused]] const ScreenVector& cursorDelta,
         const float scrollDelta,
         [[maybe_unused]] const float deltaTime)
     {
-        const auto nextCamera = PivotDolly(targetCamera, aznumeric_cast<float>(scrollDelta) * m_scrollSpeedFn());
+        const auto nextCamera = OrbitDolly(targetCamera, aznumeric_cast<float>(scrollDelta) * m_scrollSpeedFn());
         EndActivation();
         return nextCamera;
     }
 
-    PivotDollyMotionCameraInput::PivotDollyMotionCameraInput(const InputChannelId& dollyChannelId)
+    OrbitDollyMotionCameraInput::OrbitDollyMotionCameraInput(const InputChannelId& dollyChannelId)
         : m_dollyChannelId(dollyChannelId)
     {
         m_motionSpeedFn = []() constexpr
@@ -666,23 +666,23 @@ namespace AzFramework
         };
     }
 
-    bool PivotDollyMotionCameraInput::HandleEvents(
+    bool OrbitDollyMotionCameraInput::HandleEvents(
         const InputEvent& event, [[maybe_unused]] const ScreenVector& cursorDelta, [[maybe_unused]] const float scrollDelta)
     {
         HandleActivationEvents(event, m_dollyChannelId, cursorDelta, m_clickDetector, *this);
         return CameraInputUpdatingAfterMotion(*this);
     }
 
-    Camera PivotDollyMotionCameraInput::StepCamera(
+    Camera OrbitDollyMotionCameraInput::StepCamera(
         const Camera& targetCamera,
         const ScreenVector& cursorDelta,
         [[maybe_unused]] const float scrollDelta,
         [[maybe_unused]] const float deltaTime)
     {
-        return PivotDolly(targetCamera, aznumeric_cast<float>(cursorDelta.m_y) * m_motionSpeedFn());
+        return OrbitDolly(targetCamera, aznumeric_cast<float>(cursorDelta.m_y) * m_motionSpeedFn());
     }
 
-    void PivotDollyMotionCameraInput::SetDollyInputChannelId(const InputChannelId& dollyChannelId)
+    void OrbitDollyMotionCameraInput::SetDollyInputChannelId(const InputChannelId& dollyChannelId)
     {
         m_dollyChannelId = dollyChannelId;
     }

--- a/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
@@ -53,7 +53,7 @@ namespace UnitTest
             };
 
             m_firstPersonTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
-                m_translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslatePivot);
+                m_translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslatePivotLook);
 
             m_orbitCamera = AZStd::make_shared<AzFramework::OrbitCameraInput>(m_orbitChannelId);
             m_orbitCamera->SetPivotFn(
@@ -70,7 +70,7 @@ namespace UnitTest
             };
 
             auto orbitTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
-                m_translateCameraInputChannelIds, AzFramework::OrbitTranslation, AzFramework::TranslateOffset);
+                m_translateCameraInputChannelIds, AzFramework::OrbitTranslation, AzFramework::TranslateOffsetOrbit);
 
             m_orbitCamera->m_orbitCameras.AddCamera(orbitRotateCamera);
             m_orbitCamera->m_orbitCameras.AddCamera(orbitTranslateCamera);

--- a/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
@@ -55,29 +55,29 @@ namespace UnitTest
             m_firstPersonTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
                 m_translateCameraInputChannelIds, AzFramework::LookTranslation, AzFramework::TranslatePivot);
 
-            m_pivotCamera = AZStd::make_shared<AzFramework::PivotCameraInput>(m_pivotChannelId);
-            m_pivotCamera->SetPivotFn(
+            m_orbitCamera = AZStd::make_shared<AzFramework::OrbitCameraInput>(m_orbitChannelId);
+            m_orbitCamera->SetPivotFn(
                 [this](const AZ::Vector3&, const AZ::Vector3&)
                 {
                     return m_pivot;
                 });
 
-            auto pivotRotateCamera = AZStd::make_shared<AzFramework::RotateCameraInput>(AzFramework::InputDeviceMouse::Button::Left);
+            auto orbitRotateCamera = AZStd::make_shared<AzFramework::RotateCameraInput>(AzFramework::InputDeviceMouse::Button::Left);
             // set rotate speed to be a value that will scale motion delta (pixels moved) by a thousandth.
-            pivotRotateCamera->m_rotateSpeedFn = []()
+            orbitRotateCamera->m_rotateSpeedFn = []()
             {
                 return 0.001f;
             };
 
-            auto pivotTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
-                m_translateCameraInputChannelIds, AzFramework::PivotTranslation, AzFramework::TranslateOffset);
+            auto orbitTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(
+                m_translateCameraInputChannelIds, AzFramework::OrbitTranslation, AzFramework::TranslateOffset);
 
-            m_pivotCamera->m_pivotCameras.AddCamera(pivotRotateCamera);
-            m_pivotCamera->m_pivotCameras.AddCamera(pivotTranslateCamera);
+            m_orbitCamera->m_orbitCameras.AddCamera(orbitRotateCamera);
+            m_orbitCamera->m_orbitCameras.AddCamera(orbitTranslateCamera);
 
             m_cameraSystem->m_cameras.AddCamera(m_firstPersonRotateCamera);
             m_cameraSystem->m_cameras.AddCamera(m_firstPersonTranslateCamera);
-            m_cameraSystem->m_cameras.AddCamera(m_pivotCamera);
+            m_cameraSystem->m_cameras.AddCamera(m_orbitCamera);
 
             // these tests rely on using motion delta, not cursor positions (default is true)
             AzFramework::ed_cameraSystemUseCursor = false;
@@ -87,7 +87,7 @@ namespace UnitTest
         {
             AzFramework::ed_cameraSystemUseCursor = true;
 
-            m_pivotCamera.reset();
+            m_orbitCamera.reset();
             m_firstPersonRotateCamera.reset();
             m_firstPersonTranslateCamera.reset();
 
@@ -97,11 +97,11 @@ namespace UnitTest
             AllocatorsTestFixture::TearDown();
         }
 
-        AzFramework::InputChannelId m_pivotChannelId = AzFramework::InputChannelId("keyboard_key_modifier_alt_l");
+        AzFramework::InputChannelId m_orbitChannelId = AzFramework::InputChannelId("keyboard_key_modifier_alt_l");
         AzFramework::TranslateCameraInputChannelIds m_translateCameraInputChannelIds;
         AZStd::shared_ptr<AzFramework::RotateCameraInput> m_firstPersonRotateCamera;
         AZStd::shared_ptr<AzFramework::TranslateCameraInput> m_firstPersonTranslateCamera;
-        AZStd::shared_ptr<AzFramework::PivotCameraInput> m_pivotCamera;
+        AZStd::shared_ptr<AzFramework::OrbitCameraInput> m_orbitCamera;
         AZ::Vector3 m_pivot = AZ::Vector3::CreateZero();
 
         //! This is approximately Pi/2 * 1000 - this can be used to rotate the camera 90 degrees (pitch or yaw based
@@ -109,17 +109,17 @@ namespace UnitTest
         inline static const int PixelMotionDelta = 1570;
     };
 
-    TEST_F(CameraInputFixture, BeginAndEndPivotCameraInputConsumesCorrectEvents)
+    TEST_F(CameraInputFixture, BeginAndEndOrbitCameraInputConsumesCorrectEvents)
     {
-        // begin pivot camera
+        // begin orbit camera
         const bool consumed1 = HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceKeyboard::Key::ModifierAltL,
                                                                                      AzFramework::InputChannel::State::Began });
-        // begin listening for pivot rotate (click detector) - event is not consumed
+        // begin listening for orbit rotate (click detector) - event is not consumed
         const bool consumed2 = HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began });
-        // begin pivot rotate (mouse has moved sufficient distance to initiate)
+        // begin orbit rotate (mouse has moved sufficient distance to initiate)
         const bool consumed3 = HandleEventAndUpdate(AzFramework::HorizontalMotionEvent{ 5 });
-        // end pivot (mouse up) - event is not consumed
+        // end orbit (mouse up) - event is not consumed
         const bool consumed4 = HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Ended });
 
@@ -260,10 +260,10 @@ namespace UnitTest
         EXPECT_TRUE(activationEnded);
     }
 
-    TEST_F(CameraInputFixture, PivotCameraInputHandlesLookAtPointAndSelfAtSamePositionWhenPivoting)
+    TEST_F(CameraInputFixture, OrbitCameraInputHandlesLookAtPointAndSelfAtSamePositionWhenOrbiting)
     {
         // create pathological lookAtFn that just returns the same position as the camera
-        m_pivotCamera->SetPivotFn(
+        m_orbitCamera->SetPivotFn(
             [](const AZ::Vector3& position, [[maybe_unused]] const AZ::Vector3& direction)
             {
                 return position;
@@ -275,7 +275,7 @@ namespace UnitTest
             AZ::Transform::CreateFromQuaternionAndTranslation(
                 AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(0.0f, 0.0f, 90.0f)), expectedCameraPosition));
 
-        HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_pivotChannelId, AzFramework::InputChannel::State::Began });
+        HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began });
 
         // verify the camera yaw has not changed and pivot point matches the expected camera position
         using ::testing::FloatNear;
@@ -321,14 +321,14 @@ namespace UnitTest
         EXPECT_THAT(m_camera.m_offset, IsClose(AZ::Vector3::CreateZero()));
     }
 
-    TEST_F(CameraInputFixture, PivotRotateCameraInputRotatesPitchOffsetByNinetyDegreesWithRequiredPixelDelta)
+    TEST_F(CameraInputFixture, OrbitRotateCameraInputRotatesPitchOffsetByNinetyDegreesWithRequiredPixelDelta)
     {
         const auto cameraStartingPosition = AZ::Vector3::CreateAxisY(-20.0f);
         m_targetCamera.m_pivot = cameraStartingPosition;
 
         m_pivot = AZ::Vector3::CreateAxisY(-10.0f);
 
-        HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_pivotChannelId, AzFramework::InputChannel::State::Began });
+        HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began });
         HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began });
         HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ PixelMotionDelta });
@@ -344,14 +344,14 @@ namespace UnitTest
         EXPECT_THAT(m_camera.Translation(), IsCloseTolerance(expectedCameraEndingPosition, 0.01f));
     }
 
-    TEST_F(CameraInputFixture, PivotRotateCameraInputRotatesYawOffsetByNinetyDegreesWithRequiredPixelDelta)
+    TEST_F(CameraInputFixture, OrbitRotateCameraInputRotatesYawOffsetByNinetyDegreesWithRequiredPixelDelta)
     {
         const auto cameraStartingPosition = AZ::Vector3(15.0f, -20.0f, 0.0f);
         m_targetCamera.m_pivot = cameraStartingPosition;
 
         m_pivot = AZ::Vector3(10.0f, -10.0f, 0.0f);
 
-        HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_pivotChannelId, AzFramework::InputChannel::State::Began });
+        HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began });
         HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began });
         HandleEventAndUpdate(AzFramework::HorizontalMotionEvent{ -PixelMotionDelta });


### PR DESCRIPTION
After some discussion with @amzn-rhhong, to try and simplify the understanding of the CameraInput types I have renamed the public facing types again (sorry back to Orbit 🙈). This gets around the confusing issue where internally we have a camera `m_pivot` member that is useful to have but makes working with _Pivot behaviors_ more confusing.

This should be the last big rename and has some additional comments and context too