### PR TITLE
Add restricted folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Editor/EditorEventLog.xml
 Editor/EditorLayout.xml
 **/*egg-info/**
 **/*egg-link
+**/[Rr]estricted
 UserSettings.xml
 [Uu]ser/
 FrameCapture/**


### PR DESCRIPTION
This will ignore any restricted folder/subfolder in the repo. While the recommended path moving forward will be to setup the platform repos outside the o3de folder, adding as a safeguard for older restricted platform workflows. 