### PR TITLE
Fix 'focus' text appearing when it shouldn't

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/InvalidClicks.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/InvalidClicks.h
@@ -80,8 +80,9 @@ namespace AzToolsFramework
 
     private:
         AZStd::string m_message; //!< Message to display for fading text.
-        float m_opacity = 1.0f; //!< The opacity of the invalid click message.
-        AzFramework::ScreenPoint m_invalidClickPosition; //!< The position to display the invalid click message.
+        float m_opacity = 0.0f; //!< The opacity of the invalid click message.
+        //! The position to display the invalid click message.
+        AzFramework::ScreenPoint m_invalidClickPosition = AzFramework::ScreenPoint(0, 0);
     };
 
     //! Interface to begin invalid click feedback (will run all added InvalidClick behaviors).


### PR DESCRIPTION
This was a total [_schoolboy error_](https://www.urbandictionary.com/define.php?term=Schoolboy%20Error) on my part, I'd not initialized the object state correctly 🙈

Depending on the random bits that happened to be in `m_invalidClickPosition`, the message may get displayed on screen or not. The initial opacity should also _not_ have been set to `1.0`.