### PR TITLE
Increase the max time in the iOS run loop.

### DIFF
--- a/Code/Framework/AzFramework/Platform/iOS/AzFramework/Application/Application_iOS.mm
+++ b/Code/Framework/AzFramework/Platform/iOS/AzFramework/Application/Application_iOS.mm
@@ -112,9 +112,10 @@ namespace AzFramework
     void ApplicationIos::PumpSystemEventLoopUntilEmpty()
     {
         SInt32 result;
+        const CFTimeInterval MaxSecondsInRunLoop = 0.001; // One millisecond
         do
         {
-            result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, DBL_EPSILON, TRUE);
+            result = CFRunLoopRunInMode(kCFRunLoopDefaultMode, MaxSecondsInRunLoop, TRUE);
         }
         while (result == kCFRunLoopRunHandledSource);
     }


### PR DESCRIPTION
Increase the max time in the iOS run loop from DBL_EPSILON to one millisecond to address issue where the virtual keyboard is sluggish.

Signed-off-by: bosnichd <bosnichd@amazon.com>