### PR TITLE
Update open file limit on linux for applications

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Application/Application_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Application/Application_Linux.cpp
@@ -32,7 +32,7 @@ namespace AzFramework
             rlimit newLimit;
             newLimit.rlim_cur = g_minimumOpenFileHandles; // Soft Limit
             newLimit.rlim_max = g_minimumOpenFileHandles; // Hard Limit
-            [[maybe_unused]] int set_limit_result = setrlimit(RLIMIT_NOFILE,&newLimit);
+            [[maybe_unused]] int set_limit_result = setrlimit(RLIMIT_NOFILE, &newLimit);
             AZ_Assert(set_limit_result == 0, "Unable to update open file limits");
         }
         


### PR DESCRIPTION
The O3DE Editor and Tools may use more than **1024** open file handles on Linux. Using the Editor will crash or not work properly when it surpasses this number of open files. The open file limit needs to be updated to accommodate a larger number of open file handles. This fixes 2 known issues:

1. Opening the Material Editor will fail with an error: 
```
    QThreadPipe: Unable to create pipe: Too many open files
    QEventDispatcherUNIXPrivate(): Cannot continue without a thread pipe
```
2. Browsing through items in the Asset Browser will crash the editor because it spawns threads that open asset file handles (possibly for previewing) 

