### PR TITLE
Fix track view bug where postfxs do not render correctly.

### DIFF
--- a/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
+++ b/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
@@ -49,13 +49,18 @@ namespace TrackView
         m_view = AZ::RPI::View::CreateView(viewName, AZ::RPI::View::UsageCamera);
         m_renderPipeline->SetDefaultView(m_view);
         m_targetView = scene.GetDefaultRenderPipeline()->GetDefaultView();
+        if (AZ::Render::PostProcessFeatureProcessor* fp = scene.GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
+        {
+            // This will be set again to mimic the active camera in UpdateView
+            fp->SetViewAlias(m_view, m_targetView);
+        }
     }
 
     void AtomOutputFrameCapture::DestroyPipeline(AZ::RPI::Scene& scene)
     {
-        AZ::Render::PostProcessFeatureProcessor* fp = scene.GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>();
-        if (fp)
+        if (AZ::Render::PostProcessFeatureProcessor* fp = scene.GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
         {
+            // Remove view alias introduced in CreatePipeline and UpdateView
             fp->RemoveViewAlias(m_view);
         }
         scene.RemoveRenderPipeline(m_renderPipeline->GetId());
@@ -69,11 +74,9 @@ namespace TrackView
     {
         if (targetView && targetView != m_targetView)
         {
-            AZ::RPI::Scene* scene = SceneFromGameEntityContext();
-            if (scene)
+            if (AZ::RPI::Scene* scene = SceneFromGameEntityContext())
             {
-                AZ::Render::PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor <AZ::Render::PostProcessFeatureProcessor>();
-                if (fp)
+                if (AZ::Render::PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>())
                 {
                     fp->SetViewAlias(m_view, targetView);
                     m_targetView = targetView;

--- a/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
+++ b/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
@@ -13,6 +13,7 @@
 #include <Atom/RPI.Public/Scene.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Reflect/System/RenderPipelineDescriptor.h>
+#include <PostProcess/PostProcessFeatureProcessor.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/MatrixUtils.h>
 #include <AzCore/Name/Name.h>
@@ -47,18 +48,39 @@ namespace TrackView
         AZ::Name viewName = AZ::Name("MainCamera");
         m_view = AZ::RPI::View::CreateView(viewName, AZ::RPI::View::UsageCamera);
         m_renderPipeline->SetDefaultView(m_view);
+        m_targetView = scene.GetDefaultRenderPipeline()->GetDefaultView();
     }
 
     void AtomOutputFrameCapture::DestroyPipeline(AZ::RPI::Scene& scene)
     {
+        AZ::Render::PostProcessFeatureProcessor* fp = scene.GetFeatureProcessor<AZ::Render::PostProcessFeatureProcessor>();
+        if (fp)
+        {
+            fp->RemoveViewAlias(m_view);
+        }
         scene.RemoveRenderPipeline(m_renderPipeline->GetId());
         m_passHierarchy.clear();
         m_renderPipeline.reset();
         m_view.reset();
+        m_targetView.reset();
     }
 
-    void AtomOutputFrameCapture::UpdateView(const AZ::Matrix3x4& cameraTransform, const AZ::Matrix4x4& cameraProjection)
+    void AtomOutputFrameCapture::UpdateView(const AZ::Matrix3x4& cameraTransform, const AZ::Matrix4x4& cameraProjection, const AZ::RPI::ViewPtr targetView)
     {
+        if (targetView && targetView != m_targetView)
+        {
+            AZ::RPI::Scene* scene = SceneFromGameEntityContext();
+            if (scene)
+            {
+                AZ::Render::PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor <AZ::Render::PostProcessFeatureProcessor>();
+                if (fp)
+                {
+                    fp->SetViewAlias(m_view, targetView);
+                    m_targetView = targetView;
+                }
+            }
+        }
+
         m_view->SetCameraTransform(cameraTransform);
         m_view->SetViewToClipMatrix(cameraProjection);
     }

--- a/Code/Editor/TrackView/AtomOutputFrameCapture.h
+++ b/Code/Editor/TrackView/AtomOutputFrameCapture.h
@@ -39,11 +39,12 @@ namespace TrackView
             CaptureFinishedCallback captureFinishedCallback);
 
         //! Update the internal view that is associated with the created pipeline.
-        void UpdateView(const AZ::Matrix3x4& cameraTransform, const AZ::Matrix4x4& cameraProjection);
+        void UpdateView(const AZ::Matrix3x4& cameraTransform, const AZ::Matrix4x4& cameraProjection, const AZ::RPI::ViewPtr targetView = nullptr);
 
     private:
         AZ::RPI::RenderPipelinePtr m_renderPipeline; //!< The internal render pipeline.
         AZ::RPI::ViewPtr m_view; //!< The view associated with the render pipeline.
+        AZ::RPI::ViewPtr m_targetView; //!< The view that this render pipeline will mimic.
         AZStd::vector<AZStd::string> m_passHierarchy; //!< Pass hierarchy (includes pipelineName and CopyToSwapChain).
         CaptureFinishedCallback m_captureFinishedCallback; //!< Stored callback called from OnCaptureFinished.
 

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -94,10 +94,9 @@ static void UpdateAtomOutputFrameCaptureView(TrackView::AtomOutputFrameCapture& 
     const AZ::EntityId activeCameraEntityId = TrackView::ActiveCameraEntityId();
     AZ::RPI::ViewPtr view = nullptr;
     AZ::RPI::ViewProviderBus::EventResult(view, activeCameraEntityId, &AZ::RPI::ViewProvider::GetView);
-    AZ_Assert(view, "Cannot retrieve a view associated to a camera entity.");
     atomOutputFrameCapture.UpdateView(
         TrackView::TransformFromEntityId(activeCameraEntityId),
-        TrackView::ProjectionFromCameraEntityId(activeCameraEntityId, static_cast<float>(width), static_cast<float>(height)),
+        TrackView::ProjectionFromCameraEntityId(activeCameraEntityId, aznumeric_cast<float>(width), aznumeric_cast<float>(height)),
         view);
 }
 

--- a/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
+++ b/Code/Editor/TrackView/SequenceBatchRenderDialog.cpp
@@ -16,6 +16,7 @@
 
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzFramework/Windowing/WindowBus.h>
+#include <Atom/RPI.Public/ViewProviderBus.h>
 
 // Qt
 #include <QAction>
@@ -91,9 +92,13 @@ namespace
 static void UpdateAtomOutputFrameCaptureView(TrackView::AtomOutputFrameCapture& atomOutputFrameCapture, const int width, const int height)
 {
     const AZ::EntityId activeCameraEntityId = TrackView::ActiveCameraEntityId();
+    AZ::RPI::ViewPtr view = nullptr;
+    AZ::RPI::ViewProviderBus::EventResult(view, activeCameraEntityId, &AZ::RPI::ViewProvider::GetView);
+    AZ_Assert(view, "Cannot retrieve a view associated to a camera entity.");
     atomOutputFrameCapture.UpdateView(
         TrackView::TransformFromEntityId(activeCameraEntityId),
-        TrackView::ProjectionFromCameraEntityId(activeCameraEntityId, static_cast<float>(width), static_cast<float>(height)));
+        TrackView::ProjectionFromCameraEntityId(activeCameraEntityId, static_cast<float>(width), static_cast<float>(height)),
+        view);
 }
 
 CSequenceBatchRenderDialog::CSequenceBatchRenderDialog(float fps, QWidget* pParent /* = nullptr */)

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.cpp
@@ -37,12 +37,27 @@ namespace AZ
             m_currentTime = AZStd::chrono::system_clock::now();
         }
 
+        void PostProcessFeatureProcessor::Deactivate()
+        {
+            m_viewAliasMap.clear();
+        }
+
         void PostProcessFeatureProcessor::UpdateTime()
         {
             AZStd::chrono::system_clock::time_point now = AZStd::chrono::system_clock::now();
             AZStd::chrono::duration<float> deltaTime = now - m_currentTime;
             m_currentTime = now;
             m_deltaTime = deltaTime.count();
+        }
+
+        void PostProcessFeatureProcessor::SetViewAlias(const AZ::RPI::ViewPtr sourceView, const AZ::RPI::ViewPtr targetView)
+        {
+            m_viewAliasMap[sourceView.get()] = targetView.get();
+        }
+
+        void PostProcessFeatureProcessor::RemoveViewAlias(const AZ::RPI::ViewPtr sourceView)
+        {
+            m_viewAliasMap.erase(sourceView.get());
         }
 
         void PostProcessFeatureProcessor::Simulate(const FeatureProcessor::SimulatePacket& packet)
@@ -200,8 +215,12 @@ namespace AZ
 
         AZ::Render::PostProcessSettings* PostProcessFeatureProcessor::GetLevelSettingsFromView(AZ::RPI::ViewPtr view)
         {
+            // check for view aliases first
+            auto viewAliasiterator = m_viewAliasMap.find(view.get());
+            
+            // Use the view alias if it exists
+            auto settingsIterator = m_blendedPerViewSettings.find(viewAliasiterator != m_viewAliasMap.end() ? viewAliasiterator->second : view.get());
             // If no settings for the view is found, the global settings is returned.
-            auto settingsIterator = m_blendedPerViewSettings.find(view.get());
             return settingsIterator != m_blendedPerViewSettings.end()
                 ? &settingsIterator->second
                 : m_globalAggregateLevelSettings.get();

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcess/PostProcessFeatureProcessor.h
@@ -34,6 +34,7 @@ namespace AZ
 
             //! FeatureProcessor overrides...
             void Activate() override;
+            void Deactivate() override;
             void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
 
             //! PostProcessFeatureProcessorInterface...
@@ -42,6 +43,9 @@ namespace AZ
             void RemoveSettingsInterface(EntityId entityId) override;
             void OnPostProcessSettingsChanged() override;
             PostProcessSettings* GetLevelSettingsFromView(AZ::RPI::ViewPtr view);
+
+            void SetViewAlias(const AZ::RPI::ViewPtr sourceView, const AZ::RPI::ViewPtr targetView);
+            void RemoveViewAlias(const AZ::RPI::ViewPtr sourceView);
 
         private:
             PostProcessFeatureProcessor(const PostProcessFeatureProcessor&) = delete;
@@ -83,6 +87,8 @@ namespace AZ
 
             // Each camera/view will have its own PostProcessSettings
             AZStd::unordered_map<AZ::RPI::View*, PostProcessSettings> m_blendedPerViewSettings;
+            // This is used for mimicking a postfx setting of a different view
+            AZStd::unordered_map<AZ::RPI::View*, AZ::RPI::View*> m_viewAliasMap;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EyeAdaptationPass.cpp
@@ -81,7 +81,7 @@ namespace AZ
             if (scene)
             {
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
-                AZ::RPI::ViewPtr view = GetView();
+                AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
                 if (fp)
                 {
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
@@ -110,7 +110,7 @@ namespace AZ
                 PostProcessFeatureProcessor* fp = scene->GetFeatureProcessor<PostProcessFeatureProcessor>();
                 if (fp)
                 {
-                    AZ::RPI::ViewPtr view = GetView();
+                    AZ::RPI::ViewPtr view = GetRenderPipeline()->GetDefaultView();
                     PostProcessSettings* postProcessSettings = fp->GetLevelSettingsFromView(view);
                     if (postProcessSettings)
                     {


### PR DESCRIPTION
## Notes
PostFxs will not render correctly in track mode since the aggregated views that happen during PostFxLayerComponentController:OnTick are only 1). entities with a camera component, 2). editor camera.

Since track view contains its own render pipeline with its own view, the changes in this PR will allow setting up a view alias within the PostProcessFeatureProcessor in order to mimic the postfx settings of other views. This will allow other future widgets as well to perform the same behavior. 

### Highlights
* Add view alias map to post process feature processor class. This will be used to map one view to a different view when GetLevelSettingsFromView() is called by individual postfx feature passes (depth of field pass, eye adaptation pass, etc.)
* Update track view code by setting the view alias within the scene's post process feature processor. 

## Testing
ASV Tests:
![image](https://user-images.githubusercontent.com/43485729/141019784-796fbd99-3398-4b28-8a55-fe8f7b22f601.png)

Signed-off-by: hershey5045 <43485729+hershey5045@users.noreply.github.com>