### PR TITLE
[LYN-7520] Wildcard Source Dependencies include files in cache/excluded files

### DIFF
--- a/Code/Tools/AssetProcessor/assetprocessor_static_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_static_files.cmake
@@ -29,6 +29,8 @@ set(FILES
     native/AssetManager/SourceFileRelocator.h
     native/AssetManager/ControlRequestHandler.cpp
     native/AssetManager/ControlRequestHandler.h
+    native/AssetManager/ExcludedFolderCache.cpp
+    native/AssetManager/ExcludedFolderCache.h
     native/assetprocessor.h
     native/connection/connection.cpp
     native/connection/connection.h

--- a/Code/Tools/AssetProcessor/assetprocessor_static_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_static_files.cmake
@@ -31,6 +31,7 @@ set(FILES
     native/AssetManager/ControlRequestHandler.h
     native/AssetManager/ExcludedFolderCache.cpp
     native/AssetManager/ExcludedFolderCache.h
+    native/AssetManager/ExcludedFolderCacheInterface.h
     native/assetprocessor.h
     native/connection/connection.cpp
     native/connection/connection.h

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <QDirIterator>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <native/AssetManager/ExcludedFolderCache.h>
+
+namespace AssetProcessor
+{
+    const AZStd::unordered_set<AZStd::string>& ExcludedFolderCache::GetExcludedFolders()
+    {
+        if (!m_builtCache)
+        {
+            for (int i = 0; i < m_platformConfig->GetScanFolderCount(); ++i)
+            {
+                const auto& scanFolderInfo = m_platformConfig->GetScanFolderAt(i);
+                QDir rooted(scanFolderInfo.ScanPath());
+                QString absolutePath = rooted.absolutePath();
+                AZStd::stack<QString> dirs;
+                dirs.push(absolutePath);
+                
+                while (!dirs.empty())
+                {
+                    absolutePath = dirs.top();
+                    dirs.pop();
+
+                    // Scan only folders, do not recurse so we have the chance to ignore a subfolder before going deeper
+                    QDirIterator dirIterator(absolutePath, QDir::Dirs | QDir::NoSymLinks | QDir::NoDotAndDotDot);
+
+                    // Loop all the folders in this directory
+                    while (dirIterator.hasNext())
+                    {
+                        dirIterator.next();
+                        QString pathMatch = rooted.absoluteFilePath(dirIterator.filePath());
+
+                        if (m_platformConfig->IsFileExcluded(pathMatch))
+                        {
+                            // Add the folder to the list and do not proceed any deeper
+                            m_excludedFolders.emplace(pathMatch.toUtf8().constData());
+                        }
+                        else if (scanFolderInfo.RecurseSubFolders())
+                        {
+                            // Folder is not excluded and recurse is enabled, add to the list of folders to check
+                            dirs.push(pathMatch);
+                        }
+                    }
+                }
+            }
+
+            // Add the cache to the list as well
+            AZStd::string projectCacheRootValue;
+            AZ::SettingsRegistry::Get()->Get(projectCacheRootValue, AZ::SettingsRegistryMergeUtils::FilePathKey_CacheProjectRootFolder);
+            projectCacheRootValue = AssetUtilities::NormalizeFilePath(projectCacheRootValue.c_str()).toUtf8().constData();
+            m_excludedFolders.emplace(projectCacheRootValue);
+
+            m_builtCache = true;
+        }
+
+        return m_excludedFolders;
+    }
+}

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
@@ -71,6 +71,7 @@ namespace AssetProcessor
             projectCacheRootValue = AssetUtilities::NormalizeFilePath(projectCacheRootValue.c_str()).toUtf8().constData();
             m_excludedFolders.emplace(projectCacheRootValue);
 
+            // Register to be notified about deletes so we can remove old ignored folders
             auto fileStateCache = AZ::Interface<IFileStateRequests>::Get();
 
             if (fileStateCache)
@@ -86,6 +87,10 @@ namespace AssetProcessor
                 });
 
                 fileStateCache->RegisterForDeleteEvent(m_handler);
+            }
+            else
+            {
+                AZ_Error("ExcludedFolderCache", false, "Failed to find IFileStateRequests interface");
             }
 
             m_builtCache = true;
@@ -123,7 +128,7 @@ namespace AssetProcessor
         
         if (!m_platformConfig->ConvertToRelativePath(path, relativePath, scanFolderPath))
         {
-            AZ_Error("ExcludeFolderCache", false, "Failed to get relative path for newly added file %s", path.toUtf8().constData());
+            AZ_Error("ExcludedFolderCache", false, "Failed to get relative path for newly added file %s", path.toUtf8().constData());
             return;
         }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.cpp
@@ -9,6 +9,7 @@
 #include <QDirIterator>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <native/AssetManager/ExcludedFolderCache.h>
+#include <utilities/assetUtils.h>
 
 namespace AssetProcessor
 {

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.h
@@ -8,19 +8,32 @@
 
 #pragma once
 
+#include <AssetManager/ExcludedFolderCacheInterface.h>
+#include <AssetManager/FileStateCache.h>
+
 namespace AssetProcessor
 {
-    struct ExcludedFolderCache
+    class PlatformConfiguration;
+    
+    struct ExcludedFolderCache : ExcludedFolderCacheInterface
     {
-        ExcludedFolderCache(const PlatformConfiguration* platformConfig) : m_platformConfig(platformConfig) {}
+        ExcludedFolderCache(const PlatformConfiguration* platformConfig);
+        ~ExcludedFolderCache() override;
 
         // Gets a set of absolute paths to folder which have been excluded according to the platform configuration rules
         // Note - not thread safe
-        const AZStd::unordered_set<AZStd::string>& GetExcludedFolders();
+        const AZStd::unordered_set<AZStd::string>& GetExcludedFolders() override;
+
+        void FileAdded(QString path) override;
 
     private:
         bool m_builtCache = false;
         const PlatformConfiguration* m_platformConfig{};
         AZStd::unordered_set<AZStd::string> m_excludedFolders;
+
+        AZStd::recursive_mutex m_pendingNewFolderMutex;
+        AZStd::unordered_set<AZStd::string> m_pendingNewFolders; // Newly ignored folders waiting to be added to m_excludedFolders
+        AZStd::unordered_set<AZStd::string> m_pendingDeletes;
+        AZ::Event<FileStateInfo>::Handler m_handler;
     };
 }

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AssetProcessor
+{
+    struct ExcludedFolderCache
+    {
+        ExcludedFolderCache(const PlatformConfiguration* platformConfig) : m_platformConfig(platformConfig) {}
+
+        // Gets a set of absolute paths to folder which have been excluded according to the platform configuration rules
+        // Note - not thread safe
+        const AZStd::unordered_set<AZStd::string>& GetExcludedFolders();
+
+    private:
+        bool m_builtCache = false;
+        const PlatformConfiguration* m_platformConfig{};
+        AZStd::unordered_set<AZStd::string> m_excludedFolders;
+    };
+}

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCache.h
@@ -14,10 +14,10 @@
 namespace AssetProcessor
 {
     class PlatformConfiguration;
-    
+
     struct ExcludedFolderCache : ExcludedFolderCacheInterface
     {
-        ExcludedFolderCache(const PlatformConfiguration* platformConfig);
+        explicit ExcludedFolderCache(const PlatformConfiguration* platformConfig);
         ~ExcludedFolderCache() override;
 
         // Gets a set of absolute paths to folder which have been excluded according to the platform configuration rules

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCacheInterface.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCacheInterface.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <AzCore/std/containers/unordered_set.h>
+#include <QString>
+
 namespace AssetProcessor
 {
     class PlatformConfiguration;

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCacheInterface.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCacheInterface.h
@@ -23,5 +23,4 @@ namespace AssetProcessor
         virtual const AZStd::unordered_set<AZStd::string>& GetExcludedFolders() = 0;
         virtual void FileAdded(QString path) = 0;
     };
-    
 }

--- a/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCacheInterface.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ExcludedFolderCacheInterface.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AssetProcessor
+{
+    class PlatformConfiguration;
+
+    struct ExcludedFolderCacheInterface
+    {
+        AZ_RTTI(ExcludedFolderCacheInterface, "{3AC471B6-C9F8-49CF-9E9D-237BDF63328C}");
+        AZ_DISABLE_COPY_MOVE(ExcludedFolderCacheInterface);
+
+        ExcludedFolderCacheInterface() = default;
+        virtual ~ExcludedFolderCacheInterface() = default;
+
+        virtual const AZStd::unordered_set<AZStd::string>& GetExcludedFolders() = 0;
+        virtual void FileAdded(QString path) = 0;
+    };
+    
+}

--- a/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.cpp
@@ -7,10 +7,9 @@
  */
 
 #include "FileStateCache.h"
-
-#include <AssetProcessor_Traits_Windows.h>
-
 #include "native/utilities/assetUtils.h"
+#include <AssetProcessor_Traits_Platform.h>
+
 #include <QDir>
 
 namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.h
@@ -14,6 +14,7 @@
 #include <QSet>
 #include <QFileInfo>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/EBus/Event.h>
 
 namespace AssetProcessor
 {
@@ -55,7 +56,7 @@ namespace AssetProcessor
 
         AZ_DISABLE_COPY_MOVE(IFileStateRequests);
     };
-    
+
     class FileStateBase
         : public IFileStateRequests
     {
@@ -90,7 +91,6 @@ namespace AssetProcessor
     {
     public:
 
-
         // FileStateRequestBus implementation
         bool GetFileInfo(const QString& absolutePath, FileStateInfo* foundFileInfo) const override;
         bool Exists(const QString& absolutePath) const override;
@@ -118,7 +118,7 @@ namespace AssetProcessor
 
         mutable AZStd::recursive_mutex m_mapMutex;
         QHash<QString, FileStateInfo> m_fileInfoMap;
-        
+
         QHash<QString, FileHash> m_fileHashMap;
 
         AZ::Event<FileStateInfo> m_deleteEvent;

--- a/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/FileStateCache.h
@@ -51,6 +51,7 @@ namespace AssetProcessor
         /// Convenience function to check if a file or directory exists.
         virtual bool Exists(const QString& absolutePath) const = 0;
         virtual bool GetHash(const QString& absolutePath, FileHash* foundHash) = 0;
+        virtual void RegisterForDeleteEvent(AZ::Event<FileStateInfo>::Handler& handler) = 0;
 
         AZ_DISABLE_COPY_MOVE(IFileStateRequests);
     };
@@ -94,6 +95,7 @@ namespace AssetProcessor
         bool GetFileInfo(const QString& absolutePath, FileStateInfo* foundFileInfo) const override;
         bool Exists(const QString& absolutePath) const override;
         bool GetHash(const QString& absolutePath, FileHash* foundHash) override;
+        void RegisterForDeleteEvent(AZ::Event<FileStateInfo>::Handler& handler) override;
 
         void AddInfoSet(QSet<AssetFileInfo> infoSet) override;
         void AddFile(const QString& absolutePath) override;
@@ -119,6 +121,8 @@ namespace AssetProcessor
         
         QHash<QString, FileHash> m_fileHashMap;
 
+        AZ::Event<FileStateInfo> m_deleteEvent;
+
         using LockGuardType = AZStd::lock_guard<decltype(m_mapMutex)>;
     };
 
@@ -131,5 +135,10 @@ namespace AssetProcessor
         bool GetFileInfo(const QString& absolutePath, FileStateInfo* foundFileInfo) const override;
         bool Exists(const QString& absolutePath) const override;
         bool GetHash(const QString& absolutePath, FileHash* foundHash) override;
+        void RegisterForDeleteEvent(AZ::Event<FileStateInfo>::Handler& handler) override;
+
+        void SignalDeleteEvent(const QString& absolutePath) const;
+    protected:
+        AZ::Event<FileStateInfo> m_deleteEvent;
     };
 } // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -20,6 +20,10 @@
 
 
 #include "native/AssetManager/assetProcessorManager.h"
+
+#include <QDirIterator>
+#include <QRegularExpression>
+#include <regex>
 #include <AzCore/std/sort.h>
 #include <AzToolsFramework/API/AssetDatabaseBus.h>
 
@@ -66,8 +70,10 @@ namespace AssetProcessor
 
         m_sourceFileRelocator = AZStd::make_unique<SourceFileRelocator>(m_stateData, m_platformConfig);
 
-        PopulateJobStateCache();
+        m_excludedFolderCache = AZStd::make_unique<ExcludedFolderCache>(m_platformConfig);
 
+        PopulateJobStateCache();
+        
         AssetProcessor::ProcessingJobInfoBus::Handler::BusConnect();
     }
 
@@ -3573,6 +3579,8 @@ namespace AssetProcessor
                     QString knownPathBeforeWildcard = encodedFileData.left(slashBeforeWildcardIndex + 1); // include the slash
                     QString relativeSearch = encodedFileData.mid(slashBeforeWildcardIndex + 1); // skip the slash
 
+                    const auto& excludedFolders = m_excludedFolderCache->GetExcludedFolders();
+
                     // Absolute path, just check the 1 scan folder
                     if (AZ::IO::PathView(encodedFileData.toUtf8().constData()).IsAbsolute())
                     {
@@ -3592,7 +3600,8 @@ namespace AssetProcessor
                             QString scanFolderAndKnownSubPath = rooted.absoluteFilePath(knownPathBeforeWildcard);
 
                             resolvedDependencyList.append(m_platformConfig->FindWildcardMatches(
-                                scanFolderAndKnownSubPath, relativeSearch, false, scanFolderInfo->RecurseSubFolders()));
+                                scanFolderAndKnownSubPath, relativeSearch,
+                                excludedFolders, false, scanFolderInfo->RecurseSubFolders()));
                         }
                     }
                     else // Relative path, check every scan folder
@@ -3610,7 +3619,8 @@ namespace AssetProcessor
                             QString absolutePath = rooted.absoluteFilePath(knownPathBeforeWildcard);
 
                             resolvedDependencyList.append(m_platformConfig->FindWildcardMatches(
-                                absolutePath, relativeSearch, false, scanFolderInfo->RecurseSubFolders()));
+                                absolutePath, relativeSearch,
+                                excludedFolders, false, scanFolderInfo->RecurseSubFolders()));
                         }
                     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -3624,6 +3624,19 @@ namespace AssetProcessor
                         }
                     }
 
+                    // Filter out any excluded files
+                    for (auto itr = resolvedDependencyList.begin(); itr != resolvedDependencyList.end();)
+                    {
+                        if (m_platformConfig->IsFileExcluded(*itr))
+                        {
+                            itr = resolvedDependencyList.erase(itr);
+                        }
+                        else
+                        {
+                            ++itr;
+                        }
+                    }
+
                     // Convert to relative paths
                     for (auto dependencyItr = resolvedDependencyList.begin(); dependencyItr != resolvedDependencyList.end();) 
                     {

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -18,12 +18,8 @@
 
 #include <AzToolsFramework/Debug/TraceContext.h>
 
-
 #include "native/AssetManager/assetProcessorManager.h"
 
-#include <QDirIterator>
-#include <QRegularExpression>
-#include <regex>
 #include <AzCore/std/sort.h>
 #include <AzToolsFramework/API/AssetDatabaseBus.h>
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -41,6 +41,7 @@
 #include "native/utilities/JobDiagnosticTracker.h"
 #include "SourceFileRelocator.h"
 #endif
+#include <AssetManager/ExcludedFolderCache.h>
 
 class FileWatcher;
 
@@ -341,7 +342,8 @@ namespace AssetProcessor
         void CleanEmptyFolder(QString folder, QString root);
 
         void ProcessBuilders(QString normalizedPath, QString relativePathToFile, const ScanFolderInfo* scanFolder, const AssetProcessor::BuilderInfoList& builderInfoList);
-        
+        AZStd::vector<AZStd::string> GetExcludedFolders();
+
         struct SourceInfo
         {
             QString m_watchFolder;
@@ -551,6 +553,8 @@ namespace AssetProcessor
 
         // when true, a flag will be sent to builders process job indicating debug output/mode should be used
         bool m_builderDebugFlag = false;
+
+        AZStd::unique_ptr<ExcludedFolderCache> m_excludedFolderCache{};
 
 protected Q_SLOTS:
         void FinishAnalysis(AZStd::string fileToCheck);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -40,8 +40,9 @@
 #include "AssetRequestHandler.h"
 #include "native/utilities/JobDiagnosticTracker.h"
 #include "SourceFileRelocator.h"
-#endif
+
 #include <AssetManager/ExcludedFolderCache.h>
+#endif
 
 class FileWatcher;
 

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorTest.h
@@ -26,7 +26,7 @@ namespace AssetProcessor
     {
     protected:
         AZStd::unique_ptr<UnitTestUtils::AssertAbsorber> m_errorAbsorber{};
-        FileStatePassthrough m_fileStateCache;
+        AZStd::unique_ptr<FileStatePassthrough> m_fileStateCache{};
 
         void SetUp() override
         {
@@ -40,9 +40,10 @@ namespace AssetProcessor
                 m_ownsSysAllocator = true;
                 AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
             }
-            m_errorAbsorber = AZStd::make_unique<UnitTestUtils::AssertAbsorber>();
 
+            m_errorAbsorber = AZStd::make_unique<UnitTestUtils::AssertAbsorber>();
             m_application = AZStd::make_unique<AzFramework::Application>();
+            m_fileStateCache = AZStd::make_unique<FileStatePassthrough>();
 
             // Inject the AutomatedTesting project as a project path into test fixture
             using FixedValueString = AZ::SettingsRegistryInterface::FixedValueString;
@@ -60,7 +61,8 @@ namespace AssetProcessor
         void TearDown() override
         {
             AssetUtilities::ResetAssetRoot();
-            
+
+            m_fileStateCache.reset();
             m_application.reset();
             m_errorAbsorber.reset();
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -5371,6 +5371,22 @@ void WildcardSourceDependencyTest::SetUp()
     m_config->AddScanFolder(ScanFolderInfo(tempPath.filePath("no_recurse"), "no_recurse",
         "no_recurse", false, false, m_config->GetEnabledPlatforms(), 1));
 
+    {
+        ExcludeAssetRecognizer excludeFolder;
+        excludeFolder.m_name = "Exclude ignored Folder";
+        excludeFolder.m_patternMatcher =
+            AssetBuilderSDK::FilePatternMatcher(R"REGEX(^(.*\/)?ignored(\/.*)?$)REGEX", AssetBuilderSDK::AssetBuilderPattern::Regex);
+        m_config->AddExcludeRecognizer(excludeFolder);
+    }
+
+    {
+        ExcludeAssetRecognizer excludeFile;
+        excludeFile.m_name = "Exclude z.foo Files";
+        excludeFile.m_patternMatcher =
+            AssetBuilderSDK::FilePatternMatcher(R"REGEX(^(.*\/)?z\.foo$)REGEX", AssetBuilderSDK::AssetBuilderPattern::Regex);
+        m_config->AddExcludeRecognizer(excludeFile);
+    }
+
     UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/1a.foo"));
     UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder1/1b.foo"));
     UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder2/redirected/a.foo"));
@@ -5383,6 +5399,19 @@ void WildcardSourceDependencyTest::SetUp()
 
     // Add a file in the non-recursive scanfolder.  Since its not directly in the scan folder, it should always be ignored
     UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("no_recurse/one/two/three/f.foo"));
+
+    // Add a file to an ignored folder
+    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder2/redirected/folder/ignored/g.foo"));
+
+    // Add an ignored file
+    UnitTestUtils::CreateDummyFile(tempPath.absoluteFilePath("subfolder2/redirected/folder/one/z.foo"));
+
+    // Add a file in the cache
+    AZStd::string projectCacheRootValue;
+    AZ::SettingsRegistry::Get()->Get(projectCacheRootValue, AZ::SettingsRegistryMergeUtils::FilePathKey_CacheProjectRootFolder);
+    projectCacheRootValue = AssetUtilities::NormalizeFilePath(projectCacheRootValue.c_str()).toUtf8().constData();
+    auto path = AZ::IO::Path(projectCacheRootValue) / "cache.foo";
+    UnitTestUtils::CreateDummyFile(path.c_str());
 
     AzToolsFramework::AssetDatabase::SourceFileDependencyEntryContainer dependencies;
 
@@ -5515,6 +5544,49 @@ TEST_F(WildcardSourceDependencyTest, Absolute_NoWildcard)
     QDir tempPath(m_tempDir.path());
 
     ASSERT_FALSE(Test(tempPath.absoluteFilePath("subfolder1/1a.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
+}
+
+TEST_F(WildcardSourceDependencyTest, Relative_IgnoredFolder)
+{
+    AZStd::vector<AZStd::string> resolvedPaths;
+
+    ASSERT_TRUE(Test("*g.foo", resolvedPaths));
+    ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
+}
+
+TEST_F(WildcardSourceDependencyTest, Absolute_IgnoredFolder)
+{
+    AZStd::vector<AZStd::string> resolvedPaths;
+    QDir tempPath(m_tempDir.path());
+
+    ASSERT_TRUE(Test(tempPath.absoluteFilePath("*g.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
+}
+
+TEST_F(WildcardSourceDependencyTest, Relative_IgnoredFile)
+{
+    AZStd::vector<AZStd::string> resolvedPaths;
+
+    ASSERT_TRUE(Test("*z.foo", resolvedPaths));
+    ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
+}
+
+TEST_F(WildcardSourceDependencyTest, Absolute_IgnoredFile)
+{
+    AZStd::vector<AZStd::string> resolvedPaths;
+    QDir tempPath(m_tempDir.path());
+
+    ASSERT_TRUE(Test(tempPath.absoluteFilePath("*z.foo").toUtf8().constData(), resolvedPaths));
+    ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
+}
+
+TEST_F(WildcardSourceDependencyTest, Relative_CacheFolder)
+{
+    AZStd::vector<AZStd::string> resolvedPaths;
+    QDir tempPath(m_tempDir.path());
+    
+    ASSERT_TRUE(Test("*cache.foo", resolvedPaths));
     ASSERT_THAT(resolvedPaths, ::testing::UnorderedElementsAre());
 }
 

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -454,6 +454,8 @@ void ApplicationManagerBase::InitFileMonitor()
         QObject::connect(newFolderWatch, &FolderWatchCallbackEx::fileModified, [this](QString path) { m_fileStateCache->UpdateFile(path); });
         QObject::connect(newFolderWatch, &FolderWatchCallbackEx::fileRemoved, [this](QString path) { m_fileStateCache->RemoveFile(path); });
 
+        QObject::connect(newFolderWatch, &FolderWatchCallbackEx::fileAdded, [](QString path) { AZ::Interface<AssetProcessor::ExcludedFolderCacheInterface>::Get()->FileAdded(path); });
+
         QObject::connect(newFolderWatch, &FolderWatchCallbackEx::fileAdded,
             m_fileProcessor.get(), &AssetProcessor::FileProcessor::AssessAddedFile);
         QObject::connect(newFolderWatch, &FolderWatchCallbackEx::fileRemoved,

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
@@ -256,6 +256,9 @@ namespace AssetProcessor
         //! Retrieve the scan folder at a given index.
         AssetProcessor::ScanFolderInfo& GetScanFolderAt(int index);
 
+        //! Retrieve the scan folder at a given index.
+        const AssetProcessor::ScanFolderInfo& GetScanFolderAt(int index) const;
+
         //!  Manually add a scan folder.  Also used for testing.
         void AddScanFolder(const AssetProcessor::ScanFolderInfo& source, bool isUnitTesting = false);
 
@@ -298,7 +301,16 @@ namespace AssetProcessor
         QString FindFirstMatchingFile(QString relativeName) const;
 
         //! given a relative name with wildcard characters (* allowed) find a set of matching files or optionally folders
-        QStringList FindWildcardMatches(const QString& sourceFolder, QString relativeName, bool includeFolders = false, bool recursiveSearch = true) const;
+        QStringList FindWildcardMatches(const QString& sourceFolder, QString relativeName, bool includeFolders = false,
+            bool recursiveSearch = true) const;
+
+        //! given a relative name with wildcard characters (* allowed) find a set of matching files or optionally folders
+        QStringList FindWildcardMatches(
+            const QString& sourceFolder,
+            QString relativeName,
+            const AZStd::unordered_set<AZStd::string>& excludedFolders,
+            bool includeFolders = false,
+            bool recursiveSearch = true) const;
 
         //! given a fileName (as a full path), return the database source name which includes the output prefix.
         //!


### PR DESCRIPTION
Added a cache that builds a list of all watched folders that are ignored.
Added a FindWildcardMatches version which takes a list of ignored directories and will not scan any deeper if it finds one.
Updated wildcard dependency resolution code to take ignored folders into account