### PR TITLE
Test parallel Add P0 Bloom

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_Optimized.py
@@ -14,6 +14,10 @@ from ly_test_tools.o3de.editor_test import EditorSharedTest, EditorTestSuite
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
 
+    @pytest.mark.test_case_id("C36525657")
+    class AtomEditorComponents_BloomAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_BloomAdded as test_module
+
     @pytest.mark.test_case_id("C32078118")
     class AtomEditorComponents_DecalAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_DecalAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -42,12 +42,14 @@ class AtomComponentProperties:
         Bloom component properties. Requires PostFX Layer component.
           - 'requires' a list of component names as strings required by this component.
             Use editor_entity_utils EditorEntity.add_components(list) to add this list of requirements.\n
+          - 'Enable Bloom' Toggle active state of the component True/False
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """
         properties = {
             'name': 'Bloom',
             'requires': [AtomComponentProperties.postfx_layer()],
+            'Enable Bloom': 'Controller|Configuration|Enable Bloom',
         }
         return properties[property]
 
@@ -212,6 +214,7 @@ class AtomComponentProperties:
         HDR Color Grading component properties. Requires PostFX Layer component.
           - 'requires' a list of component names as strings required by this component.
             Use editor_entity_utils EditorEntity.add_components(list) to add this list of requirements.\n
+          - 'Enable HDR color grading' Toggle active state of the component True/False
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
@@ -1,0 +1,188 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    creation_undo = (
+        "UNDO Entity creation success",
+        "UNDO Entity creation failed")
+    creation_redo = (
+        "REDO Entity creation success",
+        "REDO Entity creation failed")
+    bloom_creation = (
+        "Bloom Entity successfully created",
+        "Bloom Entity failed to be created")
+    bloom_component = (
+        "Entity has a Bloom component",
+        "Entity failed to find Bloom component")
+    bloom_disabled = (
+        "Bloom component disabled",
+        "Bloom component was not disabled")
+    postfx_layer_component = (
+        "Entity has a PostFX Layer component",
+        "Entity did not have an PostFX Layer component")
+    bloom_enabled = (
+        "Bloom component enabled",
+        "Bloom component was not enabled")
+    enable_bloom_parameter_enabled = (
+        "Enable Bloom parameter enabled",
+        "Enable Bloom parameter was not enabled")
+    enter_game_mode = (
+        "Entered game mode",
+        "Failed to enter game mode")
+    exit_game_mode = (
+        "Exited game mode",
+        "Couldn't exit game mode")
+    is_visible = (
+        "Entity is visible",
+        "Entity was not visible")
+    is_hidden = (
+        "Entity is hidden",
+        "Entity was not hidden")
+    entity_deleted = (
+        "Entity deleted",
+        "Entity was not deleted")
+    deletion_undo = (
+        "UNDO deletion success",
+        "UNDO deletion failed")
+    deletion_redo = (
+        "REDO deletion success",
+        "REDO deletion failed")
+
+
+def AtomEditorComponents_Bloom_AddedToEntity():
+    """
+    Summary:
+    Tests the Bloom component can be added to an entity and has the expected functionality.
+
+    Test setup:
+    - Wait for Editor idle loop.
+    - Open the "Base" level.
+
+    Expected Behavior:
+    The component can be added, used in game mode, hidden/shown, deleted, and has accurate required components.
+    Creation and deletion undo/redo should also work.
+
+    Test Steps:
+    1) Create an Bloom entity with no components.
+    2) Add Bloom component to Bloom entity.
+    3) UNDO the entity creation and component addition.
+    4) REDO the entity creation and component addition.
+    5) Verify Bloom component not enabled.
+    6) Add PostFX Layer component since it is required by the Bloom component.
+    7) Verify Bloom component is enabled.
+    8) Enable the "Enable Bloom" parameter.
+    9) Enter/Exit game mode.
+    10) Test IsHidden.
+    11) Test IsVisible.
+    12) Delete Bloom entity.
+    13) UNDO deletion.
+    14) REDO deletion.
+    15) Look for errors.
+
+    :return: None
+    """
+
+    import azlmbr.legacy.general as general
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.utils import Report, Tracer, TestHelper
+    from Atom.atom_utils.atom_constants import AtomComponentProperties
+
+    with Tracer() as error_tracer:
+        # Test setup begins.
+        # Setup: Wait for Editor idle loop before executing Python hydra scripts then open "Base" level.
+        TestHelper.init_idle()
+        TestHelper.open_level("", "Base")
+
+        # Test steps begin.
+        # 1. Create an Bloom entity with no components.
+        bloom_entity = EditorEntity.create_editor_entity(AtomComponentProperties.bloom())
+        Report.critical_result(Tests.bloom_creation, bloom_entity.exists())
+
+        # 2. Add Bloom component to Bloom entity.
+        bloom_component = bloom_entity.add_component(AtomComponentProperties.bloom())
+        Report.critical_result(Tests.bloom_component, bloom_entity.has_component(AtomComponentProperties.bloom()))
+
+        # 3. UNDO the entity creation and component addition.
+        # -> UNDO component addition.
+        general.undo()
+        # -> UNDO naming entity.
+        general.undo()
+        # -> UNDO selecting entity.
+        general.undo()
+        # -> UNDO entity creation.
+        general.undo()
+        general.idle_wait_frames(1)
+        Report.result(Tests.creation_undo, not bloom_entity.exists())
+
+        # 4. REDO the entity creation and component addition.
+        # -> REDO entity creation.
+        general.redo()
+        # -> REDO selecting entity.
+        general.redo()
+        # -> REDO naming entity.
+        general.redo()
+        # -> REDO component addition.
+        general.redo()
+        general.idle_wait_frames(1)
+        Report.result(Tests.creation_redo, bloom_entity.exists())
+
+        # 5. Verify Bloom component not enabled.
+        Report.result(Tests.bloom_disabled, not bloom_component.is_enabled())
+
+        # 6. Add PostFX Layer component since it is required by the Bloom component.
+        bloom_entity.add_component(AtomComponentProperties.postfx_layer())
+        Report.result(
+            Tests.postfx_layer_component,
+            bloom_entity.has_component(AtomComponentProperties.postfx_layer()))
+
+        # 7. Verify Bloom component is enabled.
+        Report.result(Tests.bloom_enabled, bloom_component.is_enabled())
+
+        # 8. Enable the "Enable Bloom" parameter.
+        bloom_component.set_component_property_value(AtomComponentProperties.bloom('Enable Bloom'), True)
+        Report.result(
+            Tests.enable_bloom_parameter_enabled,
+            bloom_component.get_component_property_value(AtomComponentProperties.bloom('Enable Bloom')) is True)
+
+        # 9. Enter/Exit game mode.
+        TestHelper.enter_game_mode(Tests.enter_game_mode)
+        general.idle_wait_frames(1)
+        TestHelper.exit_game_mode(Tests.exit_game_mode)
+
+        # 10. Test IsHidden.
+        bloom_entity.set_visibility_state(False)
+        Report.result(Tests.is_hidden, bloom_entity.is_hidden() is True)
+
+        # 11. Test IsVisible.
+        bloom_entity.set_visibility_state(True)
+        general.idle_wait_frames(1)
+        Report.result(Tests.is_visible, bloom_entity.is_visible() is True)
+
+        # 12. Delete Bloom entity.
+        bloom_entity.delete()
+        Report.result(Tests.entity_deleted, not bloom_entity.exists())
+
+        # 13. UNDO deletion.
+        general.undo()
+        Report.result(Tests.deletion_undo, bloom_entity.exists())
+
+        # 14. REDO deletion.
+        general.redo()
+        Report.result(Tests.deletion_redo, not bloom_entity.exists())
+
+        # 15. Look for errors and asserts.
+        TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
+        for error_info in error_tracer.errors:
+            Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")
+        for assert_info in error_tracer.asserts:
+            Report.info(f"Assert: {assert_info.filename} {assert_info.function} | {assert_info.message}")
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(AtomEditorComponents_Bloom_AddedToEntity)

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
@@ -5,6 +5,7 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 
+
 class Tests:
     creation_undo = (
         "UNDO Entity creation success",


### PR DESCRIPTION
Added P0 test for Bloom component + Updated Docstring for missing Enable HDR Color Grading toggle

pyRunFile ../../Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
Report:
[SUCCESS] Success: Bloom Entity successfully created
[SUCCESS] Success: Entity has a Bloom component
[SUCCESS] Success: UNDO Entity creation success
[SUCCESS] Success: REDO Entity creation success
[SUCCESS] Success: Bloom component disabled
[SUCCESS] Success: Entity has a PostFX Layer component
[SUCCESS] Success: Bloom component enabled
[SUCCESS] Success: Enable Bloom parameter enabled
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS

.\python\python.cmd -m pytest --build-directory build_development\bin\profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py
=== test session starts ===
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: F:\git\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 20 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_Optimized.py XXXXXXXXXXXXXXXXXXXXX [100%]

=== 21 xpassed in 56.25s ===

Signed-off-by: Sean Masterson <semaster@amazon.com>