### PR TITLE
Moving Flaky Multiplayer Tests into Sandbox

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/CMakeLists.txt
@@ -59,5 +59,8 @@ add_subdirectory(smoke)
 ## AWS ##
 add_subdirectory(AWS)
 
+## Multiplayer ##
+add_subdirectory(Multiplayer)
+
 ## Integration tests for editor testing framework ##
 add_subdirectory(editor_test_testing)

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/CMakeLists.txt
@@ -8,19 +8,6 @@
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
     ly_add_pytest(
-        NAME AutomatedTesting::MultiplayerTests_Main
-        TEST_SUITE main
-        TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Main.py
-        RUNTIME_DEPENDENCIES
-            Legacy::Editor
-            AZ::AssetProcessor
-            AutomatedTesting.Assets
-            AutomatedTesting.ServerLauncher
-        COMPONENT
-            Multiplayer
-    )
-    ly_add_pytest(
         NAME AutomatedTesting::MultiplayerTests_Sandbox
         TEST_SUITE sandbox
         TEST_SERIAL

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/CMakeLists.txt
@@ -20,4 +20,17 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         COMPONENT
             Multiplayer
     )
+    ly_add_pytest(
+        NAME AutomatedTesting::MultiplayerTests_Sandbox
+        TEST_SUITE sandbox
+        TEST_SERIAL
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Sandbox.py
+        RUNTIME_DEPENDENCIES
+            Legacy::Editor
+            AZ::AssetProcessor
+            AutomatedTesting.Assets
+            AutomatedTesting.ServerLauncher
+        COMPONENT
+            Multiplayer
+    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Multiplayer/TestSuite_Sandbox.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../automatedtesti
 
 from base import TestAutomationBase
 
+@pytest.mark.SUITE_sandbox
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(TestAutomationBase):
@@ -26,4 +27,9 @@ class TestAutomation(TestAutomationBase):
             extra_cmdline_args=["--regset=/Amazon/Preferences/EnablePrefabSystem=true"], 
             batch_mode=batch_mode,
             autotest_mode=autotest_mode)
+
+    ## Seems to be flaky, need to investigate
+    def test_Multiplayer_AutoComponent_NetworkInput(self, request, workspace, editor, launcher_platform):
+        from .tests import Multiplayer_AutoComponent_NetworkInput as test_module
+        self._run_prefab_test(request, workspace, editor, test_module)
 


### PR DESCRIPTION
Moving flaky multiplayer tests into sandbox so they will still be ran nightly, but we can still fix and create new tests

Signed-off-by: Gene Walters <genewalt@amazon.com>