### PR TITLE
License Info is Displayed as Clickable Link in Gem Catalog + Other Inspector Improvements

### DIFF
--- a/AutomatedTesting/Gem/PythonCoverage/gem.json
+++ b/AutomatedTesting/Gem/PythonCoverage/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "PythonCoverage",
     "display_name": "PythonCoverage",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "A tool for generating gem coverage for Python tests.",

--- a/AutomatedTesting/Gem/gem.json
+++ b/AutomatedTesting/Gem/gem.json
@@ -2,10 +2,13 @@
     "gem_name": "AutomatedTesting",
     "display_name": "AutomatedTesting",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "Project Gem for customizing the AutomatedTesting project functionality.",
-    "canonical_tags": ["Gem"],
+    "canonical_tags": [
+        "Gem"
+    ],
     "user_tags": [],
     "icon_path": "preview.png",
     "requirements": ""

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInfo.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInfo.h
@@ -81,6 +81,8 @@ namespace O3DE::ProjectManager
         DownloadStatus m_downloadStatus = UnknownDownloadStatus;
         QStringList m_features;
         QString m_requirement;
+        QString m_licenseText;
+        QString m_licenseLink;
         QString m_directoryLink;
         QString m_documentationLink;
         QString m_version = "Unknown Version";

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
@@ -65,6 +65,8 @@ namespace O3DE::ProjectManager
         m_summaryLabel->setText(m_model->GetSummary(modelIndex));
         m_summaryLabel->adjustSize();
 
+        m_licenseLinkLabel->setText(m_model->GetLicenseText(modelIndex));
+        m_licenseLinkLabel->SetUrl(m_model->GetLicenseLink(modelIndex));
         m_directoryLinkLabel->SetUrl(m_model->GetDirectoryLink(modelIndex));
         m_documentationLinkLabel->SetUrl(m_model->GetDocLink(modelIndex));
 
@@ -108,17 +110,35 @@ namespace O3DE::ProjectManager
     {
         // Gem name, creator and summary
         m_nameLabel = CreateStyledLabel(m_mainLayout, 18, s_headerColor);
-        m_creatorLabel = CreateStyledLabel(m_mainLayout, 12, s_headerColor);
+        m_creatorLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_headerColor);
         m_mainLayout->addSpacing(5);
 
         // TODO: QLabel seems to have issues determining the right sizeHint() for our font with the given font size.
         // This results into squeezed elements in the layout in case the text is a little longer than a sentence.
-        m_summaryLabel = CreateStyledLabel(m_mainLayout, 12, s_textColor);
+        m_summaryLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_headerColor);
         m_mainLayout->addWidget(m_summaryLabel);
         m_summaryLabel->setWordWrap(true);
         m_summaryLabel->setTextInteractionFlags(Qt::TextBrowserInteraction);
         m_summaryLabel->setOpenExternalLinks(true);
         m_mainLayout->addSpacing(5);
+
+        // License
+        {
+            QHBoxLayout* licenseHLayout = new QHBoxLayout();
+            licenseHLayout->setMargin(0);
+            m_mainLayout->addLayout(licenseHLayout);
+
+            QLabel* licenseLabel = CreateStyledLabel(licenseHLayout, s_baseFontSize, s_headerColor);
+            licenseLabel->setText("License: ");
+
+            m_licenseLinkLabel = new LinkLabel("", QUrl(), s_baseFontSize);
+            licenseHLayout->addWidget(m_licenseLinkLabel);
+
+            QSpacerItem* licenseSpacer = new QSpacerItem(0, 0, QSizePolicy::Expanding);
+            licenseHLayout->addSpacerItem(licenseSpacer);
+
+            m_mainLayout->addSpacing(5);
+        }
 
         // Directory and documentation links
         {
@@ -144,7 +164,7 @@ namespace O3DE::ProjectManager
         // Separating line
         QFrame* hLine = new QFrame();
         hLine->setFrameShape(QFrame::HLine);
-        hLine->setStyleSheet("color: #666666;");
+        hLine->setObjectName("horizontalSeparatingLine");
         m_mainLayout->addWidget(hLine);
 
         m_mainLayout->addSpacing(10);
@@ -183,8 +203,8 @@ namespace O3DE::ProjectManager
         QLabel* additionalInfoLabel = CreateStyledLabel(m_mainLayout, 14, s_headerColor);
         additionalInfoLabel->setText("Additional Information");
 
-        m_versionLabel = CreateStyledLabel(m_mainLayout, 12, s_textColor);
-        m_lastUpdatedLabel = CreateStyledLabel(m_mainLayout, 12, s_textColor);
-        m_binarySizeLabel = CreateStyledLabel(m_mainLayout, 12, s_textColor);
+        m_versionLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_textColor);
+        m_lastUpdatedLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_textColor);
+        m_binarySizeLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_textColor);
     }
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.cpp
@@ -55,7 +55,17 @@ namespace O3DE::ProjectManager
     void SetLabelElidedText(QLabel* label, QString text)
     {
         QFontMetrics nameFontMetrics(label->font());
-        label->setText(nameFontMetrics.elidedText(text, Qt::ElideRight, label->width()));
+        int labelWidth = label->width();
+
+        // Don't elide if the widgets are sized too small (sometimes occurs when loading gem catalog)
+        if (labelWidth > 100)
+        {
+            label->setText(nameFontMetrics.elidedText(text, Qt::ElideRight, labelWidth));
+        }
+        else
+        {
+            label->setText(text);
+        }
     }
 
     void GemInspector::Update(const QModelIndex& modelIndex)
@@ -84,7 +94,7 @@ namespace O3DE::ProjectManager
             m_requirementsTextLabel->show();
             m_requirementsMainSpacer->changeSize(0, 20, QSizePolicy::Fixed, QSizePolicy::Fixed);
 
-            m_requirementsTitleLabel->setText("Requirement");
+            m_requirementsTitleLabel->setText(tr("Requirement"));
             m_requirementsTextLabel->setText(m_model->GetRequirement(modelIndex));
         }
         else
@@ -99,7 +109,7 @@ namespace O3DE::ProjectManager
         QStringList dependingGems = m_model->GetDependingGemNames(modelIndex);
         if (!dependingGems.isEmpty())
         {
-            m_dependingGems->Update("Depending Gems", "The following Gems will be automatically enabled with this Gem.", dependingGems);
+            m_dependingGems->Update(tr("Depending Gems"), tr("The following Gems will be automatically enabled with this Gem."), dependingGems);
             m_dependingGems->show();
         }
         else
@@ -108,9 +118,9 @@ namespace O3DE::ProjectManager
         }
 
         // Additional information
-        m_versionLabel->setText(QString("Gem Version: %1").arg(m_model->GetVersion(modelIndex)));
-        m_lastUpdatedLabel->setText(QString("Last Updated: %1").arg(m_model->GetLastUpdated(modelIndex)));
-        m_binarySizeLabel->setText(QString("Binary Size:  %1 KB").arg(m_model->GetBinarySizeInKB(modelIndex)));
+        m_versionLabel->setText(tr("Gem Version: %1").arg(m_model->GetVersion(modelIndex)));
+        m_lastUpdatedLabel->setText(tr("Last Updated: %1").arg(m_model->GetLastUpdated(modelIndex)));
+        m_binarySizeLabel->setText(tr("Binary Size:  %1 KB").arg(m_model->GetBinarySizeInKB(modelIndex)));
 
         m_mainWidget->adjustSize();
         m_mainWidget->show();
@@ -148,7 +158,7 @@ namespace O3DE::ProjectManager
             m_mainLayout->addLayout(licenseHLayout);
 
             QLabel* licenseLabel = CreateStyledLabel(licenseHLayout, s_baseFontSize, s_headerColor);
-            licenseLabel->setText("License: ");
+            licenseLabel->setText(tr("License: "));
 
             m_licenseLinkLabel = new LinkLabel("", QUrl(), s_baseFontSize);
             licenseHLayout->addWidget(m_licenseLinkLabel);
@@ -166,10 +176,10 @@ namespace O3DE::ProjectManager
 
             linksHLayout->addStretch();
 
-            m_directoryLinkLabel = new LinkLabel("View in Directory");
+            m_directoryLinkLabel = new LinkLabel(tr("View in Directory"));
             linksHLayout->addWidget(m_directoryLinkLabel);
             linksHLayout->addWidget(new QLabel("|"));
-            m_documentationLinkLabel  = new LinkLabel("Read Documentation");
+            m_documentationLinkLabel  = new LinkLabel(tr("Read Documentation"));
             linksHLayout->addWidget(m_documentationLinkLabel);
 
             linksHLayout->addStretch();
@@ -218,7 +228,7 @@ namespace O3DE::ProjectManager
 
         // Additional information
         QLabel* additionalInfoLabel = CreateStyledLabel(m_mainLayout, 14, s_headerColor);
-        additionalInfoLabel->setText("Additional Information");
+        additionalInfoLabel->setText(tr("Additional Information"));
 
         m_versionLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_textColor);
         m_lastUpdatedLabel = CreateStyledLabel(m_mainLayout, s_baseFontSize, s_textColor);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
@@ -16,7 +16,7 @@
 
 #include <QItemSelection>
 #include <QScrollArea>
-#include <QWidget>
+#include <QSpacerItem>
 #endif
 
 QT_FORWARD_DECLARE_CLASS(QVBoxLayout)
@@ -68,7 +68,6 @@ namespace O3DE::ProjectManager
         QLabel* m_requirementsTitleLabel = nullptr;
         QLabel* m_requirementsIconLabel = nullptr;
         QLabel* m_requirementsTextLabel = nullptr;
-
         QSpacerItem* m_requirementsMainSpacer = nullptr;
 
         // Depending and conflicting gems

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
@@ -36,6 +36,9 @@ namespace O3DE::ProjectManager
         void Update(const QModelIndex& modelIndex);
         static QLabel* CreateStyledLabel(QLayout* layout, int fontSize, const QString& colorCodeString);
 
+        // Fonts
+        inline constexpr static int s_baseFontSize = 12;
+
         // Colors
         inline constexpr static const char* s_headerColor = "#FFFFFF";
         inline constexpr static const char* s_textColor = "#DDDDDD";
@@ -57,6 +60,7 @@ namespace O3DE::ProjectManager
         QLabel* m_nameLabel = nullptr;
         QLabel* m_creatorLabel = nullptr;
         QLabel* m_summaryLabel = nullptr;
+        LinkLabel* m_licenseLinkLabel = nullptr;
         LinkLabel* m_directoryLinkLabel = nullptr;
         LinkLabel* m_documentationLinkLabel = nullptr;
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInspector.h
@@ -65,9 +65,11 @@ namespace O3DE::ProjectManager
         LinkLabel* m_documentationLinkLabel = nullptr;
 
         // Requirements
-        QLabel* m_reqirementsTitleLabel = nullptr;
-        QLabel* m_reqirementsIconLabel = nullptr;
-        QLabel* m_reqirementsTextLabel = nullptr;
+        QLabel* m_requirementsTitleLabel = nullptr;
+        QLabel* m_requirementsIconLabel = nullptr;
+        QLabel* m_requirementsTextLabel = nullptr;
+
+        QSpacerItem* m_requirementsMainSpacer = nullptr;
 
         // Depending and conflicting gems
         GemsSubWidget* m_dependingGems = nullptr;

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -58,6 +58,8 @@ namespace O3DE::ProjectManager
         item->setData(gemInfo.m_path, RolePath);
         item->setData(gemInfo.m_requirement, RoleRequirement);
         item->setData(gemInfo.m_downloadStatus, RoleDownloadStatus);
+        item->setData(gemInfo.m_licenseText, RoleLicenseText);
+        item->setData(gemInfo.m_licenseLink, RoleLicenseLink);
 
         appendRow(item);
 
@@ -246,6 +248,16 @@ namespace O3DE::ProjectManager
     QString GemModel::GetRequirement(const QModelIndex& modelIndex)
     {
         return modelIndex.data(RoleRequirement).toString();
+    }
+
+    QString GemModel::GetLicenseText(const QModelIndex& modelIndex)
+    {
+        return modelIndex.data(RoleLicenseText).toString();
+    }
+
+    QString GemModel::GetLicenseLink(const QModelIndex& modelIndex)
+    {
+        return modelIndex.data(RoleLicenseLink).toString();
     }
 
     GemModel* GemModel::GetSourceModel(QAbstractItemModel* model)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -50,6 +50,8 @@ namespace O3DE::ProjectManager
         static QStringList GetFeatures(const QModelIndex& modelIndex);
         static QString GetPath(const QModelIndex& modelIndex);
         static QString GetRequirement(const QModelIndex& modelIndex);
+        static QString GetLicenseText(const QModelIndex& modelIndex);
+        static QString GetLicenseLink(const QModelIndex& modelIndex);
         static GemModel* GetSourceModel(QAbstractItemModel* model);
         static const GemModel* GetSourceModel(const QAbstractItemModel* model);
 
@@ -107,7 +109,9 @@ namespace O3DE::ProjectManager
             RoleTypes,
             RolePath,
             RoleRequirement,
-            RoleDownloadStatus
+            RoleDownloadStatus,
+            RoleLicenseText,
+            RoleLicenseLink
         };
 
         QHash<QString, QModelIndex> m_nameToIndexMap;

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
@@ -99,7 +99,7 @@ namespace O3DE::ProjectManager
         m_nameLabel->setObjectName("gemRepoInspectorNameLabel");
         m_mainLayout->addWidget(m_nameLabel);
 
-        m_repoLinkLabel = new LinkLabel(tr("Repo Url"), QUrl(""), 12, this);
+        m_repoLinkLabel = new LinkLabel(tr("Repo Url"), QUrl(), 12, this);
         m_mainLayout->addWidget(m_repoLinkLabel);
         m_mainLayout->addSpacing(5);
 

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -709,6 +709,8 @@ namespace O3DE::ProjectManager
                 gemInfo.m_requirement = Py_To_String_Optional(data, "requirements", "");
                 gemInfo.m_creator = Py_To_String_Optional(data, "origin", "");
                 gemInfo.m_documentationLink = Py_To_String_Optional(data, "documentation_url", "");
+                gemInfo.m_licenseText = Py_To_String_Optional(data, "license", "Unspecified License");
+                gemInfo.m_licenseLink = Py_To_String_Optional(data, "license_url", "");
 
                 if (gemInfo.m_creator.contains("Open 3D Engine"))
                 {

--- a/Gems/AWSClientAuth/gem.json
+++ b/Gems/AWSClientAuth/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AWSClientAuth",
     "display_name": "AWS Client Authorization",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "AWS Client Auth provides client authentication and AWS authorization solution.",

--- a/Gems/AWSClientAuth/gem.json
+++ b/Gems/AWSClientAuth/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AWSClientAuth",
     "display_name": "AWS Client Authorization",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "AWS Client Auth provides client authentication and AWS authorization solution.",

--- a/Gems/AWSCore/gem.json
+++ b/Gems/AWSCore/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AWSCore",
     "display_name": "AWS Core",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "The AWS Core Gem provides basic shared AWS functionality such as AWS SDK initialization and client configuration, and is automatically added when selecting any AWS feature Gem.",

--- a/Gems/AWSCore/gem.json
+++ b/Gems/AWSCore/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AWSCore",
     "display_name": "AWS Core",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "The AWS Core Gem provides basic shared AWS functionality such as AWS SDK initialization and client configuration, and is automatically added when selecting any AWS feature Gem.",

--- a/Gems/AWSGameLift/gem.json
+++ b/Gems/AWSGameLift/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AWSGameLift",
     "display_name": "AWS GameLift",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "The AWS GameLift Gem provides a framework to extend O3DE networking layer to work with GameLift resources via GameLift server and client SDK.",

--- a/Gems/AWSGameLift/gem.json
+++ b/Gems/AWSGameLift/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AWSGameLift",
     "display_name": "AWS GameLift",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "The AWS GameLift Gem provides a framework to extend O3DE networking layer to work with GameLift resources via GameLift server and client SDK.",

--- a/Gems/AWSMetrics/gem.json
+++ b/Gems/AWSMetrics/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AWSMetrics",
     "display_name": "AWS Metrics",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "The AWS Metrics Gem provides a solution for AWS metrics submission and analytics.",

--- a/Gems/AWSMetrics/gem.json
+++ b/Gems/AWSMetrics/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AWSMetrics",
     "display_name": "AWS Metrics",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Amazon Web Services, Inc.",
     "type": "Code",
     "summary": "The AWS Metrics Gem provides a solution for AWS metrics submission and analytics.",

--- a/Gems/Achievements/gem.json
+++ b/Gems/Achievements/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Achievements",
     "display_name": "Achievements",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Achievements Gem provides a target platform agnostic interface for retrieving achievement details and unlocking achievements.",

--- a/Gems/Achievements/gem.json
+++ b/Gems/Achievements/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Achievements",
     "display_name": "Achievements",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Achievements Gem provides a target platform agnostic interface for retrieving achievement details and unlocking achievements.",

--- a/Gems/AssetMemoryAnalyzer/gem.json
+++ b/Gems/AssetMemoryAnalyzer/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AssetMemoryAnalyzer",
     "display_name": "Asset Memory Analyzer",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Asset Memory Analyzer Gem provides tools to profile asset memory usage in Open 3D Engine through ImGUI (Immediate Mode Graphical User Interface).",

--- a/Gems/AssetMemoryAnalyzer/gem.json
+++ b/Gems/AssetMemoryAnalyzer/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AssetMemoryAnalyzer",
     "display_name": "Asset Memory Analyzer",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Asset Memory Analyzer Gem provides tools to profile asset memory usage in Open 3D Engine through ImGUI (Immediate Mode Graphical User Interface).",

--- a/Gems/AssetValidation/gem.json
+++ b/Gems/AssetValidation/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AssetValidation",
     "display_name": "Asset Validation",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Asset Validation Gem provides seed-related commands to ensure assets have valid seeds for asset bundling.",

--- a/Gems/AssetValidation/gem.json
+++ b/Gems/AssetValidation/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AssetValidation",
     "display_name": "Asset Validation",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Asset Validation Gem provides seed-related commands to ensure assets have valid seeds for asset bundling.",

--- a/Gems/Atom/Asset/ImageProcessingAtom/gem.json
+++ b/Gems/Atom/Asset/ImageProcessingAtom/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ImageProcessingAtom",
     "display_name": "Atom Image Processing",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Asset/ImageProcessingAtom/gem.json
+++ b/Gems/Atom/Asset/ImageProcessingAtom/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ImageProcessingAtom",
     "display_name": "Atom Image Processing",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Asset/Shader/gem.json
+++ b/Gems/Atom/Asset/Shader/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomShader",
     "display_name": "Atom Shader Builder",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Asset/Shader/gem.json
+++ b/Gems/Atom/Asset/Shader/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomShader",
     "display_name": "Atom Shader Builder",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Bootstrap/gem.json
+++ b/Gems/Atom/Bootstrap/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_Bootstrap",
     "display_name": "Atom Bootstrap",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Bootstrap/gem.json
+++ b/Gems/Atom/Bootstrap/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_Bootstrap",
     "display_name": "Atom Bootstrap",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Component/DebugCamera/gem.json
+++ b/Gems/Atom/Component/DebugCamera/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_Component_DebugCamera",
     "display_name": "Atom Debug Camera Component",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Component/DebugCamera/gem.json
+++ b/Gems/Atom/Component/DebugCamera/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_Component_DebugCamera",
     "display_name": "Atom Debug Camera Component",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Feature/Common/gem.json
+++ b/Gems/Atom/Feature/Common/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_Feature_Common",
     "display_name": "Atom Feature Common",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Feature/Common/gem.json
+++ b/Gems/Atom/Feature/Common/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_Feature_Common",
     "display_name": "Atom Feature Common",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/DX12/gem.json
+++ b/Gems/Atom/RHI/DX12/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_RHI_DX12",
     "display_name": "Atom RHI DX12",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/DX12/gem.json
+++ b/Gems/Atom/RHI/DX12/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_RHI_DX12",
     "display_name": "Atom RHI DX12",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/Metal/gem.json
+++ b/Gems/Atom/RHI/Metal/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_RHI_Metal",
     "display_name": "Atom RHI Metal",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/Metal/gem.json
+++ b/Gems/Atom/RHI/Metal/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_RHI_Metal",
     "display_name": "Atom RHI Metal",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/Null/gem.json
+++ b/Gems/Atom/RHI/Null/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_RHI_Null",
     "display_name": "Atom RHI Null",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/Null/gem.json
+++ b/Gems/Atom/RHI/Null/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_RHI_Null",
     "display_name": "Atom RHI Null",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/Vulkan/gem.json
+++ b/Gems/Atom/RHI/Vulkan/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_RHI_Vulkan",
     "display_name": "Atom RHI Vulkan",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/Vulkan/gem.json
+++ b/Gems/Atom/RHI/Vulkan/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_RHI_Vulkan",
     "display_name": "Atom RHI Vulkan",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/gem.json
+++ b/Gems/Atom/RHI/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_RHI",
     "display_name": "Atom RHI",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RHI/gem.json
+++ b/Gems/Atom/RHI/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_RHI",
     "display_name": "Atom RHI",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/RPI/gem.json
+++ b/Gems/Atom/RPI/gem.json
@@ -3,6 +3,7 @@
     "display_name": "Atom API",
     "summary": "",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "canonical_tags": [

--- a/Gems/Atom/RPI/gem.json
+++ b/Gems/Atom/RPI/gem.json
@@ -3,7 +3,7 @@
     "display_name": "Atom API",
     "summary": "",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "canonical_tags": [

--- a/Gems/Atom/Tools/AtomToolsFramework/gem.json
+++ b/Gems/Atom/Tools/AtomToolsFramework/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomToolsFramework",
     "display_name": "Atom Tools Framework",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Tools/AtomToolsFramework/gem.json
+++ b/Gems/Atom/Tools/AtomToolsFramework/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomToolsFramework",
     "display_name": "Atom Tools Framework",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/Atom/Tools/MaterialEditor/gem.json
+++ b/Gems/Atom/Tools/MaterialEditor/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "MaterialEditor",
     "display_name": "Atom Material Editor",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "Editor for creating, modifying, and previewing materials",

--- a/Gems/Atom/Tools/MaterialEditor/gem.json
+++ b/Gems/Atom/Tools/MaterialEditor/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "MaterialEditor",
     "display_name": "Atom Material Editor",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "Editor for creating, modifying, and previewing materials",

--- a/Gems/Atom/gem.json
+++ b/Gems/Atom/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom",
     "display_name": "Atom Renderer",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Atom Renderer Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces.",

--- a/Gems/Atom/gem.json
+++ b/Gems/Atom/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom",
     "display_name": "Atom Renderer",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Atom Renderer Gem provides Atom Renderer and its associated tools (such as Material Editor), utilites, libraries, and interfaces.",

--- a/Gems/AtomContent/ReferenceMaterials/gem.json
+++ b/Gems/AtomContent/ReferenceMaterials/gem.json
@@ -5,8 +5,15 @@
     "origin": "https://github.com/aws-lumberyard-dev/o3de.git",
     "type": "Asset",
     "summary": "Atom Asset Gem with a library of reference materials for StandardPBR (and others in the future)",
-    "canonical_tags": ["Gem"],
-    "user_tags": ["Assets", "PBR", "Materials"],
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "Assets",
+        "PBR",
+        "Materials"
+    ],
     "icon_path": "preview.png",
-    "dependencies": []
+    "dependencies": [],
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt"
 }

--- a/Gems/AtomContent/Sponza/gem.json
+++ b/Gems/AtomContent/Sponza/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Sponza",
     "display_name": "Sponza",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "A standard test scene for Global Illumination (forked from crytek sponza scene)",

--- a/Gems/AtomContent/Sponza/gem.json
+++ b/Gems/AtomContent/Sponza/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Sponza",
     "display_name": "Sponza",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "A standard test scene for Global Illumination (forked from crytek sponza scene)",

--- a/Gems/AtomContent/gem.json
+++ b/Gems/AtomContent/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomContent",
     "display_name": "Atom Content",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Atom Content Gem provides assets for Atom Renderer and a modified version of the <a href='https://renderman.pixar.com/look-development-studio'>Pixar Look Development Studio</a>.",

--- a/Gems/AtomContent/gem.json
+++ b/Gems/AtomContent/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomContent",
     "display_name": "Atom Content",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Atom Content Gem provides assets for Atom Renderer and a modified version of the <a href='https://renderman.pixar.com/look-development-studio'>Pixar Look Development Studio</a>.",

--- a/Gems/AtomLyIntegration/AtomBridge/gem.json
+++ b/Gems/AtomLyIntegration/AtomBridge/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Atom_AtomBridge",
     "display_name": "Atom Bridge",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomBridge/gem.json
+++ b/Gems/AtomLyIntegration/AtomBridge/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Atom_AtomBridge",
     "display_name": "Atom Bridge",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomFont/gem.json
+++ b/Gems/AtomLyIntegration/AtomFont/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomFont",
     "display_name": "Atom Font",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomFont/gem.json
+++ b/Gems/AtomLyIntegration/AtomFont/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomFont",
     "display_name": "Atom Font",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomImGuiTools/gem.json
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomImGuiTools",
     "display_name": "Atom ImGui",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomImGuiTools/gem.json
+++ b/Gems/AtomLyIntegration/AtomImGuiTools/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomImGuiTools",
     "display_name": "Atom ImGui",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomViewportDisplayIcons",
     "display_name": "Atom Viewport Display Icons",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayIcons/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomViewportDisplayIcons",
     "display_name": "Atom Viewport Display Icons",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/gem.json
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomViewportDisplayInfo",
     "display_name": "Atom Viewport Display Info",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/AtomViewportDisplayInfo/gem.json
+++ b/Gems/AtomLyIntegration/AtomViewportDisplayInfo/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomViewportDisplayInfo",
     "display_name": "Atom Viewport Display Info",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/CommonFeatures/gem.json
+++ b/Gems/AtomLyIntegration/CommonFeatures/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "CommonFeaturesAtom",
     "display_name": "Common Features Atom",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/CommonFeatures/gem.json
+++ b/Gems/AtomLyIntegration/CommonFeatures/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "CommonFeaturesAtom",
     "display_name": "Common Features Atom",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/EMotionFXAtom/gem.json
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "EMotionFX_Atom",
     "display_name": "EMotionFX Atom",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/EMotionFXAtom/gem.json
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "EMotionFX_Atom",
     "display_name": "EMotionFX Atom",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/ImguiAtom/gem.json
+++ b/Gems/AtomLyIntegration/ImguiAtom/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ImguiAtom",
     "display_name": "Imgui Atom",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/ImguiAtom/gem.json
+++ b/Gems/AtomLyIntegration/ImguiAtom/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ImguiAtom",
     "display_name": "Imgui Atom",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "",

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/gem.json
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/gem.json
@@ -3,6 +3,7 @@
     "display_name": "Atom DccScriptingInterface (DCCsi)",
     "summary": "A python framework for working with various DCC tools and workflows.",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "canonical_tags": [

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/gem.json
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/gem.json
@@ -3,7 +3,7 @@
     "display_name": "Atom DccScriptingInterface (DCCsi)",
     "summary": "A python framework for working with various DCC tools and workflows.",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "canonical_tags": [

--- a/Gems/AtomLyIntegration/gem.json
+++ b/Gems/AtomLyIntegration/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomLyIntegration",
     "display_name": "Atom O3DE Integration",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Atom O3DE Integration Gem provides components, libraries, and functionality to support and integrate Atom Renderer in Open 3D Engine.",

--- a/Gems/AtomLyIntegration/gem.json
+++ b/Gems/AtomLyIntegration/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AtomLyIntegration",
     "display_name": "Atom O3DE Integration",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Atom O3DE Integration Gem provides components, libraries, and functionality to support and integrate Atom Renderer in Open 3D Engine.",

--- a/Gems/AtomTressFX/gem.json
+++ b/Gems/AtomTressFX/gem.json
@@ -2,12 +2,18 @@
     "gem_name": "AtomTressFX",
     "display_name": "Atom TressFX",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "Atom TressFX Gem provides a cutting edge hair and fur simulation and rendering in Atom enhancing the AMD TressFX 4.1.  The open source TressFX can be found here: https://github.com/GPUOpen-Effects/TressFX",
-    "canonical_tags": ["Gem"],
-    "user_tags": ["Rendering", "Physics", "Animation"],
+    "canonical_tags": [
+        "Gem"
+    ],
+    "user_tags": [
+        "Rendering",
+        "Physics",
+        "Animation"
+    ],
     "requirements": "",
     "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/rendering/amd/atom-tressfx/"
 }

--- a/Gems/AtomTressFX/gem.json
+++ b/Gems/AtomTressFX/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AtomTressFX",
     "display_name": "Atom TressFX",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "Atom TressFX Gem provides a cutting edge hair and fur simulation and rendering in Atom enhancing the AMD TressFX 4.1.  The open source TressFX can be found here: https://github.com/GPUOpen-Effects/TressFX",

--- a/Gems/AudioEngineWwise/gem.json
+++ b/Gems/AudioEngineWwise/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AudioEngineWwise",
     "display_name": "Wwise Audio Engine",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Wwise Audio Engine Gem provides support for Audiokinetic Wave Works Interactive Sound Engine (Wwise).",

--- a/Gems/AudioEngineWwise/gem.json
+++ b/Gems/AudioEngineWwise/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AudioEngineWwise",
     "display_name": "Wwise Audio Engine",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Wwise Audio Engine Gem provides support for Audiokinetic Wave Works Interactive Sound Engine (Wwise).",

--- a/Gems/AudioSystem/gem.json
+++ b/Gems/AudioSystem/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "AudioSystem",
     "display_name": "Audio System",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Audio System Gem provides the Audio Translation Layer (ATL) and Audio Controls Editor, which add support for audio in Open 3D Engine.",

--- a/Gems/AudioSystem/gem.json
+++ b/Gems/AudioSystem/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "AudioSystem",
     "display_name": "Audio System",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Audio System Gem provides the Audio Translation Layer (ATL) and Audio Controls Editor, which add support for audio in Open 3D Engine.",

--- a/Gems/BarrierInput/gem.json
+++ b/Gems/BarrierInput/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "BarrierInput",
     "display_name": "Barrier Input",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Barrier Input Gem allows the Open 3D Engine to function as a Barrier client so that it can receive input from a remote Barrier server.",

--- a/Gems/BarrierInput/gem.json
+++ b/Gems/BarrierInput/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "BarrierInput",
     "display_name": "Barrier Input",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Barrier Input Gem allows the Open 3D Engine to function as a Barrier client so that it can receive input from a remote Barrier server.",

--- a/Gems/Blast/gem.json
+++ b/Gems/Blast/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Blast",
     "display_name": "NVIDIA Blast",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The NVIDIA Blast Gem provides tools to author fractured mesh assets in Houdini, and functionality to create realistic destruction simulations in Open 3D Engine.",

--- a/Gems/Blast/gem.json
+++ b/Gems/Blast/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Blast",
     "display_name": "NVIDIA Blast",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The NVIDIA Blast Gem provides tools to author fractured mesh assets in Houdini, and functionality to create realistic destruction simulations in Open 3D Engine.",

--- a/Gems/Camera/gem.json
+++ b/Gems/Camera/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Camera",
     "display_name": "Camera",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Camera Gem provides a basic camera component that defines a frustum for runtime rendering.",

--- a/Gems/Camera/gem.json
+++ b/Gems/Camera/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Camera",
     "display_name": "Camera",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Camera Gem provides a basic camera component that defines a frustum for runtime rendering.",

--- a/Gems/CameraFramework/gem.json
+++ b/Gems/CameraFramework/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "CameraFramework",
     "display_name": "Camera Framework",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Camera Framework Gem provides a base for implementing more complex camera systems.",

--- a/Gems/CameraFramework/gem.json
+++ b/Gems/CameraFramework/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "CameraFramework",
     "display_name": "Camera Framework",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Camera Framework Gem provides a base for implementing more complex camera systems.",

--- a/Gems/CertificateManager/gem.json
+++ b/Gems/CertificateManager/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "CertificateManager",
     "display_name": "Certificate Manager",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Certificate Manager Gem provides access to authentication files for secure game connections from Amazon S3, files on disk, and other 3rd party sources.",

--- a/Gems/CertificateManager/gem.json
+++ b/Gems/CertificateManager/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "CertificateManager",
     "display_name": "Certificate Manager",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Certificate Manager Gem provides access to authentication files for secure game connections from Amazon S3, files on disk, and other 3rd party sources.",

--- a/Gems/CrashReporting/gem.json
+++ b/Gems/CrashReporting/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "CrashReporting",
     "display_name": "Crash Reporting",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Crash Reporting Gem provides support for external crash reporting for Open 3D Engine projects.",

--- a/Gems/CrashReporting/gem.json
+++ b/Gems/CrashReporting/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "CrashReporting",
     "display_name": "Crash Reporting",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Crash Reporting Gem provides support for external crash reporting for Open 3D Engine projects.",

--- a/Gems/CustomAssetExample/gem.json
+++ b/Gems/CustomAssetExample/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "CustomAssetExample",
     "display_name": "Custom Asset Example",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Custom Asset Example Gem provides example code for creating a custom asset for Open 3D Engine's asset pipeline.",

--- a/Gems/CustomAssetExample/gem.json
+++ b/Gems/CustomAssetExample/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "CustomAssetExample",
     "display_name": "Custom Asset Example",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Custom Asset Example Gem provides example code for creating a custom asset for Open 3D Engine's asset pipeline.",

--- a/Gems/DebugDraw/gem.json
+++ b/Gems/DebugDraw/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "DebugDraw",
     "display_name": "Debug Draw",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Debug Draw Gem provides Editor and runtime debug visualization features for Open 3D Engine.",

--- a/Gems/DebugDraw/gem.json
+++ b/Gems/DebugDraw/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "DebugDraw",
     "display_name": "Debug Draw",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Debug Draw Gem provides Editor and runtime debug visualization features for Open 3D Engine.",

--- a/Gems/DevTextures/gem.json
+++ b/Gems/DevTextures/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "DevTextures",
     "display_name": "Dev Textures",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Dev Textures Gem provides a collection of general purpose texture assets useful for prototypes and preproduction.",

--- a/Gems/DevTextures/gem.json
+++ b/Gems/DevTextures/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "DevTextures",
     "display_name": "Dev Textures",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Dev Textures Gem provides a collection of general purpose texture assets useful for prototypes and preproduction.",

--- a/Gems/EMotionFX/gem.json
+++ b/Gems/EMotionFX/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "EMotionFX",
     "display_name": "EMotion FX Animation",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The EMotion FX Animation Gem provides Open 3D Engine's animation system for rigged actors and includes Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors.",

--- a/Gems/EMotionFX/gem.json
+++ b/Gems/EMotionFX/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "EMotionFX",
     "display_name": "EMotion FX Animation",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The EMotion FX Animation Gem provides Open 3D Engine's animation system for rigged actors and includes Animation Editor, a tool for creating animated behaviors, simulated objects, and colliders for rigged actors.",

--- a/Gems/EditorPythonBindings/gem.json
+++ b/Gems/EditorPythonBindings/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "EditorPythonBindings",
     "display_name": "Editor Python Bindings",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Editor Python Bindings Gem provides Python commands for Open 3D Engine Editor functions.",

--- a/Gems/EditorPythonBindings/gem.json
+++ b/Gems/EditorPythonBindings/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "EditorPythonBindings",
     "display_name": "Editor Python Bindings",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Editor Python Bindings Gem provides Python commands for Open 3D Engine Editor functions.",

--- a/Gems/ExpressionEvaluation/gem.json
+++ b/Gems/ExpressionEvaluation/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ExpressionEvaluation",
     "display_name": "Expression Evaluation",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Expression Evaluation Gem provides a method for parsing and executing string expressions in Open 3D Engine.",

--- a/Gems/ExpressionEvaluation/gem.json
+++ b/Gems/ExpressionEvaluation/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ExpressionEvaluation",
     "display_name": "Expression Evaluation",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Expression Evaluation Gem provides a method for parsing and executing string expressions in Open 3D Engine.",

--- a/Gems/FastNoise/gem.json
+++ b/Gems/FastNoise/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "FastNoise",
     "display_name": "Fast Noise",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The FastNoise Gradient Gem uses the third-party, open source FastNoise library to provide a variety of high-performance noise generation algorithms.",

--- a/Gems/FastNoise/gem.json
+++ b/Gems/FastNoise/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "FastNoise",
     "display_name": "Fast Noise",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The FastNoise Gradient Gem uses the third-party, open source FastNoise library to provide a variety of high-performance noise generation algorithms.",

--- a/Gems/GameState/gem.json
+++ b/Gems/GameState/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "GameState",
     "display_name": "Game State",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Game State Gem provides a generic framework to determine and manage game states and game state transitions in Open 3D Engine.",

--- a/Gems/GameState/gem.json
+++ b/Gems/GameState/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "GameState",
     "display_name": "Game State",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Game State Gem provides a generic framework to determine and manage game states and game state transitions in Open 3D Engine.",

--- a/Gems/GameStateSamples/gem.json
+++ b/Gems/GameStateSamples/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "GameStateSamples",
     "display_name": "Game State Samples",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Game State Samples Gem provides a set of sample game states (built on top of the Game State Gem), including primary user selection, main menu, level loading, level running, and level paused.",

--- a/Gems/GameStateSamples/gem.json
+++ b/Gems/GameStateSamples/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "GameStateSamples",
     "display_name": "Game State Samples",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Game State Samples Gem provides a set of sample game states (built on top of the Game State Gem), including primary user selection, main menu, level loading, level running, and level paused.",

--- a/Gems/Gestures/gem.json
+++ b/Gems/Gestures/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Gestures",
     "display_name": "Gestures",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Gestures Gem provides detection for common gesture-based input actions on iOS and Android devices.",

--- a/Gems/Gestures/gem.json
+++ b/Gems/Gestures/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Gestures",
     "display_name": "Gestures",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Gestures Gem provides detection for common gesture-based input actions on iOS and Android devices.",

--- a/Gems/GradientSignal/gem.json
+++ b/Gems/GradientSignal/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "GradientSignal",
     "display_name": "Gradient Signal",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Gradient Signal Gem provides a number of components for generating, modifying, and mixing gradient signals.",

--- a/Gems/GradientSignal/gem.json
+++ b/Gems/GradientSignal/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "GradientSignal",
     "display_name": "Gradient Signal",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Gradient Signal Gem provides a number of components for generating, modifying, and mixing gradient signals.",

--- a/Gems/GraphCanvas/gem.json
+++ b/Gems/GraphCanvas/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "GraphCanvas",
     "display_name": "Graph Canvas",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Graph Canvas Gem provides a C++ framework for creating custom graphical node based editors for Open 3D Engine.",

--- a/Gems/GraphCanvas/gem.json
+++ b/Gems/GraphCanvas/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "GraphCanvas",
     "display_name": "Graph Canvas",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Graph Canvas Gem provides a C++ framework for creating custom graphical node based editors for Open 3D Engine.",

--- a/Gems/GraphModel/gem.json
+++ b/Gems/GraphModel/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "GraphModel",
     "display_name": "Graph Model",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Graph Model Gem provides a generic node graph data model framework for Open 3D Engine.",

--- a/Gems/GraphModel/gem.json
+++ b/Gems/GraphModel/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "GraphModel",
     "display_name": "Graph Model",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Graph Model Gem provides a generic node graph data model framework for Open 3D Engine.",

--- a/Gems/HttpRequestor/gem.json
+++ b/Gems/HttpRequestor/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "HttpRequestor",
     "display_name": "HTTP Requestor",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The HTTP Requestor Gem provides functionality to make asynchronous HTTP/HTTPS requests and return data through a user-provided call back function.",

--- a/Gems/HttpRequestor/gem.json
+++ b/Gems/HttpRequestor/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "HttpRequestor",
     "display_name": "HTTP Requestor",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The HTTP Requestor Gem provides functionality to make asynchronous HTTP/HTTPS requests and return data through a user-provided call back function.",

--- a/Gems/ImGui/gem.json
+++ b/Gems/ImGui/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ImGui",
     "display_name": "Immediate Mode GUI (IMGUI)",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Immediate Mode GUI Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine.",

--- a/Gems/ImGui/gem.json
+++ b/Gems/ImGui/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ImGui",
     "display_name": "Immediate Mode GUI (IMGUI)",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Immediate Mode GUI Gem provides the 3rdParty library IMGUI which can be used to create run time immediate mode overlays for debugging and profiling information in Open 3D Engine.",

--- a/Gems/InAppPurchases/gem.json
+++ b/Gems/InAppPurchases/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "InAppPurchases",
     "display_name": "In-App Purchases",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The In-App Purchases Gem provides functionality for in app purchases for iOS and Android.",

--- a/Gems/InAppPurchases/gem.json
+++ b/Gems/InAppPurchases/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "InAppPurchases",
     "display_name": "In-App Purchases",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The In-App Purchases Gem provides functionality for in app purchases for iOS and Android.",

--- a/Gems/LandscapeCanvas/gem.json
+++ b/Gems/LandscapeCanvas/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "LandscapeCanvas",
     "display_name": "Landscape Canvas",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Landscape Canvas Gem provides the Landscape Canvas editor, a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.",

--- a/Gems/LandscapeCanvas/gem.json
+++ b/Gems/LandscapeCanvas/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "LandscapeCanvas",
     "display_name": "Landscape Canvas",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Landscape Canvas Gem provides the Landscape Canvas editor, a node-based graph tool for authoring workflows to populate landscape with dynamic vegetation.",

--- a/Gems/LmbrCentral/gem.json
+++ b/Gems/LmbrCentral/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "LmbrCentral",
     "display_name": "O3DE Core (LmbrCentral)",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The O3DE Core (LmbrCentral) Gem provides required code and assets for running Open 3D Engine Editor.",

--- a/Gems/LmbrCentral/gem.json
+++ b/Gems/LmbrCentral/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "LmbrCentral",
     "display_name": "O3DE Core (LmbrCentral)",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The O3DE Core (LmbrCentral) Gem provides required code and assets for running Open 3D Engine Editor.",

--- a/Gems/LocalUser/gem.json
+++ b/Gems/LocalUser/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "LocalUser",
     "display_name": "Local User",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Local User Gem provides functionality for mapping local user ids to local player slots and managing local user profiles.",

--- a/Gems/LocalUser/gem.json
+++ b/Gems/LocalUser/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "LocalUser",
     "display_name": "Local User",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Local User Gem provides functionality for mapping local user ids to local player slots and managing local user profiles.",

--- a/Gems/LyShine/gem.json
+++ b/Gems/LyShine/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "LyShine",
     "display_name": "LyShine",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The LyShine Gem provides the runtime UI system and creation tools for Open 3D Engine projects.",

--- a/Gems/LyShine/gem.json
+++ b/Gems/LyShine/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "LyShine",
     "display_name": "LyShine",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The LyShine Gem provides the runtime UI system and creation tools for Open 3D Engine projects.",

--- a/Gems/LyShineExamples/gem.json
+++ b/Gems/LyShineExamples/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "LyShineExamples",
     "display_name": "LyShine Examples",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The LyShine Examples Gem provides example code and assets for LyShine, the runtime UI system and editor for Open 3D Engine projects.",

--- a/Gems/LyShineExamples/gem.json
+++ b/Gems/LyShineExamples/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "LyShineExamples",
     "display_name": "LyShine Examples",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The LyShine Examples Gem provides example code and assets for LyShine, the runtime UI system and editor for Open 3D Engine projects.",

--- a/Gems/Maestro/gem.json
+++ b/Gems/Maestro/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Maestro",
     "display_name": "Maestro Cinematics",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Maestro Cinematics Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor.",

--- a/Gems/Maestro/gem.json
+++ b/Gems/Maestro/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Maestro",
     "display_name": "Maestro Cinematics",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Maestro Cinematics Gem provides Track View, Open 3D Engine's animated sequence and cinematics editor.",

--- a/Gems/MessagePopup/gem.json
+++ b/Gems/MessagePopup/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "MessagePopup",
     "display_name": "Message Popup",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Message Popup Gem provides an example implementation of popup messages using LyShine in Open 3D Engine.",

--- a/Gems/MessagePopup/gem.json
+++ b/Gems/MessagePopup/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "MessagePopup",
     "display_name": "Message Popup",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Message Popup Gem provides an example implementation of popup messages using LyShine in Open 3D Engine.",

--- a/Gems/Metastream/gem.json
+++ b/Gems/Metastream/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Metastream",
     "display_name": "Metastream",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Metastream Gem provides functionality for an HTTP server that allows broadcasters to customize game streams with overlays of statistics and event data from a game session.",

--- a/Gems/Metastream/gem.json
+++ b/Gems/Metastream/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Metastream",
     "display_name": "Metastream",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Metastream Gem provides functionality for an HTTP server that allows broadcasters to customize game streams with overlays of statistics and event data from a game session.",

--- a/Gems/Microphone/gem.json
+++ b/Gems/Microphone/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Microphone",
     "display_name": "Microphone",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Microphone Gem provides support for audio input through microphones.",

--- a/Gems/Microphone/gem.json
+++ b/Gems/Microphone/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Microphone",
     "display_name": "Microphone",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Microphone Gem provides support for audio input through microphones.",

--- a/Gems/Multiplayer/gem.json
+++ b/Gems/Multiplayer/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Multiplayer",
     "display_name": "Multiplayer",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Multiplayer Gem provides a public API for multiplayer functionality such as connecting and hosting.",

--- a/Gems/Multiplayer/gem.json
+++ b/Gems/Multiplayer/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Multiplayer",
     "display_name": "Multiplayer",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Multiplayer Gem provides a public API for multiplayer functionality such as connecting and hosting.",

--- a/Gems/MultiplayerCompression/gem.json
+++ b/Gems/MultiplayerCompression/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "MultiplayerCompression",
     "display_name": "Multiplayer Compression",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Multiplayer Compression Gem provides an open source Compressor for use with AzNetworking's transport layer.",

--- a/Gems/MultiplayerCompression/gem.json
+++ b/Gems/MultiplayerCompression/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "MultiplayerCompression",
     "display_name": "Multiplayer Compression",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Multiplayer Compression Gem provides an open source Compressor for use with AzNetworking's transport layer.",

--- a/Gems/NvCloth/gem.json
+++ b/Gems/NvCloth/gem.json
@@ -3,7 +3,7 @@
     "display_name": "NVIDIA Cloth (NvCloth)",
     "license": "Apache-2.0 Or MIT",
     "origin": "Open 3D Engine - o3de.org",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "type": "Code",
     "summary": "The NVIDIA Cloth Gem provides functionality to create fast, realistic cloth simulation with the NVIDIA Cloth library.",
     "canonical_tags": [

--- a/Gems/NvCloth/gem.json
+++ b/Gems/NvCloth/gem.json
@@ -3,6 +3,7 @@
     "display_name": "NVIDIA Cloth (NvCloth)",
     "license": "Apache-2.0 Or MIT",
     "origin": "Open 3D Engine - o3de.org",
+    "license_url": "https://opensource.org/licenses/MIT",
     "type": "Code",
     "summary": "The NVIDIA Cloth Gem provides functionality to create fast, realistic cloth simulation with the NVIDIA Cloth library.",
     "canonical_tags": [

--- a/Gems/PhysX/gem.json
+++ b/Gems/PhysX/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "PhysX",
     "display_name": "PhysX",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The PhysX Gem provides physics simulation with NVIDIA PhysX including static and dynamic rigid body simulation, force regions, ragdolls, and dynamic PhysX joints.",

--- a/Gems/PhysX/gem.json
+++ b/Gems/PhysX/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "PhysX",
     "display_name": "PhysX",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The PhysX Gem provides physics simulation with NVIDIA PhysX including static and dynamic rigid body simulation, force regions, ragdolls, and dynamic PhysX joints.",

--- a/Gems/PhysXDebug/gem.json
+++ b/Gems/PhysXDebug/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "PhysXDebug",
     "display_name": "PhysX Debug",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The PhysX Debug Gem provides debugging functionality and visualizations for NVIDIA PhysX in Open 3D Engine.",

--- a/Gems/PhysXDebug/gem.json
+++ b/Gems/PhysXDebug/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "PhysXDebug",
     "display_name": "PhysX Debug",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The PhysX Debug Gem provides debugging functionality and visualizations for NVIDIA PhysX in Open 3D Engine.",

--- a/Gems/Prefab/PrefabBuilder/gem.json
+++ b/Gems/Prefab/PrefabBuilder/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "PrefabBuilder",
     "display_name": "Prefab Builder",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Prefab Builder Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities.",

--- a/Gems/Prefab/PrefabBuilder/gem.json
+++ b/Gems/Prefab/PrefabBuilder/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "PrefabBuilder",
     "display_name": "Prefab Builder",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Prefab Builder Gem provides an Asset Processor module for prefabs, which are complex assets built by combining smaller entities.",

--- a/Gems/Presence/gem.json
+++ b/Gems/Presence/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Presence",
     "display_name": "Presence",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Presence Gem provides a target platform agnostic interface for Presence services.",

--- a/Gems/Presence/gem.json
+++ b/Gems/Presence/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Presence",
     "display_name": "Presence",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Presence Gem provides a target platform agnostic interface for Presence services.",

--- a/Gems/PrimitiveAssets/gem.json
+++ b/Gems/PrimitiveAssets/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "PrimitiveAssets",
     "display_name": "Primitive Assets",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Primitive Assets Gem provides primitive shape mesh assets with physics enabled.",

--- a/Gems/PrimitiveAssets/gem.json
+++ b/Gems/PrimitiveAssets/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "PrimitiveAssets",
     "display_name": "Primitive Assets",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Primitive Assets Gem provides primitive shape mesh assets with physics enabled.",

--- a/Gems/Profiler/gem.json
+++ b/Gems/Profiler/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Profiler",
     "display_name": "Profiler",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "A collection of utilities for capturing performance data",

--- a/Gems/Profiler/gem.json
+++ b/Gems/Profiler/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Profiler",
     "display_name": "Profiler",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "A collection of utilities for capturing performance data",

--- a/Gems/PythonAssetBuilder/gem.json
+++ b/Gems/PythonAssetBuilder/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "PythonAssetBuilder",
     "display_name": "Python Asset Builder",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Python Asset Builder Gem provides functionality to implement custom asset builders in Python for Asset Processor.",

--- a/Gems/PythonAssetBuilder/gem.json
+++ b/Gems/PythonAssetBuilder/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "PythonAssetBuilder",
     "display_name": "Python Asset Builder",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Python Asset Builder Gem provides functionality to implement custom asset builders in Python for Asset Processor.",

--- a/Gems/QtForPython/gem.json
+++ b/Gems/QtForPython/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "QtForPython",
     "display_name": "Qt for Python",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Qt for Python Gem provides the PySide2 Python libraries to manage Qt widgets.",

--- a/Gems/QtForPython/gem.json
+++ b/Gems/QtForPython/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "QtForPython",
     "display_name": "Qt for Python",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Qt for Python Gem provides the PySide2 Python libraries to manage Qt widgets.",

--- a/Gems/SaveData/gem.json
+++ b/Gems/SaveData/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "SaveData",
     "display_name": "Save Data",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Save Data Gem provides a platform independent API to save and load persistent user data in Open 3D Engine projects.",

--- a/Gems/SaveData/gem.json
+++ b/Gems/SaveData/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "SaveData",
     "display_name": "Save Data",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Save Data Gem provides a platform independent API to save and load persistent user data in Open 3D Engine projects.",

--- a/Gems/SceneLoggingExample/gem.json
+++ b/Gems/SceneLoggingExample/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "SceneLoggingExample",
     "display_name": "Scene Logging Example",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Scene Logging Example Gem demonstrates the basics of extending the Open 3D Engine Scene API by adding additional logging to the pipeline.",

--- a/Gems/SceneLoggingExample/gem.json
+++ b/Gems/SceneLoggingExample/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "SceneLoggingExample",
     "display_name": "Scene Logging Example",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The Scene Logging Example Gem demonstrates the basics of extending the Open 3D Engine Scene API by adding additional logging to the pipeline.",

--- a/Gems/SceneProcessing/gem.json
+++ b/Gems/SceneProcessing/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "SceneProcessing",
     "display_name": "Scene Processing",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Scene Processing Gem provides Scene Settings, a tool you can use to specify the default settings for processing asset files for actors, meshes, motions, and PhysX.",

--- a/Gems/SceneProcessing/gem.json
+++ b/Gems/SceneProcessing/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "SceneProcessing",
     "display_name": "Scene Processing",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Scene Processing Gem provides Scene Settings, a tool you can use to specify the default settings for processing asset files for actors, meshes, motions, and PhysX.",

--- a/Gems/ScriptCanvas/gem.json
+++ b/Gems/ScriptCanvas/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ScriptCanvas",
     "display_name": "Script Canvas",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Script Canvas Gem provides Open 3D Engine's visual scripting environment, Script Canvas.",

--- a/Gems/ScriptCanvas/gem.json
+++ b/Gems/ScriptCanvas/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ScriptCanvas",
     "display_name": "Script Canvas",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Script Canvas Gem provides Open 3D Engine's visual scripting environment, Script Canvas.",

--- a/Gems/ScriptCanvasDeveloper/gem.json
+++ b/Gems/ScriptCanvasDeveloper/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ScriptCanvasDeveloperGem",
     "display_name": "Script Canvas Developer",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Script Canvas Developer Gem provides a suite of utility features for the development and debugging of Script Canvas systems.",

--- a/Gems/ScriptCanvasDeveloper/gem.json
+++ b/Gems/ScriptCanvasDeveloper/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ScriptCanvasDeveloperGem",
     "display_name": "Script Canvas Developer",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Script Canvas Developer Gem provides a suite of utility features for the development and debugging of Script Canvas systems.",

--- a/Gems/ScriptCanvasPhysics/gem.json
+++ b/Gems/ScriptCanvasPhysics/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ScriptCanvasPhysics",
     "display_name": "Script Canvas Physics",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Script Canvas Physics Gem provides Script Canvas nodes for physics scene queries such as raycasts.",

--- a/Gems/ScriptCanvasPhysics/gem.json
+++ b/Gems/ScriptCanvasPhysics/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ScriptCanvasPhysics",
     "display_name": "Script Canvas Physics",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Script Canvas Physics Gem provides Script Canvas nodes for physics scene queries such as raycasts.",

--- a/Gems/ScriptCanvasTesting/gem.json
+++ b/Gems/ScriptCanvasTesting/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ScriptCanvasTesting",
     "display_name": "Script Canvas Testing",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Script Canvas Testing Gem provides a framework for testing for and with Script Canvas.",

--- a/Gems/ScriptCanvasTesting/gem.json
+++ b/Gems/ScriptCanvasTesting/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ScriptCanvasTesting",
     "display_name": "Script Canvas Testing",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Script Canvas Testing Gem provides a framework for testing for and with Script Canvas.",

--- a/Gems/ScriptEvents/gem.json
+++ b/Gems/ScriptEvents/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ScriptEvents",
     "display_name": "Script Events",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Script Events Gem provides a framework for creating event assets usable from any scripting solution in Open 3D Engine.",

--- a/Gems/ScriptEvents/gem.json
+++ b/Gems/ScriptEvents/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ScriptEvents",
     "display_name": "Script Events",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Script Events Gem provides a framework for creating event assets usable from any scripting solution in Open 3D Engine.",

--- a/Gems/ScriptedEntityTweener/gem.json
+++ b/Gems/ScriptedEntityTweener/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "ScriptedEntityTweener",
     "display_name": "Scripted Entity Tweener",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Scripted Entity Tweener Gem provides a script driven animation system for Open 3D Engine projects.",

--- a/Gems/ScriptedEntityTweener/gem.json
+++ b/Gems/ScriptedEntityTweener/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "ScriptedEntityTweener",
     "display_name": "Scripted Entity Tweener",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Scripted Entity Tweener Gem provides a script driven animation system for Open 3D Engine projects.",

--- a/Gems/SliceFavorites/gem.json
+++ b/Gems/SliceFavorites/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "SliceFavorites",
     "display_name": "SliceFavorites",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "Add the ability to favorite a slice to allow easy access and instantiation",

--- a/Gems/SliceFavorites/gem.json
+++ b/Gems/SliceFavorites/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "SliceFavorites",
     "display_name": "SliceFavorites",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "Add the ability to favorite a slice to allow easy access and instantiation",

--- a/Gems/StartingPointCamera/gem.json
+++ b/Gems/StartingPointCamera/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "StartingPointCamera",
     "display_name": "Starting Point Camera",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Starting Point Camera Gem provides the behaviors used with the Camera Framework Gem to define a camera rig.",

--- a/Gems/StartingPointCamera/gem.json
+++ b/Gems/StartingPointCamera/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "StartingPointCamera",
     "display_name": "Starting Point Camera",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Starting Point Camera Gem provides the behaviors used with the Camera Framework Gem to define a camera rig.",

--- a/Gems/StartingPointInput/gem.json
+++ b/Gems/StartingPointInput/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "StartingPointInput",
     "display_name": "Starting Point Input",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Starting Point Input Gem provides functionality to map low-level input events to high-level actions.",

--- a/Gems/StartingPointInput/gem.json
+++ b/Gems/StartingPointInput/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "StartingPointInput",
     "display_name": "Starting Point Input",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Starting Point Input Gem provides functionality to map low-level input events to high-level actions.",

--- a/Gems/StartingPointMovement/gem.json
+++ b/Gems/StartingPointMovement/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "StartingPointMovement",
     "display_name": "Starting Point Movement",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Starting Point Movement Gem provides a series of Lua scripts that listen and respond to input events and trigger transform operations such as translation and rotation.",

--- a/Gems/StartingPointMovement/gem.json
+++ b/Gems/StartingPointMovement/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "StartingPointMovement",
     "display_name": "Starting Point Movement",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Starting Point Movement Gem provides a series of Lua scripts that listen and respond to input events and trigger transform operations such as translation and rotation.",

--- a/Gems/SurfaceData/gem.json
+++ b/Gems/SurfaceData/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "SurfaceData",
     "display_name": "Surface Data",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Surface Data Gem provides functionality to emit signals or tags from surfaces such as meshes and terrain.",

--- a/Gems/SurfaceData/gem.json
+++ b/Gems/SurfaceData/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "SurfaceData",
     "display_name": "Surface Data",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Surface Data Gem provides functionality to emit signals or tags from surfaces such as meshes and terrain.",

--- a/Gems/Terrain/gem.json
+++ b/Gems/Terrain/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Terrain",
     "display_name": "Terrain",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "summary": "The Terrain Gem is an experimental terrain system.  The terrain system maps height, color, and surface data to regions of the world, provides gradient-based and shape-based authoring tools and workflows, includes specialized rendering for efficient display, and integrates with physics for physical simulation.",
     "canonical_tags": [

--- a/Gems/Terrain/gem.json
+++ b/Gems/Terrain/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Terrain",
     "display_name": "Terrain",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "summary": "The Terrain Gem is an experimental terrain system.  The terrain system maps height, color, and surface data to regions of the world, provides gradient-based and shape-based authoring tools and workflows, includes specialized rendering for efficient display, and integrates with physics for physical simulation.",
     "canonical_tags": [

--- a/Gems/TestAssetBuilder/gem.json
+++ b/Gems/TestAssetBuilder/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "TestAssetBuilder",
     "display_name": "Test Asset Builder",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Test Asset Builder Gem is used to feature test Asset Processor.",

--- a/Gems/TestAssetBuilder/gem.json
+++ b/Gems/TestAssetBuilder/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "TestAssetBuilder",
     "display_name": "Test Asset Builder",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Test Asset Builder Gem is used to feature test Asset Processor.",

--- a/Gems/TextureAtlas/gem.json
+++ b/Gems/TextureAtlas/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "TextureAtlas",
     "display_name": "Texture Atlas",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Texture Atlas Gem provides the formatting for texture atlases from 2D textures for LyShine.",

--- a/Gems/TextureAtlas/gem.json
+++ b/Gems/TextureAtlas/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "TextureAtlas",
     "display_name": "Texture Atlas",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Texture Atlas Gem provides the formatting for texture atlases from 2D textures for LyShine.",

--- a/Gems/TickBusOrderViewer/gem.json
+++ b/Gems/TickBusOrderViewer/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "TickBusOrderViewer",
     "display_name": "Tick Bus Order Viewer",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Tick Bus Order Viewer Gem provides a console variable that displays the order of runtime tick events.",

--- a/Gems/TickBusOrderViewer/gem.json
+++ b/Gems/TickBusOrderViewer/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "TickBusOrderViewer",
     "display_name": "Tick Bus Order Viewer",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The Tick Bus Order Viewer Gem provides a console variable that displays the order of runtime tick events.",

--- a/Gems/Twitch/gem.json
+++ b/Gems/Twitch/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Twitch",
     "display_name": "Twitch",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Twitch Gem provides access to the Twitch API v5 SDK including social functions, channels, and other APIs.",

--- a/Gems/Twitch/gem.json
+++ b/Gems/Twitch/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Twitch",
     "display_name": "Twitch",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Twitch Gem provides access to the Twitch API v5 SDK including social functions, channels, and other APIs.",

--- a/Gems/UiBasics/gem.json
+++ b/Gems/UiBasics/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "UiBasics",
     "display_name": "UI Basics",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The UI Basics Gem provides a collection of basic UI prefabs such as image, text, and button, that can be used with LyShine, the Open 3D Engine runtime User Interface system and editor.",

--- a/Gems/UiBasics/gem.json
+++ b/Gems/UiBasics/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "UiBasics",
     "display_name": "UI Basics",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Asset",
     "summary": "The UI Basics Gem provides a collection of basic UI prefabs such as image, text, and button, that can be used with LyShine, the Open 3D Engine runtime User Interface system and editor.",

--- a/Gems/Vegetation/gem.json
+++ b/Gems/Vegetation/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "Vegetation",
     "display_name": "Vegetation",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Vegetation Gem provides tools to place natural-looking vegetation in Open 3D Engine.",

--- a/Gems/Vegetation/gem.json
+++ b/Gems/Vegetation/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "Vegetation",
     "display_name": "Vegetation",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Vegetation Gem provides tools to place natural-looking vegetation in Open 3D Engine.",

--- a/Gems/VideoPlaybackFramework/gem.json
+++ b/Gems/VideoPlaybackFramework/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "VideoPlaybackFramework",
     "display_name": "Video Playback Framework",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Video Playback Framework Gem provides the interface to play back video.",

--- a/Gems/VideoPlaybackFramework/gem.json
+++ b/Gems/VideoPlaybackFramework/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "VideoPlaybackFramework",
     "display_name": "Video Playback Framework",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Video Playback Framework Gem provides the interface to play back video.",

--- a/Gems/VirtualGamepad/gem.json
+++ b/Gems/VirtualGamepad/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "VirtualGamepad",
     "display_name": "Virtual Gamepad",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Virtual Gamepad Gem provides controls that emulate a gamepad on touch screen devices.",

--- a/Gems/VirtualGamepad/gem.json
+++ b/Gems/VirtualGamepad/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "VirtualGamepad",
     "display_name": "Virtual Gamepad",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Code",
     "summary": "The Virtual Gamepad Gem provides controls that emulate a gamepad on touch screen devices.",

--- a/Gems/WhiteBox/gem.json
+++ b/Gems/WhiteBox/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "WhiteBox",
     "display_name": "White Box",
     "license": "Apache-2.0 Or MIT",
-    "license_url": "https://opensource.org/licenses/MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The White Box Gem provides White Box rapid design components for Open 3D Engine.",

--- a/Gems/WhiteBox/gem.json
+++ b/Gems/WhiteBox/gem.json
@@ -2,6 +2,7 @@
     "gem_name": "WhiteBox",
     "display_name": "White Box",
     "license": "Apache-2.0 Or MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "Open 3D Engine - o3de.org",
     "type": "Tool",
     "summary": "The White Box Gem provides White Box rapid design components for Open 3D Engine.",

--- a/Templates/AssetGem/Template/gem.json
+++ b/Templates/AssetGem/Template/gem.json
@@ -1,7 +1,8 @@
 {
     "gem_name": "${Name}",
     "display_name": "${Name}",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Asset",
     "summary": "A short description of ${Name}.",

--- a/Templates/AssetGem/Template/gem.json
+++ b/Templates/AssetGem/Template/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "${Name}",
     "display_name": "${Name}",
     "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
-    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "license_url": "",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Asset",
     "summary": "A short description of ${Name}.",

--- a/Templates/CppToolGem/Template/gem.json
+++ b/Templates/CppToolGem/Template/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "${Name}",
     "display_name": "${Name}",
     "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
-    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "license_url": "",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of ${Name}.",

--- a/Templates/CppToolGem/Template/gem.json
+++ b/Templates/CppToolGem/Template/gem.json
@@ -1,7 +1,8 @@
 {
     "gem_name": "${Name}",
     "display_name": "${Name}",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of ${Name}.",

--- a/Templates/DefaultGem/Template/gem.json
+++ b/Templates/DefaultGem/Template/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "${Name}",
     "display_name": "${Name}",
     "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
-    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "license_url": "",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of ${Name}.",

--- a/Templates/DefaultGem/Template/gem.json
+++ b/Templates/DefaultGem/Template/gem.json
@@ -1,7 +1,8 @@
 {
     "gem_name": "${Name}",
     "display_name": "${Name}",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of ${Name}.",

--- a/Templates/PythonToolGem/Template/gem.json
+++ b/Templates/PythonToolGem/Template/gem.json
@@ -2,7 +2,7 @@
     "gem_name": "${Name}",
     "display_name": "${Name}",
     "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
-    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
+    "license_url": "",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of ${Name}.",

--- a/Templates/PythonToolGem/Template/gem.json
+++ b/Templates/PythonToolGem/Template/gem.json
@@ -1,7 +1,8 @@
 {
     "gem_name": "${Name}",
     "display_name": "${Name}",
-    "license": "What license ${Name} uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "license": "What license ${Name} uses goes here: i.e. Apache-2.0 Or MIT",
+    "license_url": "https://github.com/o3de/o3de/blob/development/LICENSE.txt",
     "origin": "The primary repo for ${Name} goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of ${Name}.",

--- a/scripts/o3de/o3de/gem_properties.py
+++ b/scripts/o3de/o3de/gem_properties.py
@@ -54,6 +54,8 @@ def edit_gem_props(gem_path: pathlib.Path = None,
                    new_icon: str = None,
                    new_requirements: str = None,
                    new_documentation_url: str = None,
+                   new_license: str = None,
+                   new_license_url: str = None,
                    new_tags: list or str = None,
                    remove_tags: list or str = None,
                    replace_tags: list or str = None,
@@ -94,6 +96,10 @@ def edit_gem_props(gem_path: pathlib.Path = None,
         update_key_dict['requirements'] = new_requirements
     if new_documentation_url:
         update_key_dict['documentation_url'] = new_documentation_url
+    if new_license:
+        update_key_dict['license'] = new_license
+    if new_license_url:
+        update_key_dict['license_url'] = new_license_url
 
     update_key_dict['user_tags'] = update_values_in_key_list(gem_json_data.get('user_tags', []), new_tags,
                                                      remove_tags, replace_tags)
@@ -114,6 +120,8 @@ def _edit_gem_props(args: argparse) -> int:
                           args.gem_icon,
                           args.gem_requirements,
                           args.gem_documentation_url,
+                          args.gem_license,
+                          args.gem_license_url,
                           args.add_tags,
                           args.remove_tags,
                           args.replace_tags)
@@ -142,6 +150,10 @@ def add_parser_args(parser):
                        help='Sets the description of the requirements needed to use the gem.')
     group.add_argument('-gdu', '--gem-documentation-url', type=str, required=False,
                        help='Sets the url for documentation of the gem.')
+    group.add_argument('-gl', '--gem-license', type=str, required=False,
+                       help='Sets the name for the license of the gem.')
+    group.add_argument('-glu', '--gem-license-url', type=str, required=False,
+                       help='Sets the url for the license of the gem.')
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument('-at', '--add-tags', type=str, nargs='*', required=False,
                        help='Adds tag(s) to user_tags property. Can be specified multiple times.')

--- a/scripts/o3de/tests/unit_test_gem_properties.py
+++ b/scripts/o3de/tests/unit_test_gem_properties.py
@@ -18,7 +18,8 @@ TEST_GEM_JSON_PAYLOAD = '''
 {
     "gem_name": "TestGem",
     "display_name": "TestGem",
-    "license": "What license TestGem uses goes here: i.e. https://opensource.org/licenses/MIT",
+    "license": "MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
     "origin": "The primary repo for TestGem goes here: i.e. http://www.mydomain.com",
     "type": "Code",
     "summary": "A short description of TestGem.",
@@ -46,26 +47,30 @@ def init_gem_json_data(request):
 class TestEditGemProperties:
     @pytest.mark.parametrize("gem_path, gem_name, gem_new_name, gem_display, gem_origin,\
                             gem_type, gem_summary, gem_icon, gem_requirements, gem_documentation_url,\
-                            add_tags, remove_tags, replace_tags, expected_tags, expected_result", [
+                            gem_license, gem_license_url, add_tags, remove_tags, replace_tags,\
+                            expected_tags, expected_result", [
         pytest.param(pathlib.PurePath('D:/TestProject'),
                      None, 'TestGem2', 'New Gem Name', 'O3DE', 'Code', 'Gem that exercises Default Gem Template',
                      'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/',
+                     'Apache 2.0', 'https://www.apache.org/licenses/LICENSE-2.0',
                      ['Physics', 'Rendering', 'Scripting'], None, None, ['TestGem', 'Physics', 'Rendering', 'Scripting'],
                      0),
         pytest.param(None,
                      'TestGem2', None, 'New Gem Name', 'O3DE', 'Asset', 'Gem that exercises Default Gem Template',
-                     'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/', None,
-                     ['Physics'], None, ['TestGem', 'Rendering', 'Scripting'], 0),
+                     'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/', 
+                     'Apache 2.0', 'https://www.apache.org/licenses/LICENSE-2.0',
+                     None, ['Physics'], None, ['TestGem', 'Rendering', 'Scripting'], 0),
         pytest.param(None,
                      'TestGem2', None, 'New Gem Name', 'O3DE', 'Tool', 'Gem that exercises Default Gem Template',
-                     'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/', None,
-                     None, ['Animation', 'TestGem'], ['Animation', 'TestGem'], 0)
+                     'new_preview.png', 'Do this extra thing', 'https://o3de.org/docs/user-guide/gems/',
+                     'Apache 2.0', 'https://www.apache.org/licenses/LICENSE-2.0',
+                     None, None, ['Animation', 'TestGem'], ['Animation', 'TestGem'], 0)
         ]
     )
     def test_edit_gem_properties(self, gem_path, gem_name, gem_new_name, gem_display, gem_origin,
                                     gem_type, gem_summary, gem_icon, gem_requirements, 
-                                    gem_documentation_url, add_tags, remove_tags, replace_tags,
-                                    expected_tags, expected_result):
+                                    gem_documentation_url, gem_license, gem_license_url, add_tags, remove_tags,
+                                    replace_tags, expected_tags, expected_result):
 
         def get_gem_json_data(gem_path: pathlib.Path) -> dict:
             return self.gem_json.data
@@ -82,7 +87,8 @@ class TestEditGemProperties:
                 patch('o3de.manifest.get_registered', side_effect=get_gem_path) as get_registered_patch:
             result = gem_properties.edit_gem_props(gem_path, gem_name, gem_new_name, gem_display, gem_origin,
                                                    gem_type, gem_summary, gem_icon, gem_requirements,
-                                                   gem_documentation_url, add_tags, remove_tags, replace_tags)
+                                                   gem_documentation_url, gem_license, gem_license_url,
+                                                   add_tags, remove_tags, replace_tags)
             assert result == expected_result
             if gem_new_name:
                 assert self.gem_json.data.get('gem_name', '') == gem_new_name
@@ -100,5 +106,9 @@ class TestEditGemProperties:
                 assert self.gem_json.data.get('requirements', '') == gem_requirements
             if gem_documentation_url:
                 assert self.gem_json.data.get('documentation_url', '') == gem_documentation_url
+            if gem_license:
+                assert self.gem_json.data.get('license', '') == gem_license
+            if gem_license_url:
+                assert self.gem_json.data.get('license_url', '') == gem_license_url
 
             assert set(self.gem_json.data.get('user_tags', [])) == set(expected_tags)


### PR DESCRIPTION
Also some general improvements to gem inspector including: Adding text eliding, fixing typos, depending gems is a conditional element now and conditional spacing.
Additionally adds license and license_url as modifiable properties in in o3de scripts.

![HQX9QQIwT1](https://user-images.githubusercontent.com/52797929/140184563-92b72705-1411-443c-a3d8-2ac9452a02b4.gif)
![eja0Yt75d0](https://user-images.githubusercontent.com/52797929/140184551-60ae323a-8aa4-4f88-8702-a335f71f4c84.gif)

F:\o3de\o3de\python>python.cmd -m pytest F:\o3de\o3de\scripts\o3de\tests\unit_test_gem_properties.py --build-directory F:\o3de\o3de\build\windows_vs2019\bin\profile
================================================= test session starts =================================================
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: F:\o3de\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 3 items

..\scripts\o3de\tests\unit_test_gem_properties.py ...                                                            [100%]

================================================== 3 passed in 0.05s ==================================================