### PR TITLE
Don't update status filter when filling gem model

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -90,6 +90,13 @@ namespace O3DE::ProjectManager
         m_projectPath = projectPath;
         m_gemModel->Clear();
         m_gemsToRegisterWithProject.clear();
+
+        if (m_filterWidget)
+        {
+            // disconnect so we don't update the status filter for every gem we add
+            disconnect(m_gemModel, &GemModel::dataChanged, m_filterWidget, &GemFilterWidget::ResetGemStatusFilter);
+        }
+
         FillModel(projectPath);
 
         m_proxyModel->ResetFilters();


### PR DESCRIPTION
Opening the Update Project screen was taking longer and longer each time because each time it opened we added another data listener which re-created the status filter UI for every gem added.  To fix we just need to disconnect before filling the model.  Fun!

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>