### PR TITLE
[Linux] Only listen for raw events from master XInput devices

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -276,7 +276,8 @@ namespace AzFramework
             int mask;
         } mask;
 
-        mask.head.deviceid = XCB_INPUT_DEVICE_ALL;
+        // use of this non-inclusive term is required due to xinput's API
+        mask.head.deviceid = XCB_INPUT_DEVICE_ALL_MASTER;
         mask.head.mask_len = 1;
 
         if (enable)


### PR DESCRIPTION
XInput organizes devices into groups. It creates one virtual device per
input type, which will be a "master" device, that forwards events from
all physical devices of that type. It then creates one physical device
per actual physical device connected to the machine, which are "slave"
devices. So, if there are 3 mice connected to a given machine, client
code can listen to events from just the master mouse and get events from
all the mice connected, or it can listen to events from each slave mouse
to distinguish input by device, or it can listen to events from all
devices, master and slave. In this case, it will get an event twice, one
from the master device and one from a slave device. This is what the
previous version was doing, and was causing one event from the user (a
single mouse button press, or a single pointer move) to be processed
twice by the mouse input system.

This fixes that bug by making the client only listen to events from
master devices.

Note: Non-inclusive terminology was used in this commit to accurately
reflect the API that X11's XInput library uses.

Signed-off-by: Chris Burel <burelc@amazon.com>