### PR TITLE
Prevent GetNodesFromGraphNodeIDs() from adding null pointers to the list that it returns.

### DIFF
--- a/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
+++ b/Gems/GraphModel/Code/Source/Integration/GraphController.cpp
@@ -698,7 +698,10 @@ namespace GraphModelIntegration
         GraphModel::NodePtrList nodeList;
         for (auto nodeId : nodeIds)
         {
-            nodeList.push_back(m_elementMap.Find<GraphModel::Node>(nodeId));
+            if (GraphModel::NodePtr nodePtr = m_elementMap.Find<GraphModel::Node>(nodeId))
+            {
+                nodeList.push_back(nodePtr);
+            }
         }
 
         return nodeList;


### PR DESCRIPTION
It should be assumed that a list of found objects contains only instantiated objects. Previously, if no `GraphModel::Node` is associated with the requested `nodeId`, a null pointer was returned from `Find` and added to the `nodeList`.