### PR TITLE
bug fix: improve display of viewport ui

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportUi/ViewportUiDisplay.cpp
@@ -339,7 +339,7 @@ namespace AzToolsFramework::ViewportUi::Internal
     {
         // no background for the widget else each set of buttons/text-fields/etc would have a black box around them
         SetTransparentBackground(mainWindow);
-        mainWindow->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
+        mainWindow->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowDoesNotAcceptFocus);
     }
 
     void ViewportUiDisplay::InitializeUiOverlay()


### PR DESCRIPTION
This is not a perfect fix but it addresses this to an extent. how would I handle the case for a minimizing window and any pointers to get started if that is to be addressed in this change. I guess ideally this should be drawn using `DisplayContext`. too much of a problem to do this through another modal window. 

- always show controls on top of main ui
- Tool window does not show visually in toolbar

issue: https://github.com/o3de/o3de/issues/4380

Signed-off-by: Michael Pollind <mpollind@gmail.com>