### PR TITLE
cherry pick atom optimizations

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -41,9 +41,12 @@ namespace AZ
                     AZ_Assert(readOnlyCache.empty(), "Inactive library has pipeline states in its global entry.");
                 }
 
+#if defined(AZ_DEBUG_BUILD)
+                // the PipelineStateSet is expensive to duplicate, only do this in debug.
                 PipelineStateSet readOnlyCacheCopy = readOnlyCache;
                 AZ_Assert(AZStd::unique(readOnlyCacheCopy.begin(), readOnlyCacheCopy.end()) == readOnlyCacheCopy.end(),
                     "'%d' Duplicates existed in the read-only cache!", readOnlyCache.size() - readOnlyCacheCopy.size());
+#endif
             }
 
             m_threadLibrarySet.ForEach([this](const ThreadLibrarySet& threadLibrarySet)

--- a/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/DX12/Code/Include/Atom/RHI.Reflect/DX12/PlatformLimitsDescriptor.h
@@ -40,7 +40,7 @@ namespace AZ
             uint32_t m_swapChainsPerCommandList = 8;
 
             // The maximum cost that can be associated with a single command list.
-            uint32_t m_commandListCostThresholdMin = 1000;
+            uint32_t m_commandListCostThresholdMin = 250;
 
             // The maximum number of command lists per scope.
             uint32_t m_commandListsPerScopeMax = 16;

--- a/Gems/Atom/RHI/Metal/Code/Include/Atom/RHI.Reflect/Metal/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/Metal/Code/Include/Atom/RHI.Reflect/Metal/PlatformLimitsDescriptor.h
@@ -31,7 +31,7 @@ namespace AZ
             uint32_t m_swapChainsPerCommandList = 8;
 
             // The maximum cost that can be associated with a single command list.
-            uint32_t m_commandListCostThresholdMin = 1000;
+            uint32_t m_commandListCostThresholdMin = 250;
 
             // The maximum number of command lists per scope.
             uint32_t m_commandListsPerScopeMax = 16;

--- a/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/PlatformLimitsDescriptor.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Include/Atom/RHI.Reflect/Vulkan/PlatformLimitsDescriptor.h
@@ -33,7 +33,7 @@ namespace AZ
             uint32_t m_swapChainsPerCommandList = 8;
 
             // The maximum cost that can be associated with a single command list.
-            uint32_t m_commandListCostThresholdMin = 1000;
+            uint32_t m_commandListCostThresholdMin = 250;
 
             // The maximum number of command lists per scope.
             uint32_t m_commandListsPerScopeMax = 16;


### PR DESCRIPTION
Pull over the changes to move some expensive validation to debug builds only, and use finer grained jobs for the frame scheduler work.