### PR TITLE
Add benchmarks for SpawnAllEntities call in SpawnableEntitiesManager

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#if defined(HAVE_BENCHMARK)
+
+#include <Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <AzToolsFramework/Prefab/Spawnable/SpawnableUtils.h>
+
+namespace Benchmark
+{
+    using BM_SpawnAllEntities = BM_Spawnable;
+
+    BENCHMARK_DEFINE_F(BM_SpawnAllEntities, SingleEntitySpawnable_SpawnCallVariable)(::benchmark::State& state)
+    {
+        const unsigned int spawnAllEntitiesCallCount = static_cast<unsigned int>(state.range());
+
+        CreateSpawnable(1);
+
+        for (auto _ : state)
+        {
+            m_spawnTicket = new AzFramework::EntitySpawnTicket(m_spawnableAsset);
+
+            for (unsigned int spwanableCounter = 0; spwanableCounter < spawnAllEntitiesCallCount; spwanableCounter++)
+            {
+                AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
+            }
+
+            m_rootSpawnableInterface->ProcessSpawnableQueue();
+
+            // Destroy the ticket so that this queues a request to delete all the entities spawned with this ticket.
+            state.PauseTiming();
+            delete m_spawnTicket;
+            m_spawnTicket = nullptr;
+
+            // This will process the request to delete all entities spawned with the ticket
+            m_rootSpawnableInterface->ProcessSpawnableQueue();
+            state.ResumeTiming();
+        }
+
+        state.SetComplexityN(spawnAllEntitiesCallCount);
+    }
+    BENCHMARK_REGISTER_F(BM_SpawnAllEntities, SingleEntitySpawnable_SpawnCallVariable)
+        ->RangeMultiplier(10)
+        ->Range(100, 10000)
+        ->Unit(benchmark::kMillisecond)
+        ->Complexity();
+
+    BENCHMARK_DEFINE_F(BM_SpawnAllEntities, SingleSpawnCall_EntityCountVariable)(::benchmark::State& state)
+    {
+        const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range() * 2);
+
+        CreateSpawnable(entityCountInSpawnable - 1);
+
+        for (auto _ : state)
+        {
+            m_spawnTicket = new AzFramework::EntitySpawnTicket(m_spawnableAsset);
+            AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
+            m_rootSpawnableInterface->ProcessSpawnableQueue();
+
+            state.PauseTiming();
+            delete m_spawnTicket;
+            m_spawnTicket = nullptr;
+            m_rootSpawnableInterface->ProcessSpawnableQueue();
+            state.ResumeTiming();
+        }
+
+        state.SetComplexityN(entityCountInSpawnable);
+    }
+    BENCHMARK_REGISTER_F(BM_SpawnAllEntities, SingleSpawnCall_EntityCountVariable)
+        ->RangeMultiplier(10)
+        ->Range(100, 10000)
+        ->Unit(benchmark::kMillisecond)
+        ->Complexity();
+
+    BENCHMARK_DEFINE_F(BM_SpawnAllEntities, EntityCountVariable_SpawnCallCountVariable)(::benchmark::State& state)
+    {
+        const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range(0));
+        const unsigned int spawnCallCount = static_cast<unsigned int>(state.range(1));
+
+        CreateSpawnable(entityCountInSpawnable - 1);
+
+        for (auto _ : state)
+        {
+            m_spawnTicket = new AzFramework::EntitySpawnTicket(m_spawnableAsset);
+
+            for (unsigned int spawnCallCounter = 0; spawnCallCounter < spawnCallCount; spawnCallCounter++)
+            {
+                AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
+            }
+
+            m_rootSpawnableInterface->ProcessSpawnableQueue();
+
+            state.PauseTiming();
+            delete m_spawnTicket;
+            m_spawnTicket = nullptr;
+            m_rootSpawnableInterface->ProcessSpawnableQueue();
+            state.ResumeTiming();
+        }
+
+        state.SetComplexityN(entityCountInSpawnable * spawnCallCount);
+    }
+    // Provide ranges here to compare times for spawning the same number of entities by altering entityCountInSpawnable and spawnCallCount.
+    BENCHMARK_REGISTER_F(BM_SpawnAllEntities, EntityCountVariable_SpawnCallCountVariable)
+        ->Args({ 10, 100 })
+        ->Args({ 100, 10 })
+        ->Args({ 10, 1000 })
+        ->Args({ 1000, 10 })
+        ->Args({ 100, 1000 })
+        ->Args({ 1000, 100 })
+        ->Unit(benchmark::kMillisecond)
+        ->Complexity();
+} // namespace Benchmark
+
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
@@ -18,8 +18,9 @@ namespace Benchmark
     BENCHMARK_DEFINE_F(BM_SpawnAllEntities, SingleEntitySpawnable_SpawnCallVariable)(::benchmark::State& state)
     {
         const unsigned int spawnAllEntitiesCallCount = static_cast<unsigned int>(state.range());
+        const unsigned int entityCountInSourcePrefab = 1;
 
-        CreateSpawnable(1);
+        CreateSpawnable(entityCountInSourcePrefab);
 
         for (auto _ : state)
         {
@@ -52,9 +53,9 @@ namespace Benchmark
 
     BENCHMARK_DEFINE_F(BM_SpawnAllEntities, SingleSpawnCall_EntityCountVariable)(::benchmark::State& state)
     {
-        const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range() * 2);
+        const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range());
 
-        CreateSpawnable(entityCountInSpawnable - 1);
+        CreateSpawnable(entityCountInSpawnable);
 
         for (auto _ : state)
         {
@@ -62,9 +63,12 @@ namespace Benchmark
             AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
             m_rootSpawnableInterface->ProcessSpawnableQueue();
 
+            // Destroy the ticket so that this queues a request to delete all the entities spawned with this ticket.
             state.PauseTiming();
             delete m_spawnTicket;
             m_spawnTicket = nullptr;
+
+            // This will process the request to delete all entities spawned with the ticket
             m_rootSpawnableInterface->ProcessSpawnableQueue();
             state.ResumeTiming();
         }
@@ -82,7 +86,7 @@ namespace Benchmark
         const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range(0));
         const unsigned int spawnCallCount = static_cast<unsigned int>(state.range(1));
 
-        CreateSpawnable(entityCountInSpawnable - 1);
+        CreateSpawnable(entityCountInSpawnable);
 
         for (auto _ : state)
         {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
@@ -17,16 +17,18 @@ namespace Benchmark
 
     BENCHMARK_DEFINE_F(BM_SpawnAllEntities, SingleEntitySpawnable_SpawnCallVariable)(::benchmark::State& state)
     {
-        const unsigned int spawnAllEntitiesCallCount = static_cast<unsigned int>(state.range());
-        const unsigned int entityCountInSourcePrefab = 1;
+        const uint64_t spawnAllEntitiesCallCount = aznumeric_cast<uint64_t>(state.range());
+        const uint64_t entityCountInSourcePrefab = 1;
 
-        CreateSpawnable(entityCountInSourcePrefab);
+        SetUpSpawnableAsset(entityCountInSourcePrefab);
 
         for (auto _ : state)
         {
+            state.PauseTiming();
             m_spawnTicket = new AzFramework::EntitySpawnTicket(m_spawnableAsset);
+            state.ResumeTiming();
 
-            for (unsigned int spwanableCounter = 0; spwanableCounter < spawnAllEntitiesCallCount; spwanableCounter++)
+            for (uint64_t spwanableCounter = 0; spwanableCounter < spawnAllEntitiesCallCount; spwanableCounter++)
             {
                 AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
             }
@@ -53,13 +55,16 @@ namespace Benchmark
 
     BENCHMARK_DEFINE_F(BM_SpawnAllEntities, SingleSpawnCall_EntityCountVariable)(::benchmark::State& state)
     {
-        const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range());
+        const uint64_t entityCountInSpawnable = aznumeric_cast<uint64_t>(state.range());
 
-        CreateSpawnable(entityCountInSpawnable);
+        SetUpSpawnableAsset(entityCountInSpawnable);
 
         for (auto _ : state)
         {
+            state.PauseTiming();
             m_spawnTicket = new AzFramework::EntitySpawnTicket(m_spawnableAsset);
+            state.ResumeTiming();
+
             AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
             m_rootSpawnableInterface->ProcessSpawnableQueue();
 
@@ -83,16 +88,18 @@ namespace Benchmark
 
     BENCHMARK_DEFINE_F(BM_SpawnAllEntities, EntityCountVariable_SpawnCallCountVariable)(::benchmark::State& state)
     {
-        const unsigned int entityCountInSpawnable = static_cast<unsigned int>(state.range(0));
-        const unsigned int spawnCallCount = static_cast<unsigned int>(state.range(1));
+        const uint64_t entityCountInSpawnable = aznumeric_cast<uint64_t>(state.range(0));
+        const uint64_t spawnCallCount = aznumeric_cast<uint64_t>(state.range(1));
 
-        CreateSpawnable(entityCountInSpawnable);
+        SetUpSpawnableAsset(entityCountInSpawnable);
 
         for (auto _ : state)
         {
+            state.PauseTiming();
             m_spawnTicket = new AzFramework::EntitySpawnTicket(m_spawnableAsset);
+            state.ResumeTiming();
 
-            for (unsigned int spawnCallCounter = 0; spawnCallCounter < spawnCallCount; spawnCallCounter++)
+            for (uint64_t spawnCallCounter = 0; spawnCallCounter < spawnCallCount; spawnCallCounter++)
             {
                 AzFramework::SpawnableEntitiesInterface::Get()->SpawnAllEntities(*m_spawnTicket);
             }

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#if defined(HAVE_BENCHMARK)
+
+#include <AzToolsFramework/Prefab/Spawnable/SpawnableUtils.h>
+
+#include <Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h>
+
+namespace Benchmark
+{
+    void BM_Spawnable::SetUp(const benchmark::State& state)
+    {
+        SetUpHelper(state);
+    }
+
+    void BM_Spawnable::SetUp(benchmark::State& state)
+    {
+        SetUpHelper(state);
+    }
+
+    void BM_Spawnable::SetUpHelper(const benchmark::State& state)
+    {
+        BM_Prefab::SetUp(state);
+        m_rootSpawnableInterface = AzFramework::RootSpawnableInterface::Get();
+        AZ_Assert(m_rootSpawnableInterface != nullptr, "RootSpawnableInterface isn't found.");
+    }
+
+    void BM_Spawnable::TearDown(const benchmark::State& state)
+    {
+        TearDownHelper(state);
+    }
+
+    void BM_Spawnable::TearDown(benchmark::State& state)
+    {
+        TearDownHelper(state);
+    }
+
+    void BM_Spawnable::TearDownHelper(const benchmark::State& state)
+    {
+        m_spawnableAsset.Release();
+        BM_Prefab::TearDown(state);
+    }
+
+    void BM_Spawnable::CreateSpawnable(unsigned int entityCount)
+    {
+        AZStd::vector<AZ::Entity*> entities;
+        entities.reserve(entityCount);
+
+        for (unsigned int i = 0; i < entityCount; i++)
+        {
+            entities.emplace_back(CreateEntity("Entity"));
+        }
+
+        AZStd::unique_ptr<Instance> instance = m_prefabSystemComponent->CreatePrefab(AZStd::move(entities), {}, m_pathString);
+        const PrefabDom& prefabDom = m_prefabSystemComponent->FindTemplateDom(instance->GetTemplateId());
+        AzFramework::Spawnable* spawnable = new AzFramework::Spawnable(
+            AZ::Data::AssetId::CreateString("{612F2AB1-30DF-44BB-AFBE-17A85199F09E}:0"), AZ::Data::AssetData::AssetStatus::Ready);
+        AzToolsFramework::Prefab::SpawnableUtils::CreateSpawnable(*spawnable, prefabDom);
+        m_spawnableAsset = AZ::Data::Asset<AzFramework::Spawnable>(spawnable, AZ::Data::AssetLoadBehavior::Default);
+    }
+} // namespace Benchmark
+
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
@@ -45,7 +45,7 @@ namespace Benchmark
         BM_Prefab::TearDown(state);
     }
 
-    void BM_Spawnable::CreateSpawnable(unsigned int entityCount)
+    void BM_Spawnable::SetUpSpawnableAsset(unsigned int entityCount)
     {
         AZStd::vector<AZ::Entity*> entities;
         entities.reserve(entityCount);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
@@ -45,12 +45,12 @@ namespace Benchmark
         BM_Prefab::TearDown(state);
     }
 
-    void BM_Spawnable::SetUpSpawnableAsset(unsigned int entityCount)
+    void BM_Spawnable::SetUpSpawnableAsset(uint64_t entityCount)
     {
         AZStd::vector<AZ::Entity*> entities;
         entities.reserve(entityCount);
 
-        for (unsigned int i = 0; i < entityCount; i++)
+        for (uint64_t i = 0; i < entityCount; i++)
         {
             entities.emplace_back(CreateEntity("Entity"));
         }

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
@@ -8,7 +8,6 @@
 #if defined(HAVE_BENCHMARK)
 
 #include <AzToolsFramework/Prefab/Spawnable/SpawnableUtils.h>
-
 #include <Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h>
 
 namespace Benchmark
@@ -58,6 +57,8 @@ namespace Benchmark
 
         AZStd::unique_ptr<Instance> instance = m_prefabSystemComponent->CreatePrefab(AZStd::move(entities), {}, m_pathString);
         const PrefabDom& prefabDom = m_prefabSystemComponent->FindTemplateDom(instance->GetTemplateId());
+
+        // Lifecycle of spawnable is managed by the asset that's created using it.
         AzFramework::Spawnable* spawnable = new AzFramework::Spawnable(
             AZ::Data::AssetId::CreateString("{612F2AB1-30DF-44BB-AFBE-17A85199F09E}:0"), AZ::Data::AssetData::AssetStatus::Ready);
         AzToolsFramework::Prefab::SpawnableUtils::CreateSpawnable(*spawnable, prefabDom);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
@@ -33,7 +33,7 @@ namespace Benchmark
         void TearDown(benchmark::State& state) override;
         void TearDownHelper(const benchmark::State& state);
 
-        void CreateSpawnable(unsigned int entityCount);
+        void SetUpSpawnableAsset(unsigned int entityCount);
 
         AZ::Data::Asset<AzFramework::Spawnable> m_spawnableAsset;
         AzFramework::EntitySpawnTicket* m_spawnTicket;

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
@@ -16,12 +16,11 @@
 namespace AzFramework
 {
     class EntitySpawnTicket;
+    class RootSpawnableDefinition;
 }
 
 namespace Benchmark
 {
-    using namespace UnitTest::PrefabTestUtils;
-
     class BM_Spawnable
         : public Benchmark::BM_Prefab
     {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#if defined(HAVE_BENCHMARK)
+
+#pragma once
+
+#include <AzFramework/Spawnable/RootSpawnableInterface.h>
+#include <Prefab/Benchmark/PrefabBenchmarkFixture.h>
+
+namespace AzFramework
+{
+    class EntitySpawnTicket;
+}
+
+namespace Benchmark
+{
+    using namespace UnitTest::PrefabTestUtils;
+
+    class BM_Spawnable
+        : public Benchmark::BM_Prefab
+    {
+    protected:
+        void SetUp(const benchmark::State& state) override;
+        void SetUp(benchmark::State& state) override;
+        void SetUpHelper(const benchmark::State& state);
+
+        void TearDown(const benchmark::State& state) override;
+        void TearDown(benchmark::State& state) override;
+        void TearDownHelper(const benchmark::State& state);
+
+        void CreateSpawnable(unsigned int entityCount);
+
+        AZ::Data::Asset<AzFramework::Spawnable> m_spawnableAsset;
+        AzFramework::EntitySpawnTicket* m_spawnTicket;
+        AzFramework::RootSpawnableDefinition* m_rootSpawnableInterface;
+    };
+} // namespace Benchmark
+
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
@@ -33,7 +33,7 @@ namespace Benchmark
         void TearDown(benchmark::State& state) override;
         void TearDownHelper(const benchmark::State& state);
 
-        void SetUpSpawnableAsset(unsigned int entityCount);
+        void SetUpSpawnableAsset(uint64_t entityCount);
 
         AZ::Data::Asset<AzFramework::Spawnable> m_spawnableAsset;
         AzFramework::EntitySpawnTicket* m_spawnTicket;

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -60,6 +60,9 @@ set(FILES
     Prefab/Benchmark/PrefabLoadBenchmarks.cpp
     Prefab/Benchmark/PrefabUpdateInstancesBenchmarks.cpp
     Prefab/Benchmark/SpawnableCreateBenchmarks.cpp
+    Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
+    Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp
+    Prefab/Benchmark/Spawnable/SpawnAllEntitiesBenchmarks.cpp
     Prefab/PrefabFocus/PrefabFocusTests.cpp
     Prefab/MockPrefabFileIOActionValidator.cpp
     Prefab/MockPrefabFileIOActionValidator.h


### PR DESCRIPTION
Adds 3 benchmarks for SpawnAllEntities call in SpawnableEntitiesManager:
1. Spawns a single spawnable a very large number of times
2. Spawns  a single big spawnable with a very large number of entities in it
3. Combines 1 and 2 to compare which performs better by altering the number of entities in a spawnable and the number of spawn calls.

Here are the results from a local run - 


Run on (20 X 3312 MHz CPU s)
CPU Caches:
  L1 Data 32K (x10)
  L1 Instruction 32K (x10)
  L2 Unified 1048K (x10)
  L3 Unified 14417K (x1)

```
Benchmark                                                                        Time             CPU   Iterations
------------------------------------------------------------------------------------------------------------------
BM_SpawnAllEntities/SingleEntitySpawnable_SpawnCallVariable/100               15.6 ms         16.0 ms           37
BM_SpawnAllEntities/SingleEntitySpawnable_SpawnCallVariable/1000               148 ms          151 ms            6
BM_SpawnAllEntities/SingleEntitySpawnable_SpawnCallVariable/10000             1458 ms         1453 ms            1
BM_SpawnAllEntities/SingleEntitySpawnable_SpawnCallVariable_BigO         145845.33 N     145370.72 N
BM_SpawnAllEntities/SingleEntitySpawnable_SpawnCallVariable_RMS                  0 %             1 %
BM_SpawnAllEntities/SingleSpawnCall_EntityCountVariable/100                   8.09 ms         8.51 ms          112
BM_SpawnAllEntities/SingleSpawnCall_EntityCountVariable/1000                  78.4 ms         79.9 ms            9
BM_SpawnAllEntities/SingleSpawnCall_EntityCountVariable/10000                  824 ms          828 ms            1
BM_SpawnAllEntities/SingleSpawnCall_EntityCountVariable_BigO              82340.73 N      82783.51 N
BM_SpawnAllEntities/SingleSpawnCall_EntityCountVariable_RMS                      1 %             1 %
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable/10/100         94.8 ms         96.0 ms            7
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable/100/10         85.8 ms         84.8 ms            7
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable/10/1000         891 ms          891 ms            1
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable/1000/10         870 ms          875 ms            1
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable/100/1000       9255 ms         9250 ms            1
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable/1000/100       9102 ms         9094 ms            1
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable_BigO       91747.13 N      91684.59 N
BM_SpawnAllEntities/EntityCountVariable_SpawnCallCountVariable_RMS               1 %             1 %
OKAY AzRunBenchmarks() returned 0
Returning code: 0
```