### PR TITLE
Atom CPU threading optimization

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h
@@ -40,7 +40,7 @@ namespace AZ
             uint32_t m_swapChainsPerCommandList = 8;
 
             // The maximum cost that can be associated with a single command list.
-            uint32_t m_commandListCostThresholdMin = 1000;
+            uint32_t m_commandListCostThresholdMin = 250;
 
             // The maximum number of command lists per scope.
             uint32_t m_commandListsPerScopeMax = 16;

--- a/Gems/Atom/RHI/Metal/Code/Include/Atom/RHI.Reflect/Metal/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/Metal/Code/Include/Atom/RHI.Reflect/Metal/PlatformLimitsDescriptor.h
@@ -31,7 +31,7 @@ namespace AZ
             uint32_t m_swapChainsPerCommandList = 8;
 
             // The maximum cost that can be associated with a single command list.
-            uint32_t m_commandListCostThresholdMin = 1000;
+            uint32_t m_commandListCostThresholdMin = 250;
 
             // The maximum number of command lists per scope.
             uint32_t m_commandListsPerScopeMax = 16;

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/PlatformLimitsDescriptor.h
@@ -33,7 +33,7 @@ namespace AZ
             uint32_t m_swapChainsPerCommandList = 8;
 
             // The maximum cost that can be associated with a single command list.
-            uint32_t m_commandListCostThresholdMin = 1000;
+            uint32_t m_commandListCostThresholdMin = 250;
 
             // The maximum number of command lists per scope.
             uint32_t m_commandListsPerScopeMax = 16;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -21,8 +21,6 @@
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/RPI.Reflect/Pass/RasterPassData.h>
 
-#include <AzCore/std/parallel/thread.h>
-
 namespace AZ
 {
     namespace RPI
@@ -213,7 +211,7 @@ namespace AZ
         void RasterPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
             RenderPass::SetupFrameGraphDependencies(frameGraph);
-            frameGraph.SetEstimatedItemCount(static_cast<uint32_t>(m_drawListView.size() * AZStd::thread::hardware_concurrency()));
+            frameGraph.SetEstimatedItemCount(static_cast<uint32_t>(m_drawListView.size()));
         }
 
         void RasterPass::CompileResources(const RHI::FrameGraphCompileContext& context)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RasterPass.cpp
@@ -21,6 +21,8 @@
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/RPI.Reflect/Pass/RasterPassData.h>
 
+#include <AzCore/std/parallel/thread.h>
+
 namespace AZ
 {
     namespace RPI
@@ -211,7 +213,7 @@ namespace AZ
         void RasterPass::SetupFrameGraphDependencies(RHI::FrameGraphInterface frameGraph)
         {
             RenderPass::SetupFrameGraphDependencies(frameGraph);
-            frameGraph.SetEstimatedItemCount(static_cast<uint32_t>(m_drawListView.size()));
+            frameGraph.SetEstimatedItemCount(static_cast<uint32_t>(m_drawListView.size() * AZStd::thread::hardware_concurrency()));
         }
 
         void RasterPass::CompileResources(const RHI::FrameGraphCompileContext& context)


### PR DESCRIPTION
Small change to make the RasterPass Scope jobs split the work more evenly over the cores, saves about 0.5ms / frame in the test scene (10K random objects)

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>

Work distribution before
![RasterPassBefore](https://user-images.githubusercontent.com/82187279/141038898-70c3d14e-44f9-406b-a248-29c077f4d096.png)

Work distribution after
![RasterPassAfter](https://user-images.githubusercontent.com/82187279/141038895-72ee0f69-8b26-49bf-8132-9ba64f49cc32.png)
