### PR TITLE
Destroy AZ::NameDictionary during module shutdown

### DIFF
--- a/Gems/Multiplayer/Code/Source/MultiplayerGem.cpp
+++ b/Gems/Multiplayer/Code/Source/MultiplayerGem.cpp
@@ -30,6 +30,11 @@ namespace Multiplayer
         CreateComponentDescriptors(m_descriptors);
     }
 
+    MultiplayerModule::~MultiplayerModule()
+    {
+        AZ::NameDictionary::Destroy();
+    }
+
     AZ::ComponentTypeList MultiplayerModule::GetRequiredSystemComponents() const
     {
         return AZ::ComponentTypeList

--- a/Gems/Multiplayer/Code/Source/MultiplayerGem.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerGem.h
@@ -21,7 +21,7 @@ namespace Multiplayer
         AZ_CLASS_ALLOCATOR(MultiplayerModule, AZ::SystemAllocator, 0);
 
         MultiplayerModule();
-        ~MultiplayerModule() override = default;
+        ~MultiplayerModule() override;
 
         AZ::ComponentTypeList GetRequiredSystemComponents() const override;
     };


### PR DESCRIPTION
Destroy AZ::NameDictionary during module shutdown to avoid crash from trying to deallocate the s_instance variable later on after the memory allocators have been shutdown
