### PR TITLE
Fix Editor crashes on asset failures

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BlendColorGradingLutsPass.cpp
@@ -46,7 +46,11 @@ namespace AZ
 
         void BlendColorGradingLutsPass::InitializeShaderVariant()
         {
-            AZ_Assert(m_shader != nullptr, "BlendColorGradingLutsPass %s has a null shader when calling InitializeShaderVariant.", GetPathName().GetCStr());
+            if (m_shader == nullptr)
+            {
+                AZ_Assert(false, "BlendColorGradingLutsPass %s has a null shader when calling InitializeShaderVariant.", GetPathName().GetCStr());
+                return;
+            }
 
             // Total variations is MaxBlendLuts plus one for the fallback case that none of the LUTs are found,
             // and hence zero LUTs are blended resulting in an identity LUT.

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -431,7 +431,12 @@ namespace AZ
         {
             // load shader
             shader = RPI::LoadCriticalShader(filePath);
-            AZ_Error("ReflectionProbeFeatureProcessor", shader, "Failed to find asset for shader [%s]", filePath);
+
+            if (shader == nullptr)
+            {
+                AZ_Error("ReflectionProbeFeatureProcessor", false, "Failed to find asset for shader [%s]", filePath);
+                return;
+            }
 
             // store drawlist tag
             drawListTag = shader->GetDrawListTag();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/FullscreenTrianglePass.cpp
@@ -136,6 +136,12 @@ namespace AZ
             RHI::DrawLinear draw = RHI::DrawLinear();
             draw.m_vertexCount = 3;
 
+            if (m_shader == nullptr)
+            {
+                AZ_Error("PassSystem", false, "[FullscreenTrianglePass]: Shader not loaded!");
+                return;
+            }
+
             RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
             // [GFX TODO][ATOM-872] The pass should be able to drive the shader variant

--- a/Registry/Platform/Mac/bootstrap_overrides.setreg
+++ b/Registry/Platform/Mac/bootstrap_overrides.setreg
@@ -1,0 +1,12 @@
+{
+    "Amazon": {
+        "AzCore": {
+            "Bootstrap": {
+                // The first time an application is launched on MacOS, each
+                // dynamic library is inspected by the OS before being loaded.
+                // This can take a while on some Macs.
+                "launch_ap_timeout": 300
+            }
+        }
+    }
+}


### PR DESCRIPTION
Bringing changes from https://github.com/o3de/o3de/pull/5421 to stabilization/2110

1. Add nullptr checks to prevent crashes when non-critical shaders fail to compile.

2. Add a higher "launch_ap_timeout" for Mac because launching a newly built/downloaded AP can take a while.

Signed-off-by: amzn-sj <srikkant@amazon.com>