### PR TITLE
Removing Old Cry Code that Causes ServerLauncher to Load Client.cfg  

### DIFF
--- a/Code/Legacy/CrySystem/SystemInit.cpp
+++ b/Code/Legacy/CrySystem/SystemInit.cpp
@@ -1186,12 +1186,6 @@ AZ_POP_DISABLE_WARNING
 
     InlineInitializationProcessing("CSystem::Init End");
 
-    if (gEnv->IsDedicated())
-    {
-        SCVarsClientConfigSink CVarsClientConfigSink;
-        LoadConfiguration("client.cfg", &CVarsClientConfigSink);
-    }
-
     // Send out EBus event
     EBUS_EVENT(CrySystemEventBus, OnCrySystemInitialized, *this, startupParams);
 


### PR DESCRIPTION
Removing old cry code that would load client.cfg for server launcher. Client.cfg should not be loaded by default. It was confusing seeing client.cfg in the server.log. If devs want to load a cfg then they can provide it via commandline (--console-command-file).

Signed-off-by: Gene Walters <genewalt@amazon.com>