### PR TITLE
Temporarily disable the platform filter

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemFilterWidget.cpp
@@ -221,7 +221,6 @@ namespace O3DE::ProjectManager
         ResetGemStatusFilter();
         ResetGemOriginFilter();
         ResetTypeFilter();
-        ResetPlatformFilter();
         ResetFeatureFilter();
     }
 


### PR DESCRIPTION
We can re-enable this in the commit that adds the platform meta data
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>