### PR TITLE
Fix asset type retrieval in AssetCatalogModel::GetAssetType

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.cpp
@@ -197,19 +197,18 @@ AssetCatalogModel::~AssetCatalogModel()
     AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
 }
 
-AZ::Data::AssetType AssetCatalogModel::GetAssetType(QString filename) const
+AZ::Data::AssetType AssetCatalogModel::GetAssetType(const QString &filename) const
 {
-    AZ::Data::AssetType returnType = AZ::Uuid::CreateNull();
 
     //  Compare file extensions with the map created from the asset database.
     int dotIndex = filename.lastIndexOf('.');
     if (dotIndex < 0)
     {
-        return returnType;
+        return AZ::Uuid::CreateNull();
     }
 
-    QString extension = filename.mid(dotIndex);
-    for (auto pair : m_extensionToAssetType)
+    QStringRef extension = filename.midRef(dotIndex);
+    for (const auto& pair : m_extensionToAssetType)
     {
         QString qExtensions = pair.first.c_str();
         if (qExtensions.indexOf(extension) < 0 || pair.second.empty())
@@ -227,7 +226,7 @@ AZ::Data::AssetType AssetCatalogModel::GetAssetType(QString filename) const
         AZ::Data::AssetId assetId;
         EBUS_EVENT_RESULT(assetId, AZ::Data::AssetCatalogRequestBus, GetAssetIdByPath, azFilename.c_str(), AZ::Data::s_invalidAssetType, false);
 
-        for (AZ::Uuid type : pair.second)
+        for (const AZ::Uuid& type : pair.second)
         {
             const AZ::Data::AssetHandler* handler = AZ::Data::AssetManager::Instance().GetHandler(type);
             if (handler && handler->CanHandleAsset(assetId))
@@ -237,7 +236,7 @@ AZ::Data::AssetType AssetCatalogModel::GetAssetType(QString filename) const
         }
     }
 
-    return returnType;
+    return AZ::Uuid::CreateNull();
 }
 
 QStandardItem* AssetCatalogModel::GetPath(QString& path, bool createIfNeeded, QStandardItem* parent)
@@ -418,7 +417,7 @@ AssetCatalogEntry* AssetCatalogModel::AddAsset(QString assetPath, AZ::Data::Asse
             //  icons' memory being reclaimed and crashing the Editor.
             QSize size = fileIcon.actualSize(QSize(16, 16));
             QIcon deepCopy = fileIcon.pixmap(size).copy(0, 0, size.width(), size.height());
-            
+
             if (!fileIcon.isNull())
             {
                 m_assetTypeToIcon[assetType] = deepCopy;

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/AssetCatalogModel.h
@@ -110,7 +110,7 @@ protected:
     void SetFilterRegExp(const AZStd::string& filterType, const QRegExp& regExp);
     void ClearFilterRegExp(const AZStd::string& filterType = AZStd::string());
 
-    AZ::Data::AssetType GetAssetType(QString filename) const;
+    AZ::Data::AssetType GetAssetType(const QString &filename) const;
     QStandardItem* GetPath(QString& path, bool createIfNeeded, QStandardItem* parent = nullptr);
 
     void ApplyFilter(QStandardItem* parent);


### PR DESCRIPTION
Previous logic would keep visiting next entries in `m_extensionToAssetType` map, if the previous entry had multiple types.

The old code was only exiting the inner loop.

The main change is that now the first found matching asset type is returned.

Signed-off-by: nemerle <96597+nemerle@users.noreply.github.com>