### PR TITLE
Hair - bug fix resulted from change in pass fetch using the new pipeline filter

### DIFF
--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -311,17 +311,17 @@ namespace AZ
                 m_forceClearRenderData = true;
             }
 
-            bool HairFeatureProcessor::HasHairParentPass()
+            bool HairFeatureProcessor::HasHairParentPass(RPI::RenderPipeline* renderPipeline)
             {
-                RPI::PassFilter passFilter = RPI::PassFilter::CreateWithPassName(HairParentPassName, GetParentScene());
+                RPI::PassFilter passFilter = RPI::PassFilter::CreateWithPassName(HairParentPassName, renderPipeline);
                 RPI::Pass* pass = RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
-                return pass;
+                return pass ? true : false;
             }
 
             void HairFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline)
             {
                 // Proceed only if this is the main pipeline that contains the parent pass
-                if (!HasHairParentPass())
+                if (!HasHairParentPass(renderPipeline.get()))
                 {
                     return;
                 }
@@ -335,7 +335,7 @@ namespace AZ
             void HairFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
             {
                 // Proceed only if this is the main pipeline that contains the parent pass
-                if (!HasHairParentPass())
+                if (!HasHairParentPass(renderPipeline))
                 {
                     return;
                 }
@@ -347,7 +347,7 @@ namespace AZ
             void HairFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
             {
                 // Proceed only if this is the main pipeline that contains the parent pass
-                if (!HasHairParentPass())
+                if (!HasHairParentPass(renderPipeline))
                 {
                     return;
                 }
@@ -623,3 +623,4 @@ namespace AZ
         } // namespace Hair
     } // namespace Render
 } // namespace AZ
+

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -165,7 +165,7 @@ namespace AZ
 
                 void EnablePasses(bool enable);
 
-                bool HasHairParentPass();
+                bool HasHairParentPass(RPI::RenderPipeline* renderPipeline);
 
                 //! The following will serve to register the FP in the Thumbnail system
                 AZStd::vector<AZStd::string> m_hairFeatureProcessorRegistryName;


### PR DESCRIPTION
Due to a previous change to the way passes are acquired, passing the scene in this case does not guarantee validity as the pipeline might be different for the same scene (a scene can have several pipelines). It can also be that the scene is also about to change and not using the new pipeline is invalid.

Signed-off-by: Adi-Amazon <barlev@amazon.com>