### PR TITLE
Fix for CSM shimmering

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -1248,6 +1248,35 @@ namespace AZ
             property.m_shadowmapViewNeedsUpdate = true;
         }
 
+        float DirectionalLightFeatureProcessor::GetShadowmapSizeFromCameraView(const LightHandle handle, const RPI::View* cameraView) const
+        {
+            const DirectionalLightShadowData& shadowData = m_shadowData.at(cameraView).GetData(handle.GetIndex());
+            return static_cast<float>(shadowData.m_shadowmapSize);
+        }
+
+        void DirectionalLightFeatureProcessor::SnapAabbToPixelIncrements(const float invShadowmapSize, Vector3& orthoMin, Vector3& orthoMax)
+        {
+            // This function stops the cascaded shadowmap from shimmering as the camera moves.
+            // See CascadedShadowsManager.cpp in the Microsoft CascadedShadowMaps11 sample for details.
+
+            const Vector3 normalizeByBufferSize = Vector3(invShadowmapSize, invShadowmapSize, invShadowmapSize);
+
+            const Vector3 worldUnitsPerTexel = (orthoMax - orthoMin) * normalizeByBufferSize;
+            static bool m_bMoveLightTexelSize = true;
+            if (m_bMoveLightTexelSize)
+            {
+                // We snap the camera to 1 pixel increments so that moving the camera does not cause the shadows to jitter.
+                // This is a matter of dividing by the world space size of a texel
+                orthoMin /= worldUnitsPerTexel;
+                orthoMin = orthoMin.GetFloor();
+                orthoMin *= worldUnitsPerTexel;
+
+                orthoMax /= worldUnitsPerTexel;
+                orthoMax = orthoMax.GetFloor();
+                orthoMax *= worldUnitsPerTexel;
+            }
+        }
+
         void DirectionalLightFeatureProcessor::UpdateShadowmapViews(LightHandle handle)
         {
             ShadowProperty& property = m_shadowProperties.GetData(handle.GetIndex());
@@ -1259,18 +1288,26 @@ namespace AZ
 
             for (auto& segmentIt : property.m_segments)
             {
+                const float invShadowmapSize = 1.0f / GetShadowmapSizeFromCameraView(handle, segmentIt.first);
+
                 for (uint16_t cascadeIndex = 0; cascadeIndex < segmentIt.second.size(); ++cascadeIndex)
                 {
-                    const Aabb viewAabb = CalculateShadowViewAabb(
-                        handle, segmentIt.first, cascadeIndex, lightTransform);
+                    const Aabb viewAabb = CalculateShadowViewAabb(handle, segmentIt.first, cascadeIndex, lightTransform);
 
                     if (viewAabb.IsValid() && viewAabb.IsFinite())
                     {
+                        const float cascadeNear = viewAabb.GetMin().GetY();
+                        const float cascadeFar = viewAabb.GetMax().GetY();
+
+                        Vector3 snappedAabbMin = viewAabb.GetMin();
+                        Vector3 snappedAabbMax = viewAabb.GetMax();
+
+                        SnapAabbToPixelIncrements(invShadowmapSize, snappedAabbMin, snappedAabbMax);
+
                         Matrix4x4 viewToClipMatrix = Matrix4x4::CreateIdentity();
-                        MakeOrthographicMatrixRH(viewToClipMatrix,
-                            viewAabb.GetMin().GetElement(0), viewAabb.GetMax().GetElement(0),
-                            viewAabb.GetMin().GetElement(2), viewAabb.GetMax().GetElement(2),
-                            viewAabb.GetMin().GetElement(1), viewAabb.GetMax().GetElement(1));
+                        MakeOrthographicMatrixRH(
+                            viewToClipMatrix, snappedAabbMin.GetElement(0), snappedAabbMax.GetElement(0), snappedAabbMin.GetElement(2),
+                            snappedAabbMax.GetElement(2), cascadeNear, cascadeFar);
 
                         CascadeSegment& segment = segmentIt.second[cascadeIndex];
                         segment.m_aabb = viewAabb;

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.cpp
@@ -1262,19 +1262,16 @@ namespace AZ
             const Vector3 normalizeByBufferSize = Vector3(invShadowmapSize, invShadowmapSize, invShadowmapSize);
 
             const Vector3 worldUnitsPerTexel = (orthoMax - orthoMin) * normalizeByBufferSize;
-            static bool m_bMoveLightTexelSize = true;
-            if (m_bMoveLightTexelSize)
-            {
-                // We snap the camera to 1 pixel increments so that moving the camera does not cause the shadows to jitter.
-                // This is a matter of dividing by the world space size of a texel
-                orthoMin /= worldUnitsPerTexel;
-                orthoMin = orthoMin.GetFloor();
-                orthoMin *= worldUnitsPerTexel;
 
-                orthoMax /= worldUnitsPerTexel;
-                orthoMax = orthoMax.GetFloor();
-                orthoMax *= worldUnitsPerTexel;
-            }
+            // We snap the camera to 1 pixel increments so that moving the camera does not cause the shadows to jitter.
+            // This is a matter of dividing by the world space size of a texel
+            orthoMin /= worldUnitsPerTexel;
+            orthoMin = orthoMin.GetFloor();
+            orthoMin *= worldUnitsPerTexel;
+
+            orthoMax /= worldUnitsPerTexel;
+            orthoMax = orthoMax.GetFloor();
+            orthoMax *= worldUnitsPerTexel;
         }
 
         void DirectionalLightFeatureProcessor::UpdateShadowmapViews(LightHandle handle)

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -341,6 +341,9 @@ namespace AZ
             //! This draws bounding boxes of cascades.
             void DrawCascadeBoundingBoxes(LightHandle handle);
 
+            float GetShadowmapSizeFromCameraView(const LightHandle handle, const RPI::View* cameraView) const;
+            void SnapAabbToPixelIncrements(const float invShadowmapSize, Vector3& orthoMin, Vector3& orthoMax);
+
             IndexedDataVector<ShadowProperty> m_shadowProperties;
             // [GFX TODO][ATOM-2012] shadow for multiple directional lights
             LightHandle m_shadowingLightHandle;


### PR DESCRIPTION
Cascade shadow maps are shimmering very badly when the camera moves. Implemented a fix taken from the Microsoft DirectX samples which is to clamp the cascade ortho matrix to a constant size based upon the camera.
### 
Before (512x512 shadowmaps with 4 cascades):


https://user-images.githubusercontent.com/61609885/141698286-162e3c67-69c5-4fe0-8880-b2d37ad84c58.mp4



### After (note, this looks slightly worse than real-life I believe due to video capture software juddering. The edges are completely stable on my machine now)

https://user-images.githubusercontent.com/61609885/141698472-6b20f555-f382-4e15-a63f-96c37350f78e.mp4

Signed-off-by: mrieggeramzn <mriegger@amazon.com>