### PR TITLE
Fix Light component GPU test expected_lines

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -148,7 +148,7 @@ class TestAllComponentsIndepthTests(object):
             golden_image_path = os.path.join(golden_images_directory(), golden_image)
             golden_images.append(golden_image_path)
 
-        expected_lines = ["Light component tests completed."]
+        expected_lines = ["spot_light Controller|Configuration|Shadows|Shadowmap size: SUCCESS"]
         unexpected_lines = [
             "Trace::Assert",
             "Trace::Error",


### PR DESCRIPTION
- This test will be replaced by the new return codes approach in the near future.
- For now, I am updating the `expected_lines` to a log message that appears both locally + in AR. The old one wasn't appearing in AR for some reason. I had a similar issue with this as part of https://github.com/o3de/o3de/pull/4511 - it appears some log messaging in AR has changed. This will impact us less when the return code tests are utilized instead.

Signed-off-by: jromnoa <jromnoa@amazon.com>