### PR TITLE
Undo P4 check before spawning thread

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
@@ -80,14 +80,7 @@ namespace AzToolsFramework
 
         // set up signals before we start thread.
         m_shutdownThreadSignal = false;
-
-        // Check to see if the 'p4' command is available at the command line
-        int p4VersionExitCode = QProcess::execute("p4", QStringList{ "-V" });
-        m_p4ApplicationDetected = (p4VersionExitCode == 0);
-        if (m_p4ApplicationDetected)
-        {
-            m_WorkerThread = AZStd::thread(AZStd::bind(&PerforceComponent::ThreadWorker, this));
-        }
+        m_WorkerThread = AZStd::thread(AZStd::bind(&PerforceComponent::ThreadWorker, this));
 
         SourceControlConnectionRequestBus::Handler::BusConnect();
         SourceControlCommandBus::Handler::BusConnect();
@@ -98,13 +91,10 @@ namespace AzToolsFramework
         SourceControlCommandBus::Handler::BusDisconnect();
         SourceControlConnectionRequestBus::Handler::BusDisconnect();
 
-        if (m_p4ApplicationDetected)
-        {
-            m_shutdownThreadSignal = true; // tell the thread to die.
-            m_WorkerSemaphore.release(1); // wake up the thread so that it sees the signal
-            m_WorkerThread.join(); // wait for the thread to finish.
-            m_WorkerThread = AZStd::thread();
-        }
+        m_shutdownThreadSignal = true; // tell the thread to die.
+        m_WorkerSemaphore.release(1); // wake up the thread so that it sees the signal
+        m_WorkerThread.join(); // wait for the thread to finish.
+        m_WorkerThread = AZStd::thread();
 
         SetConnection(nullptr);
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.h
@@ -260,7 +260,5 @@ namespace AzToolsFramework
         AZStd::atomic_bool m_validConnection;
 
         SourceControlState m_connectionState;
-
-        bool m_p4ApplicationDetected { false };
     };
 } // namespace AzToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -36,6 +36,8 @@
 #include <AzToolsFramework/UI/UICore/QTreeViewStateSaver.hxx>
 #include <AzToolsFramework/UI/UICore/QWidgetSavedState.h>
 
+#include "AtomToolsFramework_Traits_Platform.h"
+
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
 #include <QMessageBox>
 #include <QObject>
@@ -217,7 +219,7 @@ namespace AtomToolsFramework
         AzFramework::AssetSystemRequestBus::Broadcast(&AzFramework::AssetSystem::AssetSystemRequests::StartDisconnectingAssetProcessor);
 
 #if AZ_TRAIT_ATOMTOOLSFRAMEWORK_SKIP_APP_DESTROY
-        _exit(0);
+        ::_exit(0);
 #else
         Base::Destroy();
 #endif


### PR DESCRIPTION
As it turns out the logic to not spawn a P4 worker thread was the wrong approach for systems that do not have P4 installed. (see https://github.com/o3de/o3de/pull/4808 ) The thread would handle that scenario anyways, and put the p4 component into offline mode. But without that thread, calls to the P4 source control bus would hang because it is not processing the "offlineJobs".

This check is no longer needed because the thread being locked was due to issues with ProcessWatcher on Linux which was fixed by ( https://github.com/o3de/o3de/pull/4808 ). 

Also missed an include to the trait that would enable the early exit for Linux (from https://github.com/o3de/o3de/pull/4808 )

Signed-off-by: Steve Pham <spham@amazon.com>