### PR TITLE
AWS Core CDK: Add option to cleanup resources that are retained by default

### DIFF
--- a/Gems/AWSCore/cdk/README.md
+++ b/Gems/AWSCore/cdk/README.md
@@ -66,12 +66,17 @@ command.
 
 ## Optional Features
 
+Optional features are activated by passing [runtime context variables](https://docs.aws.amazon.com/cdk/latest/guide/context.html). To use multiple optional features together provide one key-value pair at a time:
+```
+cdk synth --context key1=value1 --context key2=value2 MyStack
+```
+
 ### Automatic S3 and DynamoDB Cleanup
-The S3 bucket and Dynamodb created by the sample will be left behind as the CDK defaults to retaining such storage (both default to RemovalPolicy.RETAIN). To delete
+The S3 bucket and Dynamodb created by the sample will be left behind as the CDK defaults to retaining such storage (both have default policies to retain resources on destroy). To delete
 the storage resources created when using CDK destroy, use the following commands to synthesize and destroy the CDK application.
 ```
-cdk synth -c remove_all_storage=true --all
-cdk deploy -c remove_all_storage=true --all
+cdk synth -c remove_all_storage_on_destroy=true --all
+cdk deploy -c remove_all_storage_on_destroy=true --all
 cdk destroy --all
 ```
 

--- a/Gems/AWSCore/cdk/README.md
+++ b/Gems/AWSCore/cdk/README.md
@@ -65,6 +65,17 @@ them to your `setup.py` file and rerun the `pip install -r requirements.txt`
 command.
 
 ## Optional Features
+
+### Automatic S3 and DynamoDB Cleanup
+The S3 bucket and Dynamodb created by the sample will be left behind as the CDK defaults to retaining such storage (both default to RemovalPolicy.RETAIN). To delete
+the storage resources created when using CDK destroy, use the following commands to synthesize and destroy the CDK application.
+```
+cdk synth -c remove_all_storage=true --all
+cdk deploy -c remove_all_storage=true --all
+cdk destroy --all
+```
+
+### Server Access Logging
 Server access logging is enabled by default. To disable the feature, use the following commands to synthesize and deploy this CDK application.
 
 ```

--- a/Gems/AWSCore/cdk/core/core_stack.py
+++ b/Gems/AWSCore/cdk/core/core_stack.py
@@ -88,7 +88,7 @@ class CoreStack(core.Stack):
         if self.node.try_get_context('disable_access_log') != 'true':
 
             # Auto cleanup bucket and data if requested
-            _remove_storage = self.node.try_get_context('remove_all_storage') == 'true'
+            _remove_storage = self.node.try_get_context('remove_all_storage_on_destroy') == 'true'
             _removal_policy = core.RemovalPolicy.DESTROY if _remove_storage else core.RemovalPolicy.RETAIN
 
             self._server_access_logs_bucket = s3.Bucket(

--- a/Gems/AWSCore/cdk/core/core_stack.py
+++ b/Gems/AWSCore/cdk/core/core_stack.py
@@ -86,13 +86,21 @@ class CoreStack(core.Stack):
         # Create an S3 bucket for Amazon S3 server access logging
         # See https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html
         if self.node.try_get_context('disable_access_log') != 'true':
+
+            # Auto cleanup bucket and data if requested
+            _remove_storage = self.node.try_get_context('remove_all_storage') == 'true'
+            _removal_policy = core.RemovalPolicy.DESTROY if _remove_storage else core.RemovalPolicy.RETAIN
+
             self._server_access_logs_bucket = s3.Bucket(
                 self,
                 f'{self._project_name}-{self._feature_name}-Access-Log-Bucket',
+                access_control=s3.BucketAccessControl.LOG_DELIVERY_WRITE,
+                auto_delete_objects = _remove_storage,
                 block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
                 encryption=s3.BucketEncryption.S3_MANAGED,
-                access_control=s3.BucketAccessControl.LOG_DELIVERY_WRITE
+                removal_policy=_removal_policy
             )
+
             self._server_access_logs_bucket.grant_read(self._admin_group)
 
             # Export access log bucket name

--- a/Gems/AWSCore/cdk/example/example_resources_stack.py
+++ b/Gems/AWSCore/cdk/example/example_resources_stack.py
@@ -127,7 +127,7 @@ class ExampleResources(core.Stack):
             )
 
         # Auto cleanup bucket and data if requested
-        _remove_storage = self.node.try_get_context('remove_all_storage') == 'true'
+        _remove_storage = self.node.try_get_context('remove_all_storage_on_destroy') == 'true'
         _removal_policy = core.RemovalPolicy.DESTROY if _remove_storage else core.RemovalPolicy.RETAIN
 
         example_bucket = s3.Bucket(
@@ -178,7 +178,7 @@ class ExampleResources(core.Stack):
         )
 
         # Auto-delete the table when requested
-        if self.node.try_get_context('remove_all_storage') == 'true':
+        if self.node.try_get_context('remove_all_storage_on_destroy') == 'true':
             demo_table.apply_removal_policy(core.RemovalPolicy.DESTROY)
 
         return demo_table

--- a/Gems/AWSCore/cdk/example/example_resources_stack.py
+++ b/Gems/AWSCore/cdk/example/example_resources_stack.py
@@ -126,11 +126,17 @@ class ExampleResources(core.Stack):
                 core.Fn.import_value(f"{self._project_name}:ServerAccessLogsBucket")
             )
 
+        # Auto cleanup bucket and data if requested
+        _remove_storage = self.node.try_get_context('remove_all_storage') == 'true'
+        _removal_policy = core.RemovalPolicy.DESTROY if _remove_storage else core.RemovalPolicy.RETAIN
+
         example_bucket = s3.Bucket(
             self,
             f'{self._project_name}-{self._feature_name}-Example-S3bucket',
+            auto_delete_objects=_remove_storage,
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             encryption=s3.BucketEncryption.S3_MANAGED,
+            removal_policy=_removal_policy,
             server_access_logs_bucket=
             server_access_logs_bucket if server_access_logs_bucket else None,
             server_access_logs_prefix=
@@ -170,6 +176,11 @@ class ExampleResources(core.Stack):
                 type=dynamo.AttributeType.STRING
             )
         )
+
+        # Auto-delete the table when requested
+        if self.node.try_get_context('remove_all_storage') == 'true':
+            demo_table.apply_removal_policy(core.RemovalPolicy.DESTROY)
+
         return demo_table
 
     def __create_outputs(self) -> None:

--- a/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
+++ b/scripts/build/Platform/Windows/deploy_cdk_applications.cmd
@@ -7,7 +7,7 @@ REM SPDX-License-Identifier: Apache-2.0 OR MIT
 REM
 REM
 
-REM Deploy the CDK applcations for AWS gems (Windows only)
+REM Deploy the CDK applications for AWS gems (Windows only)
 REM Prerequisites:
 REM 1) Node.js is installed
 REM 2) Node.js version >= 10.13.0, except for versions 13.0.0 - 13.6.0. A version in active long-term support is recommended.
@@ -57,7 +57,7 @@ IF ERRORLEVEL 1 (
     exit /b 1
 )
 
-CALL :DeployCDKApplication AWSCore "-c disable_access_log=true --all"
+CALL :DeployCDKApplication AWSCore "-c disable_access_log=true -c remove_all_storage_on_destroy=true --all"
 IF ERRORLEVEL 1 (
     exit /b 1
 )


### PR DESCRIPTION
Generated and deployed stack with option on, on stack deletion resources were deleted.

Generated and deployed stacks with option off, on stack deletion resources were retained as is current behaviour.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>