### PR TITLE
Jenkins reruns

### DIFF
--- a/scripts/ctest/ctest_driver.py
+++ b/scripts/ctest/ctest_driver.py
@@ -63,7 +63,7 @@ def _get_only_failed(cmake_build_path):
     
     # Test strings will be in the format of "<Run Number>:<CTest Module Name>::TEST_RUN"
     module_regex = '^\d+:(.+)::TEST_RUN$'
-    print("Running failed tests:")
+    print("List of failed tests:")
     for test_line in failed_tests_list_lines:
         module_name = re.search(module_regex, test_line).group(1)
         failed_test_modules.append(module_name)
@@ -257,7 +257,7 @@ def main():
     args, unknown_args = parser.parse_known_args()
 
     if not args.repeat and (args.only_failed or args.soft_repeat_timeout):
-        parser.error('The --only-failed and --soft-repeat-timeout option requires the --repeat option. Use --rerun-failed to run without the --repeat option.')
+        parser.error('The --only-failed and --soft-repeat-timeout option requires the --repeat option.')
 
     # handle the CTEST executable.
     # we always obey command line, and its an error if the command line has

--- a/scripts/ctest/ctest_driver.py
+++ b/scripts/ctest/ctest_driver.py
@@ -247,8 +247,7 @@ def main():
                                                "aggregated and summarized.", type=int)
     parser.add_argument('--only-failed', action='store_true',
                         help='Enable this option with the --repeat option to run all repeats against the intially failed tests.')
-    parser.add_argument('--soft-repeat-timeout', type=int, help='Enable this option with the --repeat option to set a soft timeout in seconds. 
-                        'A repeat iteration will complete its full test run, but will not start the next iteration.')
+    parser.add_argument('--soft-repeat-timeout', type=int, help='Enable this option with the --repeat option to set a soft timeout in seconds. A repeat iteration will complete its full test run, but will not start the next iteration.')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--no-gpu', action='store_true',

--- a/scripts/ctest/ctest_driver.py
+++ b/scripts/ctest/ctest_driver.py
@@ -41,13 +41,12 @@ def _regex_matching_any(words):
 
 
 def _get_only_failed(cmake_build_path):
-    # type (str) -> str or None
+    # type (str) -> str
     """
     Read and parse the LastTestsFailed log if possible to build a list of tests to run. A string is returned that is
-    passed to the CTest regex -R option. The string contains all of the failed test modules to run joined with |. If an
-    exception occurs, it will return None and be skipped.
+    passed to the CTest regex -R option. The string contains all of the failed test modules to run joined with '|'.
     :param cmake_build_path: The patch to the CMake build folder as a string
-    :return: A string to pass to CTest regex option, returns None if an exception occured
+    :return: A string to pass to CTest regex option
     """
     failed_tests_list_lines = []
     failed_test_modules = []

--- a/scripts/ctest/ctest_driver.py
+++ b/scripts/ctest/ctest_driver.py
@@ -76,7 +76,7 @@ def _get_only_failed(cmake_build_path):
 
 
 def run_single_test_suite(suite, ctest_path, cmake_build_path, build_config, disable_gpu, only_gpu, generate_xml,
-                          repeat, only_failed, extra_args, soft_repeat_timeout=0):
+                          repeat, extra_args, only_failed=False, soft_repeat_timeout=0):
     """
     Starts CTest to filter down to a specific suite
     :param suite: subset of tests to run, see SUITES_AND_DESCRIPTIONS
@@ -244,7 +244,7 @@ def main():
                                                "failures (e.g. --repeat 3 for running the test three times). When used"
                                                "with --generate-xml, the resulting test reports will be combined, "
                                                "aggregated and summarized.", type=int)
-    parser.add_argument('--only-failed', action='store_true',
+    parser.add_argument('--only-run-failed', action='store_true',
                         help='Enable this option with the --repeat option to run all repeats against the intially failed tests.')
     parser.add_argument('--soft-repeat-timeout', type=int, help='Enable this option with the --repeat option to set a soft timeout in seconds. A repeat iteration will complete its full test run, but will not start the next iteration.')
 
@@ -256,7 +256,7 @@ def main():
 
     args, unknown_args = parser.parse_known_args()
 
-    if not args.repeat and (args.only_failed or args.soft_repeat_timeout):
+    if not args.repeat and (args.only_run_failed or args.soft_repeat_timeout):
         parser.error('The --only-failed and --soft-repeat-timeout option requires the --repeat option.')
 
     # handle the CTEST executable.
@@ -302,7 +302,7 @@ def main():
         only_gpu=args.only_gpu,
         generate_xml=args.generate_xml,
         repeat=args.repeat,
-        only_failed=args.only_failed,
+        only_failed=args.only_run_failed,
         soft_repeat_timeout=args.soft_repeat_timeout,
         extra_args=unknown_args)
 

--- a/scripts/ctest/result_processing/result_processing.py
+++ b/scripts/ctest/result_processing/result_processing.py
@@ -112,12 +112,11 @@ def _merge_xml_results(xml_results_path, prefix, merged_xml_name, parent_element
         temp_dict[attribute.name] = attribute.func(0)
 
     def _aggregate_attributes(nodes):
+        missing_attribs = {}
         for node in nodes:
             for attribute in attributes_to_aggregate:
                 if attribute.name in node.attrib:
                     temp_dict[attribute.name] += attribute.func(node.attrib[attribute.name])
-                else:
-                    print("Failed to find key {} in {}, continuing...".format(attribute.name, node.tag))
 
     base_tree = xet.parse(xml_files[0])
     base_tree_root = base_tree.getroot()

--- a/scripts/ctest/result_processing/result_processing.py
+++ b/scripts/ctest/result_processing/result_processing.py
@@ -112,7 +112,6 @@ def _merge_xml_results(xml_results_path, prefix, merged_xml_name, parent_element
         temp_dict[attribute.name] = attribute.func(0)
 
     def _aggregate_attributes(nodes):
-        missing_attribs = {}
         for node in nodes:
             for attribute in attributes_to_aggregate:
                 if attribute.name in node.attrib:


### PR DESCRIPTION
do not merge! - Posting for initial review

Tested by running locally against intentionally failed tests. Tested both with and without soft timeout.

example usage:
ctest_entrypoint.cmd -s smoke --config profile -B C:\Users\evanchia\github\o3de\windows_vs2019 --repeat 10 --only-failed --soft-repeat-timeout 100 --generate-xml

This will look at the last ctest run and run all failed tests 10 times each. If 100 seconds has elapsed, it will finish the current iteration of runs but won't continue afterwards.