### PR TITLE
Updated splash screen and about dialog with development name

### DIFF
--- a/Code/Editor/AboutDialog.ui
+++ b/Code/Editor/AboutDialog.ui
@@ -125,7 +125,7 @@
             </size>
            </property>
            <property name="text">
-            <string>Stable 21.11</string>
+            <string>development</string>
            </property>
            <property name="textFormat">
             <enum>Qt::AutoText</enum>

--- a/Code/Editor/AboutDialog.ui
+++ b/Code/Editor/AboutDialog.ui
@@ -125,7 +125,7 @@
             </size>
            </property>
            <property name="text">
-            <string>General Availability</string>
+            <string>Stable 21.11</string>
            </property>
            <property name="textFormat">
             <enum>Qt::AutoText</enum>

--- a/Code/Editor/StartupLogoDialog.ui
+++ b/Code/Editor/StartupLogoDialog.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>Stable 21.11</string>
+            <string>development</string>
            </property>
           </widget>
          </item>

--- a/Code/Editor/StartupLogoDialog.ui
+++ b/Code/Editor/StartupLogoDialog.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLabel" name="label_2">
            <property name="text">
-            <string>General Availability</string>
+            <string>Stable 21.11</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Updated the name on the splash screen and about dialog to development

Cherry-picked name update in stabilization first (#5647) so that it doesn't get reverted when the stabilization/2110 -> development merge is done later today.

![DevelopmentSplashScreen](https://user-images.githubusercontent.com/7519264/142021941-66c026da-8c10-4e9e-a067-3d54420d95b4.png)
![DevelopmentAboutDialog](https://user-images.githubusercontent.com/7519264/142021954-acd4397c-fa48-413a-b712-4a5e277a1576.png)

Signed-off-by: Chris Galvan chgalvan@amazon.com