### PR TITLE
Bug fix for material editor not taking focus when opening a new docum…

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Window/AtomToolsMainWindow.cpp
@@ -50,8 +50,9 @@ namespace AtomToolsFramework
 
     void AtomToolsMainWindow::ActivateWindow()
     {
-        activateWindow();
+        show();
         raise();
+        activateWindow();
     }
 
     bool AtomToolsMainWindow::AddDockWidget(const AZStd::string& name, QWidget* widget, uint32_t area, uint32_t orientation)


### PR DESCRIPTION
…ent from the main editor or outside of the material editor

Signed-off-by: Guthrie Adams <guthadam@amazon.com>