### PR TITLE
bugfix: resolve crash with FBX Settings  (#4813) (#4944)

### DIFF
--- a/Code/Legacy/CryCommon/ISystem.h
+++ b/Code/Legacy/CryCommon/ISystem.h
@@ -1121,8 +1121,8 @@ inline ISystem* GetISystem()
 
 // Description:
 //   This function must be called once by each module at the beginning, to setup global pointers.
-extern "C" AZ_DLL_EXPORT void ModuleInitISystem(ISystem* pSystem, const char* moduleName);
-extern "C" AZ_DLL_EXPORT void ModuleShutdownISystem(ISystem* pSystem);
+void ModuleInitISystem(ISystem* pSystem, const char* moduleName);
+void ModuleShutdownISystem(ISystem* pSystem);
 extern "C" AZ_DLL_EXPORT void InjectEnvironment(void* env);
 extern "C" AZ_DLL_EXPORT void DetachEnvironment();
 

--- a/Code/Legacy/CryCommon/platform_impl.cpp
+++ b/Code/Legacy/CryCommon/platform_impl.cpp
@@ -74,7 +74,7 @@ void InitCRTHandlers() {}
 //////////////////////////////////////////////////////////////////////////
 // This is an entry to DLL initialization function that must be called for each loaded module
 //////////////////////////////////////////////////////////////////////////
-extern "C" AZ_DLL_EXPORT void ModuleInitISystem(ISystem* pSystem, [[maybe_unused]] const char* moduleName)
+void ModuleInitISystem(ISystem* pSystem, [[maybe_unused]] const char* moduleName)
 {
     if (gEnv) // Already registered.
     {
@@ -96,7 +96,7 @@ extern "C" AZ_DLL_EXPORT void ModuleInitISystem(ISystem* pSystem, [[maybe_unused
     } // if pSystem
 }
 
-extern "C" AZ_DLL_EXPORT void ModuleShutdownISystem([[maybe_unused]] ISystem* pSystem)
+void ModuleShutdownISystem([[maybe_unused]] ISystem* pSystem)
 {
     // Unregister with AZ environment.
     AZ::Environment::Detach();

--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -173,8 +173,6 @@ void CryEngineSignalHandler(int signal)
 
 //////////////////////////////////////////////////////////////////////////
 #if defined(WIN32) || defined(LINUX) || defined(APPLE)
-#   define DLL_MODULE_INIT_ISYSTEM "ModuleInitISystem"
-#   define DLL_MODULE_SHUTDOWN_ISYSTEM "ModuleShutdownISystem"
 #   define DLL_INITFUNC_RENDERER "PackageRenderConstructor"
 #   define DLL_INITFUNC_SOUND "CreateSoundSystem"
 #   define DLL_INITFUNC_FONT "CreateCryFontInterface"
@@ -188,8 +186,6 @@ void CryEngineSignalHandler(int signal)
 #if defined(AZ_RESTRICTED_SECTION_IMPLEMENTED)
 #undef AZ_RESTRICTED_SECTION_IMPLEMENTED
 #else
-#   define DLL_MODULE_INIT_ISYSTEM (LPCSTR)2
-#   define DLL_MODULE_SHUTDOWN_ISYSTEM (LPCSTR)3
 #   define DLL_INITFUNC_RENDERER  (LPCSTR)1
 #   define DLL_INITFUNC_RENDERER  (LPCSTR)1
 #   define DLL_INITFUNC_SOUND     (LPCSTR)1
@@ -445,18 +441,6 @@ AZStd::unique_ptr<AZ::DynamicModuleHandle> CSystem::LoadDLL(const char* dllName)
         return handle;
     }
 
-    //////////////////////////////////////////////////////////////////////////
-    // After loading DLL initialize it by calling ModuleInitISystem
-    //////////////////////////////////////////////////////////////////////////
-    AZStd::string moduleName = PathUtil::GetFileName(dllName);
-
-    typedef void*(*PtrFunc_ModuleInitISystem)(ISystem* pSystem, const char* moduleName);
-    PtrFunc_ModuleInitISystem pfnModuleInitISystem = handle->GetFunction<PtrFunc_ModuleInitISystem>(DLL_MODULE_INIT_ISYSTEM);
-    if (pfnModuleInitISystem)
-    {
-        pfnModuleInitISystem(this, moduleName.c_str());
-    }
-
     return handle;
 }
 
@@ -497,13 +481,6 @@ void CSystem::ShutdownModuleLibraries()
 #if !defined(AZ_MONOLITHIC_BUILD)
     for (auto iterator = m_moduleDLLHandles.begin(); iterator != m_moduleDLLHandles.end(); ++iterator)
     {
-        typedef void*( * PtrFunc_ModuleShutdownISystem )(ISystem* pSystem);
-
-        PtrFunc_ModuleShutdownISystem pfnModuleShutdownISystem = iterator->second->GetFunction<PtrFunc_ModuleShutdownISystem>(DLL_MODULE_SHUTDOWN_ISYSTEM);
-        if (pfnModuleShutdownISystem)
-        {
-            pfnModuleShutdownISystem(this);
-        }
         if (iterator->second->IsLoaded())
         {
             iterator->second->Unload();


### PR DESCRIPTION
-prevent export of ModuleInitISystem and ModuleShutdownISystem

Signed-off-by: Michael Pollind <mpollind@gmail.com>