### PR TITLE
Fixed dds loader issue with certain dds formats.

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/DdsLoader.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/DdsLoader.cpp
@@ -122,14 +122,45 @@ namespace ImageProcessingAtom
                 {
                     format = ePixelFormat_BC1;
                 }
-                else if (header.ddspf.dwFourCC == FOURCC_DXT5 || header.ddspf.dwFourCC == FOURCC_DXT4)
+                else if (header.ddspf.dwFourCC == FOURCC_DXT5)
                 {
                     format = ePixelFormat_BC3;
                 }
-                else
+                else if (header.ddspf.dwFourCC == FOURCC_3DCP)
                 {
-                    AZ_Error("Image Processing", false, "unsupported fourCC format: 0x%x", header.ddspf.dwFourCC);
-                    return nullptr;
+                    format = ePixelFormat_BC4;
+                }
+                else if (header.ddspf.dwFourCC == FOURCC_3DC)
+                {
+                    format = ePixelFormat_BC5;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_R32F)
+                {
+                    format = ePixelFormat_R32F;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_G32R32F)
+                {
+                    format = ePixelFormat_R32G32F;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_A32B32G32R32F)
+                {
+                    format = ePixelFormat_R32G32B32A32F;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_R16F)
+                {
+                    format = ePixelFormat_R16F;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_G16R16F)
+                {
+                    format = ePixelFormat_R16G16F;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_A16B16G16R16F)
+                {
+                    format = ePixelFormat_R16G16B16A16F;
+                }
+                else if (header.ddspf.dwFourCC == DDS_FOURCC_A16B16G16R16)
+                {
+                    format = ePixelFormat_R16G16B16A16;
                 }
             }
             else

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/DDSHeader.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/DDSHeader.h
@@ -260,4 +260,6 @@ namespace ImageProcessingAtom
     const static AZ::u32 FOURCC_DXT3 = IMAGE_BUIDER_MAKEFOURCC('D', 'X', 'T', '3');
     const static AZ::u32 FOURCC_DXT4 = IMAGE_BUIDER_MAKEFOURCC('D', 'X', 'T', '4');
     const static AZ::u32 FOURCC_DXT5 = IMAGE_BUIDER_MAKEFOURCC('D', 'X', 'T', '5');
+    const static AZ::u32 FOURCC_3DCP = IMAGE_BUIDER_MAKEFOURCC('A', 'T', 'I', '1');
+    const static AZ::u32 FOURCC_3DC = IMAGE_BUIDER_MAKEFOURCC('A', 'T', 'I', '2');
 }


### PR DESCRIPTION
Revert changes from previous commit which makes image builder failed to process certain dds files in ASV.
Signed-off-by: Qing Tao <qingtao@amazon.com>