### PR TITLE
Fixing double registration of hair asset

### DIFF
--- a/Gems/AtomTressFX/Code/Builders/HairBuilderComponent.cpp
+++ b/Gems/AtomTressFX/Code/Builders/HairBuilderComponent.cpp
@@ -46,14 +46,6 @@ namespace AZ
             {
                 m_hairAssetBuilder.RegisterBuilder();
                 m_hairAssetHandler.Register();
-
-                // Add asset types and extensions to AssetCatalog.
-                auto assetCatalog = AZ::Data::AssetCatalogRequestBus::FindFirstHandler();
-                if (assetCatalog)
-                {
-                    assetCatalog->EnableCatalogForAsset(azrtti_typeid<HairAsset>());
-                    assetCatalog->AddExtension(AMD::TFXCombinedFileExtension);
-                }
             }
 
             void HairBuilderComponent::Deactivate()


### PR DESCRIPTION
Errors were being reported that the hair asset was being registered with the asset manager multiple times. It was being registered once within the generic asset handler and again manually.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>