### PR TITLE
Editor crashes after changing the layout when the Prefab system is enabled (regression)

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -153,6 +153,9 @@ namespace AzToolsFramework
     {
         initEntityOutlinerWidgetResources();
 
+        m_editorEntityUiInterface = AZ::Interface<AzToolsFramework::EditorEntityUiInterface>::Get();
+        AZ_Assert(m_editorEntityUiInterface != nullptr, "EntityOutlinerWidget requires a EditorEntityUiInterface instance on Initialize.");
+
         m_gui = new Ui::EntityOutlinerWidgetUI();
         m_gui->setupUi(this);
 
@@ -281,12 +284,6 @@ namespace AzToolsFramework
         m_clearIcon = QIcon(":/AssetBrowser/Resources/close.png");
 
         m_listModel->Initialize();
-
-        m_editorEntityUiInterface = AZ::Interface<AzToolsFramework::EditorEntityUiInterface>::Get();
-
-        AZ_Assert(
-            m_editorEntityUiInterface != nullptr,
-            "EntityOutlinerWidget requires a EditorEntityUiInterface instance on Initialize.");
 
         EditorPickModeNotificationBus::Handler::BusConnect(GetEntityContextId());
         EntityHighlightMessages::Bus::Handler::BusConnect();


### PR DESCRIPTION
Move the initialization of the Editor Entity UI Handler Interface in EntityOutlinerWidget to the top, so that when the UI is initialized calls to OnTreeItemExpanded don't fail.