### PR TITLE
Sandbox Reflection Probe portion of mainsuite tests.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
@@ -3,8 +3,6 @@ Copyright (c) Contributors to the Open 3D Engine Project.
 For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
-
-Main suite tests for the Atom renderer.
 """
 import logging
 import os
@@ -25,7 +23,6 @@ TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
 class TestAtomEditorComponentsMain(object):
     """Holds tests for Atom components."""
 
-    @pytest.mark.xfail(reason="This test is being marked xfail as it failed during an unrelated development run. See LYN-7530 for more details.")
     def test_AtomEditorComponents_AddedToEntity(self, request, editor, level, workspace, project, launcher_platform):
         """
         Please review the hydra script run by this test for more specific test info.
@@ -162,21 +159,6 @@ class TestAtomEditorComponentsMain(object):
             "Display Mapper_test: Entity deleted: True",
             "Display Mapper_test: UNDO entity deletion works: True",
             "Display Mapper_test: REDO entity deletion works: True",
-            # Reflection Probe Component
-            "Reflection Probe Entity successfully created",
-            "Reflection Probe_test: Component added to the entity: True",
-            "Reflection Probe_test: Component removed after UNDO: True",
-            "Reflection Probe_test: Component added after REDO: True",
-            "Reflection Probe_test: Entered game mode: True",
-            "Reflection Probe_test: Exit game mode: True",
-            "Reflection Probe_test: Entity disabled initially: True",
-            "Reflection Probe_test: Entity enabled after adding required components: True",
-            "Reflection Probe_test: Cubemap is generated: True",
-            "Reflection Probe_test: Entity is hidden: True",
-            "Reflection Probe_test: Entity is shown: True",
-            "Reflection Probe_test: Entity deleted: True",
-            "Reflection Probe_test: UNDO entity deletion works: True",
-            "Reflection Probe_test: REDO entity deletion works: True",
         ]
 
         unexpected_lines = [

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -3,11 +3,16 @@ Copyright (c) Contributors to the Open 3D Engine Project.
 For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
-
-Sandbox suite tests for the Atom renderer.
 """
+import logging
+import os
 
 import pytest
+
+import editor_python_test_tools.hydra_test_utils as hydra
+
+logger = logging.getLogger(__name__)
+TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
 
 
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
@@ -18,3 +23,49 @@ class TestAtomEditorComponentsSandbox(object):
     # It requires at least one test
     def test_Dummy(self, request, editor, level, workspace, project, launcher_platform):
         pass
+
+    @pytest.mark.parametrize("project", ["AutomatedTesting"])
+    @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+    @pytest.mark.parametrize("level", ["auto_test"])
+    class TestAtomEditorComponentsMain(object):
+        """Holds tests for Atom components."""
+
+        def test_AtomEditorComponents_ReflectionProbeAddedToEntity(
+                self, request, editor, level, workspace, project, launcher_platform):
+            """
+            Please review the hydra script run by this test for more specific test info.
+            Tests the following Atom components and verifies all "expected_lines" appear in Editor.log:
+            1. Reflection Probe
+            """
+            cfg_args = [level]
+
+            expected_lines = [
+                # Reflection Probe Component
+                "Reflection Probe Entity successfully created",
+                "Reflection Probe_test: Component added to the entity: True",
+                "Reflection Probe_test: Component removed after UNDO: True",
+                "Reflection Probe_test: Component added after REDO: True",
+                "Reflection Probe_test: Entered game mode: True",
+                "Reflection Probe_test: Exit game mode: True",
+                "Reflection Probe_test: Entity disabled initially: True",
+                "Reflection Probe_test: Entity enabled after adding required components: True",
+                "Reflection Probe_test: Cubemap is generated: True",
+                "Reflection Probe_test: Entity is hidden: True",
+                "Reflection Probe_test: Entity is shown: True",
+                "Reflection Probe_test: Entity deleted: True",
+                "Reflection Probe_test: UNDO entity deletion works: True",
+                "Reflection Probe_test: REDO entity deletion works: True",
+            ]
+
+            hydra.launch_and_validate_results(
+                request,
+                TEST_DIRECTORY,
+                editor,
+                "hydra_AtomEditorComponents_AddedToEntity.py",
+                timeout=120,
+                expected_lines=expected_lines,
+                unexpected_lines=[],
+                halt_on_unexpected=True,
+                null_renderer=True,
+                cfg_args=cfg_args,
+            )


### PR DESCRIPTION
- The Reflection Probe checks will be re-added when the parallel tests inside `AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py` get enabled (they are currently marked `xfail` as we are slowly enabling them over time).
- Tests pass post change:
```
==== 3 passed, 1 warning in 201.09s (0:03:21) ====
```