### PR TITLE
Add quick iteration workflow to the custom python tool template.

### DIFF
--- a/Templates/PythonToolGem/Template/Editor/Scripts/${NameLower}_dialog.py
+++ b/Templates/PythonToolGem/Template/Editor/Scripts/${NameLower}_dialog.py
@@ -33,3 +33,12 @@ class ${SanitizedCppName}Dialog(QDialog):
         self.mainLayout.addWidget(self.helpLabel, 0, Qt.AlignCenter)
 
         self.setLayout(self.mainLayout)
+
+
+if __name__ == "__main__":
+    # Create a new instance of the tool if launched from the Python Scripts window,
+    # which allows for quick iteration without having to close/re-launch the Editor
+    test_dialog = ${SanitizedCppName}Dialog()
+    test_dialog.setWindowTitle("${SanitizedCppName}")
+    test_dialog.show()
+    test_dialog.adjustSize()


### PR DESCRIPTION
Updated the custom Python tool template to include logic to help the user quickly iterate on design by creating/launching a new tool if the user executes the script from the `Python Scripts` tool. This allows you to quickly makes changes in your Python script/tool and see the results immediately without having to close/re-launch the Editor.

![RelaunchPythonTool](https://user-images.githubusercontent.com/7519264/140102222-e8afa6df-d842-4941-ad4f-0fa60aae6d58.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>