### PR TITLE
Treat invalid p4 configuration as a warning for the scene settings save action so the processing popup will get the job results.

### DIFF
--- a/Code/Editor/Plugins/EditorCommon/SaveUtilities/AsyncSaveRunner.cpp
+++ b/Code/Editor/Plugins/EditorCommon/SaveUtilities/AsyncSaveRunner.cpp
@@ -76,6 +76,7 @@ namespace AZ
                     else if (info.m_status == AzToolsFramework::SourceControlStatus::SCS_ProviderIsDown)
                     {
                         message = "Failed to put entries/dependencies into source control as the provider is not available.\n";
+                        reportAsWarning = true;
                     }
                     else if (info.m_status == AzToolsFramework::SourceControlStatus::SCS_CertificateInvalid)
                     {


### PR DESCRIPTION
When saving scene settings changes, if the user has perforce enabled but with an invalid configuration, the save in progress dialog will be stuck and not show the output results from the AP after processing the save action. This is because it was treating as an error state, even though in this case the logic bypasses the perforce part and does indeed save out the changes to the file, but reports back as an error, so the progress dialog is unable to report the job results.

With this change, the actual job results will indeed be retrieved from the AP and the progress dialog will get an updated status once they are complete.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>