### PR TITLE
Fix issue with Server Launcher debug console not accepting keystrokes

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -76,6 +76,12 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             Legacy::CrySystem
         )
 
+        if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
+            set(server_runtime_dependencies
+                Legacy::CrySystem
+            )
+        endif()
+
     endif()
 
     ################################################################################

--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -333,11 +333,6 @@ void CXConsole::Init(ISystem* pSystem)
 
     m_nLoadingBackTexID = -1;
 
-    if (gEnv->IsDedicated())
-    {
-        m_bConsoleActive = true;
-    }
-
     REGISTER_COMMAND("ConsoleShow", &ConsoleShow, VF_NULL, "Opens the console");
     REGISTER_COMMAND("ConsoleHide", &ConsoleHide, VF_NULL, "Closes the console");
 


### PR DESCRIPTION
The fix simply removes the setting of a bool in server mode which had made the XConsole code process text before the DebugConsole/ImGui got a chance to.

The problem didn't occur if server launcher had loaded a map, and during load complete it will explicitly Show(false) the XConsole.  That also sets the bool to false.  So normal operation of the DebugConsole should have this XConsole bool set to false.  This will skip XConsole from handling text and pass processing along to the next handlers, so ImGuiPass would get a chance to do it properly.

Also there's a quick fix here for CMake to make sure the ServerLauncher target adds a runtime dependency on CrySystem.  If you had a clean build dir and only built ServerLauncher target, it wouldn't build CrySystem and the application would fail to start properly.

fixes #2516 