### PR TITLE
Make safe asset folder comparison for prefab creation to be case insensitive

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceUtilities.cpp
@@ -2651,11 +2651,12 @@ namespace AzToolsFramework
                     AZ::IO::FixedMaxPath lexicallyNormalPath = AZ::IO::PathView(slicePath.toUtf8().constData()).LexicallyNormal();
 
                     bool isPathSafeForAssets = false;
-                    for (AZ::IO::Path assetSafeFolder : assetSafeFolders)
+                    for (const AZStd::string& assetSafeFolder : assetSafeFolders)
                     {
+                        AZ::IO::PathView assetSafeFolderView(assetSafeFolder);
                         // Check if the slice path is relative to the safe asset directory.
                         // The Path classes are being used to make this check case insensitive.
-                        if (lexicallyNormalPath.IsRelativeTo(assetSafeFolder))
+                        if (lexicallyNormalPath.IsRelativeTo(assetSafeFolderView))
                         {
                             isPathSafeForAssets = true;
                             break;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -803,11 +803,12 @@ namespace AzToolsFramework
                 AZ::IO::FixedMaxPath lexicallyNormalPath = AZ::IO::PathView(prefabPath.toUtf8().constData()).LexicallyNormal();
 
                 bool isPathSafeForAssets = false;
-                for (AZ::IO::Path assetSafeFolder : assetSafeFolders)
+                for (const AZStd::string& assetSafeFolder : assetSafeFolders)
                 {
+                    AZ::IO::PathView assetSafeFolderView(assetSafeFolder);
                     // Check if the prefabPath is relative to the safe asset directory.
                     // The Path classes are being used to make this check case insensitive.
-                    if (lexicallyNormalPath.IsRelativeTo(assetSafeFolder))
+                    if (lexicallyNormalPath.IsRelativeTo(assetSafeFolderView))
                     {
                         isPathSafeForAssets = true;
                         break;


### PR DESCRIPTION
If a project path is given as -DLY_PROJECTS="d:\something\caseSensitiveProject" when the actual file path is "D:\Something\caseSensitiveProject", then during the time of creating a prefab, we throw an error that the prefab cannot be created. This should instead use AZ::IO: Path's relative path comparison function which is case insensitive and would solve this problem.