### PR TITLE
Fix prefab enabled automated tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main_Optimized.py
@@ -60,7 +60,7 @@ class EditorSingleTest_WithFileOverrides(EditorSingleTest):
 class TestAutomationWithPrefabSystemEnabled(EditorTestSuite):
 
     global_extra_cmdline_args = ['-BatchMode', '-autotest_mode',
-                                 'extra_cmdline_args=["--regset=/Amazon/Preferences/EnablePrefabSystem=true"]']
+                                 '--regset=/Amazon/Preferences/EnablePrefabSystem=true']
 
     @staticmethod
     def get_number_parallel_editors():


### PR DESCRIPTION
Fix the wrong cmd line args used for enable prefab system in automated tests.

Tests passed by using the following command with xfail temporally removed:
```
python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Main_Optimized.py::TestAutomationWithPrefabSystemEnabled --build-directory windows_vs2019\bin\profile
```

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>