### PR TITLE
Fixes for misc gem download issues

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -523,7 +523,9 @@ namespace O3DE::ProjectManager
             const QString& gemPath = GemModel::GetPath(modelIndex);
 
             // make sure any remote gems we added were downloaded successfully 
-            if (GemModel::GetGemOrigin(modelIndex) == GemInfo::Remote && GemModel::GetDownloadStatus(modelIndex) != GemInfo::Downloaded)
+            const GemInfo::DownloadStatus status = GemModel::GetDownloadStatus(modelIndex);
+            if (GemModel::GetGemOrigin(modelIndex) == GemInfo::Remote &&
+                !(status == GemInfo::Downloaded || status == GemInfo::DownloadSuccessful))
             {
                 QMessageBox::critical(
                     nullptr, "Cannot add gem that isn't downloaded",

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -363,6 +363,9 @@ namespace O3DE::ProjectManager
         {
             const QString selectedGemPath = m_gemModel->GetPath(modelIndex);
 
+            // Remove gem from gems to be added to update any dependencies
+            GemModel::SetIsAdded(*m_gemModel, modelIndex, false);
+
             // Unregister the gem
             auto unregisterResult = PythonBindingsInterface::Get()->UnregisterGem(selectedGemPath);
             if (!unregisterResult)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -363,9 +363,6 @@ namespace O3DE::ProjectManager
         {
             const QString selectedGemPath = m_gemModel->GetPath(modelIndex);
 
-            // Remove gem from gems to be added
-            GemModel::SetIsAdded(*m_gemModel, modelIndex, false);
-
             // Unregister the gem
             auto unregisterResult = PythonBindingsInterface::Get()->UnregisterGem(selectedGemPath);
             if (!unregisterResult)
@@ -391,6 +388,7 @@ namespace O3DE::ProjectManager
 
                 // Select remote gem
                 QModelIndex remoteGemIndex = m_gemModel->FindIndexByNameString(selectedGemName);
+                GemModel::SetWasPreviouslyAdded(*m_gemModel, remoteGemIndex, true);
                 QModelIndex proxyIndex = m_proxyModel->mapFromSource(remoteGemIndex);
                 m_proxyModel->GetSelectionModel()->setCurrentIndex(proxyIndex, QItemSelectionModel::ClearAndSelect);
             }

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -363,6 +363,9 @@ namespace O3DE::ProjectManager
         {
             const QString selectedGemPath = m_gemModel->GetPath(modelIndex);
 
+            const bool wasAdded = GemModel::WasPreviouslyAdded(modelIndex);
+            const bool wasAddedDependency = GemModel::WasPreviouslyAddedDependency(modelIndex);
+
             // Remove gem from gems to be added to update any dependencies
             GemModel::SetIsAdded(*m_gemModel, modelIndex, false);
 
@@ -391,7 +394,8 @@ namespace O3DE::ProjectManager
 
                 // Select remote gem
                 QModelIndex remoteGemIndex = m_gemModel->FindIndexByNameString(selectedGemName);
-                GemModel::SetWasPreviouslyAdded(*m_gemModel, remoteGemIndex, true);
+                GemModel::SetWasPreviouslyAdded(*m_gemModel, remoteGemIndex, wasAdded);
+                GemModel::SetWasPreviouslyAddedDependency(*m_gemModel, remoteGemIndex, wasAddedDependency);
                 QModelIndex proxyIndex = m_proxyModel->mapFromSource(remoteGemIndex);
                 m_proxyModel->GetSelectionModel()->setCurrentIndex(proxyIndex, QItemSelectionModel::ClearAndSelect);
             }

--- a/scripts/o3de/o3de/disable_gem.py
+++ b/scripts/o3de/o3de/disable_gem.py
@@ -69,7 +69,7 @@ def disable_gem_in_project(gem_name: str = None,
         return 1
     gem_path = pathlib.Path(gem_path).resolve()
     # make sure this gem already exists if we're adding.  We can always remove a gem.
-    if not gem_path.is_dir() and not gem_path.is_file():
+    if not gem_path.exists():
         logger.error(f'Gem Path {gem_path} does not exist.')
         return 1
 

--- a/scripts/o3de/o3de/disable_gem.py
+++ b/scripts/o3de/o3de/disable_gem.py
@@ -69,7 +69,7 @@ def disable_gem_in_project(gem_name: str = None,
         return 1
     gem_path = pathlib.Path(gem_path).resolve()
     # make sure this gem already exists if we're adding.  We can always remove a gem.
-    if not gem_path.is_dir():
+    if not gem_path.is_dir() and not gem_path.is_file():
         logger.error(f'Gem Path {gem_path} does not exist.')
         return 1
 

--- a/scripts/o3de/o3de/download.py
+++ b/scripts/o3de/o3de/download.py
@@ -64,11 +64,9 @@ def validate_downloaded_zip_sha256(download_uri_json_data: dict, download_zip_pa
         if key in unzipped_manifest_json_data:
             del unzipped_manifest_json_data[key]
 
-    sha256A = hashlib.sha256(json.dumps(download_uri_json_data, indent=4).encode('utf8')).hexdigest()
-    sha256B = hashlib.sha256(json.dumps(unzipped_manifest_json_data, indent=4).encode('utf8')).hexdigest()
-    if sha256A != sha256B:
-        logger.error(f'SECURITY VIOLATION: Downloaded {manifest_json_name} does not match'
-                     ' the advertised manifest json.')
+    if download_uri_json_data != unzipped_manifest_json_data:
+        logger.error(f'SECURITY VIOLATION: Downloaded {manifest_json_name} contents do not match'
+                     ' the advertised manifest json contents.')
         return 0
 
     return 1

--- a/scripts/o3de/o3de/download.py
+++ b/scripts/o3de/o3de/download.py
@@ -48,25 +48,26 @@ def validate_downloaded_zip_sha256(download_uri_json_data: dict, download_zip_pa
                     ' We cannot verify this is the actually the advertised object!!!')
         return 1
     else:
-        sha256B = hashlib.sha256(download_zip_path.open('rb').read()).hexdigest()
-        if sha256A != sha256B:
-            logger.error(f'SECURITY VIOLATION: Downloaded zip sha256 {sha256B} does not match'
-                         f' the advertised "sha256":{sha256A} in the f{manifest_json_name}.')
-            return 0
+        with download_zip_path.open('rb') as f:
+            sha256B = hashlib.sha256(f.read()).hexdigest()
+            if sha256A != sha256B:
+                logger.error(f'SECURITY VIOLATION: Downloaded zip sha256 {sha256B} does not match'
+                            f' the advertised "sha256":{sha256A} in the f{manifest_json_name}.')
+                return 0
 
     unzipped_manifest_json_data = unzip_manifest_json_data(download_zip_path, manifest_json_name)
 
-    # remove the sha256 if present in the advertised downloadable manifest json
-    # then compare it to the json in the zip, they should now be identical
-    try:
-        del download_uri_json_data['sha256']
-    except KeyError as e:
-        pass
+    # do not include the data we know will not match/exist
+    for key in ['sha256','repo_name']:
+        if key in download_uri_json_data:
+            del download_uri_json_data[key]
+        if key in unzipped_manifest_json_data:
+            del unzipped_manifest_json_data[key]
 
     sha256A = hashlib.sha256(json.dumps(download_uri_json_data, indent=4).encode('utf8')).hexdigest()
     sha256B = hashlib.sha256(json.dumps(unzipped_manifest_json_data, indent=4).encode('utf8')).hexdigest()
     if sha256A != sha256B:
-        logger.error('SECURITY VIOLATION: Downloaded manifest json does not match'
+        logger.error(f'SECURITY VIOLATION: Downloaded {manifest_json_name} does not match'
                      ' the advertised manifest json.')
         return 0
 
@@ -102,7 +103,7 @@ def download_o3de_object(object_name: str, default_folder_name: str, dest_path: 
         logger.error(f'Downloadable o3de object {object_name} not found.')
         return 1
 
-    origin_uri = downloadable_object_data['originuri']
+    origin_uri = downloadable_object_data['origin_uri']
     parsed_uri = urllib.parse.urlparse(origin_uri)
 
     download_zip_result = utils.download_zip_file(parsed_uri, download_zip_path, force_overwrite, download_progress_callback)

--- a/scripts/o3de/o3de/repo.py
+++ b/scripts/o3de/o3de/repo.py
@@ -9,7 +9,6 @@
 import json
 import logging
 import pathlib
-import shutil
 import urllib.parse
 import urllib.request
 import hashlib
@@ -220,7 +219,7 @@ def search_repo(manifest_json_data: dict,
         o3de_object_uris = manifest_json_data['template']
         manifest_json = 'template.json'
         json_key = 'template_name'
-        search_func = lambda manifest_json_data: manifest_json_data if manifest_json_data.get(json_key, '') == template_name_name else None
+        search_func = lambda manifest_json_data: manifest_json_data if manifest_json_data.get(json_key, '') == template_name else None
     elif isinstance(restricted_name, str) or isinstance(restricted_name, pathlib.PurePath):
         o3de_object_uris = manifest_json_data['restricted']
         manifest_json = 'restricted.json'

--- a/scripts/o3de/o3de/repo.py
+++ b/scripts/o3de/o3de/repo.py
@@ -216,7 +216,7 @@ def search_repo(manifest_json_data: dict,
         json_key = 'gem_name'
         search_func = lambda manifest_json_data: manifest_json_data if manifest_json_data.get(json_key, '') == gem_name else None
     elif isinstance(template_name, str) or isinstance(template_name, pathlib.PurePath):
-        o3de_object_uris = manifest_json_data['template']
+        o3de_object_uris = manifest_json_data['templates']
         manifest_json = 'template.json'
         json_key = 'template_name'
         search_func = lambda manifest_json_data: manifest_json_data if manifest_json_data.get(json_key, '') == template_name else None


### PR DESCRIPTION
- IMPORTANT: change `originuri` to `origin_uri` to match the naming scheme of the rest of gem.json
- fix issue where downloaded gems cannot be added because gem download status has changed
- fix issue where gem could not be disabled if a path to the gem.json was provided instead of the gem folder.  Remote gems that do not exist on disk do not have a folder, so project manager was sending the path to the gem.json which is not a folder
- fixed issue where downloaded gems with hashes did not match because repo_name was added to remote gem jsons programatically
- fixed file handle left open when comparing hash
- fixed `template_name_name` syntax error and removed unused shutil import
- fix issue where uninstalled gems were not removed from projects