### PR TITLE
Fix Prefab builder test

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabBuilderTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabBuilderTests.cpp
@@ -102,7 +102,9 @@ namespace UnitTest
         prefabBuilderComponent.Activate();
         
         AZStd::vector<AssetBuilderSDK::JobProduct> jobProducts;
-        auto&& prefabDom = prefabSystemComponentInterface->FindTemplateDom(parentInstance->GetTemplateId());
+        // Make a copy of the template DOM, as the prefab system still owns the existing template
+        AzToolsFramework::Prefab::PrefabDom prefabDom;
+        prefabDom.CopyFrom(prefabSystemComponentInterface->FindTemplateDom(parentInstance->GetTemplateId()), prefabDom.GetAllocator(), false);
 
         ASSERT_TRUE(prefabBuilderComponent.ProcessPrefab({AZ::Crc32("pc")}, "parent.prefab", "unused", AZ::Uuid(), prefabDom, jobProducts));
 


### PR DESCRIPTION
We were destructively moving the DOM template into the builder, leaving the Prefab system with an invalid DOM when teardown occurs. For now, this just copies the document to fix this specific test failure, but we may want to consider making `FindTemplateDom` return a const document and requiring that mutations get routed through the prefab system component to avoid similar situations in the future.

Signed-off-by: nvsickle <nvsickle@amazon.com>