### PR TITLE
Cherry-picking changes for EngineFinder.cmake.

### DIFF
--- a/Templates/DefaultProject/Template/cmake/EngineFinder.cmake
+++ b/Templates/DefaultProject/Template/cmake/EngineFinder.cmake
@@ -13,8 +13,8 @@
 include_guard()
 
 # Read the engine name from the project_json file
-file(READ ${CMAKE_CURRENT_LIST_DIR}/project.json project_json)
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/project.json)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/project.json project_json)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/project.json)
 
 string(JSON LY_ENGINE_NAME_TO_USE ERROR_VARIABLE json_error GET ${project_json} engine)
 if(json_error)

--- a/Templates/MinimalProject/Template/cmake/EngineFinder.cmake
+++ b/Templates/MinimalProject/Template/cmake/EngineFinder.cmake
@@ -13,8 +13,8 @@
 include_guard()
 
 # Read the engine name from the project_json file
-file(READ ${CMAKE_CURRENT_LIST_DIR}/project.json project_json)
-set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/project.json)
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/project.json project_json)
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/project.json)
 
 string(JSON LY_ENGINE_NAME_TO_USE ERROR_VARIABLE json_error GET ${project_json} engine)
 if(json_error)


### PR DESCRIPTION
This fixes the cmake configuration errors when using a project-centric
workflow with newly crated projects
Original Commit hash: 289d783

fixes #5643

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>