### PR TITLE
Atom parallel test cleanup and adding AtomComponentProperties

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py
@@ -26,6 +26,10 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_DirectionalLightAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_DirectionalLightAdded as test_module
 
+    @pytest.mark.test_case_id("C36525660")
+    class AtomEditorComponents_DisplayMapperAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_DisplayMapperAdded as test_module
+
     @pytest.mark.test_case_id("C32078121")
     class AtomEditorComponents_ExposureControlAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_ExposureControlAdded as test_module
@@ -34,46 +38,42 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_GlobalSkylightIBLAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_GlobalSkylightIBLAdded as test_module
 
+    @pytest.mark.test_case_id("C32078117")
+    class AtomEditorComponents_LightAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_LightAdded as test_module
+
+    @pytest.mark.test_case_id("C32078123")
+    class AtomEditorComponents_MaterialAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_MaterialAdded as test_module
+
+    @pytest.mark.test_case_id("C32078124")
+    class AtomEditorComponents_MeshAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_MeshAdded as test_module
+
     @pytest.mark.test_case_id("C32078125")
     class AtomEditorComponents_PhysicalSkyAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_PhysicalSkyAdded as test_module
+
+    @pytest.mark.test_case_id("C36525664")
+    class AtomEditorComponents_PostFXGradientWeightModifierAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_PostFXGradientWeightModifierAdded as test_module
+
+    @pytest.mark.test_case_id("C32078127")
+    class AtomEditorComponents_PostFXLayerAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_PostFXLayerAdded as test_module
 
     @pytest.mark.test_case_id("C32078131")
     class AtomEditorComponents_PostFXRadiusWeightModifierAdded(EditorSharedTest):
         from Atom.tests import (
             hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded as test_module)
 
-    @pytest.mark.test_case_id("C32078117")
-    class AtomEditorComponents_LightAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_LightAdded as test_module
-
-    @pytest.mark.test_case_id("C36525660")
-    class AtomEditorComponents_DisplayMapperAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_DisplayMapperAdded as test_module
-
-    @pytest.mark.test_case_id("C32078128")
-    class AtomEditorComponents_ReflectionProbeAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_ReflectionProbeAdded as test_module
-
-    @pytest.mark.test_case_id("C32078124")
-    class AtomEditorComponents_MeshAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_MeshAdded as test_module
-
-    @pytest.mark.test_case_id("C32078123")
-    class AtomEditorComponents_MaterialAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_MaterialAdded as test_module
-
-    @pytest.mark.test_case_id("C32078127")
-    class AtomEditorComponents_PostFXLayerAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_PostFXLayerAdded as test_module
-
     @pytest.mark.test_case_id("C36525665")
     class AtomEditorComponents_PostFXShapeWeightModifierAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_PostFxShapeWeightModifierAdded as test_module
 
-    @pytest.mark.test_case_id("C36525664")
-    class AtomEditorComponents_PostFXGradientWeightModifierAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_PostFXGradientWeightModifierAdded as test_module
+    @pytest.mark.test_case_id("C32078128")
+    class AtomEditorComponents_ReflectionProbeAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_ReflectionProbeAdded as test_module
 
     class ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges(EditorSharedTest):
         from Atom.tests import hydra_ShaderAssetBuilder_RecompilesShaderAsChainOfDependenciesChanges as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DecalAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DecalAdded.py
@@ -5,25 +5,52 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =           ("Camera Entity successfully created",           "Camera Entity failed to be created")
-    camera_component_added =    ("Camera component was added to entity",         "Camera component failed to be added to entity")
-    camera_component_check =    ("Entity has a Camera component",                "Entity failed to find Camera component")
-    creation_undo =             ("UNDO Entity creation success",                 "UNDO Entity creation failed")
-    creation_redo =             ("REDO Entity creation success",                 "REDO Entity creation failed")
-    decal_creation =            ("Decal Entity successfully created",            "Decal Entity failed to be created")
-    decal_component =           ("Entity has a Decal component",                 "Entity failed to find Decal component")
-    material_property_set =     ("Material property set on Decal component",     "Couldn't set Material property on Decal component")
-    enter_game_mode =           ("Entered game mode",                            "Failed to enter game mode")
-    exit_game_mode =            ("Exited game mode",                             "Couldn't exit game mode")
-    is_visible =                ("Entity is visible",                            "Entity was not visible")
-    is_hidden =                 ("Entity is hidden",                             "Entity was not hidden")
-    entity_deleted =            ("Entity deleted",                               "Entity was not deleted")
-    deletion_undo =             ("UNDO deletion success",                        "UNDO deletion failed")
-    deletion_redo =             ("REDO deletion success",                        "REDO deletion failed")
-    no_error_occurred =         ("No errors detected",                           "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    decal_creation = (
+        "Decal Entity successfully created",
+        "Decal Entity failed to be created")
+    decal_component = (
+        "Entity has a Decal component",
+        "Entity failed to find Decal component")
+    material_property_set = (
+        "Material property set on Decal component",
+        "Couldn't set Material property on Decal component")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_Decal_AddedToEntity():
@@ -51,35 +78,33 @@ def AtomEditorComponents_Decal_AddedToEntity():
     9) Delete Decal entity.
     10) UNDO deletion.
     11) REDO deletion.
-    12) Look for errors.
+    12) Look for errors and asserts.
 
     :return: None
     """
     import os
 
-    import azlmbr.asset as asset
-    import azlmbr.bus as bus
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
+    from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Decal entity with no components.
-        decal_name = "Decal"
-        decal_entity = EditorEntity.create_editor_entity_at(math.Vector3(512.0, 512.0, 34.0), decal_name)
+        decal_entity = EditorEntity.create_editor_entity(AtomComponentProperties.decal())
         Report.critical_result(Tests.decal_creation, decal_entity.exists())
 
         # 2. Add Decal component to Decal entity.
-        decal_component = decal_entity.add_component(decal_name)
-        Report.critical_result(Tests.decal_component, decal_entity.has_component(decal_name))
+        decal_component = decal_entity.add_component(AtomComponentProperties.decal())
+        Report.critical_result(Tests.decal_component, decal_entity.has_component(AtomComponentProperties.decal()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -106,9 +131,9 @@ def AtomEditorComponents_Decal_AddedToEntity():
         Report.result(Tests.creation_redo, decal_entity.exists())
 
         # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Test IsHidden.
         decal_entity.set_visibility_state(False)
@@ -120,13 +145,11 @@ def AtomEditorComponents_Decal_AddedToEntity():
         Report.result(Tests.is_visible, decal_entity.is_visible() is True)
 
         # 8. Set Material property on Decal component.
-        decal_material_property_path = "Controller|Configuration|Material"
-        decal_material_asset_path = os.path.join("AutomatedTesting", "Materials", "basic_grey.material")
-        decal_material_asset = asset.AssetCatalogRequestBus(
-            bus.Broadcast, "GetAssetIdByPath", decal_material_asset_path, math.Uuid(), False)
-        decal_component.set_component_property_value(decal_material_property_path, decal_material_asset)
-        get_material_property = decal_component.get_component_property_value(decal_material_property_path)
-        Report.result(Tests.material_property_set, get_material_property == decal_material_asset)
+        decal_material_asset_path = os.path.join("materials", "basic_grey.azmaterial")
+        decal_material_asset = Asset.find_asset_by_path(decal_material_asset_path, False)
+        decal_component.set_component_property_value(AtomComponentProperties.decal('Material'), decal_material_asset.id)
+        get_material_property = decal_component.get_component_property_value(AtomComponentProperties.decal('Material'))
+        Report.result(Tests.material_property_set, get_material_property == decal_material_asset.id)
 
         # 9. Delete Decal entity.
         decal_entity.delete()
@@ -141,9 +164,12 @@ def AtomEditorComponents_Decal_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not decal_entity.exists())
 
-        # 12. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 12. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DepthOfFieldAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DepthOfFieldAdded.py
@@ -5,28 +5,61 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =           ("Camera Entity successfully created",            "Camera Entity failed to be created")
-    camera_component_added =    ("Camera component was added to Camera entity",   "Camera component failed to be added to entity")
-    camera_component_check =    ("Entity has a Camera component",                 "Entity failed to find Camera component")
-    camera_property_set =       ("DepthOfField Entity set Camera Entity",         "DepthOfField Entity could not set Camera Entity")
-    creation_undo =             ("UNDO Entity creation success",                  "UNDO Entity creation failed")
-    creation_redo =             ("REDO Entity creation success",                  "REDO Entity creation failed")
-    depth_of_field_creation =   ("DepthOfField Entity successfully created",      "DepthOfField Entity failed to be created")
-    depth_of_field_component =  ("Entity has a DepthOfField component",           "Entity failed to find DepthOfField component")
-    depth_of_field_disabled =   ("DepthOfField component disabled",               "DepthOfField component was not disabled.")
-    post_fx_component =         ("Entity has a Post FX Layer component",          "Entity did not have a Post FX Layer component")
-    depth_of_field_enabled =    ("DepthOfField component enabled",                "DepthOfField component was not enabled.")
-    enter_game_mode =           ("Entered game mode",                             "Failed to enter game mode")
-    exit_game_mode =            ("Exited game mode",                              "Couldn't exit game mode")
-    is_visible =                ("Entity is visible",                             "Entity was not visible")
-    is_hidden =                 ("Entity is hidden",                              "Entity was not hidden")
-    entity_deleted =            ("Entity deleted",                                "Entity was not deleted")
-    deletion_undo =             ("UNDO deletion success",                         "UNDO deletion failed")
-    deletion_redo =             ("REDO deletion success",                         "REDO deletion failed")
-    no_error_occurred =         ("No errors detected",                            "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to Camera entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    camera_property_set = (
+        "DepthOfField Entity set Camera Entity",
+        "DepthOfField Entity could not set Camera Entity")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    depth_of_field_creation = (
+        "DepthOfField Entity successfully created",
+        "DepthOfField Entity failed to be created")
+    depth_of_field_component = (
+        "Entity has a DepthOfField component",
+        "Entity failed to find DepthOfField component")
+    depth_of_field_disabled = (
+        "DepthOfField component disabled",
+        "DepthOfField component was not disabled.")
+    post_fx_component = (
+        "Entity has a Post FX Layer component",
+        "Entity did not have a Post FX Layer component")
+    depth_of_field_enabled = (
+        "DepthOfField component enabled",
+        "DepthOfField component was not enabled.")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_DepthOfField_AddedToEntity():
@@ -59,33 +92,32 @@ def AtomEditorComponents_DepthOfField_AddedToEntity():
     14) Delete DepthOfField entity.
     15) UNDO deletion.
     16) REDO deletion.
-    17) Look for errors.
+    17) Look for errors and asserts.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a DepthOfField entity with no components.
-        depth_of_field_name = "DepthOfField"
-        depth_of_field_entity = EditorEntity.create_editor_entity_at(
-            math.Vector3(512.0, 512.0, 34.0), depth_of_field_name)
+        depth_of_field_entity = EditorEntity.create_editor_entity(AtomComponentProperties.depth_of_field())
         Report.critical_result(Tests.depth_of_field_creation, depth_of_field_entity.exists())
 
         # 2. Add a DepthOfField component to DepthOfField entity.
-        depth_of_field_component = depth_of_field_entity.add_component(depth_of_field_name)
-        Report.critical_result(Tests.depth_of_field_component, depth_of_field_entity.has_component(depth_of_field_name))
+        depth_of_field_component = depth_of_field_entity.add_component(AtomComponentProperties.depth_of_field())
+        Report.critical_result(Tests.depth_of_field_component,
+                               depth_of_field_entity.has_component(AtomComponentProperties.depth_of_field()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -115,17 +147,16 @@ def AtomEditorComponents_DepthOfField_AddedToEntity():
         Report.result(Tests.depth_of_field_disabled, not depth_of_field_component.is_enabled())
 
         # 6. Add Post FX Layer component since it is required by the DepthOfField component.
-        post_fx_layer = "PostFX Layer"
-        depth_of_field_entity.add_component(post_fx_layer)
-        Report.result(Tests.post_fx_component, depth_of_field_entity.has_component(post_fx_layer))
+        depth_of_field_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.result(Tests.post_fx_component, depth_of_field_entity.has_component(AtomComponentProperties.postfx_layer()))
 
         # 7. Verify DepthOfField component is enabled.
         Report.result(Tests.depth_of_field_enabled, depth_of_field_component.is_enabled())
 
         # 8. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 9. Test IsHidden.
         depth_of_field_entity.set_visibility_state(False)
@@ -137,19 +168,20 @@ def AtomEditorComponents_DepthOfField_AddedToEntity():
         Report.result(Tests.is_visible, depth_of_field_entity.is_visible() is True)
 
         # 11. Add Camera entity.
-        camera_name = "Camera"
-        camera_entity = EditorEntity.create_editor_entity_at(math.Vector3(512.0, 512.0, 34.0), camera_name)
+        camera_entity = EditorEntity.create_editor_entity(AtomComponentProperties.camera())
         Report.result(Tests.camera_creation, camera_entity.exists())
 
         # 12. Add Camera component to Camera entity.
-        camera_entity.add_component(camera_name)
-        Report.result(Tests.camera_component_added, camera_entity.has_component(camera_name))
+        camera_entity.add_component(AtomComponentProperties.camera())
+        Report.result(Tests.camera_component_added, camera_entity.has_component(AtomComponentProperties.camera()))
 
         # 13. Set the DepthOfField components's Camera Entity to the newly created Camera entity.
-        depth_of_field_camera_property_path = "Controller|Configuration|Camera Entity"
-        depth_of_field_component.set_component_property_value(depth_of_field_camera_property_path, camera_entity.id)
-        camera_entity_set = depth_of_field_component.get_component_property_value(depth_of_field_camera_property_path)
-        Report.result(Tests.camera_property_set, camera_entity.id == camera_entity_set)
+        depth_of_field_component.set_component_property_value(
+            AtomComponentProperties.depth_of_field('Camera Entity'), camera_entity.id)
+        Report.result(
+            Tests.camera_property_set,
+            camera_entity.id == depth_of_field_component.get_component_property_value(
+                                    AtomComponentProperties.depth_of_field('Camera Entity')))
 
         # 14. Delete DepthOfField entity.
         depth_of_field_entity.delete()
@@ -163,9 +195,12 @@ def AtomEditorComponents_DepthOfField_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not depth_of_field_entity.exists())
 
-        # 17. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 17. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DirectionalLightAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DirectionalLightAdded.py
@@ -5,25 +5,52 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =              ("Camera Entity successfully created",              "Camera Entity failed to be created")
-    camera_component_added =       ("Camera component was added to entity",            "Camera component failed to be added to entity")
-    camera_component_check =       ("Entity has a Camera component",                   "Entity failed to find Camera component")
-    creation_undo =                ("UNDO Entity creation success",                    "UNDO Entity creation failed")
-    creation_redo =                ("REDO Entity creation success",                    "REDO Entity creation failed")
-    directional_light_creation =   ("Directional Light Entity successfully created",   "Directional Light Entity failed to be created")
-    directional_light_component =  ("Entity has a Directional Light component",        "Entity failed to find Directional Light component")
-    shadow_camera_check =          ("Directional Light component Shadow camera set",   "Directional Light component Shadow camera was not set")
-    enter_game_mode =              ("Entered game mode",                               "Failed to enter game mode")
-    exit_game_mode =               ("Exited game mode",                                "Couldn't exit game mode")
-    is_visible =                   ("Entity is visible",                               "Entity was not visible")
-    is_hidden =                    ("Entity is hidden",                                "Entity was not hidden")
-    entity_deleted =               ("Entity deleted",                                  "Entity was not deleted")
-    deletion_undo =                ("UNDO deletion success",                           "UNDO deletion failed")
-    deletion_redo =                ("REDO deletion success",                           "REDO deletion failed")
-    no_error_occurred =            ("No errors detected",                              "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    directional_light_creation = (
+        "Directional Light Entity successfully created",
+        "Directional Light Entity failed to be created")
+    directional_light_component = (
+        "Entity has a Directional Light component",
+        "Entity failed to find Directional Light component")
+    shadow_camera_check = (
+        "Directional Light component Shadow camera set",
+        "Directional Light component Shadow camera was not set")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_DirectionalLight_AddedToEntity():
@@ -53,34 +80,33 @@ def AtomEditorComponents_DirectionalLight_AddedToEntity():
     11) Delete Directional Light entity.
     12) UNDO deletion.
     13) REDO deletion.
-    14) Look for errors.
+    14) Look for errors and asserts.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Directional Light entity with no components.
-        directional_light_name = "Directional Light"
-        directional_light_entity = EditorEntity.create_editor_entity_at(
-            math.Vector3(512.0, 512.0, 34.0), directional_light_name)
+        directional_light_entity = EditorEntity.create_editor_entity(AtomComponentProperties.directional_light())
         Report.critical_result(Tests.directional_light_creation, directional_light_entity.exists())
 
         # 2. Add Directional Light component to Directional Light entity.
-        directional_light_component = directional_light_entity.add_component(directional_light_name)
+        directional_light_component = directional_light_entity.add_component(AtomComponentProperties.directional_light())
         Report.critical_result(
-            Tests.directional_light_component, directional_light_entity.has_component(directional_light_name))
+            Tests.directional_light_component,
+            directional_light_entity.has_component(AtomComponentProperties.directional_light()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -107,9 +133,9 @@ def AtomEditorComponents_DirectionalLight_AddedToEntity():
         Report.result(Tests.creation_redo, directional_light_entity.exists())
 
         # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Test IsHidden.
         directional_light_entity.set_visibility_state(False)
@@ -121,19 +147,20 @@ def AtomEditorComponents_DirectionalLight_AddedToEntity():
         Report.result(Tests.is_visible, directional_light_entity.is_visible() is True)
 
         # 8. Add Camera entity.
-        camera_name = "Camera"
-        camera_entity = EditorEntity.create_editor_entity_at(math.Vector3(512.0, 512.0, 34.0), camera_name)
+        camera_entity = EditorEntity.create_editor_entity(AtomComponentProperties.camera())
         Report.result(Tests.camera_creation, camera_entity.exists())
 
         # 9. Add Camera component to Camera entity.
-        camera_entity.add_component(camera_name)
-        Report.result(Tests.camera_component_added, camera_entity.has_component(camera_name))
+        camera_entity.add_component(AtomComponentProperties.camera())
+        Report.result(Tests.camera_component_added, camera_entity.has_component(AtomComponentProperties.camera()))
 
         # 10. Set the Directional Light component property Shadow|Camera to the Camera entity.
-        shadow_camera_property_path = "Controller|Configuration|Shadow|Camera"
-        directional_light_component.set_component_property_value(shadow_camera_property_path, camera_entity.id)
-        shadow_camera_set = directional_light_component.get_component_property_value(shadow_camera_property_path)
-        Report.result(Tests.shadow_camera_check, camera_entity.id == shadow_camera_set)
+        directional_light_component.set_component_property_value(
+            AtomComponentProperties.directional_light('Camera'), camera_entity.id)
+        Report.result(
+            Tests.shadow_camera_check,
+            camera_entity.id == directional_light_component.get_component_property_value(
+                                    AtomComponentProperties.directional_light('Camera')))
 
         # 11. Delete DirectionalLight entity.
         directional_light_entity.delete()
@@ -147,9 +174,12 @@ def AtomEditorComponents_DirectionalLight_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not directional_light_entity.exists())
 
-        # 14. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 14. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_DisplayMapperAdded.py
@@ -5,24 +5,49 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =            ("Camera Entity successfully created",         "Camera Entity failed to be created")
-    camera_component_added =     ("Camera component was added to entity",       "Camera component failed to be added to entity")
-    camera_component_check =     ("Entity has a Camera component",              "Entity failed to find Camera component")
-    creation_undo =              ("UNDO Entity creation success",               "UNDO Entity creation failed")
-    creation_redo =              ("REDO Entity creation success",               "REDO Entity creation failed")
-    display_mapper_creation =    ("Display Mapper Entity successfully created", "Display Mapper Entity failed to be created")
-    display_mapper_component =   ("Entity has a Display Mapper component",      "Entity failed to find Display Mapper component")
-    enter_game_mode =            ("Entered game mode",                          "Failed to enter game mode")
-    exit_game_mode =             ("Exited game mode",                           "Couldn't exit game mode")
-    is_visible =                 ("Entity is visible",                          "Entity was not visible")
-    is_hidden =                  ("Entity is hidden",                           "Entity was not hidden")
-    entity_deleted =             ("Entity deleted",                             "Entity was not deleted")
-    deletion_undo =              ("UNDO deletion success",                      "UNDO deletion failed")
-    deletion_redo =              ("REDO deletion success",                      "REDO deletion failed")
-    no_error_occurred =          ("No errors detected",                         "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    display_mapper_creation = (
+        "Display Mapper Entity successfully created",
+        "Display Mapper Entity failed to be created")
+    display_mapper_component = (
+        "Entity has a Display Mapper component",
+        "Entity failed to find Display Mapper component")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_DisplayMapper_AddedToEntity():
@@ -49,33 +74,33 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
     8) Delete Display Mapper entity.
     9) UNDO deletion.
     10) REDO deletion.
-    11) Look for errors.
+    11) Look for errors and asserts.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Display Mapper entity with no components.
-        display_mapper = "Display Mapper"
-        display_mapper_entity = EditorEntity.create_editor_entity_at(
-            math.Vector3(512.0, 512.0, 34.0), f"{display_mapper}")
+        display_mapper_entity = EditorEntity.create_editor_entity(AtomComponentProperties.display_mapper())
         Report.critical_result(Tests.display_mapper_creation, display_mapper_entity.exists())
 
         # 2. Add Display Mapper component to Display Mapper entity.
-        display_mapper_entity.add_component(display_mapper)
-        Report.critical_result(Tests.display_mapper_component, display_mapper_entity.has_component(display_mapper))
+        display_mapper_entity.add_component(AtomComponentProperties.display_mapper())
+        Report.critical_result(
+            Tests.display_mapper_component,
+            display_mapper_entity.has_component(AtomComponentProperties.display_mapper()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -102,9 +127,9 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
         Report.result(Tests.creation_redo, display_mapper_entity.exists())
 
         # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Test IsHidden.
         display_mapper_entity.set_visibility_state(False)
@@ -127,9 +152,12 @@ def AtomEditorComponents_DisplayMapper_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not display_mapper_entity.exists())
 
-        # 11. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 11. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_ExposureControlAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_ExposureControlAdded.py
@@ -5,25 +5,58 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =              ("Camera Entity successfully created",          "Camera Entity failed to be created")
-    camera_component_added =       ("Camera component was added to entity",        "Camera component failed to be added to entity")
-    camera_component_check =       ("Entity has a Camera component",               "Entity failed to find Camera component")
-    creation_undo =                ("UNDO Entity creation success",                "UNDO Entity creation failed")
-    creation_redo =                ("REDO Entity creation success",                "REDO Entity creation failed")
-    exposure_control_creation =    ("ExposureControl Entity successfully created", "ExposureControl Entity failed to be created")
-    exposure_control_component =   ("Entity has a Exposure Control component",     "Entity failed to find Exposure Control component")
-    post_fx_component =            ("Entity has a Post FX Layer component",        "Entity did not have a Post FX Layer component")
-    enter_game_mode =              ("Entered game mode",                           "Failed to enter game mode")
-    exit_game_mode =               ("Exited game mode",                            "Couldn't exit game mode")
-    is_visible =                   ("Entity is visible",                           "Entity was not visible")
-    is_hidden =                    ("Entity is hidden",                            "Entity was not hidden")
-    entity_deleted =               ("Entity deleted",                              "Entity was not deleted")
-    deletion_undo =                ("UNDO deletion success",                       "UNDO deletion failed")
-    deletion_redo =                ("REDO deletion success",                       "REDO deletion failed")
-    no_error_occurred =            ("No errors detected",                          "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    exposure_control_creation = (
+        "ExposureControl Entity successfully created",
+        "ExposureControl Entity failed to be created")
+    exposure_control_component = (
+        "Entity has a Exposure Control component",
+        "Entity failed to find Exposure Control component")
+    exposure_control_disabled = (
+        "DepthOfField component disabled",
+        "DepthOfField component was not disabled.")
+    post_fx_component = (
+        "Entity has a Post FX Layer component",
+        "Entity did not have a Post FX Layer component")
+    exposure_control_enabled = (
+        "DepthOfField component enabled",
+        "DepthOfField component was not enabled.")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_ExposureControl_AddedToEntity():
@@ -44,41 +77,42 @@ def AtomEditorComponents_ExposureControl_AddedToEntity():
     2) Add Exposure Control component to Exposure Control entity.
     3) UNDO the entity creation and component addition.
     4) REDO the entity creation and component addition.
-    5) Enter/Exit game mode.
-    6) Test IsHidden.
-    7) Test IsVisible.
-    8) Add Post FX Layer component.
-    9) Delete Exposure Control entity.
-    10) UNDO deletion.
-    11) REDO deletion.
-    12) Look for errors.
+    5) Verify Exposure Control component not enabled.
+    6) Add Post FX Layer component since it is required by the Exposure Control component.
+    7) Verify Exposure Control component is enabled.
+    8) Enter/Exit game mode.
+    9) Test IsHidden.
+    10) Test IsVisible.
+    11) Delete Exposure Control entity.
+    12) UNDO deletion.
+    13) REDO deletion.
+    14) Look for errors and asserts.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Creation of Exposure Control entity with no components.
-        exposure_control_name = "Exposure Control"
-        exposure_control_entity = EditorEntity.create_editor_entity_at(
-            math.Vector3(512.0, 512.0, 34.0), f"{exposure_control_name}")
+        exposure_control_entity = EditorEntity.create_editor_entity(AtomComponentProperties.exposure_control())
         Report.critical_result(Tests.exposure_control_creation, exposure_control_entity.exists())
 
         # 2. Add Exposure Control component to Exposure Control entity.
-        exposure_control_entity.add_component(exposure_control_name)
+        exposure_control_component = exposure_control_entity.add_component(AtomComponentProperties.exposure_control())
         Report.critical_result(
-            Tests.exposure_control_component, exposure_control_entity.has_component(exposure_control_name))
+            Tests.exposure_control_component,
+            exposure_control_entity.has_component(AtomComponentProperties.exposure_control()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -104,40 +138,49 @@ def AtomEditorComponents_ExposureControl_AddedToEntity():
         general.idle_wait_frames(1)
         Report.result(Tests.creation_redo, exposure_control_entity.exists())
 
-        # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
-        general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        # 5. Verify Exposure Control component not enabled.
+        Report.result(Tests.exposure_control_disabled, not exposure_control_component.is_enabled())
 
-        # 6. Test IsHidden.
+        # 6. Add Post FX Layer component since it is required by the Exposure Control component.
+        exposure_control_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.result(Tests.post_fx_component,
+                      exposure_control_entity.has_component(AtomComponentProperties.postfx_layer()))
+
+        # 7. Verify Exposure Control component is enabled.
+        Report.result(Tests.exposure_control_enabled, exposure_control_component.is_enabled())
+
+        # 8. Enter/Exit game mode.
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
+        general.idle_wait_frames(1)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+        # 9. Test IsHidden.
         exposure_control_entity.set_visibility_state(False)
         Report.result(Tests.is_hidden, exposure_control_entity.is_hidden() is True)
 
-        # 7. Test IsVisible.
+        # 10. Test IsVisible.
         exposure_control_entity.set_visibility_state(True)
         general.idle_wait_frames(1)
         Report.result(Tests.is_visible, exposure_control_entity.is_visible() is True)
 
-        # 8. Add Post FX Layer component.
-        post_fx_layer_name = "PostFX Layer"
-        exposure_control_entity.add_component(post_fx_layer_name)
-        Report.result(Tests.post_fx_component, exposure_control_entity.has_component(post_fx_layer_name))
-
-        # 9. Delete ExposureControl entity.
+        # 11. Delete ExposureControl entity.
         exposure_control_entity.delete()
         Report.result(Tests.entity_deleted, not exposure_control_entity.exists())
 
-        # 10. UNDO deletion.
+        # 12. UNDO deletion.
         general.undo()
         Report.result(Tests.deletion_undo, exposure_control_entity.exists())
 
-        # 11. REDO deletion.
+        # 13. REDO deletion.
         general.redo()
         Report.result(Tests.deletion_redo, not exposure_control_entity.exists())
 
-        # 12. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 14. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_GlobalSkylightIBLAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_GlobalSkylightIBLAdded.py
@@ -5,26 +5,55 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =             ("Camera Entity successfully created",                  "Camera Entity failed to be created")
-    camera_component_added =      ("Camera component was added to entity",                "Camera component failed to be added to entity")
-    camera_component_check =      ("Entity has a Camera component",                       "Entity failed to find Camera component")
-    creation_undo =               ("UNDO Entity creation success",                        "UNDO Entity creation failed")
-    creation_redo =               ("REDO Entity creation success",                        "REDO Entity creation failed")
-    global_skylight_creation =    ("Global Skylight (IBL) Entity successfully created",   "Global Skylight (IBL) Entity failed to be created")
-    global_skylight_component =   ("Entity has a Global Skylight (IBL) component",        "Entity failed to find Global Skylight (IBL) component")
-    diffuse_image_set =           ("Entity has the Diffuse Image set",                    "Entity did not the Diffuse Image set")
-    specular_image_set =          ("Entity has the Specular Image set",                   "Entity did not the Specular Image set")
-    enter_game_mode =             ("Entered game mode",                                   "Failed to enter game mode")
-    exit_game_mode =              ("Exited game mode",                                    "Couldn't exit game mode")
-    is_visible =                  ("Entity is visible",                                   "Entity was not visible")
-    is_hidden =                   ("Entity is hidden",                                    "Entity was not hidden")
-    entity_deleted =              ("Entity deleted",                                      "Entity was not deleted")
-    deletion_undo =               ("UNDO deletion success",                               "UNDO deletion failed")
-    deletion_redo =               ("REDO deletion success",                               "REDO deletion failed")
-    no_error_occurred =           ("No errors detected",                                  "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    global_skylight_creation = (
+        "Global Skylight (IBL) Entity successfully created",
+        "Global Skylight (IBL) Entity failed to be created")
+    global_skylight_component = (
+        "Entity has a Global Skylight (IBL) component",
+        "Entity failed to find Global Skylight (IBL) component")
+    diffuse_image_set = (
+        "Entity has the Diffuse Image set",
+        "Entity did not the Diffuse Image set")
+    specular_image_set = (
+        "Entity has the Specular Image set",
+        "Entity did not the Specular Image set")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_GlobalSkylightIBL_AddedToEntity():
@@ -60,29 +89,28 @@ def AtomEditorComponents_GlobalSkylightIBL_AddedToEntity():
     import os
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Global Skylight (IBL) entity with no components.
-        global_skylight_name = "Global Skylight (IBL)"
-        global_skylight_entity = EditorEntity.create_editor_entity_at(
-            math.Vector3(512.0, 512.0, 34.0), global_skylight_name)
+        global_skylight_entity = EditorEntity.create_editor_entity(AtomComponentProperties.global_skylight())
         Report.critical_result(Tests.global_skylight_creation, global_skylight_entity.exists())
 
         # 2. Add Global Skylight (IBL) component to Global Skylight (IBL) entity.
-        global_skylight_component = global_skylight_entity.add_component(global_skylight_name)
+        global_skylight_component = global_skylight_entity.add_component(AtomComponentProperties.global_skylight())
         Report.critical_result(
-            Tests.global_skylight_component, global_skylight_entity.has_component(global_skylight_name))
+            Tests.global_skylight_component,
+            global_skylight_entity.has_component(AtomComponentProperties.global_skylight()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -109,9 +137,9 @@ def AtomEditorComponents_GlobalSkylightIBL_AddedToEntity():
         Report.result(Tests.creation_redo, global_skylight_entity.exists())
 
         # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Test IsHidden.
         global_skylight_entity.set_visibility_state(False)
@@ -123,24 +151,24 @@ def AtomEditorComponents_GlobalSkylightIBL_AddedToEntity():
         Report.result(Tests.is_visible, global_skylight_entity.is_visible() is True)
 
         # 8. Set the Diffuse Image asset on the Global Skylight (IBL) entity.
-        global_skylight_diffuse_image_property = "Controller|Configuration|Diffuse Image"
         diffuse_image_path = os.path.join("LightingPresets", "greenwich_park_02_4k_iblskyboxcm.exr.streamingimage")
         diffuse_image_asset = Asset.find_asset_by_path(diffuse_image_path, False)
         global_skylight_component.set_component_property_value(
-            global_skylight_diffuse_image_property, diffuse_image_asset.id)
-        diffuse_image_set = global_skylight_component.get_component_property_value(
-            global_skylight_diffuse_image_property)
-        Report.result(Tests.diffuse_image_set, diffuse_image_set == diffuse_image_asset.id)
+            AtomComponentProperties.global_skylight('Diffuse Image'), diffuse_image_asset.id)
+        Report.result(
+            Tests.diffuse_image_set,
+            diffuse_image_asset.id == global_skylight_component.get_component_property_value(
+                                          AtomComponentProperties.global_skylight('Diffuse Image')))
 
         # 9. Set the Specular Image asset on the Global Light (IBL) entity.
-        global_skylight_specular_image_property = "Controller|Configuration|Specular Image"
         specular_image_path = os.path.join("LightingPresets", "greenwich_park_02_4k_iblskyboxcm.exr.streamingimage")
         specular_image_asset = Asset.find_asset_by_path(specular_image_path, False)
         global_skylight_component.set_component_property_value(
-            global_skylight_specular_image_property, specular_image_asset.id)
-        specular_image_added = global_skylight_component.get_component_property_value(
-            global_skylight_specular_image_property)
-        Report.result(Tests.specular_image_set, specular_image_added == specular_image_asset.id)
+            AtomComponentProperties.global_skylight('Specular Image'), specular_image_asset.id)
+        Report.result(
+            Tests.specular_image_set,
+            specular_image_asset.id == global_skylight_component.get_component_property_value(
+                                           AtomComponentProperties.global_skylight('Specular Image')))
 
         # 10. Delete Global Skylight (IBL) entity.
         global_skylight_entity.delete()
@@ -154,9 +182,12 @@ def AtomEditorComponents_GlobalSkylightIBL_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not  global_skylight_entity.exists())
 
-        # 13. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 13. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_LightAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_LightAdded.py
@@ -5,24 +5,49 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =          ("Camera Entity successfully created",   "Camera Entity failed to be created")
-    camera_component_added =   ("Camera component was added to entity", "Camera component failed to be added to entity")
-    camera_component_check =   ("Entity has a Camera component",        "Entity failed to find Camera component")
-    creation_undo =            ("UNDO Entity creation success",         "UNDO Entity creation failed")
-    creation_redo =            ("REDO Entity creation success",         "REDO Entity creation failed")
-    light_creation =           ("Light Entity successfully created",    "Light Entity failed to be created")
-    light_component =          ("Entity has a Light component",         "Entity failed to find Light component")
-    enter_game_mode =          ("Entered game mode",                    "Failed to enter game mode")
-    exit_game_mode =           ("Exited game mode",                     "Couldn't exit game mode")
-    is_visible =               ("Entity is visible",                    "Entity was not visible")
-    is_hidden =                ("Entity is hidden",                     "Entity was not hidden")
-    entity_deleted =           ("Entity deleted",                       "Entity was not deleted")
-    deletion_undo =            ("UNDO deletion success",                "UNDO deletion failed")
-    deletion_redo =            ("REDO deletion success",                "REDO deletion failed")
-    no_error_occurred =        ("No errors detected",                   "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    light_creation = (
+        "Light Entity successfully created",
+        "Light Entity failed to be created")
+    light_component = (
+        "Entity has a Light component",
+        "Entity failed to find Light component")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_Light_AddedToEntity():
@@ -55,26 +80,25 @@ def AtomEditorComponents_Light_AddedToEntity():
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Light entity with no components.
-        light_name = "Light"
-        light_entity = EditorEntity.create_editor_entity_at(math.Vector3(512.0, 512.0, 34.0), light_name)
+        light_entity = EditorEntity.create_editor_entity(AtomComponentProperties.light())
         Report.critical_result(Tests.light_creation, light_entity.exists())
 
         # 2. Add Light component to the Light entity.
-        light_entity.add_component(light_name)
-        Report.critical_result(Tests.light_component, light_entity.has_component(light_name))
+        light_component = light_entity.add_component(AtomComponentProperties.light())
+        Report.critical_result(Tests.light_component, light_entity.has_component(AtomComponentProperties.light()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -101,9 +125,9 @@ def AtomEditorComponents_Light_AddedToEntity():
         Report.result(Tests.creation_redo, light_entity.exists())
 
         # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Test IsHidden.
         light_entity.set_visibility_state(False)
@@ -126,9 +150,12 @@ def AtomEditorComponents_Light_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not light_entity.exists())
 
-        # 11. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 11. Look for errors asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -96,6 +96,7 @@ def AtomEditorComponents_Material_AddedToEntity():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -105,15 +106,14 @@ def AtomEditorComponents_Material_AddedToEntity():
 
         # Test steps begin.
         # 1. Create a Material entity with no components.
-        material_name = "Material"
-        material_entity = EditorEntity.create_editor_entity(material_name)
+        material_entity = EditorEntity.create_editor_entity(AtomComponentProperties.material())
         Report.critical_result(Tests.material_creation, material_entity.exists())
 
         # 2. Add a Material component to Material entity.
-        material_component = material_entity.add_component(material_name)
+        material_component = material_entity.add_component(AtomComponentProperties.material())
         Report.critical_result(
             Tests.material_component,
-            material_entity.has_component(material_name))
+            material_entity.has_component(AtomComponentProperties.material()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -143,9 +143,8 @@ def AtomEditorComponents_Material_AddedToEntity():
         Report.result(Tests.material_disabled, not material_component.is_enabled())
 
         # 6. Add Actor component since it is required by the Material component.
-        actor_name = "Actor"
-        material_entity.add_component(actor_name)
-        Report.result(Tests.actor_component, material_entity.has_component(actor_name))
+        material_entity.add_component(AtomComponentProperties.actor())
+        Report.result(Tests.actor_component, material_entity.has_component(AtomComponentProperties.actor()))
 
         # 7. Verify Material component is enabled.
         Report.result(Tests.material_enabled, material_component.is_enabled())
@@ -153,15 +152,14 @@ def AtomEditorComponents_Material_AddedToEntity():
         # 8. UNDO component addition.
         general.undo()
         general.idle_wait_frames(1)
-        Report.result(Tests.actor_undo, not material_entity.has_component(actor_name))
+        Report.result(Tests.actor_undo, not material_entity.has_component(AtomComponentProperties.actor()))
 
         # 9. Verify Material component not enabled.
         Report.result(Tests.material_disabled, not material_component.is_enabled())
 
         # 10. Add Mesh component since it is required by the Material component.
-        mesh_name = "Mesh"
-        material_entity.add_component(mesh_name)
-        Report.result(Tests.mesh_component, material_entity.has_component(mesh_name))
+        material_entity.add_component(AtomComponentProperties.mesh())
+        Report.result(Tests.mesh_component, material_entity.has_component(AtomComponentProperties.mesh()))
 
         # 11. Verify Material component is enabled.
         Report.result(Tests.material_enabled, material_component.is_enabled())

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MeshAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MeshAdded.py
@@ -81,7 +81,7 @@ def AtomEditorComponents_Mesh_AddedToEntity():
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
-    from Atom.atom_utils.atom_constants import AtomComponentProperties as Atom
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -91,14 +91,14 @@ def AtomEditorComponents_Mesh_AddedToEntity():
 
         # Test steps begin.
         # 1. Create a Mesh entity with no components.
-        mesh_entity = EditorEntity.create_editor_entity(Atom.mesh())
+        mesh_entity = EditorEntity.create_editor_entity(AtomComponentProperties.mesh())
         Report.critical_result(Tests.mesh_entity_creation, mesh_entity.exists())
 
         # 2. Add a Mesh component to Mesh entity.
-        mesh_component = mesh_entity.add_component(Atom.mesh())
+        mesh_component = mesh_entity.add_component(AtomComponentProperties.mesh())
         Report.critical_result(
             Tests.mesh_component_added,
-            mesh_entity.has_component(Atom.mesh()))
+            mesh_entity.has_component(AtomComponentProperties.mesh()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -127,9 +127,9 @@ def AtomEditorComponents_Mesh_AddedToEntity():
         # 5. Set Mesh component asset property
         model_path = os.path.join('Objects', 'shaderball', 'shaderball_default_1m.azmodel')
         model = Asset.find_asset_by_path(model_path)
-        mesh_component.set_component_property_value(Atom.mesh('Mesh Asset'), model.id)
+        mesh_component.set_component_property_value(AtomComponentProperties.mesh('Mesh Asset'), model.id)
         Report.result(Tests.mesh_asset_specified,
-                      mesh_component.get_component_property_value(Atom.mesh('Mesh Asset')) == model.id)
+                      mesh_component.get_component_property_value(AtomComponentProperties.mesh('Mesh Asset')) == model.id)
 
         # 6. Enter/Exit game mode.
         TestHelper.enter_game_mode(Tests.enter_game_mode)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PhysicalSkyAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PhysicalSkyAdded.py
@@ -5,24 +5,49 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =          ("Camera Entity successfully created",         "Camera Entity failed to be created")
-    camera_component_added =   ("Camera component was added to entity",       "Camera component failed to be added to entity")
-    camera_component_check =   ("Entity has a Camera component",              "Entity failed to find Camera component")
-    creation_undo =            ("UNDO Entity creation success",               "UNDO Entity creation failed")
-    creation_redo =            ("REDO Entity creation success",               "REDO Entity creation failed")
-    physical_sky_creation =    ("Physical Sky Entity successfully created",   "Physical Sky Entity failed to be created")
-    physical_sky_component =   ("Entity has a Physical Sky component",        "Entity failed to find Physical Sky component")
-    enter_game_mode =          ("Entered game mode",                          "Failed to enter game mode")
-    exit_game_mode =           ("Exited game mode",                           "Couldn't exit game mode")
-    is_visible =               ("Entity is visible",                          "Entity was not visible")
-    is_hidden =                ("Entity is hidden",                           "Entity was not hidden")
-    entity_deleted =           ("Entity deleted",                             "Entity was not deleted")
-    deletion_undo =            ("UNDO deletion success",                      "UNDO deletion failed")
-    deletion_redo =            ("REDO deletion success",                      "REDO deletion failed")
-    no_error_occurred =        ("No errors detected",                         "Errors were detected")
-# fmt: on
+    camera_creation = (
+        "Camera Entity successfully created",
+        "Camera Entity failed to be created")
+    camera_component_added = (
+        "Camera component was added to entity",
+        "Camera component failed to be added to entity")
+    camera_component_check = (
+        "Entity has a Camera component",
+        "Entity failed to find Camera component")
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    physical_sky_creation = (
+        "Physical Sky Entity successfully created",
+        "Physical Sky Entity failed to be created")
+    physical_sky_component = (
+        "Entity has a Physical Sky component",
+        "Entity failed to find Physical Sky component")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_PhysicalSky_AddedToEntity():
@@ -49,32 +74,33 @@ def AtomEditorComponents_PhysicalSky_AddedToEntity():
     8) Delete Physical Sky entity.
     9) UNDO deletion.
     10) REDO deletion.
-    11) Look for errors.
+    11) Look for errors and asserts.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Physical Sky entity with no components.
-        physical_sky_name = "Physical Sky"
-        physical_sky_entity = EditorEntity.create_editor_entity_at(math.Vector3(512.0, 512.0, 34.0), physical_sky_name)
+        physical_sky_entity = EditorEntity.create_editor_entity(AtomComponentProperties.physical_sky())
         Report.critical_result(Tests.physical_sky_creation, physical_sky_entity.exists())
 
         # 2. Add Physical Sky component to Physical Sky entity.
-        physical_sky_entity.add_component(physical_sky_name)
-        Report.critical_result(Tests.physical_sky_component, physical_sky_entity.has_component(physical_sky_name))
+        physical_sky_component = physical_sky_entity.add_component(AtomComponentProperties.physical_sky())
+        Report.critical_result(
+            Tests.physical_sky_component,
+            physical_sky_entity.has_component(AtomComponentProperties.physical_sky()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -101,9 +127,9 @@ def AtomEditorComponents_PhysicalSky_AddedToEntity():
         Report.result(Tests.creation_redo, physical_sky_entity.exists())
 
         # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
 
         # 6. Test IsHidden.
         physical_sky_entity.set_visibility_state(False)
@@ -126,9 +152,12 @@ def AtomEditorComponents_PhysicalSky_AddedToEntity():
         general.redo()
         Report.result(Tests.deletion_redo, not physical_sky_entity.exists())
 
-        # 11. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 11. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXGradientWeightModifierAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXGradientWeightModifierAdded.py
@@ -86,6 +86,7 @@ def AtomEditorComponents_PostFXGradientWeightModifier_AddedToEntity():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -95,15 +96,15 @@ def AtomEditorComponents_PostFXGradientWeightModifier_AddedToEntity():
 
         # Test steps begin.
         # 1. Create a PostFX Gradient Weight Modifier entity with no components.
-        postfx_gradient_weight_name = "PostFX Gradient Weight Modifier"
-        postfx_gradient_weight_entity = EditorEntity.create_editor_entity(postfx_gradient_weight_name)
+        postfx_gradient_weight_entity = EditorEntity.create_editor_entity(AtomComponentProperties.postfx_gradient())
         Report.critical_result(Tests.postfx_gradient_weight_creation, postfx_gradient_weight_entity.exists())
 
         # 2. Add a PostFX Gradient Weight Modifier component to PostFX Gradient Weight Modifier entity.
-        postfx_gradient_weight_component = postfx_gradient_weight_entity.add_component(postfx_gradient_weight_name)
+        postfx_gradient_weight_component = postfx_gradient_weight_entity.add_component(
+            AtomComponentProperties.postfx_gradient())
         Report.critical_result(
             Tests.postfx_gradient_weight_component,
-            postfx_gradient_weight_entity.has_component(postfx_gradient_weight_name))
+            postfx_gradient_weight_entity.has_component(AtomComponentProperties.postfx_gradient()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -133,9 +134,10 @@ def AtomEditorComponents_PostFXGradientWeightModifier_AddedToEntity():
         Report.result(Tests.postfx_gradient_weight_disabled, not postfx_gradient_weight_component.is_enabled())
 
         # 6. Add PostFX Layer component since it is required by the PostFX Gradient Weight Modifier component.
-        postfx_layer_name = "PostFX Layer"
-        postfx_gradient_weight_entity.add_component(postfx_layer_name)
-        Report.result(Tests.postfx_layer_component, postfx_gradient_weight_entity.has_component(postfx_layer_name))
+        postfx_gradient_weight_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.result(
+            Tests.postfx_layer_component,
+            postfx_gradient_weight_entity.has_component(AtomComponentProperties.postfx_layer()))
 
         # 7. Verify PostFX Gradient Weight Modifier component is enabled.
         Report.result(Tests.postfx_gradient_weight_enabled, postfx_gradient_weight_component.is_enabled())

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXLayerAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXLayerAdded.py
@@ -76,6 +76,7 @@ def AtomEditorComponents_postfx_layer_AddedToEntity():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -85,13 +86,14 @@ def AtomEditorComponents_postfx_layer_AddedToEntity():
 
         # Test steps begin.
         # 1. Create a PostFX Layer entity with no components.
-        postfx_layer_name = "PostFX Layer"
-        postfx_layer_entity = EditorEntity.create_editor_entity(postfx_layer_name)
+        postfx_layer_entity = EditorEntity.create_editor_entity(AtomComponentProperties.postfx_layer())
         Report.critical_result(Tests.postfx_layer_entity_creation, postfx_layer_entity.exists())
 
         # 2. Add a PostFX Layer component to PostFX Layer entity.
-        postfx_layer_component = postfx_layer_entity.add_component(postfx_layer_name)
-        Report.critical_result(Tests.postfx_layer_component_added, postfx_layer_entity.has_component(postfx_layer_name))
+        postfx_layer_component = postfx_layer_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.critical_result(
+            Tests.postfx_layer_component_added,
+            postfx_layer_entity.has_component(AtomComponentProperties.postfx_layer()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXRadiusWeightModifierAdded.py
@@ -5,24 +5,49 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
-# fmt: off
 class Tests:
-    camera_creation =                  ("Camera Entity successfully created",                         "Camera Entity failed to be created")
-    camera_component_added =           ("Camera component was added to entity",                       "Camera component failed to be added to entity")
-    camera_component_check =           ("Entity has a Camera component",                              "Entity failed to find Camera component")
-    creation_undo =                    ("UNDO Entity creation success",                               "UNDO Entity creation failed")
-    creation_redo =                    ("REDO Entity creation success",                               "REDO Entity creation failed")
-    postfx_radius_weight_creation =    ("PostFX Radius Weight Modifier Entity successfully created",  "PostFX Radius Weight Modifier Entity failed to be created")
-    postfx_radius_weight_component =   ("Entity has a PostFX Radius Weight Modifier component",       "Entity failed to find PostFX Radius Weight Modifier component")
-    enter_game_mode =                  ("Entered game mode",                                          "Failed to enter game mode")
-    exit_game_mode =                   ("Exited game mode",                                           "Couldn't exit game mode")
-    is_visible =                       ("Entity is visible",                                          "Entity was not visible")
-    is_hidden =                        ("Entity is hidden",                                           "Entity was not hidden")
-    entity_deleted =                   ("Entity deleted",                                             "Entity was not deleted")
-    deletion_undo =                    ("UNDO deletion success",                                      "UNDO deletion failed")
-    deletion_redo =                    ("REDO deletion success",                                      "REDO deletion failed")
-    no_error_occurred =                ("No errors detected",                                         "Errors were detected")
-# fmt: on
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    postfx_radius_weight_creation = (
+        "PostFX Radius Weight Modifier Entity successfully created",
+        "PostFX Radius Weight Modifier Entity failed to be created")
+    postfx_radius_weight_component = (
+        "Entity has a PostFX Radius Weight Modifier component",
+        "Entity failed to find PostFX Radius Weight Modifier component")
+    postfx_radius_weight_disabled = (
+        "PostFX Radius Weight Modifier component disabled",
+        "PostFX Radius Weight Modifier component was not disabled.")
+    postfx_layer_component = (
+        "Entity has a PostFX Layer component",
+        "Entity did not have an PostFX Layer component")
+    postfx_radius_weight_enabled = (
+        "PostFX Radius Weight Modifier component enabled",
+        "PostFX Radius Weight Modifier component was not enabled.")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
 
 
 def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
@@ -43,40 +68,42 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
     2) Add Post FX Radius Weight Modifier component to Post FX Radius Weight Modifier entity.
     3) UNDO the entity creation and component addition.
     4) REDO the entity creation and component addition.
-    5) Enter/Exit game mode.
-    6) Test IsHidden.
-    7) Test IsVisible.
-    8) Delete PostFX Radius Weight Modifier entity.
-    9) UNDO deletion.
-    10) REDO deletion.
-    11) Look for errors.
+    5) Verify PostFX Radius Weight Modifier component not enabled.
+    6) Add PostFX Layer component since it is required by the PostFX Radius Weight Modifier component.
+    7) Verify PostFX Radius Weight Modifier component is enabled.
+    8) Enter/Exit game mode.
+    9) Test IsHidden.
+    10) Test IsVisible.
+    11) Delete PostFX Radius Weight Modifier entity.
+    12) UNDO deletion.
+    13) REDO deletion.
+    14) Look for errors.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
-    import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
-    from editor_python_test_tools.utils import Report, Tracer, TestHelper as helper
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
         # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
-        helper.init_idle()
-        helper.open_level("", "Base")
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
 
         # Test steps begin.
         # 1. Create a Post FX Radius Weight Modifier entity with no components.
-        postfx_radius_weight_name = "PostFX Radius Weight Modifier"
-        postfx_radius_weight_entity = EditorEntity.create_editor_entity_at(
-            math.Vector3(512.0, 512.0, 34.0), postfx_radius_weight_name)
+        postfx_radius_weight_entity = EditorEntity.create_editor_entity(AtomComponentProperties.postfx_radius())
         Report.critical_result(Tests.postfx_radius_weight_creation, postfx_radius_weight_entity.exists())
 
         # 2. Add Post FX Radius Weight Modifier component to Post FX Radius Weight Modifier entity.
-        postfx_radius_weight_entity.add_component(postfx_radius_weight_name)
+        postfx_radius_component = postfx_radius_weight_entity.add_component(AtomComponentProperties.postfx_radius())
         Report.critical_result(
-            Tests.postfx_radius_weight_component, postfx_radius_weight_entity.has_component(postfx_radius_weight_name))
+            Tests.postfx_radius_weight_component,
+            postfx_radius_weight_entity.has_component(AtomComponentProperties.postfx_radius()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -102,35 +129,50 @@ def AtomEditorComponents_PostFXRadiusWeightModifier_AddedToEntity():
         general.idle_wait_frames(1)
         Report.result(Tests.creation_redo, postfx_radius_weight_entity.exists())
 
-        # 5. Enter/Exit game mode.
-        helper.enter_game_mode(Tests.enter_game_mode)
-        general.idle_wait_frames(1)
-        helper.exit_game_mode(Tests.exit_game_mode)
+        # 5. Verify PostFX Radius Weight Modifier component not enabled.
+        Report.result(Tests.postfx_radius_weight_disabled, not postfx_radius_component.is_enabled())
 
-        # 6. Test IsHidden.
+        # 6. Add PostFX Layer component since it is required by the PostFX Radius Weight Modifier component.
+        postfx_radius_weight_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.result(
+            Tests.postfx_layer_component,
+            postfx_radius_weight_entity.has_component(AtomComponentProperties.postfx_layer()))
+
+        # 7. Verify PostFX Radius Weight Modifier component is enabled.
+        Report.result(Tests.postfx_radius_weight_enabled, postfx_radius_component.is_enabled())
+
+        # 8. Enter/Exit game mode.
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
+        general.idle_wait_frames(1)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+        # 9. Test IsHidden.
         postfx_radius_weight_entity.set_visibility_state(False)
         Report.result(Tests.is_hidden, postfx_radius_weight_entity.is_hidden() is True)
 
-        # 7. Test IsVisible.
+        # 10. Test IsVisible.
         postfx_radius_weight_entity.set_visibility_state(True)
         general.idle_wait_frames(1)
         Report.result(Tests.is_visible, postfx_radius_weight_entity.is_visible() is True)
 
-        # 8. Delete PostFX Radius Weight Modifier entity.
+        # 11. Delete PostFX Radius Weight Modifier entity.
         postfx_radius_weight_entity.delete()
         Report.result(Tests.entity_deleted, not postfx_radius_weight_entity.exists())
 
-        # 9. UNDO deletion.
+        # 12. UNDO deletion.
         general.undo()
         Report.result(Tests.deletion_undo, postfx_radius_weight_entity.exists())
 
-        # 10. REDO deletion.
+        # 13. REDO deletion.
         general.redo()
         Report.result(Tests.deletion_redo, not postfx_radius_weight_entity.exists())
 
-        # 11. Look for errors.
-        helper.wait_for_condition(lambda: error_tracer.has_errors, 1.0)
-        Report.result(Tests.no_error_occurred, not error_tracer.has_errors)
+        # 14. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFxShapeWeightModifierAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFxShapeWeightModifierAdded.py
@@ -92,6 +92,7 @@ def AtomEditorComponents_postfx_shape_weight_AddedToEntity():
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
 
     with Tracer() as error_tracer:
         # Test setup begins.
@@ -101,15 +102,14 @@ def AtomEditorComponents_postfx_shape_weight_AddedToEntity():
 
         # Test steps begin.
         # 1. Create a PostFx Shape Weight Modifier entity with no components.
-        postfx_shape_weight_name = "PostFX Shape Weight Modifier"
-        postfx_shape_weight_entity = EditorEntity.create_editor_entity(postfx_shape_weight_name)
+        postfx_shape_weight_entity = EditorEntity.create_editor_entity(AtomComponentProperties.postfx_shape())
         Report.critical_result(Tests.postfx_shape_weight_creation, postfx_shape_weight_entity.exists())
 
         # 2. Add a PostFx Shape Weight Modifier component to PostFx Shape Weight Modifier entity.
-        postfx_shape_weight_component = postfx_shape_weight_entity.add_component(postfx_shape_weight_name)
+        postfx_shape_weight_component = postfx_shape_weight_entity.add_component(AtomComponentProperties.postfx_shape())
         Report.critical_result(
             Tests.postfx_shape_weight_component,
-            postfx_shape_weight_entity.has_component(postfx_shape_weight_name))
+            postfx_shape_weight_entity.has_component(AtomComponentProperties.postfx_shape()))
 
         # 3. UNDO the entity creation and component addition.
         # -> UNDO component addition.
@@ -139,16 +139,16 @@ def AtomEditorComponents_postfx_shape_weight_AddedToEntity():
         Report.result(Tests.postfx_shape_weight_disabled, not postfx_shape_weight_component.is_enabled())
 
         # 6. Add PostFX Layer component since it is required by the PostFx Shape Weight Modifier component.
-        postfx_layer_name = "PostFX Layer"
-        postfx_shape_weight_entity.add_component(postfx_layer_name)
-        Report.result(Tests.postfx_layer_component, postfx_shape_weight_entity.has_component(postfx_layer_name))
+        postfx_shape_weight_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.result(
+            Tests.postfx_layer_component,
+            postfx_shape_weight_entity.has_component(AtomComponentProperties.postfx_layer()))
 
         # 7. Verify PostFx Shape Weight Modifier component is NOT enabled since it also requires a shape.
         Report.result(Tests.postfx_shape_weight_disabled, not postfx_shape_weight_component.is_enabled())
 
         # 8. Add a required shape looping over a list and checking if it enables PostFX Shape Weight Modifier.
-        for shape in ['Axis Aligned Box Shape', 'Box Shape', 'Capsule Shape', 'Compound Shape', 'Cylinder Shape',
-                      'Disk Shape', 'Polygon Prism Shape', 'Quad Shape', 'Sphere Shape', 'Vegetation Reference Shape']:
+        for shape in AtomComponentProperties.postfx_shape('shapes'):
             postfx_shape_weight_entity.add_component(shape)
             test_shape = (
                 f"Entity has a {shape} component",


### PR DESCRIPTION
Cleaning up parallel tests and conveting to AtomComponentProperties constants.
Added a few test steps for required component.
Fixed material asset assignment for decal.

.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py
========================================== test session starts 
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 16 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py .................                 [100%]

===================================== 17 passed in 60.20s (0:01:00)

Signed-off-by: Scott Murray <scottmur@amazon.com>