### PR TITLE
Fixed IMGUI Entity Outliner to show net entities

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -534,7 +534,7 @@ namespace AzFramework
 
     void TransformComponent::SetParentImpl(AZ::EntityId parentId, bool isKeepWorldTM)
     {
-        if (parentId == GetEntityId())
+        if (GetEntity() && parentId == GetEntityId())
         {
             AZ_Warning("TransformComponent", false, "An entity can not be set as its own parent.");
             return;

--- a/Gems/Multiplayer/Code/Source/Pipeline/NetworkPrefabProcessor.cpp
+++ b/Gems/Multiplayer/Code/Source/Pipeline/NetworkPrefabProcessor.cpp
@@ -167,7 +167,9 @@ namespace Multiplayer
                 if (parentId.IsValid() && !prefabNetEntityIds.contains(parentId))
                 {
                     // Clear parent ID for net entities parented to a non-net entity.
-                    // To be addressed by the spawnable aliases system.
+                    // To be addressed by the spawnable aliases system where non-net entities
+                    // will be spawned together with the networked ones in which case we'll keep
+                    // the cross-spawnable references.
                     transformComponent->SetParent(AZ::EntityId());
                 }
             }

--- a/Gems/Multiplayer/Code/Source/Pipeline/NetworkPrefabProcessor.cpp
+++ b/Gems/Multiplayer/Code/Source/Pipeline/NetworkPrefabProcessor.cpp
@@ -53,7 +53,7 @@ namespace Multiplayer
             ;
 
             serializeContext->Class<NetworkPrefabProcessor, PrefabProcessor>()
-                ->Version(3)
+                ->Version(4)
                 ->Field("SerializationFormat", &NetworkPrefabProcessor::m_serializationFormat)
             ;
         }
@@ -146,6 +146,8 @@ namespace Multiplayer
         networkSpawnableAsset.Create(networkSpawnable->GetId());
         networkSpawnableAsset.SetAutoLoadBehavior(AZ::Data::AssetLoadBehavior::PreLoad);
 
+        AZStd::unordered_set<AZ::EntityId> prefabNetEntityIds;
+
         for (auto* prefabEntity : prefabNetEntities)
         {
             Instance* instance = netEntityToInstanceMap[prefabEntity];
@@ -157,6 +159,20 @@ namespace Multiplayer
 
             netEntity->InvalidateDependencies();
             netEntity->EvaluateDependencies();
+
+            auto* transformComponent = netEntity->FindComponent<AzFramework::TransformComponent>();
+            if (transformComponent)
+            {
+                AZ::EntityId parentId = transformComponent->GetParentId();
+                if (parentId.IsValid() && !prefabNetEntityIds.contains(parentId))
+                {
+                    // Clear parent ID for net entities parented to a non-net entity.
+                    // To be addressed by the spawnable aliases system.
+                    transformComponent->SetParent(AZ::EntityId());
+                }
+            }
+
+            prefabNetEntityIds.insert(netEntity->GetId());
 
             // Insert the entity into the target net spawnable
             netSpawnableEntities.emplace_back(netEntity);


### PR DESCRIPTION
The change in `TransformComponent::SetParentImpl` fixes a warning when `TransformComponent::SetParent()` is called on inactive entities which is a common case to do at the Asset Builder stage.

The warning happens inside `Component::GetEntityId()` : "Can't get component %p entity ID as it is not attached to an entity yet!"

It also returns InvalidEntityId in that case which makes it impossible to do `SetParentId(InvalidEntityId)` since it prints a warning "An entity can not be set as its own parent." and doesn't update the parent ID.



Signed-off-by: Sergey Pereslavtsev <pereslav@amazon.com>