### PR TITLE
Hair and Tools Pipeline bug fixes

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -469,12 +469,12 @@
                 "Path": "Passes/OpaqueParent.pass"
             },
             {
-                "Name": "ThumbnailPipeline",
-                "Path": "Passes/ThumbnailPipeline.pass"
+                "Name": "ToolsPipeline",
+                "Path": "Passes/ToolsPipeline.pass"
             },
             {
-                "Name": "ThumbnailPipelineRenderToTexture",
-                "Path": "Passes/ThumbnailPipelineRenderToTexture.pass"
+                "Name": "ToolsPipelineRenderToTexture",
+                "Path": "Passes/ToolsPipelineRenderToTexture.pass"
             },
             {
                 "Name": "TransparentParentTemplate",

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipeline.pass
@@ -4,7 +4,7 @@
     "ClassName": "PassAsset",
     "ClassData": {
         "PassTemplate": {
-            "Name": "ThumbnailPipeline",
+            "Name": "ToolsPipeline",
             "PassClass": "ParentPass",
             "Slots": [
                 {

--- a/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipelineRenderToTexture.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/ToolsPipelineRenderToTexture.pass
@@ -4,7 +4,7 @@
     "ClassName": "PassAsset",
     "ClassData": {
         "PassTemplate": {
-            "Name": "ThumbnailPipelineRenderToTexture",
+            "Name": "ToolsPipelineRenderToTexture",
             "PassClass": "RenderToTexturePass",
             "PassData": {
                 "$type": "RenderToTexturePassData",
@@ -15,7 +15,7 @@
             "PassRequests": [
                 {
                     "Name": "Pipeline",
-                    "TemplateName": "ThumbnailPipeline",
+                    "TemplateName": "ToolsPipeline",
                     "Connections": [
                         {
                             "LocalSlot": "SwapChainOutput",

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -161,8 +161,8 @@ set(FILES
     Passes/LutGeneration.pass
     Passes/MainPipeline.pass
     Passes/MainPipelineRenderToTexture.pass
-    Passes/ThumbnailPipeline.pass
-    Passes/ThumbnailPipelineRenderToTexture.pass
+    Passes/ToolsPipeline.pass
+    Passes/ToolsPipelineRenderToTexture.pass
     Passes/MeshMotionVector.pass
     Passes/ModulateTexture.pass
     Passes/MorphTarget.pass

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -61,7 +61,7 @@ namespace AtomToolsFramework
         AZ::RPI::RenderPipelineDescriptor pipelineDesc;
         pipelineDesc.m_mainViewTagName = "MainCamera";
         pipelineDesc.m_name = pipelineName;
-        pipelineDesc.m_rootPassTemplate = "MainPipelineRenderToTexture";
+        pipelineDesc.m_rootPassTemplate = "ToolsPipelineRenderToTexture";
 
         // We have to set the samples to 4 to match the pipeline passes' setting, otherwise it may lead to device lost issue
         // [GFX TODO] [ATOM-13551] Default value sand validation required to prevent pipeline crash and device lost

--- a/Gems/AtomTressFX/Assets/Passes/HairParentPass.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairParentPass.pass
@@ -71,6 +71,12 @@
                     }
                 }
             ],
+            "FallbackConnections": [
+                {
+                    "Input": "DepthLinearInput",
+                    "Output": "DepthLinear"
+                }
+            ],
             "PassRequests": [
                 {
                     "Name": "HairGlobalShapeConstraintsComputePass",

--- a/Gems/AtomTressFX/Assets/Passes/HairParentShortCutPass.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairParentShortCutPass.pass
@@ -12,7 +12,8 @@
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "RenderTarget"
                 },
-                {   // used for copy from MSAA to regular RT
+                { 
+                    // used for copy from MSAA to regular RT
                     "Name": "RenderTargetInputOnly",
                     "SlotType": "Input",
                     "ScopeAttachmentUsage": "Shader"
@@ -29,7 +30,7 @@
                 // If DepthLinear is not availbale - connect to another viewport (non MSAA) image.
                 {
                     "Name": "DepthLinearInput",
-                    "SlotType": "InputOutput"
+                    "SlotType": "Input"
                 },
                 {
                     "Name": "DepthLinear",
@@ -69,6 +70,12 @@
                         "Pass": "DepthToDepthLinearPass",
                         "Attachment": "Output"
                     }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input": "DepthLinearInput",
+                    "Output": "DepthLinear"
                 }
             ],
             "PassRequests": [
@@ -257,7 +264,8 @@
                                 "Attachment": "HairColorRenderTarget"
                             }
                         },
-                        {   // The final render target - this is MSAA mode RT - would it be cheaper to
+                        { 
+                            // The final render target - this is MSAA mode RT - would it be cheaper to
                             // use non-MSAA and then copy?
                             "LocalSlot": "RenderTargetInputOutput",
                             "AttachmentRef": {
@@ -340,7 +348,8 @@
                     "TemplateName": "HairShortCutResolveColorPassTemplate",
                     "Enabled": true,
                     "Connections": [
-                        {   // The final render target - this is MSAA mode RT - would it be cheaper to
+                        { 
+                            // The final render target - this is MSAA mode RT - would it be cheaper to
                             // use non-MSAA and then copy?
                             "LocalSlot": "RenderTargetInputOutput",
                             "AttachmentRef": {

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -144,25 +144,11 @@ namespace AZ
 
             void HairFeatureProcessor::EnablePasses([[maybe_unused]] bool enable)
             {
-                return;
-
-                // [To Do] - This part should be enabled (remove the return) to reduce overhead
-                // when Hair is disabled / doesn't exist in the scene.
-                // Currently it might break features such as fog that depend on the output and for some
-                // reason doesn't quite work for ShortCut.
-                // The current overhead is minimal (< 0.1 msec) and this Gem is disabled by default.
-/*
-                if (!m_initialized)
-                {
-                    return;
-                }
-
                 RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(HairParentPassName);
                 if (desiredPass)
                 {
                     desiredPass->SetEnabled(enable);
                 }
-*/
             }
 
             bool HairFeatureProcessor::RemoveHairRenderObject(Data::Instance<HairRenderObject> renderObject)
@@ -184,15 +170,13 @@ namespace AZ
 
             void HairFeatureProcessor::UpdateHairSkinning()
             {
-                // Copying CPU side m_SimCB content to the GPU buffer (matrices, wind parameters..) 
-
-                for (auto objIter = m_hairRenderObjects.begin(); objIter != m_hairRenderObjects.end(); ++objIter)
+                // Copying CPU side m_SimCB content to the GPU buffer (matrices, wind parameters..)
+                for (auto& hairRenderObject : m_hairRenderObjects)
                 {
-                    if (!objIter->get()->IsEnabled())
+                    if (hairRenderObject->IsEnabled())
                     {
-                        return;
+                        hairRenderObject->Update();
                     }
-                    objIter->get()->Update();
                 }
             }
 


### PR DESCRIPTION
- Fixed fallback connections for hair pipeline to allow disabling the parent pass hierarchy when not required
- Renamed the Thumbnail pipeline to be used as generic minimal tools pipeline
- Reused the Tools pipeline for the preview renderer - minimal FPs and passes

Remark:
- The tools pipeline should have folloup submits for reducing passes to minimal required render passes

Signed-off-by: Adi-Amazon <Adi Bar-Lev barlev@amazon.com>