### PR TITLE
EMotion FX: Fix for broken workspaces after asset path change

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Workspace.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Workspace.cpp
@@ -105,7 +105,9 @@ namespace EMStudio
             }
         }
 
-        commandString = AZStd::string::format("%s -filename \"%s\"", command, resultFileName.c_str());
+        AZStd::string resultFilenameString = resultFileName.c_str();
+        AzFramework::StringFunc::AssetDatabasePath::Normalize(resultFilenameString);
+        commandString = AZStd::string::format("%s -filename \"%s\"", command, resultFilenameString.c_str());
 
         if (additionalParameters)
         {
@@ -428,7 +430,13 @@ namespace EMStudio
                 continue;
             }
 
-            AzFramework::StringFunc::Replace(commands[i], "@products@/", assetCacheFolder.c_str(), true /* case sensitive */);
+            AzFramework::StringFunc::Replace(commands[i], "@products@", assetCacheFolder.c_str());
+            AzFramework::StringFunc::Replace(commands[i], "@assets@", assetCacheFolder.c_str());
+            AzFramework::StringFunc::Replace(commands[i], "@root@", assetCacheFolder.c_str());
+            AzFramework::StringFunc::Replace(commands[i], "@projectplatformcache@", assetCacheFolder.c_str());
+            AzFramework::StringFunc::Replace(commands[i], "//", AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING);
+            AzFramework::StringFunc::Replace(commands[i], "\\\\", AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING);
+            AzFramework::StringFunc::Replace(commands[i], "/\\", AZ_CORRECT_FILESYSTEM_SEPARATOR_STRING);
 
             // add the command to the command group
             commandGroup->AddCommandString(commands[i]);


### PR DESCRIPTION
Some days ago an impactful change deprecated @assets@ and @root@ keywords from paths which our workspaces used. Some workspaces used these and were broken. This change makes them backward compatible and loads the assets correctly again. It also auto fixes broken paths that were present in some of the saved workspaces + making sure new workspaces are saved correctly.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>