### PR TITLE
New default minimum height 700px

### DIFF
--- a/Code/Tools/ProjectManager/Resources/ProjectManager.qss
+++ b/Code/Tools/ProjectManager/Resources/ProjectManager.qss
@@ -9,7 +9,7 @@ QMainWindow {
 
 #ScreensCtrl {
     min-width:1200px;
-    min-height:800px;
+    min-height:700px;
 }
 
 QPushButton:focus {


### PR DESCRIPTION
Fixes an issue where the Project Manager is too tall for devices with a 768 pixel height.
closes https://github.com/o3de/o3de/issues/3946



![PrismNewMin700](https://user-images.githubusercontent.com/26804013/138759138-c8998f36-1d54-4004-aecd-237bae94e057.JPG)
