### PR TITLE
Fixed slow Script Canvas loading by moving error icon construction in NodePaletteTreeItem.

### DIFF
--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.cpp
@@ -9,6 +9,10 @@
 
 #include <GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h>
 
+AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option")
+#include <QIcon>
+AZ_POP_DISABLE_WARNING
+
 namespace GraphCanvas
 {
     ////////////////////////
@@ -19,7 +23,6 @@ namespace GraphCanvas
 
     NodePaletteTreeItem::NodePaletteTreeItem(AZStd::string_view name, EditorId editorId)
         : GraphCanvas::GraphCanvasTreeItem()
-        , m_errorIcon(":/GraphCanvasEditorResources/toast_error_icon.png")
         , m_editorId(editorId)
         , m_name(QString::fromUtf8(name.data(), static_cast<int>(name.size())))
         , m_selected(false)
@@ -88,7 +91,7 @@ namespace GraphCanvas
             case Qt::DecorationRole:
                 if (HasError())
                 {
-                    return m_errorIcon;
+                    return QIcon(":/GraphCanvasEditorResources/toast_error_icon.png");
                 }
                 break;
             default:

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/NodePalette/TreeItems/NodePaletteTreeItem.h
@@ -9,10 +9,6 @@
 
 #include <AzCore/PlatformIncl.h>
 
-AZ_PUSH_DISABLE_WARNING(4244 4251 4800, "-Wunknown-warning-option")
-#include <QIcon>
-AZ_POP_DISABLE_WARNING
-
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/string_view.h>
@@ -113,7 +109,6 @@ namespace GraphCanvas
     private:
 
         // Error Display
-        QIcon m_errorIcon;
         QString m_errorString;
 
         AZStd::string m_styleOverride;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -881,6 +881,7 @@ namespace ScriptCanvasEditor
 
     void NodePaletteModel::RepopulateModel()
     {
+        AZ_PROFILE_FUNCTION(ScriptCanvas);
         ClearRegistry();
 
         PopulateNodePaletteModel((*this));

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -428,6 +428,8 @@ namespace ScriptCanvasEditor
         , m_closeCurrentGraphAfterSave(false)
         , m_styleManager(ScriptCanvasEditor::AssetEditorId, "ScriptCanvas/StyleSheet/graphcanvas_style.json")
     {
+        AZ_PROFILE_FUNCTION(ScriptCanvas);
+
         VariablePaletteRequestBus::Handler::BusConnect();
         GraphCanvas::AssetEditorAutomationRequestBus::Handler::BusConnect(ScriptCanvasEditor::AssetEditorId);
 


### PR DESCRIPTION
Fixes #3738 

Identified slow-down in Script Canvas tool being loaded due to the construction of a `QIcon` for the error icon of every node palette tree item (which is then x3 because the node palette is created for the actual node palette widget, the scene context menu, and connection context menu). This error icon isn't actually needed unless there is an error on the tree item, so moved the construction to the case when it actually needs to be displayed. This reduced the load time from ~1500ms to ~300ms, an improvement of ~80%.

Also added some `AZ_PROFILE_FUNCTION` calls that helped narrow down the source of the delay.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>