### PR TITLE
Remove temporary debug messages

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetDatabase/AssetDatabase.cpp
@@ -1067,15 +1067,12 @@ namespace AssetProcessor
 
         if (dropAllTables)
         {
-            AZ_TracePrintf("AssetDatabase", "Closing existing db connection\n"); // Temporary debug output to help with tracking down a crash
             // drop all tables by destroying the entire database.
             m_databaseConnection->Close();
 
-            AZ_TracePrintf("AssetDatabase", "Getting db file path\n"); // Temporary debug output to help with tracking down a crash
             AZStd::string dbFilePath = GetAssetDatabaseFilePath();
             if (dbFilePath != ":memory:")
             {
-                AZ_TracePrintf("AssetDatabase", "Deleting existing db %s\n", dbFilePath.c_str()); // Temporary debug output to help with tracking down a crash
                 // you cannot delete a memory database, but it drops all data when you close it anyway.
                 if (!AZ::IO::SystemFile::Delete(dbFilePath.c_str()))
                 {
@@ -1085,7 +1082,7 @@ namespace AssetProcessor
                     return false;
                 }
             }
-            AZ_TracePrintf("AssetDatabase", "Re-opening connection\n"); // Temporary debug output to help with tracking down a crash
+
             if (!m_databaseConnection->Open(dbFilePath, IsReadOnly()))
             {
                 delete m_databaseConnection;

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -243,9 +243,7 @@ void AssetProcessorManagerTest::SetUp()
     ASSERT_TRUE(m_mockApplicationManager->RegisterAssetRecognizerAsBuilder(rec));
     m_mockApplicationManager->BusConnect();
 
-    AZ_Printf("UnitTest", "Allocating APM\n")
     m_assetProcessorManager.reset(new AssetProcessorManager_Test(m_config.get()));
-    AZ_Printf("UnitTest", "APM ready\n");
     m_errorAbsorber->Clear();
 
     m_isIdling = false;
@@ -4468,9 +4466,7 @@ AssetBuilderSDK::AssetBuilderDesc MockBuilderInfoHandler::CreateBuilderDesc(cons
 
 void FingerprintTest::SetUp()
 {
-    AZ_Printf("FingerprintTest", "SetUp start\n");
     AssetProcessorManagerTest::SetUp();
-    AZ_Printf("FingerprintTest", "SetUp self\n");
 
     // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
     m_mockApplicationManager->BusDisconnect();
@@ -4489,23 +4485,18 @@ void FingerprintTest::SetUp()
     });
 
     ASSERT_TRUE(UnitTestUtils::CreateDummyFile(m_absolutePath, ""));
-    AZ_Printf("FingerprintTest", "SetUp end\n");
 }
 
 void FingerprintTest::TearDown()
 {
-    AZ_Printf("FingerprintTest", "TearDown start\n");
     m_jobResults = AZStd::vector<AssetProcessor::JobDetails>{};
     m_mockBuilderInfoHandler = {};
 
-    AZ_Printf("FingerprintTest", "TearDown parent\n");
     AssetProcessorManagerTest::TearDown();
-    AZ_Printf("FingerprintTest", "TearDown end\n");
 }
 
 void FingerprintTest::RunFingerprintTest(QString builderFingerprint, QString jobFingerprint, bool expectedResult)
 {
-    AZ_Printf("FingerprintTest", "Fingerprint Test Start\n");
     m_mockBuilderInfoHandler.m_builderDesc.m_analysisFingerprint = builderFingerprint.toUtf8().data();
     m_mockBuilderInfoHandler.m_jobFingerprint = jobFingerprint;
     QMetaObject::invokeMethod(m_assetProcessorManager.get(), "AssessModifiedFile", Qt::QueuedConnection, Q_ARG(QString, m_absolutePath));
@@ -4514,7 +4505,6 @@ void FingerprintTest::RunFingerprintTest(QString builderFingerprint, QString job
     ASSERT_EQ(m_mockBuilderInfoHandler.m_createJobsCount, 1);
     ASSERT_EQ(m_jobResults.size(), 1);
     ASSERT_EQ(m_jobResults[0].m_autoFail, expectedResult);
-    AZ_Printf("FingerprintTest", "Fingerprint Test End\n");
 }
 
 TEST_F(FingerprintTest, FingerprintChecking_JobFingerprint_NoBuilderFingerprint)

--- a/Code/Tools/AssetProcessor/native/unittests/UnitTestRunner.h
+++ b/Code/Tools/AssetProcessor/native/unittests/UnitTestRunner.h
@@ -156,7 +156,6 @@ namespace UnitTestUtils
 
         bool OnPreWarning([[maybe_unused]] const char* window, [[maybe_unused]] const char* fileName, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* message) override
         {
-            UnitTest::ColoredPrintf(UnitTest::COLOR_YELLOW, message);
             ++m_numWarningsAbsorbed;
             if (m_debugMessages)
             {
@@ -167,7 +166,9 @@ namespace UnitTestUtils
 
         bool OnPreAssert([[maybe_unused]] const char* fileName, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* message) override
         {
-            UnitTest::ColoredPrintf(UnitTest::COLOR_YELLOW, message);
+            // Print out absorbed asserts since asserts are pretty important and accidentally absorbing unintended ones can lead to difficult-to-detect issues
+            UnitTest::ColoredPrintf(UnitTest::COLOR_YELLOW, "Absorbed Assert: %s\n", message);
+
             ++m_numAssertsAbsorbed;
             if (m_debugMessages)
             {
@@ -178,7 +179,6 @@ namespace UnitTestUtils
 
         bool OnPreError([[maybe_unused]] const char* window, [[maybe_unused]] const char* fileName, [[maybe_unused]] int line, [[maybe_unused]] const char* func, [[maybe_unused]] const char* message) override
         {
-            UnitTest::ColoredPrintf(UnitTest::COLOR_YELLOW, message);
             ++m_numErrorsAbsorbed;
             if (m_debugMessages)
             {
@@ -187,9 +187,8 @@ namespace UnitTestUtils
             return true; // I handled this, do not forward it
         }
 
-        bool OnPrintf(const char* /*window*/, const char* message) override
+        bool OnPrintf(const char* /*window*/, const char* /*message*/) override
         {
-            UnitTest::ColoredPrintf(UnitTest::COLOR_YELLOW, message);
             ++m_numMessagesAbsorbed;
             return true;
         }


### PR DESCRIPTION
Leaving in the print for absorbed asserts to avoid running into future situations where important asserts are accidentally absorbed.  Color is yellow since the assert is absorbed so it might not be a certain error.

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>