### PR TITLE
EMotion FX: AnimGraphNode::CalcSyncFactors crashes because of improper MCORE_INVALIDINDEX32 initialization

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
@@ -597,7 +597,7 @@ namespace EMotionFX
         // reset several settings to rewind the motion instance
         motionInstance->ResetTimes();
         motionInstance->SetIsFrozen(false);
-        SetSyncIndex(animGraphInstance, MCORE_INVALIDINDEX32);
+        SetSyncIndex(animGraphInstance, InvalidIndex);
         uniqueData->SetCurrentPlayTime(motionInstance->GetCurrentTime());
         uniqueData->SetDuration(motionInstance->GetDuration());
         uniqueData->SetPreSyncTime(uniqueData->GetCurrentPlayTime());

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNode.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNode.h
@@ -213,12 +213,12 @@ namespace EMotionFX
          */
         virtual void SkipOutput([[maybe_unused]] AnimGraphInstance* animGraphInstance) {}
 
-        MCORE_INLINE float GetDuration(AnimGraphInstance* animGraphInstance) const                 { return FindOrCreateUniqueNodeData(animGraphInstance)->GetDuration(); }
+        float GetDuration(AnimGraphInstance* animGraphInstance) const                 { return FindOrCreateUniqueNodeData(animGraphInstance)->GetDuration(); }
         virtual void SetCurrentPlayTime(AnimGraphInstance* animGraphInstance, float timeInSeconds) { FindOrCreateUniqueNodeData(animGraphInstance)->SetCurrentPlayTime(timeInSeconds); }
         virtual float GetCurrentPlayTime(AnimGraphInstance* animGraphInstance) const               { return FindOrCreateUniqueNodeData(animGraphInstance)->GetCurrentPlayTime(); }
 
-        MCORE_INLINE size_t GetSyncIndex(AnimGraphInstance* animGraphInstance) const               { return FindOrCreateUniqueNodeData(animGraphInstance)->GetSyncIndex(); }
-        MCORE_INLINE void SetSyncIndex(AnimGraphInstance* animGraphInstance, size_t syncIndex)     { FindOrCreateUniqueNodeData(animGraphInstance)->SetSyncIndex(syncIndex); }
+        size_t GetSyncIndex(AnimGraphInstance* animGraphInstance) const               { return FindOrCreateUniqueNodeData(animGraphInstance)->GetSyncIndex(); }
+        void SetSyncIndex(AnimGraphInstance* animGraphInstance, size_t syncIndex)     { FindOrCreateUniqueNodeData(animGraphInstance)->SetSyncIndex(syncIndex); }
 
         virtual void SetPlaySpeed(AnimGraphInstance* animGraphInstance, float speedFactor)         { FindOrCreateUniqueNodeData(animGraphInstance)->SetPlaySpeed(speedFactor); }
         virtual float GetPlaySpeed(AnimGraphInstance* animGraphInstance) const                     { return FindOrCreateUniqueNodeData(animGraphInstance)->GetPlaySpeed(); }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeData.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNodeData.h
@@ -51,52 +51,52 @@ namespace EMotionFX
         void Init(AnimGraphInstance* animGraphInstance, AnimGraphNode* node);
         void Init(AnimGraphNodeData* nodeData);
 
-        MCORE_INLINE AnimGraphNode* GetNode() const                            { return reinterpret_cast<AnimGraphNode*>(m_object); }
-        MCORE_INLINE void SetNode(AnimGraphNode* node)                         { m_object = reinterpret_cast<AnimGraphObject*>(node); }
+        AnimGraphNode* GetNode() const                            { return reinterpret_cast<AnimGraphNode*>(m_object); }
+        void SetNode(AnimGraphNode* node)                         { m_object = reinterpret_cast<AnimGraphObject*>(node); }
 
-        MCORE_INLINE void SetSyncIndex(size_t syncIndex)                        { m_syncIndex = syncIndex; }
-        MCORE_INLINE size_t GetSyncIndex() const                                { return m_syncIndex; }
+        void SetSyncIndex(size_t syncIndex)                        { m_syncIndex = syncIndex; }
+        size_t GetSyncIndex() const                                { return m_syncIndex; }
 
-        MCORE_INLINE void SetCurrentPlayTime(float absoluteTime)                { m_currentTime = absoluteTime; }
-        MCORE_INLINE float GetCurrentPlayTime() const                           { return m_currentTime; }
+        void SetCurrentPlayTime(float absoluteTime)                { m_currentTime = absoluteTime; }
+        float GetCurrentPlayTime() const                           { return m_currentTime; }
 
-        MCORE_INLINE void SetPlaySpeed(float speed)                             { m_playSpeed = speed; }
-        MCORE_INLINE float GetPlaySpeed() const                                 { return m_playSpeed; }
+        void SetPlaySpeed(float speed)                             { m_playSpeed = speed; }
+        float GetPlaySpeed() const                                 { return m_playSpeed; }
 
-        MCORE_INLINE void SetDuration(float durationInSeconds)                  { m_duration = durationInSeconds; }
-        MCORE_INLINE float GetDuration() const                                  { return m_duration; }
+        void SetDuration(float durationInSeconds)                  { m_duration = durationInSeconds; }
+        float GetDuration() const                                  { return m_duration; }
 
-        MCORE_INLINE void SetPreSyncTime(float timeInSeconds)                   { m_preSyncTime = timeInSeconds; }
-        MCORE_INLINE float GetPreSyncTime() const                               { return m_preSyncTime; }
+        void SetPreSyncTime(float timeInSeconds)                   { m_preSyncTime = timeInSeconds; }
+        float GetPreSyncTime() const                               { return m_preSyncTime; }
 
-        MCORE_INLINE void SetGlobalWeight(float weight)                         { m_globalWeight = weight; }
-        MCORE_INLINE float GetGlobalWeight() const                              { return m_globalWeight; }
+        void SetGlobalWeight(float weight)                         { m_globalWeight = weight; }
+        float GetGlobalWeight() const                              { return m_globalWeight; }
 
-        MCORE_INLINE void SetLocalWeight(float weight)                          { m_localWeight = weight; }
-        MCORE_INLINE float GetLocalWeight() const                               { return m_localWeight; }
+        void SetLocalWeight(float weight)                          { m_localWeight = weight; }
+        float GetLocalWeight() const                               { return m_localWeight; }
 
-        MCORE_INLINE uint8 GetInheritFlags() const                              { return m_inheritFlags; }
+        uint8 GetInheritFlags() const                              { return m_inheritFlags; }
 
-        MCORE_INLINE bool GetIsBackwardPlaying() const                          { return (m_inheritFlags & INHERITFLAGS_BACKWARD) != 0; }
-        MCORE_INLINE void SetBackwardFlag()                                     { m_inheritFlags |= INHERITFLAGS_BACKWARD; }
-        MCORE_INLINE void ClearInheritFlags()                                   { m_inheritFlags = 0; }
+        bool GetIsBackwardPlaying() const                          { return (m_inheritFlags & INHERITFLAGS_BACKWARD) != 0; }
+        void SetBackwardFlag()                                     { m_inheritFlags |= INHERITFLAGS_BACKWARD; }
+        void ClearInheritFlags()                                   { m_inheritFlags = 0; }
 
-        MCORE_INLINE uint8 GetPoseRefCount() const                              { return m_poseRefCount; }
-        MCORE_INLINE void IncreasePoseRefCount()                                { m_poseRefCount++; }
-        MCORE_INLINE void DecreasePoseRefCount()                                { m_poseRefCount--; }
-        MCORE_INLINE void SetPoseRefCount(uint8 refCount)                       { m_poseRefCount = refCount; }
+        uint8 GetPoseRefCount() const                              { return m_poseRefCount; }
+        void IncreasePoseRefCount()                                { m_poseRefCount++; }
+        void DecreasePoseRefCount()                                { m_poseRefCount--; }
+        void SetPoseRefCount(uint8 refCount)                       { m_poseRefCount = refCount; }
 
-        MCORE_INLINE uint8 GetRefDataRefCount() const                           { return m_refDataRefCount; }
-        MCORE_INLINE void IncreaseRefDataRefCount()                             { m_refDataRefCount++; }
-        MCORE_INLINE void DecreaseRefDataRefCount()                             { m_refDataRefCount--; }
-        MCORE_INLINE void SetRefDataRefCount(uint8 refCount)                    { m_refDataRefCount = refCount; }
+        uint8 GetRefDataRefCount() const                           { return m_refDataRefCount; }
+        void IncreaseRefDataRefCount()                             { m_refDataRefCount++; }
+        void DecreaseRefDataRefCount()                             { m_refDataRefCount--; }
+        void SetRefDataRefCount(uint8 refCount)                    { m_refDataRefCount = refCount; }
 
-        MCORE_INLINE void SetRefCountedData(AnimGraphRefCountedData* data)     { m_refCountedData = data; }
-        MCORE_INLINE AnimGraphRefCountedData* GetRefCountedData() const        { return m_refCountedData; }
+        void SetRefCountedData(AnimGraphRefCountedData* data)     { m_refCountedData = data; }
+        AnimGraphRefCountedData* GetRefCountedData() const        { return m_refCountedData; }
 
-        MCORE_INLINE const AnimGraphSyncTrack* GetSyncTrack() const            { return m_syncTrack; }
-        MCORE_INLINE AnimGraphSyncTrack* GetSyncTrack()                        { return m_syncTrack; }
-        MCORE_INLINE void SetSyncTrack(AnimGraphSyncTrack* syncTrack)          { m_syncTrack = syncTrack; }
+        const AnimGraphSyncTrack* GetSyncTrack() const            { return m_syncTrack; }
+        AnimGraphSyncTrack* GetSyncTrack()                        { return m_syncTrack; }
+        void SetSyncTrack(AnimGraphSyncTrack* syncTrack)          { m_syncTrack = syncTrack; }
 
         bool GetIsMirrorMotion() const { return m_isMirrorMotion; }
         void SetIsMirrorMotion(bool newValue) { m_isMirrorMotion = newValue; }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphStateTransition.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphStateTransition.cpp
@@ -326,7 +326,7 @@ namespace EMotionFX
         uniqueData->m_totalSeconds   = 0.0f;
         uniqueData->m_blendProgress  = 0.0f;
 
-        m_targetNode->SetSyncIndex(animGraphInstance, MCORE_INVALIDINDEX32);
+        m_targetNode->SetSyncIndex(animGraphInstance, InvalidIndex);
 
         // Trigger action
         for (AnimGraphTriggerAction* action : m_actionSetup.GetActions())


### PR DESCRIPTION
Resolves #4820

Signed-off-by: Benjamin Jillich <jillich@amazon.com>