### PR TITLE
Initial template for API Deprecation issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/API Deprecation.md
+++ b/.github/ISSUE_TEMPLATE/API Deprecation.md
@@ -1,0 +1,19 @@
+---
+name: API Deprecation
+about: Create an issue to track an API deprecation
+title: 'API Deprecation - API(s) to deprecate'
+labels: 'needs-sig,kind/deprecation'
+
+---
+
+## Description
+
+A description of the code that is being removed and what change or alternative is being introduced.
+  
+(This information will most likely be used as part of the release notes).
+
+## Status
+
+- [ ] Deprecation notice - <PR for deprecation notice, next release>
+- [ ] Deprecation warning - <PR for deprecation warning, next release + 1>
+- [ ] Remove deprecated code - <PR for code removal, next release + 2>


### PR DESCRIPTION
This is a first pass attempt at creating a deprecation issue template to help track future API deprecations.

Please see this PR in sig-release for more context - https://github.com/o3de/sig-release/pull/23.

Note: We need a new label (`kind/deprecation`) and potentially another set of labels to track the 'stage' of deprecation. A change will be deprecated over several releases (initial notification, warning and removal) and we need an effective way to track this and 'signal' to an engineer when it's 'safe' to move a deprecation to the next stage.

For example, imagine in mid-October a piece of code began being deprecated and was merged to development. After the stabilization branch is cut, it's then actually safe for the engineer to submit the next PR to development, issuing the deprecation warning. Sometime later when the _next_ stabilization/release branch is cut, it will then be okay to perform the next deprecation step (delete the code). As a lot of time can pass between these events, we need an effective way to track and notify the teams and not let deprecated code hang around forever (which has happened a lot in the past, unfortunately...). I'm sure sig-release can decide on specifics (perhaps more labels or using the task list in queries?). I'm very much open to suggestions, we ideally would like to keep the process as lightweight as possible to incentivise deprecations that make sense.