### PR TITLE
Use source model data instead of filtered model

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -145,10 +145,11 @@ namespace O3DE::ProjectManager
         }
     }
 
-    void GemCatalogScreen::OnGemStatusChanged(const QModelIndex& modelIndex, uint32_t numChangedDependencies) 
+    void GemCatalogScreen::OnGemStatusChanged(const QString& gemName, uint32_t numChangedDependencies) 
     {
         if (m_notificationsEnabled)
         {
+            QModelIndex modelIndex = m_gemModel->FindIndexByNameString(gemName);
             bool added = GemModel::IsAdded(modelIndex);
             bool dependency = GemModel::IsAddedDependency(modelIndex);
 
@@ -233,7 +234,11 @@ namespace O3DE::ProjectManager
                 const QVector<GemInfo> allRepoGemInfos = allRepoGemInfosResult.GetValue();
                 for (const GemInfo& gemInfo : allRepoGemInfos)
                 {
-                    m_gemModel->AddGem(gemInfo);
+                    // do not add gems that have already been downloaded
+                    if (!m_gemModel->FindIndexByNameString(gemInfo.m_name).isValid())
+                    {
+                        m_gemModel->AddGem(gemInfo);
+                    }
                 }
             }
             else
@@ -257,7 +262,8 @@ namespace O3DE::ProjectManager
                         GemModel::SetWasPreviouslyAdded(*m_gemModel, modelIndex, true);
                         GemModel::SetIsAdded(*m_gemModel, modelIndex, true);
                     }
-                    else
+                    // ${Name} is a special name used in templates and is not really an error
+                    else if (enabledGemName != "${Name}")
                     {
                         AZ_Warning("ProjectManager::GemCatalog", false,
                             "Cannot find entry for gem with name '%s'. The CMake target name probably does not match the specified name in the gem.json.",

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -46,7 +46,7 @@ namespace O3DE::ProjectManager
         DownloadController* GetDownloadController() const { return m_downloadController; }
 
     public slots:
-        void OnGemStatusChanged(const QModelIndex& modelIndex, uint32_t numChangedDependencies);
+        void OnGemStatusChanged(const QString& gemName, uint32_t numChangedDependencies);
         void OnAddGemClicked();
 
     protected:

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -276,9 +276,11 @@ namespace O3DE::ProjectManager
 
     void GemModel::SetIsAdded(QAbstractItemModel& model, const QModelIndex& modelIndex, bool isAdded)
     {
+        // get the gemName first, because the modelIndex data change after adding because of filters
+        QString gemName = modelIndex.data(RoleName).toString();
         model.setData(modelIndex, isAdded, RoleIsAdded);
 
-        UpdateDependencies(model, modelIndex);
+        UpdateDependencies(model, gemName, isAdded);
     }
 
     bool GemModel::HasDependentGems(const QModelIndex& modelIndex) const
@@ -294,15 +296,17 @@ namespace O3DE::ProjectManager
         return false;
     }
 
-    void GemModel::UpdateDependencies(QAbstractItemModel& model, const QModelIndex& modelIndex)
+    void GemModel::UpdateDependencies(QAbstractItemModel& model, const QString& gemName, bool isAdded)
     {
         GemModel* gemModel = GetSourceModel(&model);
         AZ_Assert(gemModel, "Failed to obtain GemModel");
 
+        QModelIndex modelIndex = gemModel->FindIndexByNameString(gemName);
+
         QVector<QModelIndex> dependencies = gemModel->GatherGemDependencies(modelIndex);
         uint32_t numChangedDependencies = 0;
 
-        if (IsAdded(modelIndex))
+        if (isAdded)
         {
             for (const QModelIndex& dependency : dependencies)
             {
@@ -324,7 +328,7 @@ namespace O3DE::ProjectManager
             bool hasDependentGems = gemModel->HasDependentGems(modelIndex);
             if (IsAddedDependency(modelIndex) != hasDependentGems)
             {
-                SetIsAddedDependency(model, modelIndex, hasDependentGems);
+                SetIsAddedDependency(*gemModel, modelIndex, hasDependentGems);
             }
 
             for (const QModelIndex& dependency : dependencies)
@@ -343,7 +347,7 @@ namespace O3DE::ProjectManager
             }
         }
 
-        gemModel->emit gemStatusChanged(modelIndex, numChangedDependencies);
+        gemModel->emit gemStatusChanged(gemName, numChangedDependencies);
     }
 
     void GemModel::SetIsAddedDependency(QAbstractItemModel& model, const QModelIndex& modelIndex, bool isAdded)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -64,7 +64,7 @@ namespace O3DE::ProjectManager
         static bool NeedsToBeAdded(const QModelIndex& modelIndex, bool includeDependencies = false);
         static bool NeedsToBeRemoved(const QModelIndex& modelIndex, bool includeDependencies = false);
         static bool HasRequirement(const QModelIndex& modelIndex);
-        static void UpdateDependencies(QAbstractItemModel& model, const QModelIndex& modelIndex);
+        static void UpdateDependencies(QAbstractItemModel& model, const QString& gemName, bool isAdded);
         static void SetDownloadStatus(QAbstractItemModel& model, const QModelIndex& modelIndex, GemInfo::DownloadStatus status);
 
         bool DoGemsToBeAddedHaveRequirements() const;
@@ -78,7 +78,7 @@ namespace O3DE::ProjectManager
         int TotalAddedGems(bool includeDependencies = false) const;
 
     signals:
-        void gemStatusChanged(const QModelIndex& modelIndex, uint32_t numChangedDependencies);
+        void gemStatusChanged(const QString& gemName, uint32_t numChangedDependencies);
 
     private:
         void FindGemDisplayNamesByNameStrings(QStringList& inOutGemNames);


### PR DESCRIPTION
Fixes an issue where the dependencies and toasts would use the wrong gem when filters were checked (selected, unselected, active, inactive) and enabling or disabling a gem removed it from the active filter.  If you activated the last gem in the list, the gem name was missing in the toast message.  This is because the modelIndex data changes when the gem is added/removed and the filter is applied.

**Testing**
- Activated the 'inactive' filter and activated a gem
- without the change the wrong gem was displayed in the toast, with this change the correct gem and dependency info is displayed
- tested activating and deactivating gems without filters enabled to make sure that still worked
- 
Signed-off-by: AMZN-alexpete <26804013+AMZN-alexpete@users.noreply.github.com>