### PR TITLE
Static AZ::Names can cause problems during shutdown

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Decals/DecalTextureArray.cpp
@@ -25,8 +25,7 @@ namespace AZ
         {
             static AZ::Name GetMapName(const DecalMapType mapType)
             {
-                // Using local static to avoid cost of creating AZ::Name. Also so that this can be called from other static functions
-                static AZStd::array<AZ::Name, DecalMapType_Num> mapNames =
+                AZStd::array<AZ::Name, DecalMapType_Num> mapNames =
                 {
                     AZ::Name("baseColor.textureMap"),
                     AZ::Name("normal.textureMap")


### PR DESCRIPTION
AZ::Names can cause problems on shutdown as @santorac pointed out.

Normally I would have made these member variables but there are times when I am calling this without a valid object. (from a static helper function, namely IsValidDecalMaterial). These are only called during creation time and not during runtime anyway. (tested this)

Ran ASV baseviewer tests (decal one especially). Editor seemed fine.

Signed-off-by: mrieggeramzn <mriegger@amazon.com>