### PR TITLE
Fixed - Current Camera Reset - When making a new Entity, or add a new Component, you are immediately taken out of current Camera View.

### DIFF
--- a/Gems/Camera/Code/Source/ViewportCameraSelectorWindow_Internals.h
+++ b/Gems/Camera/Code/Source/ViewportCameraSelectorWindow_Internals.h
@@ -58,6 +58,8 @@ namespace Camera
         private:
             AZStd::vector<CameraListItem> m_cameraItems;
             AZ::EntityId m_sequenceCameraEntityId;
+            AZ::EntityId m_lastActiveCamera;
+            bool m_firstEntry = true;
         };
 
         struct ViewportCameraSelectorWindow


### PR DESCRIPTION
Now when you add a new entity to the level and you are on a different camera other than de Editor Camera it won't take you out
of the current camera.

Please note that this is a quick fix and this issue is related to the fact that every time you add a new entity to the level the whole level prefab resets everything.

https://user-images.githubusercontent.com/82394219/142008405-cdfe3fb7-9ca9-40dc-9594-81fce93f0414.mp4

m>