### PR TITLE
Fix: Display Repo Gems on Repo Screen Correctly

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -188,7 +188,7 @@ namespace O3DE::ProjectManager
         }
 
         // add all the gem repos into the hash
-        const AZ::Outcome<QVector<GemInfo>, AZStd::string>& allRepoGemInfosResult = PythonBindingsInterface::Get()->GetAllGemRepoGemsInfos();
+        const AZ::Outcome<QVector<GemInfo>, AZStd::string>& allRepoGemInfosResult = PythonBindingsInterface::Get()->GetAllGemReposGemInfos();
         if (allRepoGemInfosResult.IsSuccess())
         {
             const QVector<GemInfo>& allRepoGemInfos = allRepoGemInfosResult.GetValue();
@@ -435,7 +435,7 @@ namespace O3DE::ProjectManager
                 m_gemModel->AddGem(gemInfo);
             }
 
-            const AZ::Outcome<QVector<GemInfo>, AZStd::string>& allRepoGemInfosResult = PythonBindingsInterface::Get()->GetAllGemRepoGemsInfos();
+            const AZ::Outcome<QVector<GemInfo>, AZStd::string>& allRepoGemInfosResult = PythonBindingsInterface::Get()->GetAllGemReposGemInfos();
             if (allRepoGemInfosResult.IsSuccess())
             {
                 const QVector<GemInfo>& allRepoGemInfos = allRepoGemInfosResult.GetValue();

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInfo.h
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInfo.h
@@ -37,7 +37,7 @@ namespace O3DE::ProjectManager
         QString m_additionalInfo = "";
         QString m_directoryLink = "";
         QString m_repoUri = "";
-        QStringList m_includedGemPaths = {};
+        QStringList m_includedGemUris = {};
         QDateTime m_lastUpdated;
     };
 } // namespace O3DE::ProjectManager

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoInspector.cpp
@@ -60,8 +60,9 @@ namespace O3DE::ProjectManager
         }
 
         // Repo name and url link
-        QString repoUri = m_model->GetRepoUri(modelIndex);
         m_nameLabel->setText(m_model->GetName(modelIndex));
+
+        const QString repoUri = m_model->GetRepoUri(modelIndex);
         m_repoLinkLabel->setText(repoUri);
         m_repoLinkLabel->SetUrl(repoUri);
 
@@ -88,18 +89,7 @@ namespace O3DE::ProjectManager
         }
 
         // Included Gems
-        QVector<Tag> includedGemTags;
-        const AZ::Outcome<QVector<GemInfo>, AZStd::string>& gemInfosResult = PythonBindingsInterface::Get()->GetGemRepoGemInfos(repoUri);
-        if (gemInfosResult.IsSuccess())
-        {
-            const QVector<GemInfo>& allRepoGemInfos = gemInfosResult.GetValue();
-            for (const GemInfo& gemInfo : allRepoGemInfos)
-            {
-                includedGemTags.append(Tag{ gemInfo.m_displayName, gemInfo.m_name });
-            }
-        }
-
-        m_includedGems->Update(tr("Included Gems"), "", includedGemTags);
+        m_includedGems->Update(tr("Included Gems"), "", m_model->GetIncludedGemTags(modelIndex));
 
         m_mainWidget->adjustSize();
         m_mainWidget->show();

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoModel.cpp
@@ -41,7 +41,7 @@ namespace O3DE::ProjectManager
         item->setData(gemRepoInfo.m_lastUpdated, RoleLastUpdated);
         item->setData(gemRepoInfo.m_path, RolePath);
         item->setData(gemRepoInfo.m_additionalInfo, RoleAdditionalInfo);
-        item->setData(gemRepoInfo.m_includedGemPaths, RoleIncludedGems);
+        item->setData(gemRepoInfo.m_includedGemUris, RoleIncludedGems);
 
         appendRow(item);
 
@@ -98,7 +98,7 @@ namespace O3DE::ProjectManager
         return modelIndex.data(RolePath).toString();
     }
 
-    QStringList GemRepoModel::GetIncludedGemPaths(const QModelIndex& modelIndex)
+    QStringList GemRepoModel::GetIncludedGemUris(const QModelIndex& modelIndex)
     {
         return modelIndex.data(RoleIncludedGems).toStringList();
     }
@@ -118,23 +118,19 @@ namespace O3DE::ProjectManager
 
     QVector<GemInfo> GemRepoModel::GetIncludedGemInfos(const QModelIndex& modelIndex)
     {
-        QVector<GemInfo> allGemInfos;
-        QStringList repoGemPaths = GetIncludedGemPaths(modelIndex);
+        QString repoUri = GetRepoUri(modelIndex);
 
-        for (const QString& gemPath : repoGemPaths)
+        const AZ::Outcome<QVector<GemInfo>, AZStd::string>& gemInfosResult = PythonBindingsInterface::Get()->GetGemRepoGemInfos(repoUri);
+        if (gemInfosResult.IsSuccess())
         {
-            AZ::Outcome<GemInfo> gemInfoResult = PythonBindingsInterface::Get()->GetGemInfo(gemPath);
-            if (gemInfoResult.IsSuccess())
-            {
-                allGemInfos.append(gemInfoResult.GetValue());
-            }
-            else
-            {
-                QMessageBox::critical(nullptr, tr("Gem Not Found"), tr("Cannot find info for gem %1.").arg(gemPath));
-            }
+            return gemInfosResult.GetValue();
+        }
+        else
+        {
+            QMessageBox::critical(nullptr, tr("Gems not found"), tr("Cannot find info for gems from repo %1").arg(GetName(modelIndex)));
         }
 
-        return allGemInfos;
+        return QVector<GemInfo>();
     }
 
     bool GemRepoModel::IsEnabled(const QModelIndex& modelIndex)

--- a/Code/Tools/ProjectManager/Source/GemRepo/GemRepoModel.h
+++ b/Code/Tools/ProjectManager/Source/GemRepo/GemRepoModel.h
@@ -39,7 +39,7 @@ namespace O3DE::ProjectManager
         static QDateTime GetLastUpdated(const QModelIndex& modelIndex);
         static QString GetPath(const QModelIndex& modelIndex);
 
-        static QStringList GetIncludedGemPaths(const QModelIndex& modelIndex);
+        static QStringList GetIncludedGemUris(const QModelIndex& modelIndex);
         static QVector<Tag> GetIncludedGemTags(const QModelIndex& modelIndex);
         static QVector<GemInfo> GetIncludedGemInfos(const QModelIndex& modelIndex);
 

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1188,6 +1188,34 @@ namespace O3DE::ProjectManager
         return AZ::Success(AZStd::move(gemRepos));
     }
 
+    AZ::Outcome<QVector<GemInfo>, AZStd::string> PythonBindings::GetGemRepoGemInfos(const QString& repoUri)
+    {
+        QVector<GemInfo> gemInfos;
+        AZ::Outcome<void, AZStd::string> result = ExecuteWithLockErrorHandling(
+            [&]
+            {
+                auto pyUri = QString_To_Py_String(repoUri);
+                auto gemPaths = m_repo.attr("get_gem_json_paths_from_cached_repo")(pyUri);
+
+                if (pybind11::isinstance<pybind11::set>(gemPaths))
+                {
+                    for (auto path : gemPaths)
+                    {
+                        GemInfo gemInfo = GemInfoFromPath(path, pybind11::none());
+                        gemInfo.m_downloadStatus = GemInfo::DownloadStatus::NotDownloaded;
+                        gemInfos.push_back(gemInfo);
+                    }
+                }
+            });
+
+        if (!result.IsSuccess())
+        {
+            return AZ::Failure(result.GetError());
+        }
+
+        return AZ::Success(AZStd::move(gemInfos));
+    }
+
     AZ::Outcome<QVector<GemInfo>, AZStd::string> PythonBindings::GetAllGemReposGemInfos()
     {
         QVector<GemInfo> gemInfos;

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1135,11 +1135,11 @@ namespace O3DE::ProjectManager
                     gemRepoInfo.m_isEnabled = false;
                 }
 
-                if (data.contains("gem_paths"))
+                if (data.contains("gems"))
                 {
-                    for (auto gemPath : data["gem_paths"])
+                    for (auto gemPath : data["gems"])
                     {
-                        gemRepoInfo.m_includedGemPaths.push_back(Py_To_String(gemPath));
+                        gemRepoInfo.m_includedGemUris.push_back(Py_To_String(gemPath));
                     }
                 }
             }

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -1188,7 +1188,7 @@ namespace O3DE::ProjectManager
         return AZ::Success(AZStd::move(gemRepos));
     }
 
-    AZ::Outcome<QVector<GemInfo>, AZStd::string> PythonBindings::GetAllGemRepoGemsInfos()
+    AZ::Outcome<QVector<GemInfo>, AZStd::string> PythonBindings::GetAllGemReposGemInfos()
     {
         QVector<GemInfo> gemInfos;
         AZ::Outcome<void, AZStd::string> result = ExecuteWithLockErrorHandling(

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -65,7 +65,7 @@ namespace O3DE::ProjectManager
         bool AddGemRepo(const QString& repoUri) override;
         bool RemoveGemRepo(const QString& repoUri) override;
         AZ::Outcome<QVector<GemRepoInfo>, AZStd::string> GetAllGemRepoInfos() override;
-        AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemRepoGemsInfos() override;
+        AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemReposGemInfos() override;
         AZ::Outcome<void, AZStd::string> DownloadGem(const QString& gemName, std::function<void(int, int)> gemProgressCallback, bool force = false) override;
         void CancelDownload() override;
         bool IsGemUpdateAvaliable(const QString& gemName, const QString& lastUpdated) override;

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -65,6 +65,7 @@ namespace O3DE::ProjectManager
         bool AddGemRepo(const QString& repoUri) override;
         bool RemoveGemRepo(const QString& repoUri) override;
         AZ::Outcome<QVector<GemRepoInfo>, AZStd::string> GetAllGemRepoInfos() override;
+        AZ::Outcome<QVector<GemInfo>, AZStd::string> GetGemRepoGemInfos(const QString& repoUri) override;
         AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemReposGemInfos() override;
         AZ::Outcome<void, AZStd::string> DownloadGem(const QString& gemName, std::function<void(int, int)> gemProgressCallback, bool force = false) override;
         void CancelDownload() override;

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -221,7 +221,7 @@ namespace O3DE::ProjectManager
          * Gathers all gem infos for all gems registered from repos.
          * @return A list of gem infos.
          */
-        virtual AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemRepoGemsInfos() = 0;
+        virtual AZ::Outcome<QVector<GemInfo>, AZStd::string> GetAllGemReposGemInfos() = 0;
 
         /**
          * Downloads and registers a Gem.

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -218,6 +218,13 @@ namespace O3DE::ProjectManager
         virtual AZ::Outcome<QVector<GemRepoInfo>, AZStd::string> GetAllGemRepoInfos() = 0;
 
         /**
+         * Gathers all gem infos for repos
+         * @param repoUri the absolute filesystem path or url to the gem repo.
+         * @return A list of gem infos.
+         */
+        virtual AZ::Outcome<QVector<GemInfo>, AZStd::string> GetGemRepoGemInfos(const QString& repoUri) = 0;
+
+        /**
          * Gathers all gem infos for all gems registered from repos.
          * @return A list of gem infos.
          */


### PR DESCRIPTION
Also renamed GetAllGemRepoGemsInfos to GetAllGemReposGemInfos

![o3de_ObVjbvEsYw](https://user-images.githubusercontent.com/52797929/141924801-1fa610df-9f6a-401e-bc10-d8617037a549.png)

