### PR TITLE
AWSClientAuth updated to use custom CognitoCachingCredentialsProvider

### DIFF
--- a/Gems/AWSClientAuth/Code/Include/Private/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.h
+++ b/Gems/AWSClientAuth/Code/Include/Private/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <aws/cognito-identity/CognitoIdentityClient.h>
+#include <aws/identity-management/auth/CognitoCachingCredentialsProvider.h>
+#include <aws/identity-management/auth/PersistentCognitoIdentityProvider.h>
+
+namespace AWSClientAuth
+{
+    //! Cognito Caching Credentials Provider implementation that is derived from AWS Native SDK.
+    //! For use with authenticated credentials.
+    class AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider
+        : public Aws::Auth::CognitoCachingCredentialsProvider
+    {
+    public:
+        AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider(
+            const std::shared_ptr<Aws::Auth::PersistentCognitoIdentityProvider>& identityRepository,
+            const std::shared_ptr<Aws::CognitoIdentity::CognitoIdentityClient>& cognitoIdentityClient = nullptr);
+
+    protected:
+        Aws::CognitoIdentity::Model::GetCredentialsForIdentityOutcome GetCredentialsFromCognito() const override;
+    };
+
+    //! Cognito Caching Credentials Provider implementation that is eventually derived from AWS Native SDK.
+    //! For use with anonymous credentials.
+    class AWSClientAuthCachingAnonymousCredsProvider : public AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider
+    {
+    public:
+        AWSClientAuthCachingAnonymousCredsProvider(
+            const std::shared_ptr<Aws::Auth::PersistentCognitoIdentityProvider>& identityRepository,
+            const std::shared_ptr<Aws::CognitoIdentity::CognitoIdentityClient>& cognitoIdentityClient = nullptr);
+
+    protected:
+        Aws::CognitoIdentity::Model::GetCredentialsForIdentityOutcome GetCredentialsFromCognito() const override;
+    };
+
+} // namespace AWSClientAuth

--- a/Gems/AWSClientAuth/Code/Include/Private/Authorization/AWSCognitoAuthorizationController.h
+++ b/Gems/AWSClientAuth/Code/Include/Private/Authorization/AWSCognitoAuthorizationController.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <Authorization/AWSCognitoAuthorizationBus.h>
+#include <Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.h>
 #include <Authorization/AWSClientAuthPersistentCognitoIdentityProvider.h>
 #include <Authentication/AuthenticationProviderBus.h>
 #include <Credential/AWSCredentialBus.h>
@@ -51,8 +52,8 @@ namespace AWSClientAuth
 
         std::shared_ptr<AWSClientAuthPersistentCognitoIdentityProvider> m_persistentCognitoIdentityProvider;
         std::shared_ptr<AWSClientAuthPersistentCognitoIdentityProvider> m_persistentAnonymousCognitoIdentityProvider;
-        std::shared_ptr<Aws::Auth::CognitoCachingAuthenticatedCredentialsProvider> m_cognitoCachingCredentialsProvider;
-        std::shared_ptr<Aws::Auth::CognitoCachingAnonymousCredentialsProvider> m_cognitoCachingAnonymousCredentialsProvider;
+        std::shared_ptr<AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider> m_cognitoCachingCredentialsProvider;
+        std::shared_ptr<AWSClientAuthCachingAnonymousCredsProvider> m_cognitoCachingAnonymousCredentialsProvider;
 
         AZStd::string m_cognitoIdentityPoolId;
         AZStd::string m_formattedCognitoUserPoolId;

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.h>
+
+#include <AzCore/Debug/Trace.h>
+
+#include <aws/cognito-identity/CognitoIdentityClient.h>
+#include <aws/cognito-identity/model/GetCredentialsForIdentityRequest.h>
+#include <aws/cognito-identity/model/GetIdRequest.h>
+#include <aws/core/utils/Outcome.h>
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws/identity-management/auth/CognitoCachingCredentialsProvider.h>
+#include <aws/identity-management/auth/PersistentCognitoIdentityProvider.h>
+
+
+namespace AWSClientAuth
+{
+    static const char* AUTH_LOG_TAG = "AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider";
+    static const char* ANON_LOG_TAG = "AWSClientAuthCachingAnonymousCredsProvider";
+
+    // Modification of https://github.com/aws/aws-sdk-cpp/blob/main/aws-cpp-sdk-identity-management/source/auth/CognitoCachingCredentialsProvider.cpp#L92
+    // to work around account ID requirement. Account id is not required for call to succeed and is not set unless provided.
+    // see: https://github.com/aws/aws-sdk-cpp/issues/1448
+    Aws::CognitoIdentity::Model::GetCredentialsForIdentityOutcome FetchCredsFromCognito(
+        const Aws::CognitoIdentity::CognitoIdentityClient& cognitoIdentityClient,
+        Aws::Auth::PersistentCognitoIdentityProvider& identityRepository,
+        const char* logTag,
+        bool includeLogins)
+    {
+        auto logins = identityRepository.GetLogins();
+        Aws::Map<Aws::String, Aws::String> cognitoLogins;
+        for (auto& login : logins)
+        {
+            cognitoLogins[login.first] = login.second.accessToken;
+        }
+
+        if (!identityRepository.HasIdentityId())
+        {
+            auto accountId = identityRepository.GetAccountId();
+            auto identityPoolId = identityRepository.GetIdentityPoolId();
+
+            Aws::CognitoIdentity::Model::GetIdRequest getIdRequest;
+            getIdRequest.SetIdentityPoolId(identityPoolId);
+
+            if (!accountId.empty()) // new check
+            {
+                getIdRequest.SetAccountId(accountId);
+                AWS_LOGSTREAM_INFO(logTag, "Identity not found, requesting an id for accountId "
+                    << accountId << " identity pool id "
+                    << identityPoolId << " with logins.");
+            }
+            else
+            {
+                AWS_LOGSTREAM_INFO(
+                    logTag, "Identity not found, requesting an id for identity pool id %s" << identityPoolId << " with logins.");
+            }
+            if (includeLogins)
+            {
+                getIdRequest.SetLogins(cognitoLogins);
+            }
+
+            auto getIdOutcome = cognitoIdentityClient.GetId(getIdRequest);
+            if (getIdOutcome.IsSuccess())
+            {
+                auto identityId = getIdOutcome.GetResult().GetIdentityId();
+                AWS_LOGSTREAM_INFO(logTag, "Successfully retrieved identity: " << identityId);
+                identityRepository.PersistIdentityId(identityId);
+            }
+            else
+            {
+                AWS_LOGSTREAM_ERROR(
+                    logTag,
+                    "Failed to retrieve identity. Error: " << getIdOutcome.GetError().GetExceptionName() << " "
+                                                           << getIdOutcome.GetError().GetMessage());
+                return Aws::CognitoIdentity::Model::GetCredentialsForIdentityOutcome(getIdOutcome.GetError());
+            }
+        }
+
+        Aws::CognitoIdentity::Model::GetCredentialsForIdentityRequest getCredentialsForIdentityRequest;
+        getCredentialsForIdentityRequest.SetIdentityId(identityRepository.GetIdentityId());
+        if (includeLogins)
+        {
+            getCredentialsForIdentityRequest.SetLogins(cognitoLogins);
+        }
+
+        return cognitoIdentityClient.GetCredentialsForIdentity(getCredentialsForIdentityRequest);
+    }
+
+    AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider::AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider(
+        const std::shared_ptr<Aws::Auth::PersistentCognitoIdentityProvider>& identityRepository,
+        const std::shared_ptr<Aws::CognitoIdentity::CognitoIdentityClient>& cognitoIdentityClient)
+        : CognitoCachingCredentialsProvider(identityRepository, cognitoIdentityClient)
+    {
+    }
+
+    Aws::CognitoIdentity::Model::GetCredentialsForIdentityOutcome
+    AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider::GetCredentialsFromCognito() const
+    {
+        return FetchCredsFromCognito(*m_cognitoIdentityClient, *m_identityRepository, AUTH_LOG_TAG, true);
+    }
+
+    AWSClientAuthCachingAnonymousCredsProvider::AWSClientAuthCachingAnonymousCredsProvider(
+        const std::shared_ptr<Aws::Auth::PersistentCognitoIdentityProvider>& identityRepository,
+        const std::shared_ptr<Aws::CognitoIdentity::CognitoIdentityClient>& cognitoIdentityClient)
+        : AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider(identityRepository, cognitoIdentityClient)
+    {
+    }
+
+    Aws::CognitoIdentity::Model::GetCredentialsForIdentityOutcome AWSClientAuthCachingAnonymousCredsProvider::
+        GetCredentialsFromCognito() const
+    {
+        return FetchCredsFromCognito(*m_cognitoIdentityClient, *m_identityRepository, ANON_LOG_TAG, false);
+    }
+
+
+} // namespace AWSClientAuth

--- a/Gems/AWSClientAuth/Code/Source/Authorization/AWSCognitoAuthorizationController.cpp
+++ b/Gems/AWSClientAuth/Code/Source/Authorization/AWSCognitoAuthorizationController.cpp
@@ -8,6 +8,7 @@
 
 #include <AWSClientAuthBus.h>
 #include <AWSCoreBus.h>
+#include <Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.h>
 #include <Authorization/AWSCognitoAuthorizationController.h>
 #include <ResourceMapping/AWSResourceMappingBus.h>
 #include <AWSClientAuthResourceMappingConstants.h>
@@ -38,10 +39,12 @@ namespace AWSClientAuth
         auto identityClient = AZ::Interface<IAWSClientAuthRequests>::Get()->GetCognitoIdentityClient();
 
         m_cognitoCachingCredentialsProvider =
-            std::make_shared<Aws::Auth::CognitoCachingAuthenticatedCredentialsProvider>(m_persistentCognitoIdentityProvider, identityClient);
+            std::make_shared<AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider>(
+            m_persistentCognitoIdentityProvider, identityClient);
 
         m_cognitoCachingAnonymousCredentialsProvider =
-            std::make_shared<Aws::Auth::CognitoCachingAnonymousCredentialsProvider>(m_persistentAnonymousCognitoIdentityProvider, identityClient);
+            std::make_shared<AWSClientAuthCachingAnonymousCredsProvider>(
+            m_persistentAnonymousCognitoIdentityProvider, identityClient);
     }
 
     AWSCognitoAuthorizationController::~AWSCognitoAuthorizationController()
@@ -65,9 +68,13 @@ namespace AWSClientAuth
         AWSCore::AWSResourceMappingRequestBus::BroadcastResult(
             m_cognitoIdentityPoolId, &AWSCore::AWSResourceMappingRequests::GetResourceNameId, CognitoIdentityPoolIdResourceMappingKey);
 
-        if (m_awsAccountId.empty() || m_cognitoIdentityPoolId.empty())
+        if (m_awsAccountId.empty())
         {
-            AZ_Warning("AWSCognitoAuthorizationController", !m_awsAccountId.empty(), "Missing AWS account id not configured.");
+            AZ_TracePrintf("AWSCognitoAuthorizationController", "AWS account id not not configured. Proceeding without it.");
+        }
+
+        if (m_cognitoIdentityPoolId.empty())
+        {
             AZ_Warning("AWSCognitoAuthorizationController", !m_cognitoIdentityPoolId.empty(), "Missing Cognito Identity pool id in resource mappings.");
             return false;
         }

--- a/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
+++ b/Gems/AWSClientAuth/Code/Tests/Authorization/AWSCognitoAuthorizationControllerTest.cpp
@@ -62,6 +62,14 @@ TEST_F(AWSCognitoAuthorizationControllerTest, Initialize_Success)
     ASSERT_TRUE(m_mockController->m_cognitoIdentityPoolId == AWSClientAuthUnitTest::TEST_RESOURCE_NAME_ID);
 }
 
+TEST_F(AWSCognitoAuthorizationControllerTest, Initialize_Success_GetAWSAccountEmpty)
+{
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetResourceNameId(testing::_)).Times(2);
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetDefaultAccountId()).Times(1).WillOnce(testing::Return(""));
+    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetDefaultRegion()).Times(1);
+    ASSERT_TRUE(m_mockController->Initialize());
+}
+
 TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_WithLogins_Success)
 {
     AWSClientAuth::AuthenticationTokens tokens(
@@ -121,7 +129,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, MultipleCalls_UsesCacheCredentials
     m_mockController->RequestAWSCredentialsAsync();
 }
 
-TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetIdError)
+TEST_F(AWSCognitoAuthorizationControllerTest, RequestAWSCredentials_Fail_GetIdError) // fail
 {
     AWSClientAuth::AuthenticationTokens cognitoTokens(
         AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN, AWSClientAuthUnitTest::TEST_TOKEN,
@@ -321,7 +329,7 @@ TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersisted
     EXPECT_TRUE(actualCredentialsProvider == m_mockController->m_cognitoCachingAnonymousCredentialsProvider);
 }
 
-TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersistedLogins_NoAnonymousCredentials_ResultNullPtr)
+TEST_F(AWSCognitoAuthorizationControllerTest, GetCredentialsProvider_NoPersistedLogins_NoAnonymousCredentials_ResultNullPtr) // fails
 {
     Aws::Client::AWSError<Aws::CognitoIdentity::CognitoIdentityErrors> error;
     error.SetExceptionName(AWSClientAuthUnitTest::TEST_EXCEPTION);
@@ -429,13 +437,5 @@ TEST_F(AWSCognitoAuthorizationControllerTest, Initialize_Fail_GetResourceNameEmp
 {
     EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetResourceNameId(testing::_)).Times(1).WillOnce(testing::Return(""));
     EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetDefaultAccountId()).Times(1);
-    ASSERT_FALSE(m_mockController->Initialize());
-}
-
-TEST_F(AWSCognitoAuthorizationControllerTest, Initialize_Fail_GetAWSAccountEmpty)
-{
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetResourceNameId(testing::_)).Times(1);
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetDefaultAccountId()).Times(1).WillOnce(testing::Return(""));
-    EXPECT_CALL(m_awsResourceMappingRequestBusMock, GetDefaultRegion()).Times(0);
     ASSERT_FALSE(m_mockController->Initialize());
 }

--- a/Gems/AWSClientAuth/Code/awsclientauth_files.cmake
+++ b/Gems/AWSClientAuth/Code/awsclientauth_files.cmake
@@ -24,6 +24,7 @@ set(FILES
     Include/Private/Authorization/AWSCognitoAuthorizationController.h
     Include/Private/Authorization/AWSClientAuthPersistentCognitoIdentityProvider.h
     Include/Private/Authorization/AWSCognitoAuthorizationNotificationBusBehaviorHandler.h
+    Include/Private/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.h
 
     Include/Private/UserManagement/AWSCognitoUserManagementController.h
     Include/Private/UserManagement/UserManagementNotificationBusBehaviorHandler.h
@@ -45,6 +46,7 @@ set(FILES
     Source/Authorization/ClientAuthAWSCredentials.cpp
     Source/Authorization/AWSCognitoAuthorizationController.cpp
     Source/Authorization/AWSClientAuthPersistentCognitoIdentityProvider.cpp
+    Source/Authorization/AWSClientAuthCognitoCachingAuthenticatedCredentialsProvider.cpp
 
     Source/UserManagement/AWSCognitoUserManagementController.cpp
 )


### PR DESCRIPTION
Builds off changes in https://github.com/o3de/o3de/pull/5475 . Will rebase after those are merged so those commits no longer appear here.

The purpose of these changes is to allow calls to Cognito to proceed w/o providing an AWS account ID, in the event that none is provided.

### testing

unit tests pass
```
OKAY Library loaded: C:/Users/stankoa/source/o3de/build/windows_vs2019/bin/profile/AWSClientAuth.Tests.dll
OKAY Symbol found: AzRunUnitTests
[==========] Running 92 tests from 9 test cases.
[----------] Global test environment set-up.
[----------] 16 tests from AWSCognitoAuthorizationControllerTest
[ RUN      ] AWSCognitoAuthorizationControllerTest.Initialize_Success
[       OK ] AWSCognitoAuthorizationControllerTest.Initialize_Success (23 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.Initialize_Success_GetAWSAccountEmpty  // NEW
[       OK ] AWSCognitoAuthorizationControllerTest.Initialize_Success_GetAWSAccountEmpty (5 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_WithLogins_Success
[       OK ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_WithLogins_Success (5 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_WithoutLoginsAnonymous_Success
[       OK ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_WithoutLoginsAnonymous_Success (5 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.MultipleCalls_UsesCacheCredentials_Success
[       OK ] AWSCognitoAuthorizationControllerTest.MultipleCalls_UsesCacheCredentials_Success (7 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_Fail_GetIdError
[       OK ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_Fail_GetIdError (7 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_Fail_GetCredentialsForIdentityError
[       OK ] AWSCognitoAuthorizationControllerTest.RequestAWSCredentials_Fail_GetCredentialsForIdentityError (7 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.AddRemoveLogins_Succuess
[       OK ] AWSCognitoAuthorizationControllerTest.AddRemoveLogins_Succuess (6 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.ResetAuthenticated_ClearsCachedLoginsAndIdentityId_Success
[       OK ] AWSCognitoAuthorizationControllerTest.ResetAuthenticated_ClearsCachedLoginsAndIdentityId_Success (6 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.ResetAnonymous_ClearsCachedLoginsAndIdentityId_Success
[       OK ] AWSCognitoAuthorizationControllerTest.ResetAnonymous_ClearsCachedLoginsAndIdentityId_Success (6 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_ForPersistedLogins_ResultIsAuthenticatedCredentials
[       OK ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_ForPersistedLogins_ResultIsAuthenticatedCredentials (6 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_NoPersistedLogins_ResultIsAnonymousCredentials
[       OK ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_NoPersistedLogins_ResultIsAnonymousCredentials (6 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_NoPersistedLogins_NoAnonymousCredentials_ResultNullPtr
[       OK ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_NoPersistedLogins_NoAnonymousCredentials_ResultNullPtr (7 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_OneThreadPersistLogins_SecondThreadGetCredentialsProvider_GetCredentialsSuccess
[       OK ] AWSCognitoAuthorizationControllerTest.GetCredentialsProvider_OneThreadPersistLogins_SecondThreadGetCredentialsProvider_GetCredentialsSuccess (19 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.GetCredentialHandlerOrder_Call_AlwaysGetExpectedValue
[       OK ] AWSCognitoAuthorizationControllerTest.GetCredentialHandlerOrder_Call_AlwaysGetExpectedValue (7 ms)
[ RUN      ] AWSCognitoAuthorizationControllerTest.Initialize_Fail_GetResourceNameEmpty
[       OK ] AWSCognitoAuthorizationControllerTest.Initialize_Fail_GetResourceNameEmpty (19 ms)
[----------] 16 tests from AWSCognitoAuthorizationControllerTest (188 ms total)

...

[----------] Global test environment tear-down
[==========] 92 tests from 9 test cases ran. (1356 ms total)
[  PASSED  ] 92 tests.
OKAY AzRunUnitTests() returned 0
Returning code: 0

C:/Users/stankoa/source/o3de/build/windows_vs2019/bin/profile/AzTestRunner.exe (process 15300) exited with code 0.
```

_AutomatedTesting_ tests pass
```
C:\Users\stankoa\source\o3de>python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\AWS\Windows\client_auth\aws_client_auth_automation_test.py  --build-directory build\windows_vs2019\bin\profile
================================================= test session starts =================================================
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: C:\Users\stankoa\source\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 3 items

AutomatedTesting\Gem\PythonTests\AWS\Windows\client_auth\aws_client_auth_automation_test.py ...                  [100%]

============================================ 3 passed in 170.46s (0:02:50) ============================================

```
