### PR TITLE
ASV Trace::Assert Environment.h(438) You are using an invalid variable,

### DIFF
--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.cpp
@@ -50,7 +50,12 @@ namespace AZ
 
         if (!s_instance)
         {
-            s_instance = Environment::FindVariable<NameDictionary>(NameDictionaryInstanceName);
+            // Because the NameDictionary allocates memory using the AZ::Allocator and it is created
+            // in the executable memory space, it's ownership cannot be transferred to other module memory spaces
+            // Otherwise this could cause the the NameDictionary to be destroyed in static de-init
+            // after the AZ::Allocators have been destroyed
+            // Therefore we supply the isTransferOwnership value of false using CreateVariableEx
+            s_instance = AZ::Environment::CreateVariableEx<NameDictionary>(NameDictionaryInstanceName, true, false);
         }
 
         return s_instance.IsConstructed();


### PR DESCRIPTION
the owner has removed it!

This fixes the issue by forcing NameDictionary to not transfer
ownership. This means ComponentApplication()::Destroy will fully destroy
the NameDictionary before the OS::Allocator is destroyed.

In Windows the bug was not happening when running AssetProcessorBatch
because for Windows, _exit() is called before the application shutsdown
forcing all module to properly decrease the reference count of
EnvironmentVaqriableHolderBase::m_useCount for NameDictionary.

In MacOS, there's no _exit() so when the NameDictionary destructor was being called
before existing the application the reference count wouldn't be 0, and
would eventually try to destry the NameDictionary BUT the OS::Allocator
was already destroyed.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>