### PR TITLE
Rendered World Size in the Terrain World Render component set to invisible

### DIFF
--- a/Gems/Terrain/Code/Source/Components/TerrainWorldRendererComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainWorldRendererComponent.cpp
@@ -46,6 +46,7 @@ namespace Terrain
                         ->EnumAttribute(TerrainWorldRendererConfig::WorldSize::_4096Meters, "4 Kilometers")
                         ->EnumAttribute(TerrainWorldRendererConfig::WorldSize::_8192Meters, "8 Kilometers")
                         ->EnumAttribute(TerrainWorldRendererConfig::WorldSize::_16384Meters, "16 Kilometers")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, false) // Keeping invisible until it's hooked up under the hood
                         ;
             }
         }


### PR DESCRIPTION
It's not currently hooked up, so setting invisible for now until it does something.
https://github.com/o3de/o3de/issues/5179

![image](https://user-images.githubusercontent.com/1105143/140558589-d90bb7f7-5e0c-40af-b23f-773fd5aeb998.png)
