### PR TITLE
Only enable the Keyboard device in the XcbKeyboard unit tests

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/System/InputSystemComponent.cpp
@@ -20,6 +20,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace AzFramework
@@ -190,6 +191,25 @@ namespace AzFramework
     ////////////////////////////////////////////////////////////////////////////////////////////////
     void InputSystemComponent::Activate()
     {
+        const auto* settingsRegistry = AZ::SettingsRegistry::Get();
+        if (settingsRegistry)
+        {
+            AZ::u64 value = 0;
+            if (settingsRegistry->Get(value, "/O3DE/InputSystem/MouseMovementSampleRateHertz"))
+            {
+                m_mouseMovementSampleRateHertz = aznumeric_caster(value);
+            }
+            if (settingsRegistry->Get(value, "/O3DE/InputSystem/GamepadsEnabled"))
+            {
+                m_gamepadsEnabled = aznumeric_caster(value);
+            }
+            settingsRegistry->Get(m_keyboardEnabled, "/O3DE/InputSystem/KeyboardEnabled");
+            settingsRegistry->Get(m_motionEnabled, "/O3DE/InputSystem/MotionEnabled");
+            settingsRegistry->Get(m_mouseEnabled, "/O3DE/InputSystem/MouseEnabled");
+            settingsRegistry->Get(m_touchEnabled, "/O3DE/InputSystem/TouchEnabled");
+            settingsRegistry->Get(m_virtualKeyboardEnabled, "/O3DE/InputSystem/VirtualKeyboardEnabled");
+        }
+
         // Create all enabled input devices
         CreateEnabledInputDevices();
 

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -10,6 +10,7 @@
 #include <AzFramework/Windowing/NativeWindow.h>
 #include <AzFramework/XcbNativeWindow.h>
 #include <AzFramework/XcbConnectionManager.h>
+#include <AzFramework/XcbInterface.h>
 
 #include <xcb/xcb.h>
 

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbTestApplication.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbTestApplication.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/UserSettings/UserSettingsComponent.h>
+#include <AzFramework/Application/Application.h>
+
+namespace AzFramework
+{
+    class XcbTestApplication
+        : public Application
+    {
+    public:
+        XcbTestApplication(AZ::u64 enabledGamepadsCount, bool keyboardEnabled, bool motionEnabled, bool mouseEnabled, bool touchEnabled, bool virtualKeyboardEnabled)
+        {
+            auto* settingsRegistry = AZ::SettingsRegistry::Get();
+            settingsRegistry->Set("/O3DE/InputSystem/GamepadsEnabled", enabledGamepadsCount);
+            settingsRegistry->Set("/O3DE/InputSystem/KeyboardEnabled", keyboardEnabled);
+            settingsRegistry->Set("/O3DE/InputSystem/MotionEnabled", motionEnabled);
+            settingsRegistry->Set("/O3DE/InputSystem/MouseEnabled", mouseEnabled);
+            settingsRegistry->Set("/O3DE/InputSystem/TouchEnabled", touchEnabled);
+            settingsRegistry->Set("/O3DE/InputSystem/VirtualKeyboardEnabled", virtualKeyboardEnabled);
+        }
+
+        void Start(const Descriptor& descriptor = {}, const StartupParameters& startupParameters = {}) override
+        {
+            Application::Start(descriptor, startupParameters);
+            AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
+        }
+    };
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/azframework_xcb_tests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/azframework_xcb_tests_files.cmake
@@ -17,4 +17,5 @@ set(FILES
     XcbBaseTestFixture.cpp
     XcbBaseTestFixture.h
     XcbInputDeviceKeyboardTests.cpp
+    XcbTestApplication.h
 )


### PR DESCRIPTION
This prevents other input devices from interfering with the expected calls
that the Keyboard tests should make.

Signed-off-by: Chris Burel <burelc@amazon.com>