### PR TITLE
Entity Outliner - fix hover state visual bugs.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
@@ -72,7 +72,7 @@ namespace AzToolsFramework
 
     void EntityOutlinerTreeView::leaveEvent([[maybe_unused]] QEvent* event)
     {
-        m_mousePosition = QPoint();
+        m_mousePosition = QPoint(-1, -1);
         m_currentHoveredIndex = QModelIndex();
         update();
     }
@@ -200,7 +200,7 @@ namespace AzToolsFramework
         const bool isEnabled = (this->model()->flags(index) & Qt::ItemIsEnabled);
 
         const bool isSelected = selectionModel()->isSelected(index);
-        const bool isHovered = (index == indexAt(m_mousePosition)) && isEnabled;
+        const bool isHovered = (index == indexAt(m_mousePosition).siblingAtColumn(0)) && isEnabled;
 
         // Paint the branch Selection/Hover Rect
         PaintBranchSelectionHoverRect(painter, rect, isSelected, isHovered);


### PR DESCRIPTION
Very minor changes to fix hover detection for the branches column in the Entity Outliner.

Solves these 2 bugs:
![hoverbug](https://user-images.githubusercontent.com/82231674/138779563-a2484856-d039-4745-9bee-04ec00d3aab0.gif)
![hoverbug2](https://user-images.githubusercontent.com/82231674/138779566-d940fb27-2994-4fab-9120-4c3b02174c27.gif)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>