### PR TITLE
Fixed LC crash by preventing graphs from staying open after they are no longer in prefab focus.

### DIFF
--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -21,6 +21,7 @@
 #include <AzToolsFramework/Commands/EntityStateCommand.h>
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/PropertyTreeEditor/PropertyTreeEditor.h>
 #include <AzToolsFramework/ToolsComponents/EditorDisabledCompositionBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorPendingCompositionBus.h>
@@ -448,6 +449,9 @@ namespace LandscapeCanvasEditor
         AZ::ComponentApplicationBus::BroadcastResult(m_serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
         AZ_Assert(m_serializeContext, "Failed to acquire application serialize context.");
 
+        m_prefabFocusPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusPublicInterface>::Get();
+        AZ_Assert(m_prefabFocusPublicInterface, "LandscapeCanvas - could not get PrefabFocusPublicInterface on construction.");
+
         const GraphCanvas::EditorId& editorId = GetEditorId();
 
         // Register unique color palettes for our connections (data types)
@@ -459,6 +463,7 @@ namespace LandscapeCanvasEditor
         AzToolsFramework::EditorPickModeNotificationBus::Handler::BusConnect(AzToolsFramework::GetEntityContextId());
         AzToolsFramework::EntityCompositionNotificationBus::Handler::BusConnect();
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusConnect();
+        AzToolsFramework::Prefab::PrefabFocusNotificationBus::Handler::BusConnect(AzToolsFramework::GetEntityContextId());
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
         CrySystemEventBus::Handler::BusConnect();
         AZ::EntitySystemBus::Handler::BusConnect();
@@ -484,6 +489,7 @@ namespace LandscapeCanvasEditor
         AZ::EntitySystemBus::Handler::BusDisconnect();
         CrySystemEventBus::Handler::BusDisconnect();
         AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
+        AzToolsFramework::Prefab::PrefabFocusNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ToolsApplicationNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorPickModeNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::EditorEntityContextNotificationBus::Handler::BusDisconnect();
@@ -2497,6 +2503,24 @@ namespace LandscapeCanvasEditor
             // is invoked, the EditorEntityInfoRequestBus::Events::GetParent (that is used by FindGraphContainingEntity)
             // will still return the old parentId
             HandleEditorEntityCreated(entityId, newGraphId);
+        }
+    }
+
+    void MainWindow::OnPrefabFocusChanged()
+    {
+        // Make sure to close any open graphs that aren't currently in p refab focus
+        // to prevent the user from making modifications outside of the allowed focus scope
+        AZStd::vector<GraphCanvas::DockWidgetId> dockWidgetsToClose;
+        for (auto [entityId, dockWidgetId] : m_dockWidgetsByEntity)
+        {
+            if (!m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId))
+            {
+                dockWidgetsToClose.push_back(dockWidgetId);
+            }
+        }
+        for (auto dockWidgetId : dockWidgetsToClose)
+        {
+            CloseEditor(dockWidgetId);
         }
     }
 

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.cpp
@@ -2508,7 +2508,7 @@ namespace LandscapeCanvasEditor
 
     void MainWindow::OnPrefabFocusChanged()
     {
-        // Make sure to close any open graphs that aren't currently in p refab focus
+        // Make sure to close any open graphs that aren't currently in prefab focus
         // to prevent the user from making modifications outside of the allowed focus scope
         AZStd::vector<GraphCanvas::DockWidgetId> dockWidgetsToClose;
         for (auto [entityId, dockWidgetId] : m_dockWidgetsByEntity)

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -20,6 +20,7 @@
 #include <AzToolsFramework/API/EntityCompositionNotificationBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzToolsFramework/Prefab/PrefabFocusNotificationBus.h>
 #include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 #include <AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
@@ -30,6 +31,14 @@
 // LandscapeCanvas
 #include <LandscapeCanvas/LandscapeCanvasBus.h>
 #endif
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        class PrefabFocusPublicInterface;
+    }
+}
 
 namespace LandscapeCanvasEditor
 {
@@ -81,6 +90,7 @@ namespace LandscapeCanvasEditor
         , private AzToolsFramework::EntityCompositionNotificationBus::Handler
         , private AzToolsFramework::PropertyEditorEntityChangeNotificationBus::MultiHandler
         , private AzToolsFramework::ToolsApplicationNotificationBus::Handler
+        , private AzToolsFramework::Prefab::PrefabFocusNotificationBus::Handler
         , private AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
         , private CrySystemEventBus::Handler
     {
@@ -181,6 +191,9 @@ namespace LandscapeCanvasEditor
         void EntityParentChanged(AZ::EntityId entityId, AZ::EntityId newParentId, AZ::EntityId oldParentId) override;
         ////////////////////////////////////////////////////////////////////////
 
+        //! PrefabFocusNotificationBus overrides
+        void OnPrefabFocusChanged() override;
+
         //! PrefabPublicNotificationBus overrides
         void OnPrefabInstancePropagationBegin() override;
         void OnPrefabInstancePropagationEnd() override;
@@ -247,6 +260,8 @@ namespace LandscapeCanvasEditor
         GraphModel::SlotPtr EnsureInboundDataSlotWithIndex(GraphCanvas::GraphId graphId, GraphModel::NodePtr node, GraphModel::DataTypePtr dataType, int index);
 
         AZ::SerializeContext* m_serializeContext = nullptr;
+
+        AzToolsFramework::Prefab::PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
 
         bool m_ignoreGraphUpdates = false;
         bool m_prefabPropagationInProgress = false;


### PR DESCRIPTION
Fixes #5085 

Prevent crash in the Entity Outliner by preventing the user from modifying entities/components through Landscape Canvas after the graph corresponding to that entity is no longer in prefab focus. Tested modifying a Landscape Canvas component on the root instance, inside a prefab, and inside nested prefabs.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>