### PR TITLE
Fix to set the Taskbar name and Game Launcher window title to the name of the Project

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -258,10 +258,17 @@ namespace AzFramework
     ////////////////////////////////////////////////////////////////////////////////////////////////
     void XcbNativeWindow::SetWindowTitle(const AZStd::string& title)
     {
+        // Set the title of both the window and the task bar by using
+        // a buffer to hold the title twice, separated by a null-terminator
+        auto doubleTitleSize = (title.size() + 1) * 2;
+        AZStd::string doubleTitle(doubleTitleSize, '\0');
+        azstrncpy(doubleTitle.data(), doubleTitleSize, title.c_str(), title.size());
+        azstrncpy(&doubleTitle.data()[title.size() + 1], title.size(), title.c_str(), title.size());
+
         xcb_void_cookie_t xcbCheckResult;
         xcbCheckResult = xcb_change_property(
-            m_xcbConnection, XCB_PROP_MODE_REPLACE, m_xcbWindow, XCB_ATOM_WM_NAME, XCB_ATOM_STRING, 8, static_cast<uint32_t>(title.size()),
-            title.c_str());
+            m_xcbConnection, XCB_PROP_MODE_REPLACE, m_xcbWindow, XCB_ATOM_WM_CLASS, XCB_ATOM_STRING, 8, static_cast<uint32_t>(doubleTitle.size()),
+            doubleTitle.c_str());
         AZ_Assert(ValidateXcbResult(xcbCheckResult), "Failed to set window title.");
     }
 

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/NativeUI/NativeUIRequests.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzCore/Utils/Utils.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/Components/TransformComponent.h>
@@ -115,7 +116,9 @@ namespace AZ
                 {
                     // GFX TODO - investigate window creation being part of the GameApplication.
 
-                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>("O3DELauncher", AzFramework::WindowGeometry(0, 0, 1920, 1080));
+                    auto projectTitle = AZ::Utils::GetProjectName();
+
+                    m_nativeWindow = AZStd::make_unique<AzFramework::NativeWindow>(projectTitle.c_str(), AzFramework::WindowGeometry(0, 0, 1920, 1080));
                     AZ_Assert(m_nativeWindow, "Failed to create the game window\n");
 
                     m_nativeWindow->Activate();


### PR DESCRIPTION
Fixes 2 issues:
1. The title of the window is 'O3DELauncher', but this should be the name of the project.
2. The taskbar button on Linux (Gnome) shows 'Unknown'. This should be the same as the window title.

Signed-off-by: Steve Pham <spham@amazon.com>