### PR TITLE
Unlocked a mutex after modifying the associated variable

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/Archive.cpp
@@ -1241,6 +1241,7 @@ namespace AZ::IO
 
             m_arrZips.insert(revItZip.base(), desc);
 
+            lock.unlock();
             m_levelOpenEvent.Signal(levelDirs);
         }
 


### PR DESCRIPTION
This fixes an issue where mounting bundles in the Editor was causing the Editor to freeze up, because the following line, m_levelOpenEvent.Signal, resulted in another attempt to lock that same mutex.

Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>