### PR TITLE
[LYN-7245] Move Exception PrintCallstack call before any ebus calls

### DIFF
--- a/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Debug/Trace_WinAPI.cpp
+++ b/Code/Framework/AzCore/Platform/Common/WinAPI/AzCore/Debug/Trace_WinAPI.cpp
@@ -187,6 +187,8 @@ namespace AZ
         azsnprintf(message, g_maxMessageLength, "Exception : 0x%lX - '%s' [%p]\n", ExceptionInfo->ExceptionRecord->ExceptionCode, GetExeptionName(ExceptionInfo->ExceptionRecord->ExceptionCode), ExceptionInfo->ExceptionRecord->ExceptionAddress);
         Debug::Trace::Instance().Output(nullptr, message);
 
+        Debug::Trace::Instance().PrintCallstack(nullptr, 0, ExceptionInfo->ContextRecord);
+
         EBUS_EVENT(Debug::TraceMessageDrillerBus, OnException, message);
 
         bool result = false;
@@ -198,7 +200,7 @@ namespace AZ
             // if someone ever returns TRUE we assume that they somehow handled this exception and continue.
             return EXCEPTION_CONTINUE_EXECUTION;
         }
-        Debug::Trace::Instance().PrintCallstack(nullptr, 0, ExceptionInfo->ContextRecord);
+        
         Debug::Trace::Instance().Output(nullptr, "==================================================================\n");
 
         // allowing continue of execution is not valid here.  This handler gets called for serious exceptions.


### PR DESCRIPTION
 Move Exception PrintCallstack call before any ebus calls to help track down issue with crash during an exception

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>