### PR TITLE
Update RPISystem::GetCurrentTime() to use TimeSystem

### DIFF
--- a/Code/Framework/AzCore/AzCore/Time/ITime.h
+++ b/Code/Framework/AzCore/AzCore/Time/ITime.h
@@ -137,9 +137,16 @@ namespace AZ
         return AZ::Interface<ITime>::Get()->GetElapsedTimeUs();
     }
 
+    //! This is a simple convenience wrapper
     inline TimeMs GetRealElapsedTimeMs()
     {
         return AZ::Interface<ITime>::Get()->GetRealElapsedTimeMs();
+    }
+
+    //! This is a simple convenience wrapper
+    inline TimeUs GetRealElapsedTimeUs()
+    {
+        return AZ::Interface<ITime>::Get()->GetRealElapsedTimeUs();
     }
 
     //! This is a simple convenience wrapper

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPISystem.h
@@ -97,7 +97,7 @@ namespace AZ
             // SystemTickBus::OnTick
             void OnSystemTick() override;
 
-            float GetCurrentTime();
+            float GetCurrentTime() const;
 
             // The set of core asset handlers registered by the system.
             AZStd::vector<AZStd::unique_ptr<Data::AssetHandler>> m_assetHandlers;
@@ -123,7 +123,6 @@ namespace AZ
             // The job policy used for feature processor's rendering prepare
             RHI::JobPolicy m_prepareRenderJobPolicy = RHI::JobPolicy::Parallel;
 
-            ScriptTimePoint m_startTime;
             float m_currentSimulationTime = 0.0f;
 
             RPISystemDescriptor m_descriptor;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -33,6 +33,7 @@
 
 #include <AzCore/Debug/EventTrace.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/Time/ITime.h>
 
 #include <AzFramework/Asset/AssetSystemBus.h>
 
@@ -276,15 +277,10 @@ namespace AZ
             }
         }
 
-        float RPISystem::GetCurrentTime()
+        float RPISystem::GetCurrentTime() const
         {
-            ScriptTimePoint timeAtCurrentTick;
-            AZ::TickRequestBus::BroadcastResult(timeAtCurrentTick, &AZ::TickRequestBus::Events::GetTimeAtCurrentTick);
-
-            // We subtract the start time to maximize precision of the time value, since we will be converting it to a float.
-            double currentTime = timeAtCurrentTick.GetSeconds() - m_startTime.GetSeconds();
-
-            return aznumeric_cast<float>(currentTime);
+            const AZ::TimeUs currentSimulationTimeUs = AZ::GetRealElapsedTimeUs();
+            return AZ::TimeUsToSeconds(currentSimulationTimeUs);
         }
 
         void RPISystem::RenderTick()


### PR DESCRIPTION
Note: I ran the full test suite on the AtomSampleViewer with these changes and got similar results as without this change (19 test failures).

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>