### PR TITLE
Add Focus Mode integration tests.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h
@@ -43,6 +43,8 @@ namespace AzToolsFramework
     };
 
     //! Provides a bus to notify when the different editor modes are entered/exit.
+    //! @note The editor modes are not discrete states but rather each progression of mode retain the active the parent
+    //! mode that the new mode progressed from.
     class ViewportEditorModeNotifications : public AZ::EBusTraits
     {
     public:

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewportEditorModeTests.cpp
@@ -72,14 +72,6 @@ namespace UnitTest
         }
     }
 
-    bool IsComponentModeActive()
-    {
-        bool inComponentMode = false;
-        AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::BroadcastResult(
-            inComponentMode, &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::InComponentMode);
-        return inComponentMode;
-    }
-
     // Fixture for testing editor mode states
     class ViewportEditorModesTestsFixture
         : public ::testing::Test
@@ -543,7 +535,7 @@ namespace UnitTest
             AZStd::vector<AzToolsFramework::ComponentModeFramework::EntityAndComponentModeBuilders>{});
 
         // Expect to be in component mode
-        EXPECT_TRUE(IsComponentModeActive());
+        EXPECT_TRUE(AzToolsFramework::ComponentModeFramework::InComponentMode());
 
         // Expect the default and component viewport editor modes to be active
         EXPECT_TRUE(m_viewportEditorModes->IsModeActive(ViewportEditorMode::Default));
@@ -561,13 +553,13 @@ namespace UnitTest
             &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::BeginComponentMode,
             AZStd::vector<AzToolsFramework::ComponentModeFramework::EntityAndComponentModeBuilders>{});
 
-        EXPECT_TRUE(IsComponentModeActive());
+        EXPECT_TRUE(AzToolsFramework::ComponentModeFramework::InComponentMode());
 
         AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
             &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::EndComponentMode);
 
         // Expect to not be in component mode
-        EXPECT_FALSE(IsComponentModeActive());
+        EXPECT_FALSE(AzToolsFramework::ComponentModeFramework::InComponentMode());
 
         // Expect only the default viewport editor mode to be active
         ExpectOnlyModeActive(*m_viewportEditorModes, ViewportEditorMode::Default);
@@ -634,7 +626,7 @@ namespace UnitTest
         ExitingFocusModeAfterEnteringFromInitialStateHasOnlyViewportEditorModeDefaultActive)
     {
         // When entering and leaving focus mode
-        m_focusModeInterface->SetFocusRoot(AZ::EntityId(1));
+        m_focusModeInterface->SetFocusRoot(AZ::EntityId{ 1 });
         m_focusModeInterface->SetFocusRoot(AZ::EntityId());
 
         // Expect only the default mode to be active
@@ -650,7 +642,7 @@ namespace UnitTest
             AZStd::vector<AzToolsFramework::ComponentModeFramework::EntityAndComponentModeBuilders>{});
 
         // Expect to be in component mode
-        EXPECT_TRUE(IsComponentModeActive());
+        EXPECT_TRUE(AzToolsFramework::ComponentModeFramework::InComponentMode());
 
         // Expect the default, focus and component viewport editor modes to be active
         EXPECT_TRUE(m_viewportEditorModes->IsModeActive(ViewportEditorMode::Default));
@@ -669,13 +661,13 @@ namespace UnitTest
             &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::BeginComponentMode,
             AZStd::vector<AzToolsFramework::ComponentModeFramework::EntityAndComponentModeBuilders>{});
 
-        EXPECT_TRUE(IsComponentModeActive());
+        EXPECT_TRUE(AzToolsFramework::ComponentModeFramework::InComponentMode());
 
         AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequestBus::Broadcast(
             &AzToolsFramework::ComponentModeFramework::ComponentModeSystemRequests::EndComponentMode);
 
         // Expect to not be in component mode
-        EXPECT_FALSE(IsComponentModeActive());
+        EXPECT_FALSE(AzToolsFramework::ComponentModeFramework::InComponentMode());
 
         // Expect the default and focus viewport editor modes to be active
         EXPECT_TRUE(m_viewportEditorModes->IsModeActive(ViewportEditorMode::Default));


### PR DESCRIPTION
Reproduction of https://github.com/o3de/o3de/pull/4954 to accommodate different destination branch. 

Reviewed and approved by @hultonha @AMZN-daimini.

This PR adds the integration tests for focus mode, as well as adding some further integration tests to check the states after leaving different editor modes.

```
Note: Google Test filter = ViewportEditorModeTrackerIntegrationTestFixture*
[==========] Running 9 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 9 tests from ViewportEditorModeTrackerIntegrationTestFixture
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.InitialViewportEditorModeIsDefault
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.InitialViewportEditorModeIsDefault (466 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringComponentModeAfterInitialStateHasViewportEditorModesDefaultAndComponentModeActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringComponentModeAfterInitialStateHasViewportEditorModesDefaultAndComponentModeActive (303 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.ExitingComponentModeAfterEnteringFrominitialStateHasViewportEditorModesDefaultActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.ExitingComponentModeAfterEnteringFrominitialStateHasViewportEditorModesDefaultActive (318 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringEditorPickEntitySelectionAfterInitialStateHasOnlyViewportEditorModePickActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringEditorPickEntitySelectionAfterInitialStateHasOnlyViewportEditorModePickActive (328 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringEditorDefaultEntitySelectionFromEditorPickEntitySelectionHasOnlyViewportEditorModeDefaultActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringEditorDefaultEntitySelectionFromEditorPickEntitySelectionHasOnlyViewportEditorModeDefaultActive (312 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringFocusModeAfterInitialStateHasViewportEditorModeDefaultAndPickActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringFocusModeAfterInitialStateHasViewportEditorModeDefaultAndPickActive (364 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.ExitingFocusModeAfterEnteringFromInitialStateHasOnlyViewportEditorModeDefaultActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.ExitingFocusModeAfterEnteringFromInitialStateHasOnlyViewportEditorModeDefaultActive (351 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringComponentModeFromFocusModeStateHasViewportEditorModeDefaultAndFocusAndComponentActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.EnteringComponentModeFromFocusModeStateHasViewportEditorModeDefaultAndFocusAndComponentActive (345 ms)
[ RUN      ] ViewportEditorModeTrackerIntegrationTestFixture.ExitingComponentModeAfterEnteringFromFocusModeHasViewportEditorModeDefaultAndFocusActive
[       OK ] ViewportEditorModeTrackerIntegrationTestFixture.ExitingComponentModeAfterEnteringFromFocusModeHasViewportEditorModeDefaultAndFocusActive (314 ms)
[----------] 9 tests from ViewportEditorModeTrackerIntegrationTestFixture (3116 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 1 test case ran. (3142 ms total)
[  PASSED  ] 9 tests.
```

Signed-off-by: John <jonawals@amazon.com>