### PR TITLE
[LYN-7245] Fix Assert Absorber being leaked

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.h
@@ -25,7 +25,7 @@ namespace AssetProcessor
         : public ::testing::Test
     {
     protected:
-        UnitTestUtils::AssertAbsorber* m_errorAbsorber;
+        AZStd::unique_ptr<UnitTestUtils::AssertAbsorber> m_errorAbsorber{};
         FileStatePassthrough m_fileStateCache;
 
         void SetUp() override
@@ -40,7 +40,7 @@ namespace AssetProcessor
                 m_ownsSysAllocator = true;
                 AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
             }
-            m_errorAbsorber = new UnitTestUtils::AssertAbsorber();
+            m_errorAbsorber = AZStd::make_unique<UnitTestUtils::AssertAbsorber>();
 
             m_application = AZStd::make_unique<AzFramework::Application>();
 
@@ -60,8 +60,8 @@ namespace AssetProcessor
             AssetUtilities::ResetAssetRoot();
             
             m_application.reset();
-            delete m_errorAbsorber;
-            m_errorAbsorber = nullptr;
+            m_errorAbsorber.reset();
+
             if (m_ownsSysAllocator)
             {
                 AZ::AllocatorInstance<AZ::SystemAllocator>::Destroy();


### PR DESCRIPTION
Fix Assert Absorber being leaked due to one of the tests setting m_errorAbsorber to nullptr without deleting the object

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>