### PR TITLE
Improve handling of cached data limits.

### DIFF
--- a/Gems/Profiler/Code/Source/CpuProfilerImpl.cpp
+++ b/Gems/Profiler/Code/Source/CpuProfilerImpl.cpp
@@ -381,7 +381,7 @@ namespace Profiler
             if (!m_cachedTimeRegionMap.empty())
             {
                 cachedTimeRegionMap = AZStd::move(m_cachedTimeRegionMap);
-                ResetCachedData();
+                m_cachedTimeRegionMap.clear();
                 m_hitSizeLimitMap.clear();
             }
 

--- a/Gems/Profiler/Code/Source/CpuProfilerImpl.cpp
+++ b/Gems/Profiler/Code/Source/CpuProfilerImpl.cpp
@@ -282,7 +282,7 @@ namespace Profiler
             m_stackLevel = 0;
             m_cachedTimeRegionMap.clear();
             m_timeRegionStack.clear();
-            m_cachedTimeRegions.clear();
+            ResetCachedData();
         }
 
         timeRegion.m_stackDepth = aznumeric_cast<uint16_t>(m_stackLevel);
@@ -329,8 +329,21 @@ namespace Profiler
         {
             return;
         }
-        // Add an entry to the cached region
-        m_cachedTimeRegions.push_back(timeRegionCached);
+        // Add an entry to the cached region. Discard excess data in case there is too much to handle.
+        if (m_cachedTimeRegions.size() < TimeRegionStackSize)
+        {
+            m_cachedTimeRegions.push_back(timeRegionCached);
+        }
+        // Warn only once per thread if the cached data limit has been reached.
+        else if (!m_cachedDataLimitReached)
+        {
+            AZ_Warning(
+                "Profiler", false,
+                "Limit for profiling data has been reached by thread %i. Excess data will be discarded. Considering moving or reducing "
+                "profiler markers to prevent data loss.",
+                m_executingThreadId);
+            m_cachedDataLimitReached = true;
+        }
 
         // If the stack is empty, add it to the local cache map. Only gets called when the stack is empty
         // NOTE: this is where the largest overhead will be, but due to it only being called when the stack is empty
@@ -354,7 +367,7 @@ namespace Profiler
             }
 
             // Clear the cached regions
-            m_cachedTimeRegions.clear();
+            ResetCachedData();
         }
     }
 
@@ -368,11 +381,18 @@ namespace Profiler
             if (!m_cachedTimeRegionMap.empty())
             {
                 cachedTimeRegionMap = AZStd::move(m_cachedTimeRegionMap);
-                m_cachedTimeRegionMap.clear();
+                ResetCachedData();
                 m_hitSizeLimitMap.clear();
             }
+
             m_cachedTimeRegionMutex.unlock();
         }
+    }
+
+    void CpuTimingLocalStorage::ResetCachedData()
+    {
+        m_cachedTimeRegions.clear();
+        m_cachedDataLimitReached = false;
     }
 
     // --- CpuProfilingStatisticsSerializer ---

--- a/Gems/Profiler/Code/Source/CpuProfilerImpl.h
+++ b/Gems/Profiler/Code/Source/CpuProfilerImpl.h
@@ -64,7 +64,7 @@ namespace Profiler
         // Keeps track of regions that completed (i.e regions that was pushed and popped from the stack)
         // Intermediate storage point for the CachedTimeRegions, when the stack is empty, all entries will be
         // copied to the map.
-        AZStd::fixed_vector<CachedTimeRegion, TimeRegionStackSize> m_cachedTimeRegions;
+        AZStd::vector<CachedTimeRegion> m_cachedTimeRegions;
         AZStd::mutex m_cachedTimeRegionMutex;
 
         // Dirty flag which is set when the CpuProfiler's enabled state is set from false to true

--- a/Gems/Profiler/Code/Source/CpuProfilerImpl.h
+++ b/Gems/Profiler/Code/Source/CpuProfilerImpl.h
@@ -50,6 +50,9 @@ namespace Profiler
         // Tries to flush the map to the passed parameter, only if the thread's mutex is unlocked
         void TryFlushCachedMap(CpuProfiler::ThreadTimeRegionMap& cachedRegionMap);
 
+        // Clears m_cachedTimeRegions and resets m_cachedDataLimitReached flag.
+        void ResetCachedData();
+
         AZStd::thread_id m_executingThreadId;
         // Keeps track of the current thread's stack depth
         uint32_t m_stackLevel = 0u;
@@ -64,7 +67,7 @@ namespace Profiler
         // Keeps track of regions that completed (i.e regions that was pushed and popped from the stack)
         // Intermediate storage point for the CachedTimeRegions, when the stack is empty, all entries will be
         // copied to the map.
-        AZStd::vector<CachedTimeRegion> m_cachedTimeRegions;
+        AZStd::fixed_vector<CachedTimeRegion, TimeRegionStackSize> m_cachedTimeRegions;
         AZStd::mutex m_cachedTimeRegionMutex;
 
         // Dirty flag which is set when the CpuProfiler's enabled state is set from false to true
@@ -75,6 +78,9 @@ namespace Profiler
 
         // Keep track of the regions that have hit the size limit so we don't have to lock to check
         AZStd::map<AZStd::string, bool> m_hitSizeLimitMap;
+
+        // Keeps track of the first time cached data limit was reached.
+        bool m_cachedDataLimitReached = false;
     };
 
     //! CpuProfiler will keep track of the registered threads, and


### PR DESCRIPTION
The limit seems to be trigged by profiler calls to AssetDataStream::Read.

Contents of m_cachedTimeRegions when full is repeated indefinitely:
![image](https://user-images.githubusercontent.com/43485729/140001366-80422f1b-8a45-4f7c-b980-b7c559c64b84.png)

Signed-off-by: rbarrand <43485729+hershey5045@users.noreply.github.com>