### PR TITLE
LYN-7536 | Focus Mode - Introduce shortcuts to open/close prefab editing

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -86,6 +86,44 @@ namespace AzToolsFramework::Prefab
         return AZ::Success();
     }
 
+    PrefabFocusOperationResult PrefabFocusHandler::FocusOnParentOfFocusedPrefab()
+    {
+        // If only one instance is in the hierarchy, this operation is invalid
+        size_t hierarchySize = m_instanceFocusHierarchy.size();
+        if (hierarchySize <= 1)
+        {
+            return AZ::Failure(
+                AZStd::string("Prefab Focus Handler: Could not complete FocusOnParentOfFocusedPrefab operation while focusing on the root."));
+        }
+
+        // Retrieve parent of currently focused prefab.
+        InstanceOptionalReference parentInstance = m_instanceFocusHierarchy[hierarchySize - 2];
+
+        // Use container entity of parent Instance for focus operations.
+        AZ::EntityId entityId = parentInstance->get().GetContainerEntityId();
+
+        // Initialize Undo Batch object
+        ScopedUndoBatch undoBatch("Edit Prefab");
+
+        // Clear selection
+        {
+            const EntityIdList selectedEntities = EntityIdList{};
+            auto selectionUndo = aznew SelectionCommand(selectedEntities, "Clear Selection");
+            selectionUndo->SetParent(undoBatch.GetUndoBatch());
+            ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, selectedEntities);
+        }
+
+        // Edit Prefab
+        {
+            auto editUndo = aznew PrefabFocusUndo("Edit Prefab");
+            editUndo->Capture(entityId);
+            editUndo->SetParent(undoBatch.GetUndoBatch());
+            FocusOnPrefabInstanceOwningEntityId(entityId);
+        }
+
+        return AZ::Success();
+    }
+
     PrefabFocusOperationResult PrefabFocusHandler::FocusOnPathIndex([[maybe_unused]] AzFramework::EntityContextId entityContextId, int index)
     {
         if (index < 0 || index >= m_instanceFocusHierarchy.size())

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -86,7 +86,8 @@ namespace AzToolsFramework::Prefab
         return AZ::Success();
     }
 
-    PrefabFocusOperationResult PrefabFocusHandler::FocusOnParentOfFocusedPrefab()
+    PrefabFocusOperationResult PrefabFocusHandler::FocusOnParentOfFocusedPrefab(
+        [[maybe_unused]] AzFramework::EntityContextId entityContextId)
     {
         // If only one instance is in the hierarchy, this operation is invalid
         size_t hierarchySize = m_instanceFocusHierarchy.size();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -50,7 +50,7 @@ namespace AzToolsFramework::Prefab
 
         // PrefabFocusPublicInterface overrides ...
         PrefabFocusOperationResult FocusOnOwningPrefab(AZ::EntityId entityId) override;
-        PrefabFocusOperationResult FocusOnParentOfFocusedPrefab() override;
+        PrefabFocusOperationResult FocusOnParentOfFocusedPrefab(AzFramework::EntityContextId entityContextId) override;
         PrefabFocusOperationResult FocusOnPathIndex(AzFramework::EntityContextId entityContextId, int index) override;
         AZ::EntityId GetFocusedPrefabContainerEntityId(AzFramework::EntityContextId entityContextId) const override;
         bool IsOwningPrefabBeingFocused(AZ::EntityId entityId) const override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -50,6 +50,7 @@ namespace AzToolsFramework::Prefab
 
         // PrefabFocusPublicInterface overrides ...
         PrefabFocusOperationResult FocusOnOwningPrefab(AZ::EntityId entityId) override;
+        PrefabFocusOperationResult FocusOnParentOfFocusedPrefab() override;
         PrefabFocusOperationResult FocusOnPathIndex(AzFramework::EntityContextId entityContextId, int index) override;
         AZ::EntityId GetFocusedPrefabContainerEntityId(AzFramework::EntityContextId entityContextId) const override;
         bool IsOwningPrefabBeingFocused(AZ::EntityId entityId) const override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusPublicInterface.h
@@ -31,7 +31,7 @@ namespace AzToolsFramework::Prefab
         virtual PrefabFocusOperationResult FocusOnOwningPrefab(AZ::EntityId entityId) = 0;
 
         //! Set the focused prefab instance to the parent of the currently focused prefab instance. Supports undo/redo.
-        virtual PrefabFocusOperationResult FocusOnParentOfFocusedPrefab() = 0;
+        virtual PrefabFocusOperationResult FocusOnParentOfFocusedPrefab(AzFramework::EntityContextId entityContextId) = 0;
 
         //! Set the focused prefab instance to the instance at position index of the current path. Supports undo/redo.
         //! @param index The index of the instance in the current path that we want the prefab system to focus on.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusPublicInterface.h
@@ -30,6 +30,9 @@ namespace AzToolsFramework::Prefab
         //! @param entityId The entityId of the entity whose owning instance we want the prefab system to focus on.
         virtual PrefabFocusOperationResult FocusOnOwningPrefab(AZ::EntityId entityId) = 0;
 
+        //! Set the focused prefab instance to the parent of the currently focused prefab instance. Supports undo/redo.
+        virtual PrefabFocusOperationResult FocusOnParentOfFocusedPrefab() = 0;
+
         //! Set the focused prefab instance to the instance at position index of the current path. Supports undo/redo.
         //! @param index The index of the instance in the current path that we want the prefab system to focus on.
         virtual PrefabFocusOperationResult FocusOnPathIndex(AzFramework::EntityContextId entityContextId, int index) = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.cpp
@@ -8,6 +8,7 @@
 
 #include <AzToolsFramework/UI/Prefab/LevelRootUiHandler.h>
 
+#include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx>
 
@@ -91,5 +92,17 @@ namespace AzToolsFramework
         // Draw border at the bottom
         painter->drawLine(rect.bottomLeft(), rect.bottomRight());
         painter->restore();
+    }
+
+    bool LevelRootUiHandler::OnEntityDoubleClick(AZ::EntityId entityId) const
+    {
+        if (auto prefabFocusPublicInterface = AZ::Interface<Prefab::PrefabFocusPublicInterface>::Get();
+            !prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
+        {
+            prefabFocusPublicInterface->FocusOnOwningPrefab(entityId);
+        }
+
+        // Don't propagate event.
+        return true;
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.h
@@ -33,6 +33,7 @@ namespace AzToolsFramework
         bool CanToggleLockVisibility(AZ::EntityId entityId) const override;
         bool CanRename(AZ::EntityId entityId) const override;
         void PaintItemBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+        bool OnEntityDoubleClick(AZ::EntityId entityId) const override;
 
     private:
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -169,10 +169,11 @@ namespace AzToolsFramework
         void PrefabIntegrationManager::InitializeShortcuts()
         {
             // Open/Edit Prefab (+)
+            // We also support = to enable easier editing on compact US keyboards.
             {
                 m_actions.emplace_back(AZStd::make_unique<QAction>(nullptr));
 
-                m_actions.back()->setShortcuts({ QKeySequence(Qt::Key_Plus) });
+                m_actions.back()->setShortcuts({ QKeySequence(Qt::Key_Plus), QKeySequence(Qt::Key_Equal) });
                 m_actions.back()->setText("Open/Edit Prefab");
                 m_actions.back()->setStatusTip("Edit the prefab in focus mode.");
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -96,10 +96,15 @@ namespace AzToolsFramework
             static void ContextMenu_CreatePrefab(AzToolsFramework::EntityIdList selectedEntities);
             static void ContextMenu_InstantiatePrefab();
             static void ContextMenu_InstantiateProceduralPrefab();
+            static void ContextMenu_ClosePrefab();
             static void ContextMenu_EditPrefab(AZ::EntityId containerEntity);
             static void ContextMenu_SavePrefab(AZ::EntityId containerEntity);
             static void ContextMenu_DeleteSelected();
             static void ContextMenu_DetachPrefab(AZ::EntityId containerEntity);
+
+            // Shortcut setup handlers
+            void InitializeShortcuts();
+            void UninitializeShortcuts();
 
             // Prompt and resolve dialogs
             static bool QueryUserForPrefabSaveLocation(
@@ -139,6 +144,8 @@ namespace AzToolsFramework
             AZStd::unique_ptr<AzQtComponents::Card> ConstructUnsavedPrefabsCard(TemplateId templateId);
             AZStd::unique_ptr<QDialog> ConstructSavePrefabDialog(TemplateId templateId, bool useSaveAllPrefabsPreference);
             void SavePrefabsInDialog(QDialog* unsavedPrefabsDialog);
+
+            AZStd::vector<AZStd::unique_ptr<QAction>> m_actions;
 
             static const AZStd::string s_prefabFileExtension;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -148,6 +148,7 @@ namespace AzToolsFramework
             AZStd::vector<AZStd::unique_ptr<QAction>> m_actions;
 
             static const AZStd::string s_prefabFileExtension;
+            static AzFramework::EntityContextId s_editorEntityContextId;
 
             static ContainerEntityInterface* s_containerEntityInterface;
             static EditorEntityUiInterface* s_editorEntityUiInterface;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -21,6 +21,8 @@
 
 namespace AzToolsFramework
 {
+    AzFramework::EntityContextId PrefabUiHandler::s_editorEntityContextId = AzFramework::EntityContextId::CreateNull();
+
     const QColor PrefabUiHandler::m_backgroundColor = QColor("#444444");
     const QColor PrefabUiHandler::m_backgroundHoverColor = QColor("#5A5A5A");
     const QColor PrefabUiHandler::m_backgroundSelectedColor = QColor("#656565");
@@ -47,6 +49,9 @@ namespace AzToolsFramework
             AZ_Assert(false, "PrefabUiHandler - could not get PrefabFocusPublicInterface on PrefabUiHandler construction.");
             return;
         }
+
+        // Get EditorEntityContextId
+        EditorEntityContextRequestBus::BroadcastResult(s_editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
     }
 
     QString PrefabUiHandler::GenerateItemInfoString(AZ::EntityId entityId) const
@@ -425,12 +430,8 @@ namespace AzToolsFramework
 
         if (m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
         {
-            auto editorEntityContextId = AzFramework::EntityContextId::CreateNull();
-            EditorEntityContextRequestBus::BroadcastResult(editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
-
-            // Go one level up.
-            int length = m_prefabFocusPublicInterface->GetPrefabFocusPathLength(editorEntityContextId);
-            m_prefabFocusPublicInterface->FocusOnPathIndex(editorEntityContextId, length - 2);
+            // Close this prefab and focus on the parent
+            m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab(s_editorEntityContextId);
         }
     }
 
@@ -444,7 +445,7 @@ namespace AzToolsFramework
         else
         {
             // Close this prefab and focus on the parent
-            m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab();
+            m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab(s_editorEntityContextId);
         }
 
         // Don't propagate event.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -436,8 +436,16 @@ namespace AzToolsFramework
 
     bool PrefabUiHandler::OnEntityDoubleClick(AZ::EntityId entityId) const
     {
-        // Focus on this prefab
-        m_prefabFocusPublicInterface->FocusOnOwningPrefab(entityId);
+        if (!m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
+        {
+            // Focus on this prefab
+            m_prefabFocusPublicInterface->FocusOnOwningPrefab(entityId);
+        }
+        else
+        {
+            // Close this prefab and focus on the parent
+            m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab();
+        }
 
         // Don't propagate event.
         return true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -49,6 +49,8 @@ namespace AzToolsFramework
         static QModelIndex GetLastVisibleChild(const QModelIndex& parent);
         static QModelIndex Internal_GetLastVisibleChild(const QAbstractItemModel* model, const QModelIndex& index);
 
+        static AzFramework::EntityContextId s_editorEntityContextId;
+
         static constexpr int m_prefabCapsuleRadius = 6;
         static constexpr int m_prefabBorderThickness = 2;
         static const QColor m_backgroundColor;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -10,6 +10,8 @@
 
 #include <AzToolsFramework/UI/EditorEntityUi/EditorEntityUiHandlerBase.h>
 
+#include <AzFramework/Entity/EntityContextBus.h>
+
 namespace AzToolsFramework
 {
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -59,12 +59,11 @@ namespace AzToolsFramework::Prefab
         connect(m_backButton, &QToolButton::clicked, this,
             [&]()
             {
-                if (int length = m_prefabFocusPublicInterface->GetPrefabFocusPathLength(m_editorEntityContextId); length > 1)
-                {
-                    m_prefabFocusPublicInterface->FocusOnPathIndex(m_editorEntityContextId, length - 2);
-                }
+                m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab();
             }
         );
+
+        m_backButton->setToolTip("Up one level (-)");
     }
 
     void PrefabViewportFocusPathHandler::OnPrefabFocusChanged()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -59,7 +59,7 @@ namespace AzToolsFramework::Prefab
         connect(m_backButton, &QToolButton::clicked, this,
             [&]()
             {
-                m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab();
+                m_prefabFocusPublicInterface->FocusOnParentOfFocusedPrefab(m_editorEntityContextId);
             }
         );
 


### PR DESCRIPTION
Introduce shortcuts to open and close prefabs for editing. Also refactor current context menu and click interactions to match.

To be more precise:
- Right clicking on a focused prefab now correctly displays the "Close Prefab" context menu item. This will close the focused prefab, and move the focus up one level to its parent (exactly the same behavior as pressing the "up one level" button in the breadcrumbs);
- Both context menu items now show the shortcuts associated to those actions;

![focus_menuitems](https://user-images.githubusercontent.com/82231674/139970087-c1caec36-51e1-4b9b-98c0-52755d903a49.gif)



- Pressing + while a single prefab is selected opens it for editing. Since most compact US keyboards (for example on laptops) have + as a shift modifier for =, we have both = and + act as the + shortcut to simplify usage in those environments;
- Pressing - while a prefab is in focus closes it. Note that the prefab does not need to be selected for this to work; the behavior is the same as the left arrow button in the viewport breadcrumbs, as in it will move focus one step up to the owning prefab of the instance that was being focused before.

![focus_shortcuts](https://user-images.githubusercontent.com/82231674/139970511-6d68ad1d-5860-467e-a514-eb8c7c7f8a02.gif)



- Double clicking a prefab container will toggle the open state. The closing behavior is the same as the - button (one level up)

![focus_doubleclick](https://user-images.githubusercontent.com/82231674/139970197-227f415b-9575-427b-8f4a-4a7b221c1f4f.gif)



- Double clicking on the level instance whenever a prefab instance is in focus will return to focusing on the level (same as pressing Esc). Double clicking on the level while prefab mode is not active has no effect.

![focus_doubleclick_level](https://user-images.githubusercontent.com/82231674/139970252-161fe15f-921e-4200-9f88-917c98a9c703.gif)



- The current shortcuts allow the user to easily navigate the prefab hierarchy and go up/down focus mode in the viewport, without having to do any operation in the Outliner. Visualization improvements that are currently on working will make viewport navigation even simpler to understand.

![focus_shortcuts_viewport](https://user-images.githubusercontent.com/82231674/139970365-41f6ec2b-5f85-4ef8-ac70-69039d5ecaf3.gif)



PR includes some changes to simplify existing operations that would move focus up one level, since a shorthand function has been added. For example, the "Up one level" button in the viewport breadcrumbs now shows a tooltip that includes the shortcut.
![image](https://user-images.githubusercontent.com/82231674/139970837-9d1daab5-bb82-496b-a1a1-c17e6059803e.png)
