### PR TITLE
Atom Timer fix - changed milliseconds to seconds

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RenderPipeline.h
@@ -228,9 +228,6 @@ namespace AZ
             
             PipelineViewMap m_pipelineViewsByTag;
             
-            /// The system time when the last time this pipeline render was started
-            float m_lastRenderStartTime = 0;
-            
             // RenderPipeline's name id, it will be used to identify the render pipeline when it's added to a Scene
             RenderPipelineId m_nameId;
             

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -263,7 +263,7 @@ namespace AZ
             AZ::TickRequestBus::BroadcastResult(m_tickTime.m_gameDeltaTime, &AZ::TickRequestBus::Events::GetTickDeltaTime);
             ScriptTimePoint currentTime;
             AZ::TickRequestBus::BroadcastResult(currentTime, &AZ::TickRequestBus::Events::GetTimeAtCurrentTick);
-            m_tickTime.m_currentGameTime = static_cast<float>(currentTime.GetMilliseconds());
+            m_tickTime.m_currentGameTime = static_cast<float>(currentTime.GetSeconds());
         }
 
         void RPISystem::RenderTick()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -375,11 +375,9 @@ namespace AZ
             m_scene->RemoveRenderPipeline(m_nameId);
         }
 
-        void RenderPipeline::OnStartFrame(const TickTimeInfo& tick)
+        void RenderPipeline::OnStartFrame([[maybe_unused]] const TickTimeInfo& tick)
         {
             AZ_PROFILE_SCOPE(RPI, "RenderPipeline: OnStartFrame");
-
-            m_lastRenderStartTime = tick.m_currentGameTime;
 
             OnPassModified();
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -400,8 +400,7 @@ namespace AZ
         {
             AZ_PROFILE_SCOPE(RPI, "Scene: Simulate");
 
-            const float millisecondsToSeconds = 0.001f;
-            m_simulationTime = tickInfo.m_currentGameTime * millisecondsToSeconds;
+            m_simulationTime = tickInfo.m_currentGameTime;
 
             // If previous simulation job wasn't done, wait for it to finish.
             if (m_taskGraphActive)


### PR DESCRIPTION
- Tested on both fog and EyeAdaptation animations - both are the only affected systems and were broken before
- This is a small fix for pull #3969 that replaced the timer mechanism: https://github.com/o3de/o3de/pull/3969

Signed-off-by: Adi-Amazon <barlev@amazon.com>