### PR TITLE
Fix clearing material component default material not updating 

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1387,7 +1387,10 @@ namespace AzToolsFramework
                     QDataStream stream(&pixmapBytes, QIODevice::ReadOnly);
                     QPixmap pixmap;
                     stream >> pixmap;
-                    GUI->SetBrowseButtonIcon(pixmap);
+                    if (!pixmap.isNull())
+                    {
+                        GUI->SetBrowseButtonIcon(pixmap);
+                    }
                 }
             }
         }
@@ -1417,6 +1420,8 @@ namespace AzToolsFramework
         }
         else if (attrib == AZ_CRC_CE("ThumbnailIcon"))
         {
+            GUI->SetCustomThumbnailEnabled(false);
+
             AZStd::string iconPath;
             if (attrValue->Read<AZStd::string>(iconPath) && !iconPath.empty())
             {
@@ -1434,8 +1439,11 @@ namespace AzToolsFramework
                     QDataStream stream(&pixmapBytes, QIODevice::ReadOnly);
                     QPixmap pixmap;
                     stream >> pixmap;
-                    GUI->SetCustomThumbnailEnabled(true);
-                    GUI->SetCustomThumbnailPixmap(pixmap);
+                    if (!pixmap.isNull())
+                    {
+                        GUI->SetCustomThumbnailEnabled(true);
+                        GUI->SetCustomThumbnailPixmap(pixmap);
+                    }
                 }
             }
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ThumbnailPropertyCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/ThumbnailPropertyCtrl.cpp
@@ -67,16 +67,9 @@ namespace AzToolsFramework
 
     void ThumbnailPropertyCtrl::SetThumbnailKey(Thumbnailer::SharedThumbnailKey key, const char* contextName)
     {
-        if (m_customThumbnailEnabled)
-        {
-            ClearThumbnail();
-        }
-        else
-        {
-            m_key = key;
-            m_thumbnail->SetThumbnailKey(m_key, contextName);
-            m_thumbnailEnlarged->SetThumbnailKey(m_key, contextName);
-        }
+        m_key = key;
+        m_thumbnail->SetThumbnailKey(m_key, contextName);
+        m_thumbnailEnlarged->SetThumbnailKey(m_key, contextName);
         UpdateVisibility();
     }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/MaterialComponentController.cpp
@@ -121,7 +121,12 @@ namespace AZ
             MaterialComponentRequestBus::Handler::BusDisconnect();
             MaterialReceiverNotificationBus::Handler::BusDisconnect();
             TickBus::Handler::BusDisconnect();
+
             ReleaseMaterials();
+
+            // Sending notification to wipe any previously assigned material overrides
+            MaterialComponentNotificationBus::Event(
+                m_entityId, &MaterialComponentNotifications::OnMaterialsUpdated, MaterialAssignmentMap());
 
             m_queuedMaterialUpdateNotification = false;
             m_entityId = AZ::EntityId(AZ::EntityId::InvalidEntityId);
@@ -221,6 +226,11 @@ namespace AZ
             if (!anyQueued)
             {
                 ReleaseMaterials();
+
+                // If no other materials were loaded, the notification must still be sent in case there are externally managed material
+                // instances in the configuration
+                MaterialComponentNotificationBus::Event(
+                    m_entityId, &MaterialComponentNotifications::OnMaterialsUpdated, m_configuration.m_materials);
             }
         }
 
@@ -268,8 +278,6 @@ namespace AZ
             {
                 materialPair.second.Release();
             }
-
-            MaterialComponentNotificationBus::Event(m_entityId, &MaterialComponentNotifications::OnMaterialsUpdated, m_configuration.m_materials);
         }
 
         MaterialAssignmentMap MaterialComponentController::GetOriginalMaterialAssignments() const


### PR DESCRIPTION
• Changed thumbnail property control to track asset key even if image is overridden so that it will be restored if the image is cleared.
• Changed property asset control to disable the thumbnail image by default whenever the attribute is applied. It will only enable the thumbnail image if the pixmap is valid.
• Changed the material component controller to always use an empty material assignment map on deactivation so that no persistent materials are reapplied.
• Changed the material component controller to immediately send a notification that materials have updated if no materials were queued for load but the configuration contained pre created or persistent material instances. This mainly affects the material editor because it manages its own material instances.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>