### PR TITLE
Fixed logic error causing Python Scripts tree items to only show extension intead of filename.

### DIFF
--- a/Code/Editor/Controls/FolderTreeCtrl.cpp
+++ b/Code/Editor/Controls/FolderTreeCtrl.cpp
@@ -279,7 +279,7 @@ void CFolderTreeCtrl::LoadTreeRec(const QString& currentFolder)
 void CFolderTreeCtrl::AddItem(const QString& path)
 {
     AZ::IO::FixedMaxPath folder{ AZ::IO::PathView(path.toUtf8().constData()) };
-    AZ::IO::FixedMaxPath fileNameWithoutExtension = folder.Extension();
+    AZ::IO::FixedMaxPath fileNameWithoutExtension = folder.Stem();
     folder = folder.ParentPath();
 
     auto regex = QRegExp(m_fileNameSpec, Qt::CaseInsensitive, QRegExp::Wildcard);


### PR DESCRIPTION
Fixes #4601 

Fixed logic error in API refactor in the `CFolderTreeCtrl` class (currently only used by the Python Scripts dialog), which was causing the tree to be populated with only the extension, instead of the filename itself. Tested the Python Scripts dialog and verified it now shows the items as intended.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>