### PR TITLE
Removed Gem Repo Enable Button

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoItemDelegate.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoItemDelegate.cpp
@@ -39,7 +39,6 @@ namespace O3DE::ProjectManager
 
         QRect fullRect, itemRect, contentRect;
         CalcRects(options, fullRect, itemRect, contentRect);
-        QRect buttonRect = CalcButtonRect(contentRect);
 
         QFont standardFont(options.font);
         standardFont.setPixelSize(static_cast<int>(s_fontSize));
@@ -70,15 +69,12 @@ namespace O3DE::ProjectManager
             painter->restore();
         }
 
-        // Repo enabled
-        DrawButton(painter, buttonRect, modelIndex);
-
         // Repo name
         QString repoName = GemRepoModel::GetName(modelIndex);
         repoName = QFontMetrics(standardFont).elidedText(repoName, Qt::TextElideMode::ElideRight, s_nameMaxWidth);
 
         QRect repoNameRect = GetTextRect(standardFont, repoName, s_fontSize);
-        int currentHorizontalOffset = buttonRect.left() + s_buttonWidth + s_buttonSpacing;
+        int currentHorizontalOffset = contentRect.left();
         repoNameRect.moveTo(currentHorizontalOffset, contentRect.center().y() - repoNameRect.height() / 2);
         repoNameRect = painter->boundingRect(repoNameRect, Qt::TextSingleLine, repoName);
 
@@ -126,7 +122,7 @@ namespace O3DE::ProjectManager
         initStyleOption(&options, modelIndex);
 
         int marginsHorizontal = s_itemMargins.left() + s_itemMargins.right() + s_contentMargins.left() + s_contentMargins.right();
-        return QSize(marginsHorizontal + s_buttonWidth + s_buttonSpacing + s_nameMaxWidth + s_creatorMaxWidth + s_updatedMaxWidth + s_contentSpacing * 3, s_height);
+        return QSize(marginsHorizontal + s_nameMaxWidth + s_creatorMaxWidth + s_updatedMaxWidth + s_contentSpacing * 3, s_height);
     }
 
     bool GemRepoItemDelegate::editorEvent(QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option, const QModelIndex& modelIndex)
@@ -139,13 +135,8 @@ namespace O3DE::ProjectManager
         if (event->type() == QEvent::KeyPress)
         {
             auto keyEvent = static_cast<const QKeyEvent*>(event);
-            if (keyEvent->key() == Qt::Key_Space)
-            {
-                const bool isAdded = GemRepoModel::IsEnabled(modelIndex);
-                GemRepoModel::SetEnabled(*model, modelIndex, !isAdded);
-                return true;
-            }
-            else if (keyEvent->key() == Qt::Key_X)
+
+            if (keyEvent->key() == Qt::Key_X)
             {
                 emit RemoveRepo(modelIndex);
                 return true;
@@ -163,17 +154,10 @@ namespace O3DE::ProjectManager
 
             QRect fullRect, itemRect, contentRect;
             CalcRects(option, fullRect, itemRect, contentRect);
-            const QRect buttonRect = CalcButtonRect(contentRect);
             const QRect deleteButtonRect = CalcDeleteButtonRect(contentRect);
-            const QRect refreshButtonRect = CalcRefreshButtonRect(contentRect, buttonRect);
+            const QRect refreshButtonRect = CalcRefreshButtonRect(contentRect);
 
-            if (buttonRect.contains(mouseEvent->pos()))
-            {
-                const bool isAdded = GemRepoModel::IsEnabled(modelIndex);
-                GemRepoModel::SetEnabled(*model, modelIndex, !isAdded);
-                return true;
-            }
-            else if (deleteButtonRect.contains(mouseEvent->pos()))
+            if (deleteButtonRect.contains(mouseEvent->pos()))
             {
                 emit RemoveRepo(modelIndex);
                 return true;
@@ -201,50 +185,15 @@ namespace O3DE::ProjectManager
         return QFontMetrics(font).boundingRect(text);
     }
 
-    QRect GemRepoItemDelegate::CalcButtonRect(const QRect& contentRect) const
-    {
-        const QPoint topLeft = QPoint(contentRect.left(), contentRect.top() + contentRect.height() / 2 - s_buttonHeight / 2);
-        const QSize size = QSize(s_buttonWidth, s_buttonHeight);
-        return QRect(topLeft, size);
-    }
-
-    void GemRepoItemDelegate::DrawButton(QPainter* painter, const QRect& buttonRect, const QModelIndex& modelIndex) const
-    {
-        painter->save();
-        QPoint circleCenter;
-
-        const bool isEnabled = GemRepoModel::IsEnabled(modelIndex);
-        if (isEnabled)
-        {
-            painter->setBrush(m_buttonEnabledColor);
-            painter->setPen(m_buttonEnabledColor);
-
-            circleCenter = buttonRect.center() + QPoint(buttonRect.width() / 2 - s_buttonBorderRadius + 1, 1);
-        }
-        else
-        {
-            circleCenter = buttonRect.center() + QPoint(-buttonRect.width() / 2 + s_buttonBorderRadius + 1, 1);
-        }
-
-        // Rounded rect
-        painter->drawRoundedRect(buttonRect, s_buttonBorderRadius, s_buttonBorderRadius);
-
-        // Circle
-        painter->setBrush(m_textColor);
-        painter->drawEllipse(circleCenter, s_buttonCircleRadius, s_buttonCircleRadius);
-
-        painter->restore();
-    }
-
     QRect GemRepoItemDelegate::CalcDeleteButtonRect(const QRect& contentRect) const
     {
         const QPoint topLeft = QPoint(contentRect.right() - s_iconSize, contentRect.center().y() - s_iconSize / 2);
         return QRect(topLeft, QSize(s_iconSize, s_iconSize));
     }
 
-    QRect GemRepoItemDelegate::CalcRefreshButtonRect(const QRect& contentRect, const QRect& buttonRect) const
+    QRect GemRepoItemDelegate::CalcRefreshButtonRect(const QRect& contentRect) const
     {
-        const int topLeftX = buttonRect.left() + s_buttonWidth + s_buttonSpacing + s_nameMaxWidth + s_creatorMaxWidth + s_updatedMaxWidth + s_contentSpacing * 2 + s_refreshIconSpacing;
+        const int topLeftX = contentRect.left() + s_nameMaxWidth + s_creatorMaxWidth + s_updatedMaxWidth + s_contentSpacing * 2 + s_refreshIconSpacing;
         const QPoint topLeft = QPoint(topLeftX, contentRect.center().y() - s_refreshIconSize / 3);
         return QRect(topLeft, QSize(s_refreshIconSize, s_refreshIconSize));
     }

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoItemDelegate.h
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoItemDelegate.h
@@ -36,7 +36,6 @@ namespace O3DE::ProjectManager
         const QColor m_backgroundColor = QColor("#333333"); // Outside of the actual repo item
         const QColor m_itemBackgroundColor = QColor("#404040"); // Background color of the repo item
         const QColor m_borderColor = QColor("#1E70EB");
-        const QColor m_buttonEnabledColor = QColor("#1E70EB");
 
         // Item
         inline constexpr static int s_height = 72; // Repo item total height
@@ -53,13 +52,6 @@ namespace O3DE::ProjectManager
         inline constexpr static int s_creatorMaxWidth = 115;
         inline constexpr static int s_updatedMaxWidth = 125;
 
-        // Button
-        inline constexpr static int s_buttonWidth = 32;
-        inline constexpr static int s_buttonHeight = 16;
-        inline constexpr static int s_buttonBorderRadius = 8;
-        inline constexpr static int s_buttonCircleRadius = s_buttonBorderRadius - 2;
-        inline constexpr static int s_buttonSpacing = 20;
-
         // Icon
         inline constexpr static int s_iconSize = 24;
         inline constexpr static int s_iconSpacing = 16;
@@ -75,8 +67,7 @@ namespace O3DE::ProjectManager
         QRect GetTextRect(QFont& font, const QString& text, qreal fontSize) const;
         QRect CalcButtonRect(const QRect& contentRect) const;
         QRect CalcDeleteButtonRect(const QRect& contentRect) const;
-        QRect CalcRefreshButtonRect(const QRect& contentRect, const QRect& buttonRect) const;
-        void DrawButton(QPainter* painter, const QRect& contentRect, const QModelIndex& modelIndex) const;
+        QRect CalcRefreshButtonRect(const QRect& contentRect) const;
         void DrawEditButtons(QPainter* painter, const QRect& contentRect) const;
 
         QAbstractItemModel* m_model = nullptr;

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
@@ -289,23 +289,22 @@ namespace O3DE::ProjectManager
         m_gemRepoHeaderTable->setObjectName("gemRepoHeaderTable");
         m_gemRepoListHeader = m_gemRepoHeaderTable->horizontalHeader();
         m_gemRepoListHeader->setObjectName("gemRepoListHeader");
+        m_gemRepoListHeader->setDefaultAlignment(Qt::AlignLeft);
         m_gemRepoListHeader->setSectionResizeMode(QHeaderView::ResizeMode::Fixed);
 
         // Insert columns so the header labels will show up
         m_gemRepoHeaderTable->insertColumn(0);
         m_gemRepoHeaderTable->insertColumn(1);
         m_gemRepoHeaderTable->insertColumn(2);
-        m_gemRepoHeaderTable->insertColumn(3);
-        m_gemRepoHeaderTable->setHorizontalHeaderLabels({ tr("Enabled"), tr("Repository Name"), tr("Creator"), tr("Updated") });
+        m_gemRepoHeaderTable->setHorizontalHeaderLabels({ tr("Repository Name"), tr("Creator"), tr("Updated") });
 
-        const int headerExtraMargin = 10;
-        m_gemRepoListHeader->resizeSection(0, GemRepoItemDelegate::s_buttonWidth + GemRepoItemDelegate::s_buttonSpacing - 3);
-        m_gemRepoListHeader->resizeSection(1, GemRepoItemDelegate::s_nameMaxWidth + GemRepoItemDelegate::s_contentSpacing - headerExtraMargin);
-        m_gemRepoListHeader->resizeSection(2, GemRepoItemDelegate::s_creatorMaxWidth + GemRepoItemDelegate::s_contentSpacing - headerExtraMargin);
-        m_gemRepoListHeader->resizeSection(3, GemRepoItemDelegate::s_updatedMaxWidth + GemRepoItemDelegate::s_contentSpacing - headerExtraMargin);
+        const int headerExtraMargin = 18;
+        m_gemRepoListHeader->resizeSection(0, GemRepoItemDelegate::s_nameMaxWidth + GemRepoItemDelegate::s_contentSpacing + headerExtraMargin);
+        m_gemRepoListHeader->resizeSection(1, GemRepoItemDelegate::s_creatorMaxWidth + GemRepoItemDelegate::s_contentSpacing);
+        m_gemRepoListHeader->resizeSection(2, GemRepoItemDelegate::s_updatedMaxWidth + GemRepoItemDelegate::s_contentSpacing);
 
         // Required to set stylesheet in code as it will not be respected if set in qss
-        m_gemRepoHeaderTable->horizontalHeader()->setStyleSheet("QHeaderView::section { background-color:transparent; color:white; font-size:12px; text-align:left; border-style:none; }");
+        m_gemRepoHeaderTable->horizontalHeader()->setStyleSheet("QHeaderView::section { background-color:transparent; color:white; font-size:12px; border-style:none; }");
         middleVLayout->addWidget(m_gemRepoHeaderTable);
 
         m_gemRepoListView = new GemRepoListView(m_gemRepoModel, m_gemRepoModel->GetSelectionModel(), this);


### PR DESCRIPTION
![o3de_mTl2TVPfWa](https://user-images.githubusercontent.com/52797929/139272043-09b07570-87d6-4d24-a95d-0c7ccbd240c3.png)

Repos are always enabled so the button does nothing. Also fixes come header alignment issues so the headers are actually left aligned on the repo table.


Signed-off-by: nggieber <nggieber@amazon.com>