### PR TITLE
vertexbuffer / indexBuffer reserve amount seems off in the auxgeom draw queue

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
@@ -659,16 +659,17 @@ namespace AZ
 
             AuxGeomIndex vertexOffset = aznumeric_cast<AuxGeomIndex>(primBuffer.m_vertexBuffer.size());
             AuxGeomIndex indexOffset = aznumeric_cast<AuxGeomIndex>(primBuffer.m_indexBuffer.size());
+            const size_t vertexCountTotal = aznumeric_cast<size_t>(vertexOffset) + vertexCount;
 
-            if (aznumeric_cast<size_t>(vertexOffset) + vertexCount > MaxDynamicVertexCount)
+            if (vertexCountTotal > MaxDynamicVertexCount)
             {
                 AZ_WarningOnce("AuxGeom", false, "Draw function ignored, would exceed maximum allowed index of %d", MaxDynamicVertexCount);
                 return;
             }
 
             AZ::Vector3 center(0.0f, 0.0f, 0.0f);
-            primBuffer.m_vertexBuffer.reserve(vertexCount);
-            primBuffer.m_indexBuffer.reserve(vertexCount);
+            primBuffer.m_vertexBuffer.reserve(vertexCountTotal);
+            primBuffer.m_indexBuffer.reserve(vertexCountTotal);
             for (uint32_t vertexIndex = 0; vertexIndex < vertexCount; ++vertexIndex)
             {
                 AZ::u32 packedColor = packedColorFunction(vertexIndex);
@@ -734,15 +735,16 @@ namespace AZ
 
             AuxGeomIndex vertexOffset = aznumeric_cast<AuxGeomIndex>(primBuffer.m_vertexBuffer.size());
             AuxGeomIndex indexOffset = aznumeric_cast<AuxGeomIndex>(primBuffer.m_indexBuffer.size());
+            const size_t vertexCountTotal = aznumeric_cast<size_t>(vertexOffset) + vertexCount;
 
-            if (aznumeric_cast<size_t>(vertexOffset) + vertexCount > MaxDynamicVertexCount)
+            if (vertexCountTotal > MaxDynamicVertexCount)
             {
                 AZ_WarningOnce("AuxGeom", false, "Draw function ignored, would exceed maximum allowed index of %d", MaxDynamicVertexCount);
                 return;
             }
 
             AZ::Vector3 center(0.0f, 0.0f, 0.0f);
-            primBuffer.m_vertexBuffer.reserve(vertexCount);
+            primBuffer.m_vertexBuffer.reserve(vertexCountTotal);
             for (uint32_t vertexIndex = 0; vertexIndex < vertexCount; ++vertexIndex)
             {
                 AZ::u32 packedColor = packedColorFunction(vertexIndex);
@@ -753,7 +755,7 @@ namespace AZ
             }
             center /= aznumeric_cast<float>(vertexCount);
 
-            primBuffer.m_indexBuffer.reserve(indexCount);
+            primBuffer.m_indexBuffer.reserve(indexCount + indexOffset);
             for (uint32_t index = 0; index < indexCount; ++index)
             {
                 primBuffer.m_indexBuffer.push_back(vertexOffset + indexFunction(index));


### PR DESCRIPTION
When calling reserve vertex amount the function seems to ignore the previous offset.

Signed-off-by: rhhong <rhhong@amazon.com>