### PR TITLE
LYN-4831: AWCore code cleanup pass, fixing issues with ResolvePath

### DIFF
--- a/Gems/AWSCore/Code/Include/Private/AWSCoreModule.h
+++ b/Gems/AWSCore/Code/Include/Private/AWSCoreModule.h
@@ -24,7 +24,7 @@ namespace AWSCore
         /**
          * Add required SystemComponents to the SystemEntity.
          */
-        virtual AZ::ComponentTypeList GetRequiredSystemComponents() const override;
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override;
     };
 }
 

--- a/Gems/AWSCore/Code/Include/Private/Configuration/AWSCoreConfiguration.h
+++ b/Gems/AWSCore/Code/Include/Private/Configuration/AWSCoreConfiguration.h
@@ -42,7 +42,7 @@ namespace AWSCore
 
 
         AWSCoreConfiguration();
-        ~AWSCoreConfiguration() = default;
+        ~AWSCoreConfiguration() override = default;
 
         void ActivateConfig();
         void DeactivateConfig();

--- a/Gems/AWSCore/Code/Include/Private/Credential/AWSCVarCredentialHandler.h
+++ b/Gems/AWSCore/Code/Include/Private/Credential/AWSCVarCredentialHandler.h
@@ -21,7 +21,7 @@ namespace AWSCore
     {
     public:
         AWSCVarCredentialHandler() = default;
-        ~AWSCVarCredentialHandler() = default;
+        ~AWSCVarCredentialHandler() override = default;
 
         //! Activate handler and its credentials provider, make sure activation
         //! invoked after AWSNativeSDK init to avoid memory leak

--- a/Gems/AWSCore/Code/Include/Private/Credential/AWSDefaultCredentialHandler.h
+++ b/Gems/AWSCore/Code/Include/Private/Credential/AWSDefaultCredentialHandler.h
@@ -23,7 +23,7 @@ namespace AWSCore
     {
     public:
         AWSDefaultCredentialHandler();
-        ~AWSDefaultCredentialHandler() = default;
+        ~AWSDefaultCredentialHandler() override = default;
 
         //! Activate handler and its credentials provider, make sure activation
         //! invoked after AWSNativeSDK init to avoid memory leak

--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConsentDialog.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConsentDialog.h
@@ -15,13 +15,12 @@
 namespace AWSCore
 {
     //! Defines AWSCoreAttributionConsent QT dialog as QT message box.
-    class AWSCoreAttributionConsentDialog :
-        public QMessageBox
+    class AWSCoreAttributionConsentDialog
+        : public QMessageBox
     {
     public:
         AZ_CLASS_ALLOCATOR(AWSCoreAttributionConsentDialog, AZ::SystemAllocator, 0);
         AWSCoreAttributionConsentDialog();
-        virtual ~AWSCoreAttributionConsentDialog() = default;
-       
+        ~AWSCoreAttributionConsentDialog() override = default;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConstant.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConstant.h
@@ -18,4 +18,4 @@ namespace AWSCore
     static constexpr char AwsAttributionAttributeKeyActiveAWSGems[] = "aws_gems";
     static constexpr char AwsAttributionAttributeKeyTimestamp[] = "timestamp";
 
-} // namespace AWSCOre
+} // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreEditorMenu.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreEditorMenu.h
@@ -34,7 +34,7 @@ namespace AWSCore
             "Failed to launch Resource Mapping Tool, please check <a href=\"file:///%s\">logs</a> for details.";
 
         AWSCoreEditorMenu(const QString& text);
-        ~AWSCoreEditorMenu();
+        ~AWSCoreEditorMenu() override;
 
     private:
         QAction* AddExternalLinkAction(const AZStd::string& name, const AZStd::string& url, const AZStd::string& icon = "");

--- a/Gems/AWSCore/Code/Include/Private/ResourceMapping/AWSResourceMappingManager.h
+++ b/Gems/AWSCore/Code/Include/Private/ResourceMapping/AWSResourceMappingManager.h
@@ -71,7 +71,7 @@ namespace AWSCore
         };
 
         AWSResourceMappingManager();
-        ~AWSResourceMappingManager() = default;
+        ~AWSResourceMappingManager() override = default;
 
         void ActivateManager();
         void DeactivateManager();

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiClientJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiClientJobConfig.h
@@ -64,9 +64,6 @@ namespace AWSCore
 
         /// Initialize an AwsApiClientJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.
@@ -83,10 +80,10 @@ namespace AWSCore
             }
         }
 
-        virtual ~AwsApiClientJobConfig() = default;
+        ~AwsApiClientJobConfig() override = default;
 
         /// Gets a client initialized used currently applied settings. If
-        /// any settings change after first use, code must call 
+        /// any settings change after first use, code must call
         /// ApplySettings before those changes will take effect.
         std::shared_ptr<ClientType> GetClient() override
         {
@@ -112,7 +109,7 @@ namespace AWSCore
             }
             else
             {
-                // If no explict credenitals are provided then AWS C++ SDK will perform standard search
+                // If no explicit credentials are provided then AWS C++ SDK will perform standard search
                 return std::make_shared<ClientType>(Aws::Auth::AWSCredentials(), GetClientConfiguration());
             }
         }

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJob.h
@@ -14,14 +14,12 @@
 
 namespace AWSCore
 {
-
-    /// Base class for all AWS jobs. Primarily exists so that 
+    /// Base class for all AWS jobs. Primarily exists so that
     /// AwsApiJob::s_config can be used for settings that apply to
     /// all AWS jobs.
     class AwsApiJob
         : public AZ::Job
     {
-
     public:
         // To use a different allocator, extend this class and use this macro.
         AZ_CLASS_ALLOCATOR(AwsApiJob, AZ::SystemAllocator, 0);
@@ -33,11 +31,10 @@ namespace AWSCore
 
     protected:
         AwsApiJob(bool isAutoDelete, IConfig* config = GetDefaultConfig());
-        virtual ~AwsApiJob();
+        ~AwsApiJob() override = default;
 
         /// Used for error messages.
         static const char* COMPONENT_DISPLAY_NAME;
-
     };
 
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJobConfig.h
@@ -93,9 +93,6 @@ namespace AWSCore
 
         /// Initialize an AwsApiClientJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.
@@ -139,7 +136,7 @@ namespace AWSCore
         Override<bool> followRedirects;
         Override<Aws::String> caFile;
 
-        /// Applys settings changes made after first use.
+        /// Applies settings changes made after first use.
         virtual void ApplySettings();
 
         //////////////////////////////////////////////////////////////////////////
@@ -210,7 +207,7 @@ namespace AWSCore
         : protected AWSCoreNotificationsBus::Handler
     {
     public:
-        ~AwsApiJobConfigHolder()
+        ~AwsApiJobConfigHolder() override
         {
             AWSCoreNotificationsBus::Handler::BusDisconnect();
         }

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiRequestJob.h
@@ -145,10 +145,10 @@ namespace AWSCore
     AWS_API_REQUEST_TRAITS_TEMPLATE_DEFINITION_HELPER
         typename AWS_API_REQUEST_TRAITS_TEMPLATE_INSTANCE_HELPER::AsyncFunctionType AWS_API_REQUEST_TRAITS_TEMPLATE_INSTANCE_HELPER::AsyncFunction = _AsyncFunction;
 
-    /// Macro that simplifies the declaration of an AwsRequstJob that has a result.
+    /// Macro that simplifies the declaration of an AwsRequestJob that has a result.
 #define AWS_API_REQUEST_JOB(SERVICE, REQUEST) AWSCore::AwsApiRequestJob<AWS_API_REQUEST_TRAITS(SERVICE, REQUEST)>
 
-/// Macro that simplifies the declaration of an AwsRequstJob that has no result.
+/// Macro that simplifies the declaration of an AwsRequestJob that has no result.
 #define AWS_API_REQUEST_JOB_NO_RESULT(SERVICE, REQUEST) AWSCore::AwsApiRequestJob<AWS_API_REQUEST_TRAITS_NO_RESULT(SERVICE, REQUEST)>
 
 /// An Az::Job that that executes a specific AWS request.
@@ -257,7 +257,7 @@ namespace AWSCore
         /// of request data until your running on the job's worker thread,
         /// instead of setting the request data before calling Start.
         ///
-        /// \param true if the request should be made.
+        /// \return true if the request should be made.
         virtual bool PrepareRequest()
         {
             return true;

--- a/Gems/AWSCore/Code/Include/Public/Framework/HttpClientComponent.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/HttpClientComponent.h
@@ -39,7 +39,7 @@ namespace AWSCore
         : public AZ::ComponentBus
     {
     public:
-        virtual ~HttpClientComponentNotifications() {}
+        ~HttpClientComponentNotifications() override = default;
         virtual void OnHttpRequestSuccess(int responseCode, AZStd::string responseBody) {}
         virtual void OnHttpRequestFailure(int responseCode) {}
     };
@@ -55,7 +55,7 @@ namespace AWSCore
     {
     public:
         AZ_COMPONENT(HttpClientComponent, "{23ECDBDF-129A-4670-B9B4-1E0B541ACD61}");
-        virtual ~HttpClientComponent() = default;
+        ~HttpClientComponent() override = default;
 
         void Init() override;
         void Activate() override;

--- a/Gems/AWSCore/Code/Include/Public/Framework/HttpRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/HttpRequestJob.h
@@ -178,7 +178,7 @@ namespace AWSCore
         };
 
         /// Override to process the response to the HTTP request before callbacks are fired.
-        /// WARNING: This gets called on the job's thread, so observe thread safety precations.
+        /// WARNING: This gets called on the job's thread, so observe thread safety precautions.
         virtual void ProcessResponse(const std::shared_ptr<Aws::Http::HttpResponse>& response)
         {
             AZ_UNUSED(response);

--- a/Gems/AWSCore/Code/Include/Public/Framework/JsonObjectHandler.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/JsonObjectHandler.h
@@ -29,24 +29,24 @@ namespace AWSCore
         Ch Peek() const
         {
             int c = m_is.peek();
-            return c == std::char_traits<char>::eof() ? '\0' : (Ch)c;
+            return c == std::char_traits<char>::eof() ? '\0' : static_cast<Ch>(c);
         }
 
         Ch Take()
         {
             int c = m_is.get();
-            return c == std::char_traits<char>::eof() ? '\0' : (Ch)c;
+            return c == std::char_traits<char>::eof() ? '\0' : static_cast<Ch>(c);
         }
 
         size_t Tell() const
         {
-            return (size_t)m_is.tellg();
+            return static_cast<size_t>(m_is.tellg());
         }
 
         Ch* PutBegin()
         {
             AZ_Assert(false, "Not Implemented");
-            return 0;
+            return nullptr;
         }
 
         void Put(Ch)

--- a/Gems/AWSCore/Code/Include/Public/Framework/JsonWriter.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/JsonWriter.h
@@ -161,7 +161,7 @@ namespace AWSCore
         }
 
         /// Write JSON format content directly to the writer's output stream.
-        /// This can be used to efficently output static content.
+        /// This can be used to efficiently output static content.
         bool WriteJson(const Ch* json)
         {
             if (json)
@@ -182,7 +182,7 @@ namespace AWSCore
         }
 
         /// Write an object. The object can implement a WriteJson function
-        /// or you can provide an GobalWriteJson template function 
+        /// or you can provide an GlobalWriteJson template function 
         /// specialization.
         template<class ObjectType>
         bool Object(const ObjectType& obj)

--- a/Gems/AWSCore/Code/Include/Public/Framework/RequestBuilder.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/RequestBuilder.h
@@ -36,7 +36,7 @@ namespace AWSCore
     class RequestBuilder
     {
     public:
-        RequestBuilder() = default;
+        RequestBuilder();
 
         /// Converts the provided object to JSON and sends it as the
         /// body of the request. The object can implement the following

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceClientJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceClientJobConfig.h
@@ -20,7 +20,7 @@ namespace AWSCore
     {
 
     public:
-        virtual const AZStd::string GetServiceUrl() = 0;
+        virtual AZStd::string GetServiceUrl() = 0;
     };
 
     /// Encapsulates what code needs to know about a service in order to 
@@ -81,9 +81,6 @@ namespace AWSCore
 
         /// Initialize an ServiceClientJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.
@@ -102,7 +99,7 @@ namespace AWSCore
 
         /// This implementation assumes the caller will cache this value as 
         /// needed. See it's use in ServiceRequestJobConfig.
-        const AZStd::string GetServiceUrl() override
+        AZStd::string GetServiceUrl() override
         {
             if (endpointOverride.has_value())
             {

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJob.h
@@ -119,7 +119,7 @@ namespace AWSCore
         Error error;
 
         /// Determines if the AWS credentials, as supplied by the credentialsProvider from
-        /// the ServiceReqestJobConfig object (which defaults to the user's credentials), 
+        /// the ServiceRequestJobConfig object (which defaults to the user's credentials), 
         /// are used to sign the request. The default is true. Override this and return false 
         /// if calling a public API and want to avoid the overhead of signing requests.
         bool UseAWSCredentials() {
@@ -565,13 +565,11 @@ namespace AWSCore
             }
 
             AZStd::string requestContent;
-            AZStd::string responseContent;
-
-            std::istreambuf_iterator<AZStd::string::value_type> eos;
 
             std::shared_ptr<Aws::IOStream> requestStream = response->GetOriginatingRequest().GetContentBody();
             if (requestStream)
             {
+                std::istreambuf_iterator<AZStd::string::value_type> eos;
                 requestStream->clear();
                 requestStream->seekg(0);
                 requestContent = AZStd::string{ std::istreambuf_iterator<AZStd::string::value_type>(*requestStream.get()),eos };
@@ -584,7 +582,7 @@ namespace AWSCore
             Aws::IOStream& responseStream = response->GetResponseBody();
             responseStream.clear();
             responseStream.seekg(0);
-            responseContent = AZStd::string{ std::istreambuf_iterator<AZStd::string::value_type>(responseStream),responseEos };
+            AZStd::string responseContent = AZStd::string{ std::istreambuf_iterator<AZStd::string::value_type>(responseStream), responseEos };
             responseContent = EscapePercentCharsInString(responseContent);
             responseStream.seekg(0);
 

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJobConfig.h
@@ -44,9 +44,6 @@ namespace AWSCore
 
         /// Initialize an ServiceRequestJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.

--- a/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
@@ -79,7 +79,7 @@ namespace AWSCore
         QMenuBar* menuBar = mainWindow->menuBar();
         QList<QAction*> actionList = menuBar->actions();
         QAction* insertPivot = nullptr;
-        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); itr++)
+        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); ++itr)
         {
             if (QString::compare((*itr)->text(), EDITOR_HELP_MENU_TEXT) == 0)
             {
@@ -88,7 +88,7 @@ namespace AWSCore
             }
         }
 
-        auto menu = m_awsCoreEditorManager->GetAWSCoreEditorMenu();
+        const auto menu = m_awsCoreEditorManager->GetAWSCoreEditorMenu();
         if (insertPivot)
         {
             menuBar->insertMenu(insertPivot, menu);

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionConsentDialog.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionConsentDialog.cpp
@@ -35,8 +35,7 @@ namespace AWSCore
         this->setDefaultButton(QMessageBox::Save);
         this->button(QMessageBox::Cancel)->hide();
         this->setIcon(QMessageBox::Information);
-        QGridLayout* layout = (QGridLayout*)this->layout();
-        if (layout)
+        if (QGridLayout* layout = static_cast<QGridLayout*>(this->layout()))
         {
             layout->setVerticalSpacing(20);
             layout->setHorizontalSpacing(10);

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
@@ -68,19 +68,19 @@ namespace AWSCore
         AZ_Assert(fileIO, "File IO is not initialized.");
 
         // Resolve path to editor_aws_preferences.setreg
-        AZStd::string editorAWSPreferencesFilePath =
+        const AZStd::string editorAWSPreferencesFilePath =
             AZStd::string::format("@user@/%s/%s", AZ::SettingsRegistryInterface::RegistryFolder, EditorAWSPreferencesFileName);
-        AZStd::array<char, AZ::IO::MaxPathLength> resolvedPathAWSPreference{};
-        if (!fileIO->ResolvePath(editorAWSPreferencesFilePath.c_str(), resolvedPathAWSPreference.data(), resolvedPathAWSPreference.size()))
+        AZ::IO::FixedMaxPath resolvedPathAWSPreference;
+        if (!fileIO->ResolvePath(resolvedPathAWSPreference, AZ::IO::PathView(editorAWSPreferencesFilePath)))
         {
-            AZ_Warning("AWSAttributionManager", false, "Error resolving path %s", resolvedPathAWSPreference.data());
+            AZ_Warning("AWSAttributionManager", false, "Error resolving path %s", resolvedPathAWSPreference.c_str());
             return;
         }
 
-        if (fileIO->Exists(resolvedPathAWSPreference.data()))
+        if (fileIO->Exists(resolvedPathAWSPreference.c_str()))
         {
             m_settingsRegistry->MergeSettingsFile(
-                resolvedPathAWSPreference.data(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
+                resolvedPathAWSPreference.String(), AZ::SettingsRegistryInterface::Format::JsonMergePatch, "");
         }
     }
 
@@ -136,8 +136,8 @@ namespace AWSCore
             return true;
         }
 
-        AZStd::chrono::seconds lastSendTimeStamp = AZStd::chrono::seconds(lastSendTimeStampSeconds);
-        AZStd::chrono::seconds secondsSinceLastSend =
+        const AZStd::chrono::seconds lastSendTimeStamp = AZStd::chrono::seconds(lastSendTimeStampSeconds);
+        const AZStd::chrono::seconds secondsSinceLastSend =
             AZStd::chrono::duration_cast<AZStd::chrono::seconds>(AZStd::chrono::system_clock::now().time_since_epoch()) - lastSendTimeStamp;
         if (static_cast<AZ::u64>(secondsSinceLastSend.count()) >= delayInSeconds)
         {
@@ -154,7 +154,7 @@ namespace AWSCore
         if (credentialResult.result)
         {
             std::shared_ptr<Aws::Auth::AWSCredentialsProvider> provider = credentialResult.result;
-            auto creds = provider->GetAWSCredentials();
+            const auto creds = provider->GetAWSCredentials();
             if (!creds.IsEmpty())
             {
                 return true;
@@ -200,9 +200,13 @@ namespace AWSCore
                 AZ_Assert(fileIO, "File IO is not initialized.");
 
                 // Resolve path to editor_aws_preferences.setreg
-                AZStd::string editorPreferencesFilePath = AZStd::string::format("@user@/%s/%s", AZ::SettingsRegistryInterface::RegistryFolder, EditorAWSPreferencesFileName);
-                AZStd::array<char, AZ::IO::MaxPathLength> resolvedPath {};
-                fileIO->ResolvePath(editorPreferencesFilePath.c_str(), resolvedPath.data(), resolvedPath.size());
+                const AZStd::string editorPreferencesFilePath = AZStd::string::format("@user@/%s/%s", AZ::SettingsRegistryInterface::RegistryFolder, EditorAWSPreferencesFileName);
+                AZ::IO::FixedMaxPath resolvedPathAWSPreference;
+                if (!fileIO->ResolvePath(resolvedPathAWSPreference, AZ::IO::PathView(editorPreferencesFilePath)))
+                {
+                    AZ_Warning("AWSAttributionManager", false, "Error resolving path %s", editorPreferencesFilePath.c_str());
+                    return;
+                }
 
                 AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
                 dumperSettings.m_prettifyOutput = true;
@@ -215,14 +219,14 @@ namespace AWSCore
                 {
                     AZ_Warning(
                         "AWSAttributionManager", false, R"(Unable to save changes to the Editor AWS Preferences registry file at "%s"\n)",
-                        resolvedPath.data());
+                        resolvedPathAWSPreference.c_str());
                     return;
                 }
 
                 bool saved {};
                 constexpr auto configurationMode =
                     AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
-                if (AZ::IO::SystemFile outputFile; outputFile.Open(resolvedPath.data(), configurationMode))
+                if (AZ::IO::SystemFile outputFile; outputFile.Open(resolvedPathAWSPreference.c_str(), configurationMode))
                 {
                     saved = outputFile.Write(stringBuffer.data(), stringBuffer.size()) == stringBuffer.size();
                 }

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
@@ -54,7 +54,7 @@ namespace AWSCore
         {
             if (m_resourceMappingToolWatcher->IsProcessRunning())
             {
-                m_resourceMappingToolWatcher->TerminateProcess(AZ::u32(-1));
+                m_resourceMappingToolWatcher->TerminateProcess(static_cast<AZ::u32>(-1));
             }
             m_resourceMappingToolWatcher.reset();
         }
@@ -214,7 +214,7 @@ namespace AWSCore
     QMenu* AWSCoreEditorMenu::SetAWSFeatureSubMenu(const AZStd::string& menuText)
     {
         auto actionList = this->actions();
-        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); itr++)
+        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); ++itr)
         {
             if (QString::compare((*itr)->text(), menuText.c_str()) == 0)
             {

--- a/Gems/AWSCore/Code/Source/Framework/AWSApiJob.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/AWSApiJob.cpp
@@ -22,10 +22,6 @@ namespace AWSCore
     {
     }
 
-    AwsApiJob::~AwsApiJob()
-    {
-    }
-
     AwsApiJob::Config* AwsApiJob::GetDefaultConfig()
     {
         static AwsApiJobConfigHolder<AwsApiJob::Config> s_configHolder{};

--- a/Gems/AWSCore/Code/Source/Framework/MultipartFormData.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/MultipartFormData.cpp
@@ -49,7 +49,7 @@ namespace AWSCore
     {
         m_fileFields.emplace_back(FileField{ std::move(fieldName), std::move(fileName) , AZStd::vector<char>{} });
         m_fileFields.back().m_fileData.reserve(length);
-        m_fileFields.back().m_fileData.assign((const char*)bytes, (const char*)bytes + length);
+        m_fileFields.back().m_fileData.assign(static_cast<const char*>(bytes), static_cast<const char*>(bytes) + length);
     }
 
     void MultipartFormData::SetCustomBoundary(AZStd::string boundary)

--- a/Gems/AWSCore/Code/Source/Framework/RequestBuilder.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/RequestBuilder.cpp
@@ -10,6 +10,10 @@
 
 namespace AWSCore
 {
+    RequestBuilder::RequestBuilder()
+        : m_httpMethod(Aws::Http::HttpMethod::HTTP_GET)
+    {
+    }
 
     bool RequestBuilder::SetPathParameterUnescaped(const char* key, const char* value)
     {

--- a/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
+++ b/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
@@ -26,7 +26,6 @@ namespace AWSCore
         : m_status(Status::NotLoaded)
         , m_defaultAccountId("")
         , m_defaultRegion("")
-        , m_resourceMappings()
     {
     }
 
@@ -164,7 +163,7 @@ namespace AWSCore
         m_defaultRegion = jsonDocument.FindMember(ResourceMappingRegionKeyName)->value.GetString();
 
         auto resourceMappings = jsonDocument.FindMember(ResourceMappingResourcesKeyName)->value.GetObject();
-        for (auto mappingIter = resourceMappings.MemberBegin(); mappingIter != resourceMappings.MemberEnd(); mappingIter++)
+        for (auto mappingIter = resourceMappings.MemberBegin(); mappingIter != resourceMappings.MemberEnd(); ++mappingIter)
         {
             auto mappingValue = mappingIter->value.GetObject();
             if (mappingValue.MemberCount() != 0)

--- a/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorDynamoDB.cpp
+++ b/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorDynamoDB.cpp
@@ -71,7 +71,7 @@ namespace AWSCore
             [](DynamoDBGetItemRequestJob* job) // OnSuccess handler
             {
                 auto item = job->result.GetItem();
-                if (item.size() > 0)
+                if (!item.empty())
                 {
                     DynamoDBAttributeValueMap result;
                     for (const auto& itermPair : item)

--- a/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
@@ -40,7 +40,7 @@ public:
         AWSCoreNotificationsBus::Handler::BusConnect();
     }
 
-    ~AWSCoreNotificationsBusMock()
+    ~AWSCoreNotificationsBusMock() override
     {
         AWSCoreNotificationsBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/Credential/AWSCVarCredentialHandlerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSCVarCredentialHandlerTest.cpp
@@ -18,7 +18,7 @@ class AWSCVarCredentialHandlerTest
 {
 public:
     AWSCVarCredentialHandlerTest() = default;
-    virtual ~AWSCVarCredentialHandlerTest() = default;
+    ~AWSCVarCredentialHandlerTest() override = default;
 
     void SetUp() override
     {

--- a/Gems/AWSCore/Code/Tests/Credential/AWSCredentialBusTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSCredentialBusTest.cpp
@@ -36,14 +36,14 @@ public:
         m_credentialsProvider.reset();
     }
 
-    int GetCredentialHandlerOrder() const
+    int GetCredentialHandlerOrder() const override
     {
         return 1;
     }
 
-    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider()
+    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider() override
     {
-        m_handlerCounter++;
+        ++m_handlerCounter;
         return m_credentialsProvider;
     }
 
@@ -72,14 +72,14 @@ public:
         m_credentialsProvider.reset();
     }
 
-    int GetCredentialHandlerOrder() const
+    int GetCredentialHandlerOrder() const override
     {
         return 2;
     }
 
-    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider()
+    std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider() override
     {
-        m_handlerCounter++;
+        ++m_handlerCounter;
         return m_credentialsProvider;
     }
 
@@ -115,10 +115,10 @@ public:
 
 TEST_F(AWSCredentialBusTest, GetCredentialsProvider_CallFromMultithread_GetExpectedCredentialsProviderAndNumberOfCalls)
 {
-    int testThreadNumber = 10;
+    constexpr int testThreadNumber = 10;
     AZStd::atomic<int> actualEbusCalls = 0;
     AZStd::vector<AZStd::thread> testThreadPool;
-    for (int index = 0; index < testThreadNumber; index++)
+    for (int index = 0; index < testThreadNumber; ++index)
     {
         testThreadPool.emplace_back(AZStd::thread([&]() {
             AWSCredentialResult result;

--- a/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSDefaultCredentialHandlerTest.cpp
@@ -49,7 +49,7 @@ class AWSDefaultCredentialHandlerTest
 {
 public:
     AWSDefaultCredentialHandlerTest() = default;
-    virtual ~AWSDefaultCredentialHandlerTest() = default;
+    ~AWSDefaultCredentialHandlerTest() override = default;
 
     void SetUp() override
     {

--- a/Gems/AWSCore/Code/Tests/Framework/AWSApiClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/AWSApiClientJobConfigTest.cpp
@@ -23,6 +23,11 @@ class AWSApiClientJobConfigTest
     , public AWSCredentialRequestBus::Handler
 {
 public:
+    AWSApiClientJobConfigTest()
+        : m_credentialHandlerCounter(0)
+    {
+    }
+
     void SetUp() override
     {
         AWSNativeSDKInit::InitializationManager::InitAwsApi();

--- a/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
@@ -84,7 +84,7 @@ class ServiceClientJobConfigTest
     void ReloadConfigFile(bool reloadConfigFileName = false) override
     {
         AZ_UNUSED(reloadConfigFileName);
-    };
+    }
 };
 
 TEST_F(ServiceClientJobConfigTest, GetServiceUrl_CreateServiceWithServiceNameOnly_GetExpectedFeatureServiceUrl)

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
@@ -217,7 +217,7 @@ TEST_F(AWSResourceMappingManagerTest, ActivateManager_ParseValidConfigFile_Confi
     CreateTestConfigFile(TEST_VALID_RESOURCE_MAPPING_CONFIG_FILE);
     m_resourceMappingManager->ActivateManager();
 
-    int testThreadNumber = 10;
+    constexpr int testThreadNumber = 10;
     AZStd::atomic<int> actualEbusCalls = 0;
     AZStd::vector<AZStd::thread> testThreadPool;
     for (int index = 0; index < testThreadNumber; index++)
@@ -226,7 +226,7 @@ TEST_F(AWSResourceMappingManagerTest, ActivateManager_ParseValidConfigFile_Confi
             AZStd::string actualAccountId;
             AWSResourceMappingRequestBus::BroadcastResult(actualAccountId, &AWSResourceMappingRequests::GetDefaultAccountId);
             EXPECT_FALSE(actualAccountId.empty());
-            actualEbusCalls++;
+            ++actualEbusCalls;
         }));
     }
 

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingUtilsTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingUtilsTest.cpp
@@ -44,19 +44,19 @@ TEST_F(AWSResourceMappingUtilsTest, FormatRESTApiUrl_PassingInvalidRESTApiId_Ret
 {
     auto actualUrl = AWSResourceMappingUtils::FormatRESTApiUrl("", TEST_VALID_RESTAPI_REGION, TEST_VALID_RESTAPI_STAGE);
 
-    EXPECT_TRUE(actualUrl == "");
+    EXPECT_TRUE(actualUrl.empty());
 }
 
 TEST_F(AWSResourceMappingUtilsTest, FormatRESTApiUrl_PassingInvalidRESTApiRegion_ReturnEmptyResult)
 {
     auto actualUrl = AWSResourceMappingUtils::FormatRESTApiUrl(TEST_VALID_RESTAPI_ID, "", TEST_VALID_RESTAPI_STAGE);
 
-    EXPECT_TRUE(actualUrl == "");
+    EXPECT_TRUE(actualUrl.empty());
 }
 
 TEST_F(AWSResourceMappingUtilsTest, FormatRESTApiUrl_PassingInvalidRESTApiStage_ReturnEmptyResult)
 {
     auto actualUrl = AWSResourceMappingUtils::FormatRESTApiUrl(TEST_VALID_RESTAPI_ID, TEST_VALID_RESTAPI_REGION, "");
 
-    EXPECT_TRUE(actualUrl == "");
+    EXPECT_TRUE(actualUrl.empty());
 }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorDynamoDBTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorDynamoDBTest.cpp
@@ -23,7 +23,7 @@ public:
         AWSScriptBehaviorDynamoDBNotificationBus::Handler::BusConnect();
     }
 
-    ~AWSScriptBehaviorDynamoDBNotificationBusHandlerMock()
+    ~AWSScriptBehaviorDynamoDBNotificationBusHandlerMock() override
     {
         AWSScriptBehaviorDynamoDBNotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorLambdaTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorLambdaTest.cpp
@@ -22,7 +22,7 @@ public:
         AWSScriptBehaviorLambdaNotificationBus::Handler::BusConnect();
     }
 
-    ~AWSScriptBehaviorLambdaNotificationBusHandlerMock()
+    ~AWSScriptBehaviorLambdaNotificationBusHandlerMock() override
     {
         AWSScriptBehaviorLambdaNotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorS3Test.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorS3Test.cpp
@@ -24,7 +24,7 @@ public:
         AWSScriptBehaviorS3NotificationBus::Handler::BusConnect();
     }
 
-    ~AWSScriptBehaviorS3NotificationBusHandlerMock()
+    ~AWSScriptBehaviorS3NotificationBusHandlerMock() override
     {
         AWSScriptBehaviorS3NotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
+++ b/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
@@ -107,8 +107,8 @@ class AWSCoreFixture
     : public UnitTest::ScopedAllocatorSetupFixture
 {
 public:
-    AWSCoreFixture() {}
-    virtual ~AWSCoreFixture() = default;
+    AWSCoreFixture() = default;
+    ~AWSCoreFixture() override = default;
 
     void SetUp() override
     {


### PR DESCRIPTION
Stripped down version of https://github.com/o3de/o3de/pull/3767/files

Fix issue with resolve path where return value not checked, incorrectly passing params

Initial clean up of:
Add missing overrides to methods
Fix c-style cases
Fix spelling issues
Migrate to prefix operator over postfix
etc

Testing:
* Ran unit tests
* Ran editor 
* Deleted registry settings related to attribution/ deleted registry files during save.

Signed-off-by: rppotter <rppotter@amazon.com>