### PR TITLE
{lyn7283} added test for assetHint Json Serialzier callback logic

### DIFF
--- a/Code/Framework/AzCore/Tests/AssetJsonSerializerTests.cpp
+++ b/Code/Framework/AzCore/Tests/AssetJsonSerializerTests.cpp
@@ -93,6 +93,10 @@ namespace JsonSerializationTests
 
         void TearDown() override
         {
+            m_jsonRegistrationContext->EnableRemoveReflection();
+            m_jsonRegistrationContext->Serializer<AZ::Data::AssetJsonSerializer>()->HandlesType<AZ::Data::Asset>();
+            m_jsonRegistrationContext->DisableRemoveReflection();
+
             AZ::Data::AssetManager::Instance().UnregisterHandler(&m_assetHandler);
             AZ::Data::AssetManager::Destroy();
 


### PR DESCRIPTION
added unit test for the assetHint Json Serialzier callback logic
AssetTracker_Callback_Works will regress the functionality

Signed-off-by: jackalbe <23512001+jackalbe@users.noreply.github.com>