### PR TITLE
bugfix: cycle mouse to the other side of the screen when using scrollbox

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -657,12 +657,17 @@ bool SpinBoxWatcher::handleMouseDragStepping(QAbstractSpinBox* spinBox, QEvent* 
                     QPoint screenPos = mouseEvent->screenPos().toPoint();
                     const int xPos = screenPos.x();
                     int newXPos = xPos;
+                    // cursor bounces on the left and right side of the screen
+                    // looks like buggy behaviour so mouse cursor is wrapped
+                    // around to the other side of the screen.
                     if (xPos >= screenRect.right())
                     {
+                        // wraps mouse cursor around to the left side of the screen
                         newXPos = screenRect.left() + 1;
                     }
                     else if (xPos <= screenRect.left())
                     {
+                        // wraps mouse cursor around to the right side of the screen
                         newXPos = screenRect.right() - 1;
                     }
 

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/SpinBox.cpp
@@ -659,11 +659,11 @@ bool SpinBoxWatcher::handleMouseDragStepping(QAbstractSpinBox* spinBox, QEvent* 
                     int newXPos = xPos;
                     if (xPos >= screenRect.right())
                     {
-                        newXPos = screenRect.right() - 1;
+                        newXPos = screenRect.left() + 1;
                     }
                     else if (xPos <= screenRect.left())
                     {
-                        newXPos = screenRect.left() + 1;
+                        newXPos = screenRect.right() - 1;
                     }
 
                     if (newXPos != xPos)


### PR DESCRIPTION
looks like the delta already accounts for the additional change when you scroll past the edge of the screen so the delta is consistent. seems a lot nicer to use then having the movement clip at the edge of the screen. I was looking at blender and it seems to instead hides the mouse cursor when using a spinbox and does the mouse cycling behavior when using the transform widgets for an item in the editor and clips the cursor to edge of the viewport and cycles the mouse back over. I think it might be worth implementing for the viewport. 


https://user-images.githubusercontent.com/854359/139109561-ebf53d57-a4ce-440b-bddf-40462da9e3e6.mp4 

Signed-off-by: Michael Pollind <mpollind@gmail.com>