### PR TITLE
Improve the stability of metrics gem tests by removing local file operations

### DIFF
--- a/Gems/AWSMetrics/Code/Include/Private/MetricsManager.h
+++ b/Gems/AWSMetrics/Code/Include/Private/MetricsManager.h
@@ -31,7 +31,7 @@ namespace AWSMetrics
         static const unsigned int DesiredMaxWorkers = 2;
 
         MetricsManager();
-        ~MetricsManager();
+        virtual ~MetricsManager();
 
         //! Initializing the metrics manager
         //! @return Whether the operation is successful.
@@ -93,6 +93,12 @@ namespace AWSMetrics
         //! @return Total number of requests for sending metrics events.
         int GetNumTotalRequests() const;
 
+    protected:
+        //! Send metrics to a local file.
+        //! @param metricsQueue metricsQueue Metrics queue that stores the metrics.
+        //! @return Outcome of the operation.
+        virtual AZ::Outcome<void, AZStd::string> SendMetricsToFile(AZStd::shared_ptr<MetricsQueue> metricsQueue);
+
     private:
         //! Job management
         void SetupJobContext();
@@ -111,11 +117,6 @@ namespace AWSMetrics
         //! Send the batched metrics events to the Service API asynchronously.
         //! @param metricsQueue Metrics events to send.
         void SendMetricsToServiceApiAsync(const MetricsQueue& metricsQueue);
-
-        //! Send metrics to a local file.
-        //! @param metricsQueue metricsQueue Metrics queue that stores the metrics.
-        //! @return Outcome of the operation.
-        AZ::Outcome<void, AZStd::string> SendMetricsToFile(AZStd::shared_ptr<MetricsQueue> metricsQueue);
 
         //! Push metrics events to the front of the queue for retry.
         //! @param metricsEventsForRetry Metrics events for retry.

--- a/Gems/AWSMetrics/Code/Tests/AWSMetricsGemMock.h
+++ b/Gems/AWSMetrics/Code/Tests/AWSMetricsGemMock.h
@@ -139,11 +139,6 @@ namespace AWSMetrics
             return true;
         }
 
-        bool RemoveDirectory(const AZStd::string& directory)
-        {
-            return AZ::IO::SystemFile::DeleteDir(directory.c_str());
-        }
-
         AZ::IO::FileIOBase* m_priorFileIO = nullptr;
         AZ::IO::FileIOBase* m_localFileIO = nullptr;
 


### PR DESCRIPTION
Signed-off-by: Junbo Liang <junbo@amazon.com>

Based on the log at https://jenkins.build.o3de.org/blue/organizations/jenkins/O3DE/detail/PR-4727/1/pipeline, this was a test failure on Linux. It might be caused by a stuck test file written by one of the test case that resulted in miscount of notifications. With this PR change,  test metrics data will not be written to local disk and the fileIO dependency is decoupled.

- Run tests on Windows for 100 times
- Pass all unit tests (91% coverage)
- Run Linux tests on Jenkins: https://jenkins-pipeline.agscollab.com/job/O3DE-LY-FORK/job/LYN-7505/2/