### PR TITLE
Fix missing clip to world matrix data

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -169,7 +169,6 @@ namespace AZ
             Matrix4x4 m_worldToViewMatrix;
             Matrix4x4 m_viewToWorldMatrix;
             Matrix4x4 m_viewToClipMatrix;
-            Matrix4x4 m_clipToWorldMatrix;
 
             // View's position in world space
             Vector3 m_position;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -92,6 +92,8 @@ namespace AZ
             const AZ::Matrix4x4& GetViewToWorldMatrix() const;
             const AZ::Matrix4x4& GetViewToClipMatrix() const;
             const AZ::Matrix4x4& GetWorldToClipMatrix() const;
+            const AZ::Matrix4x4& GetClipToWorldMatrix() const;
+
             //! Get the camera's world transform, converted from the viewToWorld matrix's native y-up to z-up
             AZ::Transform GetCameraTransform() const;
 
@@ -169,6 +171,7 @@ namespace AZ
             Matrix4x4 m_worldToViewMatrix;
             Matrix4x4 m_viewToWorldMatrix;
             Matrix4x4 m_viewToClipMatrix;
+            Matrix4x4 m_clipToWorldMatrix;
 
             // View's position in world space
             Vector3 m_position;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -125,6 +125,7 @@ namespace AZ
 
             m_worldToViewMatrix = worldToView;
             m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
+            m_clipToWorldMatrix = m_worldToClipMatrix.GetInverseFull();
 
             m_onWorldToViewMatrixChange.Signal(m_worldToViewMatrix);
             m_onWorldToClipMatrixChange.Signal(m_worldToClipMatrix);
@@ -162,6 +163,7 @@ namespace AZ
             m_worldToViewMatrix = m_viewToWorldMatrix.GetInverseFast();
 
             m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
+            m_clipToWorldMatrix = m_worldToClipMatrix.GetInverseFull();
 
             // Only signal an update when there is a change, otherwise this might block
             // user input from changing the value.
@@ -177,6 +179,7 @@ namespace AZ
             m_viewToClipMatrix = viewToClip;
 
             m_worldToClipMatrix = m_viewToClipMatrix * m_worldToViewMatrix;
+            m_clipToWorldMatrix = m_worldToClipMatrix.GetInverseFull();
 
             // Update z depth constant simultaneously
             // zNear -> n, zFar -> f
@@ -225,6 +228,11 @@ namespace AZ
         const AZ::Matrix4x4& View::GetWorldToClipMatrix() const
         {
             return m_worldToClipMatrix;
+        }
+
+        const AZ::Matrix4x4& View::GetClipToWorldMatrix() const
+        {
+            return m_clipToWorldMatrix;
         }
 
         bool View::HasDrawListTag(RHI::DrawListTag drawListTag)
@@ -365,7 +373,7 @@ namespace AZ
                 m_shaderResourceGroup->SetConstant(m_worldToClipPrevMatrixConstantIndex, worldToClipPrevMatrix);
                 m_shaderResourceGroup->SetConstant(m_viewProjectionMatrixConstantIndex, m_worldToClipMatrix);
                 m_shaderResourceGroup->SetConstant(m_projectionMatrixConstantIndex, m_viewToClipMatrix);
-                m_shaderResourceGroup->SetConstant(m_clipToWorldMatrixConstantIndex, m_worldToClipMatrix.GetInverseFull());
+                m_shaderResourceGroup->SetConstant(m_clipToWorldMatrixConstantIndex, m_clipToWorldMatrix);
                 m_shaderResourceGroup->SetConstant(m_projectionMatrixInverseConstantIndex, m_viewToClipMatrix.GetInverseFull());
             }
             else

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -365,7 +365,7 @@ namespace AZ
                 m_shaderResourceGroup->SetConstant(m_worldToClipPrevMatrixConstantIndex, worldToClipPrevMatrix);
                 m_shaderResourceGroup->SetConstant(m_viewProjectionMatrixConstantIndex, m_worldToClipMatrix);
                 m_shaderResourceGroup->SetConstant(m_projectionMatrixConstantIndex, m_viewToClipMatrix);
-                m_shaderResourceGroup->SetConstant(m_clipToWorldMatrixConstantIndex, m_clipToWorldMatrix);
+                m_shaderResourceGroup->SetConstant(m_clipToWorldMatrixConstantIndex, m_worldToClipMatrix.GetInverseFull());
                 m_shaderResourceGroup->SetConstant(m_projectionMatrixInverseConstantIndex, m_viewToClipMatrix.GetInverseFull());
             }
             else


### PR DESCRIPTION
I was trying to use m_viewProjectionInverseMatrix in shaders and RenderDoc showed it contained garbage data which led me to discover it was never being set in code when the view was not offset.

This fix may not be optimal (uses GetInverseFull instead of GetInverseFast) and occurs everyframe so we could likely cache the data and update it every time m_worldToClipMatrix is updated.  Thoughts?

**Testing**
- verified m_viewProjectionInverseMatrix contains correct data in a shader using RenderDoc

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>