### PR TITLE
Fixed editor crash dropping an fbx to entity inspector

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Editor/Components/EditorActorComponent.cpp
@@ -195,6 +195,8 @@ namespace EMotionFX
         //////////////////////////////////////////////////////////////////////////
         void EditorActorComponent::Activate()
         {
+            AzToolsFramework::Components::EditorComponentBase::Activate();
+
             LoadActorAsset();
 
             const AZ::EntityId entityId = GetEntityId();
@@ -225,6 +227,8 @@ namespace EMotionFX
 
             DestroyActorInstance();
             m_actorAsset.Release();
+
+            AzToolsFramework::Components::EditorComponentBase::Deactivate();
         }
 
         //////////////////////////////////////////////////////////////////////////
@@ -587,7 +591,15 @@ namespace EMotionFX
             if (asset)
             {
                 m_actorAsset = asset;
-                OnAssetSelected();
+
+                // SetPrimaryAsset function can be called while this component is not activated
+                // due to incompatible services. For example by dragging and dropping a FBX to an
+                // entity that already has an actor or mesh component in it. Only proceed to load actor
+                // asset if the component is activated (by checking if it's connected to EditorActorComponentRequestBus).
+                if (EditorActorComponentRequestBus::Handler::BusIsConnected())
+                {
+                    OnAssetSelected();
+                }
             }
         }
 


### PR DESCRIPTION
The issue was that EditorActorComponent (added by the drag and drop of the FBX into the entity) continued with the loading of an actor asset even though the component is not activated due to incompatible services, which ultimately lead to logic which should never have been reached and crashing. 

Also fixed EditorActorComponent missing activation and deactivation of the base editor component class, which is necessary.

All tests from EMotionFX.Editor.Tests passed.