### PR TITLE
Test parallel PostFX Layer remove and unused import

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXLayerAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXLayerAdded.py
@@ -70,8 +70,6 @@ def AtomEditorComponents_postfx_layer_AddedToEntity():
     :return: None
     """
 
-    import os
-
     import azlmbr.legacy.general as general
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity


### PR DESCRIPTION
Removed unused import from PostFX Layer test

pyRunFile ../../Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_PostFXLayerAdded.py
Report:
[SUCCESS] Success: PostFX Layer Entity successfully created
[SUCCESS] Success: Entity has a PostFX Layer component
[SUCCESS] Success: UNDO Entity creation success
[SUCCESS] Success: REDO Entity creation success
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS

.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py
=========================================== test session starts ====
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 17 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py XXXXXXXXXXXXXXXXXX   [100%]

====================================== 18 xpassed in 81.39s (0:01:21)

Signed-off-by: Scott Murray <scottmur@amazon.com>