### PR TITLE
Allow input devices to be constructed with a custom implementation.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputDeviceRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Buses/Requests/InputDeviceRequestBus.h
@@ -230,16 +230,12 @@ namespace AzFramework
         using Bus = AZ::EBus<InputDeviceImplementationRequest<InputDeviceType>>;
 
         ////////////////////////////////////////////////////////////////////////////////////////////
-        //! Alias for the function type used to create the custom implementations
-        using CreateFunctionType = typename InputDeviceType::Implementation*(*)(InputDeviceType&);
-
-        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Set a custom implementation for this input device type, either for a specific instance
         //! by addressing the call to an InputDeviceId, or for all existing instances by broadcast.
         //! Passing InputDeviceType::Implementation::Create as the argument will create the default
         //! device implementation, while passing nullptr will delete any existing implementation.
-        //! \param[in] createFunction Pointer to the function that will create the implementation.
-        virtual void SetCustomImplementation(CreateFunctionType createFunction) = 0;
+        //! \param[in] implementationFactory Pointer to the function that creates the implementation.
+        virtual void SetCustomImplementation(typename InputDeviceType::ImplementationFactory implementationFactory) = 0;
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -268,17 +264,13 @@ namespace AzFramework
 
     protected:
         ////////////////////////////////////////////////////////////////////////////////////////////
-        //! Alias for the function type used to create the custom implementations
-        using CreateFunctionType = typename InputDeviceType::Implementation*(*)(InputDeviceType&);
-
-        ////////////////////////////////////////////////////////////////////////////////////////////
         //! \ref InputDeviceImplementationRequest<InputDeviceType>::SetCustomImplementation
-        AZ_INLINE void SetCustomImplementation(CreateFunctionType createFunction) override
+        AZ_INLINE void SetCustomImplementation(typename InputDeviceType::ImplementationFactory implementationFactory) override
         {
             AZStd::unique_ptr<typename InputDeviceType::Implementation> newImplementation;
-            if (createFunction)
+            if (implementationFactory)
             {
-                newImplementation.reset(createFunction(m_inputDevice));
+                newImplementation.reset(implementationFactory(m_inputDevice));
             }
             m_inputDevice.SetImplementation(AZStd::move(newImplementation));
         }

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.cpp
@@ -151,11 +151,8 @@ namespace AzFramework
             m_thumbStickDirectionChannelsById[channelId] = channel;
         }
 
-        // Create a custom implementation if we've been provided one,
-        // otherwise default to the platform specific implementation
-        m_pimpl.reset(implementationFactory ?
-                      implementationFactory(*this) :
-                      Implementation::Create(*this));
+        // Create the platform specific or custom implementation
+        m_pimpl.reset(implementationFactory ? implementationFactory(*this) : nullptr);
 
         // Connect to the haptic feedback request bus
         InputHapticFeedbackRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.cpp
@@ -94,7 +94,14 @@ namespace AzFramework
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     InputDeviceGamepad::InputDeviceGamepad(AZ::u32 index)
-        : InputDevice(InputDeviceId(Name, index))
+        : InputDeviceGamepad(InputDeviceId(Name, index)) // Delegated constructor
+    {
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+    InputDeviceGamepad::InputDeviceGamepad(const InputDeviceId& inputDeviceId,
+                                           ImplementationFactory implementationFactory)
+        : InputDevice(inputDeviceId)
         , m_allChannelsById()
         , m_buttonChannelsById()
         , m_triggerChannelsById()
@@ -144,8 +151,11 @@ namespace AzFramework
             m_thumbStickDirectionChannelsById[channelId] = channel;
         }
 
-        // Create the platform specific implementation
-        m_pimpl.reset(Implementation::Create(*this));
+        // Create a custom implementation if we've been provided one,
+        // otherwise default to the platform specific implementation
+        m_pimpl.reset(implementationFactory ?
+                      implementationFactory(*this) :
+                      Implementation::Create(*this));
 
         // Connect to the haptic feedback request bus
         InputHapticFeedbackRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h
@@ -188,7 +188,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename Implementation*(*)(InputDeviceGamepad&);
+        using ImplementationFactory = typename InputDeviceGamepad::Implementation*(InputDeviceGamepad&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
@@ -204,7 +204,7 @@ namespace AzFramework
         //! \param[in] inputDeviceId Id of the input device
         //! \param[in] implementationFactory Optional override of the default Implementation::Create
         explicit InputDeviceGamepad(const InputDeviceId& inputDeviceId,
-                                    ImplementationFactory implementationFactory = nullptr);
+                                    ImplementationFactory implementationFactory = &Implementation::Create);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h
@@ -188,7 +188,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename InputDeviceGamepad::Implementation*(InputDeviceGamepad&);
+        using ImplementationFactory = Implementation*(InputDeviceGamepad&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Gamepad/InputDeviceGamepad.h
@@ -183,6 +183,14 @@ namespace AzFramework
         static void Reflect(AZ::ReflectContext* context);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
+        // Foward declare the internal Implementation class so it can be passed into the constructor
+        class Implementation;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Alias for the function type used to create a custom implementation for this input device
+        using ImplementationFactory = typename Implementation*(*)(InputDeviceGamepad&);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
         explicit InputDeviceGamepad();
 
@@ -190,6 +198,13 @@ namespace AzFramework
         //! Constructor
         //! \param[in] index Index of the game-pad device
         explicit InputDeviceGamepad(AZ::u32 index);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Constructor
+        //! \param[in] inputDeviceId Id of the input device
+        //! \param[in] implementationFactory Optional override of the default Implementation::Create
+        explicit InputDeviceGamepad(const InputDeviceId& inputDeviceId,
+                                    ImplementationFactory implementationFactory = nullptr);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.cpp
@@ -204,11 +204,8 @@ namespace AzFramework
             m_keyChannelsById[channelId] = channel;
         }
 
-        // Create a custom implementation if we've been provided one,
-        // otherwise default to the platform specific implementation
-        m_pimpl.reset(implementationFactory ?
-                      implementationFactory(*this) :
-                      Implementation::Create(*this));
+        // Create the platform specific or custom implementation
+        m_pimpl.reset(implementationFactory ? implementationFactory(*this) : nullptr);
 
         // Connect to the text entry request bus
         InputTextEntryRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.cpp
@@ -182,8 +182,9 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    InputDeviceKeyboard::InputDeviceKeyboard(AzFramework::InputDeviceId id)
-        : InputDevice(id)
+    InputDeviceKeyboard::InputDeviceKeyboard(const InputDeviceId& inputDeviceId,
+                                             ImplementationFactory implementationFactory)
+        : InputDevice(inputDeviceId)
         , m_modifierKeyStates(AZStd::make_shared<ModifierKeyStates>())
         , m_allChannelsById()
         , m_keyChannelsById()
@@ -203,8 +204,11 @@ namespace AzFramework
             m_keyChannelsById[channelId] = channel;
         }
 
-        // Create the platform specific implementation
-        m_pimpl.reset(Implementation::Create(*this));
+        // Create a custom implementation if we've been provided one,
+        // otherwise default to the platform specific implementation
+        m_pimpl.reset(implementationFactory ?
+                      implementationFactory(*this) :
+                      Implementation::Create(*this));
 
         // Connect to the text entry request bus
         InputTextEntryRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h
@@ -376,7 +376,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename InputDeviceKeyboard::Implementation*(InputDeviceKeyboard&);
+        using ImplementationFactory = Implementation*(InputDeviceKeyboard&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h
@@ -371,8 +371,19 @@ namespace AzFramework
         static void Reflect(AZ::ReflectContext* context);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
+        // Foward declare the internal Implementation class so it can be passed into the constructor
+        class Implementation;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Alias for the function type used to create a custom implementation for this input device
+        using ImplementationFactory = typename Implementation*(*)(InputDeviceKeyboard&);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
-        InputDeviceKeyboard(AzFramework::InputDeviceId id = Id);
+        //! \param[in] inputDeviceId Optional override of the default input device id
+        //! \param[in] implementationFactory Optional override of the default Implementation::Create
+        explicit InputDeviceKeyboard(const InputDeviceId& inputDeviceId = Id,
+                                     ImplementationFactory implementationFactory = nullptr);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h
@@ -376,14 +376,14 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename Implementation*(*)(InputDeviceKeyboard&);
+        using ImplementationFactory = typename InputDeviceKeyboard::Implementation*(InputDeviceKeyboard&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
         //! \param[in] inputDeviceId Optional override of the default input device id
         //! \param[in] implementationFactory Optional override of the default Implementation::Create
         explicit InputDeviceKeyboard(const InputDeviceId& inputDeviceId = Id,
-                                     ImplementationFactory implementationFactory = nullptr);
+                                     ImplementationFactory implementationFactory = &Implementation::Create);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.cpp
@@ -60,8 +60,9 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    InputDeviceMotion::InputDeviceMotion()
-        : InputDevice(Id)
+    InputDeviceMotion::InputDeviceMotion(const InputDeviceId& inputDeviceId,
+                                         ImplementationFactory implementationFactory)
+        : InputDevice(inputDeviceId)
         , m_allChannelsById()
         , m_accelerationChannelsById()
         , m_rotationRateChannelsById()
@@ -107,8 +108,11 @@ namespace AzFramework
             m_orientationChannelsById[channelId] = channel;
         }
 
-        // Create the platform specific implementation
-        m_pimpl.reset(Implementation::Create(*this));
+        // Create a custom implementation if we've been provided one,
+        // otherwise default to the platform specific implementation
+        m_pimpl.reset(implementationFactory ?
+                      implementationFactory(*this) :
+                      Implementation::Create(*this));
 
         // Connect to the motion sensor request bus
         InputMotionSensorRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.cpp
@@ -108,11 +108,8 @@ namespace AzFramework
             m_orientationChannelsById[channelId] = channel;
         }
 
-        // Create a custom implementation if we've been provided one,
-        // otherwise default to the platform specific implementation
-        m_pimpl.reset(implementationFactory ?
-                      implementationFactory(*this) :
-                      Implementation::Create(*this));
+        // Create the platform specific or custom implementation
+        m_pimpl.reset(implementationFactory ? implementationFactory(*this) : nullptr);
 
         // Connect to the motion sensor request bus
         InputMotionSensorRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.h
@@ -132,7 +132,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename InputDeviceMotion::Implementation*(InputDeviceMotion&);
+        using ImplementationFactory = Implementation*(InputDeviceMotion&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.h
@@ -132,14 +132,14 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename Implementation*(*)(InputDeviceMotion&);
+        using ImplementationFactory = typename InputDeviceMotion::Implementation*(InputDeviceMotion&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
         //! \param[in] inputDeviceId Optional override of the default input device id
         //! \param[in] implementationFactory Optional override of the default Implementation::Create
         explicit InputDeviceMotion(const InputDeviceId& inputDeviceId = Id,
-                                   ImplementationFactory implementationFactory = nullptr);
+                                   ImplementationFactory implementationFactory = &Implementation::Create);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Motion/InputDeviceMotion.h
@@ -127,8 +127,19 @@ namespace AzFramework
         static void Reflect(AZ::ReflectContext* context);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
+        // Foward declare the internal Implementation class so it can be passed into the constructor
+        class Implementation;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Alias for the function type used to create a custom implementation for this input device
+        using ImplementationFactory = typename Implementation*(*)(InputDeviceMotion&);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
-        InputDeviceMotion();
+        //! \param[in] inputDeviceId Optional override of the default input device id
+        //! \param[in] implementationFactory Optional override of the default Implementation::Create
+        explicit InputDeviceMotion(const InputDeviceId& inputDeviceId = Id,
+                                   ImplementationFactory implementationFactory = nullptr);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -98,11 +98,8 @@ namespace AzFramework
         m_cursorPositionChannel = aznew InputChannelDeltaWithSharedPosition2D(SystemCursorPosition, *this, m_cursorPositionData2D);
         m_allChannelsById[SystemCursorPosition] = m_cursorPositionChannel;
 
-        // Create a custom implementation if we've been provided one,
-        // otherwise default to the platform specific implementation
-        m_pimpl.reset(implementationFactory ?
-                      implementationFactory(*this) :
-                      Implementation::Create(*this));
+        // Create the platform specific or custom implementation
+        m_pimpl.reset(implementationFactory ? implementationFactory(*this) : nullptr);
 
         // Connect to the system cursor request bus
         InputSystemCursorRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.cpp
@@ -67,8 +67,9 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    InputDeviceMouse::InputDeviceMouse(AzFramework::InputDeviceId id)
-        : InputDevice(id)
+    InputDeviceMouse::InputDeviceMouse(const InputDeviceId& inputDeviceId,
+                                       ImplementationFactory implementationFactory)
+        : InputDevice(inputDeviceId)
         , m_allChannelsById()
         , m_buttonChannelsById()
         , m_movementChannelsById()
@@ -97,8 +98,11 @@ namespace AzFramework
         m_cursorPositionChannel = aznew InputChannelDeltaWithSharedPosition2D(SystemCursorPosition, *this, m_cursorPositionData2D);
         m_allChannelsById[SystemCursorPosition] = m_cursorPositionChannel;
 
-        // Create the platform specific implementation
-        m_pimpl.reset(Implementation::Create(*this));
+        // Create a custom implementation if we've been provided one,
+        // otherwise default to the platform specific implementation
+        m_pimpl.reset(implementationFactory ?
+                      implementationFactory(*this) :
+                      Implementation::Create(*this));
 
         // Connect to the system cursor request bus
         InputSystemCursorRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
@@ -128,14 +128,14 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename Implementation*(*)(InputDeviceMouse&);
+        using ImplementationFactory = typename InputDeviceMouse::Implementation*(InputDeviceMouse&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
         //! \param[in] inputDeviceId Optional override of the default input device id
         //! \param[in] implementationFactory Optional override of the default Implementation::Create
         explicit InputDeviceMouse(const InputDeviceId& inputDeviceId = Id,
-                                  ImplementationFactory implementationFactory = nullptr);
+                                  ImplementationFactory implementationFactory = &Implementation::Create);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
@@ -128,7 +128,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename InputDeviceMouse::Implementation*(InputDeviceMouse&);
+        using ImplementationFactory = Implementation*(InputDeviceMouse&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Mouse/InputDeviceMouse.h
@@ -123,8 +123,19 @@ namespace AzFramework
         static void Reflect(AZ::ReflectContext* context);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
+        // Foward declare the internal Implementation class so it can be passed into the constructor
+        class Implementation;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Alias for the function type used to create a custom implementation for this input device
+        using ImplementationFactory = typename Implementation*(*)(InputDeviceMouse&);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
-        explicit InputDeviceMouse(AzFramework::InputDeviceId id = Id);
+        //! \param[in] inputDeviceId Optional override of the default input device id
+        //! \param[in] implementationFactory Optional override of the default Implementation::Create
+        explicit InputDeviceMouse(const InputDeviceId& inputDeviceId = Id,
+                                  ImplementationFactory implementationFactory = nullptr);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.cpp
@@ -59,8 +59,9 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    InputDeviceTouch::InputDeviceTouch()
-        : InputDevice(Id)
+    InputDeviceTouch::InputDeviceTouch(const InputDeviceId& inputDeviceId,
+                                       ImplementationFactory implementationFactory)
+        : InputDevice(inputDeviceId)
         , m_allChannelsById()
         , m_touchChannelsById()
         , m_pimpl(nullptr)
@@ -75,8 +76,11 @@ namespace AzFramework
             m_touchChannelsById[channelId] = channel;
         }
 
-        // Create the platform specific implementation
-        m_pimpl.reset(Implementation::Create(*this));
+        // Create a custom implementation if we've been provided one,
+        // otherwise default to the platform specific implementation
+        m_pimpl.reset(implementationFactory ?
+                      implementationFactory(*this) :
+                      Implementation::Create(*this));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.cpp
@@ -76,11 +76,8 @@ namespace AzFramework
             m_touchChannelsById[channelId] = channel;
         }
 
-        // Create a custom implementation if we've been provided one,
-        // otherwise default to the platform specific implementation
-        m_pimpl.reset(implementationFactory ?
-                      implementationFactory(*this) :
-                      Implementation::Create(*this));
+        // Create the platform specific or custom implementation
+        m_pimpl.reset(implementationFactory ? implementationFactory(*this) : nullptr);
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.h
@@ -78,8 +78,19 @@ namespace AzFramework
         static void Reflect(AZ::ReflectContext* context);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
+        // Foward declare the internal Implementation class so it can be passed into the constructor
+        class Implementation;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Alias for the function type used to create a custom implementation for this input device
+        using ImplementationFactory = typename Implementation*(*)(InputDeviceTouch&);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
-        InputDeviceTouch();
+        //! \param[in] inputDeviceId Optional override of the default input device id
+        //! \param[in] implementationFactory Optional override of the default Implementation::Create
+        explicit InputDeviceTouch(const InputDeviceId& inputDeviceId = Id,
+                                  ImplementationFactory implementationFactory = nullptr);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.h
@@ -83,7 +83,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename InputDeviceTouch::Implementation*(InputDeviceTouch&);
+        using ImplementationFactory = Implementation*(InputDeviceTouch&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/Touch/InputDeviceTouch.h
@@ -83,14 +83,14 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename Implementation*(*)(InputDeviceTouch&);
+        using ImplementationFactory = typename InputDeviceTouch::Implementation*(InputDeviceTouch&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
         //! \param[in] inputDeviceId Optional override of the default input device id
         //! \param[in] implementationFactory Optional override of the default Implementation::Create
         explicit InputDeviceTouch(const InputDeviceId& inputDeviceId = Id,
-                                  ImplementationFactory implementationFactory = nullptr);
+                                  ImplementationFactory implementationFactory = &Implementation::Create);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.cpp
@@ -51,8 +51,9 @@ namespace AzFramework
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    InputDeviceVirtualKeyboard::InputDeviceVirtualKeyboard()
-        : InputDevice(Id)
+    InputDeviceVirtualKeyboard::InputDeviceVirtualKeyboard(const InputDeviceId& inputDeviceId,
+                                                           ImplementationFactory implementationFactory)
+        : InputDevice(inputDeviceId)
         , m_allChannelsById()
         , m_pimpl()
         , m_implementationRequestHandler(*this)
@@ -65,8 +66,11 @@ namespace AzFramework
             m_commandChannelsById[channelId] = channel;
         }
 
-        // Create the platform specific implementation
-        m_pimpl.reset(Implementation::Create(*this));
+        // Create a custom implementation if we've been provided one,
+        // otherwise default to the platform specific implementation
+        m_pimpl.reset(implementationFactory ?
+                      implementationFactory(*this) :
+                      Implementation::Create(*this));
 
         // Connect to the text entry request bus
         InputTextEntryRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.cpp
@@ -66,11 +66,8 @@ namespace AzFramework
             m_commandChannelsById[channelId] = channel;
         }
 
-        // Create a custom implementation if we've been provided one,
-        // otherwise default to the platform specific implementation
-        m_pimpl.reset(implementationFactory ?
-                      implementationFactory(*this) :
-                      Implementation::Create(*this));
+        // Create the platform specific or custom implementation
+        m_pimpl.reset(implementationFactory ? implementationFactory(*this) : nullptr);
 
         // Connect to the text entry request bus
         InputTextEntryRequestBus::Handler::BusConnect(GetInputDeviceId());

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h
@@ -75,14 +75,14 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename Implementation*(*)(InputDeviceVirtualKeyboard&);
+        using ImplementationFactory = typename InputDeviceVirtualKeyboard::Implementation*(InputDeviceVirtualKeyboard&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
         //! \param[in] inputDeviceId Optional override of the default input device id
         //! \param[in] implementationFactory Optional override of the default Implementation::Create
         explicit InputDeviceVirtualKeyboard(const InputDeviceId& inputDeviceId = Id,
-                                            ImplementationFactory implementationFactory = nullptr);
+                                            ImplementationFactory implementationFactory = &Implementation::Create);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h
@@ -70,8 +70,19 @@ namespace AzFramework
         static void Reflect(AZ::ReflectContext* context);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
+        // Foward declare the internal Implementation class so it can be passed into the constructor
+        class Implementation;
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
+        //! Alias for the function type used to create a custom implementation for this input device
+        using ImplementationFactory = typename Implementation*(*)(InputDeviceVirtualKeyboard&);
+
+        ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor
-        InputDeviceVirtualKeyboard();
+        //! \param[in] inputDeviceId Optional override of the default input device id
+        //! \param[in] implementationFactory Optional override of the default Implementation::Create
+        explicit InputDeviceVirtualKeyboard(const InputDeviceId& inputDeviceId = Id,
+                                            ImplementationFactory implementationFactory = nullptr);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         // Disable copying

--- a/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h
+++ b/Code/Framework/AzFramework/AzFramework/Input/Devices/VirtualKeyboard/InputDeviceVirtualKeyboard.h
@@ -75,7 +75,7 @@ namespace AzFramework
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Alias for the function type used to create a custom implementation for this input device
-        using ImplementationFactory = typename InputDeviceVirtualKeyboard::Implementation*(InputDeviceVirtualKeyboard&);
+        using ImplementationFactory = Implementation*(InputDeviceVirtualKeyboard&);
 
         ////////////////////////////////////////////////////////////////////////////////////////////
         //! Constructor


### PR DESCRIPTION
This augments the existing functionality that allows for an input device implementation to be swapped out at runtime,

Signed-off-by: bosnichd <bosnichd@amazon.com>