### PR TITLE
Fix casing of editor_xml filenames to match casing in .ly files

### DIFF
--- a/Code/Editor/CryEditDoc.cpp
+++ b/Code/Editor/CryEditDoc.cpp
@@ -1273,7 +1273,7 @@ bool CCryEditDoc::SaveLevel(const QString& filename)
         if (savedEntities)
         {
             AZ_PROFILE_SCOPE(AzToolsFramework, "CCryEditDoc::SaveLevel Updated PakFile levelEntities.editor_xml");
-            pakFile.UpdateFile("LevelEntities.editor_xml", entitySaveBuffer.begin(), static_cast<int>(entitySaveBuffer.size()));
+            pakFile.UpdateFile("levelentities.editor_xml", entitySaveBuffer.begin(), static_cast<int>(entitySaveBuffer.size()));
 
             // Save XML archive to pak file.
             bool bSaved = xmlAr.SaveToPak(Path::GetPath(tempSaveFile), pakFile);
@@ -1501,7 +1501,7 @@ bool CCryEditDoc::LoadEntitiesFromLevel(const QString& levelPakFile)
         bool pakOpened = pakSystem->OpenPack(levelPakFile.toUtf8().data());
         if (pakOpened)
         {
-            const QString entityFilename = Path::GetPath(levelPakFile) + "LevelEntities.editor_xml";
+            const QString entityFilename = Path::GetPath(levelPakFile) + "levelentities.editor_xml";
 
             CCryFile entitiesFile;
             if (entitiesFile.Open(entityFilename.toUtf8().data(), "rt"))

--- a/Code/Editor/Util/XmlArchive.cpp
+++ b/Code/Editor/Util/XmlArchive.cpp
@@ -119,7 +119,7 @@ bool CXmlArchive::SaveToPak([[maybe_unused]] const QString& levelPath, CPakFile&
     _smart_ptr<IXmlStringData> pXmlStrData = root->getXMLData(5000000);
 
     // Save xml file.
-    QString xmlFilename = "Level.editor_xml";
+    QString xmlFilename = "level.editor_xml";
     pakFile.UpdateFile(xmlFilename.toUtf8().data(), (void*)pXmlStrData->GetString(), static_cast<int>(pXmlStrData->GetStringLength()));
 
     if (pakFile.GetArchive())
@@ -134,7 +134,7 @@ bool CXmlArchive::SaveToPak([[maybe_unused]] const QString& levelPath, CPakFile&
 //////////////////////////////////////////////////////////////////////////
 bool CXmlArchive::LoadFromPak(const QString& levelPath, CPakFile& pakFile)
 {
-    QString xmlFilename = QDir(levelPath).absoluteFilePath("Level.editor_xml");
+    QString xmlFilename = QDir(levelPath).absoluteFilePath("level.editor_xml");
     root = XmlHelpers::LoadXmlFromFile(xmlFilename.toUtf8().data());
     if (!root)
     {


### PR DESCRIPTION
The files level.editor_xml and levelentities.editor_xml are lower-case in the legacy ly level files, but is referred to in the code with mixed casing `LevelEntities.editor_xml` and `Level.editor_xml`. 

This fixes the issue with loading legacy levels (non-prefab) in Linux



Signed-off-by: Steve Pham <spham@amazon.com>