### PR TITLE
Flipped y value on uv so that macro material matches height

### DIFF
--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.cpp
@@ -567,13 +567,15 @@ namespace Terrain
                         ShaderMacroMaterialData& shaderData = macroMaterialData.at(i);
                         const AZ::Aabb& materialBounds = materialData.m_bounds;
 
+                        // Use reverse coordinates (1 - y) for the y direction so that the lower left corner of the macro material images
+                        // map to the lower left corner in world space.  This will match up with the height uv coordinate mapping.
                         shaderData.m_uvMin = {
                             (xPatch - materialBounds.GetMin().GetX()) / materialBounds.GetXExtent(),
-                            (yPatch - materialBounds.GetMin().GetY()) / materialBounds.GetYExtent()
+                            1.0f - ((yPatch - materialBounds.GetMin().GetY()) / materialBounds.GetYExtent())
                         };
                         shaderData.m_uvMax = {
                             ((xPatch + GridMeters) - materialBounds.GetMin().GetX()) / materialBounds.GetXExtent(),
-                            ((yPatch + GridMeters) - materialBounds.GetMin().GetY()) / materialBounds.GetYExtent()
+                            1.0f - (((yPatch + GridMeters) - materialBounds.GetMin().GetY()) / materialBounds.GetYExtent())
                         };
                         shaderData.m_normalFactor = materialData.m_normalFactor;
                         shaderData.m_flipNormalX = materialData.m_normalFlipX;


### PR DESCRIPTION
If you imagine a quad that spans from 0,0 to 1,1 in world space, this change flips the y value so that the lower left pixel in the image appears at 0,0 in world space, and the upper right appears at 1,1.  This matches what the gradient system is providing for height values, which makes it easier to line the two up.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>