### PR TITLE
Removed AZ_ENABLE_TRACING from Archive::GetPakPriority

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -1924,13 +1924,11 @@ namespace AZ::IO
     ArchiveLocationPriority Archive::GetPakPriority() const
     {
         int pakPriority = aznumeric_cast<int>(ArchiveVars{}.nPriority);
-#if defined(AZ_ENABLE_TRACING)
         if (auto console = AZ::Interface<AZ::IConsole>::Get(); console != nullptr)
         {
-            AZ::GetValueResult getCvarResult = console->GetCvarValue("sys_PakPriority", pakPriority);
+            [[maybe_unused]] AZ::GetValueResult getCvarResult = console->GetCvarValue("sys_PakPriority", pakPriority);
             AZ_Error("Archive", getCvarResult == AZ::GetValueResult::Success, "Lookup of 'sys_PakPriority console variable failed with error %s", AZ::GetEnumString(getCvarResult));
         }
-#endif
         return static_cast<ArchiveLocationPriority>(pakPriority);
     }
 


### PR DESCRIPTION
The AZ_ENABLE_TRACING check was preventing the Archive System from using the sys_PakPriority value set from the CVar system

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>