### PR TITLE
[Linux] Avoid duplicating inotify watches in forked AssetBuilder processes

### DIFF
--- a/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp
+++ b/Code/Tools/AssetProcessor/Platform/Linux/native/FileWatcher/FileWatcher_linux.cpp
@@ -32,7 +32,8 @@ struct FolderRootWatch::PlatformImplementation
     {
         if (m_iNotifyHandle < 0)
         {
-            m_iNotifyHandle = inotify_init();
+            // The CLOEXEC flag prevents the inotify watchers from copying on fork/exec
+            m_iNotifyHandle = inotify_init1(IN_CLOEXEC);
         }
         return (m_iNotifyHandle >= 0);
     }


### PR DESCRIPTION
The AssetProcessor on Linux uses `inotify` to monitor for file updates.
The AssetProcessor also uses a `ProcessWatcher` to launch child
AssetBuilder processes. `ProcessWatcher` accomplishes this by calling
`fork()`, which duplicates the current process, then calling `exec()`.
The `fork()` call also appears to duplicate any inotify fds. This
results in the subprocess consuming duplicate inotify watches, which is
a limited system resource (Ubunut 20 defaults
`/proc/sys/fs/inotify/max_user_watches` to 65536). The AssetProcessor
still has issues with this max, but this should free up at least half of
the uses.

Signed-off-by: Chris Burel <burelc@amazon.com>