### PR TITLE
Cherry Pick: [LYN-7463] Fix insert streaming request failure (#5604)

### DIFF
--- a/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
+++ b/Code/Framework/AzCore/AzCore/Asset/AssetManager.cpp
@@ -1677,9 +1677,13 @@ namespace AZ
                 // they will trigger a ReleaseAsset call sometime after the AssetManager has begun to shut down, which can lead to
                 // race conditions.
 
+                // Make sure the streamer request is removed first before the asset is released
+                // If the asset is released first it could lead to a race condition where another thread starts loading the asset
+                // again and attempts to add a new streamer request with the same ID before the old one has been removed, causing
+                // that load request to fail
+                RemoveActiveStreamerRequest(assetId);
                 weakAsset = {};
                 loadingAsset.Reset();
-                RemoveActiveStreamerRequest(assetId);
             };
 
             auto&& [deadline, priority] = GetEffectiveDeadlineAndPriority(*handler, asset.GetType(), loadParams);

--- a/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
+++ b/Code/Framework/AzCore/Tests/Asset/AssetManagerLoadingTests.cpp
@@ -652,7 +652,7 @@ namespace UnitTest
             threads.emplace_back([this, &threadCount, &cv, assetUuid]() {
                 bool checkLoaded = true;
 
-                for (int i = 0; i < 5000; i++)
+                for (int i = 0; i < 1000; i++)
                 {
                     Asset<AssetWithAssetReference> asset1 =
                         m_testAssetManager->GetAsset(assetUuid, azrtti_typeid<AssetWithAssetReference>(), AZ::Data::AssetLoadBehavior::PreLoad);
@@ -678,7 +678,7 @@ namespace UnitTest
         while (threadCount > 0 && !timedOut)
         {
             AZStd::unique_lock<AZStd::mutex> lock(mutex);
-            timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds * 20000));
+            timedOut = (AZStd::cv_status::timeout == cv.wait_until(lock, AZStd::chrono::system_clock::now() + DefaultTimeoutSeconds));
         }
 
         ASSERT_EQ(threadCount, 0) << "Thread count is non-zero, a thread has likely deadlocked.  Test will not shut down cleanly.";
@@ -1190,7 +1190,7 @@ namespace UnitTest
 #if AZ_TRAIT_DISABLE_FAILED_ASSET_MANAGER_TESTS
     TEST_F(AssetJobsFloodTest, DISABLED_ContainerFilterTest_ContainersWithAndWithoutFiltering_Success)
 #else
-    TEST_F(AssetJobsFloodTest, DISABLED_ContainerFilterTest_ContainersWithAndWithoutFiltering_Success)
+    TEST_F(AssetJobsFloodTest, ContainerFilterTest_ContainersWithAndWithoutFiltering_Success)
 #endif // !AZ_TRAIT_DISABLE_FAILED_ASSET_MANAGER_TESTS
     {
         m_assetHandlerAndCatalog->AssetCatalogRequestBus::Handler::BusConnect();


### PR DESCRIPTION
* Fix race condition where asset would finish loading and another request would start before the streamer request could be cleared

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>

* Re-enable disabled test which was failing for the same reason.

Fix test timeout which was way too long.
Reduce test iterations to keep test time safely under 5 seconds.

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>

* Instead of using a mutex, re-order the statements to remove the streamer request first

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>
(cherry picked from commit 0cea59d66998585f07c54e55f68dd117363fb4ea)
Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>