### PR TITLE
[Linux] Unify Editor and Game raw mouse event handling

### DIFF
--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.h
@@ -6,18 +6,34 @@
  *
  */
 
+#if !defined(Q_MOC_RUN)
 #include <Editor/Core/QtEditorApplication.h>
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#endif
+
+using xcb_connection_t = struct xcb_connection_t;
 
 namespace Editor
 {
-    class EditorQtApplicationXcb : public EditorQtApplication
+    class EditorQtApplicationXcb
+        : public EditorQtApplication
+        , public AzToolsFramework::EditorEntityContextNotificationBus::Handler
     {
         Q_OBJECT
     public:
         EditorQtApplicationXcb(int& argc, char** argv)
             : EditorQtApplication(argc, argv)
         {
+            // Connect bus to listen for OnStart/StopPlayInEditor events
+            AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusConnect();
         }
+
+        xcb_connection_t* GetXcbConnectionFromQt();
+
+        ///////////////////////////////////////////////////////////////////////
+        // AzToolsFramework::EditorEntityContextNotificationBus overrides
+        void OnStartPlayInEditor() override;
+        void OnStopPlayInEditor() override;
 
         // QAbstractNativeEventFilter:
         bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override;

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbApplication.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbApplication.cpp
@@ -10,6 +10,8 @@
 #include <AzFramework/XcbEventHandler.h>
 #include <AzFramework/XcbInterface.h>
 
+#include <xcb/xinput.h>
+
 namespace AzFramework
 {
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -32,6 +34,31 @@ namespace AzFramework
         xcb_connection_t* GetXcbConnection() const override
         {
             return m_xcbConnection.get();
+        }
+
+        void SetEnableXInput(xcb_connection_t* connection, bool enable) override
+        {
+            struct Mask
+            {
+                xcb_input_event_mask_t head;
+                xcb_input_xi_event_mask_t mask;
+            };
+            const Mask mask {
+                /*.head=*/{
+                    /*.device_id=*/XCB_INPUT_DEVICE_ALL_MASTER,
+                    /*.mask_len=*/1
+                },
+                /*.mask=*/ enable ?
+                    (xcb_input_xi_event_mask_t)(XCB_INPUT_XI_EVENT_MASK_RAW_MOTION | XCB_INPUT_XI_EVENT_MASK_RAW_BUTTON_PRESS | XCB_INPUT_XI_EVENT_MASK_RAW_BUTTON_RELEASE) :
+                    (xcb_input_xi_event_mask_t)XCB_NONE
+            };
+
+            const xcb_setup_t* xcbSetup = xcb_get_setup(connection);
+            const xcb_screen_t* xcbScreen = xcb_setup_roots_iterator(xcbSetup).data;
+
+            xcb_input_xi_select_events(connection, xcbScreen->root, 1, &mask.head);
+
+            xcb_flush(connection);
         }
 
     private:

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbConnectionManager.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbConnectionManager.h
@@ -24,6 +24,9 @@ namespace AzFramework
         virtual ~XcbConnectionManager() = default;
 
         virtual xcb_connection_t* GetXcbConnection() const = 0;
+
+        //! Enables/Disables XInput Raw Input events.
+        virtual void SetEnableXInput(xcb_connection_t* connection, bool enable) = 0;
     };
 
     class XcbConnectionManagerBusTraits

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbEventHandler.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbEventHandler.h
@@ -23,9 +23,6 @@ namespace AzFramework
         virtual ~XcbEventHandler() = default;
 
         virtual void HandleXcbEvent(xcb_generic_event_t* event) = 0;
-
-        // ATTN This is used as a workaround for RAW Input events when using the Editor.
-        virtual void PollSpecialEvents(){};
     };
 
     class XcbEventHandlerBusTraits : public AZ::EBusTraits

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.cpp
@@ -24,9 +24,6 @@ namespace AzFramework
             return XCB_NONE;
         }
 
-        // TODO Clang compile error because cast .... loses information. On GNU/Linux HWND is void* and on 64-bit
-        // machines its obviously 64 bit but we receive the window id from m_renderOverlay.winId() which is xcb_window_t 32-bit.
-
         return static_cast<xcb_window_t>(reinterpret_cast<uint64_t>(systemCursorFocusWindow));
     }
 
@@ -57,7 +54,7 @@ namespace AzFramework
 
     InputDeviceMouse::Implementation* XcbInputDeviceMouse::Create(InputDeviceMouse& inputDevice)
     {
-        auto* interface = AzFramework::XcbConnectionManagerInterface::Get();
+        const auto* interface = AzFramework::XcbConnectionManagerInterface::Get();
         if (!interface)
         {
             AZ_Warning("XcbInput", false, "XCB interface not available");
@@ -126,7 +123,7 @@ namespace AzFramework
 
             // Get window information.
             const XcbStdFreePtr<xcb_get_geometry_reply_t> xcbGeometryReply{ xcb_get_geometry_reply(
-                s_xcbConnection, xcb_get_geometry(s_xcbConnection, window), NULL) };
+                s_xcbConnection, xcb_get_geometry(s_xcbConnection, window), nullptr) };
 
             if (!xcbGeometryReply)
             {
@@ -137,7 +134,7 @@ namespace AzFramework
                 xcb_translate_coordinates(s_xcbConnection, window, s_xcbScreen->root, 0, 0);
 
             const XcbStdFreePtr<xcb_translate_coordinates_reply_t> xkbTranslateCoordReply{ xcb_translate_coordinates_reply(
-                s_xcbConnection, translate_coord, NULL) };
+                s_xcbConnection, translate_coord, nullptr) };
 
             if (!xkbTranslateCoordReply)
             {
@@ -173,11 +170,11 @@ namespace AzFramework
             for (const auto& barrier : m_activeBarriers)
             {
                 xcb_void_cookie_t cookie = xcb_xfixes_create_pointer_barrier_checked(
-                    s_xcbConnection, barrier.id, window, barrier.x0, barrier.y0, barrier.x1, barrier.y1, barrier.direction, 0, NULL);
-                const XcbStdFreePtr<xcb_generic_error_t> xkbError{ xcb_request_check(s_xcbConnection, cookie) };
+                    s_xcbConnection, barrier.id, window, barrier.x0, barrier.y0, barrier.x1, barrier.y1, barrier.direction, 0, nullptr);
+                const XcbStdFreePtr<xcb_generic_error_t> xcbError{ xcb_request_check(s_xcbConnection, cookie) };
 
                 AZ_Warning(
-                    "XcbInput", !xkbError, "XFixes, failed to create barrier %d at (%d %d %d %d)", barrier.id, barrier.x0, barrier.y0,
+                    "XcbInput", !xcbError, "XFixes, failed to create barrier %d at (%d %d %d %d)", barrier.id, barrier.x0, barrier.y0,
                     barrier.x1, barrier.y1);
             }
         }
@@ -207,7 +204,7 @@ namespace AzFramework
 
         const xcb_xfixes_query_version_cookie_t query_cookie = xcb_xfixes_query_version(s_xcbConnection, 5, 0);
 
-        xcb_generic_error_t* error = NULL;
+        xcb_generic_error_t* error = nullptr;
         const XcbStdFreePtr<xcb_xfixes_query_version_reply_t> xkbQueryRequestReply{ xcb_xfixes_query_version_reply(
             s_xcbConnection, query_cookie, &error) };
 
@@ -244,7 +241,7 @@ namespace AzFramework
 
         const xcb_input_xi_query_version_cookie_t query_version_cookie = xcb_input_xi_query_version(s_xcbConnection, 2, 2);
 
-        xcb_generic_error_t* error = NULL;
+        xcb_generic_error_t* error = nullptr;
         const XcbStdFreePtr<xcb_input_xi_query_version_reply_t> xkbQueryRequestReply{ xcb_input_xi_query_version_reply(
             s_xcbConnection, query_version_cookie, &error) };
 
@@ -340,7 +337,7 @@ namespace AzFramework
     {
         // TODO Basically not done at all. Added only the basic functions needed.
         const XcbStdFreePtr<xcb_get_geometry_reply_t> xkbGeometryReply{ xcb_get_geometry_reply(
-            s_xcbConnection, xcb_get_geometry(s_xcbConnection, window), NULL) };
+            s_xcbConnection, xcb_get_geometry(s_xcbConnection, window), nullptr) };
 
         if (!xkbGeometryReply)
         {
@@ -372,7 +369,7 @@ namespace AzFramework
 
         const xcb_query_pointer_cookie_t pointer = xcb_query_pointer(s_xcbConnection, window);
 
-        const XcbStdFreePtr<xcb_query_pointer_reply_t> xkbQueryPointerReply{ xcb_query_pointer_reply(s_xcbConnection, pointer, NULL) };
+        const XcbStdFreePtr<xcb_query_pointer_reply_t> xkbQueryPointerReply{ xcb_query_pointer_reply(s_xcbConnection, pointer, nullptr) };
 
         if (!xkbQueryPointerReply)
         {
@@ -380,7 +377,7 @@ namespace AzFramework
         }
 
         const XcbStdFreePtr<xcb_get_geometry_reply_t> xkbGeometryReply{ xcb_get_geometry_reply(
-            s_xcbConnection, xcb_get_geometry(s_xcbConnection, window), NULL) };
+            s_xcbConnection, xcb_get_geometry(s_xcbConnection, window), nullptr) };
 
         if (!xkbGeometryReply)
         {
@@ -426,11 +423,11 @@ namespace AzFramework
             cookie = xcb_xfixes_hide_cursor_checked(s_xcbConnection, window);
         }
 
-        const XcbStdFreePtr<xcb_generic_error_t> xkbError{ xcb_request_check(s_xcbConnection, cookie) };
+        const XcbStdFreePtr<xcb_generic_error_t> xcbError{ xcb_request_check(s_xcbConnection, cookie) };
 
-        if (xkbError)
+        if (xcbError)
         {
-            AZ_Warning("XcbInput", false, "ShowCursor failed: %d", xkbError->error_code);
+            AZ_Warning("XcbInput", false, "ShowCursor failed: %d", xcbError->error_code);
 
             return;
         }

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
@@ -161,9 +161,6 @@ namespace AzFramework
         //! Will be true if the xinput2 extension could be initialized.
         static bool m_xInputInitialized;
 
-        //! The window that had focus
-        xcb_window_t m_prevConstraintWindow;
-
         //! The current window that has focus
         xcb_window_t m_focusWindow;
 

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceMouse.h
@@ -65,9 +65,6 @@ namespace AzFramework
         //! \ref AzFramework::InputDeviceMouse::Implementation::TickInputDevice
         void TickInputDevice() override;
 
-        //! This method is called by the Editor to accommodate some events with the Editor. Never called in Game mode.
-        void PollSpecialEvents() override;
-
         //! Handle X11 events.
         void HandleXcbEvent(xcb_generic_event_t* event) override;
 
@@ -76,9 +73,6 @@ namespace AzFramework
 
         //! Initialize XInput extension. Used for raw input during confinement and showing/hiding the cursor.
         static bool InitializeXInput();
-
-        //! Enables/Disables XInput Raw Input events.
-        void SetEnableXInput(bool enable);
 
         //! Create barriers.
         void CreateBarriers(xcb_window_t window, bool create);
@@ -97,9 +91,6 @@ namespace AzFramework
 
         //! Handle button press/release events.
         void HandleButtonPressEvents(uint32_t detail, bool pressed);
-
-        //! Handle motion notify events.
-        void HandlePointerMotionEvents(const xcb_generic_event_t* event);
 
         //! Will set cursor states and confinement modes.
         void HandleCursorState(xcb_window_t window, SystemCursorState systemCursorState);
@@ -160,7 +151,6 @@ namespace AzFramework
         AZ::Vector2 m_cursorHiddenPosition;
 
         AZ::Vector2 m_systemCursorPositionNormalized;
-        uint32_t m_systemCursorPosition[MAX_XI_RAW_AXIS];
 
         static xcb_connection_t* s_xcbConnection;
         static xcb_screen_t* s_xcbScreen;

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/Actions.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/Actions.h
@@ -13,6 +13,13 @@
 
 ACTION_TEMPLATE(ReturnMalloc,
                 HAS_1_TEMPLATE_PARAMS(typename, T),
+                AND_0_VALUE_PARAMS()) {
+    T* value = static_cast<T*>(malloc(sizeof(T)));
+    *value = T{};
+    return value;
+}
+ACTION_TEMPLATE(ReturnMalloc,
+                HAS_1_TEMPLATE_PARAMS(typename, T),
                 AND_1_VALUE_PARAMS(p0)) {
     T* value = static_cast<T*>(malloc(sizeof(T)));
     *value = T{ p0 };
@@ -23,5 +30,33 @@ ACTION_TEMPLATE(ReturnMalloc,
                 AND_2_VALUE_PARAMS(p0, p1)) {
     T* value = static_cast<T*>(malloc(sizeof(T)));
     *value = T{ p0, p1 };
+    return value;
+}
+ACTION_TEMPLATE(ReturnMalloc,
+                HAS_1_TEMPLATE_PARAMS(typename, T),
+                AND_3_VALUE_PARAMS(p0, p1, p2)) {
+    T* value = static_cast<T*>(malloc(sizeof(T)));
+    *value = T{ p0, p1, p2 };
+    return value;
+}
+ACTION_TEMPLATE(ReturnMalloc,
+                HAS_1_TEMPLATE_PARAMS(typename, T),
+                AND_4_VALUE_PARAMS(p0, p1, p2, p3)) {
+    T* value = static_cast<T*>(malloc(sizeof(T)));
+    *value = T{ p0, p1, p2, p3 };
+    return value;
+}
+ACTION_TEMPLATE(ReturnMalloc,
+                HAS_1_TEMPLATE_PARAMS(typename, T),
+                AND_5_VALUE_PARAMS(p0, p1, p2, p3, p4)) {
+    T* value = static_cast<T*>(malloc(sizeof(T)));
+    *value = T{ p0, p1, p2, p3, p4 };
+    return value;
+}
+ACTION_TEMPLATE(ReturnMalloc,
+                HAS_1_TEMPLATE_PARAMS(typename, T),
+                AND_6_VALUE_PARAMS(p0, p1, p2, p3, p4, p5)) {
+    T* value = static_cast<T*>(malloc(sizeof(T)));
+    *value = T{ p0, p1, p2, p3, p4, p5 };
     return value;
 }

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/Actions.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/Actions.h
@@ -60,3 +60,10 @@ ACTION_TEMPLATE(ReturnMalloc,
     *value = T{ p0, p1, p2, p3, p4, p5 };
     return value;
 }
+ACTION_TEMPLATE(ReturnMalloc,
+                HAS_1_TEMPLATE_PARAMS(typename, T),
+                AND_7_VALUE_PARAMS(p0, p1, p2, p3, p4, p5, p6)) {
+    T* value = static_cast<T*>(malloc(sizeof(T)));
+    *value = T{ p0, p1, p2, p3, p4, p5, p6 };
+    return value;
+}

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
@@ -77,6 +77,37 @@ xcb_void_cookie_t xcb_warp_pointer(
 {
     return MockXcbInterface::Instance()->xcb_warp_pointer(c, src_window, dst_window, src_x, src_y, src_width, src_height, dst_x, dst_y);
 }
+xcb_intern_atom_cookie_t xcb_intern_atom(xcb_connection_t* c, uint8_t only_if_exists, uint16_t name_len, const char* name)
+{
+    return MockXcbInterface::Instance()->xcb_intern_atom(c, only_if_exists, name_len, name);
+}
+xcb_intern_atom_reply_t* xcb_intern_atom_reply(xcb_connection_t* c, xcb_intern_atom_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_intern_atom_reply(c, cookie, e);
+}
+xcb_get_property_cookie_t xcb_get_property(
+    xcb_connection_t* c,
+    uint8_t _delete,
+    xcb_window_t window,
+    xcb_atom_t property,
+    xcb_atom_t type,
+    uint32_t long_offset,
+    uint32_t long_length)
+{
+    return MockXcbInterface::Instance()->xcb_get_property(c, _delete, window, property, type, long_offset, long_length);
+}
+xcb_get_property_reply_t* xcb_get_property_reply(xcb_connection_t* c, xcb_get_property_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_get_property_reply(c, cookie, e);
+}
+void* xcb_get_property_value(const xcb_get_property_reply_t* R)
+{
+    return MockXcbInterface::Instance()->xcb_get_property_value(R);
+}
+uint32_t xcb_generate_id(xcb_connection_t *c)
+{
+    return MockXcbInterface::Instance()->xcb_generate_id(c);
+}
 
 // ----------------------------------------------------------------------------
 // xcb-xkb
@@ -180,6 +211,32 @@ xcb_void_cookie_t xcb_xfixes_show_cursor_checked(xcb_connection_t* c, xcb_window
 xcb_void_cookie_t xcb_xfixes_hide_cursor_checked(xcb_connection_t* c, xcb_window_t window)
 {
     return MockXcbInterface::Instance()->xcb_xfixes_hide_cursor_checked(c, window);
+}
+xcb_void_cookie_t xcb_xfixes_delete_pointer_barrier_checked(xcb_connection_t* c, xcb_xfixes_barrier_t barrier)
+{
+    return MockXcbInterface::Instance()->xcb_xfixes_delete_pointer_barrier_checked(c, barrier);
+}
+xcb_translate_coordinates_cookie_t xcb_translate_coordinates(xcb_connection_t* c, xcb_window_t src_window, xcb_window_t dst_window, int16_t src_x, int16_t src_y)
+{
+    return MockXcbInterface::Instance()->xcb_translate_coordinates(c, src_window, dst_window, src_x, src_y);
+}
+xcb_translate_coordinates_reply_t* xcb_translate_coordinates_reply(xcb_connection_t* c, xcb_translate_coordinates_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_translate_coordinates_reply(c, cookie, e);
+}
+xcb_void_cookie_t xcb_xfixes_create_pointer_barrier_checked(
+    xcb_connection_t* c,
+    xcb_xfixes_barrier_t barrier,
+    xcb_window_t window,
+    uint16_t x1,
+    uint16_t y1,
+    uint16_t x2,
+    uint16_t y2,
+    uint32_t directions,
+    uint16_t num_devices,
+    const uint16_t* devices)
+{
+    return MockXcbInterface::Instance()->xcb_xfixes_create_pointer_barrier_checked(c, barrier, window, x1, y1, x2, y2, directions, num_devices, devices);
 }
 
 // ----------------------------------------------------------------------------

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.cpp
@@ -32,6 +32,51 @@ xcb_generic_error_t* xcb_request_check(xcb_connection_t* c, xcb_void_cookie_t co
 {
     return MockXcbInterface::Instance()->xcb_request_check(c, cookie);
 }
+const xcb_setup_t* xcb_get_setup(xcb_connection_t *c)
+{
+    return MockXcbInterface::Instance()->xcb_get_setup(c);
+}
+xcb_screen_iterator_t xcb_setup_roots_iterator(const xcb_setup_t* R)
+{
+    return MockXcbInterface::Instance()->xcb_setup_roots_iterator(R);
+}
+const xcb_query_extension_reply_t* xcb_get_extension_data(xcb_connection_t* c, xcb_extension_t* ext)
+{
+    return MockXcbInterface::Instance()->xcb_get_extension_data(c, ext);
+}
+int xcb_flush(xcb_connection_t *c)
+{
+    return MockXcbInterface::Instance()->xcb_flush(c);
+}
+xcb_query_pointer_cookie_t xcb_query_pointer(xcb_connection_t* c, xcb_window_t window)
+{
+    return MockXcbInterface::Instance()->xcb_query_pointer(c, window);
+}
+xcb_query_pointer_reply_t* xcb_query_pointer_reply(xcb_connection_t* c, xcb_query_pointer_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_query_pointer_reply(c, cookie, e);
+}
+xcb_get_geometry_cookie_t xcb_get_geometry(xcb_connection_t* c, xcb_drawable_t drawable)
+{
+    return MockXcbInterface::Instance()->xcb_get_geometry(c, drawable);
+}
+xcb_get_geometry_reply_t* xcb_get_geometry_reply(xcb_connection_t* c, xcb_get_geometry_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_get_geometry_reply(c, cookie, e);
+}
+xcb_void_cookie_t xcb_warp_pointer(
+    xcb_connection_t* c,
+    xcb_window_t src_window,
+    xcb_window_t dst_window,
+    int16_t src_x,
+    int16_t src_y,
+    uint16_t src_width,
+    uint16_t src_height,
+    int16_t dst_x,
+    int16_t dst_y)
+{
+    return MockXcbInterface::Instance()->xcb_warp_pointer(c, src_window, dst_window, src_x, src_y, src_width, src_height, dst_x, dst_y);
+}
 
 // ----------------------------------------------------------------------------
 // xcb-xkb
@@ -114,6 +159,52 @@ xkb_state_component xkb_state_update_mask(
 {
     return MockXcbInterface::Instance()->xkb_state_update_mask(
         state, depressed_mods, latched_mods, locked_mods, depressed_layout, latched_layout, locked_layout);
+}
+
+// ----------------------------------------------------------------------------
+// xcb-xfixes
+xcb_xfixes_query_version_cookie_t xcb_xfixes_query_version(
+    xcb_connection_t* c, uint32_t client_major_version, uint32_t client_minor_version)
+{
+    return MockXcbInterface::Instance()->xcb_xfixes_query_version(c, client_major_version, client_minor_version);
+}
+xcb_xfixes_query_version_reply_t* xcb_xfixes_query_version_reply(
+    xcb_connection_t* c, xcb_xfixes_query_version_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_xfixes_query_version_reply(c, cookie, e);
+}
+xcb_void_cookie_t xcb_xfixes_show_cursor_checked(xcb_connection_t* c, xcb_window_t window)
+{
+    return MockXcbInterface::Instance()->xcb_xfixes_show_cursor_checked(c, window);
+}
+xcb_void_cookie_t xcb_xfixes_hide_cursor_checked(xcb_connection_t* c, xcb_window_t window)
+{
+    return MockXcbInterface::Instance()->xcb_xfixes_hide_cursor_checked(c, window);
+}
+
+// ----------------------------------------------------------------------------
+// xcb-xinput
+xcb_input_xi_query_version_cookie_t xcb_input_xi_query_version(xcb_connection_t* c, uint16_t major_version, uint16_t minor_version)
+{
+    return MockXcbInterface::Instance()->xcb_input_xi_query_version(c, major_version, minor_version);
+}
+xcb_input_xi_query_version_reply_t* xcb_input_xi_query_version_reply(
+    xcb_connection_t* c, xcb_input_xi_query_version_cookie_t cookie, xcb_generic_error_t** e)
+{
+    return MockXcbInterface::Instance()->xcb_input_xi_query_version_reply(c, cookie, e);
+}
+xcb_void_cookie_t xcb_input_xi_select_events(
+    xcb_connection_t* c, xcb_window_t window, uint16_t num_mask, const xcb_input_event_mask_t* masks)
+{
+    return MockXcbInterface::Instance()->xcb_input_xi_select_events(c, window, num_mask, masks);
+}
+int xcb_input_raw_button_press_axisvalues_length (const xcb_input_raw_button_press_event_t *R)
+{
+    return MockXcbInterface::Instance()->xcb_input_raw_button_press_axisvalues_length(R);
+}
+xcb_input_fp3232_t* xcb_input_raw_button_press_axisvalues_raw(const xcb_input_raw_button_press_event_t* R)
+{
+    return MockXcbInterface::Instance()->xcb_input_raw_button_press_axisvalues_raw(R);
 }
 
 }

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
@@ -18,6 +18,8 @@
 #undef explicit
 #include <xkbcommon/xkbcommon.h>
 #include <xkbcommon/xkbcommon-x11.h>
+#include <xcb/xfixes.h>
+#include <xcb/xinput.h>
 
 #include "Printers.h"
 
@@ -62,6 +64,24 @@ public:
     MOCK_CONST_METHOD1(xcb_disconnect, void(xcb_connection_t* c));
     MOCK_CONST_METHOD1(xcb_poll_for_event, xcb_generic_event_t*(xcb_connection_t* c));
     MOCK_CONST_METHOD2(xcb_request_check, xcb_generic_error_t*(xcb_connection_t* c, xcb_void_cookie_t cookie));
+    MOCK_CONST_METHOD1(xcb_get_setup, const xcb_setup_t*(xcb_connection_t *c));
+    MOCK_CONST_METHOD1(xcb_setup_roots_iterator, xcb_screen_iterator_t(const xcb_setup_t* R));
+    MOCK_CONST_METHOD2(xcb_get_extension_data, const xcb_query_extension_reply_t*(xcb_connection_t* c, xcb_extension_t* ext));
+    MOCK_CONST_METHOD1(xcb_flush, int(xcb_connection_t *c));
+    MOCK_CONST_METHOD2(xcb_query_pointer, xcb_query_pointer_cookie_t(xcb_connection_t* c, xcb_window_t window));
+    MOCK_CONST_METHOD3(xcb_query_pointer_reply, xcb_query_pointer_reply_t*(xcb_connection_t* c, xcb_query_pointer_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD2(xcb_get_geometry, xcb_get_geometry_cookie_t(xcb_connection_t* c, xcb_drawable_t drawable));
+    MOCK_CONST_METHOD3(xcb_get_geometry_reply, xcb_get_geometry_reply_t*(xcb_connection_t* c, xcb_get_geometry_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD9(xcb_warp_pointer, xcb_void_cookie_t(
+        xcb_connection_t* c,
+        xcb_window_t src_window,
+        xcb_window_t dst_window,
+        int16_t src_x,
+        int16_t src_y,
+        uint16_t src_width,
+        uint16_t src_height,
+        int16_t dst_x,
+        int16_t dst_y));
 
     // xcb-xkb
     MOCK_CONST_METHOD3(xcb_xkb_use_extension, xcb_xkb_use_extension_cookie_t(xcb_connection_t* c, uint16_t wantedMajor, uint16_t wantedMinor));
@@ -82,6 +102,19 @@ public:
     MOCK_CONST_METHOD2(xkb_state_key_get_one_sym, xkb_keysym_t(xkb_state* state, xkb_keycode_t key));
     MOCK_CONST_METHOD4(xkb_state_key_get_utf8, int(xkb_state* state, xkb_keycode_t key, char* buffer, size_t size));
     MOCK_CONST_METHOD7(xkb_state_update_mask, xkb_state_component(xkb_state* state, xkb_mod_mask_t depressed_mods, xkb_mod_mask_t latched_mods, xkb_mod_mask_t locked_mods, xkb_layout_index_t depressed_layout, xkb_layout_index_t latched_layout, xkb_layout_index_t locked_layout));
+
+    // xcb-xfixes
+    MOCK_CONST_METHOD3(xcb_xfixes_query_version, xcb_xfixes_query_version_cookie_t(xcb_connection_t* c, uint32_t client_major_version, uint32_t client_minor_version));
+    MOCK_CONST_METHOD3(xcb_xfixes_query_version_reply, xcb_xfixes_query_version_reply_t*(xcb_connection_t* c, xcb_xfixes_query_version_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD2(xcb_xfixes_show_cursor_checked, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window));
+    MOCK_CONST_METHOD2(xcb_xfixes_hide_cursor_checked, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window));
+
+    // xcb-xinput
+    MOCK_CONST_METHOD3(xcb_input_xi_query_version, xcb_input_xi_query_version_cookie_t(xcb_connection_t* c, uint16_t major_version, uint16_t minor_version));
+    MOCK_CONST_METHOD3(xcb_input_xi_query_version_reply, xcb_input_xi_query_version_reply_t*(xcb_connection_t* c, xcb_input_xi_query_version_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD4(xcb_input_xi_select_events, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window, uint16_t num_mask, const xcb_input_event_mask_t* masks));
+    MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_length, int(const xcb_input_raw_button_press_event_t* R));
+    MOCK_CONST_METHOD1(xcb_input_raw_button_press_axisvalues_raw, xcb_input_fp3232_t*(const xcb_input_raw_button_press_event_t* R));
 
 private:
     static inline MockXcbInterface* self = nullptr;

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/MockXcbInterface.h
@@ -82,6 +82,19 @@ public:
         uint16_t src_height,
         int16_t dst_x,
         int16_t dst_y));
+    MOCK_CONST_METHOD4(xcb_intern_atom, xcb_intern_atom_cookie_t(xcb_connection_t* c, uint8_t only_if_exists, uint16_t name_len, const char* name));
+    MOCK_CONST_METHOD3(xcb_intern_atom_reply, xcb_intern_atom_reply_t*(xcb_connection_t* c, xcb_intern_atom_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD7(xcb_get_property, xcb_get_property_cookie_t(
+        xcb_connection_t* c,
+        uint8_t _delete,
+        xcb_window_t window,
+        xcb_atom_t property,
+        xcb_atom_t type,
+        uint32_t long_offset,
+        uint32_t long_length));
+    MOCK_CONST_METHOD3(xcb_get_property_reply, xcb_get_property_reply_t*(xcb_connection_t* c, xcb_get_property_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD1(xcb_get_property_value, void*(const xcb_get_property_reply_t* R));
+    MOCK_CONST_METHOD1(xcb_generate_id, uint32_t(xcb_connection_t *c));
 
     // xcb-xkb
     MOCK_CONST_METHOD3(xcb_xkb_use_extension, xcb_xkb_use_extension_cookie_t(xcb_connection_t* c, uint16_t wantedMajor, uint16_t wantedMinor));
@@ -108,6 +121,20 @@ public:
     MOCK_CONST_METHOD3(xcb_xfixes_query_version_reply, xcb_xfixes_query_version_reply_t*(xcb_connection_t* c, xcb_xfixes_query_version_cookie_t cookie, xcb_generic_error_t** e));
     MOCK_CONST_METHOD2(xcb_xfixes_show_cursor_checked, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window));
     MOCK_CONST_METHOD2(xcb_xfixes_hide_cursor_checked, xcb_void_cookie_t(xcb_connection_t* c, xcb_window_t window));
+    MOCK_CONST_METHOD2(xcb_xfixes_delete_pointer_barrier_checked, xcb_void_cookie_t(xcb_connection_t* c, xcb_xfixes_barrier_t barrier));
+    MOCK_CONST_METHOD5(xcb_translate_coordinates, xcb_translate_coordinates_cookie_t(xcb_connection_t* c, xcb_window_t src_window, xcb_window_t dst_window, int16_t src_x, int16_t src_y));
+    MOCK_CONST_METHOD3(xcb_translate_coordinates_reply, xcb_translate_coordinates_reply_t*(xcb_connection_t* c, xcb_translate_coordinates_cookie_t cookie, xcb_generic_error_t** e));
+    MOCK_CONST_METHOD10(xcb_xfixes_create_pointer_barrier_checked, xcb_void_cookie_t(
+        xcb_connection_t* c,
+        xcb_xfixes_barrier_t barrier,
+        xcb_window_t window,
+        uint16_t x1,
+        uint16_t y1,
+        uint16_t x2,
+        uint16_t y2,
+        uint32_t directions,
+        uint16_t num_devices,
+        const uint16_t* devices));
 
     // xcb-xinput
     MOCK_CONST_METHOD3(xcb_input_xi_query_version, xcb_input_xi_query_version_cookie_t(xcb_connection_t* c, uint16_t major_version, uint16_t minor_version));

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbBaseTestFixture.h
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbBaseTestFixture.h
@@ -22,6 +22,12 @@ namespace AzFramework
     public:
         void SetUp() override;
 
+        template<typename T>
+        static xcb_generic_event_t MakeEvent(T event)
+        {
+            return *reinterpret_cast<xcb_generic_event_t*>(&event);
+        }
+
     protected:
         testing::NiceMock<MockXcbInterface> m_interface;
         xcb_connection_t m_connection{};

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceKeyboardTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceKeyboardTests.cpp
@@ -21,12 +21,6 @@
 #include "XcbBaseTestFixture.h"
 #include "XcbTestApplication.h"
 
-template<typename T>
-xcb_generic_event_t MakeEvent(T event)
-{
-    return *reinterpret_cast<xcb_generic_event_t*>(&event);
-}
-
 namespace AzFramework
 {
     // Sets up default behavior for mock keyboard responses to xcb methods

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceMouseTests.cpp
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/XcbInputDeviceMouseTests.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <xcb/xcb.h>
+
+#include <AzFramework/Input/Buses/Requests/InputSystemCursorRequestBus.h>
+#include <AzFramework/Input/Devices/Mouse/InputDeviceMouse.h>
+
+#include "XcbBaseTestFixture.h"
+#include "XcbTestApplication.h"
+#include "Matchers.h"
+#include "Actions.h"
+
+namespace AzFramework
+{
+    // Sets up default behavior for mock keyboard responses to xcb methods
+    class XcbInputDeviceMouseTests
+        : public XcbBaseTestFixture
+    {
+    public:
+        void SetUp() override
+        {
+            using testing::Return;
+            using testing::_;
+
+            XcbBaseTestFixture::SetUp();
+
+            ON_CALL(m_interface, xcb_get_setup(&m_connection))
+                .WillByDefault(Return(&s_xcbSetup));
+            ON_CALL(m_interface, xcb_setup_roots_iterator(&s_xcbSetup))
+                .WillByDefault(Return(xcb_screen_iterator_t{&s_xcbScreen}));
+
+            ON_CALL(m_interface, xcb_get_extension_data(&m_connection, &xcb_xfixes_id))
+                .WillByDefault(Return(&s_xfixesExtensionReply));
+            ON_CALL(m_interface, xcb_xfixes_query_version_reply(&m_connection, _, _))
+                .WillByDefault(ReturnMalloc<xcb_xfixes_query_version_reply_t>(
+                    /*response_type=*/(uint8_t)XCB_XFIXES_QUERY_VERSION,
+                    /*pad0=*/(uint8_t)0,
+                    /*sequence=*/(uint16_t)1,
+                    /*length=*/0u,
+                    /*major_version=*/5u,
+                    /*minor_version=*/0u
+                ));
+
+            ON_CALL(m_interface, xcb_get_extension_data(&m_connection, &xcb_input_id))
+                .WillByDefault(Return(&s_xfixesExtensionReply));
+            ON_CALL(m_interface, xcb_input_xi_query_version_reply(&m_connection, _, _))
+                .WillByDefault(ReturnMalloc<xcb_input_xi_query_version_reply_t>(
+                    /*response_type=*/(uint8_t)XCB_INPUT_XI_QUERY_VERSION,
+                    /*pad0=*/(uint8_t)0,
+                    /*sequence=*/(uint16_t)1,
+                    /*length=*/0u,
+                    /*major_version=*/(uint16_t)2,
+                    /*minor_version=*/(uint16_t)2
+                ));
+        }
+
+        void PumpApplication()
+        {
+            m_application.PumpSystemEventLoopUntilEmpty();
+            m_application.TickSystem();
+            m_application.Tick();
+        }
+
+    protected:
+        static constexpr inline uint8_t s_xinputMajorOpcode = 131;
+        static constexpr inline xcb_window_t s_rootWindow = 1;
+        static constexpr inline xcb_input_device_id_t s_virtualCorePointerId = 2;
+        static constexpr inline xcb_input_device_id_t s_physicalPointerDeviceId = 3;
+        static constexpr inline uint16_t s_screenWidthInPixels = 3840;
+        static constexpr inline uint16_t s_screenHeightInPixels = 2160;
+        static constexpr inline xcb_setup_t s_xcbSetup{
+            /*.status=*/1,
+            /*.pad0=*/0,
+            /*.protocol_major_version=*/11,
+            /*.protocol_minor_version=*/0,
+        };
+        static inline xcb_screen_t s_xcbScreen{
+            /*.root=*/s_rootWindow,
+            /*.default_colormap=*/32,
+            /*.white_pixel=*/16777215,
+            /*.black_pixel=*/0,
+            /*.current_input_masks=*/0,
+            /*.width_in_pixels=*/s_screenWidthInPixels,
+            /*.height_in_pixels=*/s_screenHeightInPixels,
+            /*.width_in_millimeters=*/602,
+            /*.height_in_millimeters=*/341,
+        };
+        static constexpr inline xcb_query_extension_reply_t s_xfixesExtensionReply{
+            /*.response_type=*/XCB_QUERY_EXTENSION,
+            /*.pad0=*/0,
+            /*.sequence=*/1,
+            /*.length=*/0,
+            /*.present=*/1,
+        };
+        static constexpr inline xcb_query_extension_reply_t s_xinputExtensionReply{
+            /*.response_type=*/XCB_QUERY_EXTENSION,
+            /*.pad0=*/0,
+            /*.sequence=*/1,
+            /*.length=*/0,
+            /*.present=*/1,
+            /*.major_opcode=*/s_xinputMajorOpcode,
+        };
+        XcbTestApplication m_application{
+            /*enabledGamepadsCount=*/0,
+            /*keyboardEnabled=*/false,
+            /*motionEnabled=*/false,
+            /*mouseEnabled=*/true,
+            /*touchEnabled=*/false,
+            /*virtualKeyboardEnabled=*/false
+        };
+    };
+
+    struct MouseButtonTestData
+    {
+        xcb_button_index_t m_button;
+    };
+
+    class XcbInputDeviceMouseButtonTests
+        : public XcbInputDeviceMouseTests
+        , public testing::WithParamInterface<MouseButtonTestData>
+    {
+    public:
+        static InputChannelId GetInputChannelIdForButton(const xcb_button_index_t button)
+        {
+            switch (button)
+            {
+                case XCB_BUTTON_INDEX_1:
+                    return InputDeviceMouse::Button::Left;
+                case XCB_BUTTON_INDEX_2:
+                    return InputDeviceMouse::Button::Right;
+                case XCB_BUTTON_INDEX_3:
+                    return InputDeviceMouse::Button::Middle;
+            }
+            return InputChannelId{};
+        }
+
+        AZStd::array<InputChannelId, 4> GetIdleChannelIdsForButton(const xcb_button_index_t button)
+        {
+            switch (button)
+            {
+            case XCB_BUTTON_INDEX_1:
+                return { InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
+            case XCB_BUTTON_INDEX_2:
+                return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
+            case XCB_BUTTON_INDEX_3:
+                return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Other1, InputDeviceMouse::Button::Other2 };
+            case XCB_BUTTON_INDEX_4:
+                return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other2 };
+            case XCB_BUTTON_INDEX_5:
+                return { InputDeviceMouse::Button::Left, InputDeviceMouse::Button::Right, InputDeviceMouse::Button::Middle, InputDeviceMouse::Button::Other1 };
+            }
+            return AZStd::array<InputChannelId, 4>();
+        }
+    };
+
+    TEST_P(XcbInputDeviceMouseButtonTests, ButtonInputChannelsUpdateStateFromXcbEvents)
+    {
+        using testing::Each;
+        using testing::Eq;
+        using testing::NotNull;
+        using testing::Property;
+        using testing::Return;
+
+        // Set the expectations for the events that will be generated
+        // nullptr entries represent when the event queue is empty, and will cause
+        // PumpSystemEventLoopUntilEmpty to return
+        //
+        // Event pointers are freed by the calling code, so these actions
+        // malloc new copies
+        //
+        // The xcb mouse does not react to the `XCB_BUTTON_PRESS` /
+        // `XCB_BUTTON_RELEASE` events, but it will still receive those events
+        // from the X server.
+        EXPECT_CALL(m_interface, xcb_poll_for_event(&m_connection))
+            .WillOnce(ReturnMalloc<xcb_generic_event_t>(MakeEvent(xcb_input_raw_button_press_event_t{
+                /*response_type=*/XCB_GE_GENERIC,
+                /*extension=*/s_xinputMajorOpcode,
+                /*sequence=*/4,
+                /*length=*/2,
+                /*event_type=*/XCB_INPUT_RAW_BUTTON_PRESS,
+                /*deviceid=*/s_virtualCorePointerId,
+                /*time=*/3984920,
+                /*detail=*/GetParam().m_button,
+                /*sourceid=*/s_physicalPointerDeviceId,
+                /*valuators_len=*/2,
+                /*flags=*/0,
+                /*pad0[4]=*/{},
+                /*full_sequence=*/4
+            })))
+            .WillOnce(Return(nullptr))
+            .WillOnce(ReturnMalloc<xcb_generic_event_t>(MakeEvent(xcb_button_press_event_t{
+                /*response_type=*/XCB_BUTTON_PRESS,
+                /*detail=*/static_cast<xcb_button_t>(GetParam().m_button),
+                /*sequence=*/4,
+                /*time=*/3984920,
+                /*root=*/s_rootWindow,
+                /*event=*/119537664,
+                /*child=*/0,
+                /*root_x=*/55,
+                /*root_y=*/1099,
+                /*event_x=*/55,
+                /*event_y=*/55,
+                /*state=*/0,
+                /*same_screen=*/1
+            })))
+            .WillOnce(Return(nullptr))
+            .WillOnce(ReturnMalloc<xcb_generic_event_t>(MakeEvent(xcb_input_raw_button_release_event_t{
+                /*response_type=*/XCB_GE_GENERIC,
+                /*extension=*/s_xinputMajorOpcode,
+                /*sequence=*/4,
+                /*length=*/2,
+                /*event_type=*/XCB_INPUT_RAW_BUTTON_RELEASE,
+                /*deviceid=*/s_virtualCorePointerId,
+                /*time=*/3984964,
+                /*detail=*/GetParam().m_button,
+                /*sourceid=*/s_physicalPointerDeviceId,
+                /*valuators_len=*/2,
+                /*flags=*/0,
+                /*pad0[4]=*/{},
+                /*full_sequence=*/4
+            })))
+            .WillOnce(Return(nullptr))
+            .WillOnce(ReturnMalloc<xcb_generic_event_t>(MakeEvent(xcb_button_release_event_t{
+                /*response_type=*/XCB_BUTTON_RELEASE,
+                /*detail=*/static_cast<xcb_button_t>(GetParam().m_button),
+                /*sequence=*/4,
+                /*time=*/3984964,
+                /*root=*/s_rootWindow,
+                /*event=*/119537664,
+                /*child=*/0,
+                /*root_x=*/55,
+                /*root_y=*/1099,
+                /*event_x=*/55,
+                /*event_y=*/55,
+                /*state=*/XCB_KEY_BUT_MASK_BUTTON_1,
+                /*same_screen=*/1
+            })))
+            .WillOnce(Return(nullptr))
+            ;
+
+        m_application.Start();
+        InputSystemCursorRequestBus::Event(
+            InputDeviceMouse::Id,
+            &InputSystemCursorRequests::SetSystemCursorState,
+            SystemCursorState::ConstrainedAndHidden);
+
+        const InputChannel* activeButtonChannel = InputChannelRequests::FindInputChannel(GetInputChannelIdForButton(GetParam().m_button));
+        const auto inactiveButtonChannels = [this]()
+        {
+            const auto inactiveButtonChannelIds = GetIdleChannelIdsForButton(GetParam().m_button);
+            AZStd::array<const InputChannel*, 4> channels{};
+            AZStd::transform(begin(inactiveButtonChannelIds), end(inactiveButtonChannelIds), begin(channels), [](const InputChannelId& id)
+            {
+                return InputChannelRequests::FindInputChannel(id);
+            });
+            return channels;
+        }();
+
+        ASSERT_TRUE(activeButtonChannel);
+        ASSERT_THAT(inactiveButtonChannels, Each(NotNull()));
+
+        EXPECT_THAT(activeButtonChannel->GetState(), Eq(InputChannel::State::Idle));
+        EXPECT_THAT(inactiveButtonChannels, Each(Property(&InputChannel::GetState, Eq(InputChannel::State::Idle))));
+
+        PumpApplication();
+
+        EXPECT_THAT(activeButtonChannel->GetState(), Eq(InputChannel::State::Began));
+        EXPECT_THAT(inactiveButtonChannels, Each(Property(&InputChannel::GetState, Eq(InputChannel::State::Idle))));
+
+        PumpApplication();
+
+        EXPECT_THAT(activeButtonChannel->GetState(), Eq(InputChannel::State::Updated));
+        EXPECT_THAT(inactiveButtonChannels, Each(Property(&InputChannel::GetState, Eq(InputChannel::State::Idle))));
+
+        PumpApplication();
+
+        EXPECT_THAT(activeButtonChannel->GetState(), Eq(InputChannel::State::Ended));
+        EXPECT_THAT(inactiveButtonChannels, Each(Property(&InputChannel::GetState, Eq(InputChannel::State::Idle))));
+
+        PumpApplication();
+
+        EXPECT_THAT(activeButtonChannel->GetState(), Eq(InputChannel::State::Idle));
+        EXPECT_THAT(inactiveButtonChannels, Each(Property(&InputChannel::GetState, Eq(InputChannel::State::Idle))));
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        AllButtons,
+        XcbInputDeviceMouseButtonTests,
+        testing::Values(
+            MouseButtonTestData{ XCB_BUTTON_INDEX_1 },
+            MouseButtonTestData{ XCB_BUTTON_INDEX_2 },
+            MouseButtonTestData{ XCB_BUTTON_INDEX_3 }
+            // XCB_BUTTON_INDEX_4 and XCB_BUTTON_INDEX_5 map to positive and
+            // negative scroll wheel events, which are handled as motion events
+        )
+    );
+
+    TEST_F(XcbInputDeviceMouseTests, MovementInputChannelsUpdateStateFromXcbEvents)
+    {
+        using testing::Each;
+        using testing::Eq;
+        using testing::FloatEq;
+        using testing::NotNull;
+        using testing::Property;
+        using testing::Return;
+
+        // Set the expectations for the events that will be generated
+        // nullptr entries represent when the event queue is empty, and will cause
+        // PumpSystemEventLoopUntilEmpty to return
+        //
+        // Event pointers are freed by the calling code, so these actions
+        // malloc new copies
+        //
+        // The xcb mouse does not react to the `XCB_MOTION_NOTIFY` event, but
+        // it will still receive it from the X server.
+        EXPECT_CALL(m_interface, xcb_poll_for_event(&m_connection))
+            .WillOnce(ReturnMalloc<xcb_generic_event_t>(MakeEvent(xcb_input_raw_motion_event_t{
+                /*response_type=*/XCB_GE_GENERIC,
+                /*extension=*/s_xinputMajorOpcode,
+                /*sequence=*/5,
+                /*length=*/10,
+                /*event_type=*/XCB_INPUT_RAW_MOTION,
+                /*deviceid=*/s_virtualCorePointerId,
+                /*time=*/0, // use the time value to identify each event
+                /*detail=*/XCB_MOTION_NORMAL,
+                /*sourceid=*/s_physicalPointerDeviceId,
+                /*valuators_len=*/2, // number of axes that have values for this event
+                /*flags=*/0,
+                /*pad0[4]=*/{},
+                /*full_sequence=*/5,
+            })))
+            .WillOnce(Return(nullptr))
+            .WillOnce(ReturnMalloc<xcb_generic_event_t>(MakeEvent(xcb_motion_notify_event_t{
+                /*response_type=*/XCB_MOTION_NOTIFY,
+                /*detail=*/XCB_MOTION_NORMAL,
+                /*sequence=*/5,
+                /*time=*/1, // use the time value to identify each event
+                /*root=*/s_rootWindow,
+                /*event=*/127926272,
+                /*child=*/0,
+                /*root_x=*/95,
+                /*root_y=*/1079,
+                /*event_x=*/95,
+                /*event_y=*/20,
+                /*state=*/0,
+                /*same_screen=*/1,
+            })))
+            .WillOnce(Return(nullptr))
+            ;
+
+        AZStd::array axisValues
+        {
+            xcb_input_fp3232_t{ /*.integral=*/ 1, /*.fraction=*/0 }, // x motion
+            xcb_input_fp3232_t{ /*.integral=*/ 2, /*.fraction=*/0 }  // y motion
+        };
+
+        EXPECT_CALL(m_interface, xcb_input_raw_button_press_axisvalues_length(testing::Field(&xcb_input_raw_button_press_event_t::time, 0)))
+            .WillRepeatedly(testing::Return(2)); // x and y axis
+        EXPECT_CALL(m_interface, xcb_input_raw_button_press_axisvalues_raw(testing::Field(&xcb_input_raw_button_press_event_t::time, 0)))
+            .WillRepeatedly(testing::Return(axisValues.data())); // x and y axis
+
+        m_application.Start();
+        InputSystemCursorRequestBus::Event(
+            InputDeviceMouse::Id,
+            &InputSystemCursorRequests::SetSystemCursorState,
+            SystemCursorState::ConstrainedAndHidden);
+
+        const InputChannel* xMotionChannel = InputChannelRequests::FindInputChannel(InputDeviceMouse::Movement::X);
+        const InputChannel* yMotionChannel = InputChannelRequests::FindInputChannel(InputDeviceMouse::Movement::Y);
+        ASSERT_TRUE(xMotionChannel);
+        ASSERT_TRUE(yMotionChannel);
+
+        EXPECT_THAT(xMotionChannel->GetState(), Eq(InputChannel::State::Idle));
+        EXPECT_THAT(yMotionChannel->GetState(), Eq(InputChannel::State::Idle));
+        EXPECT_THAT(xMotionChannel->GetValue(), FloatEq(0.0f));
+        EXPECT_THAT(yMotionChannel->GetValue(), FloatEq(0.0f));
+
+        PumpApplication();
+
+        EXPECT_THAT(xMotionChannel->GetState(), Eq(InputChannel::State::Began));
+        EXPECT_THAT(yMotionChannel->GetState(), Eq(InputChannel::State::Began));
+        EXPECT_THAT(xMotionChannel->GetValue(), FloatEq(1.0f));
+        EXPECT_THAT(yMotionChannel->GetValue(), FloatEq(2.0f));
+
+        PumpApplication();
+
+        EXPECT_THAT(xMotionChannel->GetState(), Eq(InputChannel::State::Ended));
+        EXPECT_THAT(yMotionChannel->GetState(), Eq(InputChannel::State::Ended));
+        EXPECT_THAT(xMotionChannel->GetValue(), FloatEq(0.0f));
+        EXPECT_THAT(yMotionChannel->GetValue(), FloatEq(0.0f));
+    }
+} // namespace AzFramework

--- a/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/azframework_xcb_tests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/Platform/Common/Xcb/azframework_xcb_tests_files.cmake
@@ -17,5 +17,6 @@ set(FILES
     XcbBaseTestFixture.cpp
     XcbBaseTestFixture.h
     XcbInputDeviceKeyboardTests.cpp
+    XcbInputDeviceMouseTests.cpp
     XcbTestApplication.h
 )


### PR DESCRIPTION
This does a few things:
* [Linux] Return the active window when there's no cursor constraint window
* [Linux] Add unit tests for xcb mouse input
* [Linux] Unify Editor and Game raw mouse event handling

Signed-off-by: Chris Burel <burelc@amazon.com>