### PR TITLE
StandardMultilayerPBR_ForwardPass.azsl. the type of input.m_normal is

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_ForwardPass.azsl
@@ -153,7 +153,7 @@ struct StandardMaterialInputs
 
     float2 m_vertexUv[UvSetCount];
     float3x3 m_uvMatrix;
-    float m_normal;
+    float3 m_normal;
     float3 m_tangents[UvSetCount];
     float3 m_bitangents[UvSetCount];
 


### PR DESCRIPTION
StandardMultilayerPBR_ForwardPass.azsl. the type of input.m_normal is float

Github issue: https://github.com/o3de/o3de/issues/2522

Changed to float3. The current ASV tests are not affected but
using the RPI/Mesh example with Mesh: objects/suzanne.azmodel
and the material:
StandardMultilayerPbrTestCases/005_UseDisplacement.material

Showed a clear improvement.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>