### PR TITLE
Fix brute force mesh intersection function

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Vector3.h
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.h
@@ -100,7 +100,7 @@ namespace AZ
         void Set(float x, float y, float z);
 
         //! Sets components from an array of 3 floats in xyz order.
-        void Set(float values[]);
+        void Set(const float values[]);
 
         //! Indexed access using operator(), just for convenience.
         float operator()(int32_t index) const;

--- a/Code/Framework/AzCore/AzCore/Math/Vector3.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Vector3.inl
@@ -186,7 +186,7 @@ namespace AZ
     }
 
 
-    AZ_MATH_INLINE void Vector3::Set(float values[])
+    AZ_MATH_INLINE void Vector3::Set(const float values[])
     {
         m_value = Simd::Vec3::LoadImmediate(values[0], values[1], values[2]);
     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -2088,7 +2088,7 @@ namespace AZ
                 AZ::Vector3 vpos;    //note: it seems to be fastest to reuse a local Vector3 rather than constructing new ones each loop iteration
                 for (uint32_t i = 0; i < elementCount; ++i)
                 {
-                    vpos.Set(const_cast<float*>(reinterpret_cast<const float*>(&buffer[i])));
+                    vpos.Set(reinterpret_cast<const float*>(&buffer[i]));
                     aabb.AddPoint(vpos);
                 }
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/ModelAsset.cpp
@@ -222,19 +222,19 @@ namespace AZ
                 // Position is 3 floats
                 if (positionElementSize != sizeof(float) * 3)
                 {
-                    AZ_Warning("ModelAsset", false, "unsupported mesh posiiton format, only full 3 floats per vertex are supported at the moment");
+                    AZ_Warning(
+                        "ModelAsset", false, "unsupported mesh posiiton format, only full 3 floats per vertex are supported at the moment");
                     return false;
                 }
 
                 RHI::BufferViewDescriptor indexBufferViewDesc = indexBufferView.GetBufferViewDescriptor();
                 AZStd::array_view<uint8_t> indexRawBuffer = indexAssetViewPtr->GetBuffer();
 
-                bool anyHit = false;
-
                 const AZ::Vector3 rayEnd = rayStart + rayDir;
                 AZ::Vector3 a, b, c;
                 AZ::Vector3 intersectionNormal;
 
+                bool anyHit = false;
                 float shortestDistanceNormalized = AZStd::numeric_limits<float>::max();
 
                 const AZ::u32* indexPtr = reinterpret_cast<const AZ::u32*>(
@@ -243,8 +243,7 @@ namespace AZ
                     positionRawBuffer.data() + (positionBufferViewDesc.m_elementOffset * positionBufferViewDesc.m_elementSize));
 
                 constexpr int StepSize = 3; // number of values per vertex (x, y, z)
-                for (uint32_t indexIter = 0; indexIter <= indexBufferViewDesc.m_elementCount - StepSize;
-                     indexIter += StepSize, indexPtr += StepSize)
+                for (uint32_t indexIter = 0; indexIter < indexBufferViewDesc.m_elementCount; indexIter += StepSize, indexPtr += StepSize)
                 {
                     AZ::u32 index0 = indexPtr[0];
                     AZ::u32 index1 = indexPtr[1];
@@ -265,7 +264,8 @@ namespace AZ
                     c.Set(cRef);
 
                     float currentDistanceNormalized;
-                    if (AZ::Intersect::IntersectSegmentTriangleCCW(rayStart, rayEnd, a, b, c, intersectionNormal, currentDistanceNormalized))
+                    if (AZ::Intersect::IntersectSegmentTriangleCCW(
+                            rayStart, rayEnd, a, b, c, intersectionNormal, currentDistanceNormalized))
                     {
                         anyHit = true;
 

--- a/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
@@ -1102,7 +1102,7 @@ namespace UnitTest
             Add(lodCreator, positions, positionCount, positionOffset, positionBuffer, indices, indexCount, indexOffset, indexBuffer);
         }
 
-        // complete the asset lot creation process
+        // complete the asset lod creation process
         void End(AZ::RPI::ModelLodAssetCreator& lodCreator)
         {
             AZ::Data::Asset<AZ::RPI::ModelLodAsset> lodAsset;

--- a/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
@@ -1237,7 +1237,7 @@ namespace UnitTest
         constexpr float rayLength = 100.0f;
         EXPECT_THAT(
             m_kdTree->RayIntersection(
-                AZ::Vector3::CreateZero(), AZ::Vector3::CreateAxisZ(-rayLength), t, normal), testing::Eq(true));
+                AZ::Vector3::CreateZero(), AZ::Vector3::CreateAxisZ(-rayLength), t, normal), testing::IsTrue());
         EXPECT_THAT(t, testing::FloatEq(0.005f));
     }
 
@@ -1248,7 +1248,7 @@ namespace UnitTest
 
         constexpr float rayLength = 10.0f;
         EXPECT_THAT(
-            m_kdTree->RayIntersection(AZ::Vector3::CreateAxisZ(0.75f), AZ::Vector3::CreateAxisZ(-rayLength), t, normal), testing::Eq(true));
+            m_kdTree->RayIntersection(AZ::Vector3::CreateAxisZ(0.75f), AZ::Vector3::CreateAxisZ(-rayLength), t, normal), testing::IsTrue());
         EXPECT_THAT(t, testing::FloatEq(0.025f));
     }
 
@@ -1326,7 +1326,7 @@ namespace UnitTest
         EXPECT_THAT(
             m_mesh->GetModel()->LocalRayIntersectionAgainstModel(
                 AZ::Vector3::CreateAxisZ(5.0f), -AZ::Vector3::CreateAxisZ(10.0f), AllowBruteForce, t, normal),
-            testing::Eq(true));
+            testing::IsTrue());
         EXPECT_THAT(t, testing::FloatEq(0.4f));
     }
 
@@ -1340,7 +1340,7 @@ namespace UnitTest
         EXPECT_THAT(
             m_mesh->GetModel()->LocalRayIntersectionAgainstModel(
                 AZ::Vector3::CreateAxisY(10.0f), -AZ::Vector3::CreateAxisY(9.0f), AllowBruteForce, t, normal),
-            testing::Eq(true));
+            testing::IsTrue());
         EXPECT_THAT(t, testing::FloatEq(1.0f));
         EXPECT_THAT(normal, IsClose(AZ::Vector3::CreateAxisY()));
     }
@@ -1407,7 +1407,7 @@ namespace UnitTest
         EXPECT_THAT(
             m_mesh->GetModel()->LocalRayIntersectionAgainstModel(
                 AZ::Vector3(QuadOffsetX, 0.0f, 5.0f), -AZ::Vector3::CreateAxisZ(10.0f), AllowBruteForce, t, normal),
-            testing::Eq(true));
+            testing::IsTrue());
         EXPECT_THAT(t, testing::FloatEq(0.5f));
         EXPECT_THAT(normal, IsClose(AZ::Vector3::CreateAxisZ()));
     }

--- a/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp
@@ -38,7 +38,7 @@ namespace UnitTest
         bufferData.resize(bufferSize);
 
         //The actual data doesn't matter
-        const uint8_t bufferDataSize = static_cast<uint8_t>(bufferData.size());
+        const uint8_t bufferDataSize = aznumeric_cast<uint8_t>(bufferData.size());
         for (uint8_t i = 0; i < bufferDataSize; ++i)
         {
             bufferData[i] = i;
@@ -1044,50 +1044,65 @@ namespace UnitTest
         {
             AZ::RPI::ModelLodAssetCreator lodCreator;
             Begin(lodCreator);
-            Add(lodCreator, positions, positionCount, indices, indicesCount);
+            Add(lodCreator, positions, positionCount, /*positionOffset=*/0, indices, indicesCount, /*indexOffset=*/0);
             End(lodCreator);
         }
 
+        // initiate the asset lod creation process (note: End must be called after meshes have been added).
         void Begin(AZ::RPI::ModelLodAssetCreator& lodCreator)
         {
             lodCreator.Begin(AZ::Data::AssetId(AZ::Uuid::CreateRandom()));
         }
 
+        // add a sub mesh and reuse existing position/index buffer (be very careful with the offsets used)
         void Add(
             AZ::RPI::ModelLodAssetCreator& lodCreator,
             const float* positions,
             size_t positionCount,
+            size_t positionOffset,
+            AZ::Data::Asset<AZ::RPI::BufferAsset> positionBuffer,
             const uint32_t* indices,
-            size_t indicesCount)
+            size_t indexCount,
+            size_t indexOffset,
+            AZ::Data::Asset<AZ::RPI::BufferAsset> indexBuffer)
         {
             lodCreator.BeginMesh();
             lodCreator.SetMeshAabb(AZ::Aabb::CreateFromMinMax({ -1.0f, -1.0f, -0.5f }, { 1.0f, 1.0f, 0.5f }));
             lodCreator.SetMeshMaterialSlot(AZ::Sfmt::GetInstance().Rand32());
 
-            {
-                AZ::Data::Asset<AZ::RPI::BufferAsset> indexBuffer = BuildTestBuffer(static_cast<uint32_t>(indicesCount), sizeof(uint32_t));
-                AZStd::copy(
-                    indices, indices + indicesCount, reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(indexBuffer->GetBuffer().data())));
-                lodCreator.SetMeshIndexBuffer(
-                    { indexBuffer,
-                      AZ::RHI::BufferViewDescriptor::CreateStructured(0, static_cast<uint32_t>(indicesCount), sizeof(uint32_t)) });
-            }
-
-            {
-                AZ::Data::Asset<AZ::RPI::BufferAsset> positionBuffer =
-                    BuildTestBuffer(static_cast<uint32_t>(positionCount / 3), sizeof(float) * 3);
-                AZStd::copy(
-                    positions, positions + positionCount,
-                    reinterpret_cast<float*>(const_cast<uint8_t*>(positionBuffer->GetBuffer().data())));
-                lodCreator.AddMeshStreamBuffer(
-                    AZ::RHI::ShaderSemantic(AZ::Name("POSITION")), AZ::Name(),
-                    { positionBuffer,
-                      AZ::RHI::BufferViewDescriptor::CreateStructured(0, static_cast<uint32_t>(positionCount / 3), sizeof(float) * 3) });
-            }
+            AZStd::copy(indices, indices + indexCount, reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(indexBuffer->GetBuffer().data())));
+            lodCreator.SetMeshIndexBuffer({ indexBuffer,
+                                            AZ::RHI::BufferViewDescriptor::CreateStructured(
+                                                aznumeric_cast<uint32_t>(indexOffset), aznumeric_cast<uint32_t>(indexCount), sizeof(uint32_t)) });
+            AZStd::copy(
+                positions, positions + positionCount, reinterpret_cast<float*>(const_cast<uint8_t*>(positionBuffer->GetBuffer().data())));
+            lodCreator.AddMeshStreamBuffer(
+                AZ::RHI::ShaderSemantic(AZ::Name("POSITION")), AZ::Name(),
+                { positionBuffer,
+                  AZ::RHI::BufferViewDescriptor::CreateStructured(
+                      aznumeric_cast<uint32_t>(positionOffset), aznumeric_cast<uint32_t>(positionCount / 3), sizeof(float) * 3) });
 
             lodCreator.EndMesh();
         }
 
+        // overload of Add - here a new index/position buffer is created for the new data instead of potentially reusing an existing buffer
+        void Add(
+            AZ::RPI::ModelLodAssetCreator& lodCreator,
+            const float* positions,
+            size_t positionCount,
+            size_t positionOffset,
+            const uint32_t* indices,
+            size_t indexCount,
+            size_t indexOffset)
+        {
+            AZ::Data::Asset<AZ::RPI::BufferAsset> indexBuffer = BuildTestBuffer(aznumeric_cast<uint32_t>(indexCount), sizeof(uint32_t));
+            AZ::Data::Asset<AZ::RPI::BufferAsset> positionBuffer =
+                BuildTestBuffer(aznumeric_cast<uint32_t>(positionCount / 3), sizeof(float) * 3);
+
+            Add(lodCreator, positions, positionCount, positionOffset, positionBuffer, indices, indexCount, indexOffset, indexBuffer);
+        }
+
+        // complete the asset lot creation process
         void End(AZ::RPI::ModelLodAssetCreator& lodCreator)
         {
             AZ::Data::Asset<AZ::RPI::ModelLodAsset> lodAsset;
@@ -1330,9 +1345,13 @@ namespace UnitTest
         EXPECT_THAT(normal, IsClose(AZ::Vector3::CreateAxisY()));
     }
 
+    // test to verify that each secondary sub meshes are still intersected with correctly when using brute-force
+    // ray intersection
     class BruteForceMultiModelIntersectsFixture : public ModelTests
     {
     public:
+        inline static const float QuadOffsetX = 15.0f;
+
         void SetUp() override
         {
             ModelTests::SetUp();
@@ -1341,74 +1360,30 @@ namespace UnitTest
             AZ::RPI::ModelLodAssetCreator lodCreator;
             m_mesh->Begin(lodCreator);
 
-            
-
+            // take default quad positions and offset in X by set amount
             AZStd::vector<float> offsetQuadPositions;
             offsetQuadPositions.resize(QuadPositions.size());
             AZStd::copy(QuadPositions.begin(), QuadPositions.end(), offsetQuadPositions.begin());
             for (size_t xVertIndex = 0; xVertIndex < offsetQuadPositions.size(); xVertIndex += 3)
             {
-                offsetQuadPositions[xVertIndex] += 15.0f;
+                offsetQuadPositions[xVertIndex] += QuadOffsetX;
             }
 
+            // create shared buffer to store cube and quad mesh in the same buffer
             const size_t indicesCount = QuadIndices.size() + CubeIndices.size();
-            AZ::Data::Asset<AZ::RPI::BufferAsset> indexBuffer = BuildTestBuffer(static_cast<uint32_t>(indicesCount), sizeof(uint32_t));
-
             const size_t positionCount = QuadPositions.size() + CubePositions.size();
+            AZ::Data::Asset<AZ::RPI::BufferAsset> indexBuffer = BuildTestBuffer(aznumeric_cast<uint32_t>(indicesCount), sizeof(uint32_t));
             AZ::Data::Asset<AZ::RPI::BufferAsset> positionBuffer =
-                BuildTestBuffer(static_cast<uint32_t>(positionCount / 3), sizeof(float) * 3);
+                BuildTestBuffer(aznumeric_cast<uint32_t>(positionCount / 3), sizeof(float) * 3);
 
-            lodCreator.BeginMesh();
-            lodCreator.SetMeshAabb(AZ::Aabb::CreateFromMinMax({ -1.0f, -1.0f, -0.5f }, { 1.0f, 1.0f, 0.5f }));
-            lodCreator.SetMeshMaterialSlot(AZ::Sfmt::GetInstance().Rand32());
-
-            {
-                AZStd::copy(
-                    CubeIndices.begin(), CubeIndices.end(),
-                    reinterpret_cast<uint32_t*>(const_cast<uint8_t*>(indexBuffer->GetBuffer().data())));
-                lodCreator.SetMeshIndexBuffer(
-                    { indexBuffer,
-                      AZ::RHI::BufferViewDescriptor::CreateStructured(0, static_cast<uint32_t>(CubeIndices.size()), sizeof(uint32_t)) });
-            }
-
-            {
-                AZStd::copy(
-                    CubePositions.begin(), CubePositions.end(),
-                    reinterpret_cast<float*>(const_cast<uint8_t*>(positionBuffer->GetBuffer().data())));
-                lodCreator.AddMeshStreamBuffer(
-                    AZ::RHI::ShaderSemantic(AZ::Name("POSITION")), AZ::Name(),
-                    { positionBuffer,
-                      AZ::RHI::BufferViewDescriptor::CreateStructured(
-                          0, static_cast<uint32_t>(CubePositions.size() / 3), sizeof(float) * 3) });
-            }
-
-            lodCreator.EndMesh();
-
-            lodCreator.BeginMesh();
-            lodCreator.SetMeshAabb(AZ::Aabb::CreateFromMinMax({ -1.0f, -1.0f, -0.5f }, { 1.0f, 1.0f, 0.5f }));
-            lodCreator.SetMeshMaterialSlot(AZ::Sfmt::GetInstance().Rand32());
-
-            AZStd::copy(
-                QuadIndices.begin(), QuadIndices.end(),
-                reinterpret_cast<uint32_t*>(
-                    const_cast<uint8_t*>(indexBuffer->GetBuffer().data() + (CubeIndices.size() * sizeof(uint32_t)))));
-            lodCreator.SetMeshIndexBuffer({ indexBuffer,
-                                            AZ::RHI::BufferViewDescriptor::CreateStructured(
-                                                static_cast<uint32_t>(CubeIndices.size()),
-                                                static_cast<uint32_t>(QuadIndices.size()), sizeof(uint32_t)) });
-
-            AZStd::copy(
-                offsetQuadPositions.begin(), offsetQuadPositions.end(),
-                reinterpret_cast<float*>(
-                    const_cast<uint8_t*>(positionBuffer->GetBuffer().data() + (CubePositions.size() * sizeof(float)))));
-            lodCreator.AddMeshStreamBuffer(
-                AZ::RHI::ShaderSemantic(AZ::Name("POSITION")), AZ::Name(),
-                { positionBuffer,
-                  AZ::RHI::BufferViewDescriptor::CreateStructured(
-                      static_cast<uint32_t>(CubePositions.size() / 3), static_cast<uint32_t>(offsetQuadPositions.size() / 3),
-                      sizeof(float) * 3) });
-
-            lodCreator.EndMesh();
+            // add the cube mesh
+            m_mesh->Add(
+                lodCreator, CubePositions.data(), CubePositions.size(), 0, positionBuffer, CubeIndices.data(), CubeIndices.size(), 0,
+                indexBuffer);
+            // add the quad mesh (offset by the cube position and index data into the same buffer)
+            m_mesh->Add(
+                lodCreator, offsetQuadPositions.data(), offsetQuadPositions.size(), /*offset=*/CubePositions.size() / 3, positionBuffer,
+                QuadIndices.data(), QuadIndices.size(), /*offset=*/CubeIndices.size(), indexBuffer);
 
             m_mesh->End(lodCreator);
         }
@@ -1422,16 +1397,18 @@ namespace UnitTest
         AZStd::unique_ptr<TestMesh> m_mesh;
     };
 
-    TEST_F(BruteForceMultiModelIntersectsFixture, IntersectWithSecondMesh)
+    TEST_F(BruteForceMultiModelIntersectsFixture, RayIntersectsWithSecondMesh)
     {
         float t = 0.0f;
         AZ::Vector3 normal = AZ::Vector3::CreateOne(); // invalid starting normal
 
+        // fire a ray at the second sub mesh and ensure a successful hit is returned
         constexpr bool AllowBruteForce = false;
         EXPECT_THAT(
             m_mesh->GetModel()->LocalRayIntersectionAgainstModel(
-                AZ::Vector3(15.0f, 0.0f, 5.0f), -AZ::Vector3::CreateAxisZ(10.0f), AllowBruteForce, t, normal),
+                AZ::Vector3(QuadOffsetX, 0.0f, 5.0f), -AZ::Vector3::CreateAxisZ(10.0f), AllowBruteForce, t, normal),
             testing::Eq(true));
         EXPECT_THAT(t, testing::FloatEq(0.5f));
+        EXPECT_THAT(normal, IsClose(AZ::Vector3::CreateAxisZ()));
     }
 } // namespace UnitTest


### PR DESCRIPTION
Update: PR now comes with a test and is ready for review. The problem was we were not looking at the right 'view' of the mesh data when there is more than one `ModelLodAsset::Mesh`.

### Before:

https://user-images.githubusercontent.com/82228511/140947276-8d20518a-2975-41e6-948a-fb91883e5987.mp4

### After:

https://user-images.githubusercontent.com/82228511/140948367-a0bec721-6c15-432e-989c-38f36c3414cd.mp4

## Example Mesh

### Part 1

![image](https://user-images.githubusercontent.com/82228511/140948646-21715a5d-c952-4a84-bf4a-f82829027f29.png)

### Part 2

![image](https://user-images.githubusercontent.com/82228511/140948721-13b9aa62-d678-4e9e-9d08-df8f347a1bb9.png)

## Update: Tests!

I've added a test that reproduces the old issue, see the below output with my changes reverted

```bash
[----------] 1 test from BruteForceMultiModelIntersectsFixture
[ RUN      ] BruteForceMultiModelIntersectsFixture.IntersectWithSecondMesh
D:/o3de-2/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp(1437): error: Value of: m_mesh->GetModel()->LocalRayIntersectionAgainstModel( AZ::Vector3(15.0f, 0.0f, 5.0f), -AZ::Vector3::CreateAxisZ(10.0f), AllowBruteForce, t, normal)
Expected: is equal to true
  Actual: false (of type bool)
D:/o3de-2/Gems/Atom/RPI/Code/Tests/Model/ModelTests.cpp(1438): error: Value of: t
Expected: is approximately 0.5
  Actual: 0 (of type float)
[  FAILED  ] BruteForceMultiModelIntersectsFixture.IntersectWithSecondMesh (74 ms)
[----------] 1 test from BruteForceMultiModelIntersectsFixture (74 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (75 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] BruteForceMultiModelIntersectsFixture.IntersectWithSecondMesh
```

and with the change reintroduced:

```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from BruteForceMultiModelIntersectsFixture
[ RUN      ] BruteForceMultiModelIntersectsFixture.IntersectWithSecondMesh
[       OK ] BruteForceMultiModelIntersectsFixture.IntersectWithSecondMesh (70 ms)
[----------] 1 test from BruteForceMultiModelIntersectsFixture (72 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (72 ms total)
[  PASSED  ] 1 test.
```

## Update 2:

Additional test to catch pointer offset mistake

```
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from BruteForceMultiModelIntersectsFixture
[ RUN      ] BruteForceMultiModelIntersectsFixture.RayIntersectsWithFirstSubMesh
[       OK ] BruteForceMultiModelIntersectsFixture.RayIntersectsWithFirstSubMesh (73 ms)
[ RUN      ] BruteForceMultiModelIntersectsFixture.RayIntersectsWithSecondSubMesh
[       OK ] BruteForceMultiModelIntersectsFixture.RayIntersectsWithSecondSubMesh (56 ms)
[----------] 2 tests from BruteForceMultiModelIntersectsFixture (131 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (132 ms total)
[  PASSED  ] 2 tests.
```