### PR TITLE
Fixes debug console's "quit" issues

### DIFF
--- a/Code/Legacy/CrySystem/ViewSystem/ViewSystem.cpp
+++ b/Code/Legacy/CrySystem/ViewSystem/ViewSystem.cpp
@@ -167,6 +167,11 @@ CViewSystem::~CViewSystem()
     {
         m_pSystem->GetILevelSystem()->RemoveListener(this);
     }
+
+    if (s_debugCamera)
+    {
+        delete s_debugCamera;
+    }
 }
 
 //------------------------------------------------------------------------

--- a/Code/Legacy/CrySystem/ViewSystem/ViewSystem.cpp
+++ b/Code/Legacy/CrySystem/ViewSystem/ViewSystem.cpp
@@ -168,10 +168,17 @@ CViewSystem::~CViewSystem()
         m_pSystem->GetILevelSystem()->RemoveListener(this);
     }
 
+#if !defined(_RELEASE) && !defined(DEDICATED_SERVER)
+    UNREGISTER_COMMAND("debugCameraToggle");
+    UNREGISTER_COMMAND("debugCameraInvertY");
+    UNREGISTER_COMMAND("debugCameraMove");
+
     if (s_debugCamera)
     {
         delete s_debugCamera;
+        s_debugCamera = nullptr;
     }
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/Code/Legacy/CrySystem/ViewSystem/ViewSystem.cpp
+++ b/Code/Legacy/CrySystem/ViewSystem/ViewSystem.cpp
@@ -115,17 +115,20 @@ CViewSystem::CViewSystem(ISystem* pSystem)
     , m_useDeferredViewSystemUpdate(false)
     , m_bControlsAudioListeners(true)
 {
-#if !defined(_RELEASE) && !defined(DEDICATED_SERVER)
-    if (!s_debugCamera)
+#if !defined(_RELEASE)
+    if (!gEnv->IsDedicated())
     {
-        s_debugCamera = new DebugCamera;
-    }
+        if (!s_debugCamera)
+        {
+            s_debugCamera = new DebugCamera;
+        }
 
-    REGISTER_COMMAND("debugCameraToggle", ToggleDebugCamera, VF_DEV_ONLY, "Toggle the debug camera.\n");
-    REGISTER_COMMAND("debugCameraInvertY", ToggleDebugCameraInvertY, VF_DEV_ONLY, "Toggle debug camera Y-axis inversion.\n");
-    REGISTER_COMMAND("debugCameraMove", DebugCameraMove, VF_DEV_ONLY, "Move the debug camera the specified distance (x y z).\n");
-    gEnv->pConsole->CreateKeyBind("ctrl_keyboard_key_punctuation_backslash", "debugCameraToggle");
-    gEnv->pConsole->CreateKeyBind("alt_keyboard_key_punctuation_backslash", "debugCameraInvertY");
+        REGISTER_COMMAND("debugCameraToggle", ToggleDebugCamera, VF_DEV_ONLY, "Toggle the debug camera.\n");
+        REGISTER_COMMAND("debugCameraInvertY", ToggleDebugCameraInvertY, VF_DEV_ONLY, "Toggle debug camera Y-axis inversion.\n");
+        REGISTER_COMMAND("debugCameraMove", DebugCameraMove, VF_DEV_ONLY, "Move the debug camera the specified distance (x y z).\n");
+        gEnv->pConsole->CreateKeyBind("ctrl_keyboard_key_punctuation_backslash", "debugCameraToggle");
+        gEnv->pConsole->CreateKeyBind("alt_keyboard_key_punctuation_backslash", "debugCameraInvertY");
+    }
 #endif
 
     REGISTER_CVAR2("cl_camera_noise", &m_fCameraNoise, -1, 0,
@@ -168,15 +171,18 @@ CViewSystem::~CViewSystem()
         m_pSystem->GetILevelSystem()->RemoveListener(this);
     }
 
-#if !defined(_RELEASE) && !defined(DEDICATED_SERVER)
-    UNREGISTER_COMMAND("debugCameraToggle");
-    UNREGISTER_COMMAND("debugCameraInvertY");
-    UNREGISTER_COMMAND("debugCameraMove");
-
-    if (s_debugCamera)
+#if !defined(_RELEASE)
+    if (!gEnv->IsDedicated())
     {
-        delete s_debugCamera;
-        s_debugCamera = nullptr;
+        UNREGISTER_COMMAND("debugCameraToggle");
+        UNREGISTER_COMMAND("debugCameraInvertY");
+        UNREGISTER_COMMAND("debugCameraMove");
+
+        if (s_debugCamera)
+        {
+            delete s_debugCamera;
+            s_debugCamera = nullptr;
+        }
     }
 #endif
 }

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/Code/Source/AtomViewportDisplayInfoSystemComponent.cpp
@@ -130,7 +130,8 @@ namespace AZ::Render
         }
         AZ::RPI::ViewportContextPtr viewportContext = GetViewportContext();
 
-        if (!m_fontDrawInterface || !viewportContext || !viewportContext->GetRenderScene())
+        if (!m_fontDrawInterface || !viewportContext || !viewportContext->GetRenderScene() ||
+            !AZ::Interface<AzFramework::FontQueryInterface>::Get())
         {
             return;
         }


### PR DESCRIPTION
Fixes two unrelated crashes when attempting to "quit" launcher from the debug console. 

- AtomViewportDisplayInfo's `OnRenderTick()` relies on data that was being released from memory by `~AtomFont()` dtor lines 367-372.
- Invoke wouldn't dispatch because `__vfptr` points to an empty vftable. Memory tests reveal that the empty table belonged to CrySystem's `LegacyViewSystem > DebugCamera > InputChannelEventListener.` DebugCamera dtor was never called.

Since memory issues are not consistently reproducible, I've included video:

https://user-images.githubusercontent.com/90814386/138777413-1dd63c84-c0d9-4c89-91e4-70ef5d919822.mp4

 
