### PR TITLE
[MacOS] Launching Editor from ProjectManager and other misc. fixes

### DIFF
--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Asset/AssetSystemComponentHelper_Mac.cpp
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Asset/AssetSystemComponentHelper_Mac.cpp
@@ -10,6 +10,8 @@
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 
+#include <AzFramework/Process/ProcessWatcher.h>
+
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -24,14 +26,20 @@ namespace AzFramework::AssetSystem::Platform
         AZ::IO::FixedMaxPath assetProcessorPath{ executableDirectory };
         // In Mac the Editor and game is within a bundle, so the path to the sibling app
         // has to go up from the Contents/MacOS folder the binary is in
-        assetProcessorPath /= "../../../AssetProcessor.app";
+        assetProcessorPath /= "../../../AssetProcessor.app/Contents/MacOS/AssetProcessor";
         assetProcessorPath = assetProcessorPath.LexicallyNormal();
 
         if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
         {
-            // Check for existence of one under a "bin" directory, i.e. engineRoot is an SDK structure.
-            assetProcessorPath =
-                AZ::IO::FixedMaxPath{engineRoot} / "bin" / AZ_TRAIT_OS_PLATFORM_NAME / AZ_BUILD_CONFIGURATION_TYPE / "AssetProcessor.app";
+            if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+            {
+                if (AZ::IO::FixedMaxPath installedBinariesPath;
+                    settingsRegistry->Get(installedBinariesPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_InstalledBinaryFolder))
+                {
+                    // Check for existence of one under a "bin" directory, i.e. engineRoot is an SDK structure.
+                    assetProcessorPath = AZ::IO::FixedMaxPath{ engineRoot } / installedBinariesPath / "AssetProcessor.app/Contents/MacOS/AssetProcessor";
+                }
+            }
 
             if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
             {
@@ -39,23 +47,21 @@ namespace AzFramework::AssetSystem::Platform
             }
         }
 
-        auto fullLaunchCommand = AZ::IO::FixedMaxPathString::format(R"(open -g "%s" --args --start-hidden)", assetProcessorPath.c_str());
+        AZStd::string commandLineParams;
         // Add the engine path to the launch command if not empty
         if (!engineRoot.empty())
         {
-            fullLaunchCommand += R"( --engine-path=")";
-            fullLaunchCommand += engineRoot;
-            fullLaunchCommand += '"';
+            commandLineParams += AZStd::string::format("\"--engine-path=\"%s\"\"", engineRoot.data());
         }
 
-        // Add the active project path to the launch command if not empty
         if (!projectPath.empty())
         {
-            fullLaunchCommand += R"( --project-path=")";
-            fullLaunchCommand += projectPath;
-            fullLaunchCommand += '"';
+            commandLineParams += AZStd::string::format(" \"--regset=/Amazon/AzCore/Bootstrap/project_path=\"%s\"\"", projectPath.data());
         }
 
-        return system(fullLaunchCommand.c_str()) == 0;
+        AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;
+        processLaunchInfo.m_processExecutableString = AZStd::move(assetProcessorPath.Native());
+        processLaunchInfo.m_commandlineParameters = commandLineParams;
+        return AzFramework::ProcessLauncher::LaunchUnwatchedProcess(processLaunchInfo);
     }
 }

--- a/Code/Tools/BundleLauncher/O3DE_SDK_Launcher.cpp
+++ b/Code/Tools/BundleLauncher/O3DE_SDK_Launcher.cpp
@@ -49,6 +49,12 @@ int main(int argc, char* argv[])
     AZStd::unique_ptr<AzFramework::ProcessWatcher> shellProcess(AzFramework::ProcessWatcher::LaunchProcess(shellProcessLaunch, AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_NONE));
     shellProcess->WaitForProcessToExit(120);
     shellProcess.reset();
+
+    parameters = AZStd::string::format("-c \"%s/scripts/o3de.sh register --this-engine\"", enginePath.c_str());
+    shellProcessLaunch.m_commandlineParameters = parameters;
+    shellProcess.reset(AzFramework::ProcessWatcher::LaunchProcess(shellProcessLaunch, AzFramework::ProcessCommunicationType::COMMUNICATOR_TYPE_NONE));
+    shellProcess->WaitForProcessToExit(120);
+    shellProcess.reset();
     
     AZ::IO::FixedMaxPath projectManagerPath = installedBinariesFolder/"o3de.app"/"Contents"/"MacOS"/"o3de";
     AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -94,5 +94,10 @@ namespace O3DE::ProjectManager
                 QProcessEnvironment::systemEnvironment(),
                 QObject::tr("Running get_python script..."));
         }
+
+        AZ::IO::FixedMaxPath GetEditorDirectory()
+        {
+            return AZ::Utils::GetExecutableDirectory();
+        }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -10,6 +10,8 @@
 #include <QProcessEnvironment>
 #include <QDir>
 
+#include <AzCore/Utils/Utils.h>
+
 namespace O3DE::ProjectManager
 {
     namespace ProjectUtils

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -11,6 +11,9 @@
 #include <QStandardPaths>
 #include <QDir>
 
+#include <AzCore/Utils/Utils.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+
 namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
@@ -103,6 +106,36 @@ namespace O3DE::ProjectManager
                 {},
                 QProcessEnvironment::systemEnvironment(),
                 QObject::tr("Running get_python script..."));
+        }
+
+        AZ::IO::FixedMaxPath GetEditorDirectory()
+        {
+            AZ::IO::FixedMaxPath executableDirectory = AZ::Utils::GetExecutableDirectory();
+            AZ::IO::FixedMaxPath editorPath{ executableDirectory };
+            editorPath /= "../../../Editor.app/Contents/MacOS";
+            editorPath = editorPath.LexicallyNormal();
+            if (!AZ::IO::SystemFile::IsDirectory(editorPath.c_str()))
+            {
+                if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+                {
+                    if (AZ::IO::FixedMaxPath installedBinariesPath;
+                        settingsRegistry->Get(installedBinariesPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_InstalledBinaryFolder))
+                    {
+                        if (AZ::IO::FixedMaxPath engineRootFolder;
+                            settingsRegistry->Get(engineRootFolder.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder))
+                        {
+                            editorPath = engineRootFolder / installedBinariesPath / "Editor.app/Contents/MacOS";
+                        }
+                    }
+                }
+
+                if (!AZ::IO::SystemFile::IsDirectory(editorPath.c_str()))
+                {
+                    AZ_Error("ProjectManager", false, "Unable to find the Editor app bundle!");
+                }
+            }
+
+            return editorPath;
         }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -139,5 +139,10 @@ namespace O3DE::ProjectManager
                 QProcessEnvironment::systemEnvironment(),
                 QObject::tr("Running get_python script..."));
         }
+
+        AZ::IO::FixedMaxPath GetEditorDirectory()
+        {
+            return AZ::Utils::GetExecutableDirectory();
+        }
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -14,6 +14,8 @@
 #include <QProcess>
 #include <QProcessEnvironment>
 
+#include <AzCore/Utils/Utils.h>
+
 namespace O3DE::ProjectManager
 {
     namespace ProjectUtils

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -14,6 +14,7 @@
 #include <QWidget>
 #include <QProcessEnvironment>
 
+#include <AzCore/IO/Path/Path_fwd.h>
 #include <AzCore/Outcome/Outcome.h>
 
 namespace O3DE::ProjectManager
@@ -67,7 +68,8 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> GetProjectBuildPath(const QString& projectPath);
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath);
         AZ::Outcome<QString, QString> RunGetPythonScript(const QString& enginePath);
-
+        
+        AZ::IO::FixedMaxPath GetEditorDirectory();
 
     } // namespace ProjectUtils
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -392,11 +392,11 @@ namespace O3DE::ProjectManager
         {
             if (!WarnIfInBuildQueue(projectPath))
             {
-                AZ::IO::FixedMaxPath executableDirectory = AZ::Utils::GetExecutableDirectory();
+                AZ::IO::FixedMaxPath executableDirectory = ProjectUtils::GetEditorDirectory();
                 AZStd::string executableFilename = "Editor";
                 AZ::IO::FixedMaxPath editorExecutablePath = executableDirectory / (executableFilename + AZ_TRAIT_OS_EXECUTABLE_EXTENSION);
                 auto cmdPath = AZ::IO::FixedMaxPathString::format(
-                    "%s -regset=\"/Amazon/AzCore/Bootstrap/project_path=%s\"", editorExecutablePath.c_str(),
+                    "%s --regset=\"/Amazon/AzCore/Bootstrap/project_path=%s\"", editorExecutablePath.c_str(),
                     projectPath.toStdString().c_str());
 
                 AzFramework::ProcessLauncher::ProcessLaunchInfo processLaunchInfo;


### PR DESCRIPTION
1. Fix "Open Editor" button not launching Editor on Mac.
2. Update LaunchAssetProcessor() paths on Mac.
3. LaunchAssetProcessor() uses ProcessWatcher wrappers.
4. SDK Launcher registers the engine when launching.

Signed-off-by: amzn-sj <srikkant@amazon.com>

NOTE: Mac doesn't support running AP in tethered mode yet. Linux uses `prctl()` which isn't an option on MacOS. MacOS does support process termination notifications through kqueues/kevents or Grand Central Dispatch. But those options are callback based and would require modifying the child process's(in our case AP) source. This needs more investigation on Mac.