### PR TITLE
[Mac] Fix QtEditorApplication_mac include

### DIFF
--- a/Code/Editor/Platform/Mac/Editor/Core/QtEditorApplication_mac.mm
+++ b/Code/Editor/Platform/Mac/Editor/Core/QtEditorApplication_mac.mm
@@ -9,7 +9,7 @@
 #import <AppKit/NSEvent.h>
 
 #include "EditorDefs.h"
-#include "QtEditorApplication.h"
+#include "QtEditorApplication_mac.h"
 
 // AzFramework
 #include <AzFramework/Input/Buses/Notifications/RawInputNotificationBus_Platform.h>


### PR DESCRIPTION
Commit 8e03d6f3065105f53a171345a2cf4a661cec4eb0 missed updating the
platform-specific mac QApplication implementation file to include the
class declaration from the new header.

From #4799

Signed-off-by: Chris Burel <burelc@amazon.com>