### PR TITLE
ATOM-16747 RPISystemInterface::GetDefaultScene returns the scene crea…

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -272,6 +272,7 @@ namespace AZ
 
                 // Create and register a scene with all available feature processors
                 RPI::SceneDescriptor sceneDesc;
+                sceneDesc.m_nameId = AZ::Name("Main");
                 AZ::RPI::ScenePtr atomScene = RPI::Scene::CreateScene(sceneDesc);
                 atomScene->EnableAllFeatureProcessors();
                 atomScene->Activate();

--- a/Gems/Atom/Feature/Common/Code/Source/LuxCore/LuxCoreTexture.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/LuxCore/LuxCoreTexture.cpp
@@ -32,7 +32,7 @@ namespace AZ
         {
             if (m_rtPipeline)
             {
-                AZ::RPI::RPISystemInterface::Get()->GetDefaultScene()->RemoveRenderPipeline(m_rtPipeline->GetId());
+                m_rtPipeline->RemoveFromScene();
                 m_rtPipeline = nullptr;
             }
             
@@ -111,8 +111,12 @@ namespace AZ
                 parentPass->SetSourceTexture(m_texture, RHI::Format::R8G8B8A8_UNORM);
                 break;
             }
-
-            AZ::RPI::RPISystemInterface::Get()->GetDefaultScene()->AddRenderPipeline(m_rtPipeline);
+            
+            const auto mainScene = AZ::RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("RPI"));
+            if (mainScene)
+            {
+                mainScene->AddRenderPipeline(m_rtPipeline);
+            }
         }
 
         bool LuxCoreTexture::IsIBLTexture()

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
@@ -70,7 +70,8 @@ namespace AZ
             void InitializeSystemAssets() override;
             void RegisterScene(ScenePtr scene) override;
             void UnregisterScene(ScenePtr scene) override;
-            ScenePtr GetScene(const SceneId& sceneId) const override;
+            Scene* GetScene(const SceneId& sceneId) const override;
+            Scene* GetSceneByName(const AZ::Name& name) const override;
             ScenePtr GetDefaultScene() const override;
             RenderPipelinePtr GetRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle) override;
             Data::Asset<ShaderAsset> GetCommonShaderAssetForSrgs() const override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystemInterface.h
@@ -13,6 +13,7 @@
 
 #include <Atom/RPI.Public/Base.h>
 
+#include <AzCore/Name/Name.h>
 #include <AzFramework/Windowing/WindowBus.h>
 
 namespace AZ
@@ -46,11 +47,14 @@ namespace AZ
             //! Unregister a scene from RPISystem. The scene won't be simulated or rendered.
             virtual void UnregisterScene(ScenePtr scene) = 0;
 
-            // [GFX TODO] to be removed when we have scene setup in AZ Core
-            virtual ScenePtr GetDefaultScene() const = 0;
-
+            //! Deprecated. Use GetSceneByName(name), GetSceneForEntityContextId(entityContextId) or Scene::GetSceneForEntityId(AZ::EntityId entityId) instead
+            AZ_DEPRECATED(virtual ScenePtr GetDefaultScene() const = 0;, "This method has been deprecated. Please use GetSceneByName(name), GetSceneForEntityContextId(entityContextId) or Scene::GetSceneForEntityId(AZ::EntityId entityId) instead.");
+            
             //! Get scene by using scene id.
-            virtual ScenePtr GetScene(const SceneId& sceneId) const = 0;
+            virtual Scene* GetScene(const SceneId& sceneId) const = 0;
+
+            //! Get scene by using scene name.
+            virtual Scene* GetSceneByName(const AZ::Name& name) const = 0;
 
             //! Get the render pipeline created for a window
             virtual RenderPipelinePtr GetRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle) = 0;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -80,6 +80,9 @@ namespace AZ
             //! Gets the RPI::Scene for a given entityContextId.
             //! May return nullptr if there is no RPI::Scene created for that entityContext.
             static Scene* GetSceneForEntityContextId(AzFramework::EntityContextId entityContextId);
+            
+            //! Gets the RPI::Scene for a given entityId.
+            static Scene* GetSceneForEntityId(AZ::EntityId entityId);
 
             ~Scene();
 
@@ -134,6 +137,8 @@ namespace AZ
             Data::Instance<ShaderResourceGroup> GetShaderResourceGroup() const;
 
             const SceneId& GetId() const;
+
+            AZ::Name GetName() const;
 
             //! Set default pipeline by render pipeline ID.
             //! It returns true if the default render pipeline was set from the input ID.
@@ -245,6 +250,9 @@ namespace AZ
             // The uuid to identify this scene.
             SceneId m_id;
 
+            // Scene's name which is set at initialization. Can be empty
+            AZ::Name m_name;
+
             bool m_activated = false;
             bool m_taskGraphActive = false; // update during tick, to ensure it only changes on frame boundaries
 
@@ -286,13 +294,10 @@ namespace AZ
         template<typename FeatureProcessorType>
         FeatureProcessorType* Scene::GetFeatureProcessorForEntity(AZ::EntityId entityId)
         {
-            // Find the entity context for the entity ID.
-            AzFramework::EntityContextId entityContextId = AzFramework::EntityContextId::CreateNull();
-            AzFramework::EntityIdContextQueryBus::EventResult(entityContextId, entityId, &AzFramework::EntityIdContextQueryBus::Events::GetOwningContextId);
-
-            if (!entityContextId.IsNull())
+            RPI::Scene* renderScene = GetSceneForEntityId(entityId);            
+            if (renderScene)
             {
-                return GetFeatureProcessorForEntityContextId<FeatureProcessorType>(entityContextId);
+                return renderScene->GetFeatureProcessor<FeatureProcessorType>();
             }
             return nullptr;
         };

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/System/SceneDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/System/SceneDescriptor.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Name/Name.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 
@@ -25,6 +26,9 @@ namespace AZ
 
             //! List of feature processors which the scene will initially enable.
             AZStd::vector<AZStd::string> m_featureProcessorNames;
+
+            //! A name used as scene id. It can be used to search a registered scene via RPISystemInterface::GetScene()
+            AZ::Name m_nameId;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -699,9 +699,7 @@ namespace AZ
             m_parentScene = parentScene;
 
             AZ_Assert(m_visScene == nullptr, "IVisibilityScene already created for this RPI::Scene");
-            char sceneIdBuf[40] = "";
-            m_parentScene->GetId().ToString(sceneIdBuf);
-            AZ::Name visSceneName(AZStd::string::format("RenderCullScene[%s]", sceneIdBuf));
+            AZ::Name visSceneName(AZStd::string::format("RenderCullScene[%s]", m_parentScene->GetName().GetCStr()));
             m_visScene = AZ::Interface<AzFramework::IVisibilitySystem>::Get()->CreateVisibilityScene(visSceneName);
 
 #ifdef AZ_CULL_DEBUG_ENABLED

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -159,6 +159,11 @@ namespace AZ
                     AZ_Assert(false, "Scene was already registered");
                     return;
                 }
+                else if (!scene->GetName().IsEmpty() && scene->GetName() == sceneItem->GetName())
+                {
+                    // only report a warning if there is a scene with duplicated name
+                    AZ_Warning("RPISystem", false, "There is a registered scene with same name [%s]", scene->GetName().GetCStr());
+                }
             }
 
             m_scenes.push_back(scene);
@@ -177,27 +182,41 @@ namespace AZ
             AZ_Assert(false, "Can't unregister scene which wasn't registered");
         }
 
-        ScenePtr RPISystem::GetScene(const SceneId& sceneId) const
+        Scene* RPISystem::GetScene(const SceneId& sceneId) const
         {
             for (const auto& scene : m_scenes)
             {
                 if (scene->GetId() == sceneId)
+                {
+                    return scene.get();
+                }
+            }
+            return nullptr;
+        }
+
+        Scene* RPISystem::GetSceneByName(const AZ::Name& name) const
+        {
+            for (const auto& scene : m_scenes)
+            {
+                if (scene->GetName() == name)
+                {
+                    return scene.get();
+                }
+            }
+            return nullptr;
+        }
+        
+        ScenePtr RPISystem::GetDefaultScene() const
+        {
+            for (const auto& scene : m_scenes)
+            {
+                if (scene->GetName() == AZ::Name("Main"))
                 {
                     return scene;
                 }
             }
             return nullptr;
         }
-
-        ScenePtr RPISystem::GetDefaultScene() const
-        {
-            if (m_scenes.size() > 0)
-            {
-                return m_scenes[0];
-            }
-            return nullptr;
-        }
-
 
         RenderPipelinePtr RPISystem::GetRenderPipelineForWindow(AzFramework::NativeWindowHandle windowHandle)
         {

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/PreviewRenderer/PreviewRenderer.cpp
@@ -43,6 +43,7 @@ namespace AtomToolsFramework
             &PreviewerFeatureProcessorProviderBus::Handler::GetRequiredFeatureProcessors, featureProcessors);
 
         AZ::RPI::SceneDescriptor sceneDesc;
+        sceneDesc.m_nameId = AZ::Name("PreviewRenderer");
         sceneDesc.m_featureProcessorNames.assign(featureProcessors.begin(), featureProcessors.end());
         m_scene = AZ::RPI::Scene::CreateScene(sceneDesc);
 

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/InputController/MaterialEditorViewportInputController.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/InputController/MaterialEditorViewportInputController.cpp
@@ -279,9 +279,9 @@ namespace MaterialEditor
         // reset environment
         AZ::Transform iblTransform = AZ::Transform::CreateIdentity();
         AZ::TransformBus::Event(m_iblEntityId, &AZ::TransformBus::Events::SetLocalTM, iblTransform);
+
         const AZ::Matrix4x4 rotationMatrix = AZ::Matrix4x4::CreateIdentity();
-        AZ::RPI::ScenePtr scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene();
-        auto skyBoxFeatureProcessorInterface = scene->GetFeatureProcessor<AZ::Render::SkyBoxFeatureProcessorInterface>();
+        auto skyBoxFeatureProcessorInterface = AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::SkyBoxFeatureProcessorInterface>(m_iblEntityId);
         skyBoxFeatureProcessorInterface->SetCubemapRotationMatrix(rotationMatrix);
 
         if (m_behavior)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/InputController/RotateEnvironmentBehavior.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/InputController/RotateEnvironmentBehavior.cpp
@@ -25,8 +25,7 @@ namespace MaterialEditor
             m_iblEntityId,
             &MaterialEditorViewportInputControllerRequestBus::Handler::GetIblEntityId);
         AZ_Assert(m_iblEntityId.IsValid(), "Failed to find m_iblEntityId");
-        AZ::RPI::ScenePtr scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene();
-        m_skyBoxFeatureProcessorInterface = scene->GetFeatureProcessor<AZ::Render::SkyBoxFeatureProcessorInterface>();
+        m_skyBoxFeatureProcessorInterface = AZ::RPI::Scene::GetFeatureProcessorForEntity<AZ::Render::SkyBoxFeatureProcessorInterface>(m_iblEntityId);
     }
 
     void RotateEnvironmentBehavior::TickInternal(float x, float y, float z)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportRenderer.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportRenderer.cpp
@@ -67,6 +67,7 @@ namespace MaterialEditor
 
         // Create and register a scene with all available feature processors
         AZ::RPI::SceneDescriptor sceneDesc;
+        sceneDesc.m_nameId = AZ::Name("MaterialViewport");
         m_scene = AZ::RPI::Scene::CreateScene(sceneDesc);
         m_scene->EnableAllFeatureProcessors();
 

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomBridgeSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomBridgeSystemComponent.cpp
@@ -108,7 +108,7 @@ namespace AZ
         { 
             m_dynamicDrawManager.reset();
             AZ::RPI::ViewportContextManagerNotificationsBus::Handler::BusDisconnect();
-            RPI::Scene* scene = RPI::RPISystemInterface::Get()->GetDefaultScene().get();
+            RPI::Scene* scene = AZ::RPI::Scene::GetSceneForEntityContextId(m_entityContextId);
             // Check if scene is emptry since scene might be released already when running AtomSampleViewer 
             if (scene)
             {
@@ -157,9 +157,9 @@ namespace AZ
 
         void AtomBridgeSystemComponent::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
         {
-            AZ_UNUSED(bootstrapScene);
             // Make default AtomDebugDisplayViewportInterface
-            AZStd::shared_ptr<AtomDebugDisplayViewportInterface> mainEntityDebugDisplay = AZStd::make_shared<AtomDebugDisplayViewportInterface>(AzFramework::g_defaultSceneEntityDebugDisplayId);
+            AZStd::shared_ptr<AtomDebugDisplayViewportInterface> mainEntityDebugDisplay =
+                AZStd::make_shared<AtomDebugDisplayViewportInterface>(AzFramework::g_defaultSceneEntityDebugDisplayId, bootstrapScene);
             m_activeViewportsList[AzFramework::g_defaultSceneEntityDebugDisplayId] = mainEntityDebugDisplay;
         }
 

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -256,12 +256,11 @@ namespace AZ::AtomBridge
         viewportContextPtr->ConnectSceneChangedHandler(m_sceneChangeHandler);
     }
 
-    AtomDebugDisplayViewportInterface::AtomDebugDisplayViewportInterface(uint32_t defaultInstanceAddress)
+    AtomDebugDisplayViewportInterface::AtomDebugDisplayViewportInterface(uint32_t defaultInstanceAddress, RPI::Scene* scene)
     {
         ResetRenderState();
         m_viewportId = defaultInstanceAddress;
         m_defaultInstance = true;
-        RPI::Scene* scene = RPI::RPISystemInterface::Get()->GetDefaultScene().get();
         InitInternal(scene, nullptr);
     }
 

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.h
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.h
@@ -124,7 +124,7 @@ namespace AZ::AtomBridge
         AZ_RTTI(AtomDebugDisplayViewportInterface, "{09AF6A46-0100-4FBF-8F94-E6B221322D14}", AzFramework::DebugDisplayRequestBus::Handler);
 
         explicit AtomDebugDisplayViewportInterface(AZ::RPI::ViewportContextPtr viewportContextPtr);
-        explicit AtomDebugDisplayViewportInterface(uint32_t defaultInstanceAddress);
+        explicit AtomDebugDisplayViewportInterface(uint32_t defaultInstanceAddress, RPI::Scene* scene);
         ~AtomDebugDisplayViewportInterface();
 
         void ResetRenderState();

--- a/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
+++ b/Gems/AtomLyIntegration/AtomFont/Code/Include/AtomLyIntegration/AtomFont/FFont.h
@@ -133,18 +133,6 @@ namespace AZ
         typedef std::vector<FontEffect> FontEffects;
         typedef FontEffects::iterator FontEffectsIterator;
 
-        struct FontPipelineStateMapKey
-        {
-            AZ::RPI::SceneId m_sceneId;         // which scene pipeline state is attached to (via Render Pipeline)
-            AZ::RHI::DrawListTag m_drawListTag; // which render pass this pipeline draws in by default
-
-            bool operator<(const FontPipelineStateMapKey& other) const
-            {
-                return m_sceneId < other.m_sceneId
-                       ||      (m_sceneId == other.m_sceneId && m_drawListTag < other.m_drawListTag);
-            }
-        };
-
         struct FontShaderData
         {
             AZ::RHI::ShaderInputNameIndex m_imageInputIndex = "m_texture";

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationComponentController.cpp
@@ -48,11 +48,7 @@ namespace AZ
 
         void DiffuseGlobalIlluminationComponentController::Activate(EntityId entityId)
         {
-            AZ_UNUSED(entityId);
-
-            const RPI::Scene* scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene().get();
-            m_featureProcessor = scene->GetFeatureProcessor<DiffuseGlobalIlluminationFeatureProcessorInterface>();
-
+            m_featureProcessor = AZ::RPI::Scene::GetFeatureProcessorForEntity<DiffuseGlobalIlluminationFeatureProcessorInterface>(entityId);
             OnConfigChanged();
         }
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Grid/GridComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Grid/GridComponentController.cpp
@@ -79,7 +79,7 @@ namespace AZ
             m_entityId = entityId;
             m_dirty = true;
 
-            RPI::ScenePtr scene = RPI::RPISystemInterface::Get()->GetDefaultScene();
+            RPI::Scene* scene = RPI::Scene::GetSceneForEntityId(m_entityId);
             if (scene)
             {
                 AZ::RPI::SceneNotificationBus::Handler::BusConnect(scene->GetId());

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DisplayMapper/DisplayMapperComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/DisplayMapper/DisplayMapperComponentController.cpp
@@ -357,8 +357,7 @@ namespace AZ
         void DisplayMapperComponentController::OnConfigChanged()
         {
             // Register the configuration with the  AcesDisplayMapperFeatureProcessor for this scene.
-            const AZ::RPI::Scene* scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene().get();
-            DisplayMapperFeatureProcessorInterface* fp = scene->GetFeatureProcessor<DisplayMapperFeatureProcessorInterface>();
+            DisplayMapperFeatureProcessorInterface* fp = AZ::RPI::Scene::GetFeatureProcessorForEntity<DisplayMapperFeatureProcessorInterface>(m_entityId);
             DisplayMapperConfigurationDescriptor desc;
             desc.m_operationType = m_configuration.m_displayMapperOperation;
             desc.m_ldrGradingLutEnabled = m_configuration.m_ldrColorGradingLutEnabled;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkinnedMesh/SkinnedMeshDebugDisplay.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SkinnedMesh/SkinnedMeshDebugDisplay.h
@@ -48,7 +48,7 @@ namespace AZ
             // CVar for toggling the display of the scene stats
             int r_skinnedMeshDisplaySceneStats = 0;
             // SceneId to query for the stats
-            RPI::SceneId m_sceneId = RPI::SceneId::CreateNull();
+            RPI::SceneId m_sceneId;
         };
     }// namespace Render
 }// namespace AZ

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -60,6 +60,7 @@ namespace EMStudio
 
         // Create and register a scene with all available feature processors
         AZ::RPI::SceneDescriptor sceneDesc;
+        sceneDesc.m_nameId = AZ::Name("AnimViewport");
         m_scene = AZ::RPI::Scene::CreateScene(sceneDesc);
         m_scene->EnableAllFeatureProcessors();
 
@@ -213,8 +214,7 @@ namespace EMStudio
         AZ::TransformBus::Event(m_iblEntity->GetId(), &AZ::TransformBus::Events::SetLocalTM, iblTransform);
 
         const AZ::Matrix4x4 rotationMatrix = AZ::Matrix4x4::CreateIdentity();
-        AZ::RPI::ScenePtr scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene();
-        auto skyBoxFeatureProcessorInterface = scene->GetFeatureProcessor<AZ::Render::SkyBoxFeatureProcessorInterface>();
+        auto skyBoxFeatureProcessorInterface = m_scene->GetFeatureProcessor<AZ::Render::SkyBoxFeatureProcessorInterface>();
         skyBoxFeatureProcessorInterface->SetCubemapRotationMatrix(rotationMatrix);
     }
 

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -255,19 +255,22 @@ namespace Blast
             BlastFamilyComponentRequestBus::Broadcast(
                 &BlastFamilyComponentRequests::FillDebugRenderBuffer, buffer, m_debugRenderMode);
 
-            // This is a system component, and thus is not associated with a specific scene, so use the default scene
+            // This is a system component, and thus is not associated with a specific scene, so use the bootstrap scene
             // for the debug drawing
-            const auto defaultScene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene();
-            auto drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(defaultScene);
-
-            for (DebugLine& line : buffer.m_lines)
+            const auto mainScene = AZ::RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("Main"));
+            if (mainScene)
             {
-                AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArguments;
-                drawArguments.m_verts = &line.m_p0;
-                drawArguments.m_vertCount = 2;
-                drawArguments.m_colors = &line.m_color;
-                drawArguments.m_colorCount = 1;
-                drawQueue->DrawLines(drawArguments);
+                auto drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(mainScene);
+
+                for (DebugLine& line : buffer.m_lines)
+                {
+                    AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArguments;
+                    drawArguments.m_verts = &line.m_p0;
+                    drawArguments.m_vertCount = 2;
+                    drawArguments.m_colors = &line.m_color;
+                    drawArguments.m_colorCount = 1;
+                    drawQueue->DrawLines(drawArguments);
+                }
             }
         }
     }

--- a/Gems/LyShine/Code/Source/Draw2d.cpp
+++ b/Gems/LyShine/Code/Source/Draw2d.cpp
@@ -65,7 +65,7 @@ CDraw2d::~CDraw2d()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void CDraw2d::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstrapScene)
+void CDraw2d::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
 {
     // At this point the RPI is ready for use
 
@@ -74,16 +74,16 @@ void CDraw2d::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstrapSc
     AZ::Data::Instance<AZ::RPI::Shader> shader = AZ::RPI::LoadCriticalShader(shaderFilepath);
 
     // Set scene to be associated with the dynamic draw context
-    AZ::RPI::ScenePtr scene;
+    AZ::RPI::Scene* scene = nullptr;
     if (m_viewportContext)
     {
         // Use scene associated with the specified viewport context
-        scene = m_viewportContext->GetRenderScene();
+        scene = m_viewportContext->GetRenderScene().get();
     }
     else
     {
-        // No viewport context specified, use default scene
-        scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene();
+        // No viewport context specified, use main scene
+        scene = bootstrapScene;
     }
     AZ_Assert(scene != nullptr, "Attempting to create a DynamicDrawContext for a viewport context that has not been associated with a scene yet.");
 
@@ -113,7 +113,7 @@ void CDraw2d::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstrapSc
     else
     {
         // Render target support is disabled
-        m_dynamicDraw->SetOutputScope(scene.get());
+        m_dynamicDraw->SetOutputScope(scene);
     }
     m_dynamicDraw->EndInit();
 

--- a/Gems/LyShine/Code/Source/LyShine.cpp
+++ b/Gems/LyShine/Code/Source/LyShine.cpp
@@ -653,12 +653,12 @@ void CLyShine::OnRenderTick()
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-void CLyShine::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstrapScene)
+void CLyShine::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
 {
     // Load cursor if its path was set before RPI was initialized
     LoadUiCursor();
 
-    LyShinePassDataRequestBus::Handler::BusConnect(AZ::RPI::RPISystemInterface::Get()->GetDefaultScene()->GetId());
+    LyShinePassDataRequestBus::Handler::BusConnect(bootstrapScene->GetId());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -52,7 +52,7 @@ bool UiRenderer::IsReady()
     return m_isRPIReady;
 }
 
-void UiRenderer::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstrapScene)
+void UiRenderer::OnBootstrapSceneReady(AZ::RPI::Scene* bootstrapScene)
 {
     // At this point the RPI is ready for use
 
@@ -64,16 +64,17 @@ void UiRenderer::OnBootstrapSceneReady([[maybe_unused]] AZ::RPI::Scene* bootstra
     if (m_viewportContext)
     {
         // Create a new scene based on the user specified viewport context
-        m_scene = CreateScene(m_viewportContext);
+        m_ownedScene = CreateScene(m_viewportContext);
+        m_scene = m_ownedScene.get();
     }
     else
     {
         // No viewport context specified, use default scene
-        m_scene = AZ::RPI::RPISystemInterface::Get()->GetDefaultScene();
+        m_scene = bootstrapScene;
     }
 
     // Create a dynamic draw context for UI Canvas drawing for the scene
-    m_dynamicDraw = CreateDynamicDrawContext(m_scene, uiShader);
+    m_dynamicDraw = CreateDynamicDrawContext(uiShader);
 
     if (m_dynamicDraw)
     {
@@ -93,6 +94,7 @@ AZ::RPI::ScenePtr UiRenderer::CreateScene(AZStd::shared_ptr<AZ::RPI::ViewportCon
 {
     // Create a scene with the necessary feature processors
     AZ::RPI::SceneDescriptor sceneDesc;
+    sceneDesc.m_nameId = AZ::Name("UiRenderer");
     AZ::RPI::ScenePtr atomScene = AZ::RPI::Scene::CreateScene(sceneDesc);
     atomScene->EnableAllFeatureProcessors(); // LYSHINE_ATOM_TODO - have a UI pipeline and enable only needed fps
 
@@ -116,7 +118,6 @@ AZ::RPI::ScenePtr UiRenderer::CreateScene(AZStd::shared_ptr<AZ::RPI::ViewportCon
 }
 
 AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> UiRenderer::CreateDynamicDrawContext(
-    AZ::RPI::ScenePtr scene,
     AZ::Data::Instance<AZ::RPI::Shader> uiShader)
 {
     // Find the pass that renders the UI canvases after the rtt passes
@@ -144,7 +145,7 @@ AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> UiRenderer::CreateDynamicDrawContext(
     else
     {
         // Render target support is disabled
-        dynamicDraw->SetOutputScope(m_scene.get());
+        dynamicDraw->SetOutputScope(m_scene);
     }
     dynamicDraw->EndInit();
 

--- a/Gems/LyShine/Code/Source/UiRenderer.h
+++ b/Gems/LyShine/Code/Source/UiRenderer.h
@@ -152,7 +152,6 @@ private: // member functions
 
     //! Create a dynamic draw context for this renderer
     AZ::RHI::Ptr<AZ::RPI::DynamicDrawContext> CreateDynamicDrawContext(
-        AZ::RPI::ScenePtr scene,
         AZ::Data::Instance<AZ::RPI::Shader> uiShader);
 
     //! Bind the global white texture for all the texture units we use
@@ -175,7 +174,8 @@ protected: // attributes
     // Set by user when viewport context is not the main/default viewport
     AZStd::shared_ptr<AZ::RPI::ViewportContext> m_viewportContext;
 
-    AZ::RPI::ScenePtr m_scene;
+    AZ::RPI::ScenePtr m_ownedScene;
+    AZ::RPI::Scene* m_scene = nullptr;
 
 #ifndef _RELEASE
     int m_debugTextureDataRecordLevel = 0;


### PR DESCRIPTION
…… (#5153)

* ATOM-16747 RPISystemInterface::GetDefaultScene returns the scene created by PreviewRenderer but not the Main Scene
Deprecate GetDefaultScene() function.
Update all the places which use GetDefaultScene to use Scene::GetFeatureProcessorFromEntityId or GetMainScene.
Tested with Editor, UI Editor, Material Editor, game launcher.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>
(cherry picked from commit 8da6bea0733aa43c19937fc8ba46d5ab3e514968)