### PR TITLE
Adding P0 Occlusion Culling Plane test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py
@@ -54,6 +54,10 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_MeshAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_MeshAdded as test_module
 
+    @pytest.mark.test_case_id("C36525663")
+    class AtomEditorComponents_OcclusionCullingPlaneAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_OcclusionCullingPlaneAdded as test_module
+
     @pytest.mark.test_case_id("C32078125")
     class AtomEditorComponents_PhysicalSkyAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_PhysicalSkyAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
@@ -41,10 +41,10 @@ class Tests:
         "REDO deletion failed")
 
 
-def AtomEditorComponents_occlusion_culling_plane_AddedToEntity():
+def AtomEditorComponents_OcclusionCullingPlane_AddedToEntity():
     """
     Summary:
-    Tests the occlusion_culling_plane component can be added to an entity and has the expected functionality.
+    Tests the occlusion culling plane component can be added to an entity and has the expected functionality.
 
     Test setup:
     - Wait for Editor idle loop.
@@ -156,4 +156,4 @@ def AtomEditorComponents_occlusion_culling_plane_AddedToEntity():
 
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
-    Report.start_test(AtomEditorComponents_occlusion_culling_plane_AddedToEntity)
+    Report.start_test(AtomEditorComponents_OcclusionCullingPlane_AddedToEntity)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
@@ -1,0 +1,156 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    Occlusion_Culling_Plane_entity_creation = (
+        "Occlusion Culling Plane Entity successfully created",
+        "Occlusion Culling Plane Entity failed to be created")
+    Occlusion_Culling_Plane_component_added = (
+        "Entity has a Occlusion Culling Plane component",
+        "Entity failed to find Occlusion Culling Plane component")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
+
+
+def AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity():
+    """
+    Summary:
+    Tests the Occlusion_Culling_Plane component can be added to an entity and has the expected functionality.
+
+    Test setup:
+    - Wait for Editor idle loop.
+    - Open the "Base" level.
+
+    Expected Behavior:
+    The component can be added, used in game mode, hidden/shown, deleted, and has accurate required components.
+    Creation and deletion undo/redo should also work.
+
+    Test Steps:
+    1) Create a Occlusion Culling Plane entity with no components.
+    2) Add a Occlusion Culling Plane component to Occlusion Culling Plane entity.
+    3) UNDO the entity creation and component addition.
+    4) REDO the entity creation and component addition.
+    5) Enter/Exit game mode.
+    6) Test IsHidden.
+    7) Test IsVisible.
+    8) Delete Occlusion Culling Plane entity.
+    9) UNDO deletion.
+    10) REDO deletion.
+    11) Look for errors.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
+
+    with Tracer() as error_tracer:
+        # Test setup begins.
+        # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
+
+        # Test steps begin.
+        # 1. Create a Occlusion_Culling_Plane entity with no components.
+        occlusion_culling_plane_entity = EditorEntity.create_editor_entity(AtomComponentProperties.occlusion_culling_plane())
+        Report.critical_result(Tests.Occlusion_Culling_Plane_entity_creation, occlusion_culling_plane_entity.exists())
+
+        # 2. Add a Occlusion_Culling_Plane component to Occlusion_Culling_Plane entity.
+        Occlusion_Culling_Plane_component = occlusion_culling_plane_entity.add_component(AtomComponentProperties.occlusion_culling_plane())
+        Report.critical_result(
+            Tests.Occlusion_Culling_Plane_component_added,
+            occlusion_culling_plane_entity.has_component(AtomComponentProperties.occlusion_culling_plane()))
+
+        # 3. UNDO the entity creation and component addition.
+        # -> UNDO component addition.
+        general.undo()
+        # -> UNDO naming entity.
+        general.undo()
+        # -> UNDO selecting entity.
+        general.undo()
+        # -> UNDO entity creation.
+        general.undo()
+        general.idle_wait_frames(1)
+        Report.result(Tests.creation_undo, not occlusion_culling_plane_entity.exists())
+
+        # 4. REDO the entity creation and component addition.
+        # -> REDO entity creation.
+        general.redo()
+        # -> REDO selecting entity.
+        general.redo()
+        # -> REDO naming entity.
+        general.redo()
+        # -> REDO component addition.
+        general.redo()
+        general.idle_wait_frames(1)
+        Report.result(Tests.creation_redo, occlusion_culling_plane_entity.exists())
+
+        # 5. Enter/Exit game mode.
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
+        general.idle_wait_frames(1)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+        # 6. Test IsHidden.
+        occlusion_culling_plane_entity.set_visibility_state(False)
+        Report.result(Tests.is_hidden, occlusion_culling_plane_entity.is_hidden() is True)
+
+        # 7. Test IsVisible.
+        occlusion_culling_plane_entity.set_visibility_state(True)
+        general.idle_wait_frames(1)
+        Report.result(Tests.is_visible, occlusion_culling_plane_entity.is_visible() is True)
+
+        # 8. Delete Occlusion_Culling_Plane entity.
+        occlusion_culling_plane_entity.delete()
+        Report.result(Tests.entity_deleted, not occlusion_culling_plane_entity.exists())
+
+        # 9. UNDO deletion.
+        general.undo()
+        Report.result(Tests.deletion_undo, occlusion_culling_plane_entity.exists())
+
+        # 10. REDO deletion.
+        general.redo()
+        Report.result(Tests.deletion_redo, not occlusion_culling_plane_entity.exists())
+
+        # 11. Look for errors or asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
@@ -84,14 +84,14 @@ def AtomEditorComponents_OcclusionCullingPlane_AddedToEntity():
 
         # Test steps begin.
         # 1. Create a occlusion culling plane entity with no components.
-        occlusion_culling_plane_entity = EditorEntity.\
-            create_editor_entity(AtomComponentProperties.occlusion_culling_plane())
+        occlusion_culling_plane_entity = EditorEntity.create_editor_entity(
+            AtomComponentProperties.occlusion_culling_plane())
         Report.critical_result(Tests.occlusion_culling_plane_entity_creation, 
                                occlusion_culling_plane_entity.exists())
 
         # 2. Add a occlusion culling plane component to occlusion culling plane entity.
-        occlusion_culling_plane_component = occlusion_culling_plane_entity.\
-            add_component(AtomComponentProperties.occlusion_culling_plane())
+        occlusion_culling_plane_component = occlusion_culling_plane_entity.add_component(
+            AtomComponentProperties.occlusion_culling_plane())
         Report.critical_result(
             Tests.occlusion_culling_plane_component_added,
             occlusion_culling_plane_entity.has_component(AtomComponentProperties.occlusion_culling_plane()))

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py
@@ -12,10 +12,10 @@ class Tests:
     creation_redo = (
         "REDO Entity creation success",
         "REDO Entity creation failed")
-    Occlusion_Culling_Plane_entity_creation = (
+    occlusion_culling_plane_entity_creation = (
         "Occlusion Culling Plane Entity successfully created",
         "Occlusion Culling Plane Entity failed to be created")
-    Occlusion_Culling_Plane_component_added = (
+    occlusion_culling_plane_component_added = (
         "Entity has a Occlusion Culling Plane component",
         "Entity failed to find Occlusion Culling Plane component")
     enter_game_mode = (
@@ -41,10 +41,10 @@ class Tests:
         "REDO deletion failed")
 
 
-def AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity():
+def AtomEditorComponents_occlusion_culling_plane_AddedToEntity():
     """
     Summary:
-    Tests the Occlusion_Culling_Plane component can be added to an entity and has the expected functionality.
+    Tests the occlusion_culling_plane component can be added to an entity and has the expected functionality.
 
     Test setup:
     - Wait for Editor idle loop.
@@ -83,14 +83,17 @@ def AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity():
         TestHelper.open_level("", "Base")
 
         # Test steps begin.
-        # 1. Create a Occlusion_Culling_Plane entity with no components.
-        occlusion_culling_plane_entity = EditorEntity.create_editor_entity(AtomComponentProperties.occlusion_culling_plane())
-        Report.critical_result(Tests.Occlusion_Culling_Plane_entity_creation, occlusion_culling_plane_entity.exists())
+        # 1. Create a occlusion culling plane entity with no components.
+        occlusion_culling_plane_entity = EditorEntity.\
+            create_editor_entity(AtomComponentProperties.occlusion_culling_plane())
+        Report.critical_result(Tests.occlusion_culling_plane_entity_creation, 
+                               occlusion_culling_plane_entity.exists())
 
-        # 2. Add a Occlusion_Culling_Plane component to Occlusion_Culling_Plane entity.
-        Occlusion_Culling_Plane_component = occlusion_culling_plane_entity.add_component(AtomComponentProperties.occlusion_culling_plane())
+        # 2. Add a occlusion culling plane component to occlusion culling plane entity.
+        occlusion_culling_plane_component = occlusion_culling_plane_entity.\
+            add_component(AtomComponentProperties.occlusion_culling_plane())
         Report.critical_result(
-            Tests.Occlusion_Culling_Plane_component_added,
+            Tests.occlusion_culling_plane_component_added,
             occlusion_culling_plane_entity.has_component(AtomComponentProperties.occlusion_culling_plane()))
 
         # 3. UNDO the entity creation and component addition.
@@ -131,7 +134,7 @@ def AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity():
         general.idle_wait_frames(1)
         Report.result(Tests.is_visible, occlusion_culling_plane_entity.is_visible() is True)
 
-        # 8. Delete Occlusion_Culling_Plane entity.
+        # 8. Delete occlusion_culling_plane entity.
         occlusion_culling_plane_entity.delete()
         Report.result(Tests.entity_deleted, not occlusion_culling_plane_entity.exists())
 
@@ -153,4 +156,4 @@ def AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity():
 
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
-    Report.start_test(AtomEditorComponents_Occlusion_Culling_Plane_AddedToEntity)
+    Report.start_test(AtomEditorComponents_occlusion_culling_plane_AddedToEntity)


### PR DESCRIPTION
Adding P0 Occlusion Culling Plane test, and including it in the TestSuite_Main_Optimized.py.

Here is the output from running the grid test ("hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py") in editor:

pyRunFile ../../Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_OcclusionCullingPlaneAdded.py

Report:
[SUCCESS] Success: Occlusion Culling Plane Entity successfully created
[SUCCESS] Success: Entity has a Occlusion Culling Plane component
[SUCCESS] Success: UNDO Entity creation success
[SUCCESS] Success: REDO Entity creation success
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS

Output of running "TestSuite_Main_Optimized.py" from a cmd line within O3de: 

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py XXXXXXXXXXXXXXXXXXX                                                                                                            [100%]

========================================================================================== warnings summary ===========================================================================================
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py::TestAutomation::run_parallel_batched_tests[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py::TestAutomation::run_parallel_batched_tests[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py::TestAutomation::run_parallel_batched_tests[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py::TestAutomation::run_parallel_batched_tests[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py::TestAutomation::run_parallel_batched_tests[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py::TestAutomation::run_parallel_batched_tests[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
  c:\ly_git\o3de\tools\lytesttools\ly_test_tools\launchers\platforms\base.py:94: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn(f'Unable to remove artifact: {artifact}, skipping.')

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================== 19 xpassed, 6 warnings in 54.17s ===================================================================================

C:\LY_Git\o3de>




Signed-off-by: Neil Widmaier <nwidmaie@amazon.com>