### PR TITLE
[LYN-7245] AP unit test segfault - Clean up debug messages

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -1067,12 +1067,15 @@ namespace AssetProcessor
 
         if (dropAllTables)
         {
+            AZ_TracePrintf("AssetDatabase", "Closing existing db connection\n"); // Temporary debug output to help with tracking down a crash
             // drop all tables by destroying the entire database.
             m_databaseConnection->Close();
 
+            AZ_TracePrintf("AssetDatabase", "Getting db file path\n"); // Temporary debug output to help with tracking down a crash
             AZStd::string dbFilePath = GetAssetDatabaseFilePath();
             if (dbFilePath != ":memory:")
             {
+                AZ_TracePrintf("AssetDatabase", "Deleting existing db\n"); // Temporary debug output to help with tracking down a crash
                 // you cannot delete a memory database, but it drops all data when you close it anyway.
                 if (!AZ::IO::SystemFile::Delete(dbFilePath.c_str()))
                 {
@@ -1082,7 +1085,7 @@ namespace AssetProcessor
                     return false;
                 }
             }
-
+            AZ_TracePrintf("AssetDatabase", "Re-opening connection\n"); // Temporary debug output to help with tracking down a crash
             if (!m_databaseConnection->Open(dbFilePath, IsReadOnly()))
             {
                 delete m_databaseConnection;

--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -1075,7 +1075,7 @@ namespace AssetProcessor
             AZStd::string dbFilePath = GetAssetDatabaseFilePath();
             if (dbFilePath != ":memory:")
             {
-                AZ_TracePrintf("AssetDatabase", "Deleting existing db\n"); // Temporary debug output to help with tracking down a crash
+                AZ_TracePrintf("AssetDatabase", "Deleting existing db %s\n", dbFilePath.c_str()); // Temporary debug output to help with tracking down a crash
                 // you cannot delete a memory database, but it drops all data when you close it anyway.
                 if (!AZ::IO::SystemFile::Delete(dbFilePath.c_str()))
                 {

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -241,7 +241,9 @@ void AssetProcessorManagerTest::SetUp()
     ASSERT_TRUE(m_mockApplicationManager->RegisterAssetRecognizerAsBuilder(rec));
     m_mockApplicationManager->BusConnect();
 
+    AZ_Printf("UnitTest", "Allocating APM\n")
     m_assetProcessorManager.reset(new AssetProcessorManager_Test(m_config.get()));
+    AZ_Printf("UnitTest", "APM ready\n");
     m_assertAbsorber.Clear();
 
     m_isIdling = false;
@@ -4447,9 +4449,9 @@ AssetBuilderSDK::AssetBuilderDesc MockBuilderInfoHandler::CreateBuilderDesc(cons
 
 void FingerprintTest::SetUp()
 {
-    AZ_Printf("FingerprintTest", "SetUp start");
+    AZ_Printf("FingerprintTest", "SetUp start\n");
     AssetProcessorManagerTest::SetUp();
-    AZ_Printf("FingerprintTest", "SetUp self");
+    AZ_Printf("FingerprintTest", "SetUp self\n");
 
     // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
     m_mockApplicationManager->BusDisconnect();
@@ -4468,23 +4470,23 @@ void FingerprintTest::SetUp()
     });
 
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(m_absolutePath, ""));
-    AZ_Printf("FingerprintTest", "SetUp end");
+    AZ_Printf("FingerprintTest", "SetUp end\n");
 }
 
 void FingerprintTest::TearDown()
 {
-    AZ_Printf("FingerprintTest", "TearDown start");
+    AZ_Printf("FingerprintTest", "TearDown start\n");
     m_jobResults = AZStd::vector<AssetProcessor::JobDetails>{};
     m_mockBuilderInfoHandler = {};
 
-    AZ_Printf("FingerprintTest", "TearDown parent");
+    AZ_Printf("FingerprintTest", "TearDown parent\n");
     AssetProcessorManagerTest::TearDown();
-    AZ_Printf("FingerprintTest", "TearDown end");
+    AZ_Printf("FingerprintTest", "TearDown end\n");
 }
 
 void FingerprintTest::RunFingerprintTest(QString builderFingerprint, QString jobFingerprint, bool expectedResult)
 {
-    AZ_Printf("FingerprintTest", "Fingerprint Test Start");
+    AZ_Printf("FingerprintTest", "Fingerprint Test Start\n");
     m_mockBuilderInfoHandler.m_builderDesc.m_analysisFingerprint = builderFingerprint.toUtf8().data();
     m_mockBuilderInfoHandler.m_jobFingerprint = jobFingerprint;
     QMetaObject::invokeMethod(m_assetProcessorManager.get(), "AssessModifiedFile", Qt::QueuedConnection, Q_ARG(QString, m_absolutePath));
@@ -4493,7 +4495,7 @@ void FingerprintTest::RunFingerprintTest(QString builderFingerprint, QString job
     ASSERT_EQ(m_mockBuilderInfoHandler.m_createJobsCount, 1);
     ASSERT_EQ(m_jobResults.size(), 1);
     ASSERT_EQ(m_jobResults[0].m_autoFail, expectedResult);
-    AZ_Printf("FingerprintTest", "Fingerprint Test End");
+    AZ_Printf("FingerprintTest", "Fingerprint Test End\n");
 }
 
 TEST_F(FingerprintTest, FingerprintChecking_JobFingerprint_NoBuilderFingerprint)


### PR DESCRIPTION
Cleaning up and adding additional debug messages to track down SEGFAULT occurring in unit tests.

These will be removed once the issue is fixed.