### PR TITLE
Follow up fix for ATOM-13512

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.h
@@ -238,7 +238,6 @@ namespace AssetUtilities
     // hashMsDelay is only for automated tests to test that writing to a file while it's hashing does not cause a crash.
     // hashMsDelay is not used in non-unit test builds.
     AZ::u64 GetFileHash(const char* filePath, bool force = false, AZ::IO::SizeType* bytesReadOut = nullptr, int hashMsDelay = 0);
-    inline constexpr AZ::u64 FileHashBufferSize = 1024 * 64;
 
     //! Adjusts a timestamp to fix timezone settings and account for any precision adjustment needed
     AZ::u64 AdjustTimestamp(QDateTime timestamp);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
@@ -106,20 +106,21 @@
             "_em": [ "Emissive" ],
             "_emit": [ "Emissive" ],
             // displacement
-            "_displ": [ "Emissive" ],
-            "_disp": [ "Emissive" ],
-            "_dsp": [ "Emissive" ],
-            "_d": [ "Emissive" ],
-            "_dm": [ "Emissive" ],
-            "_displacement": [ "Emissive" ],
-            "_height": [ "Emissive" ],
-            "_hm": [ "Emissive" ],
-            "_ht": [ "Emissive" ],
-            "_h": [ "Emissive" ],
+            "_displ": [ "Displacement" ],
+            "_disp": [ "Displacement" ],
+            "_dsp": [ "Displacement" ],
+            "_d": [ "Displacement" ],
+            "_dm": [ "Displacement" ],
+            "_displacement": [ "Displacement" ],
+            "_height": [ "Displacement" ],
+            "_hm": [ "Displacement" ],
+            "_ht": [ "Displacement" ],
+            "_h": [ "Displacement" ],
             // cubemap
             "_ibldiffusecm": [ "IBLDiffuse" ],
             "_iblskyboxcm": [ "IBLSkybox" ],
             "_iblspecularcm": [ "IBLSpecular" ],
+            "_iblspecularcm64": [ "IBLSpecularVeryLow" ],
             "_iblspecularcm128": [ "IBLSpecularLow" ],
             "_iblspecularcm256": [ "IBLSpecular" ],
             "_iblspecularcm512": [ "IBLSpecularHigh" ],
@@ -133,7 +134,10 @@
             // lut
             "_lut": [ "LUT_RG8" ],
             "_lutr32f": [ "LUT_R32F" ],
+            "_lutrgba8": [ "LUT_RGBA8" ],
             "_lutrgba16": [ "LUT_RGBA16" ],
+            "_lutrgba16f": [ "LUT_RGBA16F" ],
+            "_lutrg16": [ "LUT_RG16" ],
             "_lutrg32f": [ "LUT_RG32F" ],
             "_lutrgba32f": [ "LUT_RGBA32F" ],
             // layer mask
@@ -142,7 +146,7 @@
             // decal
             "_decal": [ "Decal_AlbedoWithOpacity" ],
             // ui
-            "_ui": [ "UserInterface_Lossless" ]
+            "_ui": [ "UserInterface_Compressed","UserInterface_Lossless" ]
         },
         "DefaultPreset": "Albedo",
         "DefaultPresetAlpha": "AlbedoWithGenericAlpha"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Reflectance.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/Reflectance.preset
@@ -8,7 +8,7 @@
             "Name": "Reflectance",
             "SourceColor": "Linear",
             "DestColor": "Linear",
-            "PixelFormat": "BC1",
+            "PixelFormat": "BC4",
             "IsPowerOf2": true,
             "MipMapSetting": {
                 "MipGenType": "Box"
@@ -21,6 +21,7 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "PixelFormat": "ASTC_6x6",
+                "Swizzle": "rrr1",
                 "MaxTextureSize": 2048,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
@@ -33,6 +34,7 @@
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
                 "PixelFormat": "ASTC_6x6",
+                "Swizzle": "rrr1",
                 "MaxTextureSize": 2048,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
@@ -44,7 +46,7 @@
                 "Name": "Reflectance",
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
-                "PixelFormat": "BC1",
+                "PixelFormat": "BC4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -55,7 +57,7 @@
                 "Name": "Reflectance",
                 "SourceColor": "Linear",
                 "DestColor": "Linear",
-                "PixelFormat": "BC1",
+                "PixelFormat": "BC4",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"


### PR DESCRIPTION
Update the file mask mapping in ImageBuilder.settings.
Change Reflectance.preset to use BC4 format since it only needs once channel.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>