### PR TITLE
EMotion FX: Taskify dual quat skinning deformer

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/DualQuatSkinDeformer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/Task/TaskGraph.h>
 #include <AzCore/Outcome/Outcome.h>
 #include "EMotionFXConfig.h"
 #include <MCore/Source/DualQuaternion.h>
@@ -138,6 +139,8 @@ namespace EMotionFX
 
         //! Number of vertices per batch/job used for multi-threaded software skinning.
         static constexpr AZ::u32 s_numVerticesPerBatch = 10000;
+        AZ::TaskGraph m_taskGraph;
+        bool m_useTaskGraph = true;
 
         /**
          * Default constructor.


### PR DESCRIPTION
* Moved from job system to task graph for the multi-threaded dual quaternion skinning deformer.
* Prepare the task graph at init time and reuse it at runtime.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>