### PR TITLE
Fully Replaces Remote Gems in Model and Selects Them When Downloading and Deleting

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -363,6 +363,9 @@ namespace O3DE::ProjectManager
         {
             const QString selectedGemPath = m_gemModel->GetPath(modelIndex);
 
+            // Remove gem from gems to be added
+            GemModel::SetIsAdded(*m_gemModel, modelIndex, false);
+
             // Unregister the gem
             auto unregisterResult = PythonBindingsInterface::Get()->UnregisterGem(selectedGemPath);
             if (!unregisterResult)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -26,14 +26,14 @@ namespace O3DE::ProjectManager
         return m_selectionModel;
     }
 
-    void GemModel::AddGem(const GemInfo& gemInfo)
+    QModelIndex GemModel::AddGem(const GemInfo& gemInfo)
     {
         if (FindIndexByNameString(gemInfo.m_name).isValid())
         {
             // do not add gems with duplicate names
             // this can happen by mistake or when a gem repo has a gem with the same name as a local gem
             AZ_TracePrintf("GemModel", "Ignoring duplicate gem: %s", gemInfo.m_name.toUtf8().constData());
-            return;
+            return QModelIndex();
         }
 
         QStandardItem* item = new QStandardItem();
@@ -67,6 +67,22 @@ namespace O3DE::ProjectManager
 
         const QModelIndex modelIndex = index(rowCount()-1, 0);
         m_nameToIndexMap[gemInfo.m_name] = modelIndex;
+
+        return modelIndex;
+    }
+
+    void GemModel::RemoveGem(const QModelIndex& modelIndex)
+    {
+        removeRow(modelIndex.row());
+    }
+
+    void GemModel::RemoveGem(const QString& gemName)
+    {
+        auto nameFind = m_nameToIndexMap.find(gemName);
+        if (nameFind != m_nameToIndexMap.end())
+        {
+            removeRow(nameFind->row());
+        }
     }
 
     void GemModel::Clear()
@@ -391,11 +407,11 @@ namespace O3DE::ProjectManager
         // Select a valid row if currently selected row was removed
         if (selectedRowRemoved)
         {
-            for (const QModelIndex& index :  m_nameToIndexMap)
+            for (const QModelIndex& index : m_nameToIndexMap)
             {
                 if (index.isValid())
                 {
-                    GetSelectionModel()->select(index, QItemSelectionModel::ClearAndSelect);
+                    GetSelectionModel()->setCurrentIndex(index, QItemSelectionModel::ClearAndSelect);
                     break;
                 }
             }

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -55,7 +55,9 @@ namespace O3DE::ProjectManager
             RoleRepoUri
         };
 
-        void AddGem(const GemInfo& gemInfo);
+        QModelIndex AddGem(const GemInfo& gemInfo);
+        void RemoveGem(const QModelIndex& modelIndex);
+        void RemoveGem(const QString& gemName);
         void Clear();
         void UpdateGemDependencies();
 

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoScreen.cpp
@@ -75,7 +75,7 @@ namespace O3DE::ProjectManager
         // Select the first entry after everything got correctly sized
         QTimer::singleShot(200, [=]{
             QModelIndex firstModelIndex = m_gemRepoListView->model()->index(0,0);
-            m_gemRepoListView->selectionModel()->select(firstModelIndex, QItemSelectionModel::ClearAndSelect);
+            m_gemRepoListView->selectionModel()->setCurrentIndex(firstModelIndex, QItemSelectionModel::ClearAndSelect);
         });
     }
 


### PR DESCRIPTION
**PSA: Don't use select on _QItemSelectionModel_ it does not set _currentIndex_ so it can get out of sync with what is actually selected causing confusing bugs. Instead use _setCurrentIndex_**

Replaces gem and selects new gem when downloading and deleting remote gems, 
Fixes other gem selection issues

![mB8V2INQES](https://user-images.githubusercontent.com/52797929/141516211-e08c7745-019e-4b71-a3f2-d662ac73d3df.gif)

Signed-off-by: nggieber <nggieber@amazon.com>