### PR TITLE
Hair - crucial optimization and bug fix

### DIFF
--- a/Gems/AtomTressFX/Assets/Passes/HairParentShortCutPass.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairParentShortCutPass.pass
@@ -264,7 +264,7 @@
                                 "Attachment": "HairColorRenderTarget"
                             }
                         },
-                        { 
+                        {
                             // The final render target - this is MSAA mode RT - would it be cheaper to
                             // use non-MSAA and then copy?
                             "LocalSlot": "RenderTargetInputOutput",
@@ -278,6 +278,13 @@
                             "AttachmentRef": {
                                 "Pass": "Parent",
                                 "Attachment": "DepthLinearInput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "AccumulatedInverseAlpha",
+                            "AttachmentRef": {
+                                "Pass": "HairShortCutGeometryDepthAlphaPass",
+                                "Attachment": "InverseAlphaRTOutput"
                             }
                         },
                         {

--- a/Gems/AtomTressFX/Assets/Passes/HairShortCutGeometryShading.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairShortCutGeometryShading.pass
@@ -32,6 +32,12 @@
                     "SlotType": "Input",
                     "ScopeAttachmentUsage": "Shader"
                 },
+                { // Used as the thickness accumulation to block TT (back) lobe lighting
+                    "Name": "AccumulatedInverseAlpha",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ShaderInputName": "m_accumInvAlpha"
+                },
                 { // For comparing the depth to early disqualify but not to write
                     "Name": "Depth",
                     "SlotType": "Input",

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
@@ -51,9 +51,6 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     RWTexture2D<uint>               m_fragmentListHead;
     RWStructuredBuffer<PPLL_STRUCT> m_linkedListNodes;
     RWBuffer<uint>                  m_linkedListCounter;
-
-    // Linear depth is used for getting the screen to world transform
-    Texture2D<float>                m_linearDepth;
 }
 
 //------------------------------------------------------------------------------

--- a/Gems/AtomTressFX/Assets/Shaders/HairShortCutGeometryShading.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairShortCutGeometryShading.azsl
@@ -52,6 +52,9 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     //! Originally in TressFXRendering.hlsl this is space 0 
     HairObjectShadeParams   m_hairParams[AMD_TRESSFX_MAX_HAIR_GROUP_RENDER];
 
+    // Will be used as thickness indication to block TT (back) lobe
+    Texture2D<float>        m_accumInvAlpha;
+
     // Linear depth is used for getting the screen to world transform
     Texture2D<float>        m_linearDepth;
 
@@ -164,9 +167,11 @@ float4 HairShortCutGeometryColorPS(PS_INPUT_HAIR input) : SV_Target
 
     float2 pixelCoord = input.Position.xy;
     float depth = input.Position.z;
-    // [To Do] - the thickness will need to be corrected somehow since this technique doesn't 
-    // keeps track of the accumulated alpha / thickness
-    float thickness = alpha;  
+
+    // The following is a quick correction to remove the TT lobe (back lobe) contribution in case 
+    // the hair is thick.  We do that by accumulating alpha from the hair for the blend operation
+    // and this can be used here as an indication of thickness.
+    float thickness = saturate(1.0 - PassSrg::m_accumInvAlpha[int2(pixelCoord)]);
     float3 shadedFragment = TressFXShading(pixelCoord, depth, input.Tangent.xyz, strandColor.rgb, thickness, RenderParamsIndex);
 
     // Color channel: Pre-multiply with alpha to create non-normalized weighted sum.


### PR DESCRIPTION
- Removing unused depth buffer from Srg to fix metal shader build
- Back light correction.  This fix will block TT lobe (back lobe) from allowing light transfer
- By doing this we remove the requirement to add self shadowing in most cases, hence removing heavy render pass.

Exception:
- Thin hair will still pass light and therefor there is still a need to read depth buffer and compare as a second step to avoid adding heavy shadowing pass / comparison.

Before change - TT lighting not blocked:
![image](https://user-images.githubusercontent.com/82479970/140240569-7ee62505-83b3-48f5-be17-7a21db8f05c1.png)

After change - preventing TT back light transfer due to thickness:
![image](https://user-images.githubusercontent.com/82479970/140240591-ece7b001-69cf-478e-a191-0739b7102d9e.png)

Images courtesy of Apocalypse Studios and Denis Dyack and are WIP on the hair technology enhancing the TressFX by AMD

Signed-off-by: Adi Bar-Lev <82479970+Adi-Amazon@users.noreply.github.com>