### PR TITLE
Use Ground Plane non functional

### DIFF
--- a/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainHeightGradientListComponent.cpp
@@ -161,14 +161,17 @@ namespace Terrain
         // make this list a prioritized list from top to bottom for any points that overlap.
         for (auto& gradientId : m_configuration.m_gradientEntities)
         {
-            // If gradients ever provide bounds, or if we add a value threshold in this component, it would be possible for terrain
-            // to *not* exist at a specific point.
-            terrainExists = true;
+            if (gradientId.IsValid())
+            {
+                // If gradients ever provide bounds, or if we add a value threshold in this component, it would be possible for terrain
+                // to *not* exist at a specific point.
+                terrainExists = true;
 
-            float sample = 0.0f;
-            GradientSignal::GradientRequestBus::EventResult(
-                sample, gradientId, &GradientSignal::GradientRequestBus::Events::GetValue, params);
-            maxSample = AZ::GetMax(maxSample, sample);
+                float sample = 0.0f;
+                GradientSignal::GradientRequestBus::EventResult(
+                    sample, gradientId, &GradientSignal::GradientRequestBus::Events::GetValue, params);
+                maxSample = AZ::GetMax(maxSample, sample);
+            }
         }
 
         const float height = AZ::Lerp(m_cachedShapeBounds.GetMin().GetZ(), m_cachedShapeBounds.GetMax().GetZ(), maxSample);

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.h
@@ -168,7 +168,14 @@ namespace Terrain
         bool m_terrainSurfacesDirty = false;
         AZ::Aabb m_dirtyRegion;
 
+        // Cached data for each terrain area to use when looking up terrain data.
+        struct TerrainAreaData
+        {
+            AZ::Aabb m_areaBounds{ AZ::Aabb::CreateNull() };
+            bool m_useGroundPlane{ false };
+        };
+
         mutable AZStd::shared_mutex m_areaMutex;
-        AZStd::map<AZ::EntityId, AZ::Aabb, TerrainLayerPriorityComparator> m_registeredAreas;
+        AZStd::map<AZ::EntityId, TerrainAreaData, TerrainLayerPriorityComparator> m_registeredAreas;
     };
 } // namespace Terrain


### PR DESCRIPTION
Added functionality to the "Use Ground Plane" toggle.  Now, when it's enabled, the Terrain Layer Spawner will always provide valid terrain data at the minimum height of the spawner box, even if no Terrain Height Gradient List exists.  If it's disabled, it won't provide any terrain data unless the Terrain Height Gradient List exists.

![image](https://user-images.githubusercontent.com/82224783/140519071-1302c30a-564d-4a71-8c01-70fd5d31854e.png)

![image](https://user-images.githubusercontent.com/82224783/140519115-04ddda3d-bbb0-445c-874e-bd3ee10aff2b.png)
