### PR TITLE
Fix frozen metrics on the timestamp view when using the 'Once per Second' update frequency mode

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.h
@@ -249,7 +249,7 @@ namespace AZ
 
             // Controls how often the timestamp data is refreshed
             RefreshType m_refreshType = RefreshType::Realtime;
-            AZStd::sys_time_t m_lastUpdateTimeMicroSecond;
+            AZStd::sys_time_t m_lastUpdateTimeMicroSecond = 0;
 
         };
 

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/ImGuiGpuProfiler.inl
@@ -651,7 +651,7 @@ namespace AZ
                 if (m_refreshType == RefreshType::OncePerSecond)
                 {
                     auto now = AZStd::GetTimeNowMicroSecond();
-                    if (m_lastUpdateTimeMicroSecond == 0 || now - m_lastUpdateTimeMicroSecond > 1000000)
+                    if (now - m_lastUpdateTimeMicroSecond > 1000000)
                     {
                         needEnable = true;
                         m_lastUpdateTimeMicroSecond = now;


### PR DESCRIPTION
This was happening because the time variable storing the last update time was not initialized, therefore an arbitrarily large value was assigned and the update condition was never satisfied.  

Furthermore, the condition `m_lastUpdateTimeMicroSecond == 0` could be ignored since the alternative condition `now - m_lastUpdateTimeMicroSecond > 1000000` will be already satisfied after the first tick, which can be considered as negligible.

https://github.com/o3de/o3de/issues/5079

Signed-off-by: Santi Paprika <santi.gonzalez.cs@gmail.com>