### PR TITLE
The .shader file must now include the .azsl extension when referencing a .azsl file

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -81,7 +81,7 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 105; // [AZSL] Changing inlineConstant to rootConstant keyword work.
+            shaderAssetBuilderDescriptor.m_version = 107; // Required .azsl extension in .shader file references
             // .shader file changes trigger rebuilds
             shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderAssetBuilder.cpp
@@ -151,11 +151,11 @@ namespace AZ
 
         void ShaderAssetBuilder::CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response) const
         {
-            AZStd::string fullPath;
-            AzFramework::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), fullPath, true);
+            AZStd::string shaderAssetSourceFileFullPath;
+            AzFramework::StringFunc::Path::ConstructFull(request.m_watchFolder.data(), request.m_sourceFile.data(), shaderAssetSourceFileFullPath, true);
             ShaderBuilderUtility::IncludedFilesParser includedFilesParser;
 
-            AZ_TracePrintf(ShaderAssetBuilderName, "CreateJobs for Shader \"%s\"\n", fullPath.data());
+            AZ_TracePrintf(ShaderAssetBuilderName, "CreateJobs for Shader \"%s\"\n", shaderAssetSourceFileFullPath.data());
 
             // Used to synchronize versions of the ShaderAsset and ShaderVariantTreeAsset, especially during hot-reload.
             // Note it's probably important for this to be set once outside the platform loop so every platform's ShaderAsset
@@ -166,7 +166,7 @@ namespace AZ
 
             // Need to get the name of the azsl file from the .shader source asset, to be able to declare a dependency to SRG Layout Job.
             // and the macro options to preprocess.
-            auto descriptorParseOutcome = ShaderBuilderUtility::LoadShaderDataJson(fullPath);
+            auto descriptorParseOutcome = ShaderBuilderUtility::LoadShaderDataJson(shaderAssetSourceFileFullPath);
             if (!descriptorParseOutcome.IsSuccess())
             {
                 AZ_Error(
@@ -178,7 +178,7 @@ namespace AZ
             RPI::ShaderSourceData shaderSourceData = descriptorParseOutcome.TakeValue();
 
             AZStd::string azslFullPath;
-            ShaderBuilderUtility::GetAbsolutePathToAzslFile(fullPath, shaderSourceData.m_source, azslFullPath);
+            ShaderBuilderUtility::GetAbsolutePathToAzslFile(shaderAssetSourceFileFullPath, shaderSourceData.m_source, azslFullPath);
 
             {
                 // Add the AZSL as source dependency
@@ -191,9 +191,9 @@ namespace AZ
             {
                 AZ_Error(
                     ShaderAssetBuilderName, false, "Shader program listed as the source entry does not exist: %s.", azslFullPath.c_str());
-                // Treat as success, so when the azsl file shows up the AP will try to recompile.
-                response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
-                return;
+                // Even though there was an error here, don't stop, because we need to report the SourceFileDependency so when the azsl
+                // file shows up the AP will try to recompile. We will go ahead and create the job anyway, and then ProcessJob can
+                // report the failure.
             }
 
             GlobalBuildOptions buildOptions = ReadBuildOptions(ShaderAssetBuilderName);
@@ -229,7 +229,7 @@ namespace AZ
             }  // for all request.m_enabledPlatforms
 
             AZ_TracePrintf(
-                ShaderAssetBuilderName, "CreateJobs for %s took %llu microseconds", fullPath.c_str(),
+                ShaderAssetBuilderName, "CreateJobs for %s took %llu microseconds", shaderAssetSourceFileFullPath.c_str(),
                 AZStd::GetTimeNowMicroSecond() - shaderAssetBuildTimestamp);
 
             response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.cpp
@@ -70,11 +70,11 @@ namespace AZ
                 return AZ::Success(shaderSourceData);
             }
 
-            void GetAbsolutePathToAzslFile(const AZStd::string& shaderTemplatePathAndFile, AZStd::string specifiedShaderPathAndName, AZStd::string& absoluteAzslPath)
+            void GetAbsolutePathToAzslFile(const AZStd::string& shaderSourceFileFullPath, AZStd::string specifiedShaderPathAndName, AZStd::string& absoluteAzslPath)
             {
                 AZStd::string sourcePath;
 
-                AzFramework::StringFunc::Path::GetFullPath(shaderTemplatePathAndFile.data(), sourcePath);
+                AzFramework::StringFunc::Path::GetFullPath(shaderSourceFileFullPath.c_str(), sourcePath);
                 AzFramework::StringFunc::Path::Normalize(specifiedShaderPathAndName);
 
                 bool shaderNameHasPath = (specifiedShaderPathAndName.find(AZ_CORRECT_FILESYSTEM_SEPARATOR) != AZStd::string::npos);
@@ -82,15 +82,27 @@ namespace AZ
                 // Join will handle overlapping directory structures for us 
                 AzFramework::StringFunc::Path::Join(sourcePath.data(), specifiedShaderPathAndName.data(), absoluteAzslPath, shaderNameHasPath /* handle directory overlap? */, false /* be case insensitive? */);
 
-                AzFramework::StringFunc::Path::ReplaceExtension(absoluteAzslPath, "azsl");
+                // The builders used to automatically set the ".azsl" extension, but no more, because that would make the .shader file confusing to read.
+                // Here we just detect the issue and instruct the user what to change.
+                // (There's no need to return a failure code, the builder will eventually fail anyway when it can't find the file).
+                if (!IO::FileIOBase::GetInstance()->Exists(absoluteAzslPath.c_str()))
+                {
+                    AZStd::string absoluteAzslPathWithForcedExtension = absoluteAzslPath;
+                    AzFramework::StringFunc::Path::ReplaceExtension(absoluteAzslPathWithForcedExtension, "azsl");
+
+                    if (IO::FileIOBase::GetInstance()->Exists(absoluteAzslPathWithForcedExtension.c_str()))
+                    {
+                        AZ_Error(ShaderBuilderUtilityName, false, "When the .shader file references a .azsl file, it must include the \".azsl\" extension.");
+                    }
+                }
             }
 
             AZStd::shared_ptr<ShaderFiles> PrepareSourceInput(
                 [[maybe_unused]] const char* builderName,
-                const AZStd::string& shaderAssetSourcePath,
+                const AZStd::string& shaderSourceFileFullPath,
                 RPI::ShaderSourceData& sourceAsset)
             {
-                auto shaderAssetSourceFileParseOutput = ShaderBuilderUtility::LoadShaderDataJson(shaderAssetSourcePath);
+                auto shaderAssetSourceFileParseOutput = ShaderBuilderUtility::LoadShaderDataJson(shaderSourceFileFullPath);
                 if (!shaderAssetSourceFileParseOutput.IsSuccess())
                 {
                     AZ_Error(builderName, false, "Failed to load/parse Shader Descriptor JSON: %s", shaderAssetSourceFileParseOutput.GetError().c_str());
@@ -100,7 +112,7 @@ namespace AZ
 
                 AZStd::shared_ptr<ShaderFiles> files(new ShaderFiles);
                 const AZStd::string& specifiedAzslName = sourceAsset.m_source;
-                ShaderBuilderUtility::GetAbsolutePathToAzslFile(shaderAssetSourcePath, specifiedAzslName, files->m_azslSourceFullPath);
+                ShaderBuilderUtility::GetAbsolutePathToAzslFile(shaderSourceFileFullPath, specifiedAzslName, files->m_azslSourceFullPath);
 
                 // specifiedAzslName may have a relative path on it so need to strip it
                 AzFramework::StringFunc::Path::GetFileName(specifiedAzslName.c_str(), files->m_azslFileName);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/ShaderBuilderUtility.h
@@ -33,12 +33,12 @@ namespace AZ
         {
             Outcome<RPI::ShaderSourceData, AZStd::string> LoadShaderDataJson(const AZStd::string& fullPathToJsonFile);
 
-            void GetAbsolutePathToAzslFile(const AZStd::string& shaderTemplatePathAndFile, AZStd::string specifiedShaderPathAndName, AZStd::string& absoluteShaderPath);
+            void GetAbsolutePathToAzslFile(const AZStd::string& shaderSourceFileFullPath, AZStd::string specifiedShaderPathAndName, AZStd::string& absoluteShaderPath);
 
             //! Opens and read the .shader, returns expanded file paths
             AZStd::shared_ptr<ShaderFiles> PrepareSourceInput(
                 const char* builderName,
-                const AZStd::string& shaderAssetSourcePath,
+                const AZStd::string& shaderSourceFileFullPath,
                 RPI::ShaderSourceData& sourceAsset);
 
             namespace AzslSubProducts

--- a/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObject.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObject.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "AuxGeomObject",
+    "Source" : "AuxGeomObject.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObjectLit.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomObjectLit.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "AuxGeomObjectLit",
+    "Source" : "AuxGeomObjectLit.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomWorld.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/AuxGeom/AuxGeomWorld.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "AuxGeomWorld",
+    "Source" : "AuxGeomWorld.azsl",
     
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/BRDFTexture/BRDFTextureCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/BRDFTexture/BRDFTextureCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "BRDFTextureCS",
+    "Source": "BRDFTextureCS.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Checkerboard/CheckerboardColorResolveCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Checkerboard/CheckerboardColorResolveCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "CheckerboardColorResolveCS",
+    "Source": "CheckerboardColorResolveCS.azsl",
    
     "CompilerHints":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/ColorGrading/LutGeneration.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/ColorGrading/LutGeneration.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "LutGeneration",
+    "Source" : "LutGeneration.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Depth/DepthPassSkin.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Depth/DepthPassSkin.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthPassSkin",
+    "Source" : "DepthPassSkin.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseComposite.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DiffuseComposite",
+    "Source" : "DiffuseComposite.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseGlobalFullscreen.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseGlobalFullscreen.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DiffuseGlobalFullscreen",
+    "Source" : "DiffuseGlobalFullscreen.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DiffuseProbeGridDownsample",
+    "Source" : "DiffuseProbeGridDownsample.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/ImGui/ImGui.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/ImGui/ImGui.shader
@@ -1,6 +1,6 @@
 {
  
-    "Source" : "ImGui",
+    "Source" : "ImGui.azsl",
 
     
     "RasterState" : { "CullMode" : "None" },

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCulling.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "LightCulling",
+    "Source": "LightCulling.azsl",
    
     "CompilerHints":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "LightCullingHeatmap",
+    "Source" : "LightCullingHeatmap.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingRemap.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingRemap.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "LightCullingRemap",
+    "Source": "LightCullingRemap.azsl",
 
     "Compiler":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingTilePrepare.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingTilePrepare.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "LightCullingTilePrepare",
+    "Source": "LightCullingTilePrepare.azsl",
 
     "CompilerHints":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LuxCore/RenderTexture.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LuxCore/RenderTexture.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "RenderTexture",
+    "Source" : "RenderTexture.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "MorphTargetCS",
+    "Source": "MorphTargetCS.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/CameraMotionVector.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/CameraMotionVector.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "CameraMotionVector",
+    "Source": "CameraMotionVector.azsl",
     
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/MeshMotionVector.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/MeshMotionVector.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "MeshMotionVector",
+    "Source" : "MeshMotionVector.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/MeshMotionVectorSkin.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MotionVector/MeshMotionVectorSkin.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "MeshMotionVectorSkin",
+    "Source" : "MeshMotionVectorSkin.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/AcesOutputTransformLut.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/AcesOutputTransformLut.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "AcesOutputTransformLut",
+    "Source" : "AcesOutputTransformLut.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ApplyShaperLookupTable.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ApplyShaperLookupTable.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ApplyShaperLookupTable",
+    "Source" : "ApplyShaperLookupTable.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BakeAcesOutputTransformLutCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BakeAcesOutputTransformLutCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "BakeAcesOutputTransformLutCS",
+    "Source": "BakeAcesOutputTransformLutCS.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BlendColorGradingLuts.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BlendColorGradingLuts.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "BlendColorGradingLuts",
+    "Source": "BlendColorGradingLuts.azsl",
 
     "DrawList" : "forward",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomBlurCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomBlurCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "BloomBlurCS",
+    "Source": "BloomBlurCS.azsl",
     
     "DrawList" : "forward",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomCompositeCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomCompositeCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "BloomCompositeCS",
+    "Source": "BloomCompositeCS.azsl",
     
     "DrawList" : "forward",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomDownsampleCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/BloomDownsampleCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "BloomDownsampleCS",
+    "Source": "BloomDownsampleCS.azsl",
     
     "DrawList" : "forward",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ContrastAdaptiveSharpening.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ContrastAdaptiveSharpening.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "ContrastAdaptiveSharpening",
+    "Source": "ContrastAdaptiveSharpening.azsl",
     "ProgramSettings": {
         "EntryPoints": [
             {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ConvertToAcescg.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ConvertToAcescg.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ConvertToAcescg",
+    "Source" : "ConvertToAcescg.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthDownsample.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthDownsample.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DepthDownsample",
+    "Source": "DepthDownsample.azsl",
 
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldBlurBokeh.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldBlurBokeh.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthOfFieldBlurBokeh",
+    "Source" : "DepthOfFieldBlurBokeh.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldComposite.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthOfFieldComposite",
+    "Source" : "DepthOfFieldComposite.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldDownSample.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldDownSample.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthOfFieldDownSample",
+    "Source" : "DepthOfFieldDownSample.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldMask.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldMask.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthOfFieldMask",
+    "Source" : "DepthOfFieldMask.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldPrepare.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldPrepare.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthOfFieldPrepare",
+    "Source" : "DepthOfFieldPrepare.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldWriteFocusDepthFromGpu.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthOfFieldWriteFocusDepthFromGpu.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DepthOfFieldWriteFocusDepthFromGpu",
+    "Source": "DepthOfFieldWriteFocusDepthFromGpu.azsl",
     
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthToLinearDepth.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthToLinearDepth.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "DepthToLinearDepth",
+    "Source" : "DepthToLinearDepth.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthUpsample.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DepthUpsample.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DepthUpsample",
+    "Source": "DepthUpsample.azsl",
 
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DiffuseSpecularMerge.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DiffuseSpecularMerge.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "DiffuseSpecularMerge",
+    "Source" : "DiffuseSpecularMerge.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapper.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapper.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "DisplayMapper",
+    "Source" : "DisplayMapper.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperOnlyGammaCorrection.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DisplayMapperOnlyGammaCorrection.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "DisplayMapperOnlyGammaCorrection",
+    "Source" : "DisplayMapperOnlyGammaCorrection.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DownsampleLuminanceMinAvgMaxCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DownsampleLuminanceMinAvgMaxCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DownsampleLuminanceMinAvgMaxCS",
+    "Source": "DownsampleLuminanceMinAvgMaxCS.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DownsampleMinAvgMaxCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/DownsampleMinAvgMaxCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DownsampleMinAvgMaxCS",
+    "Source": "DownsampleMinAvgMaxCS.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EyeAdaptation.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EyeAdaptation.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "EyeAdaptation",
+    "Source": "EyeAdaptation.azsl",
     
     
     "ProgramSettings" :

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurHor.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurHor.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "FastDepthAwareBlurHor",
+    "Source": "FastDepthAwareBlurHor.azsl",
 
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurVer.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FastDepthAwareBlurVer.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "FastDepthAwareBlurVer",
+    "Source": "FastDepthAwareBlurVer.azsl",
 
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FullscreenCopy.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/FullscreenCopy.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "FullscreenCopy",
+    "Source" : "FullscreenCopy.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/HDRColorGrading.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/HDRColorGrading.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "HDRColorGrading",
+    "Source" : "HDRColorGrading.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LookModificationTransform.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LookModificationTransform.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "LookModificationTransform",
+    "Source" : "LookModificationTransform.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHeatmap.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHeatmap.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "LuminanceHeatmap",
+    "Source" : "LuminanceHeatmap.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHistogramGenerator.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/LuminanceHistogramGenerator.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "LuminanceHistogramGenerator",
+    "Source": "LuminanceHistogramGenerator.azsl",
 
     "DrawList" : "forward",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MSAAResolveCustom.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MSAAResolveCustom.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "MSAAResolveCustom",
+    "Source": "MSAAResolveCustom.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MSAAResolveDepth.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/MSAAResolveDepth.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "MSAAResolveDepth",
+    "Source" : "MSAAResolveDepth.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "Always" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ModulateTexture.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ModulateTexture.shader
@@ -1,5 +1,5 @@
 { 
-    "Source": "ModulateTexture",
+    "Source": "ModulateTexture.azsl",
 
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/OutputTransform.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "OutputTransform",
+    "Source" : "OutputTransform.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAABlendingWeightCalculation.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAABlendingWeightCalculation.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "SMAABlendingWeightCalculation",
+    "Source" : "SMAABlendingWeightCalculation.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAAConvertToPerceptualColor.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAAConvertToPerceptualColor.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "SMAAConvertToPerceptualColor",
+    "Source" : "SMAAConvertToPerceptualColor.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAAEdgeDetection.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAAEdgeDetection.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "SMAAEdgeDetection",
+    "Source" : "SMAAEdgeDetection.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAANeighborhoodBlending.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SMAANeighborhoodBlending.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "SMAANeighborhoodBlending",
+    "Source" : "SMAANeighborhoodBlending.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/ScreenSpaceSubsurfaceScatteringCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "ScreenSpaceSubsurfaceScatteringCS",
+    "Source": "ScreenSpaceSubsurfaceScatteringCS.azsl",
     
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SsaoCompute.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/SsaoCompute.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "SsaoCompute",
+    "Source": "SsaoCompute.azsl",
 
     "ProgramSettings" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/Taa.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/Taa.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "Taa",
+    "Source": "Taa.azsl",
     "ProgramSettings": {
         "EntryPoints": [
             {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/UniformColor.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/UniformColor.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "UniformColor",
+    "Source" : "UniformColor.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionComposite.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ReflectionComposite",
+    "Source" : "ReflectionComposite.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionGlobalFullscreen.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ReflectionGlobalFullscreen",
+    "Source" : "ReflectionGlobalFullscreen.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeBlendWeight.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeBlendWeight.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ReflectionProbeBlendWeight",
+    "Source" : "ReflectionProbeBlendWeight.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderInner.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderInner.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ReflectionProbeRenderInner",
+    "Source" : "ReflectionProbeRenderInner.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderOuter.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeRenderOuter.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ReflectionProbeRenderOuter",
+    "Source" : "ReflectionProbeRenderOuter.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeStencil.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionProbeStencil.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ReflectionProbeStencil",
+    "Source" : "ReflectionProbeStencil.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceBlurHorizontal.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceBlurHorizontal.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ReflectionScreenSpaceBlurHorizontal",
+    "Source" : "ReflectionScreenSpaceBlurHorizontal.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceBlurVertical.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceBlurVertical.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ReflectionScreenSpaceBlurVertical",
+    "Source" : "ReflectionScreenSpaceBlurVertical.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceComposite.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceComposite.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ReflectionScreenSpaceComposite",
+    "Source" : "ReflectionScreenSpaceComposite.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Reflections/ReflectionScreenSpaceTrace.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ReflectionScreenSpaceTrace",
+    "Source" : "ReflectionScreenSpaceTrace.azsl",
 
     "RasterState" :
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/DepthExponentiation.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DepthExponentiation",
+    "Source" : "DepthExponentiation.azsl",
 
     "DrawList" : "shadow",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/KawaseShadowBlur.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/KawaseShadowBlur.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "KawaseShadowBlur",
+    "Source" : "KawaseShadowBlur.azsl",
 
     "DrawList" : "shadow",
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/Shadowmap.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/Shadowmap.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Shadowmap",
+    "Source" : "Shadowmap.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/ShadowmapSkin.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Shadow/ShadowmapSkin.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ShadowmapSkin",
+    "Source" : "ShadowmapSkin.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "LinearSkinningCS",
+    "Source": "LinearSkinningCS.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "SkyBox",
+    "Source" : "SkyBox.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox_TwoOutputs.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkyBox/SkyBox_TwoOutputs.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "SkyBox_TwoOutputs",
+    "Source" : "SkyBox_TwoOutputs.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Gems/Atom/RPI/Assets/Shader/DecomposeMsImage.shader
+++ b/Gems/Atom/RPI/Assets/Shader/DecomposeMsImage.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DecomposeMsImage",
+    "Source": "DecomposeMsImage.azsl",
 
     "ProgramSettings":
     {

--- a/Gems/Atom/RPI/Assets/Shader/ImagePreview.shader
+++ b/Gems/Atom/RPI/Assets/Shader/ImagePreview.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ImagePreview",
+    "Source" : "ImagePreview.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Gems/AtomLyIntegration/AtomBridge/Assets/Shaders/LyShineUI.shader
+++ b/Gems/AtomLyIntegration/AtomBridge/Assets/Shaders/LyShineUI.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "LyShineUI",
+    "Source" : "LyShineUI.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { 

--- a/Gems/AtomLyIntegration/AtomBridge/Assets/Shaders/SimpleTextured.shader
+++ b/Gems/AtomLyIntegration/AtomBridge/Assets/Shaders/SimpleTextured.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "SimpleTextured",
+    "Source" : "SimpleTextured.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { 

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Assets/Shaders/TexturedIcon.shader
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/Assets/Shaders/TexturedIcon.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "TexturedIcon",
+    "Source" : "TexturedIcon.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { 

--- a/Gems/AtomLyIntegration/ImguiAtom/Assets/Shaders/ImGuiAtom/ImGuiAtom.shader
+++ b/Gems/AtomLyIntegration/ImguiAtom/Assets/Shaders/ImGuiAtom/ImGuiAtom.shader
@@ -1,6 +1,6 @@
 {
  
-    "Source" : "ImGuiAtom",
+    "Source" : "ImGuiAtom.azsl",
 
     
     "RasterState" : { "CullMode" : "None" },

--- a/Gems/Terrain/Assets/Shaders/Terrain/Terrain_Shadowmap.shader
+++ b/Gems/Terrain/Assets/Shaders/Terrain/Terrain_Shadowmap.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Terrain_DepthPass",
+    "Source" : "Terrain_DepthPass.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }


### PR DESCRIPTION
The .shader file must now include the .azsl extension when referencing a .azsl file. It will no longer be automatically appended.

Fixed an issue where the shader builder would incorrectly succeed when the .azsl file is missing.
Also renamed some variables for more consistency.
Updated all .shader files accordingly.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>