### PR TITLE
Add missing field labels to AWSMetrics node SubmitMetrics

### DIFF
--- a/Gems/AWSMetrics/Code/Source/AWSMetricsSystemComponent.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsSystemComponent.cpp
@@ -76,10 +76,10 @@ namespace AWSMetrics
                 ->Attribute(AZ::Script::Attributes::Category, "AWSMetrics")
                 ->Event(
                     "SubmitMetrics", &AWSMetricsRequestBus::Events::SubmitMetrics,
-                    { { { "Metrics Attributes list", "The list of metrics attributes to submit" },
+                    { { { "Metrics Attributes list", "The list of metrics attributes to submit." },
                         { "Event priority", "Priority of the event. Defaults to 0, which is highest priority." }, 
-                        { "Event source override", "Event source used to override the default, 'AWSMetricGem'" },
-                        { "Buffer metrics", "Whether to buffer metrics and send them in a batch" } } })
+                        { "Event source override", "Event source used to override the default, 'AWSMetricGem'." },
+                        { "Buffer metrics", "Whether to buffer metrics and send them in a batch." } } })
                 ->Event("FlushMetrics", &AWSMetricsRequestBus::Events::FlushMetrics)
                 ;
 


### PR DESCRIPTION
Part of https://github.com/o3de/o3de/issues/4502

### testing
before/after 
![image](https://user-images.githubusercontent.com/34254888/136291100-d684d352-a701-4e8e-af4e-a494c0b67a54.png)

unit tests pass
![image](https://user-images.githubusercontent.com/34254888/136291175-2f1cf83e-5c7b-48a5-886c-241176b1e13b.png)


--
Signed-off-by: Stanko <stankoa@amazon.com>