### PR TITLE
Enable Atom CullingScene to use TaskGraph

### DIFF
--- a/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskExecutor.cpp
@@ -363,7 +363,11 @@ namespace AZ
     {
         ++m_graphsRemaining;
 
-        event->m_executor = this; // Used to validate event is not waited for inside a job
+        if (event)
+        {
+            event->IncWaitCount();
+            event->m_executor = this; // Used to validate event is not waited for inside a job
+        }
 
         // Submit all tasks that have no inbound edges
         for (Internal::Task& task : graph.Tasks())

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -20,6 +20,41 @@ namespace AZ
         m_semaphore.acquire();
     }
 
+    void TaskGraphEvent::IncWaitCount()
+    {
+        int expectedValue = 0; // guess zero to optimize for single task graph using an event, if multiple are using it then this will take 2+ comp_exch calls
+        while(!m_waitCount.compare_exchange_weak(expectedValue, expectedValue + 1))
+        {
+            AZ_Assert(expectedValue >= 0, "Called TaskGraphEvent::IncWaitCount on a signalled event"); // value will be negative once event is ready to signal or has been signaled. Shouldn't happen.
+            if (expectedValue < 0) // event already signaled, skip
+            {
+                return;
+            }
+        };
+    }
+
+    void TaskGraphEvent::Signal()
+    {
+        int expectedValue = 1; // guess one to optimize for single task graph using an event, if multiple are using it then this will take 2+ comp_exch calls
+        while(!m_waitCount.compare_exchange_weak(expectedValue, expectedValue - 1))
+        {
+            AZ_Assert(expectedValue > 0, "Called TaskGraphEvent::Signal when event is either signaled or unused"); // It's an error for Signal to be called if no one is waiting, or the event has already been signaled
+            if (expectedValue < 0) // return if already signaled
+            {
+                return;
+            }
+        };
+
+        if (expectedValue == 1) // This call decremented the value to 0.
+        {
+            expectedValue = 0;
+            if (m_waitCount.compare_exchange_strong(expectedValue, -1)) // validate no one incremented the wait count and mark signalling state
+            {
+                m_semaphore.release();
+            }
+        }
+    }
+
     void TaskToken::PrecedesInternal(TaskToken& comesAfter)
     {
         AZ_Assert(!m_parent.m_submitted, "Cannot mutate a TaskGraph that was previously submitted.");

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.cpp
@@ -22,10 +22,12 @@ namespace AZ
 
     void TaskGraphEvent::IncWaitCount()
     {
-        int expectedValue = 0; // guess zero to optimize for single task graph using an event, if multiple are using it then this will take 2+ comp_exch calls
+        // guess zero to optimize for single task graph using an event, if multiple are using it then this will take 2+ comp_exch calls
+        int expectedValue = 0;
         while(!m_waitCount.compare_exchange_weak(expectedValue, expectedValue + 1))
         {
-            AZ_Assert(expectedValue >= 0, "Called TaskGraphEvent::IncWaitCount on a signalled event"); // value will be negative once event is ready to signal or has been signaled. Shouldn't happen.
+             // value will be negative once event is ready to signal or has been signaled. Shouldn't happen.
+            AZ_Assert(expectedValue >= 0, "Called TaskGraphEvent::IncWaitCount on a signalled event");
             if (expectedValue < 0) // event already signaled, skip
             {
                 return;
@@ -35,20 +37,23 @@ namespace AZ
 
     void TaskGraphEvent::Signal()
     {
-        int expectedValue = 1; // guess one to optimize for single task graph using an event, if multiple are using it then this will take 2+ comp_exch calls
+        // guess one to optimize for single task graph using an event, if multiple are using it then this will take 2+ comp_exch calls
+        int expectedValue = 1;
         while(!m_waitCount.compare_exchange_weak(expectedValue, expectedValue - 1))
         {
-            AZ_Assert(expectedValue > 0, "Called TaskGraphEvent::Signal when event is either signaled or unused"); // It's an error for Signal to be called if no one is waiting, or the event has already been signaled
+            // It's an error for Signal to be called if no one is waiting, or the event has already been signaled
+            AZ_Assert(expectedValue > 0, "Called TaskGraphEvent::Signal when event is either signaled or unused");
             if (expectedValue < 0) // return if already signaled
             {
                 return;
             }
         };
 
-        if (expectedValue == 1) // This call decremented the value to 0.
+        if (expectedValue == 1) // This call to Signal decremented the value to 0.
         {
             expectedValue = 0;
-            if (m_waitCount.compare_exchange_strong(expectedValue, -1)) // validate no one incremented the wait count and mark signalling state
+            // validate no one incremented the wait count and mark signalling state
+            if (m_waitCount.compare_exchange_strong(expectedValue, -1))
             {
                 m_semaphore.release();
             }

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -81,9 +81,11 @@ namespace AZ
         friend class TaskGraph;
         friend class TaskExecutor;
 
+        void IncWaitCount();
         void Signal();
 
         AZStd::binary_semaphore m_semaphore;
+        AZStd::atomic_int   m_waitCount = 0;
         TaskExecutor* m_executor = nullptr;
     };
 

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.h
@@ -61,14 +61,14 @@ namespace AZ
         uint32_t m_index;
     };
 
-    // A TaskGraphEvent may be used to block until a task graph has finished executing. Usage
+    // A TaskGraphEvent may be used to block until one or more task graphs has finished executing. Usage
     // is NOT recommended for the majority of tasks (prefer to simply containing expanding/contracting
     // the graph without synchronization over the course of the frame). However, the event
     // is useful for the edges of the computation graph.
     //
     // You are responsible for ensuring the event object lifetime exceeds the task graph lifetime.
     //
-    // After the TaskGraphEvent is signaled, you are allowed to reuse the same TaskGraphEvent
+    // After the TaskGraphEvent is signaled, you are NOT allowed to reuse the same TaskGraphEvent
     // for a future submission.
     class TaskGraphEvent
     {
@@ -85,8 +85,8 @@ namespace AZ
         void Signal();
 
         AZStd::binary_semaphore m_semaphore;
-        AZStd::atomic_int   m_waitCount = 0;
-        TaskExecutor* m_executor = nullptr;
+        AZStd::atomic_int       m_waitCount = 0;
+        TaskExecutor*           m_executor = nullptr;
     };
 
     // The TaskGraph encapsulates a set of tasks and their interdependencies. After adding

--- a/Code/Framework/AzCore/AzCore/Task/TaskGraph.inl
+++ b/Code/Framework/AzCore/AzCore/Task/TaskGraph.inl
@@ -33,11 +33,6 @@ namespace AZ
         return m_semaphore.try_acquire_for(AZStd::chrono::milliseconds{ 0 });
     }
 
-    inline void TaskGraphEvent::Signal()
-    {
-        m_semaphore.release();
-    }
-
     template<typename Lambda>
     TaskToken TaskGraph::AddTask(TaskDescriptor const& desc, Lambda&& lambda)
     {

--- a/Code/Framework/AzCore/Tests/TaskTests.cpp
+++ b/Code/Framework/AzCore/Tests/TaskTests.cpp
@@ -610,15 +610,16 @@ namespace UnitTest
         g.Follows(e, f);
         g.Precedes(d);
 
-        TaskGraphEvent ev;
-        graph.SubmitOnExecutor(*m_executor, &ev);
-        ev.Wait();
+        TaskGraphEvent ev1;
+        graph.SubmitOnExecutor(*m_executor, &ev1);
+        ev1.Wait();
 
         EXPECT_EQ(3 | 0b100000, x);
         x = 0;
 
-        graph.SubmitOnExecutor(*m_executor, &ev);
-        ev.Wait();
+        TaskGraphEvent ev2;
+        graph.SubmitOnExecutor(*m_executor, &ev2);
+        ev2.Wait();
 
         EXPECT_EQ(3 | 0b100000, x);
     }

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -29,6 +29,8 @@
 #include <AzCore/Script/ScriptContextAttributes.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
+#include <AzCore/Task/TaskGraph.h>
+
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
@@ -50,6 +52,15 @@ namespace AZ
             "Sets the compression level for saving png screenshots. Valid values are from 0 to 8"
         );
 
+        AZ_CVAR(int,
+            r_pngCompressionNumThreads,
+            8, // Number of threads to use for the png r<->b channel data swap
+            nullptr,
+            ConsoleFunctorFlags::Null,
+            "Sets the number of threads for saving png screenshots. Valid values are from 1 to 128, although less than or equal the number of hw threads is recommended"
+        );
+
+
         FrameCaptureOutputResult PngFrameCaptureOutput(
             const AZStd::string& outputFilePath, const AZ::RPI::AttachmentReadback::ReadbackResult& readbackResult)
         {
@@ -65,33 +76,67 @@ namespace AZ
 
                 buffer = AZStd::make_shared<AZStd::vector<uint8_t>>(readbackResult.m_dataBuffer->size());
                 AZStd::copy(readbackResult.m_dataBuffer->begin(), readbackResult.m_dataBuffer->end(), buffer->begin());
-
-                AZ::JobCompletion jobCompletion;
-                const int numThreads = 8;
+                const int numThreads = r_pngCompressionNumThreads;
                 const int numPixelsPerThread = static_cast<int>(buffer->size() / numChannels / numThreads);
-                for (int i = 0; i < numThreads; ++i)
+
+                AZ::TaskGraphActiveInterface* taskGraphActiveInterface = AZ::Interface<AZ::TaskGraphActiveInterface>::Get();
+                bool taskGraphActive = taskGraphActiveInterface && taskGraphActiveInterface->IsTaskGraphActive();
+
+                if (taskGraphActive)
                 {
-                    int startPixel = i * numPixelsPerThread;
+                    static AZ::TaskDescriptor pngTaskDescriptor{"PngWriteOutChannelSwap", "Graphics"};
+                    AZ::TaskGraph taskGraph;
+                    for (int i = 0; i < numThreads; ++i)
+                    {
+                        int startPixel = i * numPixelsPerThread;
 
-                    AZ::Job* job = AZ::CreateJobFunction(
-                        [&, startPixel, numPixelsPerThread]()
-                        {
-                            for (int pixelOffset = 0; pixelOffset < numPixelsPerThread; ++pixelOffset)
+                        taskGraph.AddTask(
+                            pngTaskDescriptor,
+                            [&, startPixel, numPixelsPerThread]()
                             {
-                                if (startPixel * numChannels + numChannels < buffer->size())
+                                for (int pixelOffset = 0; pixelOffset < numPixelsPerThread; ++pixelOffset)
                                 {
-                                    AZStd::swap(
-                                        buffer->data()[(startPixel + pixelOffset) * numChannels],
-                                        buffer->data()[(startPixel + pixelOffset) * numChannels + 2]
-                                    );
+                                    if (startPixel * numChannels + numChannels < buffer->size())
+                                    {
+                                        AZStd::swap(
+                                            buffer->data()[(startPixel + pixelOffset) * numChannels],
+                                            buffer->data()[(startPixel + pixelOffset) * numChannels + 2]
+                                        );
+                                    }
                                 }
-                            }
-                        }, true, nullptr);
-
-                    job->SetDependent(&jobCompletion);
-                    job->Start();
+                            });
+                    }
+                    AZ::TaskGraphEvent taskGraphFinishedEvent;
+                    taskGraph.Submit(&taskGraphFinishedEvent);
+                    taskGraphFinishedEvent.Wait();
                 }
-                jobCompletion.StartAndWaitForCompletion();
+                else
+                {
+                    AZ::JobCompletion jobCompletion;
+                    for (int i = 0; i < numThreads; ++i)
+                    {
+                        int startPixel = i * numPixelsPerThread;
+
+                        AZ::Job* job = AZ::CreateJobFunction(
+                            [&, startPixel, numPixelsPerThread]()
+                            {
+                                for (int pixelOffset = 0; pixelOffset < numPixelsPerThread; ++pixelOffset)
+                                {
+                                    if (startPixel * numChannels + numChannels < buffer->size())
+                                    {
+                                        AZStd::swap(
+                                            buffer->data()[(startPixel + pixelOffset) * numChannels],
+                                            buffer->data()[(startPixel + pixelOffset) * numChannels + 2]
+                                        );
+                                    }
+                                }
+                            }, true, nullptr);
+
+                        job->SetDependent(&jobCompletion);
+                        job->Start();
+                    }
+                    jobCompletion.StartAndWaitForCompletion();
+                }
             }
 
             Utils::PngFile image = Utils::PngFile::Create(readbackResult.m_imageDescriptor.m_size, format, *buffer);

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -92,7 +92,7 @@ namespace AZ
 
                         taskGraph.AddTask(
                             pngTaskDescriptor,
-                            [&, startPixel, numPixelsPerThread]()
+                            [&, startPixel]()
                             {
                                 for (int pixelOffset = 0; pixelOffset < numPixelsPerThread; ++pixelOffset)
                                 {
@@ -118,7 +118,7 @@ namespace AZ
                         int startPixel = i * numPixelsPerThread;
 
                         AZ::Job* job = AZ::CreateJobFunction(
-                            [&, startPixel, numPixelsPerThread]()
+                            [&, startPixel]()
                             {
                                 for (int pixelOffset = 0; pixelOffset < numPixelsPerThread; ++pixelOffset)
                                 {

--- a/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/FrameCaptureSystemComponent.cpp
@@ -84,7 +84,7 @@ namespace AZ
 
                 if (taskGraphActive)
                 {
-                    static AZ::TaskDescriptor pngTaskDescriptor{"PngWriteOutChannelSwap", "Graphics"};
+                    static const AZ::TaskDescriptor pngTaskDescriptor{"PngWriteOutChannelSwap", "Graphics"};
                     AZ::TaskGraph taskGraph;
                     for (int i = 0; i < numThreads; ++i)
                     {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -39,6 +39,7 @@ namespace AZ
 {
     class Job;
     class TaskGraphActiveInterface;
+    class TaskGraph;
 
     namespace RHI
     {
@@ -257,7 +258,13 @@ namespace AZ
             //! Must be called between BeginCulling() and EndCulling(), once for each active scene/view pair.
             //! Will create child jobs under the parentJob to do the processing in parallel.
             //! Can be called in parallel (i.e. to perform culling on multiple views at the same time).
-            void ProcessCullables(const Scene& scene, View& view, AZ::Job& parentJob);
+            void ProcessCullablesJobs(const Scene& scene, View& view, AZ::Job& parentJob);
+
+            //! Performs render culling and lod selection for a View, then adds the visible renderpackets to that View.
+            //! Must be called between BeginCulling() and EndCulling(), once for each active scene/view pair.
+            //! Will create child task graphs that signal the TaskGraphEvent to do the processing in parallel.
+            //! Can be called in parallel (i.e. to perform culling on multiple views at the same time).
+            void ProcessCullablesTG(const Scene& scene, View& view, AZ::TaskGraph& taskGraph);
 
             //! Adds a Cullable to the underlying visibility system(s).
             //! Must be called at least once on initialization and whenever a Cullable's position or bounds is changed.
@@ -277,15 +284,13 @@ namespace AZ
                 return m_debugCtx;
             }
 
-            static const size_t WorkListCapacity = 5;
-            using WorkListType = AZStd::fixed_vector<AzFramework::IVisibilityScene::NodeData, WorkListCapacity>;
-
         protected:
             size_t CountObjectsInScene();
 
         private:
             void BeginCullingTaskGraph(const AZStd::vector<ViewPtr>& views);
             void BeginCullingJobs(const AZStd::vector<ViewPtr>& views);
+            void ProcessCullablesCommon(const Scene& scene, View& view, AZ::Frustum& frustum, void*& maskedOcclusionCulling);
 
             const Scene* m_parentScene = nullptr;
             AzFramework::IVisibilityScene* m_visScene = nullptr;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Culling.h
@@ -38,6 +38,7 @@
 namespace AZ
 {
     class Job;
+    class TaskGraphActiveInterface;
 
     namespace RHI
     {
@@ -282,11 +283,16 @@ namespace AZ
         protected:
             size_t CountObjectsInScene();
 
+        private:
+            void BeginCullingTaskGraph(const AZStd::vector<ViewPtr>& views);
+            void BeginCullingJobs(const AZStd::vector<ViewPtr>& views);
+
             const Scene* m_parentScene = nullptr;
             AzFramework::IVisibilityScene* m_visScene = nullptr;
             CullingDebugContext m_debugCtx;
             AZStd::concurrency_checker m_cullDataConcurrencyCheck;
             OcclusionPlaneVector m_occlusionPlanes;
+            AZ::TaskGraphActiveInterface* m_taskGraphActive = nullptr;
         };
         
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -200,8 +200,8 @@ namespace AZ
             // This function is called every time scene's render pipelines change.
             void RebuildPipelineStatesLookup();
 
-            // Helper function to wait for end of TaskGraph
-            void WaitTGEvent(AZ::TaskGraphEvent& completionTGEvent, AZStd::atomic_bool* workToWaitOn = nullptr);
+            // Helper function to wait for end of TaskGraph and then delete the TaskGraphEvent
+            void WaitAndCleanTGEvent(AZ::TaskGraphEvent*& completionTGEvent);
 
             // Helper function for wait and clean up a completion job
             void WaitAndCleanCompletionJob(AZ::JobCompletion*& completionJob);
@@ -230,8 +230,7 @@ namespace AZ
             AZStd::vector<RenderPipelinePtr> m_pipelines;
 
             // CPU simulation TaskGraphEvent to wait for completion of all the simulation tasks
-            AZ::TaskGraphEvent m_simulationFinishedTGEvent;
-            AZStd::atomic_bool m_simulationFinishedWorkActive = false;
+            AZ::TaskGraphEvent* m_simulationFinishedTGEvent = nullptr;
 
             // CPU simulation job completion for track all feature processors' simulation jobs
             AZ::JobCompletion* m_simulationCompletion = nullptr;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -201,7 +201,7 @@ namespace AZ
             void RebuildPipelineStatesLookup();
 
             // Helper function to wait for end of TaskGraph and then delete the TaskGraphEvent
-            void WaitAndCleanTGEvent(AZ::TaskGraphEvent*& completionTGEvent);
+            void WaitAndCleanTGEvent(AZStd::unique_ptr<AZ::TaskGraphEvent>&& completionTGEvent);
 
             // Helper function for wait and clean up a completion job
             void WaitAndCleanCompletionJob(AZ::JobCompletion*& completionJob);
@@ -230,7 +230,7 @@ namespace AZ
             AZStd::vector<RenderPipelinePtr> m_pipelines;
 
             // CPU simulation TaskGraphEvent to wait for completion of all the simulation tasks
-            AZ::TaskGraphEvent* m_simulationFinishedTGEvent = nullptr;
+            AZStd::unique_ptr<AZ::TaskGraphEvent> m_simulationFinishedTGEvent;
 
             // CPU simulation job completion for track all feature processors' simulation jobs
             AZ::JobCompletion* m_simulationCompletion = nullptr;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -301,13 +301,7 @@ namespace AZ
         using WorkListType = AZStd::fixed_vector<AzFramework::IVisibilityScene::NodeData, WorkListCapacity>;
 
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-        enum CullingResult : uint8_t
-        {
-            Visible    = 0x0,
-            Occluded   = 0x1,
-            ViewCulled = 0x3
-        };
-        static CullingResult TestOcclusionCulling(
+        static MaskedOcclusionCulling::CullingResult TestOcclusionCulling(
                     const AZStd::shared_ptr<WorklistData>& worklistData, 
                     AzFramework::VisibilityEntry* visibleEntry);
 #endif
@@ -352,7 +346,7 @@ namespace AZ
                                 }
 
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-                                if (TestOcclusionCulling(worklistData, visibleEntry) == CullingResult::Visible)
+                                if (TestOcclusionCulling(worklistData, visibleEntry) == MaskedOcclusionCulling::CullingResult::VISIBLE)
 #endif
                                 {
                                     numDrawPackets += AddLodDataToView(c->m_cullData.m_boundingSphere.GetCenter(), c->m_lodData, *worklistData->m_view);
@@ -388,7 +382,7 @@ namespace AZ
                             else if (res == IntersectResult::Interior || ShapeIntersection::Overlaps(worklistData->m_frustum, c->m_cullData.m_boundingObb))
                             {
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-                                if (TestOcclusionCulling(worklistData, visibleEntry) == CullingResult::Visible)
+                                if (TestOcclusionCulling(worklistData, visibleEntry) == MaskedOcclusionCulling::CullingResult::VISIBLE)
 #endif
                                 {
                                     numDrawPackets += AddLodDataToView(c->m_cullData.m_boundingSphere.GetCenter(), c->m_lodData, *worklistData->m_view);
@@ -465,19 +459,19 @@ namespace AZ
         }
 
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
-        static CullingResult TestOcclusionCulling(
+        static MaskedOcclusionCulling::CullingResult TestOcclusionCulling(
             const AZStd::shared_ptr<WorklistData>& worklistData, 
             AzFramework::VisibilityEntry* visibleEntry)
         {
             if (!worklistData->m_maskedOcclusionCulling)
             {
-                return CullingResult::Visible;
+                return MaskedOcclusionCulling::CullingResult::VISIBLE;
             }
 
             if (visibleEntry->m_boundingVolume.Contains(worklistData->m_view->GetCameraTransform().GetTranslation()))
             {
                 // camera is inside bounding volume
-                return CullingResult::Visible;
+                return MaskedOcclusionCulling::CullingResult::VISIBLE;
             }
 
             const Vector3& minBound = visibleEntry->m_boundingVolume.GetMin();
@@ -505,7 +499,7 @@ namespace AZ
                 minDepth = AZStd::min(minDepth, corners[index].GetW());
                 if (minDepth < 0.00000001f)
                 {
-                    return CullingResult::Visible;
+                    return MaskedOcclusionCulling::CullingResult::VISIBLE;
                 }
 
 
@@ -519,7 +513,7 @@ namespace AZ
             }
 
             // test against the occlusion buffer, which contains only the manually placed occlusion planes
-            return static_cast<CullingResult>(worklistData->m_maskedOcclusionCulling->TestRect(ndcMinX, ndcMinY, ndcMaxX, ndcMaxY, minDepth));
+            return worklistData->m_maskedOcclusionCulling->TestRect(ndcMinX, ndcMinY, ndcMaxX, ndcMaxY, minDepth);
         }
 #endif
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -111,7 +111,7 @@ namespace AZ
         {
             if (m_taskGraphActive)
             {
-                WaitAndCleanTGEvent(m_simulationFinishedTGEvent);
+                WaitAndCleanTGEvent(AZStd::move(m_simulationFinishedTGEvent));
             }
             else
             {
@@ -385,8 +385,8 @@ namespace AZ
                     });
             }
             simulationTG.Detach();
-            m_simulationFinishedTGEvent = new AZ::TaskGraphEvent;
-            simulationTG.Submit(m_simulationFinishedTGEvent);
+            m_simulationFinishedTGEvent = AZStd::make_unique<TaskGraphEvent>();
+            simulationTG.Submit(m_simulationFinishedTGEvent.get());
         }
 
         void Scene::SimulateJobs()
@@ -419,7 +419,7 @@ namespace AZ
             // If previous simulation job wasn't done, wait for it to finish.
             if (m_taskGraphActive)
             {
-                WaitAndCleanTGEvent(m_simulationFinishedTGEvent);
+                WaitAndCleanTGEvent(AZStd::move(m_simulationFinishedTGEvent));
             }
             else
             {
@@ -449,15 +449,14 @@ namespace AZ
             }
         }
 
-        void Scene::WaitAndCleanTGEvent(AZ::TaskGraphEvent*& completionTGEvent)
+        void Scene::WaitAndCleanTGEvent(AZStd::unique_ptr<AZ::TaskGraphEvent>&&  completionTGEvent)
         {
             AZ_PROFILE_SCOPE(RPI, "Scene: WaitAndCleanTGEvent");
             if (completionTGEvent)
             {
                 completionTGEvent->Wait();
-                delete completionTGEvent;
-                completionTGEvent = nullptr;
             }
+            // allow completionTGEvent to go out of scope and be deleted
         }
 
         void Scene::WaitAndCleanCompletionJob(AZ::JobCompletion*& completionJob)
@@ -646,7 +645,7 @@ namespace AZ
 
             if (m_taskGraphActive)
             {
-                WaitAndCleanTGEvent(m_simulationFinishedTGEvent);
+                WaitAndCleanTGEvent(AZStd::move(m_simulationFinishedTGEvent));
             }
             else
             {


### PR DESCRIPTION
Enable use of TaskGraph in the png capture code.
Enable TaskGraphEvents to wait for multiple TaskGraphs to complete.