### PR TITLE
Fixed physics tests on linux

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/utils/FileManagement.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/utils/FileManagement.py
@@ -218,6 +218,7 @@ class FileManagement:
         src_file_path = os.path.join(src_path, src_file)
         if os.path.exists(target_file_path):
             fs.unlock_file(target_file_path)
+        os.makedirs(target_path, exist_ok=True)
         shutil.copyfile(src_file_path, target_file_path)
 
     @staticmethod

--- a/Tools/LyTestTools/ly_test_tools/environment/file_system.py
+++ b/Tools/LyTestTools/ly_test_tools/environment/file_system.py
@@ -219,7 +219,8 @@ def unlock_file(file_name):
     :return: True if unlock succeeded, else False
     """
     if not os.access(file_name, os.W_OK):
-        os.chmod(file_name, stat.S_IWRITE)
+        file_stat = os.stat(file_name)
+        os.chmod(file_name, file_stat.st_mode | stat.S_IWRITE)
         logger.warning(f'Clearing write lock for file {file_name}.')
         return True
     else:
@@ -235,7 +236,8 @@ def lock_file(file_name):
     :return: True if lock succeeded, else False
     """
     if os.access(file_name, os.W_OK):
-        os.chmod(file_name, stat.S_IREAD)
+        file_stat = os.stat(file_name)
+        os.chmod(file_name, file_stat.st_mode | stat.S_IREAD)
         logger.warning(f'Write locking file {file_name}')
         return True
     else:

--- a/Tools/LyTestTools/ly_test_tools/environment/file_system.py
+++ b/Tools/LyTestTools/ly_test_tools/environment/file_system.py
@@ -237,7 +237,7 @@ def lock_file(file_name):
     """
     if os.access(file_name, os.W_OK):
         file_stat = os.stat(file_name)
-        os.chmod(file_name, file_stat.st_mode | stat.S_IREAD)
+        os.chmod(file_name, file_stat.st_mode & (~stat.S_IWRITE))
         logger.warning(f'Write locking file {file_name}')
         return True
     else:

--- a/Tools/LyTestTools/tests/unit/test_file_system.py
+++ b/Tools/LyTestTools/tests/unit/test_file_system.py
@@ -464,24 +464,24 @@ class TestUnlockFile(unittest.TestCase):
     def setUp(self):
         self.file_name = 'file'
 
+    @mock.patch('os.stat')
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    @mock.patch('os.stat')
     def test_UnlockFile_WriteLocked_UnlockFile(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = False
-        mock_stat.return_value = MockStatResult(stat.S_IREAD)
+        os.stat.return_value = MockStatResult(stat.S_IREAD)
 
         success = file_system.unlock_file(self.file_name)
         mock_chmod.assert_called_once_with(self.file_name, stat.S_IREAD | stat.S_IWRITE)
 
         self.assertTrue(success)
 
+    @mock.patch('os.stat')
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    @mock.patch('os.stat')
     def test_UnlockFile_AlreadyUnlocked_LogAlreadyUnlocked(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = True
-        mock_stat.return_value = MockStatResult(stat.S_IREAD | stat.S_IWRITE)
+        os.stat.return_value = MockStatResult(stat.S_IREAD | stat.S_IWRITE)
 
         success = file_system.unlock_file(self.file_name)
 
@@ -493,24 +493,24 @@ class TestLockFile(unittest.TestCase):
     def setUp(self):
         self.file_name = 'file'
 
+    @mock.patch('os.stat')
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    @mock.patch('os.stat')
     def test_LockFile_UnlockedFile_FileLockedSuccessReturnsTrue(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = True
-        mock_stat.return_value = MockStatResult(stat.S_IREAD | stat.S_IWRITE)
+        os.stat.return_value = MockStatResult(stat.S_IREAD | stat.S_IWRITE)
 
         success = file_system.lock_file(self.file_name)
         mock_chmod.assert_called_once_with(self.file_name, stat.S_IREAD)
 
         self.assertTrue(success)
 
+    @mock.patch('os.stat')
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    @mock.patch('os.stat')
     def test_LockFile_AlreadyLocked_FileLockedFailedReturnsFalse(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = False
-        mock_stat.return_value = MockStatResult(stat.S_IREAD)
+        os.stat.return_value = MockStatResult(stat.S_IREAD)
 
         success = file_system.lock_file(self.file_name)
 

--- a/Tools/LyTestTools/tests/unit/test_file_system.py
+++ b/Tools/LyTestTools/tests/unit/test_file_system.py
@@ -8,6 +8,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 import errno
 import logging
 import os
+import stat
 import psutil
 import subprocess
 import sys
@@ -454,6 +455,10 @@ class TestChangePermissions(unittest.TestCase):
         self.assertEqual(file_system.change_permissions('.', 0o777), False)
 
 
+class MockStatResult():
+    def __init__(self, st_mode):
+        self.st_mode = st_mode
+
 class TestUnlockFile(unittest.TestCase):
 
     def setUp(self):
@@ -461,17 +466,22 @@ class TestUnlockFile(unittest.TestCase):
 
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    def test_UnlockFile_WriteLocked_UnlockFile(self, mock_access, mock_chmod):
+    @mock.patch('os.stat')
+    def test_UnlockFile_WriteLocked_UnlockFile(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = False
+        mock_stat.return_value = MockStatResult(stat.S_IREAD)
 
         success = file_system.unlock_file(self.file_name)
+        mock_chmod.assert_called_once_with(self.file_name, stat.S_IREAD | stat.S_IWRITE)
 
         self.assertTrue(success)
 
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    def test_UnlockFile_AlreadyUnlocked_LogAlreadyUnlocked(self, mock_access, mock_chmod):
+    @mock.patch('os.stat')
+    def test_UnlockFile_AlreadyUnlocked_LogAlreadyUnlocked(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = True
+        mock_stat.return_value = MockStatResult(stat.S_IREAD | stat.S_IWRITE)
 
         success = file_system.unlock_file(self.file_name)
 
@@ -485,17 +495,22 @@ class TestLockFile(unittest.TestCase):
 
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    def test_UnlockFile_UnlockedFile_FileLockedSuccessReturnsTrue(self, mock_access, mock_chmod):
+    @mock.patch('os.stat')
+    def test_LockFile_UnlockedFile_FileLockedSuccessReturnsTrue(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = True
+        mock_stat.return_value = MockStatResult(stat.S_IREAD | stat.S_IWRITE)
 
         success = file_system.lock_file(self.file_name)
+        mock_chmod.assert_called_once_with(self.file_name, stat.S_IREAD)
 
         self.assertTrue(success)
 
     @mock.patch('os.chmod')
     @mock.patch('os.access')
-    def test_UnlockFile_AlreadyLocked_FileLockedFailedReturnsFalse(self, mock_access, mock_chmod):
+    @mock.patch('os.stat')
+    def test_LockFile_AlreadyLocked_FileLockedFailedReturnsFalse(self, mock_access, mock_chmod, mock_stat):
         mock_access.return_value = False
+        mock_stat.return_value = MockStatResult(stat.S_IREAD)
 
         success = file_system.lock_file(self.file_name)
 


### PR DESCRIPTION
os.chmod() sets the file attributes, not adds/removes.
The lock/unlock file utilities were wrong and they were setting the file attributes to be only-writtable (clearing any other permissions like readable). On windows this doesn't affect read access but it does on linux.

So a file that was
R-- becoming -W-

instead of the expected
R-- becoming RW-


Platform linux -- Python 3.7.10+, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: /o3de/o3de_aljanru, inifile: pytest.ini
plugins: timeout-1.3.4, mock-2.0.0, ly-test-tools-1.0.0
collected 14 items
AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main.py ..xx..........                                                                                             [100%]
============= 12 passed, 2 xfailed in 83.72s (0:01:23) ===========================