### PR TITLE
Reduce material editor update interval when inactive

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -79,12 +79,18 @@ namespace AtomToolsFramework
         m_styleManager.reset(new AzQtComponents::StyleManager(this));
         m_styleManager->initialize(this, engineRootPath);
 
-        connect(&m_timer, &QTimer::timeout, this, [&]()
+        m_timer.setInterval(1);
+        connect(&m_timer, &QTimer::timeout, this, [this]()
         {
             this->PumpSystemEventLoopUntilEmpty();
             this->Tick();
         });
 
+        connect(this, &QGuiApplication::applicationStateChanged, this, [this]()
+        {
+            // Limit the update interval when not in focus to reduce power consumption and interference with other applications
+            this->m_timer.setInterval((applicationState() & Qt::ApplicationActive) ? 1 : 32);
+        });
     }
 
     AtomToolsApplication ::~AtomToolsApplication()


### PR DESCRIPTION
This change reduces the application update interval when the material editor is not the active application. This should resolve the usability issues that have been reported relating to significant decreases in performance when running the material editor alongside the main editor or other DCC tools. It will also decrease power consumption when the application is not active.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>