### PR TITLE
Fix prefab close dialog Editor crash on Linux

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -1393,34 +1393,7 @@ namespace AzToolsFramework
 
         AZStd::unique_ptr<AzQtComponents::Card> PrefabIntegrationManager::ConstructUnsavedPrefabsCard(TemplateId templateId)
         {
-#if defined(Q_OS_LINUX)
-            // TODO: Determine the proper fix for a Null Pointer Exception caused by using the main window widget
-            //       for FlowLayoutParent on Linux
-            // 
-            // On Linux, the AzToolsFramework::GetActiveWindow() will fall back to the main window
-            // because QApplication::activeWindow() is null. (There are no active windows that has keyboard
-            // focus). When using the main window as the parent for the FlowLayout below, the Prefabs Card
-            // will encounter a NPE, thus causing the editor to shut down and therefore lose any unsaved data.
-            // To temporarily prevent this, we use the first visible widget that we find that doesnt have a parent
-            // as the parent just for the FlowLayout, which prevents this problem.
-            QWidget* prefabCardParent = QApplication::activeWindow();
-            if (prefabCardParent == nullptr)
-            {
-                QWidgetList allWidgets = QApplication::allWidgets();
-                for (QWidget* widget : allWidgets)
-                {
-                    if (widget->isVisible() && widget->parentWidget() == nullptr)
-                    {
-                        prefabCardParent = widget;
-                        break;
-                    }
-                }
-            }
-#else
-            QWidget* prefabCardParent = AzToolsFramework::GetActiveWindow();
-#endif // defined(Q_OS_LINUX)
-
-            FlowLayout* unsavedPrefabsLayout = new FlowLayout(prefabCardParent);
+            FlowLayout* unsavedPrefabsLayout = new FlowLayout(nullptr);
 
             AZStd::set<AZ::IO::PathView> dirtyTemplatePaths = s_prefabSystemComponentInterface->GetDirtyTemplatePaths(templateId);
 


### PR DESCRIPTION
**Summary**
On Linux with Prefabs enabled, if you attempt to switch to a different or new level from the current level and the current level has unsaved changes, it will crash the editor.

** Cause **
It appears when the custom prefab close dialog is rendering, the flow separator's paint device is null. 

```
PainterPrivate::attachPainterPrivate(QPainter*, QPaintDevice*) (@QPainterPrivate::attachPainterPrivate(QPainter*, QPaintDevice*):15)
QPainter::QPainter(QPaintDevice*) (@QPainter::QPainter(QPaintDevice*):12)
QMainWindowLayoutSeparatorHelper<QMainWindowLayout>::windowEvent(QEvent*) (@QMainWindowLayoutSeparatorHelper<QMainWindowLayout>::windowEvent(QEvent*):340)
QMainWindow::event(QEvent*) (@QMainWindow::event(QEvent*):18)
MainWindow::event(QEvent*) (/home/ANT.AMAZON.COM/spham/github/o3de/Code/Editor/MainWindow.cpp:1785)
QApplicationPrivate::notify_helper(QObject*, QEvent*) (@QApplicationPrivate::notify_helper(QObject*, QEvent*):49)
QApplication::notify(QObject*, QEvent*) (@QApplication::notify(QObject*, QEvent*):139)
QCoreApplication::notifyInternal2(QObject*, QEvent*) (@QCoreApplication::notifyInternal2(QObject*, QEvent*):77)
QWidgetPrivate::sendPaintEvent(QRegion const&) (@QWidgetPrivate::sendPaintEvent(QRegion const&):18)
QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*) (@QWidgetPrivate::drawWidget(QPaintDevice*, QRegion const&, QPoint const&, QFlags<QWidgetPrivate::DrawWidgetFlag>, QPainter*, QWidgetRepaintManager*):649)
...
```

After trying a variety of different things to troubleshoot the issue, it was narrowed down to the parent QWidget of the FlowLayout that is used to create the custom Card widget. If the parent is the main window, the crash occurs. 

**Fix**
It turns out that the FlowLayout does not need to set a parent widget. Leaving it as nullptr resolves this crash

