### PR TITLE
ShaderVariantAssetBuilder: Provide registry property to disable

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -23,6 +23,7 @@
 
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 #include <CommonFiles/Preprocessor.h>
 #include <CommonFiles/GlobalBuildOptions.h>
@@ -91,19 +92,31 @@ namespace AZ
             m_shaderAssetBuilder.BusConnect(shaderAssetBuilderDescriptor.m_busId);
             AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBus::Handler::RegisterBuilderInformation, shaderAssetBuilderDescriptor);
 
-            // Register Shader Variant Asset Builder
-            AssetBuilderSDK::AssetBuilderDesc shaderVariantAssetBuilderDescriptor;
-            shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
-            // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
-            // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
-            shaderVariantAssetBuilderDescriptor.m_version = 26; // [AZSL] Changing inlineConstant to rootConstant keyword work.
-            shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", RPI::ShaderVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
-            shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();
-            shaderVariantAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::CreateJobs, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
-            shaderVariantAssetBuilderDescriptor.m_processJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::ProcessJob, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
+            // If, either the SettingsRegistry doesn't exist, or the property @EnableShaderVariantAssetBuilderRegistryKey is not found,
+            // the default is to enable the ShaderVariantAssetBuilder.
+            m_enableShaderVariantAssetBuilder = true;
+            auto settingsRegistry = AZ::SettingsRegistry::Get();
+            if (settingsRegistry)
+            {
+                settingsRegistry->Get(m_enableShaderVariantAssetBuilder, EnableShaderVariantAssetBuilderRegistryKey);
+            }
 
-            m_shaderVariantAssetBuilder.BusConnect(shaderVariantAssetBuilderDescriptor.m_busId);
-            AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBus::Handler::RegisterBuilderInformation, shaderVariantAssetBuilderDescriptor);
+            if (m_enableShaderVariantAssetBuilder)
+            {
+                // Register Shader Variant Asset Builder
+                AssetBuilderSDK::AssetBuilderDesc shaderVariantAssetBuilderDescriptor;
+                shaderVariantAssetBuilderDescriptor.m_name = "Shader Variant Asset Builder";
+                // Both "Shader Variant Asset Builder" and "Shader Asset Builder" produce ShaderVariantAsset products. If you update
+                // ShaderVariantAsset you will need to update BOTH version numbers, not just "Shader Variant Asset Builder".
+                shaderVariantAssetBuilderDescriptor.m_version = 26; // [AZSL] Changing inlineConstant to rootConstant keyword work.
+                shaderVariantAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", RPI::ShaderVariantListSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
+                shaderVariantAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderVariantAssetBuilder>();
+                shaderVariantAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::CreateJobs, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
+                shaderVariantAssetBuilderDescriptor.m_processJobFunction = AZStd::bind(&ShaderVariantAssetBuilder::ProcessJob, &m_shaderVariantAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);
+
+                m_shaderVariantAssetBuilder.BusConnect(shaderVariantAssetBuilderDescriptor.m_busId);
+                AssetBuilderSDK::AssetBuilderBus::Broadcast(&AssetBuilderSDK::AssetBuilderBus::Handler::RegisterBuilderInformation, shaderVariantAssetBuilderDescriptor);
+            }
 
             // Register Precompiled Shader Builder
             AssetBuilderSDK::AssetBuilderDesc precompiledShaderBuilderDescriptor;
@@ -121,7 +134,10 @@ namespace AZ
         void AzslShaderBuilderSystemComponent::Deactivate()
         {
             m_shaderAssetBuilder.BusDisconnect();
-            m_shaderVariantAssetBuilder.BusDisconnect();
+            if (m_enableShaderVariantAssetBuilder)
+            {
+                m_shaderVariantAssetBuilder.BusDisconnect();
+            }
             m_precompiledShaderBuilder.BusDisconnect();
 
             RHI::ShaderPlatformInterfaceRegisterBus::Handler::BusDisconnect();

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.h
@@ -61,7 +61,17 @@ namespace AZ
 
         private:
             ShaderAssetBuilder m_shaderAssetBuilder;
+
+            // The ShaderVariantAssetBuilder can be disabled with this registry key.
+            // By default it is enabled. A user might want to disable it when doing look development
+            // work with shaders or doing lots of iterative changes to shaders. In these cases
+            // GPU performance doesn't matter at all so it is important to not waste time
+            // building ShaderVariantAssets (Other than the Root ShaderVariantAsset, of course.).
+            static constexpr char EnableShaderVariantAssetBuilderRegistryKey[] = "/O3DE/Atom/Shaders/BuildVariants";
+            bool m_enableShaderVariantAssetBuilder = true;
+
             ShaderVariantAssetBuilder m_shaderVariantAssetBuilder;
+
             PrecompiledShaderBuilder m_precompiledShaderBuilder;
 
             /// Contains the ShaderPlatformInterface for all registered RHIs

--- a/Gems/Atom/Asset/Shader/Registry/atom_shaders.setreg
+++ b/Gems/Atom/Asset/Shader/Registry/atom_shaders.setreg
@@ -1,0 +1,10 @@
+{
+    "O3DE": {
+        "Atom": {
+            "Shaders": {
+                "BuildVariants": true
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The registry property name is:
"/O3DE/Atom/Shaders/BuildVariants"
Default value is true.

Signed-off-by: garrieta <garrieta@amazon.com>