### PR TITLE
Fix Vulkan issues with VK_ERROR_OUT_OF_DATE caused by the swapchain not being updated on a resize

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -123,7 +123,6 @@ namespace AtomToolsFramework
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
         // QWidget overrides ...
-        void resizeEvent(QResizeEvent *event) override;
         bool event(QEvent* event) override;
         void enterEvent(QEvent* event) override;
         void leaveEvent(QEvent* event) override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -194,13 +194,21 @@ namespace AtomToolsFramework
         m_controllerList->UpdateViewport({GetId(), AzFramework::FloatSeconds(deltaTime), m_time});
     }
 
-    void RenderViewportWidget::resizeEvent([[maybe_unused]] QResizeEvent* event)
-    {
-        SendWindowResizeEvent();
-    }
-
     bool RenderViewportWidget::event(QEvent* event)
     {
+        // On some types of QEvents, a resize event is needed to make sure that the current viewport window
+        // needs to be updated based on a potential new surface dimensions.
+        switch (event->type()) 
+        {
+            case QEvent::ScreenChangeInternal:
+            case QEvent::UpdateLater:
+            case QEvent::Resize:
+                SendWindowResizeEvent();
+                break;
+
+            default:
+                break;
+        }
         return QWidget::event(event);
     }
 


### PR DESCRIPTION
On Linux using the MaterialEditor, it was observed that at least `ScreenChangeInternal` and `UpdateLater` needed the swapchain to be recreated. Will test on Windows

* Updated the RenderViewportWidget::event method to call 'SendWindowResizeEvent' on specific events
* Moved the onResize to one of the events in RenderViewportWidget::event

Signed-off-by: Steve Pham <spham@amazon.com>