### PR TITLE
Update resource mapping schema to make default account ID optional

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/AWS/common/resource_mappings.py
+++ b/AutomatedTesting/Gem/PythonTests/AWS/common/resource_mappings.py
@@ -102,3 +102,17 @@ class ResourceMappings:
 
     def get_resource_name_id(self, resource_key: str):
         return self._resource_mappings[AWS_RESOURCE_MAPPINGS_KEY][resource_key]['Name/ID']
+
+    def clear_select_keys(self, resource_keys=None) -> None:
+        """
+        Clears values from select resource mapping keys.
+        :param resource_keys: list of keys to clear out
+        """
+        with open(self._resource_mapping_file_path) as file_content:
+            resource_mappings = json.load(file_content)
+
+        for key in resource_keys:
+            resource_mappings[key] = ''
+
+        with open(self._resource_mapping_file_path, 'w') as file_content:
+            json.dump(resource_mappings, file_content, indent=4)

--- a/Gems/AWSCore/Code/Include/Private/ResourceMapping/AWSResourceMappingConstants.h
+++ b/Gems/AWSCore/Code/Include/Private/ResourceMapping/AWSResourceMappingConstants.h
@@ -68,7 +68,7 @@ namespace AWSCore
     },
     "AccountIdString": {
         "type": "string",
-        "pattern": "^[0-9]{12}$|EMPTY"
+        "pattern": "^[0-9]{12}$|EMPTY|^$"
     },
     "NonEmptyString": {
         "type": "string",

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
@@ -59,6 +59,34 @@ R"({
     "Version": "1.0.0"
 })";
 
+static constexpr const char TEST_VALID_EMPTY_ACCOUNTID_RESOURCE_MAPPING_CONFIG_FILE[] =
+    R"({
+    "AWSResourceMappings": {
+        "TestLambda": {
+            "Type": "AWS::Lambda::Function",
+            "Name/ID": "MyTestLambda",
+            "Region": "us-east-1",
+            "AccountId": "012345678912"
+        },
+        "TestS3Bucket": {
+            "Type": "AWS::S3::Bucket",
+            "Name/ID": "MyTestS3Bucket"
+        },
+        "TestService.RESTApiId": {
+            "Type": "AWS::ApiGateway::RestApi",
+            "Name/ID": "1234567890"
+        },
+        "TestService.RESTApiStage": {
+            "Type": "AWS::ApiGateway::Stage",
+            "Name/ID": "prod",
+            "Region": "us-east-1"
+        }
+    },
+    "AccountId": "",
+    "Region": "us-west-2",
+    "Version": "1.0.0"
+})";
+
 static constexpr const char TEST_INVALID_RESOURCE_MAPPING_CONFIG_FILE[] =
 R"({
     "AWSResourceMappings": {},
@@ -235,6 +263,21 @@ TEST_F(AWSResourceMappingManagerTest, ActivateManager_ParseValidConfigFile_Confi
         testThread.join();
     }
     EXPECT_TRUE(actualEbusCalls == testThreadNumber);
+}
+
+TEST_F(AWSResourceMappingManagerTest, ActivateManager_ParseValidConfigFile_GlobalAccountIdEmpty)
+{
+    CreateTestConfigFile(TEST_VALID_EMPTY_ACCOUNTID_RESOURCE_MAPPING_CONFIG_FILE);
+    m_resourceMappingManager->ActivateManager();
+
+    AZStd::string actualAccountId;
+    AZStd::string actualRegion;
+    AWSResourceMappingRequestBus::BroadcastResult(actualAccountId, &AWSResourceMappingRequests::GetDefaultAccountId);
+    AWSResourceMappingRequestBus::BroadcastResult(actualRegion, &AWSResourceMappingRequests::GetDefaultRegion);
+    EXPECT_EQ(m_reloadConfigurationCounter, 0);
+    EXPECT_TRUE(actualAccountId.empty());
+    EXPECT_FALSE(actualRegion.empty());
+    EXPECT_TRUE(m_resourceMappingManager->GetStatus() == AWSResourceMappingManager::Status::Ready);
 }
 
 TEST_F(AWSResourceMappingManagerTest, DeactivateManager_AfterActivatingWithValidConfigFile_ConfigDataGetCleanedUp)


### PR DESCRIPTION
Same changes as https://github.com/o3de/o3de/pull/4885, but includes python test.

### Testing

unit tests pass 
```
Loading: C:/Users/stankoa/source/o3de/build/windows_vs2019/bin/profile/AWSCore.Tests.dll
OKAY Library loaded: C:/Users/stankoa/source/o3de/build/windows_vs2019/bin/profile/AWSCore.Tests.dll
OKAY Symbol found: AzRunUnitTests
[==========] Running 101 tests from 21 test cases.
[----------] Global test environment set-up.
[----------] 22 tests from AWSResourceMappingManagerTest
[ RUN      ] AWSResourceMappingManagerTest.ActivateManager_ParseInvalidConfigFile_ConfigDataIsEmpty
[       OK ] AWSResourceMappingManagerTest.ActivateManager_ParseInvalidConfigFile_ConfigDataIsEmpty (13 ms)
[ RUN      ] AWSResourceMappingManagerTest.ActivateManager_ParseValidConfigFile_ConfigDataIsNotEmpty
[       OK ] AWSResourceMappingManagerTest.ActivateManager_ParseValidConfigFile_ConfigDataIsNotEmpty (3 ms)
[ RUN      ] AWSResourceMappingManagerTest.ActivateManager_ParseTemplateConfigFile_ConfigDataIsNotEmpty
[       OK ] AWSResourceMappingManagerTest.ActivateManager_ParseTemplateConfigFile_ConfigDataIsNotEmpty (3 ms)
[ RUN      ] AWSResourceMappingManagerTest.ActivateManager_ParseValidConfigFile_ConfigDataIsNotEmptyWithMultithreadCalls
[       OK ] AWSResourceMappingManagerTest.ActivateManager_ParseValidConfigFile_ConfigDataIsNotEmptyWithMultithreadCalls (12 ms)
[ RUN      ] AWSResourceMappingManagerTest.ActivateManager_ParseValidConfigFile_GlobalAccountIdEmpty
[       OK ] AWSResourceMappingManagerTest.ActivateManager_ParseValidConfigFile_GlobalAccountIdEmpty (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.DeactivateManager_AfterActivatingWithValidConfigFile_ConfigDataGetCleanedUp
[       OK ] AWSResourceMappingManagerTest.DeactivateManager_AfterActivatingWithValidConfigFile_ConfigDataGetCleanedUp (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetDefaultAccountId_AfterParsingValidConfigFile_GetExpectedDefaultAccountId
[       OK ] AWSResourceMappingManagerTest.GetDefaultAccountId_AfterParsingValidConfigFile_GetExpectedDefaultAccountId (3 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetDefaultRegion_AfterParsingValidConfigFile_GetExpectedDefaultRegion
[       OK ] AWSResourceMappingManagerTest.GetDefaultRegion_AfterParsingValidConfigFile_GetExpectedDefaultRegion (3 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceAccountId_AfterParsingValidConfigFile_GetExpectedAccountId
[       OK ] AWSResourceMappingManagerTest.GetResourceAccountId_AfterParsingValidConfigFile_GetExpectedAccountId (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceAccountId_QueryNonexistResourceMappingKeyName_GetEmptyAccountId
[       OK ] AWSResourceMappingManagerTest.GetResourceAccountId_QueryNonexistResourceMappingKeyName_GetEmptyAccountId (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceNameId_AfterParsingValidConfigFile_GetExpectedNameId
[       OK ] AWSResourceMappingManagerTest.GetResourceNameId_AfterParsingValidConfigFile_GetExpectedNameId (5 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceNameId_QueryNonexistResourceMappingKeyName_GetEmptyNameId
[       OK ] AWSResourceMappingManagerTest.GetResourceNameId_QueryNonexistResourceMappingKeyName_GetEmptyNameId (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceRegion_AfterParsingValidConfigFile_GetExpectedRegion
[       OK ] AWSResourceMappingManagerTest.GetResourceRegion_AfterParsingValidConfigFile_GetExpectedRegion (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceRegion_QueryNonexistResourceMappingKeyName_GetEmptyRegion
[       OK ] AWSResourceMappingManagerTest.GetResourceRegion_QueryNonexistResourceMappingKeyName_GetEmptyRegion (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceType_AfterParsingValidConfigFile_GetExpectedType
[       OK ] AWSResourceMappingManagerTest.GetResourceType_AfterParsingValidConfigFile_GetExpectedType (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetResourceType_QueryNonexistResourceMappingKeyName_GetEmptyType
[       OK ] AWSResourceMappingManagerTest.GetResourceType_QueryNonexistResourceMappingKeyName_GetEmptyType (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetServiceUrl_PassingEmptyServiceName_GetEmptyUrl
[       OK ] AWSResourceMappingManagerTest.GetServiceUrl_PassingEmptyServiceName_GetEmptyUrl (6 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetServiceUrl_PassingEmptyRESTApiIdAndStage_GetEmptyUrl
[       OK ] AWSResourceMappingManagerTest.GetServiceUrl_PassingEmptyRESTApiIdAndStage_GetEmptyUrl (6 ms)
[ RUN      ] AWSResourceMappingManagerTest.GetServiceUrl_RESTApiIdAndStageHaveInconsistentRegion_GetEmptyUrl
[       OK ] AWSResourceMappingManagerTest.GetServiceUrl_RESTApiIdAndStageHaveInconsistentRegion_GetEmptyUrl (4 ms)
[ RUN      ] AWSResourceMappingManagerTest.ReloadConfigFile_ParseValidConfigFileAfterParsingInvalid_ConfigDataGetParsed
[       OK ] AWSResourceMappingManagerTest.ReloadConfigFile_ParseValidConfigFileAfterParsingInvalid_ConfigDataGetParsed (5 ms)
[ RUN      ] AWSResourceMappingManagerTest.ReloadConfigFile_ReloadConfigFileNameAndParseValidConfigFile_ConfigDataGetParsed
[       OK ] AWSResourceMappingManagerTest.ReloadConfigFile_ReloadConfigFileNameAndParseValidConfigFile_ConfigDataGetParsed (3 ms)
[ RUN      ] AWSResourceMappingManagerTest.ReloadConfigFile_MissingSetRegFile_ConfigDataIsNotParsed
[       OK ] AWSResourceMappingManagerTest.ReloadConfigFile_MissingSetRegFile_ConfigDataIsNotParsed (1 ms)
[----------] 22 tests from AWSResourceMappingManagerTest (182 ms total)

...

[----------] Global test environment tear-down
[==========] 101 tests from 21 test cases ran. (887 ms total)
[  PASSED  ] 101 tests.
OKAY AzRunUnitTests() returned 0
Returning code: 0

C:/Users/stankoa/source/o3de/build/windows_vs2019/bin/profile/AzTestRunner.exe (process 15336) exited with code 0.
```

AutomatedTesting tests pass
```
C:\Users\stankoa\source\o3de>python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\AWS\Windows  --build-directory build\windows_vs2019\bin\profile
================================================================= test session starts =================================================================
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: C:\Users\stankoa\source\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 7 items

AutomatedTesting\Gem\PythonTests\AWS\Windows\aws_metrics\aws_metrics_automation_test.py ...                                                      [ 42%]
AutomatedTesting\Gem\PythonTests\AWS\Windows\client_auth\aws_client_auth_automation_test.py ..                                                   [ 71%]
AutomatedTesting\Gem\PythonTests\AWS\Windows\core\test_aws_resource_interaction.py ..                                                            [100%]

============================================================ 7 passed in 506.63s (0:08:26) ============================================================

```