### PR TITLE
A parameter’s text box of Blend Space 2D and 1D Motions only takes one numerical input value including fractions

### DIFF
--- a/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionContainerHandler.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/PropertyWidgets/BlendSpaceMotionContainerHandler.cpp
@@ -55,6 +55,7 @@ namespace EMotionFX
         m_spinboxX->setDecimals(4);
         m_spinboxX->setRange(-FLT_MAX, FLT_MAX);
         m_spinboxX->setProperty("motionId", motionId.c_str());
+        m_spinboxX->setKeyboardTracking(false);
         layoutX->addWidget(m_spinboxX);
 
         layout->addLayout(layoutX, row, column);
@@ -76,6 +77,7 @@ namespace EMotionFX
             m_spinboxY->setDecimals(4);
             m_spinboxY->setRange(-FLT_MAX, FLT_MAX);
             m_spinboxY->setProperty("motionId", motionId.c_str());
+            m_spinboxX->setKeyboardTracking(false);
             layoutY->addWidget(m_spinboxY);
 
             layout->addLayout(layoutY, row, column);


### PR DESCRIPTION
The on value changed event was recevied too often - with every newly typed character. As we're updating elements outside of the value spinbox, we need to wait for the actual done editing signal. This can be achieved by not tracking the keyboard for the spinbox.

Resolves #3827

Signed-off-by: Benjamin Jillich <jillich@amazon.com>