### PR TITLE
Fix for Issue #5239: Component Edit Mode does not disable Entity Inspector interaction

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -606,6 +606,7 @@ namespace AzToolsFramework
 
         AzToolsFramework::ComponentModeFramework::EditorComponentModeNotificationBus::Handler::BusConnect(
             AzToolsFramework::GetEntityContextId());
+        ViewportEditorModeNotificationsBus::Handler::BusConnect(GetEntityContextId());
     }
 
     EntityPropertyEditor::~EntityPropertyEditor()
@@ -618,7 +619,8 @@ namespace AzToolsFramework
         AZ::EntitySystemBus::Handler::BusDisconnect();
         EditorEntityContextNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ComponentModeFramework::EditorComponentModeNotificationBus::Handler::BusDisconnect();
-
+        ViewportEditorModeNotificationsBus::Handler::BusDisconnect();
+        
         for (auto& entityId : m_overrideSelectedEntityIds)
         {
             DisconnectFromEntityBuses(entityId);


### PR DESCRIPTION
Fix for issue [Component Edit Mode does not disable Entity Inspector interaction](https://github.com/o3de/o3de/issues/5239).

The `EntityPropertyEditor` class was missing the connection/disconnection to the `ViewportEditorModeNotificationsBus` which caused it to not respond to component mode enter/leave events. This has now been fixed by adding the pertinent calls to the class constructor and destructor.

https://user-images.githubusercontent.com/77458631/141110506-07dfb04b-1abf-448a-b831-a643dc77e553.mp4

Signed-off-by: John <jonawals@amazon.com>