### PR TITLE
Linux: Fix failure to load newly created level

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -2631,7 +2631,7 @@ void CCryEditApp::OnShowHelpers()
 void CCryEditApp::OnEditLevelData()
 {
     auto dir = QFileInfo(GetIEditor()->GetDocument()->GetLevelPathName()).dir();
-    CFileUtil::EditTextFile(dir.absoluteFilePath("LevelData.xml").toUtf8().data());
+    CFileUtil::EditTextFile(dir.absoluteFilePath("leveldata.xml").toUtf8().data());
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/GameExporter.cpp
+++ b/Code/Editor/GameExporter.cpp
@@ -31,11 +31,11 @@
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 
 //////////////////////////////////////////////////////////////////////////
-#define MUSIC_LEVEL_LIBRARY_FILE "Music.xml"
-#define MATERIAL_LEVEL_LIBRARY_FILE "Materials.xml"
-#define RESOURCE_LIST_FILE "ResourceList.txt"
-#define USED_RESOURCE_LIST_FILE "UsedResourceList.txt"
-#define SHADER_LIST_FILE "ShadersList.txt"
+#define MUSIC_LEVEL_LIBRARY_FILE "music.xml"
+#define MATERIAL_LEVEL_LIBRARY_FILE "materials.xml"
+#define RESOURCE_LIST_FILE "resourcelist.txt"
+#define USED_RESOURCE_LIST_FILE "usedresourcelist.txt"
+#define SHADER_LIST_FILE "shaderslist.txt"
 
 #define GetAValue(rgb)      ((BYTE)((rgb) >> 24))
 
@@ -185,9 +185,9 @@ bool CGameExporter::Export(unsigned int flags, [[maybe_unused]] EEndian eExportE
             ExportOcclusionMesh(sLevelPath.toUtf8().data());
 
             //! Export Level data.
-            CLogFile::WriteLine("Exporting LevelData.xml");
+            CLogFile::WriteLine("Exporting leveldata.xml");
             ExportLevelData(sLevelPath);
-            CLogFile::WriteLine("Exporting LevelData.xml done.");
+            CLogFile::WriteLine("Exporting leveldata.xml done.");
 
             ExportLevelInfo(sLevelPath);
 
@@ -266,26 +266,26 @@ void CGameExporter::ExportOcclusionMesh(const char* pszGamePath)
 void CGameExporter::ExportLevelData(const QString& path, bool /*bExportMission*/)
 {
     IEditor* pEditor = GetIEditor();
-    pEditor->SetStatusText(QObject::tr("Exporting LevelData.xml..."));
+    pEditor->SetStatusText(QObject::tr("Exporting leveldata.xml..."));
 
     char versionString[256];
     pEditor->GetFileVersion().ToString(versionString);
 
-    XmlNodeRef root = XmlHelpers::CreateXmlNode("LevelData");
+    XmlNodeRef root = XmlHelpers::CreateXmlNode("leveldata");
     root->setAttr("SandboxVersion", versionString);
-    XmlNodeRef rootAction = XmlHelpers::CreateXmlNode("LevelDataAction");
+    XmlNodeRef rootAction = XmlHelpers::CreateXmlNode("leveldataaction");
     rootAction->setAttr("SandboxVersion", versionString);
 
     //////////////////////////////////////////////////////////////////////////
     // Save Level Data XML
     //////////////////////////////////////////////////////////////////////////
-    QString levelDataFile = path + "LevelData.xml";
+    QString levelDataFile = path + "leveldata.xml";
     XmlString xmlData = root->getXML();
     CCryMemFile file;
     file.Write(xmlData.c_str(), static_cast<unsigned int>(xmlData.length()));
     m_levelPak.m_pakFile.UpdateFile(levelDataFile.toUtf8().data(), file);
 
-    QString levelDataActionFile = path + "LevelDataAction.xml";
+    QString levelDataActionFile = path + "leveldataaction.xml";
     XmlString xmlDataAction = rootAction->getXML();
     CCryMemFile fileAction;
     fileAction.Write(xmlDataAction.c_str(), static_cast<unsigned int>(xmlDataAction.length()));
@@ -298,7 +298,7 @@ void CGameExporter::ExportLevelData(const QString& path, bool /*bExportMission*/
     if (savedEntities)
     {
         QString entitiesFile;
-        entitiesFile = QStringLiteral("%1%2.entities_xml").arg(path, "Mission0");
+        entitiesFile = QStringLiteral("%1%2.entities_xml").arg(path, "mission0");
         m_levelPak.m_pakFile.UpdateFile(entitiesFile.toUtf8().data(), entitySaveBuffer.begin(), static_cast<int>(entitySaveBuffer.size()));
     }
 }
@@ -326,7 +326,7 @@ void CGameExporter::ExportLevelInfo(const QString& path)
     //////////////////////////////////////////////////////////////////////////
     // Save LevelInfo file.
     //////////////////////////////////////////////////////////////////////////
-    QString filename = path + "LevelInfo.xml";
+    QString filename = path + "levelinfo.xml";
     XmlString xmlData = root->getXML();
 
     CCryMemFile file;

--- a/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
+++ b/Code/Legacy/CrySystem/LevelSystem/LevelSystem.cpp
@@ -86,7 +86,7 @@ bool CLevelInfo::ReadInfo()
         usePrefabSystemForLevels, &AzFramework::ApplicationRequests::IsPrefabSystemForLevelsEnabled);
 
     // Set up a default game type for legacy code.
-    m_defaultGameTypeName = "Mission0";
+    m_defaultGameTypeName = "mission0";
 
     if (usePrefabSystemForLevels)
     {
@@ -96,17 +96,17 @@ bool CLevelInfo::ReadInfo()
 
     AZStd::string levelPath(m_levelPath);
     AZStd::string xmlFile(levelPath);
-    xmlFile += "/LevelInfo.xml";
+    xmlFile += "/levelinfo.xml";
     XmlNodeRef rootNode = GetISystem()->LoadXmlFromFile(xmlFile.c_str());
 
     if (rootNode)
     {
         AZStd::string dataFile(levelPath);
-        dataFile += "/LevelDataAction.xml";
+        dataFile += "/leveldataaction.xml";
         XmlNodeRef dataNode = GetISystem()->LoadXmlFromFile(dataFile.c_str());
         if (!dataNode)
         {
-            dataFile = levelPath + "/LevelData.xml";
+            dataFile = levelPath + "/leveldata.xml";
             dataNode = GetISystem()->LoadXmlFromFile(dataFile.c_str());
         }
 
@@ -614,7 +614,7 @@ ILevel* CLevelSystem::LoadLevelInternal(const char* _levelName)
         }
 
         {
-            AZStd::string missionXml("Mission_");
+            AZStd::string missionXml("mission_");
             missionXml += pLevelInfo->m_defaultGameTypeName;
             missionXml += ".xml";
             AZStd::string xmlFile(pLevelInfo->GetPath());


### PR DESCRIPTION
Update all the hardcoded filenames inside the level.pak file to be lowercase now the editor no longer forces them to be lower case.
New levels will require a re-export to engine to work on Linux

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>