### PR TITLE
Change the joint setup display to an Enum of Never, Selected and Always.

### DIFF
--- a/Gems/PhysX/Code/Editor/EditorJointConfiguration.h
+++ b/Gems/PhysX/Code/Editor/EditorJointConfiguration.h
@@ -100,12 +100,21 @@ namespace PhysX
         AZ_TYPE_INFO(EditorJointConfig, "{8A966D65-CA97-4786-A13C-ACAA519D97EA}");
         static void Reflect(AZ::ReflectContext* context);
 
+        enum class DisplaySetupState : AZ::u8
+        {
+            Never = 0,
+            Selected,
+            Always
+        };
+
         void SetLeadEntityId(AZ::EntityId leadEntityId);
         JointGenericProperties ToGenericProperties() const;
         JointComponentConfiguration ToGameTimeConfig() const;
 
+        bool ShowSetupDisplay() const;
+
         bool m_breakable = false;
-        bool m_displayJointSetup = false;
+        DisplaySetupState m_displayJointSetup = DisplaySetupState::Selected;
         bool m_inComponentMode = false;
         bool m_selectLeadOnSnap = true;
         bool m_selfCollide = false;
@@ -129,3 +138,8 @@ namespace PhysX
     };
 
 } // namespace PhysX
+
+namespace AZ
+{
+    AZ_TYPE_INFO_SPECIALIZE(PhysX::EditorJointConfig::DisplaySetupState, "{17EBE6BD-289A-4326-8A24-DCE3B7FEC51E}");
+} // namespace AZ

--- a/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
@@ -215,7 +215,7 @@ namespace PhysX
     {
         EditorJointComponent::DisplayEntityViewport(viewportInfo, debugDisplay);
 
-        if (!m_config.m_displayJointSetup && 
+        if (!m_config.ShowSetupDisplay() && 
             !m_config.m_inComponentMode)
         {
             return;

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -211,7 +211,7 @@ namespace PhysX
     {
         EditorJointComponent::DisplayEntityViewport(viewportInfo, debugDisplay);
 
-        if (!m_config.m_displayJointSetup && 
+        if (!m_config.ShowSetupDisplay() && 
             !m_config.m_inComponentMode)
         {
             return;


### PR DESCRIPTION
Instead of an off/on state for the setup display on joints, There is now 3 options.
Never = Off.
Selected = Displayed when entity is selected. [Default]
Always = Always displayed.

![image](https://user-images.githubusercontent.com/75276488/142200036-9297f98a-6082-4dcd-bb2f-3b746ce7d6c4.png)

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>