### PR TITLE
Update env var setting instructions in AWS Gem test README

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/AWS/README.md
+++ b/AutomatedTesting/Gem/PythonTests/AWS/README.md
@@ -8,11 +8,14 @@
 ## Deploy CDK Applications
 1. Go to the AWS IAM console and create an IAM role called o3de-automation-tests which adds your own account as as a trusted entity and uses the "AdministratorAccess" permissions policy.
 2. Copy {engine_root}\scripts\build\Platform\Windows\deploy_cdk_applications.cmd to your engine root folder.
-3. Open a new Command Prompt window at the engine root and set the following environment variables:  
+3. Open a new Command Prompt window at the engine root and set the following environment variables:
+```
    Set O3DE_AWS_PROJECT_NAME=AWSAUTO
    Set O3DE_AWS_DEPLOY_REGION=us-east-1
+   Set O3DE_AWS_DEPLOY_ACCOUNT={your_aws_account_id}
    Set ASSUME_ROLE_ARN=arn:aws:iam::{your_aws_account_id}:role/o3de-automation-tests
    Set COMMIT_ID=HEAD
+```
 4. In the same Command Prompt window, Deploy the CDK applications for AWS gems by running deploy_cdk_applications.cmd.
    
 ## Run Automation Tests


### PR DESCRIPTION
Adding a missing env var and updating markdown to retain line breaks. 
Naively executing the command as show will result in the vars being set incorrectly.

### Testing
[before](https://github.com/o3de/o3de/tree/development/AutomatedTesting/Gem/PythonTests/AWS#deploy-cdk-applications)
![image](https://user-images.githubusercontent.com/34254888/137952244-79e560ca-20b6-481f-9f09-7b52210e7e1d.png)

[after](https://github.com/aws-lumberyard-dev/o3de/tree/allisaurus/aws-test-readme/AutomatedTesting/Gem/PythonTests/AWS#deploy-cdk-applications)
![image](https://user-images.githubusercontent.com/34254888/137952152-1bbb49dd-f725-4a34-994b-ca64f234f454.png)


Signed-off-by: Stanko <stankoa@amazon.com>
