### PR TITLE
Increase the timeout for ForceRegion_LinearDampingForceOnRigidBodies.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_LinearDampingForceOnRigidBodies.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/force_region/ForceRegion_LinearDampingForceOnRigidBodies.py
@@ -126,7 +126,7 @@ def ForceRegion_LinearDampingForceOnRigidBodies():
 
     # Constants
     CLOSE_ENOUGH = 0.001
-    TIME_OUT = 3.0
+    TIME_OUT = 10.0
     INITIAL_VELOCITY = azmath.Vector3(0.0, 0.0, -10.0)
 
     # 1) Open level / Enter game mode


### PR DESCRIPTION
The Test runs with a wait_for_condition, and the original timeout was right on the edge of how long the test takes to reach that condition.

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>