### PR TITLE
Optimize PipelineStateCache::ValidateCacheIntegrity in profile builds.

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -41,9 +41,12 @@ namespace AZ
                     AZ_Assert(readOnlyCache.empty(), "Inactive library has pipeline states in its global entry.");
                 }
 
+#if defined(AZ_DEBUG_BUILD)
+                // the PipelineStateSet is expensive to duplicate, only do this in debug.
                 PipelineStateSet readOnlyCacheCopy = readOnlyCache;
                 AZ_Assert(AZStd::unique(readOnlyCacheCopy.begin(), readOnlyCacheCopy.end()) == readOnlyCacheCopy.end(),
                     "'%d' Duplicates existed in the read-only cache!", readOnlyCache.size() - readOnlyCacheCopy.size());
+#endif
             }
 
             m_threadLibrarySet.ForEach([this](const ThreadLibrarySet& threadLibrarySet)


### PR DESCRIPTION
Move PipelineStateCache validation of set uniqeness to only be active in debug builds.
Saves 0.9ms / frame in my test.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>