### PR TITLE
EMotion FX: Actor component: Skeleton rendering is not working

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/ActorComponent.cpp
@@ -576,7 +576,7 @@ namespace EMotionFX
 
                 // The configuration stores some debug option. When that is enabled, we override it on top of the render flags.
                 m_debugRenderFlags[RENDER_AABB] = m_debugRenderFlags[RENDER_AABB] || m_configuration.m_renderBounds;
-                m_debugRenderFlags[RENDER_SKELETON] = m_debugRenderFlags[RENDER_SKELETON] || m_configuration.m_renderSkeleton;
+                m_debugRenderFlags[RENDER_LINESKELETON] = m_debugRenderFlags[RENDER_LINESKELETON] || m_configuration.m_renderSkeleton;
                 m_debugRenderFlags[RENDER_EMFX_DEBUG] = true;
                 m_renderActorInstance->DebugDraw(m_debugRenderFlags);
             }

--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -606,7 +606,7 @@ namespace EMotionFX
                 m_renderActorInstance->UpdateBounds();
 
                 m_debugRenderFlags[RENDER_AABB] = m_renderBounds;
-                m_debugRenderFlags[RENDER_SKELETON] = m_renderSkeleton;
+                m_debugRenderFlags[RENDER_LINESKELETON] = m_renderSkeleton;
                 m_debugRenderFlags[RENDER_EMFX_DEBUG] = true;
                 m_renderActorInstance->DebugDraw(m_debugRenderFlags);
             }


### PR DESCRIPTION
Enabling the "Draw skeleton" checkbox in the actor component does not show the skeleton.

Resolves #5083

![image](https://user-images.githubusercontent.com/43751992/139250655-87d8b390-c616-4242-b292-e8261e63d080.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>