### PR TITLE
Updated splash screen and about dialog with Stable 21.11 name

### DIFF
--- a/Code/Editor/AboutDialog.ui
+++ b/Code/Editor/AboutDialog.ui
@@ -125,7 +125,7 @@
             </size>
            </property>
            <property name="text">
-            <string>General Availability</string>
+            <string>Stable 21.11</string>
            </property>
            <property name="textFormat">
             <enum>Qt::AutoText</enum>

--- a/Code/Editor/StartupLogoDialog.ui
+++ b/Code/Editor/StartupLogoDialog.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>General Availability</string>
+            <string>Stable 21.11</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Updated the name on the splash screen and about dialog to `Stable 21.11`

![SplashScreen](https://user-images.githubusercontent.com/7519264/142000566-3e982f31-ca5b-4a73-99ab-fe73f9477ffa.png)
![AboutDialog](https://user-images.githubusercontent.com/7519264/142000577-fec762bb-8668-409c-968e-8ac274160a2e.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>