### PR TITLE
CameraRigComponent - Disable Component Checkbox when the two others are toggled

### DIFF
--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.cpp
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.cpp
@@ -9,8 +9,8 @@
 #include "SlideAlongAxisBasedOnAngle.h"
 #include "StartingPointCamera/StartingPointCameraUtilities.h"
 #include <AzCore/Math/Quaternion.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Math/Transform.h>
+#include <AzCore/Serialization/EditContext.h>
 
 namespace Camera
 {
@@ -32,31 +32,47 @@ namespace Camera
             AZ::EditContext* editContext = serializeContext->GetEditContext();
             if (editContext)
             {
-                editContext->Class<SlideAlongAxisBasedOnAngle>("SlideAlongAxisBasedOnAngle", "Slide 0..SlideDistance along Axis based on Angle Type.  Maps from 90..-90 degrees")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_axisToSlideAlong, "Axis to slide along", "The Axis to slide along")
-                        ->EnumAttribute(RelativeAxisType::ForwardBackward, "Forwards and Backwards")
-                        ->EnumAttribute(RelativeAxisType::LeftRight, "Right and Left")
-                        ->EnumAttribute(RelativeAxisType::UpDown, "Up and Down")
-                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_angleTypeToChangeFor, "Angle Type", "The angle type to base the slide off of")
-                        ->EnumAttribute(EulerAngleType::Pitch, "Pitch")
-                        ->EnumAttribute(EulerAngleType::Roll, "Roll")
-                        ->EnumAttribute(EulerAngleType::Yaw, "Yaw")
-                    ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_maximumPositiveSlideDistance, "Max Positive Slide Distance", "The maximum distance to slide in the positive")
-                        ->Attribute(AZ::Edit::Attributes::Suffix, "m")
-                    ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_maximumNegativeSlideDistance, "Max Negative Slide Distance", "The maximum distance to slide in the negative")
-                        ->Attribute(AZ::Edit::Attributes::Suffix, "m")
-                    ->ClassElement(AZ::Edit::ClassElements::Group, "Vector Components To Ignore")
-                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                        ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreX, "X", "When active, the X Component will be ignored.")
-                        ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreY, "Y", "When active, the Y Component will be ignored.")
-                        ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreZ, "Z", "When active, the Z Component will be ignored.")
-                    ;
+                editContext
+                    ->Class<SlideAlongAxisBasedOnAngle>(
+                        "SlideAlongAxisBasedOnAngle", "Slide 0..SlideDistance along Axis based on Angle Type.  Maps from 90..-90 degrees")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                            ->DataElement(
+                                AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_axisToSlideAlong, "Axis to slide along",
+                                "The Axis to slide along")
+                                ->EnumAttribute(RelativeAxisType::ForwardBackward, "Forwards and Backwards")
+                                ->EnumAttribute(RelativeAxisType::LeftRight, "Right and Left")
+                                ->EnumAttribute(RelativeAxisType::UpDown, "Up and Down")
+                            ->DataElement(
+                                AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_angleTypeToChangeFor, "Angle Type",
+                                "The angle type to base the slide off of")
+                                ->EnumAttribute(EulerAngleType::Pitch, "Pitch")
+                                ->EnumAttribute(EulerAngleType::Roll, "Roll")
+                                ->EnumAttribute(EulerAngleType::Yaw, "Yaw")
+                            ->DataElement(
+                                0, &SlideAlongAxisBasedOnAngle::m_maximumPositiveSlideDistance, "Max Positive Slide Distance",
+                                "The maximum distance to slide in the positive")
+                                    ->Attribute(AZ::Edit::Attributes::Suffix, "m")
+                            ->DataElement(
+                                0, &SlideAlongAxisBasedOnAngle::m_maximumNegativeSlideDistance, "Max Negative Slide Distance",
+                                "The maximum distance to slide in the negative")
+                                    ->Attribute(AZ::Edit::Attributes::Suffix, "m")
+                            ->ClassElement(AZ::Edit::ClassElements::Group, "Vector Components To Ignore")
+                                ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                                ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreX, "X", "When active, the X Component will be ignored.")
+                                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::YAndZIgnored)
+                                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                                ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreY, "Y", "When active, the Y Component will be ignored.")
+                                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndZIgnored)
+                                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                                ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreZ, "Z", "When active, the Z Component will be ignored.")
+                                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndYIgnored)
+                                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
             }
         }
     }
 
-    void SlideAlongAxisBasedOnAngle::AdjustLookAtTarget([[maybe_unused]] float deltaTime, [[maybe_unused]] const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform)
+    void SlideAlongAxisBasedOnAngle::AdjustLookAtTarget(
+        [[maybe_unused]] float deltaTime, [[maybe_unused]] const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform)
     {
         float angle = GetEulerAngleFromTransform(outLookAtTargetTransform, m_angleTypeToChangeFor);
         float currentPositionOnRange = -angle / AZ::Constants::HalfPi;
@@ -67,4 +83,20 @@ namespace Camera
 
         outLookAtTargetTransform.SetTranslation(outLookAtTargetTransform.GetTranslation() + basis * currentPositionOnRange * slideScale);
     }
-}
+
+    bool SlideAlongAxisBasedOnAngle::XAndYIgnored() const
+    {
+        return m_ignoreX && m_ignoreY;
+    }
+
+    bool SlideAlongAxisBasedOnAngle::XAndZIgnored() const
+    {
+        return m_ignoreX && m_ignoreZ;
+    }
+
+    bool SlideAlongAxisBasedOnAngle::YAndZIgnored() const
+    {
+        return m_ignoreY && m_ignoreZ;
+    }
+
+} // namespace Camera

--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.cpp
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.cpp
@@ -61,7 +61,8 @@ namespace Camera
                                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
                             ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreZ, "Z", "When active, the Z Component will be ignored.")
                                 ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndYIgnored)
-                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                    ;
             }
         }
     }
@@ -70,7 +71,7 @@ namespace Camera
         [[maybe_unused]] float deltaTime, [[maybe_unused]] const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform)
     {
         float angle = GetEulerAngleFromTransform(outLookAtTargetTransform, m_angleTypeToChangeFor);
-        float currentPositionOnRange = -angle / AZ::Constants::HalfPi;  
+        float currentPositionOnRange = -angle / AZ::Constants::HalfPi;
         float slideScale = currentPositionOnRange > 0.0f ? m_maximumPositiveSlideDistance : m_maximumNegativeSlideDistance;
 
         AZ::Vector3 basis = outLookAtTargetTransform.GetBasis(m_axisToSlideAlong);

--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.cpp
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.cpp
@@ -32,41 +32,36 @@ namespace Camera
             AZ::EditContext* editContext = serializeContext->GetEditContext();
             if (editContext)
             {
-                editContext
-                    ->Class<SlideAlongAxisBasedOnAngle>(
-                        "SlideAlongAxisBasedOnAngle", "Slide 0..SlideDistance along Axis based on Angle Type.  Maps from 90..-90 degrees")
+                editContext->Class<SlideAlongAxisBasedOnAngle>("SlideAlongAxisBasedOnAngle",
+                    "Slide 0..SlideDistance along Axis based on Angle Type.  Maps from 90..-90 degrees")
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                            ->DataElement(
-                                AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_axisToSlideAlong, "Axis to slide along",
-                                "The Axis to slide along")
-                                ->EnumAttribute(RelativeAxisType::ForwardBackward, "Forwards and Backwards")
-                                ->EnumAttribute(RelativeAxisType::LeftRight, "Right and Left")
-                                ->EnumAttribute(RelativeAxisType::UpDown, "Up and Down")
-                            ->DataElement(
-                                AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_angleTypeToChangeFor, "Angle Type",
-                                "The angle type to base the slide off of")
-                                ->EnumAttribute(EulerAngleType::Pitch, "Pitch")
-                                ->EnumAttribute(EulerAngleType::Roll, "Roll")
-                                ->EnumAttribute(EulerAngleType::Yaw, "Yaw")
-                            ->DataElement(
-                                0, &SlideAlongAxisBasedOnAngle::m_maximumPositiveSlideDistance, "Max Positive Slide Distance",
-                                "The maximum distance to slide in the positive")
-                                    ->Attribute(AZ::Edit::Attributes::Suffix, "m")
-                            ->DataElement(
-                                0, &SlideAlongAxisBasedOnAngle::m_maximumNegativeSlideDistance, "Max Negative Slide Distance",
-                                "The maximum distance to slide in the negative")
-                                    ->Attribute(AZ::Edit::Attributes::Suffix, "m")
-                            ->ClassElement(AZ::Edit::ClassElements::Group, "Vector Components To Ignore")
-                                ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                                ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreX, "X", "When active, the X Component will be ignored.")
-                                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::YAndZIgnored)
-                                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
-                                ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreY, "Y", "When active, the Y Component will be ignored.")
-                                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndZIgnored)
-                                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
-                                ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreZ, "Z", "When active, the Z Component will be ignored.")
-                                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndYIgnored)
-                                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_axisToSlideAlong, "Axis to slide along",
+                            "The Axis to slide along")
+                            ->EnumAttribute(RelativeAxisType::ForwardBackward, "Forwards and Backwards")
+                            ->EnumAttribute(RelativeAxisType::LeftRight, "Right and Left")
+                            ->EnumAttribute(RelativeAxisType::UpDown, "Up and Down")
+                        ->DataElement(AZ::Edit::UIHandlers::ComboBox, &SlideAlongAxisBasedOnAngle::m_angleTypeToChangeFor, "Angle Type",
+                            "The angle type to base the slide off of")
+                            ->EnumAttribute(EulerAngleType::Pitch, "Pitch")
+                            ->EnumAttribute(EulerAngleType::Roll, "Roll")
+                            ->EnumAttribute(EulerAngleType::Yaw, "Yaw")
+                        ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_maximumPositiveSlideDistance, "Max Positive Slide Distance",
+                            "The maximum distance to slide in the positive")
+                            ->Attribute(AZ::Edit::Attributes::Suffix, "m")
+                        ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_maximumNegativeSlideDistance, "Max Negative Slide Distance",
+                            "The maximum distance to slide in the negative")
+                            ->Attribute(AZ::Edit::Attributes::Suffix, "m")
+                        ->ClassElement(AZ::Edit::ClassElements::Group, "Vector Components To Ignore")
+                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                            ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreX, "X", "When active, the X Component will be ignored.")
+                                ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::YAndZIgnored)
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                            ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreY, "Y", "When active, the Y Component will be ignored.")
+                                ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndZIgnored)
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                            ->DataElement(0, &SlideAlongAxisBasedOnAngle::m_ignoreZ, "Z", "When active, the Z Component will be ignored.")
+                                ->Attribute(AZ::Edit::Attributes::ReadOnly, &SlideAlongAxisBasedOnAngle::XAndYIgnored)
+                                ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues);
             }
         }
     }
@@ -75,7 +70,7 @@ namespace Camera
         [[maybe_unused]] float deltaTime, [[maybe_unused]] const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform)
     {
         float angle = GetEulerAngleFromTransform(outLookAtTargetTransform, m_angleTypeToChangeFor);
-        float currentPositionOnRange = -angle / AZ::Constants::HalfPi;
+        float currentPositionOnRange = -angle / AZ::Constants::HalfPi;  
         float slideScale = currentPositionOnRange > 0.0f ? m_maximumPositiveSlideDistance : m_maximumNegativeSlideDistance;
 
         AZ::Vector3 basis = outLookAtTargetTransform.GetBasis(m_axisToSlideAlong);

--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
@@ -34,12 +34,8 @@ namespace Camera
         //////////////////////////////////////////////////////////////////////////
         // ICameraLookAtBehavior
         void AdjustLookAtTarget(float deltaTime, const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform) override;
-        void Activate(AZ::EntityId) override
-        {
-        }
-        void Deactivate() override
-        {
-        }
+        void Activate(AZ::EntityId) override{}
+        void Deactivate() override {}
 
         bool XAndYIgnored() const;
         bool XAndZIgnored() const;

--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
@@ -6,11 +6,11 @@
  *
  */
 #pragma once
-#include <CameraFramework/ICameraLookAtBehavior.h>
-#include <AzCore/Math/Transform.h>
-#include <AzCore/RTTI/ReflectContext.h>
 #include "StartingPointCamera/StartingPointCameraConstants.h"
+#include <AzCore/Math/Transform.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/RTTI/ReflectContext.h>
+#include <CameraFramework/ICameraLookAtBehavior.h>
 
 namespace Camera
 {
@@ -23,8 +23,7 @@ namespace Camera
     /// will occur when looking up.  This could also be used for peeking around
     /// corners.  This is primarily useful for third person cameras.
     //////////////////////////////////////////////////////////////////////////
-    class SlideAlongAxisBasedOnAngle
-        : public ICameraLookAtBehavior
+    class SlideAlongAxisBasedOnAngle : public ICameraLookAtBehavior
     {
     public:
         ~SlideAlongAxisBasedOnAngle() override = default;
@@ -35,8 +34,16 @@ namespace Camera
         //////////////////////////////////////////////////////////////////////////
         // ICameraLookAtBehavior
         void AdjustLookAtTarget(float deltaTime, const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform) override;
-        void Activate(AZ::EntityId) override {}
-        void Deactivate() override {}
+        void Activate(AZ::EntityId) override
+        {
+        }
+        void Deactivate() override
+        {
+        }
+
+        bool XAndYIgnored() const;
+        bool XAndZIgnored() const;
+        bool YAndZIgnored() const;
 
     private:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
@@ -34,7 +34,7 @@ namespace Camera
         //////////////////////////////////////////////////////////////////////////
         // ICameraLookAtBehavior
         void AdjustLookAtTarget(float deltaTime, const AZ::Transform& targetTransform, AZ::Transform& outLookAtTargetTransform) override;
-        void Activate(AZ::EntityId) override{}
+        void Activate(AZ::EntityId) override {}
         void Deactivate() override {}
 
         bool XAndYIgnored() const;

--- a/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
+++ b/Gems/StartingPointCamera/Code/Source/CameraLookAtBehaviors/SlideAlongAxisBasedOnAngle.h
@@ -23,7 +23,8 @@ namespace Camera
     /// will occur when looking up.  This could also be used for peeking around
     /// corners.  This is primarily useful for third person cameras.
     //////////////////////////////////////////////////////////////////////////
-    class SlideAlongAxisBasedOnAngle : public ICameraLookAtBehavior
+    class SlideAlongAxisBasedOnAngle
+        : public ICameraLookAtBehavior
     {
     public:
         ~SlideAlongAxisBasedOnAngle() override = default;


### PR DESCRIPTION
This is a followup PR to #5410 
This disables the checkbox when the other two are activated so you cannot pass a zero vector.

https://user-images.githubusercontent.com/82394219/141302570-830c122d-e3e2-45d5-8aa6-47fc26a9df8a.mp4

