### PR TITLE
Blast gem cleanup m_materialLibrary asset on Deactivate

### DIFF
--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -151,6 +151,8 @@ namespace Blast
         SaveConfiguration();
         DeactivatePhysics();
 
+        m_configuration.m_materialLibrary.Release();
+
         m_assetHandlers.clear();
     };
 


### PR DESCRIPTION
Blast gem cleanup m_materialLibrary asset on Deactivate to avoid holding onto asset reference after AssetManager has shutdown