### PR TITLE
Updates and fixes to viewport placement

### DIFF
--- a/Code/Editor/2DViewport.cpp
+++ b/Code/Editor/2DViewport.cpp
@@ -234,7 +234,7 @@ void Q2DViewport::UpdateContent(int flags)
 }
 
 //////////////////////////////////////////////////////////////////////////
-void Q2DViewport::OnRButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& point)
+void Q2DViewport::OnRButtonDown([[maybe_unused]] Qt::KeyboardModifiers modifiers, const QPoint& point)
 {
     if (GetIEditor()->IsInGameMode())
     {
@@ -245,9 +245,6 @@ void Q2DViewport::OnRButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& p
     {
         setFocus();
     }
-
-    // Check Edit Tool.
-    MouseCallback(eMouseRDown, point, modifiers);
 
     SetCurrentCursor(STD_CURSOR_MOVE, QString());
 
@@ -273,17 +270,8 @@ void Q2DViewport::OnRButtonUp([[maybe_unused]] Qt::KeyboardModifiers modifiers, 
 }
 
 //////////////////////////////////////////////////////////////////////////
-void Q2DViewport::OnMButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& point)
+void Q2DViewport::OnMButtonDown([[maybe_unused]] Qt::KeyboardModifiers modifiers, const QPoint& point)
 {
-    ////////////////////////////////////////////////////////////////////////
-    // User pressed the middle mouse button
-    ////////////////////////////////////////////////////////////////////////
-    // Check Edit Tool.
-    if (MouseCallback(eMouseMDown, point, modifiers))
-    {
-        return;
-    }
-
     // Save the mouse down position
     m_RMouseDownPos = point;
 
@@ -300,14 +288,8 @@ void Q2DViewport::OnMButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& p
 }
 
 //////////////////////////////////////////////////////////////////////////
-void Q2DViewport::OnMButtonUp(Qt::KeyboardModifiers modifiers, const QPoint& point)
+void Q2DViewport::OnMButtonUp([[maybe_unused]] Qt::KeyboardModifiers modifiers, [[maybe_unused]] const QPoint& point)
 {
-    // Check Edit Tool.
-    if (MouseCallback(eMouseMUp, point, modifiers))
-    {
-        return;
-    }
-
     SetViewMode(NothingMode);
 
     ReleaseMouse();

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2307,10 +2307,10 @@ void* EditorViewportWidget::GetSystemCursorConstraintWindow() const
     return systemCursorConstrained ? renderOverlayHWND() : nullptr;
 }
 
-void EditorViewportWidget::BuildDragDropContext(AzQtComponents::ViewportDragContext& context, const QPoint& pt)
+void EditorViewportWidget::BuildDragDropContext(
+    AzQtComponents::ViewportDragContext& context, const AzFramework::ViewportId viewportId, const QPoint& point)
 {
-    const auto scaledPoint = WidgetToViewport(pt);
-    QtViewport::BuildDragDropContext(context, scaledPoint);
+    QtViewport::BuildDragDropContext(context, viewportId, point);
 }
 
 void EditorViewportWidget::RestoreViewportAfterGameMode()

--- a/Code/Editor/EditorViewportWidget.h
+++ b/Code/Editor/EditorViewportWidget.h
@@ -273,7 +273,8 @@ private:
 
     bool CheckRespondToInput() const;
 
-    void BuildDragDropContext(AzQtComponents::ViewportDragContext& context, const QPoint& pt) override;
+    void BuildDragDropContext(
+        AzQtComponents::ViewportDragContext& context, AzFramework::ViewportId viewportId, const QPoint& point) override;
 
     void SetAsActiveViewport();
     void PushDisableRendering();

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -56,6 +56,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx>
 #include <AzToolsFramework/UI/Layer/NameConflictWarning.hxx>
 #include <AzToolsFramework/ViewportSelection/EditorHelpers.h>
+#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <MathConversion.h>
 
 #include <Atom/RPI.Public/ViewportContext.h>
@@ -1397,8 +1398,9 @@ void SandboxIntegrationManager::ContextMenu_NewEntity()
     // will be created at the origin.
     if (CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport())
     {
-        worldPosition = AzToolsFramework::CalculateWorldPosition(
-            view->GetViewportId(), AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint), GetDefaultEntityPlacementDistance());
+        worldPosition = AzToolsFramework::FindClosestPickIntersection(
+            view->GetViewportId(), AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint), AzToolsFramework::EditorPickRayLength,
+            GetDefaultEntityPlacementDistance());
     }
 
     CreateNewEntityAtPosition(worldPosition);

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
-#include <AzCore/Console/IConsole.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/RTTI/AttributeReader.h>

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -28,7 +28,6 @@
 #include <AzFramework/Physics/Material.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzFramework/Visibility/BoundsBus.h>
-#include <AzFramework/Render/IntersectorInterface.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
 #include <AzToolsFramework/API/EditorEntityAPI.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
@@ -1407,33 +1406,8 @@ void SandboxIntegrationManager::ContextMenu_NewEntity()
     // will be created at the origin.
     if (CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport())
     {
-        const auto viewportId = view->GetViewportId();
-        using AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus;
-        AzToolsFramework::ViewportInteraction::ProjectedViewportRay viewportRay{};
-        ViewportInteractionRequestBus::EventResult(
-            viewportRay, viewportId, &ViewportInteractionRequestBus::Events::ViewportScreenToWorldRay,
-            AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint));
-
-        const float RayDistance = 1000.0f;
-        AzFramework::RenderGeometry::RayRequest ray;
-        ray.m_startWorldPosition = viewportRay.origin;
-        ray.m_endWorldPosition = viewportRay.origin + viewportRay.direction * RayDistance;
-        ray.m_onlyVisible = true;
-
-        AzFramework::RenderGeometry::RayResult renderGeometryIntersectionResult;
-        AzFramework::RenderGeometry::IntersectorBus::EventResult(
-            renderGeometryIntersectionResult, AzToolsFramework::GetEntityContextId(),
-            &AzFramework::RenderGeometry::IntersectorBus::Events::RayIntersect, ray);
-
-        // attempt a ray intersection with any visible mesh and return the intersection position if successful
-        if (renderGeometryIntersectionResult)
-        {
-            worldPosition = renderGeometryIntersectionResult.m_worldPosition;
-        }
-        else
-        {
-            worldPosition = viewportRay.origin + viewportRay.direction * ed_defaultEntityPlacementDistance;
-        }
+        worldPosition = AzToolsFramework::CalculateWorldPosition(
+            view->GetViewportId(), AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint), ed_defaultEntityPlacementDistance);
     }
 
     CreateNewEntityAtPosition(worldPosition);

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -99,14 +99,6 @@
 #undef CreateDirectory
 #endif
 
-AZ_CVAR(
-    float,
-    ed_defaultEntityPlacementDistance,
-    10.0f,
-    nullptr,
-    AZ::ConsoleFunctorFlags::Null,
-    "The default distance to place an entity from the camera if no intersection is found");
-
 //////////////////////////////////////////////////////////////////////////
 // Gathers all selected entities, culling any that have an ancestor in the selection.
 void GetSelectedEntitiesSetWithFlattenedHierarchy(AzToolsFramework::EntityIdSet& out)
@@ -1406,7 +1398,7 @@ void SandboxIntegrationManager::ContextMenu_NewEntity()
     if (CViewport* view = GetIEditor()->GetViewManager()->GetGameViewport())
     {
         worldPosition = AzToolsFramework::CalculateWorldPosition(
-            view->GetViewportId(), AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint), ed_defaultEntityPlacementDistance);
+            view->GetViewportId(), AzFramework::ScreenPointFromVector2(m_contextMenuViewPoint), GetDefaultEntityPlacementDistance());
     }
 
     CreateNewEntityAtPosition(worldPosition);

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -10,6 +10,7 @@
 #define CRYINCLUDE_COMPONENTENTITYEDITORPLUGIN_SANDBOXINTEGRATION_H
 
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Console/IConsole.h>
 #include <AzCore/Slice/SliceBus.h>
 #include <AzCore/Slice/SliceComponent.h>
 #include <AzCore/Math/Uuid.h>
@@ -38,6 +39,8 @@
 
 #include <QApplication>
 #include <QPointer>
+
+AZ_CVAR_EXTERNED(float, ed_defaultEntityPlacementDistance);
 
 /**
 * Integration of ToolsApplication behavior and Cry undo/redo and selection systems

--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -10,7 +10,6 @@
 #define CRYINCLUDE_COMPONENTENTITYEDITORPLUGIN_SANDBOXINTEGRATION_H
 
 #include <AzCore/Component/ComponentApplicationBus.h>
-#include <AzCore/Console/IConsole.h>
 #include <AzCore/Slice/SliceBus.h>
 #include <AzCore/Slice/SliceComponent.h>
 #include <AzCore/Math/Uuid.h>
@@ -39,8 +38,6 @@
 
 #include <QApplication>
 #include <QPointer>
-
-AZ_CVAR_EXTERNED(float, ed_defaultEntityPlacementDistance);
 
 /**
 * Integration of ToolsApplication behavior and Cry undo/redo and selection systems

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -23,6 +23,7 @@
 #include <AzToolsFramework/API/ComponentEntitySelectionBus.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
+#include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 
 // Editor
 #include "Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h"
@@ -60,8 +61,9 @@ float GetDefaultEntityPlacementDistance()
 void QtViewport::BuildDragDropContext(
     AzQtComponents::ViewportDragContext& context, const AzFramework::ViewportId viewportId, const QPoint& point)
 {
-    context.m_hitLocation = AzToolsFramework::CalculateWorldPosition(
-        viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), GetDefaultEntityPlacementDistance());
+    context.m_hitLocation = AzToolsFramework::FindClosestPickIntersection(
+        viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), AzToolsFramework::EditorPickRayLength,
+        GetDefaultEntityPlacementDistance());
 }
 
 void QtViewport::dragEnterEvent(QDragEnterEvent* event)

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -22,6 +22,7 @@
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 // Editor
+#include "Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h"
 #include "ViewManager.h"
 #include "Include/ITransformManipulator.h"
 #include "Include/HitContext.h"
@@ -44,7 +45,7 @@
 void QtViewport::BuildDragDropContext(AzQtComponents::ViewportDragContext& context, const AzFramework::ViewportId viewportId, const QPoint& point)
 {
     context.m_hitLocation =
-        AzToolsFramework::CalculateWorldPosition(viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), 10.0f);
+        AzToolsFramework::CalculateWorldPosition(viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), ed_defaultEntityPlacementDistance);
 }
 
 void QtViewport::dragEnterEvent(QDragEnterEvent* event)

--- a/Code/Editor/Viewport.cpp
+++ b/Code/Editor/Viewport.cpp
@@ -14,6 +14,9 @@
 // Qt
 #include <QPainter>
 
+// AzCore
+#include <AzCore/Console/IConsole.h>
+
 // AzQtComponents
 #include <AzQtComponents/DragAndDrop/ViewportDragAndDrop.h>
 
@@ -33,19 +36,32 @@
 #include "GameEngine.h"
 #include "Settings.h"
 
-
 #ifdef LoadCursor
 #undef LoadCursor
 #endif
+
+AZ_CVAR(
+    float,
+    ed_defaultEntityPlacementDistance,
+    10.0f,
+    nullptr,
+    AZ::ConsoleFunctorFlags::Null,
+    "The default distance to place an entity from the camera if no intersection is found");
+
+float GetDefaultEntityPlacementDistance()
+{
+    return ed_defaultEntityPlacementDistance;
+}
 
 //////////////////////////////////////////////////////////////////////
 // Viewport drag and drop support
 //////////////////////////////////////////////////////////////////////
 
-void QtViewport::BuildDragDropContext(AzQtComponents::ViewportDragContext& context, const AzFramework::ViewportId viewportId, const QPoint& point)
+void QtViewport::BuildDragDropContext(
+    AzQtComponents::ViewportDragContext& context, const AzFramework::ViewportId viewportId, const QPoint& point)
 {
-    context.m_hitLocation =
-        AzToolsFramework::CalculateWorldPosition(viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), ed_defaultEntityPlacementDistance);
+    context.m_hitLocation = AzToolsFramework::CalculateWorldPosition(
+        viewportId, AzToolsFramework::ViewportInteraction::ScreenPointFromQPoint(point), GetDefaultEntityPlacementDistance());
 }
 
 void QtViewport::dragEnterEvent(QDragEnterEvent* event)

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -522,9 +522,6 @@ protected:
     void setRenderOverlayVisible(bool);
     bool isRenderOverlayVisible() const;
 
-    // called to process mouse callback inside the viewport.
-    virtual bool MouseCallback(EMouseEvent event, const QPoint& point, Qt::KeyboardModifiers modifiers, Qt::MouseButtons buttons = Qt::NoButton);
-
     void ProcessRenderLisneters(DisplayContext& rstDisplayContext);
 
     void mousePressEvent(QMouseEvent* event) override;
@@ -535,23 +532,21 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
     void keyReleaseEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
-    void leaveEvent(QEvent* event) override;
-
     void paintEvent(QPaintEvent* event) override;
 
-    virtual void OnMouseMove(Qt::KeyboardModifiers modifiers, Qt::MouseButtons buttons, const QPoint& point);
-    virtual void OnMouseWheel(Qt::KeyboardModifiers modifiers, short zDelta, const QPoint& pt);
-    virtual void OnLButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnLButtonUp(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnRButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnRButtonUp(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnMButtonDblClk(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnMButtonDown(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnMButtonUp(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnLButtonDblClk(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnRButtonDblClk(Qt::KeyboardModifiers modifiers, const QPoint& point);
-    virtual void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
-    virtual void OnKeyUp(UINT nChar, UINT nRepCnt, UINT nFlags);
+    virtual void OnMouseMove(Qt::KeyboardModifiers, Qt::MouseButtons, const QPoint&) {}
+    virtual void OnMouseWheel(Qt::KeyboardModifiers, short zDelta, const QPoint&);
+    virtual void OnLButtonDown(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnLButtonUp(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnRButtonDown(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnRButtonUp(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnMButtonDblClk(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnMButtonDown(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnMButtonUp(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnLButtonDblClk(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnRButtonDblClk(Qt::KeyboardModifiers, const QPoint&) {}
+    virtual void OnKeyDown([[maybe_unused]] UINT nChar, [[maybe_unused]] UINT nRepCnt, [[maybe_unused]] UINT nFlags) {}
+    virtual void OnKeyUp([[maybe_unused]] UINT nChar, [[maybe_unused]] UINT nRepCnt, [[maybe_unused]] UINT nFlags) {}
 #if defined(AZ_PLATFORM_WINDOWS)
     void OnRawInput(UINT wParam, HRAWINPUT lParam);
 #endif

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -6,9 +6,7 @@
  *
  */
 
-
 // Description : interface for the CViewport class.
-
 
 #pragma once
 
@@ -88,6 +86,9 @@ enum EStdCursor
 
     STD_CURSOR_LAST,
 };
+
+//! The default distance an entity is placed from the camera if there is no intersection
+SANDBOX_API float GetDefaultEntityPlacementDistance();
 
 AZ_PUSH_DISABLE_DLL_EXPORT_BASECLASS_WARNING
 class SANDBOX_API CViewport

--- a/Code/Editor/Viewport.h
+++ b/Code/Editor/Viewport.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #if !defined(Q_MOC_RUN)
+#include <AzFramework/Viewport/ViewportId.h>
 #include <AzToolsFramework/Viewport/ViewportTypes.h>
 #include <AzToolsFramework/ViewportUi/ViewportUiManager.h>
 #include <Cry_Color.h>
@@ -201,7 +202,6 @@ public:
 
     //! Performs hit testing of 2d point in view to find which object hit.
     virtual bool HitTest(const QPoint& point, HitContext& hitInfo) = 0;
-    virtual AZ::Vector3 GetHitLocation(const QPoint& point) = 0;
 
     virtual void MakeConstructionPlane(int axis) = 0;
 
@@ -432,7 +432,6 @@ public:
 
     //! Performs hit testing of 2d point in view to find which object hit.
     bool HitTest(const QPoint& point, HitContext& hitInfo) override;
-    AZ::Vector3 GetHitLocation(const QPoint& point) override;
 
     //! Do 2D hit testing of line in world space.
     // pToCameraDistance is an optional output parameter in which distance from the camera to the line is returned.
@@ -552,7 +551,9 @@ protected:
 #endif
     void OnSetCursor();
 
-    virtual void BuildDragDropContext(AzQtComponents::ViewportDragContext& context, const QPoint& pt);
+    virtual void BuildDragDropContext(
+        AzQtComponents::ViewportDragContext& context, AzFramework::ViewportId viewportId, const QPoint& point);
+
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
     void dragLeaveEvent(QDragLeaveEvent* event) override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzFramework/Render/IntersectorInterface.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
 namespace AzToolsFramework
@@ -61,5 +62,35 @@ namespace AzToolsFramework
         }
 
         return circleBoundWidth;
+    }
+
+    AZ::Vector3 CalculateWorldPosition(
+        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, const float defaultDistance)
+    {
+        using AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus;
+        AzToolsFramework::ViewportInteraction::ProjectedViewportRay viewportRay{};
+        ViewportInteractionRequestBus::EventResult(
+            viewportRay, viewportId, &ViewportInteractionRequestBus::Events::ViewportScreenToWorldRay, screenPoint);
+
+        const float RayDistance = 1000.0f;
+        AzFramework::RenderGeometry::RayRequest ray;
+        ray.m_startWorldPosition = viewportRay.origin;
+        ray.m_endWorldPosition = viewportRay.origin + viewportRay.direction * RayDistance;
+        ray.m_onlyVisible = true;
+
+        AzFramework::RenderGeometry::RayResult renderGeometryIntersectionResult;
+        AzFramework::RenderGeometry::IntersectorBus::EventResult(
+            renderGeometryIntersectionResult, AzToolsFramework::GetEntityContextId(),
+            &AzFramework::RenderGeometry::IntersectorBus::Events::RayIntersect, ray);
+
+        // attempt a ray intersection with any visible mesh and return the intersection position if successful
+        if (renderGeometryIntersectionResult)
+        {
+            return renderGeometryIntersectionResult.m_worldPosition;
+        }
+        else
+        {
+            return viewportRay.origin + viewportRay.direction * defaultDistance;
+        }
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.cpp
@@ -64,18 +64,17 @@ namespace AzToolsFramework
         return circleBoundWidth;
     }
 
-    AZ::Vector3 CalculateWorldPosition(
-        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, const float defaultDistance)
+    AZ::Vector3 FindClosestPickIntersection(
+        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, const float rayLength, const float defaultDistance)
     {
         using AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus;
         AzToolsFramework::ViewportInteraction::ProjectedViewportRay viewportRay{};
         ViewportInteractionRequestBus::EventResult(
             viewportRay, viewportId, &ViewportInteractionRequestBus::Events::ViewportScreenToWorldRay, screenPoint);
 
-        const float RayDistance = 1000.0f;
         AzFramework::RenderGeometry::RayRequest ray;
         ray.m_startWorldPosition = viewportRay.origin;
-        ray.m_endWorldPosition = viewportRay.origin + viewportRay.direction * RayDistance;
+        ray.m_endWorldPosition = viewportRay.origin + viewportRay.direction * rayLength;
         ray.m_onlyVisible = true;
 
         AzFramework::RenderGeometry::RayResult renderGeometryIntersectionResult;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -334,6 +334,12 @@ namespace AzToolsFramework
         return entityContextId;
     }
 
+    //! Performs an intersection test against the world, if there is a hit (the ray intersects
+    //! a mesh), that position is returned, otherwise a point projected defaultDistance infront
+    //! of the camera will returned along the pick ray.
+    AZ::Vector3 CalculateWorldPosition(
+        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, float defaultDistance);
+
     //! Maps a mouse interaction event to a ClickDetector event.
     //! @note Function only cares about up or down events, all other events are mapped to Nil (ignored).
     AzFramework::ClickDetector::ClickEvent ClickDetectorEventFromViewportInteraction(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -334,11 +334,11 @@ namespace AzToolsFramework
         return entityContextId;
     }
 
-    //! Performs an intersection test against the world, if there is a hit (the ray intersects
-    //! a mesh), that position is returned, otherwise a point projected defaultDistance infront
-    //! of the camera will returned along the pick ray.
-    AZ::Vector3 CalculateWorldPosition(
-        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, float defaultDistance);
+    //! Performs an intersection test against meshes in the scene, if there is a hit (the ray intersects
+    //! a mesh), that position is returned, otherwise a point projected defaultDistance from the
+    //! origin of the ray will be returned.
+    AZ::Vector3 FindClosestPickIntersection(
+        AzFramework::ViewportId viewportId, const AzFramework::ScreenPoint& screenPoint, float rayLength, float defaultDistance);
 
     //! Maps a mouse interaction event to a ClickDetector event.
     //! @note Function only cares about up or down events, all other events are mapped to Nil (ignored).

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.cpp
@@ -18,9 +18,6 @@
 
 namespace AzToolsFramework
 {
-    // default ray length for picking in the viewport
-    static const float EditorPickRayLength = 1000.0f;
-
     AZ::Vector3 CalculateCenterOffset(const AZ::EntityId entityId, const EditorTransformComponentSelectionRequests::Pivot pivot)
     {
         if (Centered(pivot))

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorSelectionUtil.h
@@ -26,6 +26,9 @@ namespace AzFramework
 
 namespace AzToolsFramework
 {
+    //! Default ray length for picking in the viewport.
+    inline constexpr float EditorPickRayLength = 1000.0f;
+
     //! Is the pivot at the center of the object (middle of extents) or at the
     //! exported authored object root position.
     inline bool Centered(const EditorTransformComponentSelectionRequests::Pivot pivot)


### PR DESCRIPTION
This fix replaces legacy calls to `GetHitLocation` with `CalculateWorldPosition` which uses the new `IntersectorBus`.

The PR also removes legacy viewport calls that are no longer used.