### PR TITLE
Enable lifetime tethering of the AP by default

### DIFF
--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Asset/AssetSystemComponentHelper_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Asset/AssetSystemComponentHelper_Windows.cpp
@@ -14,7 +14,7 @@
 
 #include <Psapi.h>
 
-AZ_CVAR(bool, ap_tether_lifetime, false, nullptr, AZ::ConsoleFunctorFlags::Null,
+AZ_CVAR(bool, ap_tether_lifetime, true, nullptr, AZ::ConsoleFunctorFlags::Null,
     "If enabled, a parent process that launches the AP will terminate the AP on exit");
 
 namespace AzFramework::AssetSystem::Platform


### PR DESCRIPTION
After this change, the AssetProcessor process will be torn down by
default after its parent process shuts down (if it was spawned by a
parent process).