### PR TITLE
ATOM-16656 PassTree tool: ParentPass image attachment preview doesn't…

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassFilter.h>
-#include <Atom/RPI.Public/Pass/RenderPass.h>
+#include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/Pass/Specific/SwapChainPass.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -12,6 +12,7 @@
 #include <Atom/RPI.Public/GpuQuery/GpuQuerySystemInterface.h>
 #include <Atom/RPI.Reflect/Image/Image.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
+#include <Atom/RPI.Public/Image/AttachmentImage.h>
 #include <Atom/RPI.Public/Pass/PassAttachment.h>
 #include <Atom/RPI.Public/Pass/PassDefines.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
@@ -59,6 +60,7 @@ namespace AZ
         struct PassRequest;
         struct PassValidationResults;
         class AttachmentReadback;
+        class ImageAttachmentCopy;
 
         using SortedPipelineViewTags = AZStd::set<PipelineViewTag, AZNameSortAscending>;
         using PassesByDrawList = AZStd::map<RHI::DrawListTag, const Pass*>;
@@ -93,6 +95,8 @@ namespace AZ
             : public AZStd::intrusive_base
         {
             AZ_RPI_PASS(Pass);
+
+            friend class ImageAttachmentPreviewPass;
 
         public:
             using ChildPassIndex = RHI::Handle<uint32_t, class ChildPass>;
@@ -369,6 +373,9 @@ namespace AZ
 
             void UpdateReadbackAttachment(FramePrepareParams params, bool beforeAddScopes);
 
+            // Setup ImageAttachmentCopy
+            void UpdateAttachmentCopy(FramePrepareParams params);
+
             // --- Protected Members ---
 
             const Name PassNameThis{"This"};
@@ -465,6 +472,9 @@ namespace AZ
             // For read back attachment
             AZStd::shared_ptr<AttachmentReadback> m_attachmentReadback;
             PassAttachmentReadbackOption m_readbackOption;
+
+            // For image attachment preview
+            AZStd::weak_ptr<ImageAttachmentCopy> m_attachmentCopy;
 
         private:
             // Return the Timestamp result of this pass

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/RenderPass.h
@@ -13,9 +13,7 @@
 #include <Atom/RHI/DrawList.h>
 #include <Atom/RHI/ScopeProducer.h>
 
-#include <Atom/RPI.Public/Pass/AttachmentReadback.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
-#include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 namespace AZ
@@ -29,7 +27,6 @@ namespace AZ
 
     namespace RPI
     {
-        class ImageAttachmentCopy;
         class RenderPass;
         class Query;
 
@@ -40,8 +37,6 @@ namespace AZ
             public RHI::ScopeProducer
         {
             AZ_RPI_PASS(RenderPass);
-
-            friend class ImageAttachmentPreviewPass;
 
             using ScopeQuery = AZStd::array<RHI::Ptr<Query>, static_cast<size_t>(ScopeQueryType::Count)>;
 
@@ -142,8 +137,6 @@ namespace AZ
 
             // Readback the results from the ScopeQueries
             void ReadbackScopeQueryResults();
-
-            AZStd::weak_ptr<ImageAttachmentCopy> m_attachmentCopy;
 
             // Readback results from the Timestamp queries
             TimestampResult m_timestampResult;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h
@@ -78,7 +78,7 @@ namespace AZ
             ~ImageAttachmentPreviewPass();
             
             //! Preview the PassAttachment of a pass' PassAttachmentBinding
-            void PreviewImageAttachmentForPass(RenderPass* pass, const PassAttachment* passAttachment);
+            void PreviewImageAttachmentForPass(Pass* pass, const PassAttachment* passAttachment);
 
             //! Set the output color attachment for this pass
             void SetOutputColorAttachment(RHI::Ptr<PassAttachment> outputImageAttachment);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -26,6 +26,7 @@
 #include <Atom/RPI.Public/Pass/PassLibrary.h>
 #include <Atom/RPI.Public/Pass/PassDefines.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
+#include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
 
 #include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
@@ -1215,6 +1216,12 @@ namespace AZ
             m_queueState = PassQueueState::NoQueue;
 
             InitializeInternal();
+            
+            // Need to recreate the dest attachment because the source attachment might be changed
+            if (!m_attachmentCopy.expired())
+            {
+                m_attachmentCopy.lock()->InvalidateDestImage();
+            }
 
             m_state = PassState::Initialized;
         }
@@ -1300,6 +1307,9 @@ namespace AZ
             
             // readback attachment with output state
             UpdateReadbackAttachment(params, false);
+
+            // update attachment copy for preview
+            UpdateAttachmentCopy(params);
 
             UpdateConnectedOutputBindings();
         }
@@ -1486,6 +1496,14 @@ namespace AZ
                 // Read the attachment for one frame. The reference can be released afterwards
                 m_attachmentReadback->FrameBegin(params);
                 m_attachmentReadback = nullptr;
+            }
+        }
+
+        void Pass::UpdateAttachmentCopy(FramePrepareParams params)
+        {
+            if (!m_attachmentCopy.expired())
+            {
+                m_attachmentCopy.lock()->FrameBegin(params);
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -177,12 +177,6 @@ namespace AZ
                     }
                 }
             }
-
-            // Need to recreate the dest attachment because the source attachment might be changed
-            if (!m_attachmentCopy.expired())
-            {
-                m_attachmentCopy.lock()->InvalidateDestImage();
-            }
         }
 
         void RenderPass::FrameBeginInternal(FramePrepareParams params)
@@ -196,11 +190,7 @@ namespace AZ
 
             // Read back the ScopeQueries submitted from previous frames
             ReadbackScopeQueryResults();
-             
-            if (!m_attachmentCopy.expired())
-            {
-                m_attachmentCopy.lock()->FrameBegin(params);
-            }
+
             CollectSrgs();
 
             PassSystemInterface::Get()->IncrementFrameRenderPassCount();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -14,7 +14,7 @@
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/Image/AttachmentImagePool.h>
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
-#include <Atom/RPI.Public/Pass/RenderPass.h>
+#include <Atom/RPI.Public/Pass/AttachmentReadback.h>
 #include <Atom/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -131,7 +131,7 @@ namespace AZ
             Data::AssetBus::Handler::BusDisconnect();
         }
 
-        void ImageAttachmentPreviewPass::PreviewImageAttachmentForPass(RenderPass* pass, const PassAttachment* passAttachment)
+        void ImageAttachmentPreviewPass::PreviewImageAttachmentForPass(Pass* pass, const PassAttachment* passAttachment)
         {
             if (passAttachment->GetAttachmentType() != RHI::AttachmentType::Image)
             {

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiPassTree.h
@@ -39,6 +39,8 @@ namespace AZ
             bool m_showAttachments = false;
 
             AZ::RPI::Pass* m_selectedPass = nullptr;
+            AZ::RPI::Pass* m_lastSelectedPass = nullptr;
+            AZ::Name m_selectedPassPath;
             AZ::RHI::AttachmentId m_attachmentId;
             AZ::Name m_slotName;
             bool m_selectedChanged = false;


### PR DESCRIPTION
… work

Move imageAttachmentCopy instance from RenderPass to Pass so it can support preview image for all passes but not only for RenderPass.
Fixed an issue with image attachment preview when switching render pipeline with attachment preview on.

Signed-off-by: Qing Tao <qingtao@amazon.com>