### PR TITLE
Removed reference to opacity.doubleSided property that no longer exists.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_HandleOpacityMode.lua
@@ -81,7 +81,6 @@ function ProcessEditor(context)
     context:SetMaterialPropertyVisibility("opacity.textureMap", mainVisibility)
     context:SetMaterialPropertyVisibility("opacity.textureMapUv", mainVisibility)
     context:SetMaterialPropertyVisibility("opacity.factor", mainVisibility)
-    context:SetMaterialPropertyVisibility("opacity.doubleSided", mainVisibility)
 
     if(opacityMode == OpacityMode_Blended or opacityMode == OpacityMode_TintedTransparent) then
         context:SetMaterialPropertyVisibility("opacity.alphaAffectsSpecular", MaterialPropertyVisibility_Enabled)


### PR DESCRIPTION
Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>