### PR TITLE
bugfix[linux]: handle moving files for inode-watch for AssetProcessor (#4656)

### DIFF
--- a/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp
+++ b/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp
@@ -72,7 +72,7 @@ struct FolderRootWatch::PlatformImplementation
             // Add the folder to watch and track it
             int watchHandle = inotify_add_watch(m_iNotifyHandle, 
                                                 cleanPath.toUtf8().constData(),
-                                                IN_CREATE | IN_CLOSE_WRITE | IN_DELETE | IN_DELETE_SELF | IN_MODIFY);
+                                                IN_CREATE | IN_CLOSE_WRITE | IN_DELETE | IN_DELETE_SELF | IN_MODIFY | IN_MOVE);
             
             if (!m_handleToFolderMapLock.tryLock(s_handleToFolderMapLockTimeout))
             {
@@ -95,7 +95,7 @@ struct FolderRootWatch::PlatformImplementation
                 
                 int watchHandle = inotify_add_watch(m_iNotifyHandle, 
                                                     dirName.toUtf8().constData(),
-                                                    IN_CREATE | IN_CLOSE_WRITE | IN_DELETE | IN_DELETE_SELF | IN_MODIFY);
+                                                    IN_CREATE | IN_CLOSE_WRITE | IN_DELETE | IN_DELETE_SELF | IN_MODIFY | IN_MOVE);
 
                 if (!m_handleToFolderMapLock.tryLock(s_handleToFolderMapLockTimeout))
                 {


### PR DESCRIPTION
add this debug text  to WatchFolderLoop. 
```
                    if(!pathStr.contains("log")) {
                        AZ_Printf("File Watcher","trigger: %s", pathStr.toStdString().c_str());
                    }
```

should see the file show up in the logs when renaming/moving the file now. 

Signed-off-by: Michael Pollind <mpollind@gmail.com>