### PR TITLE
ATOM-16414 Vulkan stencil reference bits are used incorrectly

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -729,8 +729,7 @@ namespace AZ
 
         void CommandList::SetStencilRef(uint8_t stencilRef)
         {
-            vkCmdSetStencilReference(m_nativeCommandBuffer, VK_STENCIL_FACE_FRONT_BIT, static_cast<uint32_t>(stencilRef));
-            vkCmdSetStencilReference(m_nativeCommandBuffer, VK_STENCIL_FACE_BACK_BIT, static_cast<uint32_t>(stencilRef));
+            vkCmdSetStencilReference(m_nativeCommandBuffer, VK_STENCIL_FACE_FRONT_AND_BACK, aznumeric_cast<uint32_t>(stencilRef));
         }
 
         void CommandList::BindPipeline(const PipelineState* pipelineState)


### PR DESCRIPTION
Simply combine the 2 bits together so the command is invoked once only.