### PR TITLE
Add missing runtime dependency to atom ly integration

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/CMakeLists.txt
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/CMakeLists.txt
@@ -111,6 +111,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         RUNTIME_DEPENDENCIES
             Gem::Atom_RPI.Editor
             Gem::Atom_Feature_Common.Editor
+            Gem::AtomToolsFramework.Editor
             Legacy::EditorCommon
     )
 


### PR DESCRIPTION
Signed-off-by: Guthrie Adams <guthadam@amazon.com>