### PR TITLE
Created custom JSON serializer for editor material component

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.cpp
@@ -6,23 +6,24 @@
  *
  */
 
-#include <Material/EditorMaterialComponent.h>
-#include <Material/EditorMaterialComponentExporter.h>
-
-#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
-#include <AzToolsFramework/API/ToolsApplicationAPI.h>
-#include <AzCore/RTTI/BehaviorContext.h>
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <Atom/RPI.Edit/Material/MaterialPropertyId.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <Atom/RPI.Reflect/Material/MaterialTypeAsset.h>
 #include <AtomLyIntegration/CommonFeatures/Mesh/MeshComponentBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzToolsFramework/API/EditorAssetSystemAPI.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <Material/EditorMaterialComponent.h>
+#include <Material/EditorMaterialComponentExporter.h>
+#include <Material/EditorMaterialComponentSerializer.h>
 
 AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option") // disable warnings spawned by QT
-#include <QMenu>
 #include <QAction>
 #include <QCursor>
+#include <QMenu>
 AZ_POP_DISABLE_WARNING
 
 namespace AZ
@@ -59,7 +60,12 @@ namespace AZ
             BaseClass::Reflect(context);
             EditorMaterialComponentSlot::Reflect(context);
 
-            if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+            if (auto jsonContext = azrtti_cast<JsonRegistrationContext*>(context))
+            {
+                jsonContext->Serializer<JsonEditorMaterialComponentSerializer>()->HandlesType<EditorMaterialComponent>();
+            }
+
+            if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->RegisterGenericType<EditorMaterialComponentSlotContainer>();
                 serializeContext->RegisterGenericType<EditorMaterialComponentSlotsByLodContainer>();
@@ -76,7 +82,7 @@ namespace AZ
                 serializeContext->RegisterGenericType<AZStd::unordered_map<MaterialAssignmentId, Data::AssetId, AZStd::hash<MaterialAssignmentId>, AZStd::equal_to<MaterialAssignmentId>, AZStd::allocator>>();
                 serializeContext->RegisterGenericType<AZStd::unordered_map<MaterialAssignmentId, MaterialPropertyOverrideMap, AZStd::hash<MaterialAssignmentId>, AZStd::equal_to<MaterialAssignmentId>, AZStd::allocator>>();
 
-                if (AZ::EditContext* editContext = serializeContext->GetEditContext())
+                if (auto editContext = serializeContext->GetEditContext())
                 {
                     editContext->Class<EditorMaterialComponent>(
                         "Material", "The material component specifies the material to use for this entity")
@@ -129,7 +135,7 @@ namespace AZ
                 }
             }
 
-            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
                 behaviorContext->ConstantProperty("EditorMaterialComponentTypeId", BehaviorConstant(Uuid(EditorMaterialComponentTypeId)))
                     ->Attribute(AZ::Script::Attributes::Module, "render")

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponent.h
@@ -27,6 +27,8 @@ namespace AZ
             , public EditorMaterialSystemComponentNotificationBus::Handler
         {
         public:
+            friend class JsonEditorMaterialComponentSerializer;
+
             using BaseClass = EditorRenderComponentAdapter<MaterialComponentController, MaterialComponent, MaterialComponentConfig>;
             AZ_EDITOR_COMPONENT(EditorMaterialComponent, EditorMaterialComponentTypeId, BaseClass);
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
- * this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
+ * this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/Json/JsonSerializationResult.h>
+#include <Material/EditorMaterialComponent.h>
+#include <Material/EditorMaterialComponentSerializer.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        AZ_CLASS_ALLOCATOR_IMPL(JsonEditorMaterialComponentSerializer, AZ::SystemAllocator, 0);
+
+        AZ::JsonSerializationResult::Result JsonEditorMaterialComponentSerializer::Load(
+            void* outputValue,
+            [[maybe_unused]] const AZ::Uuid& outputValueTypeId,
+            const rapidjson::Value& inputValue,
+            AZ::JsonDeserializerContext& context)
+        {
+            namespace JSR = AZ::JsonSerializationResult;
+
+            AZ_Assert(
+                azrtti_typeid<EditorMaterialComponent>() == outputValueTypeId,
+                "Unable to deserialize EditorMaterialComponent from json because the provided type is %s.",
+                outputValueTypeId.ToString<AZStd::string>().c_str());
+
+            auto componentInstance = reinterpret_cast<EditorMaterialComponent*>(outputValue);
+            AZ_Assert(componentInstance, "Output value for JsonEditorMaterialComponentSerializer can't be null.");
+
+            JSR::ResultCode result(JSR::Tasks::ReadField);
+
+            result.Combine(ContinueLoadingFromJsonObjectField(
+                &componentInstance->m_id, azrtti_typeid<decltype(componentInstance->m_id)>(), inputValue, "Id", context));
+
+            result.Combine(ContinueLoadingFromJsonObjectField(
+                &componentInstance->m_controller, azrtti_typeid<decltype(componentInstance->m_controller)>(), inputValue, "Controller",
+                context));
+
+            result.Combine(ContinueLoadingFromJsonObjectField(
+                &componentInstance->m_materialSlotsByLodEnabled, azrtti_typeid<decltype(componentInstance->m_materialSlotsByLodEnabled)>(),
+                inputValue, "materialSlotsByLodEnabled", context));
+
+            return context.Report(
+                result,
+                result.GetProcessing() != JSR::Processing::Halted ? "Successfully loaded EditorMaterialComponent information."
+                                                                  : "Failed to load EditorMaterialComponent information.");
+        }
+
+        AZ::JsonSerializationResult::Result JsonEditorMaterialComponentSerializer::Store(
+            rapidjson::Value& outputValue,
+            const void* inputValue,
+            const void* defaultValue,
+            [[maybe_unused]] const AZ::Uuid& valueTypeId,
+            AZ::JsonSerializerContext& context)
+        {
+            namespace JSR = AZ::JsonSerializationResult;
+
+            AZ_Assert(
+                azrtti_typeid<EditorMaterialComponent>() == valueTypeId,
+                "Unable to Serialize EditorMaterialComponent because the provided type is %s.",
+                valueTypeId.ToString<AZStd::string>().c_str());
+
+            auto componentInstance = reinterpret_cast<const EditorMaterialComponent*>(inputValue);
+            AZ_Assert(componentInstance, "Input value for JsonEditorMaterialComponentSerializer can't be null.");
+            auto defaultComponentInstance = reinterpret_cast<const EditorMaterialComponent*>(defaultValue);
+
+            JSR::ResultCode result(JSR::Tasks::WriteValue);
+            {
+                AZ::ScopedContextPath subPathName(context, "m_id");
+                const auto componentId = &componentInstance->m_id;
+                const auto defaultComponentId = defaultComponentInstance ? &defaultComponentInstance->m_id : nullptr;
+
+                result.Combine(ContinueStoringToJsonObjectField(
+                    outputValue, "Id", componentId, defaultComponentId, azrtti_typeid<decltype(componentInstance->m_id)>(), context));
+            }
+
+            {
+                AZ::ScopedContextPath subPathName(context, "Controller");
+                const auto controller = &componentInstance->m_controller;
+                const auto defaultController = defaultComponentInstance ? &defaultComponentInstance->m_controller : nullptr;
+
+                result.Combine(ContinueStoringToJsonObjectField(
+                    outputValue, "Controller", controller, defaultController, azrtti_typeid<decltype(componentInstance->m_controller)>(),
+                    context));
+            }
+
+            {
+                AZ::ScopedContextPath subPathName(context, "materialSlotsByLodEnabled");
+                const auto enabled = &componentInstance->m_materialSlotsByLodEnabled;
+                const auto defaultEnabled = defaultComponentInstance ? &defaultComponentInstance->m_materialSlotsByLodEnabled : nullptr;
+
+                result.Combine(ContinueStoringToJsonObjectField(
+                    outputValue, "materialSlotsByLodEnabled", enabled, defaultEnabled,
+                    azrtti_typeid<decltype(componentInstance->m_materialSlotsByLodEnabled)>(), context));
+            }
+
+            return context.Report(
+                result,
+                result.GetProcessing() != JSR::Processing::Halted ? "Successfully stored EditorMaterialComponent information."
+                                                                  : "Failed to store EditorMaterialComponent information.");
+        }
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
- * this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialComponentSerializer.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
+ * this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        // JsonEditorMaterialComponentSerializer skips serialization of EditorMaterialComponentSlot(s) which are only needed at runtime in
+        // the editor
+        class JsonEditorMaterialComponentSerializer : public AZ::BaseJsonSerializer
+        {
+        public:
+            AZ_RTTI(JsonEditorMaterialComponentSerializer, "{D354FE3C-34D2-4E80-B3F9-49450D252336}", BaseJsonSerializer);
+            AZ_CLASS_ALLOCATOR_DECL;
+
+            AZ::JsonSerializationResult::Result Load(
+                void* outputValue,
+                const AZ::Uuid& outputValueTypeId,
+                const rapidjson::Value& inputValue,
+                AZ::JsonDeserializerContext& context) override;
+
+            AZ::JsonSerializationResult::Result Store(
+                rapidjson::Value& outputValue,
+                const void* inputValue,
+                const void* defaultValue,
+                const AZ::Uuid& valueTypeId,
+                AZ::JsonSerializerContext& context) override;
+        };
+
+    } // namespace Render
+} // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/atomlyintegration_commonfeatures_editor_files.cmake
@@ -31,6 +31,8 @@ set(FILES
     Source/ImageBasedLights/EditorImageBasedLightComponent.cpp
     Source/Material/EditorMaterialComponent.cpp
     Source/Material/EditorMaterialComponent.h
+    Source/Material/EditorMaterialComponentSerializer.cpp
+    Source/Material/EditorMaterialComponentSerializer.h
     Source/Material/EditorMaterialComponentUtil.cpp
     Source/Material/EditorMaterialComponentUtil.h
     Source/Material/EditorMaterialComponentSlot.cpp


### PR DESCRIPTION
The editor component contains an editor specific, dynamically generated version of the material slots to display all the possible options, organize properties for the user interface, and add custom actions.
The critical data is already stored inside of the component controller configuration, which only stores a map of modified or overridden values.
This change disables serialization of the redundant data for prefabs.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>