### PR TITLE
LYN-7189 | Outliner - Disable context menu if right clicking on disabled entity

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -552,8 +552,9 @@ namespace AzToolsFramework
             return;
         }
 
-        // Do not display the context menu if the item under the mouse cursor is unselectable.
-        if (const QModelIndex& index = m_gui->m_objectTree->indexAt(pos); index.isValid() && !(index.flags() & Qt::ItemIsSelectable))
+        // Do not display the context menu if the item under the mouse cursor is not selectable.
+        if (const QModelIndex& index = m_gui->m_objectTree->indexAt(pos); index.isValid()
+            && (index.flags() & Qt::ItemIsSelectable) == 0)
         {
             return;
         }


### PR DESCRIPTION
Currently, right clicking on an item in the Outliner relies on the fact that the click will trigger the selection of the item under the cursor before populating the context menu. This means that right clicking an element in the Outliner and then selecting "Create Entity" will create a new entity parented under whatever was being selected.

With the introduction of unselectable entities in focus mode, the behavior is now confusing. Since clicking on a non selectable entity in the Outliner produces no result, the previous selection is maintained, meaning that all menu items in the context menu will refer to the current selection. This is quite confusing.

To prevent issues, we determined not showing the context menu in these situations is actually clearer.

Potentially in the future we could populate the menu differently in these situation, allowing to (for example) edit unselectable prefabs via right click.

![noContextMenuOnUnselectable](https://user-images.githubusercontent.com/82231674/137082457-5aa35bd4-462f-4b49-a728-541e666c9aa4.gif)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>