### PR TITLE
fix issue #5172

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/EntityOutliner.qss
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/EntityOutliner.qss
@@ -11,7 +11,6 @@ OutlinerWidget #m_display_options
 {
     qproperty-icon: url(:/Menu/menu.svg);
     qproperty-iconSize: 16px 16px;
-    qproperty-flat: true;
 }
 
 OutlinerWidget QWidget[PulseHighlight="true"]

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutliner.qss
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutliner.qss
@@ -10,7 +10,6 @@ AzToolsFramework--EntityOutlinerWidget #m_display_options
 {
     qproperty-icon: url(:/stylesheet/img/UI20/menu-centered.svg);
     qproperty-iconSize: 16px 16px;
-    qproperty-flat: true;
 }
 
 AzToolsFramework--EntityOutlinerWidget QTreeView


### PR DESCRIPTION
Closes #5172

Removed line including property `flat` in `m_display_options` from both the `EntityOutliner.qss`