### PR TITLE
bugfix: remove redundant clear (#4379)

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/FrameGraphExecuteGroupMerged.cpp
@@ -77,9 +77,9 @@ namespace AZ
 
             const Scope* scope = m_scopes[contextIndex];
             context.SetCommandList(*m_commandList);
-
-            scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Aliasing);
+            
             scope->ProcessClearRequests(*m_commandList);
+            scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Aliasing);
             scope->EmitScopeBarriers(*m_commandList, Scope::BarrierSlot::Prologue);
             scope->ResetQueryPools(*m_commandList);
             scope->Begin(*m_commandList);


### PR DESCRIPTION
not sure if this is an appropriate change. so it seems that both the VkAttachmentDescription with VK_ATTACHMENT_LOAD_OP_CLEAR and an explicit vkCmdClearColorImage is also issued in CommandList. any explicit reason why both are issued and what cases would to appropriate for a clear command to be explicitly issued. seems like VK_ATTACHMENT_LOAD_OP_CLEAR does what vkCmdClearColorImage is doing.

Signed-off-by: Michael Pollind <mpollind@gmail.com>