### PR TITLE
Move SC runtime asset static initialization out of data loading threads

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/CanvasWidget.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/CanvasWidget.cpp
@@ -84,9 +84,10 @@ namespace ScriptCanvasEditor
         {
             m_assetId = assetId;
 
-            EditorGraphRequests* editorGraphRequests = EditorGraphRequestBus::FindFirstHandler(m_scriptCanvasId);
-
-            editorGraphRequests->SetAssetId(m_assetId);
+            if (EditorGraphRequests* editorGraphRequests = EditorGraphRequestBus::FindFirstHandler(m_scriptCanvasId))
+            {
+                editorGraphRequests->SetAssetId(m_assetId);
+            }
         }
 
         const GraphCanvas::ViewId& CanvasWidget::GetViewId() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.cpp
@@ -59,6 +59,7 @@ namespace ScriptCanvas
             m_script = AZStd::move(other.m_script);
             m_requiredAssets = AZStd::move(other.m_requiredAssets);
             m_requiredScriptEvents = AZStd::move(other.m_requiredScriptEvents);
+            m_areStaticsInitialized = AZStd::move(other.m_areStaticsInitialized);
         }
 
         return *this;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.h
@@ -76,7 +76,7 @@ namespace ScriptCanvas
         AZStd::vector<AZ::BehaviorValueParameter> m_activationInputStorage;
         Execution::ActivationInputRange m_activationInputRange;
 
-        // used to initialized statics only once, and not necessarily on the loading thread
+        // used to initialize statics only once, and not necessarily on the loading thread
         bool m_areStaticsInitialized = false;
 
         bool RequiresStaticInitialization() const;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAsset.h
@@ -76,6 +76,9 @@ namespace ScriptCanvas
         AZStd::vector<AZ::BehaviorValueParameter> m_activationInputStorage;
         Execution::ActivationInputRange m_activationInputRange;
 
+        // used to initialized statics only once, and not necessarily on the loading thread
+        bool m_areStaticsInitialized = false;
+
         bool RequiresStaticInitialization() const;
 
         bool RequiresDependencyConstructionParameters() const;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAssetHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAssetHandler.cpp
@@ -94,7 +94,6 @@ namespace ScriptCanvas
             RuntimeAsset* runtimeAsset = asset.GetAs<RuntimeAsset>();
             AZ_Assert(runtimeAsset, "RuntimeAssetHandler::InitAsset This should be a Script Canvas runtime asset, as this is the only type this handler processes!");
             Execution::Context::InitializeActivationData(runtimeAsset->GetData());
-            Execution::InitializeInterpretedStatics(runtimeAsset->GetData());
         }
     }
 
@@ -157,4 +156,5 @@ namespace ScriptCanvas
             }
         }
     }
+
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionState.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/ExecutionState.h
@@ -19,6 +19,10 @@
 #include <ScriptCanvas/Execution/ExecutionStateDeclarations.h>
 #include <ScriptCanvas/Grammar/PrimitivesDeclarations.h>
 
+#if !defined(_RELEASE)
+#define SCRIPT_CANVAS_RUNTIME_ASSET_CHECK
+#endif
+
 namespace AZ
 {
     class ReflectContext;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.cpp
@@ -506,6 +506,8 @@ namespace ScriptCanvas
 #if defined(AZ_PROFILE_BUILD) || defined(AZ_DEBUG_BUILD)
             Execution::InitializeFromLuaStackFunctions(const_cast<Grammar::DebugSymbolMap&>(runtimeData.m_debugMap));
 #endif
+            AZ_WarningOnce("ScriptCanvas", !runtimeData.m_areStaticsInitialized, "ScriptCanvas runtime data already initalized");
+
             if (runtimeData.RequiresStaticInitialization())
             {
                 AZ::ScriptLoadResult result{};

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpreted.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/Interpreted/ExecutionStateInterpreted.cpp
@@ -6,14 +6,13 @@
  *
  */
 
-#include "ExecutionStateInterpreted.h"
-
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Script/ScriptContext.h>
 #include <AzCore/Script/ScriptSystemBus.h>
-
-#include "Execution/Interpreted/ExecutionStateInterpretedUtility.h"
-#include "Execution/RuntimeComponent.h"
+#include <Execution/Interpreted/ExecutionInterpretedAPI.h>
+#include <Execution/Interpreted/ExecutionStateInterpreted.h>
+#include <Execution/Interpreted/ExecutionStateInterpretedUtility.h>
+#include <Execution/RuntimeComponent.h>
 
 namespace ExecutionStateInterpretedCpp
 {
@@ -33,7 +32,29 @@ namespace ScriptCanvas
     ExecutionStateInterpreted::ExecutionStateInterpreted(const ExecutionStateConfig& config)
         : ExecutionState(config)
         , m_interpretedAsset(config.runtimeData.m_script)
-    {}
+    {
+        RuntimeAsset* runtimeAsset = config.asset.Get();
+
+#if defined(SCRIPT_CANVAS_RUNTIME_ASSET_CHECK)
+        if (!runtimeAsset)
+        {
+            AZ_Error("ScriptCanvas", false
+                , "ExecutionStateInterpreted created with ExecutionStateConfig that contained bad runtime asset data. %s"
+                , config.asset.GetId().ToString<AZStd::string>().data());
+            return;
+        }
+#else
+        AZ_Assert(false
+            , "ExecutionStateInterpreted created with ExecutionStateConfig that contained bad runtime asset data. %s"
+            , config.asset.GetId().ToString<AZStd::string>().data());
+#endif
+
+        if (!runtimeAsset->GetData().m_areStaticsInitialized)
+        {
+            runtimeAsset->GetData().m_areStaticsInitialized = true;
+            Execution::InitializeInterpretedStatics(runtimeAsset->GetData());
+        }
+    }
 
     void ExecutionStateInterpreted::ClearLuaRegistryIndex()
     {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
@@ -22,11 +22,6 @@
 #include <ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.h>
 #include <AzCore/Asset/AssetSerializer.h>
 
-namespace AZ
-{
-    AZ_TYPE_INFO_SPECIALIZE(AZ::Data::Asset<AZ::DynamicSliceAsset>, "{D9A4EB57-198B-4A0D-B1FB-D1B11FF88C66}");
-}
-
 AZ_DECLARE_BUDGET(ScriptCanvas);
 
 namespace RuntimeComponentCpp

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Execution/RuntimeComponent.cpp
@@ -19,9 +19,13 @@
 #include <ScriptCanvas/Execution/ExecutionContext.h>
 #include <ScriptCanvas/Execution/ExecutionState.h>
 
-#if !defined(_RELEASE)
-#define SCRIPT_CANVAS_RUNTIME_ASSET_CHECK
-#endif
+#include <ScriptCanvas/Execution/Interpreted/ExecutionInterpretedAPI.h>
+#include <AzCore/Asset/AssetSerializer.h>
+
+namespace AZ
+{
+    AZ_TYPE_INFO_SPECIALIZE(AZ::Data::Asset<AZ::DynamicSliceAsset>, "{D9A4EB57-198B-4A0D-B1FB-D1B11FF88C66}");
+}
 
 AZ_DECLARE_BUDGET(ScriptCanvas);
 
@@ -112,11 +116,13 @@ namespace ScriptCanvas
 #if defined(SCRIPT_CANVAS_RUNTIME_ASSET_CHECK)
         if (!m_runtimeOverrides.m_runtimeAsset.Get())
         {
-            AZ_Error("ScriptCanvas", false, "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+            AZ_Error("ScriptCanvas", false, "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run"
+                , m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
             return;
         }
 #else
-        AZ_Assert(m_runtimeOverrides.m_runtimeAsset.Get(), "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+        AZ_Assert(m_runtimeOverrides.m_runtimeAsset.Get(), "RuntimeComponent::m_runtimeAsset AssetId: %s was valid, but the data was not pre-loaded, so this script will not run"
+            , m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
 #endif
 
         AZ_PROFILE_SCOPE(ScriptCanvas, "RuntimeComponent::InitializeExecution (%s)", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().c_str());
@@ -126,11 +132,13 @@ namespace ScriptCanvas
 #if defined(SCRIPT_CANVAS_RUNTIME_ASSET_CHECK)
         if (!m_executionState)
         {
-            AZ_Error("ScriptCanvas", false, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+            AZ_Error("ScriptCanvas", false, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run"
+                , m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
             return;
         }
 #else
-        AZ_Assert(m_executionState, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run", m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
+        AZ_Assert(m_executionState, "RuntimeComponent::m_runtimeAsset AssetId: %s failed to create an execution state, possibly due to missing dependent asset, script will not run"
+            , m_runtimeOverrides.m_runtimeAsset.GetId().ToString<AZStd::string>().data());
 #endif
 
         AZ::EntityBus::Handler::BusConnect(GetEntityId());
@@ -179,4 +187,3 @@ namespace ScriptCanvas
     }
 }
 
-#undef SCRIPT_CANVAS_RUNTIME_ASSET_CHECK


### PR DESCRIPTION
In order to prevent dead locks when SC assets require each other, or worse catastrophic side effects from modifying the Lua state in places other than the main thread, SC runtime assets that require one time, static initialization do so when their first using entity activates.

Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>