### PR TITLE
Do not clear input channels everytime focus changes

### DIFF
--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -200,7 +200,7 @@ namespace UnitTest
             m_inputChannelMapper.get(), &AzToolsFramework::QtEventToAzInputMapper::InputChannelUpdated, m_rootWidget.get(),
             [&endedEvent](const AzFramework::InputChannel* inputChannel, [[maybe_unused]] QEvent* event)
             {
-                if (inputChannel->GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::ModifierAltL &&
+                if (inputChannel->GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::AlphanumericW &&
                     inputChannel->IsStateEnded())
                 {
                     endedEvent = true;
@@ -216,7 +216,7 @@ namespace UnitTest
         m_rootWidget->setFocus();
 
         // simulate a key press when root widget has focus
-        QTest::keyPress(m_rootWidget.get(), Qt::Key_Alt, Qt::KeyboardModifier::AltModifier);
+        QTest::keyPress(m_rootWidget.get(), Qt::Key_W);
 
         // when
         // change the window state

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzFramework/Viewport/CameraInput.h>
 #include <AzFramework/Viewport/ViewportControllerList.h>
 #include <AzToolsFramework/Input/QtEventToAzInputManager.h>
@@ -91,10 +92,23 @@ namespace UnitTest
             m_controllerList->RegisterViewportContext(TestViewportId);
 
             m_inputChannelMapper = AZStd::make_unique<AzToolsFramework::QtEventToAzInputMapper>(m_rootWidget.get(), TestViewportId);
+
+            m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
+
+            m_settingsRegistry->Set("/O3DE/InputSystem/GamepadsEnabled", false);
+            m_settingsRegistry->Set("/O3DE/InputSystem/KeyboardEnabled", false);
+            m_settingsRegistry->Set("/O3DE/InputSystem/MotionEnabled", false);
+            m_settingsRegistry->Set("/O3DE/InputSystem/MouseEnabled", false);
+            m_settingsRegistry->Set("/O3DE/InputSystem/TouchEnabled", false);
+            m_settingsRegistry->Set("/O3DE/InputSystem/VirtualKeyboardEnabled", false);
         }
 
         void TearDown() override
         {
+            AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
+            m_settingsRegistry.reset();
+
             m_inputChannelMapper.reset();
 
             m_controllerList->UnregisterViewportContext(TestViewportId);
@@ -108,6 +122,7 @@ namespace UnitTest
 
         AZStd::unique_ptr<QWidget> m_rootWidget;
         AzFramework::ViewportControllerListPtr m_controllerList;
+        AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
         AZStd::unique_ptr<AzToolsFramework::QtEventToAzInputMapper> m_inputChannelMapper;
     };
 

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -110,7 +110,7 @@ namespace UnitTest
 
     const AzFramework::ViewportId ViewportManipulatorControllerFixture::TestViewportId = AzFramework::ViewportId(0);
 
-    TEST_F(ViewportManipulatorControllerFixture, An_event_is_not_propagated_to_the_viewport_when_a_manipulator_handles_it_first)
+    TEST_F(ViewportManipulatorControllerFixture, AnEventIsNotPropagatedToTheViewportWhenAManipulatorHandlesItFirst)
     {
         // forward input events to our controller list
         QObject::connect(
@@ -150,5 +150,31 @@ namespace UnitTest
         EXPECT_FALSE(viewportInteractionCalled);
 
         editorInteractionViewportFake.Disconnect();
+    }
+
+    TEST_F(ViewportManipulatorControllerFixture, ChangingFocusDoesNotClearInput)
+    {
+        bool endedEvent = false;
+
+        // forward input events to our controller list
+        QObject::connect(
+            m_inputChannelMapper.get(), &AzToolsFramework::QtEventToAzInputMapper::InputChannelUpdated, m_rootWidget.get(),
+            [this, &endedEvent](const AzFramework::InputChannel* inputChannel, [[maybe_unused]] QEvent* event)
+            {
+                if (inputChannel->GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::ModifierAltL &&
+                    inputChannel->IsStateEnded())
+                {
+                    endedEvent = true;
+                }
+            });
+
+        AZStd::unique_ptr<QWidget> separateWidget = AZStd::make_unique<QWidget>();
+        separateWidget->setParent(m_rootWidget.release());
+
+        separateWidget->setFocus();
+
+        QTest::keyPress(separateWidget.get(), Qt::Key_Alt, Qt::KeyboardModifier::AltModifier);
+
+        m_rootWidget->setFocus();
     }
 } // namespace UnitTest

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -159,7 +159,7 @@ namespace UnitTest
         // forward input events to our controller list
         QObject::connect(
             m_inputChannelMapper.get(), &AzToolsFramework::QtEventToAzInputMapper::InputChannelUpdated, m_rootWidget.get(),
-            [this, &endedEvent](const AzFramework::InputChannel* inputChannel, [[maybe_unused]] QEvent* event)
+            [&endedEvent](const AzFramework::InputChannel* inputChannel, [[maybe_unused]] QEvent* event)
             {
                 if (inputChannel->GetInputChannelId() == AzFramework::InputDeviceKeyboard::Key::ModifierAltL &&
                     inputChannel->IsStateEnded())
@@ -168,13 +168,15 @@ namespace UnitTest
                 }
             });
 
-        AZStd::unique_ptr<QWidget> separateWidget = AZStd::make_unique<QWidget>();
-        separateWidget->setParent(m_rootWidget.release());
+        QWidget* separateWidget = new QWidget();
+        separateWidget->setParent(m_rootWidget.get());
 
         separateWidget->setFocus();
 
-        QTest::keyPress(separateWidget.get(), Qt::Key_Alt, Qt::KeyboardModifier::AltModifier);
+        QTest::keyPress(separateWidget, Qt::Key_Alt, Qt::KeyboardModifier::AltModifier);
 
         m_rootWidget->setFocus();
+
+        EXPECT_FALSE(endedEvent);
     }
 } // namespace UnitTest

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-#include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzFramework/Viewport/CameraInput.h>
 #include <AzFramework/Viewport/ViewportControllerList.h>
 #include <AzToolsFramework/Input/QtEventToAzInputManager.h>
@@ -92,23 +91,10 @@ namespace UnitTest
             m_controllerList->RegisterViewportContext(TestViewportId);
 
             m_inputChannelMapper = AZStd::make_unique<AzToolsFramework::QtEventToAzInputMapper>(m_rootWidget.get(), TestViewportId);
-
-            m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
-            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
-
-            m_settingsRegistry->Set("/O3DE/InputSystem/GamepadsEnabled", false);
-            m_settingsRegistry->Set("/O3DE/InputSystem/KeyboardEnabled", false);
-            m_settingsRegistry->Set("/O3DE/InputSystem/MotionEnabled", false);
-            m_settingsRegistry->Set("/O3DE/InputSystem/MouseEnabled", false);
-            m_settingsRegistry->Set("/O3DE/InputSystem/TouchEnabled", false);
-            m_settingsRegistry->Set("/O3DE/InputSystem/VirtualKeyboardEnabled", false);
         }
 
         void TearDown() override
         {
-            AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
-            m_settingsRegistry.reset();
-
             m_inputChannelMapper.reset();
 
             m_controllerList->UnregisterViewportContext(TestViewportId);
@@ -122,7 +108,6 @@ namespace UnitTest
 
         AZStd::unique_ptr<QWidget> m_rootWidget;
         AzFramework::ViewportControllerListPtr m_controllerList;
-        AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
         AZStd::unique_ptr<AzToolsFramework::QtEventToAzInputMapper> m_inputChannelMapper;
     };
 

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -234,11 +234,12 @@ namespace UnitTest
         QTest::keyPress(m_rootWidget.get(), Qt::Key_W);
 
         // when
-        // change the window state
-        m_rootWidget->setWindowState(Qt::WindowState::WindowMinimized);
+        // simulate changing the window state
+        QApplicationStateChangeEvent applicationStateChangeEvent(Qt::ApplicationState::ApplicationInactive);
+        QCoreApplication::sendEvent(m_rootWidget.get(), &applicationStateChangeEvent);
 
         // then
-        // the alt key was released (cleared)
+        // the key was released (cleared)
         EXPECT_TRUE(endedEvent);
     }
 } // namespace UnitTest

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -179,7 +179,7 @@ namespace UnitTest
         m_rootWidget->setFocus();
 
         // simulate a key press when root widget has focus
-        QTest::keyPress(secondaryWidget, Qt::Key_Alt, Qt::KeyboardModifier::AltModifier);
+        QTest::keyPress(m_rootWidget.get(), Qt::Key_Alt, Qt::KeyboardModifier::AltModifier);
 
         // when
         // change focus to secondary widget

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
@@ -264,9 +264,6 @@ namespace AzToolsFramework
 
         if (eventType == QEvent::FocusIn || eventType == QEvent::FocusOut)
         {
-            // If our focus changes, go ahead and reset all input devices.
-            HandleFocusChange(event);
-
             // If we focus in on the source widget and the mouse is contained in its
             // bounds, refresh the cached cursor position to ensure it is up to date (this
             // ensures cursor positions are refreshed correctly with context menu focus changes)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.cpp
@@ -259,11 +259,7 @@ namespace AzToolsFramework
         // main editor window) then ensure all input channels are cleared
         if (eventType == QEvent::ApplicationStateChange)
         {
-            if (const auto* applicationStateChange = static_cast<QApplicationStateChangeEvent*>(event);
-                applicationStateChange->applicationState() != Qt::ApplicationState::ApplicationActive)
-            {
-                ClearInputChannels(event);
-            }
+            ClearInputChannels(event);
         }
 
         // Only accept mouse & key release events that originate from an object that is not our target widget,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Input/QtEventToAzInputManager.h
@@ -138,8 +138,9 @@ namespace AzToolsFramework
         void HandleKeyEvent(QKeyEvent* keyEvent);
         // Handles mouse wheel events.
         void HandleWheelEvent(QWheelEvent* wheelEvent);
-        // Handles focus change events.
-        void HandleFocusChange(QEvent* event);
+
+        // Clear all input channels (set all channel states to 'ended').
+        void ClearInputChannels(QEvent* event);
 
         // Populates m_keyMappings.
         void InitializeKeyMappings();


### PR DESCRIPTION
This change stops all inputs being cleared when focus changes between windows/widgets.

How things currently stand there's a problem when holding Alt (to begin camera orbit). If the user clicks outside the Viewport (e.g. changing selection of an entity in the outliner), then as the input is cleared it's as if Alt was released and clicking back in the viewport has the camera no longer orbit. This can be very disruptive to an artist/designer's flow, so I'd like to avoid it but at the same time I don't want this to cause any other issues.

I'd be very grateful to get people's feedback and ideas/suggestions and can potentially get QA involved too if they know of any existing edge cases or good things to test.

~I'm also going to investigate authoring a test for this which is why this is in draft status right now.~. I've now added some tests to codify this behavior.

Thanks!

Test output:

Before changes:

```
[ RUN      ] ViewportManipulatorControllerFixture.ChangingFocusDoesNotClearInput
D:/o3de/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp(195): error: Value of: endedEvent
  Actual: true
Expected: false
[  FAILED  ] ViewportManipulatorControllerFixture.ChangingFocusDoesNotClearInput (97 ms)
[----------] 1 test from ViewportManipulatorControllerFixture (97 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (99 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ViewportManipulatorControllerFixture.ChangingFocusDoesNotClearInput
```

After changes:

```
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from ViewportManipulatorControllerFixture
[ RUN      ] ViewportManipulatorControllerFixture.AnEventIsNotPropagatedToTheViewportWhenAManipulatorHandlesItFirst
[       OK ] ViewportManipulatorControllerFixture.AnEventIsNotPropagatedToTheViewportWhenAManipulatorHandlesItFirst (2 ms)
[ RUN      ] ViewportManipulatorControllerFixture.ChangingFocusDoesNotClearInput
[       OK ] ViewportManipulatorControllerFixture.ChangingFocusDoesNotClearInput (107 ms)
[ RUN      ] ViewportManipulatorControllerFixture.ApplicationStateChangeDoesClearInput
[       OK ] ViewportManipulatorControllerFixture.ApplicationStateChangeDoesClearInput (38 ms)
[----------] 3 tests from ViewportManipulatorControllerFixture (150 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (152 ms total)
[  PASSED  ] 3 tests.
```

