### PR TITLE
Material editor creates material assets from source JSON data instead of relying on AP

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
@@ -99,7 +99,8 @@ namespace AZ
                 Data::AssetId assetId,
                 AZStd::string_view materialSourceFilePath = "",
                 bool elevateWarnings = true,
-                bool includeMaterialPropertyNames = true) const;
+                bool includeMaterialPropertyNames = true,
+                AZStd::unordered_set<AZStd::string>* sourceDependencies = nullptr) const;
 
         private:
             void ApplyPropertiesToAssetCreator(

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
@@ -31,6 +31,7 @@ namespace AZ
         static constexpr const char UvGroupName[] = "uvSets";
 
         class MaterialAsset;
+        class MaterialAssetCreator;
 
         //! This is a simple data structure for serializing in/out material source files.
         class MaterialSourceData final
@@ -78,15 +79,33 @@ namespace AZ
 
             //! Creates a MaterialAsset from the MaterialSourceData content.
             //! @param assetId ID for the MaterialAsset
-            //! @param materialSourceFilePath Indicates the path of the .material file that the MaterialSourceData represents. Used for resolving file-relative paths.
+            //! @param materialSourceFilePath Indicates the path of the .material file that the MaterialSourceData represents. Used for
+            //! resolving file-relative paths.
             //! @param elevateWarnings Indicates whether to treat warnings as errors
             //! @param includeMaterialPropertyNames Indicates whether to save material property names into the material asset file
             Outcome<Data::Asset<MaterialAsset>> CreateMaterialAsset(
                 Data::AssetId assetId,
                 AZStd::string_view materialSourceFilePath = "",
                 bool elevateWarnings = true,
-                bool includeMaterialPropertyNames = true
-            ) const;
+                bool includeMaterialPropertyNames = true) const;
+
+            //! Creates a MaterialAsset from the MaterialSourceData content.
+            //! @param assetId ID for the MaterialAsset
+            //! @param materialSourceFilePath Indicates the path of the .material file that the MaterialSourceData represents. Used for
+            //! resolving file-relative paths.
+            //! @param elevateWarnings Indicates whether to treat warnings as errors
+            //! @param includeMaterialPropertyNames Indicates whether to save material property names into the material asset file
+            Outcome<Data::Asset<MaterialAsset>> CreateMaterialAssetFromSourceData(
+                Data::AssetId assetId,
+                AZStd::string_view materialSourceFilePath = "",
+                bool elevateWarnings = true,
+                bool includeMaterialPropertyNames = true) const;
+
+        private:
+            static void ApplyMaterialSourceDataPropertiesToAssetCreator(
+                AZ::RPI::MaterialAssetCreator& materialAssetCreator,
+                const AZStd::string_view& materialSourceFilePath,
+                const MaterialSourceData& materialSourceData);
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
@@ -95,6 +95,7 @@ namespace AZ
             //! resolving file-relative paths.
             //! @param elevateWarnings Indicates whether to treat warnings as errors
             //! @param includeMaterialPropertyNames Indicates whether to save material property names into the material asset file
+            //! @param sourceDependencies if not null, will be populated with a set of all of the loaded material and material type paths
             Outcome<Data::Asset<MaterialAsset>> CreateMaterialAssetFromSourceData(
                 Data::AssetId assetId,
                 AZStd::string_view materialSourceFilePath = "",

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Material/MaterialSourceData.h
@@ -102,10 +102,8 @@ namespace AZ
                 bool includeMaterialPropertyNames = true) const;
 
         private:
-            static void ApplyMaterialSourceDataPropertiesToAssetCreator(
-                AZ::RPI::MaterialAssetCreator& materialAssetCreator,
-                const AZStd::string_view& materialSourceFilePath,
-                const MaterialSourceData& materialSourceData);
+            void ApplyPropertiesToAssetCreator(
+                AZ::RPI::MaterialAssetCreator& materialAssetCreator, const AZStd::string_view& materialSourceFilePath) const;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/AssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/AssetCreator.h
@@ -118,7 +118,7 @@ namespace AZ
 
             ResetIssueCounts(); // Because the asset creator can be used multiple times
 
-            m_asset = Data::AssetManager::Instance().CreateAsset<AssetDataT>(assetId, AZ::Data::AssetLoadBehavior::PreLoad);
+            m_asset = Data::Asset<AssetDataT>(assetId, aznew AssetDataT, AZ::Data::AssetLoadBehavior::PreLoad);
             m_beginCalled = true;
 
             if (!m_asset)
@@ -138,6 +138,7 @@ namespace AZ
             }
             else
             {
+                Data::AssetManager::Instance().AssignAssetData(m_asset);
                 result = AZStd::move(m_asset);
                 success = true;
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/LuaMaterialFunctorSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/LuaMaterialFunctorSourceData.cpp
@@ -137,7 +137,10 @@ namespace AZ
             }
             else if (!m_luaSourceFile.empty())
             {
-                auto loadOutcome = RPI::AssetUtils::LoadAsset<ScriptAsset>(materialTypeSourceFilePath, m_luaSourceFile, ScriptAsset::CompiledAssetSubId);
+                // The sub ID for script assets must be explicit.
+                // LUA source files output a compiled as well as an uncompiled asset, sub Ids of 1 and 2.
+                auto loadOutcome =
+                    RPI::AssetUtils::LoadAsset<ScriptAsset>(materialTypeSourceFilePath, m_luaSourceFile, ScriptAsset::CompiledAssetSubId);
                 if (!loadOutcome)
                 {
                     AZ_Error("LuaMaterialFunctorSourceData", false, "Could not load script file '%s'", m_luaSourceFile.c_str());

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/LuaMaterialFunctorSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/LuaMaterialFunctorSourceData.cpp
@@ -137,7 +137,7 @@ namespace AZ
             }
             else if (!m_luaSourceFile.empty())
             {
-                auto loadOutcome = RPI::AssetUtils::LoadAsset<ScriptAsset>(materialTypeSourceFilePath, m_luaSourceFile);
+                auto loadOutcome = RPI::AssetUtils::LoadAsset<ScriptAsset>(materialTypeSourceFilePath, m_luaSourceFile, ScriptAsset::CompiledAssetSubId);
                 if (!loadOutcome)
                 {
                     AZ_Error("LuaMaterialFunctorSourceData", false, "Could not load script file '%s'", m_luaSourceFile.c_str());

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -250,7 +250,7 @@ namespace AZ
                 const auto parentTypeAssetId = AssetUtils::MakeAssetId(parentSourceAbsPath, parentSourceData.m_materialType, 0);
                 if (!parentTypeAssetId)
                 {
-                    AZ_Error("MaterialSourceData", false, "Parent material asset ID isn't valid: '%s'.", parentSourceAbsPath.c_str());
+                    AZ_Error("MaterialSourceData", false, "Parent material asset ID wasn't found: '%s'.", parentSourceAbsPath.c_str());
                     return Failure();
                 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -193,6 +193,7 @@ namespace AZ
             MaterialAssetCreator materialAssetCreator;
             materialAssetCreator.SetElevateWarnings(elevateWarnings);
 
+#if 0
             MaterialTypeSourceData materialTypeSourceData;
             AZStd::string materialTypeSourcePath = AssetUtils::ResolvePathReference(materialSourceFilePath, m_materialType);
             if (!AZ::RPI::JsonUtils::LoadObjectFromFile(materialTypeSourcePath, materialTypeSourceData))
@@ -208,6 +209,13 @@ namespace AZ
             {
                 return Failure();
             }
+#else
+            auto materialTypeAsset = AssetUtils::LoadAsset<MaterialTypeAsset>(materialSourceFilePath, m_materialType);
+            if (!materialTypeAsset.IsSuccess())
+            {
+                return Failure();
+            }
+#endif
 
             materialAssetCreator.Begin(assetId, *materialTypeAsset.GetValue().Get(), includeMaterialPropertyNames);
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -193,7 +193,7 @@ namespace AZ
             MaterialAssetCreator materialAssetCreator;
             materialAssetCreator.SetElevateWarnings(elevateWarnings);
 
-#if 0
+#if 1
             MaterialTypeSourceData materialTypeSourceData;
             AZStd::string materialTypeSourcePath = AssetUtils::ResolvePathReference(materialSourceFilePath, m_materialType);
             if (!AZ::RPI::JsonUtils::LoadObjectFromFile(materialTypeSourcePath, materialTypeSourceData))

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialSourceData.cpp
@@ -235,7 +235,7 @@ namespace AZ
             {
                 if (!dependencies.insert(parentSourceAbsPath).second)
                 {
-                    AZ_Error("MaterialSourceData", false, "Detected circular dependency between materials: '%s' and '%s'.", materialSourceFilePath, parentSourceAbsPath.c_str());
+                    AZ_Error("MaterialSourceData", false, "Detected circular dependency between materials: '%s' and '%s'.", materialSourceFilePath.data(), parentSourceAbsPath.c_str());
                     return Failure();
                 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -393,11 +393,14 @@ namespace AZ
             for (const ShaderVariantReferenceData& shaderRef : m_shaderCollection)
             {
                 const auto& shaderFile = shaderRef.m_shaderFilePath;
-                const auto& shaderAsset = AssetUtils::LoadAsset<ShaderAsset>(materialTypeSourceFilePath, shaderFile, 0);
+                auto shaderAssetResult = AssetUtils::LoadAsset<ShaderAsset>(materialTypeSourceFilePath, shaderFile, 0);
 
-                if (shaderAsset)
+                if (shaderAssetResult)
                 {
-                    auto optionsLayout = shaderAsset.GetValue()->GetShaderOptionGroupLayout();
+                    auto shaderAsset = shaderAssetResult.GetValue();
+                    shaderAsset.SetAutoLoadBehavior(Data::AssetLoadBehavior::PreLoad);
+
+                    auto optionsLayout = shaderAsset->GetShaderOptionGroupLayout();
                     ShaderOptionGroup options{ optionsLayout };
                     for (auto& iter : shaderRef.m_shaderOptionValues)
                     {
@@ -408,12 +411,11 @@ namespace AZ
                     }
 
                     materialTypeAssetCreator.AddShader(
-                        shaderAsset.GetValue(), options.GetShaderVariantId(),
-                        shaderRef.m_shaderTag.IsEmpty() ? Uuid::CreateRandom().ToString<AZ::Name>() : shaderRef.m_shaderTag
-                    );
+                        shaderAsset, options.GetShaderVariantId(),
+                        shaderRef.m_shaderTag.IsEmpty() ? Uuid::CreateRandom().ToString<AZ::Name>() : shaderRef.m_shaderTag);
 
                     // Gather UV names
-                    const ShaderInputContract& shaderInputContract = shaderAsset.GetValue()->GetInputContract();
+                    const ShaderInputContract& shaderInputContract = shaderAsset->GetInputContract();
                     for (const ShaderInputContract::StreamChannelInfo& channel : shaderInputContract.m_streamChannels)
                     {
                         const RHI::ShaderSemantic& semantic = channel.m_semantic;
@@ -493,15 +495,20 @@ namespace AZ
                         {
                         case MaterialPropertyDataType::Image:
                         {
-                            Outcome<Data::Asset<ImageAsset>> imageAssetResult = MaterialUtils::GetImageAssetReference(materialTypeSourceFilePath, property.m_value.GetValue<AZStd::string>());
+                            auto imageAssetResult = MaterialUtils::GetImageAssetReference(
+                                materialTypeSourceFilePath, property.m_value.GetValue<AZStd::string>());
 
-                            if (imageAssetResult.IsSuccess())
+                            if (imageAssetResult)
                             {
-                                materialTypeAssetCreator.SetPropertyValue(propertyId.GetFullName(), imageAssetResult.GetValue());
+                                auto imageAsset = imageAssetResult.GetValue();
+                                imageAsset.SetAutoLoadBehavior(Data::AssetLoadBehavior::PreLoad);
+                                materialTypeAssetCreator.SetPropertyValue(propertyId.GetFullName(), imageAsset);
                             }
                             else
                             {
-                                materialTypeAssetCreator.ReportError("Material property '%s': Could not find the image '%s'", propertyId.GetFullName().GetCStr(), property.m_value.GetValue<AZStd::string>().data());
+                                materialTypeAssetCreator.ReportError(
+                                    "Material property '%s': Could not find the image '%s'", propertyId.GetFullName().GetCStr(),
+                                    property.m_value.GetValue<AZStd::string>().data());
                             }
                         }
                         break;

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Material/MaterialTypeSourceData.cpp
@@ -398,8 +398,6 @@ namespace AZ
                 if (shaderAssetResult)
                 {
                     auto shaderAsset = shaderAssetResult.GetValue();
-                    shaderAsset.SetAutoLoadBehavior(Data::AssetLoadBehavior::PreLoad);
-
                     auto optionsLayout = shaderAsset->GetShaderOptionGroupLayout();
                     ShaderOptionGroup options{ optionsLayout };
                     for (auto& iter : shaderRef.m_shaderOptionValues)
@@ -501,7 +499,6 @@ namespace AZ
                             if (imageAssetResult)
                             {
                                 auto imageAsset = imageAssetResult.GetValue();
-                                imageAsset.SetAutoLoadBehavior(Data::AssetLoadBehavior::PreLoad);
                                 materialTypeAssetCreator.SetPropertyValue(propertyId.GetFullName(), imageAsset);
                             }
                             else

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAsset.cpp
@@ -188,6 +188,10 @@ namespace AZ
         void MaterialTypeAsset::SetReady()
         {
             m_status = AssetStatus::Ready;
+
+            // If this was created dynamically using MaterialTypeAssetCreator (which is what calls SetReady()),
+            // we need to connect to the AssetBus for reloads.
+            PostLoadInit();
         }
 
         bool MaterialTypeAsset::PostLoadInit()

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
@@ -43,6 +43,7 @@ namespace AZ
                 return false; 
             }
 
+            m_asset->PostLoadInit();
             m_asset->SetReady();
 
             m_materialShaderResourceGroupLayout = nullptr;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/MaterialTypeAssetCreator.cpp
@@ -43,7 +43,6 @@ namespace AZ
                 return false; 
             }
 
-            m_asset->PostLoadInit();
             m_asset->SetReady();
 
             m_materialShaderResourceGroupLayout = nullptr;

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/ShaderCollection.cpp
@@ -126,8 +126,8 @@ namespace AZ
         }
 
         ShaderCollection::Item::Item()
+            : m_renderStatesOverlay(RHI::GetInvalidRenderStates())
         {
-            m_renderStatesOverlay = RHI::GetInvalidRenderStates();
         }
 
         ShaderCollection::Item& ShaderCollection::operator[](size_t i)
@@ -156,7 +156,8 @@ namespace AZ
         }
 
         ShaderCollection::Item::Item(const Data::Asset<ShaderAsset>& shaderAsset, const AZ::Name& shaderTag, ShaderVariantId variantId)
-            : m_shaderAsset(shaderAsset)
+            : m_renderStatesOverlay(RHI::GetInvalidRenderStates())
+            , m_shaderAsset(shaderAsset)
             , m_shaderVariantId(variantId)
             , m_shaderTag(shaderTag)
             , m_shaderOptionGroup(shaderAsset->GetShaderOptionGroupLayout(), variantId)
@@ -164,7 +165,8 @@ namespace AZ
         }
 
         ShaderCollection::Item::Item(Data::Asset<ShaderAsset>&& shaderAsset, const AZ::Name& shaderTag, ShaderVariantId variantId)
-            : m_shaderAsset(AZStd::move(shaderAsset))
+            : m_renderStatesOverlay(RHI::GetInvalidRenderStates())
+            , m_shaderAsset(AZStd::move(shaderAsset))
             , m_shaderVariantId(variantId)
             , m_shaderTag(shaderTag)
             , m_shaderOptionGroup(shaderAsset->GetShaderOptionGroupLayout(), variantId)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystemComponent.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystemComponent.cpp
@@ -159,7 +159,7 @@ namespace AtomToolsFramework
 
     void AtomToolsDocumentSystemComponent::OnDocumentExternallyModified(const AZ::Uuid& documentId)
     {
-        m_documentIdsToReopen.insert(documentId);
+        m_documentIdsWithExternalChanges.insert(documentId);
         if (!AZ::TickBus::Handler::BusIsConnected())
         {
             AZ::TickBus::Handler::BusConnect();
@@ -168,7 +168,7 @@ namespace AtomToolsFramework
 
     void AtomToolsDocumentSystemComponent::OnDocumentDependencyModified(const AZ::Uuid& documentId)
     {
-        m_documentIdsToReopen.insert(documentId);
+        m_documentIdsWithDependencyChanges.insert(documentId);
         if (!AZ::TickBus::Handler::BusIsConnected())
         {
             AZ::TickBus::Handler::BusConnect();
@@ -177,7 +177,7 @@ namespace AtomToolsFramework
 
     void AtomToolsDocumentSystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        for (const AZ::Uuid& documentId : m_documentIdsToReopen)
+        for (const AZ::Uuid& documentId : m_documentIdsWithExternalChanges)
         {
             AZStd::string documentPath;
             AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
@@ -190,6 +190,8 @@ namespace AtomToolsFramework
             {
                 continue;
             }
+
+            m_documentIdsWithDependencyChanges.erase(documentId);
 
             AtomToolsFramework::TraceRecorder traceRecorder(m_maxMessageBoxLineCount);
 
@@ -204,7 +206,7 @@ namespace AtomToolsFramework
             }
         }
 
-        for (const AZ::Uuid& documentId : m_documentIdsToReopen)
+        for (const AZ::Uuid& documentId : m_documentIdsWithDependencyChanges)
         {
             AZStd::string documentPath;
             AtomToolsDocumentRequestBus::EventResult(documentPath, documentId, &AtomToolsDocumentRequestBus::Events::GetAbsolutePath);
@@ -231,8 +233,8 @@ namespace AtomToolsFramework
             }
         }
 
-        m_documentIdsToReopen.clear();
-        m_documentIdsToReopen.clear();
+        m_documentIdsWithDependencyChanges.clear();
+        m_documentIdsWithExternalChanges.clear();
         AZ::TickBus::Handler::BusDisconnect();
     }
 

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystemComponent.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Document/AtomToolsDocumentSystemComponent.h
@@ -85,8 +85,8 @@ namespace AtomToolsFramework
         AZStd::intrusive_ptr<AtomToolsDocumentSystemSettings> m_settings;
         AZStd::function<AtomToolsDocument*()> m_documentCreator;
         AZStd::unordered_map<AZ::Uuid, AZStd::shared_ptr<AtomToolsDocument>> m_documentMap;
-        AZStd::unordered_set<AZ::Uuid> m_documentIdsToRebuild;
-        AZStd::unordered_set<AZ::Uuid> m_documentIdsToReopen;
+        AZStd::unordered_set<AZ::Uuid> m_documentIdsWithExternalChanges;
+        AZStd::unordered_set<AZ::Uuid> m_documentIdsWithDependencyChanges;
         const size_t m_maxMessageBoxLineCount = 15;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -762,8 +762,8 @@ namespace MaterialEditor
                 return false;
             }
 
-            auto parentMaterialAssetResult = m_materialSourceData.CreateMaterialAssetFromSourceData(
-                parentMaterialAssetIdResult.GetValue(), parentMaterialFilePath, true, true, &m_sourceDependencies);
+            auto parentMaterialAssetResult = parentMaterialSourceData.CreateMaterialAssetFromSourceData(
+                parentMaterialAssetIdResult.GetValue(), parentMaterialFilePath, true, true);
             if (!parentMaterialAssetResult)
             {
                 AZ_Error("MaterialDocument", false, "Material parent asset could not be created from source data: '%s'.", parentMaterialFilePath.c_str());

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.cpp
@@ -722,7 +722,7 @@ namespace MaterialEditor
         // we can create the asset dynamically from the source data.
         // Long term, the material document should not be concerned with assets at all. The viewport window should be the
         // only thing concerned with assets or instances.
-        auto createResult = m_materialSourceData.CreateMaterialAsset(Uuid::CreateRandom(), m_absolutePath, true);
+        auto createResult = m_materialSourceData.CreateMaterialAssetFromSourceData(Uuid::CreateRandom(), m_absolutePath, true);
         if (!createResult)
         {
             AZ_Error("MaterialDocument", false, "Material asset could not be created from source data: '%s'.", m_absolutePath.c_str());

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Document/MaterialDocument.h
@@ -29,7 +29,6 @@ namespace MaterialEditor
         : public AtomToolsFramework::AtomToolsDocument
         , public MaterialDocumentRequestBus::Handler
         , private AZ::TickBus::Handler
-        , private AZ::Data::AssetBus::MultiHandler
         , private AzToolsFramework::AssetSystemBus::Handler
     {
     public:
@@ -105,11 +104,6 @@ namespace MaterialEditor
         void SourceFileChanged(AZStd::string relativePath, AZStd::string scanFolder, AZ::Uuid sourceUUID) override;
         //////////////////////////////////////////////////////////////////////////
 
-        //////////////////////////////////////////////////////////////////////////
-        // AZ::Data::AssetBus::Router overrides...
-        void OnAssetReloaded(AZ::Data::Asset<AZ::Data::AssetData> asset) override;
-        //////////////////////////////////////////////////////////////////////////
-
         bool SavePropertiesToSourceData(AZ::RPI::MaterialSourceData& sourceData, PropertyFilterFunction propertyFilter) const;
 
         bool OpenInternal(AZStd::string_view loadPath);
@@ -137,11 +131,8 @@ namespace MaterialEditor
         // Material instance being edited
         AZ::Data::Instance<AZ::RPI::Material> m_materialInstance;
 
-        // Asset used to open document
-        AZ::Data::AssetId m_sourceAssetId;
-
         // Set of assets that can trigger a document reload
-        AZStd::unordered_set<AZ::Data::AssetId> m_dependentAssetIds;
+        AZStd::unordered_set<AZStd::string> m_sourceDependencies;
 
         // Track if document saved itself last to skip external modification notification
         bool m_saveTriggeredInternally = false;


### PR DESCRIPTION
The material editor document and material source data can now load and create material and type assets directly from JSON after loading into source data structures. The material editor no longer requires the asset processor to cook materials, parent materials, material types before material documents can be opened. 

This should resolve intermittent AR and automated test failures that were caused by rapidly saving and reopening interdependant documents back to back before they could be processed by the AP. This has also been a longstanding issue in the material editor for the user but was rarely encountered.

The material document is also now only monitoring external changes from the source files.

Other fixes were made to the atom tools framework document system. The containers and mechanism for tracking external changes probably broke during a refactor. The same container was being utilized for major and minor changes. This resulted in multiple notifications being presented to the user to reload their document. 

Discovered a potential asset manager bug that prevented lua assets from being loaded. This is currently being investigated by helios and compensated for by calling QueueLoad in AZ::RPI::AssetUtils::LoadAsset