### PR TITLE
Add step to verify drive is in an offline state

### DIFF
--- a/scripts/build/bootstrap/incremental_build_util.py
+++ b/scripts/build/bootstrap/incremental_build_util.py
@@ -335,7 +335,8 @@ def mount_volume_to_device(created):
 
             if created:
                 print('Creating filesystem on new volume')
-                f.write("""create partition primary
+                f.write("""
+                create partition primary
                 select partition 1
                 format quick fs=ntfs
                 assign


### PR DESCRIPTION
This change fixes an issue causing build failures during the setup step of the pipeline. Some Windows nodes will automatically set new drives as online causing the diskpart setup script to fail. This adds a step in the pipe to verify the drive is offline. 

Testing:
- Tested in our fork running the pipeline with new volumes and existing volumes: pipeline successfully mounts and unmounts drives