### PR TITLE
Procedural Prefabs: Don't activate prefab when saving to manifest

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -126,7 +126,7 @@ namespace AZ::SceneAPI::Behaviors
 
         const rapidjson::Document& generatedInstanceDom = prefabSystemComponentInterface->FindTemplateDom(templateId);
         auto proceduralPrefab = AZStd::make_unique<rapidjson::Document>(rapidjson::kObjectType);
-        instanceToTemplateInterface->GenerateDomForInstance(*proceduralPrefab.get(), *instance.get());
+        proceduralPrefab->CopyFrom(generatedInstanceDom, proceduralPrefab->GetAllocator(), true);
 
         return proceduralPrefab;
     }


### PR DESCRIPTION
This changes PrefabGroupBehavior to serialize a Prefab without activating it as it is generally advised not to activate editor entities in an AssetBuilder.