### PR TITLE
Camera fixes follow-up

### DIFF
--- a/Code/Editor/EditorModularViewportCameraComposer.cpp
+++ b/Code/Editor/EditorModularViewportCameraComposer.cpp
@@ -145,11 +145,25 @@ namespace SandboxEditor
             }
         };
 
+        const auto trackingTransform = [viewportId = m_viewportId]
+        {
+            bool tracking = false;
+            AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+                tracking, viewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::IsTrackingTransform);
+
+            return tracking;
+        };
+
         m_firstPersonRotateCamera = AZStd::make_shared<AzFramework::RotateCameraInput>(SandboxEditor::CameraFreeLookChannelId());
 
         m_firstPersonRotateCamera->m_rotateSpeedFn = []
         {
             return SandboxEditor::CameraRotateSpeed();
+        };
+
+        m_firstPersonRotateCamera->m_constrainPitch = [trackingTransform]
+        {
+            return !trackingTransform();
         };
 
         // default behavior is to hide the cursor but this can be disabled (useful for remote desktop)
@@ -253,6 +267,11 @@ namespace SandboxEditor
         m_orbitRotateCamera->m_invertYawFn = []
         {
             return SandboxEditor::CameraOrbitYawRotationInverted();
+        };
+
+        m_orbitRotateCamera->m_constrainPitch = [trackingTransform]
+        {
+            return !trackingTransform();
         };
 
         m_orbitTranslateCamera = AZStd::make_shared<AzFramework::TranslateCameraInput>(

--- a/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
+++ b/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
@@ -39,6 +39,8 @@ namespace UnitTest
         AZStd::unique_ptr<AZ::Entity> m_entity;
 
         static inline constexpr AzFramework::ViewportId TestViewportId = 2345;
+        static inline constexpr float HalfInterpolateToTransformDuration =
+            AtomToolsFramework::ModularViewportCameraControllerRequests::InterpolateToTransformDuration * 0.5f;
 
         void SetUp() override
         {
@@ -147,8 +149,10 @@ namespace UnitTest
             transformToInterpolateTo);
 
         // simulate interpolation
-        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
-        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
+        m_controllerList->UpdateViewport(
+            { TestViewportId, AzFramework::FloatSeconds(HalfInterpolateToTransformDuration), AZ::ScriptTimePoint() });
+        m_controllerList->UpdateViewport(
+            { TestViewportId, AzFramework::FloatSeconds(HalfInterpolateToTransformDuration), AZ::ScriptTimePoint() });
 
         const auto finalTransform = m_cameraViewportContextView->GetCameraTransform();
 
@@ -173,8 +177,10 @@ namespace UnitTest
             transformToInterpolateTo);
 
         // simulate interpolation
-        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
-        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
+        m_controllerList->UpdateViewport(
+            { TestViewportId, AzFramework::FloatSeconds(HalfInterpolateToTransformDuration), AZ::ScriptTimePoint() });
+        m_controllerList->UpdateViewport(
+            { TestViewportId, AzFramework::FloatSeconds(HalfInterpolateToTransformDuration), AZ::ScriptTimePoint() });
 
         const auto finalTransform = m_cameraViewportContextView->GetCameraTransform();
 
@@ -204,9 +210,10 @@ namespace UnitTest
             &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
             AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
 
-        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
+        m_controllerList->UpdateViewport(
+            { TestViewportId, AzFramework::FloatSeconds(HalfInterpolateToTransformDuration), AZ::ScriptTimePoint() });
 
-        bool nextInterpolationBegan = false;
+        bool nextInterpolationBegan = true;
         AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
             nextInterpolationBegan, TestViewportId,
             &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
@@ -214,7 +221,7 @@ namespace UnitTest
 
         bool interpolating = false;
         AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
-            interpolating, TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::Interpolating);
+            interpolating, TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::IsInterpolating);
 
         // Then
         EXPECT_THAT(initialInterpolationBegan, ::testing::IsTrue());
@@ -231,11 +238,14 @@ namespace UnitTest
             &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
             AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
 
-        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(1.5f), AZ::ScriptTimePoint() });
+        m_controllerList->UpdateViewport(
+            { TestViewportId,
+              AzFramework::FloatSeconds(AtomToolsFramework::ModularViewportCameraControllerRequests::InterpolateToTransformDuration + 0.5f),
+              AZ::ScriptTimePoint() });
 
         bool interpolating = true;
         AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
-            interpolating, TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::Interpolating);
+            interpolating, TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::IsInterpolating);
 
         bool nextInterpolationBegan = false;
         AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(

--- a/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
+++ b/Code/Editor/Lib/Tests/Camera/test_EditorCamera.cpp
@@ -38,7 +38,7 @@ namespace UnitTest
         AzFramework::ViewportControllerListPtr m_controllerList;
         AZStd::unique_ptr<AZ::Entity> m_entity;
 
-        static const AzFramework::ViewportId TestViewportId;
+        static inline constexpr AzFramework::ViewportId TestViewportId = 2345;
 
         void SetUp() override
         {
@@ -76,8 +76,6 @@ namespace UnitTest
             m_editorLibHandle = {};
         }
     };
-
-    const AzFramework::ViewportId EditorCameraFixture::TestViewportId = AzFramework::ViewportId(1337);
 
     TEST_F(EditorCameraFixture, ModularViewportCameraControllerReferenceFrameUpdatedWhenViewportEntityisChanged)
     {
@@ -182,6 +180,73 @@ namespace UnitTest
 
         // Then
         EXPECT_THAT(finalTransform, IsClose(transformToInterpolateTo));
+    }
+
+    TEST_F(EditorCameraFixture, BeginningCameraInterpolationReturnsTrue)
+    {
+        // Given/When
+        bool interpolationBegan = false;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            interpolationBegan, TestViewportId,
+            &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
+
+        // Then
+        EXPECT_THAT(interpolationBegan, ::testing::IsTrue());
+    }
+
+    TEST_F(EditorCameraFixture, CameraInterpolationDoesNotBeginDuringAnExistingInterpolation)
+    {
+        // Given/When
+        bool initialInterpolationBegan = false;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            initialInterpolationBegan, TestViewportId,
+            &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
+
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(0.5f), AZ::ScriptTimePoint() });
+
+        bool nextInterpolationBegan = false;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            nextInterpolationBegan, TestViewportId,
+            &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
+
+        bool interpolating = false;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            interpolating, TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::Interpolating);
+
+        // Then
+        EXPECT_THAT(initialInterpolationBegan, ::testing::IsTrue());
+        EXPECT_THAT(nextInterpolationBegan, ::testing::IsFalse());
+        EXPECT_THAT(interpolating, ::testing::IsTrue());
+    }
+
+    TEST_F(EditorCameraFixture, CameraInterpolationCanBeginAfterAnInterpolationCompletes)
+    {
+        // Given/When
+        bool initialInterpolationBegan = false;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            initialInterpolationBegan, TestViewportId,
+            &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
+
+        m_controllerList->UpdateViewport({ TestViewportId, AzFramework::FloatSeconds(1.5f), AZ::ScriptTimePoint() });
+
+        bool interpolating = true;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            interpolating, TestViewportId, &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::Interpolating);
+
+        bool nextInterpolationBegan = false;
+        AtomToolsFramework::ModularViewportCameraControllerRequestBus::EventResult(
+            nextInterpolationBegan, TestViewportId,
+            &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform,
+            AZ::Transform::CreateTranslation(AZ::Vector3(10.0f, 10.0f, 10.0f)));
+
+        // Then
+        EXPECT_THAT(initialInterpolationBegan, ::testing::IsTrue());
+        EXPECT_THAT(interpolating, ::testing::IsFalse());
+        EXPECT_THAT(nextInterpolationBegan, ::testing::IsTrue());
     }
 } // namespace UnitTest
 

--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -74,7 +74,7 @@ namespace UnitTest
     class ModularViewportCameraControllerFixture : public AllocatorsTestFixture
     {
     public:
-        static const AzFramework::ViewportId TestViewportId;
+        static inline constexpr AzFramework::ViewportId TestViewportId = 1234;
 
         void SetUp() override
         {
@@ -219,8 +219,6 @@ namespace UnitTest
         AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
         AZStd::unique_ptr<SandboxEditor::EditorModularViewportCameraComposer> m_editorModularViewportCameraComposer;
     };
-
-    const AzFramework::ViewportId ModularViewportCameraControllerFixture::TestViewportId = AzFramework::ViewportId(0);
 
     TEST_F(ModularViewportCameraControllerFixture, MouseMovementDoesNotAccumulateExcessiveDriftInModularViewportCameraWithVaryingDeltaTime)
     {

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1675,6 +1675,12 @@ void SandboxIntegrationManager::GoToEntitiesInViewports(const AzToolsFramework::
         if (auto viewportContext = viewportContextManager->GetViewportContextById(viewIndex))
         {
             const AZ::Transform cameraTransform = viewportContext->GetCameraTransform();
+            // do not attempt to interpolate to where we currently are
+            if (cameraTransform.GetTranslation().IsClose(center))
+            {
+                continue;
+            }
+
             const AZ::Vector3 forward = (center - cameraTransform.GetTranslation()).GetNormalized();
 
             // move camera 25% further back than required

--- a/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
+++ b/Code/Framework/AzFramework/AzFramework/Viewport/CameraInput.h
@@ -347,6 +347,7 @@ namespace AzFramework
         AZStd::function<float()> m_rotateSpeedFn;
         AZStd::function<bool()> m_invertPitchFn;
         AZStd::function<bool()> m_invertYawFn;
+        AZStd::function<bool()> m_constrainPitch;
 
     private:
         InputChannelId m_rotateChannelId; //!< Input channel to begin the rotate camera input.

--- a/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
@@ -104,8 +104,8 @@ namespace UnitTest
         AZStd::shared_ptr<AzFramework::OrbitCameraInput> m_orbitCamera;
         AZ::Vector3 m_pivot = AZ::Vector3::CreateZero();
 
-        //! This is approximately Pi/2 * 1000 - this can be used to rotate the camera 90 degrees (pitch or yaw based
-        //! on vertical or horizontal motion) as the rotate speed function is set to be 1/1000.
+        // this is approximately Pi/2 * 1000 - this can be used to rotate the camera 90 degrees (pitch or yaw based
+        // on vertical or horizontal motion) as the rotate speed function is set to be 1/1000.
         inline static const int PixelMotionDelta90Degrees = 1570;
         inline static const int PixelMotionDelta135Degrees = 2356;
     };

--- a/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraInputTests.cpp
@@ -106,7 +106,8 @@ namespace UnitTest
 
         //! This is approximately Pi/2 * 1000 - this can be used to rotate the camera 90 degrees (pitch or yaw based
         //! on vertical or horizontal motion) as the rotate speed function is set to be 1/1000.
-        inline static const int PixelMotionDelta = 1570;
+        inline static const int PixelMotionDelta90Degrees = 1570;
+        inline static const int PixelMotionDelta135Degrees = 2356;
     };
 
     TEST_F(CameraInputFixture, BeginAndEndOrbitCameraInputConsumesCorrectEvents)
@@ -292,7 +293,7 @@ namespace UnitTest
 
         HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Right, AzFramework::InputChannel::State::Began });
-        HandleEventAndUpdate(AzFramework::HorizontalMotionEvent{ PixelMotionDelta });
+        HandleEventAndUpdate(AzFramework::HorizontalMotionEvent{ PixelMotionDelta90Degrees });
 
         const float expectedYaw = AzFramework::WrapYawRotation(-AZ::Constants::HalfPi);
 
@@ -310,7 +311,7 @@ namespace UnitTest
 
         HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Right, AzFramework::InputChannel::State::Began });
-        HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ PixelMotionDelta });
+        HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ PixelMotionDelta90Degrees });
 
         const float expectedPitch = AzFramework::ClampPitchRotation(-AZ::Constants::HalfPi);
 
@@ -331,7 +332,7 @@ namespace UnitTest
         HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began });
         HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began });
-        HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ PixelMotionDelta });
+        HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ PixelMotionDelta90Degrees });
 
         const auto expectedCameraEndingPosition = AZ::Vector3(0.0f, -10.0f, 10.0f);
         const float expectedPitch = AzFramework::ClampPitchRotation(-AZ::Constants::HalfPi);
@@ -354,7 +355,7 @@ namespace UnitTest
         HandleEventAndUpdate(AzFramework::DiscreteInputEvent{ m_orbitChannelId, AzFramework::InputChannel::State::Began });
         HandleEventAndUpdate(
             AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Left, AzFramework::InputChannel::State::Began });
-        HandleEventAndUpdate(AzFramework::HorizontalMotionEvent{ -PixelMotionDelta });
+        HandleEventAndUpdate(AzFramework::HorizontalMotionEvent{ -PixelMotionDelta90Degrees });
 
         const auto expectedCameraEndingPosition = AZ::Vector3(20.0f, -5.0f, 0.0f);
         const float expectedYaw = AzFramework::WrapYawRotation(AZ::Constants::HalfPi);
@@ -365,5 +366,43 @@ namespace UnitTest
         EXPECT_THAT(m_camera.m_pivot, IsClose(m_pivot));
         EXPECT_THAT(m_camera.m_offset, IsClose(AZ::Vector3(5.0f, -10.0f, 0.0f)));
         EXPECT_THAT(m_camera.Translation(), IsCloseTolerance(expectedCameraEndingPosition, 0.01f));
+    }
+
+    TEST_F(CameraInputFixture, CameraPitchCanNotBeMovedPastNinetyDegreesWhenConstrained)
+    {
+        const auto cameraStartingPosition = AZ::Vector3(15.0f, -20.0f, 0.0f);
+        m_targetCamera.m_pivot = cameraStartingPosition;
+
+        HandleEventAndUpdate(
+            AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Right, AzFramework::InputChannel::State::Began });
+        // pitch by 135.0 degrees
+        HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ -PixelMotionDelta135Degrees });
+
+        // clamped to 90.0 degrees
+        const float expectedPitch = AZ::DegToRad(90.0f);
+
+        using ::testing::FloatNear;
+        EXPECT_THAT(m_camera.m_pitch, FloatNear(expectedPitch, 0.001f));
+    }
+
+    TEST_F(CameraInputFixture, CameraPitchCanBeMovedPastNinetyDegreesWhenUnconstrained)
+    {
+        m_firstPersonRotateCamera->m_constrainPitch = []
+        {
+            return false;
+        };
+
+        const auto cameraStartingPosition = AZ::Vector3(15.0f, -20.0f, 0.0f);
+        m_targetCamera.m_pivot = cameraStartingPosition;
+
+        HandleEventAndUpdate(
+            AzFramework::DiscreteInputEvent{ AzFramework::InputDeviceMouse::Button::Right, AzFramework::InputChannel::State::Began });
+        // pitch by 135.0 degrees
+        HandleEventAndUpdate(AzFramework::VerticalMotionEvent{ -PixelMotionDelta135Degrees });
+
+        const float expectedPitch = AZ::DegToRad(135.0f);
+
+        using ::testing::FloatNear;
+        EXPECT_THAT(m_camera.m_pitch, FloatNear(expectedPitch, 0.001f));
     }
 } // namespace UnitTest

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -113,7 +113,7 @@ namespace AtomToolsFramework
 
         // ModularViewportCameraControllerRequestBus overrides ...
         bool InterpolateToTransform(const AZ::Transform& worldFromLocal) override;
-        bool Interpolating() const override;
+        bool IsInterpolating() const override;
         void StartTrackingTransform(const AZ::Transform& worldFromLocal) override;
         void StopTrackingTransform() override;
         bool IsTrackingTransform() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -112,7 +112,8 @@ namespace AtomToolsFramework
         void UpdateViewport(const AzFramework::ViewportControllerUpdateEvent& event) override;
 
         // ModularViewportCameraControllerRequestBus overrides ...
-        void InterpolateToTransform(const AZ::Transform& worldFromLocal) override;
+        bool InterpolateToTransform(const AZ::Transform& worldFromLocal) override;
+        bool Interpolating() const override;
         void StartTrackingTransform(const AZ::Transform& worldFromLocal) override;
         void StopTrackingTransform() override;
         bool IsTrackingTransform() const override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
@@ -29,7 +29,12 @@ namespace AtomToolsFramework
 
         //! Begin a smooth transition of the camera to the requested transform.
         //! @param worldFromLocal The transform of where the camera should end up.
-        virtual void InterpolateToTransform(const AZ::Transform& worldFromLocal) = 0;
+        //! @return Returns true if the call began an interpolation and false otherwise. Calls to InterpolateToTransform
+        //! will have no effect if an interpolation is currently in progress.
+        virtual bool InterpolateToTransform(const AZ::Transform& worldFromLocal) = 0;
+
+        //! Returns if the camera is currently interpolating to a new transform.
+        virtual bool Interpolating() const = 0;
 
         //! Start tracking a transform.
         //! Store the current camera transform and move to the next camera transform.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
@@ -23,6 +23,8 @@ namespace AtomToolsFramework
     class ModularViewportCameraControllerRequests : public AZ::EBusTraits
     {
     public:
+        static inline constexpr float InterpolateToTransformDuration = 1.0f;
+
         using BusIdType = AzFramework::ViewportId;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
@@ -34,7 +36,7 @@ namespace AtomToolsFramework
         virtual bool InterpolateToTransform(const AZ::Transform& worldFromLocal) = 0;
 
         //! Returns if the camera is currently interpolating to a new transform.
-        virtual bool Interpolating() const = 0;
+        virtual bool IsInterpolating() const = 0;
 
         //! Start tracking a transform.
         //! Store the current camera transform and move to the next camera transform.

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -265,8 +265,11 @@ namespace AtomToolsFramework
 
     void ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal)
     {
-        m_cameraMode = CameraMode::Animation;
-        m_cameraAnimation = CameraAnimation{ CombinedCameraTransform(), worldFromLocal, 0.0f };
+        if (m_cameraMode != CameraMode::Animation)
+        {
+            m_cameraMode = CameraMode::Animation;
+            m_cameraAnimation = CameraAnimation{ CombinedCameraTransform(), worldFromLocal, 0.0f };
+        }
     }
 
     void ModularViewportCameraControllerInstance::StartTrackingTransform(const AZ::Transform& worldFromLocal)

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -235,7 +235,10 @@ namespace AtomToolsFramework
                 return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
             };
 
-            m_cameraAnimation.m_time = AZ::GetClamp(m_cameraAnimation.m_time + event.m_deltaTime.count(), 0.0f, 1.0f);
+            m_cameraAnimation.m_time = AZ::GetClamp(
+                m_cameraAnimation.m_time +
+                    (event.m_deltaTime.count() / ModularViewportCameraControllerRequests::InterpolateToTransformDuration),
+                0.0f, 1.0f);
 
             const auto& [transformStart, transformEnd, animationTime] = m_cameraAnimation;
 
@@ -265,7 +268,7 @@ namespace AtomToolsFramework
 
     bool ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal)
     {
-        if (m_cameraMode != CameraMode::Animation)
+        if (!IsInterpolating())
         {
             m_cameraMode = CameraMode::Animation;
             m_cameraAnimation = CameraAnimation{ CombinedCameraTransform(), worldFromLocal, 0.0f };
@@ -276,7 +279,7 @@ namespace AtomToolsFramework
         return false;
     }
 
-    bool ModularViewportCameraControllerInstance::Interpolating() const
+    bool ModularViewportCameraControllerInstance::IsInterpolating() const
     {
         return m_cameraMode == CameraMode::Animation;
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -263,13 +263,22 @@ namespace AtomToolsFramework
         m_updatingTransformInternally = false;
     }
 
-    void ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal)
+    bool ModularViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal)
     {
         if (m_cameraMode != CameraMode::Animation)
         {
             m_cameraMode = CameraMode::Animation;
             m_cameraAnimation = CameraAnimation{ CombinedCameraTransform(), worldFromLocal, 0.0f };
+
+            return true;
         }
+
+        return false;
+    }
+
+    bool ModularViewportCameraControllerInstance::Interpolating() const
+    {
+        return m_cameraMode == CameraMode::Animation;
     }
 
     void ModularViewportCameraControllerInstance::StartTrackingTransform(const AZ::Transform& worldFromLocal)


### PR DESCRIPTION
This PR is a quick follow-up on https://github.com/o3de/o3de/pull/5658

It allows the camera to no longer be constrained in pitch when tracking a transform (using 'Be this camera') as the transform being tracked _might_ have a really funky transform and we want to not limit users when using this feature).

This PR also fixes a couple of more minor camera bugs

Closes https://github.com/o3de/o3de/issues/3926
Closes https://github.com/o3de/o3de/issues/4141