### PR TITLE
Create file in project directory on successful build for Project Manager

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectBuilderController.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderController.cpp
@@ -17,8 +17,6 @@
 #include <QDesktopServices>
 #include <QUrl>
 
-
-
 namespace O3DE::ProjectManager
 {
     ProjectBuilderController::ProjectBuilderController(const ProjectInfo& projectInfo, ProjectButton* projectButton, QWidget* parent)
@@ -35,7 +33,7 @@ namespace O3DE::ProjectManager
         if (settingsRegistry)
         {
             // Remove key here in case Project Manager crashing while building that causes HandleResults to not be called
-            QString settingsKey = QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(m_projectInfo.m_projectName);
+            QString settingsKey = GetProjectBuiltSuccessfullyKey(m_projectInfo.m_projectName);
             settingsRegistry->Remove(settingsKey.toStdString().c_str());
             SaveProjectManagerSettings();
         }
@@ -93,7 +91,7 @@ namespace O3DE::ProjectManager
 
     void ProjectBuilderController::HandleResults(const QString& result)
     {
-        QString settingsKey = QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(m_projectInfo.m_projectName);
+        QString settingsKey = GetProjectBuiltSuccessfullyKey(m_projectInfo.m_projectName);
 
         if (!result.isEmpty())
         {

--- a/Code/Tools/ProjectManager/Source/ProjectManagerSettings.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerSettings.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ProjectManagerSettings.h"
+
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
+#include <AzCore/IO/ByteContainerStream.h>
+#include <AzCore/Utils/Utils.h>
+
+namespace O3DE::ProjectManager
+{
+    void SaveProjectManagerSettings()
+    {
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
+        dumperSettings.m_prettifyOutput = true;
+        dumperSettings.m_jsonPointerPrefix = ProjectManagerKeyPrefix;
+
+        AZStd::string stringBuffer;
+        AZ::IO::ByteContainerStream stringStream(&stringBuffer);
+        if (!AZ::SettingsRegistryMergeUtils::DumpSettingsRegistryToStream(
+                *settingsRegistry, ProjectManagerKeyPrefix, stringStream, dumperSettings))
+        {
+            AZ_Warning("ProjectManager", false, "Could not save Project Manager settings to stream");
+            return;
+        }
+
+        AZ::IO::FixedMaxPath o3deUserPath = AZ::Utils::GetO3deManifestDirectory();
+        o3deUserPath /= AZ::SettingsRegistryInterface::RegistryFolder;
+        o3deUserPath /= "ProjectManager.setreg";
+
+        bool saved = false;
+        constexpr auto configurationMode =
+            AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
+
+        AZ::IO::SystemFile outputFile;
+        if (outputFile.Open(o3deUserPath.c_str(), configurationMode))
+        {
+            saved = outputFile.Write(stringBuffer.data(), stringBuffer.size()) == stringBuffer.size();
+        }
+
+        AZ_Warning("ProjectManager", saved, "Unable to save Project Manager registry file to path: %s", o3deUserPath.c_str());
+    }
+}

--- a/Code/Tools/ProjectManager/Source/ProjectManagerSettings.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerSettings.cpp
@@ -46,4 +46,9 @@ namespace O3DE::ProjectManager
 
         AZ_Warning("ProjectManager", saved, "Unable to save Project Manager registry file to path: %s", o3deUserPath.c_str());
     }
+
+    QString GetProjectBuiltSuccessfullyKey(const QString& projectName)
+    {
+        return QString("%1/Projects/%2/BuiltSuccessfully").arg(ProjectManagerKeyPrefix).arg(projectName);
+    }
 }

--- a/Code/Tools/ProjectManager/Source/ProjectManagerSettings.h
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerSettings.h
@@ -8,9 +8,14 @@
 
 #pragma once
 
+#if !defined(Q_MOC_RUN)
+#include <QString>
+#endif
+
 namespace O3DE::ProjectManager
 {
     static constexpr char ProjectManagerKeyPrefix[] = "/O3DE/ProjectManager";
 
     void SaveProjectManagerSettings();
+    QString GetProjectBuiltSuccessfullyKey(const QString& projectName);
 }

--- a/Code/Tools/ProjectManager/Source/ProjectManagerSettings.h
+++ b/Code/Tools/ProjectManager/Source/ProjectManagerSettings.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace O3DE::ProjectManager
+{
+    static constexpr char ProjectManagerKeyPrefix[] = "/O3DE/ProjectManager";
+
+    void SaveProjectManagerSettings();
+}

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -14,6 +14,7 @@
 #include <ProjectUtils.h>
 #include <ProjectBuilderController.h>
 #include <ScreensCtrl.h>
+#include <ProjectManagerSettings.h>
 
 #include <AzQtComponents/Components/FlowLayout.h>
 #include <AzCore/Platform.h>
@@ -22,7 +23,7 @@
 #include <AzFramework/Process/ProcessCommon.h>
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzCore/Utils/Utils.h>
-#include <AzFramework/IO/LocalFileIO.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -290,11 +291,15 @@ namespace O3DE::ProjectManager
                 // Check whether project manager has successfully built the project
                 if (currentButton)
                 {
-                    AZStd::string successfulBuildFilePath = AZStd::string::format("%s/%s",
-                        project.m_path.toStdString().c_str(), "ProjectManagerBuildSuccess");
-
-                    AZ::IO::LocalFileIO fileIO;
-                    if (!fileIO.Exists(successfulBuildFilePath.c_str()))
+                    auto settingsRegistry = AZ::SettingsRegistry::Get();
+                    bool projectBuiltSuccessfully = false;
+                    if (settingsRegistry)
+                    {
+                        QString settingsKey =
+                            QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(project.m_projectName);
+                        settingsRegistry->Get(projectBuiltSuccessfully, settingsKey.toStdString().c_str());
+                    }
+                    if (!projectBuiltSuccessfully)
                     {
                         currentButton->ShowBuildRequired();
                     }

--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -295,8 +295,7 @@ namespace O3DE::ProjectManager
                     bool projectBuiltSuccessfully = false;
                     if (settingsRegistry)
                     {
-                        QString settingsKey =
-                            QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(project.m_projectName);
+                        QString settingsKey = GetProjectBuiltSuccessfullyKey(project.m_projectName);
                         settingsRegistry->Get(projectBuiltSuccessfully, settingsKey.toStdString().c_str());
                     }
                     if (!projectBuiltSuccessfully)

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -286,10 +286,8 @@ namespace O3DE::ProjectManager
             if (newProjectSettings.m_projectName != m_projectInfo.m_projectName)
             {
                 // update reg key
-                QString oldSettingsKey =
-                    QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(m_projectInfo.m_projectName);
-                QString newSettingsKey =
-                    QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(newProjectSettings.m_projectName);
+                QString oldSettingsKey = GetProjectBuiltSuccessfullyKey(m_projectInfo.m_projectName);
+                QString newSettingsKey = GetProjectBuiltSuccessfullyKey(newProjectSettings.m_projectName);
 
                 auto settingsRegistry = AZ::SettingsRegistry::Get();
                 bool projectBuiltSuccessfully = false;

--- a/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
+++ b/Code/Tools/ProjectManager/Source/UpdateProjectCtrl.cpp
@@ -15,6 +15,9 @@
 #include <UpdateProjectCtrl.h>
 #include <UpdateProjectSettingsScreen.h>
 #include <ProjectUtils.h>
+#include <ProjectManagerSettings.h>
+
+#include <AzCore/Settings/SettingsRegistry.h>
 
 #include <QDialogButtonBox>
 #include <QMessageBox>
@@ -277,6 +280,23 @@ namespace O3DE::ProjectManager
                 {
                     QMessageBox::critical(this, tr("Project update failed"), tr(result.GetError().c_str()));
                     return false;
+                }
+            }
+
+            if (newProjectSettings.m_projectName != m_projectInfo.m_projectName)
+            {
+                // update reg key
+                QString oldSettingsKey =
+                    QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(m_projectInfo.m_projectName);
+                QString newSettingsKey =
+                    QString("%1/Projects/%2/BuiltSuccesfully").arg(ProjectManagerKeyPrefix).arg(newProjectSettings.m_projectName);
+
+                auto settingsRegistry = AZ::SettingsRegistry::Get();
+                bool projectBuiltSuccessfully = false;
+                if (settingsRegistry && settingsRegistry->Get(projectBuiltSuccessfully, oldSettingsKey.toStdString().c_str()))
+                {
+                    settingsRegistry->Set(newSettingsKey.toStdString().c_str(), projectBuiltSuccessfully);
+                    SaveProjectManagerSettings();
                 }
             }
 

--- a/Code/Tools/ProjectManager/project_manager_files.cmake
+++ b/Code/Tools/ProjectManager/project_manager_files.cmake
@@ -58,6 +58,8 @@ set(FILES
     Source/CreateProjectCtrl.cpp
     Source/UpdateProjectCtrl.h
     Source/UpdateProjectCtrl.cpp
+    Source/ProjectManagerSettings.h
+    Source/ProjectManagerSettings.cpp
     Source/ProjectsScreen.h
     Source/ProjectsScreen.cpp
     Source/ProjectSettingsScreen.h


### PR DESCRIPTION
Temporary solution to show the build button in more instances when the project has not been built correctly by Project Manager. Project Manager creates a file when a project is successfully built. This will be replaced by a more permanent solution that will cover more instances without a tracking file.

Signed-off-by: AMZN-Phil <pconroy@amazon.com>