### PR TITLE
Fix new project path when enabling gem

### DIFF
--- a/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/CreateProjectCtrl.cpp
@@ -240,7 +240,7 @@ namespace O3DE::ProjectManager
                     PythonBindingsInterface::Get()->AddProject(projectInfo.m_path);
 
 #ifdef TEMPLATE_GEM_CONFIGURATION_ENABLED
-                    const GemCatalogScreen::EnableDisableGemsResult gemResult = m_gemCatalogScreen->EnableDisableGemsForProject(m_projectInfo.m_path);
+                    const GemCatalogScreen::EnableDisableGemsResult gemResult = m_gemCatalogScreen->EnableDisableGemsForProject(projectInfo.m_path);
                     if (gemResult == GemCatalogScreen::EnableDisableGemsResult::Failed)
                     {
                         QMessageBox::critical(this, tr("Failed to configure gems"), tr("Failed to configure gems for template."));

--- a/Code/Tools/ProjectManager/Source/CreateProjectCtrl.h
+++ b/Code/Tools/ProjectManager/Source/CreateProjectCtrl.h
@@ -62,9 +62,6 @@ namespace O3DE::ProjectManager
         QPushButton* m_secondaryButton = nullptr;
 #endif // TEMPLATE_GEM_CONFIGURATION_ENABLED
 
-        QString m_projectTemplatePath;
-        ProjectInfo m_projectInfo;
-        
         NewProjectSettingsScreen* m_newProjectSettingsScreen = nullptr;
         GemCatalogScreen* m_gemCatalogScreen = nullptr;
     };


### PR DESCRIPTION
Fixes an issue https://github.com/o3de/o3de/issues/4754 caused by a copy/paste error in a previous update which resulted in an empty path being submitted when enabling a gem.

**Testing** 
- created a new project with an added gem, which failed before the change and succeeds after.

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>