### PR TITLE
Perform sse float comparisons with the floating-point intrinsics

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathCommon_sse.inl
@@ -383,36 +383,36 @@ namespace AZ
 
             AZ_MATH_INLINE bool CmpAllEq(__m128 arg1, __m128 arg2, int32_t mask)
             {
-                const __m128i compare = CastToInt(CmpNeq(arg1, arg2));
-                return (_mm_movemask_epi8(compare) & mask) == 0;
+                const __m128 compare = CmpEq(arg1, arg2);
+                return (_mm_movemask_ps(compare) & mask) == mask;
             }
 
 
             AZ_MATH_INLINE bool CmpAllLt(__m128 arg1, __m128 arg2, int32_t mask)
             {
-                const __m128i compare = CastToInt(CmpGtEq(arg1, arg2));
-                return (_mm_movemask_epi8(compare) & mask) == 0;
+                const __m128 compare = CmpLt(arg1, arg2);
+                return (_mm_movemask_ps(compare) & mask) == mask;
             }
 
 
             AZ_MATH_INLINE bool CmpAllLtEq(__m128 arg1, __m128 arg2, int32_t mask)
             {
-                const __m128i compare = CastToInt(CmpGt(arg1, arg2));
-                return (_mm_movemask_epi8(compare) & mask) == 0;
+                const __m128 compare = CmpLtEq(arg1, arg2);
+                return (_mm_movemask_ps(compare) & mask) == mask;
             }
 
 
             AZ_MATH_INLINE bool CmpAllGt(__m128 arg1, __m128 arg2, int32_t mask)
             {
-                const __m128i compare = CastToInt(CmpLtEq(arg1, arg2));
-                return (_mm_movemask_epi8(compare) & mask) == 0;
+                const __m128 compare = CmpGt(arg1, arg2);
+                return (_mm_movemask_ps(compare) & mask) == mask;
             }
 
 
             AZ_MATH_INLINE bool CmpAllGtEq(__m128 arg1, __m128 arg2, int32_t mask)
             {
-                const __m128i compare = CastToInt(CmpLt(arg1, arg2));
-                return (_mm_movemask_epi8(compare) & mask) == 0;
+                const __m128 compare = CmpGtEq(arg1, arg2);
+                return (_mm_movemask_ps(compare) & mask) == mask;
             }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec1_sse.inl
@@ -331,31 +331,32 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec1::CmpAllEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0x000F);
+            // Only check the first bit for Vector1
+            return Sse::CmpAllEq(arg1, arg2, 0b0001);
         }
 
 
         AZ_MATH_INLINE bool Vec1::CmpAllLt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLt(arg1, arg2, 0x000F);
+            return Sse::CmpAllLt(arg1, arg2, 0b0001);
         }
 
 
         AZ_MATH_INLINE bool Vec1::CmpAllLtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLtEq(arg1, arg2, 0x000F);
+            return Sse::CmpAllLtEq(arg1, arg2, 0b0001);
         }
 
 
         AZ_MATH_INLINE bool Vec1::CmpAllGt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGt(arg1, arg2, 0x000F);
+            return Sse::CmpAllGt(arg1, arg2, 0b0001);
         }
 
 
         AZ_MATH_INLINE bool Vec1::CmpAllGtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGtEq(arg1, arg2, 0x000F);
+            return Sse::CmpAllGtEq(arg1, arg2, 0b0001);
         }
 
 
@@ -397,7 +398,7 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec1::CmpAllEq(Int32ArgType arg1, Int32ArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0x000F);
+            return Sse::CmpAllEq(arg1, arg2, 0b0001);
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec2_sse.inl
@@ -383,31 +383,32 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec2::CmpAllEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0x00FF);
+            // Only check the first two bits for Vector2
+            return Sse::CmpAllEq(arg1, arg2, 0b0011);
         }
 
 
         AZ_MATH_INLINE bool Vec2::CmpAllLt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLt(arg1, arg2, 0x00FF);
+            return Sse::CmpAllLt(arg1, arg2, 0b0011);
         }
 
 
         AZ_MATH_INLINE bool Vec2::CmpAllLtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLtEq(arg1, arg2, 0x00FF);
+            return Sse::CmpAllLtEq(arg1, arg2, 0b0011);
         }
 
 
         AZ_MATH_INLINE bool Vec2::CmpAllGt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGt(arg1, arg2, 0x00FF);
+            return Sse::CmpAllGt(arg1, arg2, 0b0011);
         }
 
 
         AZ_MATH_INLINE bool Vec2::CmpAllGtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGtEq(arg1, arg2, 0x00FF);
+            return Sse::CmpAllGtEq(arg1, arg2, 0b0011);
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_sse.inl
@@ -419,31 +419,32 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec3::CmpAllEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0x0FFF);
+            // Only check the first three bits for Vector3
+            return Sse::CmpAllEq(arg1, arg2, 0b0111);
         }
 
 
         AZ_MATH_INLINE bool Vec3::CmpAllLt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLt(arg1, arg2, 0x0FFF);
+            return Sse::CmpAllLt(arg1, arg2, 0b0111);
         }
 
 
         AZ_MATH_INLINE bool Vec3::CmpAllLtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLtEq(arg1, arg2, 0x0FFF);
+            return Sse::CmpAllLtEq(arg1, arg2, 0b0111);
         }
 
 
         AZ_MATH_INLINE bool Vec3::CmpAllGt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGt(arg1, arg2, 0x0FFF);
+            return Sse::CmpAllGt(arg1, arg2, 0b0111);
         }
 
 
         AZ_MATH_INLINE bool Vec3::CmpAllGtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGtEq(arg1, arg2, 0x0FFF);
+            return Sse::CmpAllGtEq(arg1, arg2, 0b0111);
         }
 
 
@@ -485,7 +486,7 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec3::CmpAllEq(Int32ArgType arg1, Int32ArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0x0FFF);
+            return Sse::CmpAllEq(arg1, arg2, 0b0111);
         }
 
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec4_sse.inl
@@ -455,31 +455,32 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec4::CmpAllEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0xFFFF);
+            // Check the first four bits for Vector4
+            return Sse::CmpAllEq(arg1, arg2, 0b1111);
         }
 
 
         AZ_MATH_INLINE bool Vec4::CmpAllLt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLt(arg1, arg2, 0xFFFF);
+            return Sse::CmpAllLt(arg1, arg2, 0b1111);
         }
 
 
         AZ_MATH_INLINE bool Vec4::CmpAllLtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllLtEq(arg1, arg2, 0xFFFF);
+            return Sse::CmpAllLtEq(arg1, arg2, 0b1111);
         }
 
 
         AZ_MATH_INLINE bool Vec4::CmpAllGt(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGt(arg1, arg2, 0xFFFF);
+            return Sse::CmpAllGt(arg1, arg2, 0b1111);
         }
 
 
         AZ_MATH_INLINE bool Vec4::CmpAllGtEq(FloatArgType arg1, FloatArgType arg2)
         {
-            return Sse::CmpAllGtEq(arg1, arg2, 0xFFFF);
+            return Sse::CmpAllGtEq(arg1, arg2, 0b1111);
         }
 
 
@@ -521,7 +522,7 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec4::CmpAllEq(Int32ArgType arg1, Int32ArgType arg2)
         {
-            return Sse::CmpAllEq(arg1, arg2, 0xFFFF);
+            return Sse::CmpAllEq(arg1, arg2, 0b1111);
         }
 
 


### PR DESCRIPTION
This fixes an issue that was causing unit tests to fail on Linux in profile
builds with clang 12, specifically the `MATH_Vector2.TestReciprocal`
test:

```
TEST(MATH_Vector2, TestReciprocal)
{
    AZ_TEST_ASSERT(Vector2(2.0f, 4.0f).GetReciprocal().IsClose(Vector2(0.5f, 0.25f)));
    AZ_TEST_ASSERT(Vector2(2.0f, 4.0f).GetReciprocalEstimate().IsClose(Vector2(0.5f, 0.25f)));
}
```

The second test, `GetReciprocalEstimate()`, is the one that was failing.
`GetReciprocalEstimate()` would return the same value in both clang 6 and
clang 12, but clang 12 would generate different code for `IsClose()`.

`IsClose(Vector2 a, Vector2 b, float tolerance)` works like this:
* subtract b from a, and take the absolute value of the result, store in c
* check that all the elements of c are less than the tolerance

The less than comparison done in `IsClose()` uses simd registers and sse
instructions to vectorize the comparisons. That is done in the function
`Simd::Vec2::CmpAllLtEq`, which on Linux uses the SSE implementation. The
previous implementation was this:

```cpp
AZ_MATH_INLINE bool CmpAllLtEq(__m128 arg1, __m128 arg2, int32_t mask)
{
    const __m128i compare = CastToInt(CmpGt(arg1, arg2));
    return (_mm_movemask_epi8(compare) & mask) == 0;
}
```

This function is used by all 4 vector types. It uses the same instructions
to test a Vector2 as it does a Vector4, and uses the `mask` parameter to
determine which floats from the vector to include in the test.

On clang 6, this function would generate the following instructions:
```asm
cmpltps  xmm0, xmm1
pmovmskb ecx, xmm0
xor      eax, eax
test     cl, cl
```

* `cmpltps` compares the 4 floats in `xmm0` and `xmm1`. If
  `xmm0[0] < xmm1[0]`, it writes `0x00000000` to `xmm0[0]`. Otherwise, it
  writes `0xFFFFFFFF` to `xmm0[0]`. It repeats that for all 4 floats.
* `pmovmskb` creates a mask made up of the most significant bit of each
  byte of the source operand and stores the result in the low byte
  of the destination operand. For our use case, using it on the result of
  `cmpltps`, the result is 4 `1` bits for each element that returned true
  in the cmp, and 4 `0` bits otherwise

So if we have some example:
vector a is (0.50, 0.25, 0.1, 0.1)
vector b is (0.49, 0.25, 0.1, 0.0)
`cmpltps` will produce:
`0xffffffff`, `0x00000000`, `0x00000000`, `0xffffffff`
Then `pmovmskb` will produce:
`0x00f00f`

On clang 12, the same function would generate these instructions:
```asm
cmpltps  xmm0, xmm1
movmskps ecx, xmm0
xor      eax, eax
test     ecx, ecx
```

The `cmpltps` is the same, but the mask instruction used is `movmskps`.
This instruction extracts just the sign bits from the floating-point
values in the source and formats them into a 4-bit mask. So taking the same
example:
vector a is (0.50, 0.25, 0.1, 0.1)
vector b is (0.49, 0.25, 0.1, 0.0)
`cmpltps` will produce:
`0xffffffff`, `0x00000000`, `0x00000000`, `0xffffffff`
Then `movmskps` will produce:
`0b00000000000000000000000000001001`

This happens due to LLVM commit [0741b75ad543d108759c0658fedb5fdfcf064487](https://reviews.llvm.org/rG0741b75ad543d108759c0658fedb5fdfcf064487):
> [X86][SSE] Attempt to widen MOVMSK vector input if the signbits are splatted.
> As shown on PR37087, if we have a MOVMSK(BICAST(X)) from a wider vector, then by using MOVMSK from the wider type (32/64-bit elements) we can improve the chances of further combines with SimplifyDemandedBits/Elts and on some targets (skylake) can be more efficient.

That change in clang will conditionally transform what would've been a call to
`pmovmskb` to be a call to `movmskps` instead. This change results in a
`movmskps` instruction always, in both clang and MSVC.

The masks used by each vector type was updated to have only 1 bit per
used element: for Vector1, it is `0b0001`, for Vector 2, it is `0b0011`,
etc.

In addition, the previous version of the code implemented a
less-than-or-equal-to comparison using the greater-than intrinsic, and
checking if the result was false. This new version implements
less-than-or-equal-to using the less-than-or-equal-to intrinsic, and checks
if the result is true.

Signed-off-by: Chris Burel <burelc@amazon.com>