### PR TITLE
Fix bug in LocalFileIO::ConvertToAliasBuffer when a resolved alias ends in a path separator.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -651,7 +651,10 @@ namespace AZ
                     // Check if the input path is relative to the alias value
                     if (AZ::IO::PathView(inBuffer).IsRelativeTo(AZ::IO::PathView(resolvedAlias)))
                     {
-                        longestMatch = resolvedAlias.size();
+                        // If the resolved alias ends in a path separator, do not consume it.
+                        const bool resolvedAliasEndsInPathSeparator = (resolvedAlias.ends_with(AZ::IO::PosixPathSeparator) ||
+                                                                       resolvedAlias.ends_with(AZ::IO::WindowsPathSeparator));
+                        longestMatch = resolvedAliasEndsInPathSeparator ? resolvedAlias.size() - 1 : resolvedAlias.size();
                         longestAlias = alias;
                     }
                 }

--- a/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
+++ b/Code/Framework/AzFramework/AzFramework/IO/LocalFileIO.cpp
@@ -635,6 +635,7 @@ namespace AZ
             size_t longestMatch = 0;
             size_t bufStringLength = inBuffer.size();
             AZStd::string_view longestAlias;
+            AZStd::string_view longestResolvedAlias;
 
             for (const auto& [alias, resolvedAlias] : m_aliases)
             {
@@ -651,11 +652,9 @@ namespace AZ
                     // Check if the input path is relative to the alias value
                     if (AZ::IO::PathView(inBuffer).IsRelativeTo(AZ::IO::PathView(resolvedAlias)))
                     {
-                        // If the resolved alias ends in a path separator, do not consume it.
-                        const bool resolvedAliasEndsInPathSeparator = (resolvedAlias.ends_with(AZ::IO::PosixPathSeparator) ||
-                                                                       resolvedAlias.ends_with(AZ::IO::WindowsPathSeparator));
-                        longestMatch = resolvedAliasEndsInPathSeparator ? resolvedAlias.size() - 1 : resolvedAlias.size();
+                        longestMatch = resolvedAlias.size();
                         longestAlias = alias;
+                        longestResolvedAlias = resolvedAlias;
                     }
                 }
             }
@@ -664,7 +663,10 @@ namespace AZ
                 // rearrange the buffer to have
                 // [alias][old path]
                 size_t aliasSize = longestAlias.size();
-                size_t charsToAbsorb = longestMatch;
+                // If the resolved alias ends in a path separator, do not consume it.
+                const bool resolvedAliasEndsInPathSeparator = (longestResolvedAlias.ends_with(AZ::IO::PosixPathSeparator) ||
+                                                               longestResolvedAlias.ends_with(AZ::IO::WindowsPathSeparator));
+                const size_t charsToAbsorb = resolvedAliasEndsInPathSeparator ? longestMatch - 1 : longestMatch;
                 size_t remainingData = bufStringLength - charsToAbsorb;
                 size_t finalStringSize = aliasSize + remainingData;
                 if (finalStringSize >= outBufferLength)


### PR DESCRIPTION
Fix bug in LocalFileIO::ConvertToAliasBuffer when a resolved alias ends in a path separator, in which case we do not want to consume it when replacing it with the alias.

eg. If the @products@ alias resolves to "C:\\" and we call ConvertToAliasBuffer with "C:\\some_folder\\some_file.txt", the current behaviour results in "@products@some_folder\\some_file.txt", but it needs to be "@products@\\some_folder\\some_file.txt"

Signed-off-by: bosnichd <bosnichd@amazon.com>