### PR TITLE
Updated splash screen and about dialog with development name

### DIFF
--- a/Code/Editor/AboutDialog.ui
+++ b/Code/Editor/AboutDialog.ui
@@ -125,7 +125,7 @@
             </size>
            </property>
            <property name="text">
-            <string>Stable 21.11</string>
+            <string>development</string>
            </property>
            <property name="textFormat">
             <enum>Qt::AutoText</enum>

--- a/Code/Editor/AboutDialog.ui
+++ b/Code/Editor/AboutDialog.ui
@@ -125,7 +125,7 @@
             </size>
            </property>
            <property name="text">
-            <string>General Availability</string>
+            <string>Stable 21.11</string>
            </property>
            <property name="textFormat">
             <enum>Qt::AutoText</enum>

--- a/Code/Editor/StartupLogoDialog.ui
+++ b/Code/Editor/StartupLogoDialog.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>Stable 21.11</string>
+            <string>development</string>
            </property>
           </widget>
          </item>

--- a/Code/Editor/StartupLogoDialog.ui
+++ b/Code/Editor/StartupLogoDialog.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>General Availability</string>
+            <string>Stable 21.11</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Updated the name on the splash screen and about dialog to `development`

Cherry-picked name update in stabilization first (https://github.com/o3de/o3de/pull/5647) so that it doesn't get reverted when the stabilization/2110 -> development merge is done later today.

![DevelopmentSplashScreen](https://user-images.githubusercontent.com/7519264/142020981-6eea714e-d5a4-4822-b7f7-8792b6dd53e8.png)
![DevelopmentAboutDialog](https://user-images.githubusercontent.com/7519264/142021000-1cf2d80c-a14c-4dd8-8311-f8fad5d9460e.png)


Signed-off-by: Chris Galvan chgalvan@amazon.com