### PR TITLE
Set window flags so the processing overlay widget always appears on top.

### DIFF
--- a/Code/Tools/SceneAPI/SceneUI/CommonWidgets/ProcessingOverlayWidget.cpp
+++ b/Code/Tools/SceneAPI/SceneUI/CommonWidgets/ProcessingOverlayWidget.cpp
@@ -63,7 +63,7 @@ namespace AZ
             }
 
             ProcessingOverlayWidget::ProcessingOverlayWidget(UI::OverlayWidget* overlay, Layout layout, Uuid traceTag)
-                : QWidget()
+                : QWidget(nullptr, Qt::Tool | Qt::WindowStaysOnTopHint)
                 , m_traceTag(traceTag)
                 , ui(new Ui::ProcessingOverlayWidget())
                 , m_overlay(overlay)


### PR DESCRIPTION
Set the appropriate window flags on the `ProcessingOverlayWidget` so that it always appears on top of the asset importer window which creates it. Tested making a change in the scene settings and verified the processing dialog always shows on top.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>