### PR TITLE
Added .gitignore for __pycache__ and pyc files to the python tool gemplate

### DIFF
--- a/Templates/PythonToolGem/Template/.gitignore
+++ b/Templates/PythonToolGem/Template/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Templates/PythonToolGem/template.json
+++ b/Templates/PythonToolGem/template.json
@@ -13,6 +13,12 @@
     "icon_path": "preview.png",
     "copyFiles": [
         {
+            "file": ".gitignore",
+            "origin": ".gitignore",
+            "isTemplated": false,
+            "isOptional": false
+        },
+        {
             "file": "CMakeLists.txt",
             "origin": "CMakeLists.txt",
             "isTemplated": true,


### PR DESCRIPTION
Added .gitignore file to the gemplate for our base python tool so that `__pycache__` and `.pyc` files will be ignored.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>