### PR TITLE
Queuing inspector invalidation to remove stall opening/closing several documents

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorPropertyGroupWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Inspector/InspectorPropertyGroupWidget.cpp
@@ -43,7 +43,7 @@ namespace AtomToolsFramework
         m_propertyEditor->Setup(context, instanceNotificationHandler, false);
         m_propertyEditor->AddInstance(instance, instanceClassId, nullptr, instanceToCompare);
         m_propertyEditor->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
-        m_propertyEditor->InvalidateAll();
+        m_propertyEditor->QueueInvalidation(AzToolsFramework::PropertyModificationRefreshLevel::Refresh_EntireTree);
 
         m_layout->addWidget(m_propertyEditor);
         setLayout(m_layout);


### PR DESCRIPTION
Changed material editor inspector to queue its initial invalidation instead of invalidating immediately. If several documents are opened at the same time they will each destroy properties from the previous document and repopulate with their own, rebuilding the UI between documents, causing a huge delay.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>