### PR TITLE
LYN-8194 | Remove Back Arrow button temporarily from the navigation bar

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabViewportFocusPathHandler.cpp
@@ -64,6 +64,9 @@ namespace AzToolsFramework::Prefab
         );
 
         m_backButton->setToolTip("Up one level (-)");
+
+        // Currently hide this button until we can correctly disable/enable it based on context.
+        m_backButton->hide();
     }
 
     void PrefabViewportFocusPathHandler::OnPrefabFocusChanged()


### PR DESCRIPTION
Temporarily remove the "Up one level" button in the viewport toolbar breadcrumbs for prefab focus mode, since it makes the UX confusing. It will be restored after the upcoming release, but that work requires some areas to be refactored.

![image](https://user-images.githubusercontent.com/82231674/141534439-6e2882f3-c553-4865-a3e2-1d933ae966ab.png)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>