### PR TITLE
Fix for shadowmaps not behaving properly with two viewports in the Editor

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/DirectionalLightFeatureProcessor.h
@@ -134,9 +134,6 @@ namespace AZ
                 // Default far depth of each cascade.
                 AZStd::array<float, Shadow::MaxNumberOfCascades> m_defaultFarDepths;
 
-                // Transforms of camera who offers view frustum for each camera view.
-                AZStd::unordered_map<const RPI::View*, Transform> m_cameraTransforms;
-
                 // Configuration offers shape of the camera view frustum for each camera view.
                 AZStd::unordered_map<const RPI::View*, CascadeShadowCameraConfiguration> m_cameraConfigurations;
 
@@ -258,11 +255,6 @@ namespace AZ
             //! If it has not been registered for the given camera view.
             //! it returns one of the fallback render pipeline ID.
             const CascadeShadowCameraConfiguration& GetCameraConfiguration(LightHandle handle, const RPI::View* cameraView) const;
-
-            //! This returns the camera transform.
-            //! If it has not been registered for the given camera view.
-            //! it returns one of the fallback render pipeline ID.
-            const Transform& GetCameraTransform(LightHandle handle, const RPI::View* cameraView) const;
 
             //! This update view frustum of camera.
             void UpdateFrustums(LightHandle handle);


### PR DESCRIPTION
Shadows were behaving very badly with 2+ viewports in the Editor. With two viewports you would get bad clipping on one or the other.

Basically the DirectionalLightFeatureProcessor was trying to cache the camera matrices but it ended up just putting them all in the same slot in a hash table.

I removed the hash table lookup entirely and switched to just calling GetCameraTransform() directly. The function looks pretty cheap and the code is much simpler.

Checked ASV and tried many viewport configurations in the Editor. Seems perfectly stable now.

ATOM-16535

Signed-off-by: mrieggeramzn <mriegger@amazon.com>