### PR TITLE
Move gamelift client usage into each activity scope

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.cpp
@@ -139,7 +139,7 @@ namespace AWSGameLift
         {
             const AWSGameLiftAcceptMatchRequest& gameliftStartMatchmakingRequest =
                 static_cast<const AWSGameLiftAcceptMatchRequest&>(acceptMatchRequest);
-            AcceptMatchHelper(gameliftStartMatchmakingRequest);
+            AcceptMatchActivity::AcceptMatch(gameliftStartMatchmakingRequest);
         }
     }
 
@@ -157,9 +157,9 @@ namespace AWSGameLift
         AZ::JobContext* jobContext = nullptr;
         AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
         AZ::Job* acceptMatchJob = AZ::CreateJobFunction(
-            [this, gameliftStartMatchmakingRequest]()
+            [gameliftStartMatchmakingRequest]()
             {
-                AcceptMatchHelper(gameliftStartMatchmakingRequest);
+                AcceptMatchActivity::AcceptMatch(gameliftStartMatchmakingRequest);
 
                 AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
                     &AzFramework::MatchmakingAsyncRequestNotifications::OnAcceptMatchAsyncComplete);
@@ -169,21 +169,6 @@ namespace AWSGameLift
         acceptMatchJob->Start(); 
     }
 
-    void AWSGameLiftClientManager::AcceptMatchHelper(const AWSGameLiftAcceptMatchRequest& acceptMatchRequest)
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-
-        AZStd::string response;
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            AcceptMatchActivity::AcceptMatch(*gameliftClient, acceptMatchRequest);
-        }
-    }
-
     AZStd::string AWSGameLiftClientManager::CreateSession(const AzFramework::CreateSessionRequest& createSessionRequest)
     {
         AZStd::string result = "";
@@ -191,13 +176,13 @@ namespace AWSGameLift
         {
             const AWSGameLiftCreateSessionRequest& gameliftCreateSessionRequest =
                 static_cast<const AWSGameLiftCreateSessionRequest&>(createSessionRequest);
-            result = CreateSessionHelper(gameliftCreateSessionRequest);
+            result = CreateSessionActivity::CreateSession(gameliftCreateSessionRequest);
         }
         else if (CreateSessionOnQueueActivity::ValidateCreateSessionOnQueueRequest(createSessionRequest))
         {
             const AWSGameLiftCreateSessionOnQueueRequest& gameliftCreateSessionOnQueueRequest =
                 static_cast<const AWSGameLiftCreateSessionOnQueueRequest&>(createSessionRequest);
-            result = CreateSessionOnQueueHelper(gameliftCreateSessionOnQueueRequest);
+            result = CreateSessionOnQueueActivity::CreateSessionOnQueue(gameliftCreateSessionOnQueueRequest);
         }
         else
         {
@@ -217,9 +202,9 @@ namespace AWSGameLift
             AZ::JobContext* jobContext = nullptr;
             AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
             AZ::Job* createSessionJob = AZ::CreateJobFunction(
-                [this, gameliftCreateSessionRequest]()
+                [gameliftCreateSessionRequest]()
                 {
-                    AZStd::string result = CreateSessionHelper(gameliftCreateSessionRequest);
+                    AZStd::string result = CreateSessionActivity::CreateSession(gameliftCreateSessionRequest);
 
                     AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
                         &AzFramework::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, result);
@@ -235,9 +220,9 @@ namespace AWSGameLift
             AZ::JobContext* jobContext = nullptr;
             AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
             AZ::Job* createSessionOnQueueJob = AZ::CreateJobFunction(
-                [this, gameliftCreateSessionOnQueueRequest]()
+                [gameliftCreateSessionOnQueueRequest]()
                 {
-                    AZStd::string result = CreateSessionOnQueueHelper(gameliftCreateSessionOnQueueRequest);
+                    AZStd::string result = CreateSessionOnQueueActivity::CreateSessionOnQueue(gameliftCreateSessionOnQueueRequest);
 
                     AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
                         &AzFramework::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, result);
@@ -253,38 +238,6 @@ namespace AWSGameLift
         }
     }
 
-    AZStd::string AWSGameLiftClientManager::CreateSessionHelper(
-        const AWSGameLiftCreateSessionRequest& createSessionRequest)
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-        AZStd::string result = "";
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            result = CreateSessionActivity::CreateSession(*gameliftClient, createSessionRequest);
-        }
-        return result;
-    }
-
-    AZStd::string AWSGameLiftClientManager::CreateSessionOnQueueHelper(
-        const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest)
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-        AZStd::string result;
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            result = CreateSessionOnQueueActivity::CreateSessionOnQueue(*gameliftClient, createSessionOnQueueRequest);
-        }
-        return result;
-    }
-
     bool AWSGameLiftClientManager::JoinSession(const AzFramework::JoinSessionRequest& joinSessionRequest)
     {
         bool result = false;
@@ -292,7 +245,8 @@ namespace AWSGameLift
         {
             const AWSGameLiftJoinSessionRequest& gameliftJoinSessionRequest =
                 static_cast<const AWSGameLiftJoinSessionRequest&>(joinSessionRequest);
-            result = JoinSessionHelper(gameliftJoinSessionRequest);
+            auto createPlayerSessionOutcome = JoinSessionActivity::CreatePlayerSession(gameliftJoinSessionRequest);
+            result = JoinSessionActivity::RequestPlayerJoinSession(createPlayerSessionOutcome);
         }
 
         return result;
@@ -313,9 +267,10 @@ namespace AWSGameLift
         AZ::JobContext* jobContext = nullptr;
         AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
         AZ::Job* joinSessionJob = AZ::CreateJobFunction(
-            [this, gameliftJoinSessionRequest]()
+            [gameliftJoinSessionRequest]()
             {
-                bool result = JoinSessionHelper(gameliftJoinSessionRequest);
+                auto createPlayerSessionOutcome = JoinSessionActivity::CreatePlayerSession(gameliftJoinSessionRequest);
+                bool result = JoinSessionActivity::RequestPlayerJoinSession(createPlayerSessionOutcome);
 
                 AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
                     &AzFramework::SessionAsyncRequestNotifications::OnJoinSessionAsyncComplete, result);
@@ -323,23 +278,6 @@ namespace AWSGameLift
             true, jobContext);
 
         joinSessionJob->Start();
-    }
-
-    bool AWSGameLiftClientManager::JoinSessionHelper(const AWSGameLiftJoinSessionRequest& joinSessionRequest)
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-        bool result = false;
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            auto createPlayerSessionOutcome = JoinSessionActivity::CreatePlayerSession(*gameliftClient, joinSessionRequest);
-
-            result = JoinSessionActivity::RequestPlayerJoinSession(createPlayerSessionOutcome);
-        }
-        return result;
     }
 
     void AWSGameLiftClientManager::LeaveSession()
@@ -371,7 +309,7 @@ namespace AWSGameLift
         {
             const AWSGameLiftSearchSessionsRequest& gameliftSearchSessionsRequest =
                 static_cast<const AWSGameLiftSearchSessionsRequest&>(searchSessionsRequest);
-            response = SearchSessionsHelper(gameliftSearchSessionsRequest);
+            response = SearchSessionsActivity::SearchSessions(gameliftSearchSessionsRequest);
         }
 
         return response;
@@ -392,9 +330,9 @@ namespace AWSGameLift
         AZ::JobContext* jobContext = nullptr;
         AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
         AZ::Job* searchSessionsJob = AZ::CreateJobFunction(
-            [this, gameliftSearchSessionsRequest]()
+            [gameliftSearchSessionsRequest]()
             {
-                AzFramework::SearchSessionsResponse response = SearchSessionsHelper(gameliftSearchSessionsRequest);
+                AzFramework::SearchSessionsResponse response = SearchSessionsActivity::SearchSessions(gameliftSearchSessionsRequest);
 
                 AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
                     &AzFramework::SessionAsyncRequestNotifications::OnSearchSessionsAsyncComplete, response);
@@ -404,22 +342,6 @@ namespace AWSGameLift
         searchSessionsJob->Start(); 
     }
 
-    AzFramework::SearchSessionsResponse AWSGameLiftClientManager::SearchSessionsHelper(
-        const AWSGameLiftSearchSessionsRequest& searchSessionsRequest) const
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-        AzFramework::SearchSessionsResponse response;
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            response = SearchSessionsActivity::SearchSessions(*gameliftClient, searchSessionsRequest);
-        }
-        return response;
-    }
-
     AZStd::string AWSGameLiftClientManager::StartMatchmaking(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest)
     {
         AZStd::string response;
@@ -427,7 +349,7 @@ namespace AWSGameLift
         {
             const AWSGameLiftStartMatchmakingRequest& gameliftStartMatchmakingRequest =
                 static_cast<const AWSGameLiftStartMatchmakingRequest&>(startMatchmakingRequest);
-            response = StartMatchmakingHelper(gameliftStartMatchmakingRequest);
+            response = StartMatchmakingActivity::StartMatchmaking(gameliftStartMatchmakingRequest);
         }
 
         return response;
@@ -448,9 +370,9 @@ namespace AWSGameLift
         AZ::JobContext* jobContext = nullptr;
         AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
         AZ::Job* startMatchmakingJob = AZ::CreateJobFunction(
-            [this, gameliftStartMatchmakingRequest]()
+            [gameliftStartMatchmakingRequest]()
             {
-                AZStd::string response = StartMatchmakingHelper(gameliftStartMatchmakingRequest);
+                AZStd::string response = StartMatchmakingActivity::StartMatchmaking(gameliftStartMatchmakingRequest);
 
                 AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
                     &AzFramework::MatchmakingAsyncRequestNotifications::OnStartMatchmakingAsyncComplete, response);
@@ -460,29 +382,14 @@ namespace AWSGameLift
         startMatchmakingJob->Start(); 
     }
 
-    AZStd::string AWSGameLiftClientManager::StartMatchmakingHelper(const AWSGameLiftStartMatchmakingRequest& startMatchmakingRequest)
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-
-        AZStd::string response;
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            response = StartMatchmakingActivity::StartMatchmaking(*gameliftClient, startMatchmakingRequest);
-        }
-        return response;
-    }
-
     void AWSGameLiftClientManager::StopMatchmaking(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest)
     {
         if (StopMatchmakingActivity::ValidateStopMatchmakingRequest(stopMatchmakingRequest))
         {
             const AWSGameLiftStopMatchmakingRequest& gameliftStopMatchmakingRequest =
                 static_cast<const AWSGameLiftStopMatchmakingRequest&>(stopMatchmakingRequest);
-            StopMatchmakingHelper(gameliftStopMatchmakingRequest);
+
+            StopMatchmakingActivity::StopMatchmaking(gameliftStopMatchmakingRequest);
         }
     }
 
@@ -501,9 +408,9 @@ namespace AWSGameLift
         AZ::JobContext* jobContext = nullptr;
         AWSCore::AWSCoreRequestBus::BroadcastResult(jobContext, &AWSCore::AWSCoreRequests::GetDefaultJobContext);
         AZ::Job* stopMatchmakingJob = AZ::CreateJobFunction(
-            [this, gameliftStopMatchmakingRequest]()
+            [gameliftStopMatchmakingRequest]()
             {
-                StopMatchmakingHelper(gameliftStopMatchmakingRequest);
+                StopMatchmakingActivity::StopMatchmaking(gameliftStopMatchmakingRequest);
 
                 AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
                     &AzFramework::MatchmakingAsyncRequestNotifications::OnStopMatchmakingAsyncComplete);
@@ -511,19 +418,5 @@ namespace AWSGameLift
             true, jobContext);
 
         stopMatchmakingJob->Start(); 
-    }
-
-    void AWSGameLiftClientManager::StopMatchmakingHelper(const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest)
-    {
-        auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
-
-        if (!gameliftClient)
-        {
-            AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftClientMissingErrorMessage);
-        }
-        else
-        {
-            StopMatchmakingActivity::StopMatchmaking(*gameliftClient, stopMatchmakingRequest);
-        }
     }
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.h
@@ -175,14 +175,5 @@ namespace AWSGameLift
         bool JoinSession(const AzFramework::JoinSessionRequest& joinSessionRequest) override;
         AzFramework::SearchSessionsResponse SearchSessions(const AzFramework::SearchSessionsRequest& searchSessionsRequest) const override;
         void LeaveSession() override;
-
-    private:
-        void AcceptMatchHelper(const AWSGameLiftAcceptMatchRequest& createSessionRequest);
-        AZStd::string CreateSessionHelper(const AWSGameLiftCreateSessionRequest& createSessionRequest);
-        AZStd::string CreateSessionOnQueueHelper(const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest);
-        bool JoinSessionHelper(const AWSGameLiftJoinSessionRequest& joinSessionRequest);
-        AzFramework::SearchSessionsResponse SearchSessionsHelper(const AWSGameLiftSearchSessionsRequest& searchSessionsRequest) const;
-        AZStd::string StartMatchmakingHelper(const AWSGameLiftStartMatchmakingRequest& startMatchmakingRequest);
-        void StopMatchmakingHelper(const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest);
     };
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.cpp
@@ -7,9 +7,11 @@
  */
 
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 
 #include <Activity/AWSGameLiftAcceptMatchActivity.h>
 #include <AWSGameLiftSessionConstants.h>
+#include <Request/IAWSGameLiftInternalRequests.h>
 
 #include <aws/core/utils/Outcome.h>
 #include <aws/gamelift/model/AcceptMatchRequest.h>
@@ -42,13 +44,19 @@ namespace AWSGameLift
             return request;
         }
 
-        void AcceptMatch(const Aws::GameLift::GameLiftClient& gameliftClient,
-            const AWSGameLiftAcceptMatchRequest& AcceptMatchRequest)
+        void AcceptMatch(const AWSGameLiftAcceptMatchRequest& AcceptMatchRequest)
         {
+            auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
+            if (!gameliftClient)
+            {
+                AZ_Error(AWSGameLiftAcceptMatchActivityName, false, AWSGameLiftClientMissingErrorMessage);
+                return;
+            }
+
             AZ_TracePrintf(AWSGameLiftAcceptMatchActivityName, "Requesting AcceptMatch against Amazon GameLift service ...");
 
             Aws::GameLift::Model::AcceptMatchRequest request = BuildAWSGameLiftAcceptMatchRequest(AcceptMatchRequest);
-            auto AcceptMatchOutcome = gameliftClient.AcceptMatch(request);
+            auto AcceptMatchOutcome = gameliftClient->AcceptMatch(request);
 
             if (AcceptMatchOutcome.IsSuccess())
             {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.h
@@ -23,7 +23,7 @@ namespace AWSGameLift
         Aws::GameLift::Model::AcceptMatchRequest BuildAWSGameLiftAcceptMatchRequest(const AWSGameLiftAcceptMatchRequest& AcceptMatchRequest);
 
         // Create AcceptMatchRequest and make a AcceptMatch call through GameLift client
-        void AcceptMatch(const Aws::GameLift::GameLiftClient& gameliftClient, const AWSGameLiftAcceptMatchRequest& AcceptMatchRequest);
+        void AcceptMatch(const AWSGameLiftAcceptMatchRequest& AcceptMatchRequest);
 
         // Validate AcceptMatchRequest and check required request parameters
         bool ValidateAcceptMatchRequest(const AzFramework::AcceptMatchRequest& AcceptMatchRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.cpp
@@ -6,9 +6,16 @@
  *
  */
 
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+
 #include <Activity/AWSGameLiftActivityUtils.h>
 #include <Activity/AWSGameLiftCreateSessionActivity.h>
 #include <AWSGameLiftSessionConstants.h>
+#include <Request/IAWSGameLiftInternalRequests.h>
+
+#include <aws/core/utils/Outcome.h>
+#include <aws/gamelift/model/CreateGameSessionRequest.h>
 
 namespace AWSGameLift
 {
@@ -63,15 +70,21 @@ namespace AWSGameLift
             return request;
         }
 
-        AZStd::string CreateSession(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
-            const AWSGameLiftCreateSessionRequest& createSessionRequest)
+        AZStd::string CreateSession(const AWSGameLiftCreateSessionRequest& createSessionRequest)
         {
+            AZStd::string result = "";
+
+            auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
+            if (!gameliftClient)
+            {
+                AZ_Error(AWSGameLiftCreateSessionActivityName, false, AWSGameLiftClientMissingErrorMessage);
+                return result;
+            }
+
             AZ_TracePrintf(AWSGameLiftCreateSessionActivityName, "Requesting CreateGameSession against Amazon GameLift service ...");
 
-            AZStd::string result = "";
             Aws::GameLift::Model::CreateGameSessionRequest request = BuildAWSGameLiftCreateGameSessionRequest(createSessionRequest);
-            auto createSessionOutcome = gameliftClient.CreateGameSession(request);
+            auto createSessionOutcome = gameliftClient->CreateGameSession(request);
             AZ_TracePrintf(AWSGameLiftCreateSessionActivityName, "CreateGameSession request against Amazon GameLift service is complete");
 
             if (createSessionOutcome.IsSuccess())

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.h
@@ -10,9 +10,7 @@
 
 #include <Request/AWSGameLiftCreateSessionRequest.h>
 
-#include <aws/core/utils/Outcome.h>
 #include <aws/gamelift/GameLiftClient.h>
-#include <aws/gamelift/model/CreateGameSessionRequest.h>
 
 namespace AWSGameLift
 {
@@ -24,9 +22,7 @@ namespace AWSGameLift
         Aws::GameLift::Model::CreateGameSessionRequest BuildAWSGameLiftCreateGameSessionRequest(const AWSGameLiftCreateSessionRequest& createSessionRequest);
 
         // Create CreateGameSessionRequest and make a CreateGameSession call through GameLift client
-        AZStd::string CreateSession(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
-            const AWSGameLiftCreateSessionRequest& createSessionRequest);
+        AZStd::string CreateSession(const AWSGameLiftCreateSessionRequest& createSessionRequest);
 
         // Validate CreateSessionRequest and check required request parameters
         bool ValidateCreateSessionRequest(const AzFramework::CreateSessionRequest& createSessionRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.cpp
@@ -6,9 +6,16 @@
  *
  */
 
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+
 #include <AWSGameLiftSessionConstants.h>
 #include <Activity/AWSGameLiftActivityUtils.h>
 #include <Activity/AWSGameLiftCreateSessionOnQueueActivity.h>
+#include <Request/IAWSGameLiftInternalRequests.h>
+
+#include <aws/core/utils/Outcome.h>
+#include <aws/gamelift/model/StartGameSessionPlacementRequest.h>
 
 namespace AWSGameLift
 {
@@ -47,17 +54,23 @@ namespace AWSGameLift
             return request;
         }
 
-        AZStd::string CreateSessionOnQueue(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
-            const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest)
+        AZStd::string CreateSessionOnQueue(const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest)
         {
+            AZStd::string result = "";
+
+            auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
+            if (!gameliftClient)
+            {
+                AZ_Error(AWSGameLiftCreateSessionOnQueueActivityName, false, AWSGameLiftClientMissingErrorMessage);
+                return result;
+            }
+
             AZ_TracePrintf(AWSGameLiftCreateSessionOnQueueActivityName,
                 "Requesting StartGameSessionPlacement against Amazon GameLift service ...");
 
-            AZStd::string result = "";
             Aws::GameLift::Model::StartGameSessionPlacementRequest request =
                 BuildAWSGameLiftStartGameSessionPlacementRequest(createSessionOnQueueRequest);
-            auto createSessionOnQueueOutcome = gameliftClient.StartGameSessionPlacement(request);
+            auto createSessionOnQueueOutcome = gameliftClient->StartGameSessionPlacement(request);
             AZ_TracePrintf(AWSGameLiftCreateSessionOnQueueActivityName,
                 "StartGameSessionPlacement request against Amazon GameLift service is complete.");
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.h
@@ -10,9 +10,7 @@
 
 #include <Request/AWSGameLiftCreateSessionOnQueueRequest.h>
 
-#include <aws/core/utils/Outcome.h>
 #include <aws/gamelift/GameLiftClient.h>
-#include <aws/gamelift/model/StartGameSessionPlacementRequest.h>
 
 namespace AWSGameLift
 {
@@ -25,9 +23,7 @@ namespace AWSGameLift
             const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest);
 
         // Create StartGameSessionPlacementRequest and make a CreateGameSession call through GameLift client
-        AZStd::string CreateSessionOnQueue(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
-            const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest);
+        AZStd::string CreateSessionOnQueue(const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest);
 
         // Validate CreateSessionOnQueueRequest and check required request parameters
         bool ValidateCreateSessionOnQueueRequest(const AzFramework::CreateSessionRequest& createSessionRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.cpp
@@ -7,10 +7,11 @@
  */
 
 #include <AzCore/Interface/Interface.h>
-#include <AzFramework/Session/ISessionHandlingRequests.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 
 #include <Activity/AWSGameLiftJoinSessionActivity.h>
 #include <AWSGameLiftSessionConstants.h>
+#include <Request/IAWSGameLiftInternalRequests.h>
 
 namespace AWSGameLift
 {
@@ -59,16 +60,24 @@ namespace AWSGameLift
         }
 
         Aws::GameLift::Model::CreatePlayerSessionOutcome CreatePlayerSession(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftJoinSessionRequest& joinSessionRequest)
         {
+            Aws::GameLift::Model::CreatePlayerSessionOutcome createPlayerSessionOutcome;
+
+            auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
+            if (!gameliftClient)
+            {
+                AZ_Error(AWSGameLiftJoinSessionActivityName, false, AWSGameLiftClientMissingErrorMessage);
+                return createPlayerSessionOutcome;
+            }
+
             AZ_TracePrintf(AWSGameLiftJoinSessionActivityName,
                 "Requesting CreatePlayerSession for player %s against Amazon GameLift service ...",
                 joinSessionRequest.m_playerId.c_str());
 
             Aws::GameLift::Model::CreatePlayerSessionRequest request =
                 BuildAWSGameLiftCreatePlayerSessionRequest(joinSessionRequest);
-            auto createPlayerSessionOutcome = gameliftClient.CreatePlayerSession(request);
+            createPlayerSessionOutcome = gameliftClient->CreatePlayerSession(request);
             AZ_TracePrintf(AWSGameLiftJoinSessionActivityName,
                 "CreatePlayerSession request for player %s against Amazon GameLift service is complete", joinSessionRequest.m_playerId.c_str());
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.h
@@ -36,7 +36,6 @@ namespace AWSGameLift
 
         // Create CreatePlayerSessionRequest and make a CreatePlayerSession call through GameLift client
         Aws::GameLift::Model::CreatePlayerSessionOutcome CreatePlayerSession(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftJoinSessionRequest& joinSessionRequest);
 
         // Request to setup networking connection for player

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftLeaveSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftLeaveSessionActivity.cpp
@@ -6,10 +6,11 @@
  *
  */
 
-#include <Activity/AWSGameLiftLeaveSessionActivity.h>
-
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzFramework/Session/ISessionHandlingRequests.h>
+
+#include <Activity/AWSGameLiftLeaveSessionActivity.h>
 
 namespace AWSGameLift
 {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.cpp
@@ -6,10 +6,16 @@
  *
  */
 
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzFramework/Session/SessionConfig.h>
 
 #include <Activity/AWSGameLiftSearchSessionsActivity.h>
 #include <AWSGameLiftSessionConstants.h>
+#include <Request/IAWSGameLiftInternalRequests.h>
+
+#include <aws/core/utils/Outcome.h>
+#include <aws/gamelift/model/SearchGameSessionsRequest.h>
 
 namespace AWSGameLift
 {
@@ -62,14 +68,21 @@ namespace AWSGameLift
         }
 
         AzFramework::SearchSessionsResponse SearchSessions(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftSearchSessionsRequest& searchSessionsRequest)
         {
+            AzFramework::SearchSessionsResponse response;
+
+            auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
+            if (!gameliftClient)
+            {
+                AZ_Error(AWSGameLiftSearchSessionsActivityName, false, AWSGameLiftClientMissingErrorMessage);
+                return response;
+            }
+
             AZ_TracePrintf(AWSGameLiftSearchSessionsActivityName, "Requesting SearchGameSessions against Amazon GameLift service ...");
 
-            AzFramework::SearchSessionsResponse response;
             Aws::GameLift::Model::SearchGameSessionsRequest request = BuildAWSGameLiftSearchGameSessionsRequest(searchSessionsRequest);
-            Aws::GameLift::Model::SearchGameSessionsOutcome outcome = gameliftClient.SearchGameSessions(request);
+            Aws::GameLift::Model::SearchGameSessionsOutcome outcome = gameliftClient->SearchGameSessions(request);
             AZ_TracePrintf(AWSGameLiftSearchSessionsActivityName, "SearchGameSessions request against Amazon GameLift service is complete");
 
             if (outcome.IsSuccess())

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.h
@@ -10,9 +10,7 @@
 
 #include <Request/AWSGameLiftSearchSessionsRequest.h>
 
-#include <aws/core/utils/Outcome.h>
 #include <aws/gamelift/GameLiftClient.h>
-#include <aws/gamelift/model/SearchGameSessionsRequest.h>
 
 namespace AWSGameLift
 {
@@ -28,7 +26,6 @@ namespace AWSGameLift
 
         // Create SearchGameSessionsRequest and make a SeachGameSessions call through GameLift client
         AzFramework::SearchSessionsResponse SearchSessions(
-            const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftSearchSessionsRequest& searchSessionsRequest);
 
         // Convert from Aws::GameLift::Model::SearchGameSessionsResult to AzFramework::SearchSessionsResponse.

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStartMatchmakingActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStartMatchmakingActivity.h
@@ -23,7 +23,7 @@ namespace AWSGameLift
         Aws::GameLift::Model::StartMatchmakingRequest BuildAWSGameLiftStartMatchmakingRequest(const AWSGameLiftStartMatchmakingRequest& startMatchmakingRequest);
 
         // Create StartMatchmakingRequest and make a StartMatchmaking call through GameLift client
-        AZStd::string StartMatchmaking(const Aws::GameLift::GameLiftClient& gameliftClient, const AWSGameLiftStartMatchmakingRequest& startMatchmakingRequest);
+        AZStd::string StartMatchmaking(const AWSGameLiftStartMatchmakingRequest& startMatchmakingRequest);
 
         // Validate StartMatchmakingRequest and check required request parameters
         bool ValidateStartMatchmakingRequest(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.cpp
@@ -7,9 +7,11 @@
  */
 
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
 
 #include <Activity/AWSGameLiftStopMatchmakingActivity.h>
 #include <AWSGameLiftSessionConstants.h>
+#include <Request/IAWSGameLiftInternalRequests.h>
 
 #include <aws/core/utils/Outcome.h>
 #include <aws/gamelift/model/StopMatchmakingRequest.h>
@@ -32,13 +34,19 @@ namespace AWSGameLift
             return request;
         }
 
-        void StopMatchmaking(const Aws::GameLift::GameLiftClient& gameliftClient,
-            const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest)
+        void StopMatchmaking(const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest)
         {
+            auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
+            if (!gameliftClient)
+            {
+                AZ_Error(AWSGameLiftStopMatchmakingActivityName, false, AWSGameLiftClientMissingErrorMessage);
+                return;
+            }
+
             AZ_TracePrintf(AWSGameLiftStopMatchmakingActivityName, "Requesting StopMatchmaking against Amazon GameLift service ...");
 
             Aws::GameLift::Model::StopMatchmakingRequest request = BuildAWSGameLiftStopMatchmakingRequest(stopMatchmakingRequest);
-            auto stopMatchmakingOutcome = gameliftClient.StopMatchmaking(request);
+            auto stopMatchmakingOutcome = gameliftClient->StopMatchmaking(request);
 
             if (stopMatchmakingOutcome.IsSuccess())
             {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.h
@@ -23,7 +23,7 @@ namespace AWSGameLift
         Aws::GameLift::Model::StopMatchmakingRequest BuildAWSGameLiftStopMatchmakingRequest(const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest);
 
         // Create StopMatchmakingRequest and make a StopMatchmaking call through GameLift client
-        void StopMatchmaking(const Aws::GameLift::GameLiftClient& gameliftClient, const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest);
+        void StopMatchmaking(const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest);
 
         // Validate StopMatchmakingRequest and check required request parameters
         bool ValidateStopMatchmakingRequest(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionActivityTest.cpp
@@ -9,6 +9,8 @@
 #include <Activity/AWSGameLiftCreateSessionActivity.h>
 #include <AWSGameLiftClientFixture.h>
 
+#include <aws/gamelift/model/CreateGameSessionRequest.h>
+
 using namespace AWSGameLift;
 
 using AWSGameLiftCreateSessionActivityTest = AWSGameLiftClientFixture;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionOnQueueActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionOnQueueActivityTest.cpp
@@ -9,6 +9,8 @@
 #include <AWSGameLiftClientFixture.h>
 #include <Activity/AWSGameLiftCreateSessionOnQueueActivity.h>
 
+#include <aws/gamelift/model/StartGameSessionPlacementRequest.h>
+
 using namespace AWSGameLift;
 
 using AWSGameLiftCreateSessionOnQueueActivityTest = AWSGameLiftClientFixture;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftJoinSessionActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftJoinSessionActivityTest.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <AzFramework/Session/ISessionHandlingRequests.h>
+
 #include <AWSGameLiftClientFixture.h>
 #include <Activity/AWSGameLiftJoinSessionActivity.h>
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftSearchSessionsActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftSearchSessionsActivityTest.cpp
@@ -12,6 +12,9 @@
 #include <AWSGameLiftClientFixture.h>
 #include <AWSGameLiftSessionConstants.h>
 
+#include <aws/core/utils/Outcome.h>
+#include <aws/gamelift/model/SearchGameSessionsRequest.h>
+
 using namespace AWSGameLift;
 
 using AWSGameLiftSearchSessionsActivityTest = AWSGameLiftClientFixture;


### PR DESCRIPTION
## Details
Previously we move gamelift client ownership to the system component, so we don't need to pass it to each activity. Instead we can get it in activity scope directly.

## Testing
Pass unit test

Signed-off-by: onecent1101 <liug@amazon.com>