### PR TITLE
[LYN-8102] Failed to open asset catalog file

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/bundler_batch_setup_fixture.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/bundler_batch_setup_fixture.py
@@ -158,7 +158,7 @@ def bundler_batch_setup_fixture(request, workspace, asset_processor, timeout) ->
                 else:
                     cmd.append(f"--{key}")
             if append_defaults:
-                cmd.append(f"--project-path={workspace.project}")
+                cmd.append(f"--project-path={os.path.join(workspace.paths.engine_root(), workspace.project)}")
             return cmd
 
         # ******


### PR DESCRIPTION
Updated to use absolute project path since paths are now relative to the working directory