### PR TITLE
Ensure QtForPython is a proper dependency for the PythonToolGem.

### DIFF
--- a/Templates/PythonToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/Code/CMakeLists.txt
@@ -53,6 +53,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 Gem::${Name}.Editor.Static
+        RUNTIME_DEPENDENCIES
+            Gem::QtForPython.Editor
     )
 
     # By default, we will specify that the above target ${Name} would be used by

--- a/Templates/PythonToolGem/Template/gem.json
+++ b/Templates/PythonToolGem/Template/gem.json
@@ -13,5 +13,8 @@
         "${Name}"
     ],
     "icon_path": "preview.png",
-    "requirements": ""
+    "requirements": "",
+    "dependencies": [
+        "QtForPython"
+    ]
 }


### PR DESCRIPTION
The `PythonToolGem` gemplate needs to have the `QtForPython` gem as a proper dependency, otherwise the user would need to separately/explicitly enable the `QtForPython` gem in their project in order to make use of `PySide2` and all of our helper methods.

1. Adding it to the `dependencies` in the `gem.json` makes sure that the `QtForPython` gem will be enabled as a dependency (if not already enabled in the project) when the user enables the gem that was created from the gemplate.
2. Having it listed in the `RUNTIME_DEPENDENCIES` of the `.Editor` module will make sure it gets registered properly in the `<build-dir>/bin/$<CONFIG>/Registry/cmake_dependencies.<project-name>.editor.setreg`, which in turn will make sure the `EditorPythonBindings` will be able to bootstrap it.

Thanks to @lumberyard-employee-dm for this

 

Signed-off-by: Chris Galvan <chgalvan@amazon.com>