### PR TITLE
Disable custom titlebar on Mac, Linux

### DIFF
--- a/Code/Tools/ProjectManager/CMakeLists.txt
+++ b/Code/Tools/ProjectManager/CMakeLists.txt
@@ -34,6 +34,7 @@ ly_add_target(
     INCLUDE_DIRECTORIES
         PRIVATE
             Source
+            Platform/${PAL_PLATFORM_NAME}
     BUILD_DEPENDENCIES
         PRIVATE
             3rdParty::Qt::Core

--- a/Code/Tools/ProjectManager/Platform/Linux/PAL_linux_files.cmake
+++ b/Code/Tools/ProjectManager/Platform/Linux/PAL_linux_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     ProjectBuilderWorker_linux.cpp
     ProjectUtils_linux.cpp
     ProjectManagerDefs_linux.cpp
+    ProjectManager_Traits_Platform.h
+    ProjectManager_Traits_Linux.h
 )

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectManager_Traits_Linux.h
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectManager_Traits_Linux.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#define AZ_TRAIT_PROJECT_MANAGER_CUSTOM_TITLEBAR false

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectManager_Traits_Platform.h
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectManager_Traits_Platform.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ProjectManager_Traits_Linux.h>

--- a/Code/Tools/ProjectManager/Platform/Mac/PAL_mac_files.cmake
+++ b/Code/Tools/ProjectManager/Platform/Mac/PAL_mac_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     ProjectBuilderWorker_mac.cpp
     ProjectUtils_mac.cpp
     ProjectManagerDefs_mac.cpp
+    ProjectManager_Traits_Platform.h
+    ProjectManager_Traits_Mac.h
 )

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectManager_Traits_Mac.h
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectManager_Traits_Mac.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#define AZ_TRAIT_PROJECT_MANAGER_CUSTOM_TITLEBAR false

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectManager_Traits_Platform.h
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectManager_Traits_Platform.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ProjectManager_Traits_Mac.h>

--- a/Code/Tools/ProjectManager/Platform/Windows/PAL_windows_files.cmake
+++ b/Code/Tools/ProjectManager/Platform/Windows/PAL_windows_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     ProjectBuilderWorker_windows.cpp
     ProjectUtils_windows.cpp
     ProjectManagerDefs_windows.cpp
+    ProjectManager_Traits_Platform.h
+    ProjectManager_Traits_Windows.h
 )

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectManager_Traits_Platform.h
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectManager_Traits_Platform.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <ProjectManager_Traits_Windows.h>

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectManager_Traits_Windows.h
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectManager_Traits_Windows.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#define AZ_TRAIT_PROJECT_MANAGER_CUSTOM_TITLEBAR true

--- a/Code/Tools/ProjectManager/Source/Application.cpp
+++ b/Code/Tools/ProjectManager/Source/Application.cpp
@@ -16,6 +16,7 @@
 #include <AzQtComponents/Utilities/HandleDpiAwareness.h>
 #include <AzQtComponents/Components/StyleManager.h>
 #include <AzQtComponents/Components/WindowDecorationWrapper.h>
+#include <ProjectManager_Traits_Platform.h>
 
 #include <QApplication>
 #include <QDir>
@@ -194,8 +195,12 @@ namespace O3DE::ProjectManager
         // set stylesheet after creating the main window or their styles won't get updated
         AzQtComponents::StyleManager::setStyleSheet(m_mainWindow.data(), QStringLiteral("style:ProjectManager.qss"));
 
-        // the decoration wrapper is intended to remember window positioning and sizing 
+        // the decoration wrapper is intended to remember window positioning and sizing
+#if AZ_TRAIT_PROJECT_MANAGER_CUSTOM_TITLEBAR
         auto wrapper = new AzQtComponents::WindowDecorationWrapper();
+#else
+        auto wrapper = new AzQtComponents::WindowDecorationWrapper(AzQtComponents::WindowDecorationWrapper::OptionDisabled);
+#endif
         wrapper->setGuest(m_mainWindow.data());
 
         // show the main window here to apply the stylesheet before restoring geometry or we


### PR DESCRIPTION
This change disables the custom titlebar on the ProjectManager on Linux and Mac and uses the default OS titlebar so that users can resize the window.  Qt does not allow window resizing when using a custom titlebar on Mac and Linux.

NOTE: This means the app no longer respects the minimum window size defined in Qt.  Once the user resizes the window below the minimum size, content larger than minimum size will be clipped.

Mac create project screen now can be resized (yes the dialog buttons look odd, but that's a know issue and is a Qt on mac thing)

<img width="1205" alt="Screen Shot 2021-10-25 at 2 51 01 PM" src="https://user-images.githubusercontent.com/26804013/138776236-ca0c925c-c5d2-42aa-afcd-c3240347546b.png">

**Testing**
Built and ran this on Mac, and verified I could grab the edges of the screen and resize the window.