### PR TITLE
Removed ShaderAsset related unnecessary warning

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAsset.cpp
@@ -264,7 +264,6 @@ namespace AZ
             {
                 // When rebuilding shaders we may be in a state where the ShaderAsset and root ShaderVariantAsset have been rebuilt and reloaded, but some (or all)
                 // shader variants haven't been built yet. Since we want to use the latest version of the shader code, ignore the old variants and fall back to the newer root variant instead.
-                AZ_Warning("ShaderAsset", false, "ShaderAsset and ShaderVariantAsset are out of sync; defaulting to root shader variant. (This is common while reloading shaders).");
                 return GetRootVariant(supervariantIndex);
             }
         }


### PR DESCRIPTION
Removed ShaderAsset related unnecessary warning
that pollutes the logs.

Signed-off-by: garrieta <garrieta@amazon.com>