### PR TITLE
LYN-7054 + LYN-7704 | Exit Focus Mode when starting Game Mode, correct painting of Prefab capsules in Outliner.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntityInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntityInterface.h
@@ -58,6 +58,10 @@ namespace AzToolsFramework
         //! @return The highest closed entity container id if any, or entityId otherwise.
         virtual AZ::EntityId FindHighestSelectableEntity(AZ::EntityId entityId) const = 0;
 
+        //! Triggers the OnContainerEntityStatusChanged notifications for all registered containers,
+        //! allowing listeners to update correctly.
+        virtual void RefreshAllContainerEntities(AzFramework::EntityContextId entityContextId) const = 0;
+
         //! Clears all open state information for Container Entities for the EntityContextId provided.
         //! Used when context is switched, for example in the case of a new root prefab being loaded
         //! in place of an old one.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.cpp
@@ -142,6 +142,15 @@ namespace AzToolsFramework
         Clear(editorEntityContextId);
     }
 
+    void ContainerEntitySystemComponent::RefreshAllContainerEntities([[maybe_unused]] AzFramework::EntityContextId entityContextId) const
+    {
+        for (AZ::EntityId containerEntityId : m_containers)
+        {
+            ContainerEntityNotificationBus::Broadcast(
+                &ContainerEntityNotificationBus::Events::OnContainerEntityStatusChanged, containerEntityId, m_openContainers.contains(containerEntityId));
+        }
+    }
+
     ContainerEntityOperationResult ContainerEntitySystemComponent::Clear(AzFramework::EntityContextId entityContextId)
     {
         // We don't yet support multiple entity contexts, so only clear the default.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ContainerEntity/ContainerEntitySystemComponent.h
@@ -47,6 +47,7 @@ namespace AzToolsFramework
         ContainerEntityOperationResult SetContainerOpen(AZ::EntityId entityId, bool open) override;
         bool IsContainerOpen(AZ::EntityId entityId) const override;
         AZ::EntityId FindHighestSelectableEntity(AZ::EntityId entityId) const override;
+        void RefreshAllContainerEntities(AzFramework::EntityContextId entityContextId) const override;
         ContainerEntityOperationResult Clear(AzFramework::EntityContextId entityContextId) override;
         bool IsUnderClosedContainerEntity(AZ::EntityId entityId) const override;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -2180,20 +2180,9 @@ namespace AzToolsFramework
 
     void EntityOutlinerItemDelegate::PaintAncestorForegrounds(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
     {
-        // Go through ancestors and add them to the stack
-        AZStd::stack<QModelIndex> handlerStack;
-
+        // Ancestor foregrounds are painted on top of the childrens'.
         for (QModelIndex ancestorIndex = index.parent(); ancestorIndex.isValid(); ancestorIndex = ancestorIndex.parent())
         {
-            handlerStack.push(ancestorIndex);
-        }
-
-        // Apply the ancestor overrides from top to bottom
-        while (!handlerStack.empty())
-        {
-            QModelIndex ancestorIndex = handlerStack.top();
-            handlerStack.pop();
-
             AZ::EntityId ancestorEntityId(ancestorIndex.data(EntityOutlinerListModel::EntityIdRole).value<AZ::u64>());
             auto ancestorUiHandler = m_editorEntityFrameworkInterface->GetHandler(ancestorEntityId);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserSourceDropBus.h>
 #include <AzToolsFramework/Editor/EditorContextMenuBus.h>
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/UI/Prefab/LevelRootUiHandler.h>
@@ -56,6 +57,7 @@ namespace AzToolsFramework
             , public PrefabInstanceContainerNotificationBus::Handler
             , public PrefabIntegrationInterface
             , public QObject
+            , private EditorEntityContextNotificationBus::Handler
         {
         public:
             AZ_CLASS_ALLOCATOR(PrefabIntegrationManager, AZ::SystemAllocator, 0);
@@ -75,6 +77,10 @@ namespace AzToolsFramework
 
             // EntityOutlinerSourceDropHandlingBus overrides ...
             void HandleSourceFileType(AZStd::string_view sourceFilePath, AZ::EntityId parentId, AZ::Vector3 position) const override;
+
+            // EditorEntityContextNotificationBus overrides ...
+            void OnStartPlayInEditorBegin() override;
+            void OnStopPlayInEditor() override;
 
             // PrefabInstanceContainerNotificationBus overrides ...
             void OnPrefabComponentActivate(AZ::EntityId entityId) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -185,7 +185,7 @@ namespace AzToolsFramework
         painter->restore();
     }
 
-    void PrefabUiHandler::PaintDescendantBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
+    void PrefabUiHandler::PaintDescendantForeground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
         const QModelIndex& descendantIndex) const
     {
         if (!painter)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -36,9 +36,12 @@ namespace AzToolsFramework
         QString GenerateItemTooltip(AZ::EntityId entityId) const override;
         QIcon GenerateItemIcon(AZ::EntityId entityId) const override;
         void PaintItemBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
-        void PaintDescendantBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
-            const QModelIndex& descendantIndex) const override;
         void PaintItemForeground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+        void PaintDescendantForeground(
+            QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index,
+            const QModelIndex& descendantIndex) const override;
         bool OnOutlinerItemClick(const QPoint& position, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
         void OnOutlinerItemCollapse(const QModelIndex& index) const override;
         bool OnEntityDoubleClick(AZ::EntityId entityId) const override;


### PR DESCRIPTION
2-in-1 fix as they were relatively small :)

- If the Editor is in Focus Mode and the user enters Game Mode (via Ctrl+G or the play button on the top right), the Editor will automatically leave Focus Mode. This needed an extra function that refreshes the state of all Container Entities to ensure everything is synced.

![gameModeCancelsFocusMode](https://user-images.githubusercontent.com/82231674/140219358-cc15b155-2373-4816-bef8-802f9c565f43.gif)

- Minor changes to the way Prefab capsules are drawn in the Outliner. This makes the lines on the children be drawn in reverse order, making it look like the children are "contained" in the parent.
![PrefabCapsuleBorderInversion](https://user-images.githubusercontent.com/82231674/140220110-69ec43be-2be4-4d1f-b0f6-7496e02a3541.png)
![PrefabCapsuleBorderInversion2](https://user-images.githubusercontent.com/82231674/140220149-e0e6aa0f-9704-41b8-8992-51aa78c5d66f.png)

