### PR TITLE
Removed the zeroAnalysisMode option from the ${project}.Assets target

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -35,7 +35,6 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
                 -DLY_LOCK_FILE=$<GENEX_EVAL:$<TARGET_FILE_DIR:AZ::AssetProcessorBatch>>/project_assets.lock
                 -P ${LY_ROOT_FOLDER}/cmake/CommandExecution.cmake
                     EXEC_COMMAND $<GENEX_EVAL:$<TARGET_FILE:AZ::AssetProcessorBatch>>
-                        --zeroAnalysisMode 
                         --project-path=${project_real_path} 
                         --platforms=${LY_ASSET_DEPLOY_ASSET_TYPE}
         )


### PR DESCRIPTION
Running the AssetProcessorBatch as part of the build step should process
any out of date source assets and the zeroAnalysisMode option prevents
scanning for updates to a source asset if it is modified while the
AssetProcessor isn't running.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>