### PR TITLE
ShaderMetricsSystem spawns a lot of warnings

### DIFF
--- a/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
@@ -69,7 +69,16 @@ namespace UnitTest
         assetPath /= "Cache";
         AZ::IO::FileIOBase::GetInstance()->SetAlias("@products@", assetPath.c_str());
 
-        AZ::IO::Path userPath = AZStd::string_view{ AZ::Utils::GetProjectPath() };
+        // Remark, AZ::Utils::GetProjectPath() is not used when defining "user" folder,
+        // instead We use AZ::Test::GetEngineRootPath();.
+        // Reason:
+        // When running unit tests, using AZ::Utils::GetProjectPath() will resolve to something like:
+        // "/data/workspace/o3de/build/linux/External/Atom-9a4d112b/RPI/Code/Cache"
+        // The ShaderMetricSystem.cpp writes to the @user@ folder and the following runtime error occurs:
+        // "You may not alter data inside the asset cache.  Please check the call stack and consider writing into the source asset folder instead."
+        // "Attempted write location: /data/workspace/o3de/build/linux/External/Atom-9a4d112b/RPI/Code/Cache/user/shadermetrics.json"
+        // To avoid the error We use AZ::Test::GetEngineRootPath();
+        AZ::IO::Path userPath = AZ::Test::GetEngineRootPath();
         userPath /= "user";
         AZ::IO::FileIOBase::GetInstance()->SetAlias("@user@", userPath.c_str());
 

--- a/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
+++ b/Gems/Atom/RPI/Code/Tests/Common/RPITestFixture.cpp
@@ -69,6 +69,10 @@ namespace UnitTest
         assetPath /= "Cache";
         AZ::IO::FileIOBase::GetInstance()->SetAlias("@products@", assetPath.c_str());
 
+        AZ::IO::Path userPath = AZStd::string_view{ AZ::Utils::GetProjectPath() };
+        userPath /= "user";
+        AZ::IO::FileIOBase::GetInstance()->SetAlias("@user@", userPath.c_str());
+
         m_jsonRegistrationContext = AZStd::make_unique<AZ::JsonRegistrationContext>();
         m_jsonSystemComponent = AZStd::make_unique<AZ::JsonSystemComponent>();
         m_jsonSystemComponent->Reflect(m_jsonRegistrationContext.get());


### PR DESCRIPTION
ShaderMetricsSystem spawns a lot of warnings when run Atom_RPI.Tests

Added @user@ path alias definition.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>