### PR TITLE
Fixed memory leak of the in the AssetBrowserComponent

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -102,7 +102,7 @@ namespace AzToolsFramework
             AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
             AZ::TickBus::Handler::BusDisconnect();
             AssetSystemBus::Handler::BusDisconnect();
-            m_assetBrowserModel.release();
+            m_assetBrowserModel.reset();
             EntryCache::DestroyInstance();
         }
 


### PR DESCRIPTION
There seemed to be a memory leak in the AssetBrowserComponent. It was calling `release` instead of `reset` in `m_assetBrowserModel` so it wasn´t really being deleted.