### PR TITLE
Fix attempted rendering of invalid Entity selection boxes.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -1177,8 +1177,10 @@ namespace AzToolsFramework
                         continue;
                     }
 
-                    const AZ::Aabb bound = CalculateEditorEntitySelectionBounds(entityId, viewportInfo);
-                    debugDisplay.DrawSolidBox(bound.GetMin(), bound.GetMax());
+                    if (const AZ::Aabb bound = CalculateEditorEntitySelectionBounds(entityId, viewportInfo); bound.IsValid())
+                    {
+                        debugDisplay.DrawSolidBox(bound.GetMin(), bound.GetMax());
+                    }
                 }
 
                 debugDisplay.DepthTestOn();


### PR DESCRIPTION
Fix for [Trying to select multiple entities by clicking and dragging on the viewport crashes the Editor](https://github.com/o3de/o3de/issues/4300).

The issue couldn't be reproduced locally due to lack of dual monitors so a fix has been put in place in `EditorTransformComponentSelection::SetupBoxSelect()` to only attempt to draw the box if the `min` and `max` vectors of the AABB are valid.

Signed-off-by: John <jonawals@amazon.com>