### PR TITLE
Remove timeout in the mount step

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -277,9 +277,7 @@ def HandleDriveMount(String snapshot, String repositoryName, String projectName,
     if(recreateVolume) {
         palSh("${pythonCmd} ${INCREMENTAL_BUILD_SCRIPT_PATH} --action delete --repository_name ${repositoryName} --project ${projectName} --pipeline ${pipeline} --branch ${branchName} --platform ${platform} --build_type ${buildType}", 'Deleting volume', winSlashReplacement=false)
     }
-    timeout(5) {
-        palSh("${pythonCmd} ${INCREMENTAL_BUILD_SCRIPT_PATH} --action mount --snapshot ${snapshot} --repository_name ${repositoryName} --project ${projectName} --pipeline ${pipeline} --branch ${branchName} --platform ${platform} --build_type ${buildType}", 'Mounting volume', winSlashReplacement=false)
-    }
+    palSh("${pythonCmd} ${INCREMENTAL_BUILD_SCRIPT_PATH} --action mount --snapshot ${snapshot} --repository_name ${repositoryName} --project ${projectName} --pipeline ${pipeline} --branch ${branchName} --platform ${platform} --build_type ${buildType}", 'Mounting volume', winSlashReplacement=false)
 
     if(env.IS_UNIX) {
         sh label: 'Setting volume\'s ownership',


### PR DESCRIPTION
Fixes: https://github.com/o3de/o3de/issues/5425 

We no longer need a timeout here. A timeout mechanism was added to the mount script to raise an exeception if the EBS volume is not mounted in the configured timeframe.

This also causes a bug with the retry mechanism where Jenkins will hit this timeout in the event the node goes offline during the setup stage instead of raising an exception.