### PR TITLE
Add a name to JobManager

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.cpp
+++ b/Code/Framework/AzCore/AzCore/IO/Streamer/FullFileDecompressor.cpp
@@ -62,6 +62,7 @@ namespace AZ
             , m_alignment(alignment)
         {
             JobManagerDesc jobDesc;
+            jobDesc.m_jobManagerName = "Full File Decompressor";
             u32 numThreads = AZ::GetMin(maxNumJobs, AZStd::thread::hardware_concurrency());
             for (u32 i = 0; i < numThreads; ++i)
             {

--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
@@ -633,14 +633,12 @@ JobManagerWorkStealing::ThreadList JobManagerWorkStealing::CreateWorkerThreads(c
         info->m_owningManager = this;
         info->m_workerId = iThread;
 
-        char threadName[64];
-        sprintf_s(
-            threadName, 
+        AZStd::fixed_string<128> threadName = AZStd::fixed_string<128>::format(
             "%s worker thread %d", 
             jmDesc.m_jobManagerName[0] != '\0' ? jmDesc.m_jobManagerName : "AZ JobManager", 
             iThread);
         AZStd::thread_desc threadDesc;
-        threadDesc.m_name = threadName;
+        threadDesc.m_name = threadName.c_str();
         threadDesc.m_cpuId = desc.m_cpuId;
         threadDesc.m_priority = desc.m_priority;
         if (desc.m_stackSize != 0)

--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
@@ -83,7 +83,7 @@ AZ_THREAD_LOCAL JobManagerWorkStealing::ThreadInfo* JobManagerWorkStealing::m_cu
 
 JobManagerWorkStealing::JobManagerWorkStealing(const JobManagerDesc& desc)
     : m_isAsynchronous(!desc.m_workerThreads.empty())
-    , m_workerThreads(AZStd::move(CreateWorkerThreads(desc.m_workerThreads)))
+    , m_workerThreads(AZStd::move(CreateWorkerThreads(desc)))
 {
     //allow workers to begin processing after they have all been created, needed to wait since they may access each others queues
     m_initSemaphore.release(static_cast<unsigned int>(desc.m_workerThreads.size()));
@@ -618,8 +618,9 @@ JobManagerWorkStealing::ThreadInfo* JobManagerWorkStealing::FindCurrentThreadInf
     return info;
 }
 
-JobManagerWorkStealing::ThreadList JobManagerWorkStealing::CreateWorkerThreads(const JobManagerDesc::DescList& workerDescList)
+JobManagerWorkStealing::ThreadList JobManagerWorkStealing::CreateWorkerThreads(const JobManagerDesc& jmDesc)
 {
+    const JobManagerDesc::DescList& workerDescList = jmDesc.m_workerThreads;
     ThreadList workerThreads(workerDescList.size());
     m_threads.reserve(workerDescList.size());
 
@@ -632,8 +633,14 @@ JobManagerWorkStealing::ThreadList JobManagerWorkStealing::CreateWorkerThreads(c
         info->m_owningManager = this;
         info->m_workerId = iThread;
 
+        char threadName[64];
+        sprintf_s(
+            threadName, 
+            "%s worker thread %d", 
+            jmDesc.m_jobManagerName[0] != '\0' ? jmDesc.m_jobManagerName : "AZ JobManager", 
+            iThread);
         AZStd::thread_desc threadDesc;
-        threadDesc.m_name = "AZ JobManager worker thread";
+        threadDesc.m_name = threadName;
         threadDesc.m_cpuId = desc.m_cpuId;
         threadDesc.m_priority = desc.m_priority;
         if (desc.m_stackSize != 0)

--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/std/parallel/thread.h>
 #include <AzCore/std/parallel/lock.h>
 #include <AzCore/std/functional.h>
+#include <AzCore/std/string/fixed_string.h>
 
 #include <AzCore/Debug/Profiler.h>
 

--- a/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/Internal/JobManagerWorkStealing.h
@@ -115,7 +115,7 @@ namespace AZ
             void ProcessJobsAssist(ThreadInfo* info, Job* suspendedJob, AZStd::atomic<bool>* notifyFlag);
             void ProcessJobsSynchronous(ThreadInfo* info, Job* suspendedJob, AZStd::atomic<bool>* notifyFlag);
             void ProcessJobsInternal(ThreadInfo* info, Job* suspendedJob, AZStd::atomic<bool>* notifyFlag);
-            ThreadList CreateWorkerThreads(const JobManagerDesc::DescList& workerDescList);
+            ThreadList CreateWorkerThreads(const JobManagerDesc& jmDesc);
 #ifndef AZ_MONOLITHIC_BUILD
             ThreadInfo* CrossModuleFindAndSetWorkerThreadInfo() const;
 #endif

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -51,6 +51,7 @@ namespace AZ
         JobManagerBus::Handler::BusConnect();
 
         JobManagerDesc desc;
+        desc.m_jobManagerName = "Default JobManager";
         JobManagerThreadDesc threadDesc;
 
         int numberOfWorkerThreads = m_numberOfWorkerThreads;

--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerDesc.h
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerDesc.h
@@ -51,6 +51,8 @@ namespace AZ
     {
         JobManagerDesc() {}
 
+        const char* m_jobManagerName = "";
+
         using DescList = AZStd::fixed_vector<JobManagerThreadDesc, 64>;
         DescList m_workerThreads; ///< List of worker threads to create
     };

--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
@@ -160,7 +160,7 @@ namespace AWSCore
                 // If m_firstThreadCPU isn't -1, then each thread will be
                 // assigned to a specific CPU starting with the specified CPU.
                 AZ::JobManagerDesc jobManagerDesc{};
-                JobManagerDesc.m_jobManagerName = "AWSCore JobManager";
+                jobManagerDesc.m_jobManagerName = "AWSCore JobManager";
                 AZ::JobManagerThreadDesc threadDesc(m_firstThreadCPU, m_threadPriority, m_threadStackSize);
                 for (int i = 0; i < m_threadCount; ++i)
                 {

--- a/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreSystemComponent.cpp
@@ -160,6 +160,7 @@ namespace AWSCore
                 // If m_firstThreadCPU isn't -1, then each thread will be
                 // assigned to a specific CPU starting with the specified CPU.
                 AZ::JobManagerDesc jobManagerDesc{};
+                JobManagerDesc.m_jobManagerName = "AWSCore JobManager";
                 AZ::JobManagerThreadDesc threadDesc(m_firstThreadCPU, m_threadPriority, m_threadStackSize);
                 for (int i = 0; i < m_threadCount; ++i)
                 {

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImagePreview.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImagePreview.cpp
@@ -101,6 +101,8 @@ namespace ImageProcessingAtom
     void ImagePreview::InitializeJobSettings()
     {
         AZ::JobManagerDesc desc;
+        jobDesc.m_jobManagerName = "ImagePreview";
+
         AZ::JobManagerThreadDesc threadDesc;
         desc.m_workerThreads.push_back(threadDesc);
         // Check to ensure these have not already been initialized.

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImagePreview.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImagePreview.cpp
@@ -101,7 +101,7 @@ namespace ImageProcessingAtom
     void ImagePreview::InitializeJobSettings()
     {
         AZ::JobManagerDesc desc;
-        jobDesc.m_jobManagerName = "ImagePreview";
+        desc.m_jobManagerName = "ImagePreview";
 
         AZ::JobManagerThreadDesc threadDesc;
         desc.m_workerThreads.push_back(threadDesc);

--- a/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
+++ b/Gems/Atom/Utils/Code/Source/AssetCollectionAsyncLoader.cpp
@@ -123,6 +123,8 @@ namespace AZ
 
         // Prepare to create a cancellable job.
         AZ::JobManagerDesc desc;
+        desc.m_jobManagerName = "AssetCollectionAsyncLoader";
+
         AZ::JobManagerThreadDesc threadDesc;
         desc.m_workerThreads.push_back(threadDesc);
         m_jobManager = AZStd::make_unique<AZ::JobManager>(desc);


### PR DESCRIPTION
 all worker threads use that name to label their threads

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>

With this change we now see these names in pix
![image](https://user-images.githubusercontent.com/82187279/141388325-7b12d77a-b0a7-46c2-b62d-ad70961a5b52.png)
