### PR TITLE
Emit product dependencies from the AnyAsset builder

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Common/AnyAssetBuilder.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Common/AnyAssetBuilder.cpp
@@ -60,7 +60,7 @@ namespace AZ
                 AZStd::placeholders::_1, AZStd::placeholders::_2);
             builderDescriptor.m_processJobFunction = AZStd::bind(&AnyAssetBuilder::ProcessJob, this,
                 AZStd::placeholders::_1, AZStd::placeholders::_2);
-            builderDescriptor.m_version = 9;
+            builderDescriptor.m_version = 10; // Emit product dependencies from the anyasset builder
 
             BusConnect(builderDescriptor.m_busId);
 


### PR DESCRIPTION
This makes it so that the passes in PassTemplates.azasset are listed as dependencies and thus included in an asset list/asset bundle for release builds.