### PR TITLE
Prevent track editor view's default size to be zero

### DIFF
--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
@@ -284,9 +284,9 @@ BOOL CUiAnimViewDialog::OnInitDialog()
     m_wndCurveEditorDock->setVisible(false);
     m_wndCurveEditorDock->setEnabled(false);
 
-    // In order to prevent the track editor view is collapsed and invisible, and track & curve editors
-    // are using the same view widget in UI animation editor while not in "Both" mode, we make the
-    // minimum size of track editor and curve editor the same.
+    // In order to prevent the track editor view from collapsing and becoming invisible, we use the
+    // minimum size of the curve editor for the track editor as well. Since both editors use the same
+    // view widget in the UI animation editor when not in 'Both' mode, the sizes can be identical.
     m_wndDopeSheet->setMinimumSize(m_wndCurveEditor->minimumSizeHint());
 
     InitSequences();

--- a/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
+++ b/Gems/LyShine/Code/Editor/Animation/UiAnimViewDialog.cpp
@@ -257,6 +257,7 @@ BOOL CUiAnimViewDialog::OnInitDialog()
     m_wndSplitter->addWidget(m_wndDopeSheet);
     m_wndSplitter->setStretchFactor(0, 1);
     m_wndSplitter->setStretchFactor(1, 10);
+    m_wndSplitter->setChildrenCollapsible(false);
     l->addWidget(m_wndSplitter);
     w->setLayout(l);
     setCentralWidget(w);
@@ -282,6 +283,11 @@ BOOL CUiAnimViewDialog::OnInitDialog()
     // Close/hide by default to avoid the pane to show up as a standalone, white window when not displayed in a layout.
     m_wndCurveEditorDock->setVisible(false);
     m_wndCurveEditorDock->setEnabled(false);
+
+    // In order to prevent the track editor view is collapsed and invisible, and track & curve editors
+    // are using the same view widget in UI animation editor while not in "Both" mode, we make the
+    // minimum size of track editor and curve editor the same.
+    m_wndDopeSheet->setMinimumSize(m_wndCurveEditor->minimumSizeHint());
 
     InitSequences();
 


### PR DESCRIPTION
This is a fix for issue https://github.com/o3de/o3de/issues/2709.

Users couldn't find track editor view in UI animation editor due to for somehow the default size of the view is set to zero. The view could also be collapsed by users clicking on the vertical separator line and dragging to the right to resize the view to be zero, causing users to think the track editor is missing or broken.

In order to prevent the track editor view is collapsed and invisible, we make the minimum size of track editor and curve editor the same since both track and curve editors are using the same view widget in UI animation editor while not in "Both" mode.

Verified in UI animation editor that this fix works even set the size of the view be zero by manually modifying value from the Windows registry(`HKEY_CURRENT_USER/Software/O3DE/O3DE/UiAnimView`'s splitter).

Signed-off-by: chiyteng <chiyteng@amazon.com>