### PR TITLE
Improvements to feedback for default camera orbit point (when no entity is selected)

### DIFF
--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -348,7 +348,12 @@ namespace SandboxEditor
 
     void EditorModularViewportCameraComposer::OnTick(const float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        const float delta = deltaTime / ed_cameraDefaultOrbitFadeDuration;
+        const float delta = [duration = &ed_cameraDefaultOrbitFadeDuration, deltaTime] {
+            if (*duration == 0.0f) {
+                return 1.0f;
+            }
+            return deltaTime / *duration;
+        }();
 
         if (m_defaultOrbiting)
         {

--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -37,7 +37,7 @@ AZ_CVAR(
     0.5f,
     nullptr,
     AZ::ConsoleFunctorFlags::Null,
-    "Sets whether to draw the default orbit point as orthographic or not");
+    "Sets how long the default orbit point should take to appear and disappear");
 
 namespace SandboxEditor
 {
@@ -346,7 +346,6 @@ namespace SandboxEditor
         }
     }
 
-    //! AZ::TickBus overrides ...
     void EditorModularViewportCameraComposer::OnTick(const float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
         const float delta = deltaTime / ed_cameraDefaultOrbitFadeDuration;

--- a/Code/Editor/EditorModularViewportCameraComposer.h
+++ b/Code/Editor/EditorModularViewportCameraComposer.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <AtomToolsFramework/Viewport/ModularViewportCameraController.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Viewport/CameraInput.h>
 #include <AzToolsFramework/API/EditorCameraBus.h>
 #include <EditorModularViewportCameraComposerBus.h>
@@ -20,6 +22,8 @@ namespace SandboxEditor
     class EditorModularViewportCameraComposer
         : private EditorModularViewportCameraComposerNotificationBus::Handler
         , private Camera::EditorCameraNotificationBus::Handler
+        , private AzFramework::ViewportDebugDisplayEventBus::Handler
+        , private AZ::TickBus::Handler
     {
     public:
         SANDBOX_API explicit EditorModularViewportCameraComposer(AzFramework::ViewportId viewportId);
@@ -29,6 +33,12 @@ namespace SandboxEditor
         SANDBOX_API AZStd::shared_ptr<AtomToolsFramework::ModularViewportCameraController> CreateModularViewportCameraController();
 
     private:
+        // AzFramework::ViewportDebugDisplayEventBus overrides ...
+        void DisplayViewport(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
+
+        //! AZ::TickBus overrides ...
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
         //! Setup all internal camera inputs.
         void SetupCameras();
 
@@ -52,5 +62,9 @@ namespace SandboxEditor
         AZStd::shared_ptr<AzFramework::FocusCameraInput> m_orbitFocusCamera;
 
         AzFramework::ViewportId m_viewportId;
+
+        float m_defaultOrbitOpacity = 0.0f; //!< The default orbit axes opacity (to fade in and out).
+        AZ::Vector3 m_defaultOrbitPoint = AZ::Vector3::CreateZero(); //!< The default orbit point.
+        bool m_defaultOrbiting = false; //!< Is the camera default orbiting (orbiting when there's no selected entity).
     };
 } // namespace SandboxEditor

--- a/Code/Editor/EditorModularViewportCameraComposer.h
+++ b/Code/Editor/EditorModularViewportCameraComposer.h
@@ -36,7 +36,7 @@ namespace SandboxEditor
         // AzFramework::ViewportDebugDisplayEventBus overrides ...
         void DisplayViewport(const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
 
-        //! AZ::TickBus overrides ...
+        // AZ::TickBus overrides ...
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
         //! Setup all internal camera inputs.
@@ -64,7 +64,7 @@ namespace SandboxEditor
         AzFramework::ViewportId m_viewportId;
 
         float m_defaultOrbitOpacity = 0.0f; //!< The default orbit axes opacity (to fade in and out).
-        AZ::Vector3 m_defaultOrbitPoint = AZ::Vector3::CreateZero(); //!< The default orbit point.
+        AZ::Vector3 m_defaultOrbitPoint = AZ::Vector3::CreateZero(); //!< The orbit point to use when no entity is selected.
         bool m_defaultOrbiting = false; //!< Is the camera default orbiting (orbiting when there's no selected entity).
     };
 } // namespace SandboxEditor


### PR DESCRIPTION
This is a follow-up PR to https://github.com/o3de/o3de/pull/5301 to improve the feedback for the default orbit point.