### PR TITLE
Added API for finding components based on required/incompatible services

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIBus.h
@@ -36,6 +36,10 @@ namespace AzToolsFramework
         //! the entity type.
         virtual AZStd::vector<AZ::Uuid> FindComponentTypeIdsByEntityType(const AZStd::vector<AZStd::string>& componentTypeNames, EntityType entityType) = 0;
 
+        //! Return a list of type ids for components that match the required services filter,
+        //! and don't conflict with any of the incompatible services filter
+        virtual AZStd::vector<AZ::Uuid> FindComponentTypeIdsByService(const AZStd::vector<AZ::ComponentServiceType>& serviceFilter, const AZStd::vector<AZ::ComponentServiceType>& incompatibleServiceFilter) = 0;
+
         //! Finds the component names from their type ids
         virtual AZStd::vector<AZStd::string> FindComponentTypeNames(const AZ::ComponentTypeList& componentTypeIds) = 0;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Component/EditorComponentAPIComponent.h
@@ -35,6 +35,7 @@ namespace AzToolsFramework
 
             // EditorComponentAPIBus ...
             AZStd::vector<AZ::Uuid> FindComponentTypeIdsByEntityType(const AZStd::vector<AZStd::string>& componentTypeNames, EditorComponentAPIRequests::EntityType entityType) override;
+            AZStd::vector<AZ::Uuid> FindComponentTypeIdsByService(const AZStd::vector<AZ::ComponentServiceType>& serviceFilter, const AZStd::vector<AZ::ComponentServiceType>& incompatibleServiceFilter) override;
             AZStd::vector<AZStd::string> FindComponentTypeNames(const AZ::ComponentTypeList& componentTypeIds) override;
             AZStd::vector<AZStd::string> BuildComponentTypeNameListByEntityType(EditorComponentAPIRequests::EntityType entityType) override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
@@ -271,6 +271,68 @@ namespace AzToolsFramework
         return editorComponentBaseComponent;
     }
 
+    bool OffersRequiredServices(
+        const AZ::SerializeContext::ClassData* componentClass,
+        const AZStd::vector<AZ::ComponentServiceType>& serviceFilter,
+        const AZStd::vector<AZ::ComponentServiceType>& incompatibleServiceFilter
+    )
+    {
+        AZ_Assert(componentClass, "Component class must not be null");
+
+        if (!componentClass)
+        {
+            return false;
+        }
+
+        AZ::ComponentDescriptor* componentDescriptor = nullptr;
+        AZ::ComponentDescriptorBus::EventResult(
+            componentDescriptor, componentClass->m_typeId, &AZ::ComponentDescriptor::GetDescriptor);
+        if (!componentDescriptor)
+        {
+            return false;
+        }
+
+        // If no services are provided, this function returns true
+        if (serviceFilter.empty())
+        {
+            return true;
+        }
+
+        AZ::ComponentDescriptor::DependencyArrayType providedServices;
+        componentDescriptor->GetProvidedServices(providedServices, nullptr);
+
+        //reject this component if it does not offer any of the required services
+        if (AZStd::find_first_of(
+            providedServices.begin(),
+            providedServices.end(),
+            serviceFilter.begin(),
+            serviceFilter.end()) == providedServices.end())
+        {
+            return false;
+        }
+
+        //reject this component if it does offer any of the incompatible services
+        if (AZStd::find_first_of(
+            providedServices.begin(),
+            providedServices.end(),
+            incompatibleServiceFilter.begin(),
+            incompatibleServiceFilter.end()) != providedServices.end())
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool OffersRequiredServices(
+        const AZ::SerializeContext::ClassData* componentClass,
+        const AZStd::vector<AZ::ComponentServiceType>& serviceFilter
+    )
+    {
+        const AZStd::vector<AZ::ComponentServiceType> incompatibleServices;
+        return OffersRequiredServices(componentClass, serviceFilter, incompatibleServices);
+    }
+
     bool ShouldInspectorShowComponent(const AZ::Component* component)
     {
         if (!component)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.h
@@ -105,6 +105,16 @@ namespace AzToolsFramework
     AZ::ComponentDescriptor* GetComponentDescriptor(const AZ::Component* component);
     Components::EditorComponentDescriptor* GetEditorComponentDescriptor(const AZ::Component* component);
     Components::EditorComponentBase* GetEditorComponent(AZ::Component* component);
+    // Returns true if the given component provides at least one of the services specified or no services are provided
+    bool OffersRequiredServices(
+        const AZ::SerializeContext::ClassData* componentClass,
+        const AZStd::vector<AZ::ComponentServiceType>& serviceFilter,
+        const AZStd::vector<AZ::ComponentServiceType>& incompatibleServiceFilter
+    );
+    bool OffersRequiredServices(
+        const AZ::SerializeContext::ClassData* componentClass,
+        const AZStd::vector<AZ::ComponentServiceType>& serviceFilter
+    );
 
     /// Return true if the editor should show this component to users,
     /// false if the component should be hidden from users.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option") // 4251: 'QLayoutItem::align': class 'QFlags<Qt::AlignmentFlag>' needs to have dll-interface to be used by clients of class 'QLayoutItem'
 #include <AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx>
 AZ_POP_DISABLE_WARNING
@@ -20,67 +21,6 @@ namespace AzToolsFramework
 {
     namespace ComponentPaletteUtil
     {
-        bool OffersRequiredServices(
-            const AZ::SerializeContext::ClassData* componentClass,
-            const AZStd::vector<AZ::ComponentServiceType>& serviceFilter,
-            const AZStd::vector<AZ::ComponentServiceType>& incompatibleServiceFilter
-        )
-        {
-            AZ_Assert(componentClass, "Component class must not be null");
-
-            if (!componentClass)
-            {
-                return false;
-            }
-
-            AZ::ComponentDescriptor* componentDescriptor = nullptr;
-            EBUS_EVENT_ID_RESULT(componentDescriptor, componentClass->m_typeId, AZ::ComponentDescriptorBus, GetDescriptor);
-            if (!componentDescriptor)
-            {
-                return false;
-            }
-
-            // If no services are provided, this function returns true
-            if (serviceFilter.empty())
-            {
-                return true;
-            }
-
-            AZ::ComponentDescriptor::DependencyArrayType providedServices;
-            componentDescriptor->GetProvidedServices(providedServices, nullptr);
-
-            //reject this component if it does not offer any of the required services
-            if (AZStd::find_first_of(
-                providedServices.begin(),
-                providedServices.end(),
-                serviceFilter.begin(),
-                serviceFilter.end()) == providedServices.end())
-            {
-                return false;
-            }
-
-            //reject this component if it does offer any of the incompatible services
-            if (AZStd::find_first_of(
-                providedServices.begin(),
-                providedServices.end(),
-                incompatibleServiceFilter.begin(),
-                incompatibleServiceFilter.end()) != providedServices.end())
-            {
-                return false;
-            }
-
-            return true;
-        }
-
-        bool OffersRequiredServices(
-            const AZ::SerializeContext::ClassData* componentClass,
-            const AZStd::vector<AZ::ComponentServiceType>& serviceFilter
-        )
-        {
-            const AZStd::vector<AZ::ComponentServiceType> incompatibleServices;
-            return OffersRequiredServices(componentClass, serviceFilter, incompatibleServices);
-        }
-
         bool IsAddableByUser(const AZ::SerializeContext::ClassData* componentClass)
         {
             AZ_Assert(componentClass, "component class must not be null");

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/ComponentPalette/ComponentPaletteUtil.hxx
@@ -26,18 +26,6 @@ namespace AzToolsFramework
 
         using ComponentIconTable = AZStd::map<const AZ::SerializeContext::ClassData*, QString>;
 
-        // Returns true if the given component provides at least one of the services specified or no services are provided
-        bool OffersRequiredServices(
-            const AZ::SerializeContext::ClassData* componentClass,
-            const AZStd::vector<AZ::ComponentServiceType>& serviceFilter,
-            const AZStd::vector<AZ::ComponentServiceType>& incompatibleServiceFilter
-        );
-
-        bool OffersRequiredServices(
-            const AZ::SerializeContext::ClassData* componentClass,
-            const AZStd::vector<AZ::ComponentServiceType>& serviceFilter
-        );
-
         // Returns true if the given component is addable by the user
         bool IsAddableByUser(const AZ::SerializeContext::ClassData* componentClass);
 

--- a/Code/Framework/AzToolsFramework/Tests/EntityInspectorTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EntityInspectorTests.cpp
@@ -22,6 +22,7 @@
 #include <AzToolsFramework/Application/ToolsApplication.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
 #include <AzToolsFramework/UnitTest/ToolsTestApplication.h>
 
 // Inspector Test Includes
@@ -313,17 +314,17 @@ namespace UnitTest
         AZ_TEST_ASSERT(testComponent1_ProvidedServices.size() == 1);
         const AZ::SerializeContext::ClassData* testComponent1_ClassData = context->FindClassData(testComponent1_typeId);
 
-        EXPECT_TRUE(AzToolsFramework::ComponentPaletteUtil::OffersRequiredServices(testComponent1_ClassData, testComponent1_ProvidedServices));
+        EXPECT_TRUE(AzToolsFramework::OffersRequiredServices(testComponent1_ClassData, testComponent1_ProvidedServices));
 
         // Verify that OffersRequiredServices returns when given services provided by a different component
         AZ::ComponentDescriptor::DependencyArrayType testComponent2_ProvidedServices;
         Inspector_TestComponent2::GetProvidedServices(testComponent2_ProvidedServices);
         AZ_TEST_ASSERT(testComponent2_ProvidedServices.size() == 1);
         AZ_TEST_ASSERT(testComponent1_ProvidedServices != testComponent2_ProvidedServices);
-        EXPECT_FALSE(AzToolsFramework::ComponentPaletteUtil::OffersRequiredServices(testComponent1_ClassData, testComponent2_ProvidedServices));
+        EXPECT_FALSE(AzToolsFramework::OffersRequiredServices(testComponent1_ClassData, testComponent2_ProvidedServices));
 
         // verify that OffersRequiredServices returns true when provided with an empty list of services
-        EXPECT_TRUE(AzToolsFramework::ComponentPaletteUtil::OffersRequiredServices(testComponent1_ClassData, AZ::ComponentDescriptor::DependencyArrayType()));
+        EXPECT_TRUE(AzToolsFramework::OffersRequiredServices(testComponent1_ClassData, AZ::ComponentDescriptor::DependencyArrayType()));
 
         //////////////////////////////////////////////////////////////////////////
         // TEST IsAddableByUser()


### PR DESCRIPTION
Added `FindComponentTypeIdsByService` API in order to find components based on their required/incompatible services. Moved helper methods from `ComponentPaletteUtil` to more generic place for re-use.

Ran unit tests and verified they still pass. Tested in python to verify the API can be used from there as well:

```
shape_service = math.Crc32_CreateCrc32("ShapeService")
required_services = [shape_service.value]
incompatible_services = []
shape_type_ids = editor.EditorComponentAPIBus(bus.Broadcast, 'FindComponentTypeIdsByService', required_services, incompatible_services)
# shape_type_ids will have the type ids of all components that satisfy provide the ShapeService (e.g. box shape, sphere shape, etc...)
```

Signed-off-by: Chris Galvan <chgalvan@amazon.com>