### PR TITLE
Console changes: Added a new SettingsRegistry root key for executing console commands.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Console/Console.cpp
+++ b/Code/Framework/AzCore/AzCore/Console/Console.cpp
@@ -476,15 +476,16 @@ namespace AZ
 
         // Responsible for using the Json Serialization Issue Callback system
         // to determine when a JSON Patch or JSON Merge Patch modifies a value
-        // at a path underneath the IConsole::ConsoleRootCommandKey JSON pointer
+        // at a path underneath the IConsole::ConsoleRuntimeCommandKey JSON pointer
         JsonSerializationResult::ResultCode operator()(AZStd::string_view message,
             JsonSerializationResult::ResultCode result, AZStd::string_view path)
         {
-            AZ::IO::PathView consoleRootCommandKey{ IConsole::ConsoleRootCommandKey, AZ::IO::PosixPathSeparator };
+            constexpr AZ::IO::PathView consoleRootCommandKey{ IConsole::ConsoleRuntimeCommandKey, AZ::IO::PosixPathSeparator };
+            constexpr AZ::IO::PathView consoleAutoexecCommandKey{ IConsole::ConsoleAutoexecCommandKey, AZ::IO::PosixPathSeparator };
             AZ::IO::PathView inputKey{ path, AZ::IO::PosixPathSeparator };
             if (result.GetTask() == JsonSerializationResult::Tasks::Merge
                 && result.GetProcessing() == JsonSerializationResult::Processing::Completed
-                && inputKey.IsRelativeTo(consoleRootCommandKey))
+                && (inputKey.IsRelativeTo(consoleRootCommandKey) || inputKey.IsRelativeTo(consoleAutoexecCommandKey)))
             {
                 if (auto type = m_settingsRegistry.GetType(path); type != SettingsRegistryInterface::Type::NoType)
                 {
@@ -510,12 +511,24 @@ namespace AZ
         {
             using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
 
-            AZ::IO::PathView consoleRootCommandKey{ IConsole::ConsoleRootCommandKey, AZ::IO::PosixPathSeparator };
+            constexpr AZ::IO::PathView consoleRuntimeCommandKey{ IConsole::ConsoleRuntimeCommandKey, AZ::IO::PosixPathSeparator };
+            constexpr AZ::IO::PathView consoleAutoexecCommandKey{ IConsole::ConsoleAutoexecCommandKey, AZ::IO::PosixPathSeparator };
             AZ::IO::PathView inputKey{ path, AZ::IO::PosixPathSeparator };
-            // The ConsoleRootComamndKey is not a command itself so strictly children keys are being examined
-            if (inputKey.IsRelativeTo(consoleRootCommandKey) && inputKey != consoleRootCommandKey)
+
+            // Abuses the IsRelativeToFuncton function of the path class to extract the console
+            // command from the settings registry objects
+            FixedValueString command;
+            if (inputKey != consoleRuntimeCommandKey && inputKey.IsRelativeTo(consoleRuntimeCommandKey))
             {
-                FixedValueString command = inputKey.LexicallyRelative(consoleRootCommandKey).Native();
+                command = inputKey.LexicallyRelative(consoleRuntimeCommandKey).Native();
+            }
+            else if (inputKey != consoleAutoexecCommandKey && inputKey.IsRelativeTo(consoleAutoexecCommandKey))
+            {
+                command = inputKey.LexicallyRelative(consoleAutoexecCommandKey).Native();
+            }
+
+            if (!command.empty())
+            {
                 ConsoleCommandContainer commandArgs;
                 // Argument string which stores the value from the Settings Registry long enough
                 // to pass into the PerformCommand. The ConsoleCommandContainer stores string_views
@@ -603,9 +616,10 @@ namespace AZ
 
     void Console::RegisterCommandInvokerWithSettingsRegistry(AZ::SettingsRegistryInterface& settingsRegistry)
     {
-        // Make sure the there is a JSON object at the path of AZ::IConsole::ConsoleRootCommandKey
+        // Make sure the there is a JSON object at the ConsoleRuntimeCommandKey or ConsoleAutoexecKey
         // So that JSON Patch is able to add values underneath that object (JSON Patch doesn't create intermediate objects)
-        settingsRegistry.MergeSettings(R"({ "Amazon": { "AzCore": { "Runtime": { "ConsoleCommands": {} } }}})",
+        settingsRegistry.MergeSettings(R"({ "Amazon": { "AzCore": { "Runtime": { "ConsoleCommands": {} } } })"
+            R"(,"O3DE": { "Autoexec": { "ConsoleCommands": {} } } })",
             SettingsRegistryInterface::Format::JsonMergePatch);
         m_consoleCommandKeyHandler = settingsRegistry.RegisterNotifier(ConsoleCommandKeyNotificationHandler{ settingsRegistry, *this });
 

--- a/Code/Framework/AzCore/AzCore/Console/IConsole.h
+++ b/Code/Framework/AzCore/AzCore/Console/IConsole.h
@@ -31,7 +31,8 @@ namespace AZ
 
         using FunctorVisitor = AZStd::function<void(ConsoleFunctorBase*)>;
 
-        inline static constexpr AZStd::string_view ConsoleRootCommandKey = "/Amazon/AzCore/Runtime/ConsoleCommands";
+        inline static constexpr AZStd::string_view ConsoleRuntimeCommandKey = "/Amazon/AzCore/Runtime/ConsoleCommands";
+        inline static constexpr AZStd::string_view ConsoleAutoexecCommandKey = "/O3DE/Autoexec/ConsoleCommands";
 
         IConsole() = default;
         virtual ~IConsole() = default;


### PR DESCRIPTION
The new key is "/O3DE/Autoexec/ConsoleCommands" and the only difference
with the "/Amazon/AzCore/Runtime/ConosleCommands" key is that it isn't
excluded by the SettingsRegistryBuilder.

Due to not being excluded by the SettingsRegistryBuilder this key can be
used to forward console commands to the aggregate
`bootstrap.game.<config>.<platform>.setreg` files.

For GameLauncher specific console commands it is recommend to be put them in
.setreg file that uses the "game" specialization, such as
"autoexec.game.setreg".

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>