### PR TITLE
Added a null pointer check to EMFX system component

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -626,7 +626,7 @@ namespace EMotionFX
                 // Check if we are in game mode.
                 IEditor* editor = nullptr;
                 AzToolsFramework::EditorRequestBus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::GetEditor);
-                inGameMode = editor && editor->IsInGameMode();
+                inGameMode = !editor || editor->IsInGameMode();
 #endif
 
                 // Apply the motion extraction deltas to the character controller / entity transform for all entities.

--- a/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/System/SystemComponent.cpp
@@ -626,7 +626,7 @@ namespace EMotionFX
                 // Check if we are in game mode.
                 IEditor* editor = nullptr;
                 AzToolsFramework::EditorRequestBus::BroadcastResult(editor, &AzToolsFramework::EditorRequests::GetEditor);
-                inGameMode = editor->IsInGameMode();
+                inGameMode = editor && editor->IsInGameMode();
 #endif
 
                 // Apply the motion extraction deltas to the character controller / entity transform for all entities.


### PR DESCRIPTION
Material editor and other tools load runtime dependencies from game projects. The EMFX system component is checking for game mode by getting a pointer to the editor interface, which will not exist outside of the main O3DE editor.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>