### PR TITLE
Add missing reflection calls

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.cpp
@@ -26,8 +26,12 @@ namespace AzToolsFramework
         AZ::Interface<ContainerEntityInterface>::Unregister(this);
     }
 
-    void ContainerEntitySystemComponent::Reflect([[maybe_unused]] AZ::ReflectContext* context)
+    void ContainerEntitySystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ContainerEntitySystemComponent, AZ::Component>()->Version(1);
+        }
     }
 
     void ContainerEntitySystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeSystemComponent.cpp
@@ -47,8 +47,12 @@ namespace AzToolsFramework
         AZ::Interface<FocusModeInterface>::Unregister(this);
     }
 
-    void FocusModeSystemComponent::Reflect([[maybe_unused]] AZ::ReflectContext* context)
+    void FocusModeSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<FocusModeSystemComponent, AZ::Component>()->Version(1);
+        }
     }
 
     void FocusModeSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)

--- a/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.cpp
@@ -28,9 +28,12 @@ namespace UnitTest
         return true;
     }
 
-    void BoundsTestComponent::Reflect([[maybe_unused]] AZ::ReflectContext* context)
+    void BoundsTestComponent::Reflect(AZ::ReflectContext* context)
     {
-        // noop
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<BoundsTestComponent, EditorComponentBase>()->Version(1);
+        }
     }
 
     void BoundsTestComponent::Activate()

--- a/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.h
+++ b/Code/Framework/AzToolsFramework/Tests/BoundsTestComponent.h
@@ -42,5 +42,4 @@ namespace UnitTest
         AZ::Aabb GetWorldBounds() override;
         AZ::Aabb GetLocalBounds() override;
     };
-
 } // namespace UnitTest


### PR DESCRIPTION
These missing calls were causing a lot of tests to fail afterwards when running `AzToolsFrameworkTests` locally. These calls are required and there's spam in the logs without them unfortunately.

```
[==========] Running 945 tests from 156 test cases.
...
[----------] Global test environment tear-down
[==========] 945 tests from 156 test cases ran. (197202 ms total)
[  PASSED  ] 945 tests.
```