### PR TITLE
Mock Atom RPISystem in ViewportInteractionTests

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -132,21 +132,16 @@ namespace AZ
             //! Returns the masked occlusion culling interface
             MaskedOcclusionCulling* GetMaskedOcclusionCulling();
 
-            //! This is called by RenderPipeline when this view is added to the pipeline.
-            void OnAddToRenderPipeline();
-
         private:
             View() = delete;
             View(const AZ::Name& name, UsageFlags usage);
+
 
             //! Sorts the finalized draw lists in this view
             void SortFinalizedDrawLists();
 
             //! Sorts a drawList using the sort function from a pass with the corresponding drawListTag
             void SortDrawList(RHI::DrawList& drawList, RHI::DrawListTag tag);
-
-            //! Attempt to create a shader resource group.
-            void TryCreateShaderResourceGroup();
 
             AZ::Name m_name;
             UsageFlags m_usageFlags;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -178,10 +178,7 @@ namespace AZ
                     pipelineViews.m_views.resize(1);
                 }
                 ViewPtr previousView = pipelineViews.m_views[0];
-                if (view)
-                {
-                    view->OnAddToRenderPipeline();
-                }
+                view->OnAddToRenderPipeline();
                 pipelineViews.m_views[0] = view;
 
                 if (previousView)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -178,7 +178,6 @@ namespace AZ
                     pipelineViews.m_views.resize(1);
                 }
                 ViewPtr previousView = pipelineViews.m_views[0];
-                view->OnAddToRenderPipeline();
                 pipelineViews.m_views[0] = view;
 
                 if (previousView)
@@ -239,7 +238,6 @@ namespace AZ
                     pipelineViews.m_type = PipelineViewType::Transient;
                 }
                 view->SetPassesByDrawList(&pipelineViews.m_passesByDrawList);
-                view->OnAddToRenderPipeline();
                 pipelineViews.m_views.push_back(view);
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -453,7 +453,7 @@ namespace AZ
             TryCreateShaderResourceGroup();
             if (!m_shaderResourceGroup)
             {
-                AZ_Warning("RPI::View", false, "Shader Resource Group failed to initialize");
+                AZ_Error("RPI::View", false, "Shader Resource Group failed to initialize");
             }
         }
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/View.cpp
@@ -53,8 +53,15 @@ namespace AZ
             AZ::MakePerspectiveFovMatrixRH(viewToClipMatrix, AZ::Constants::HalfPi, 1, 0.1f, 1000.f, true);
             SetViewToClipMatrix(viewToClipMatrix);
 
-            TryCreateShaderResourceGroup();
-
+            if (auto rpiSystemInterface = RPISystemInterface::Get())
+            {
+                if (Data::Asset<ShaderAsset> viewSrgShaderAsset = rpiSystemInterface->GetCommonShaderAssetForSrgs();
+                    viewSrgShaderAsset.IsReady())
+                {
+                    m_shaderResourceGroup =
+                        ShaderResourceGroup::Create(viewSrgShaderAsset, rpiSystemInterface->GetViewSrgLayout()->GetName());
+                }
+            }
 #if AZ_TRAIT_MASKED_OCCLUSION_CULLING_SUPPORTED
             m_maskedOcclusionCulling = MaskedOcclusionCulling::Create();
             m_maskedOcclusionCulling->SetResolution(MaskedSoftwareOcclusionCullingWidth, MaskedSoftwareOcclusionCullingHeight);
@@ -430,31 +437,6 @@ namespace AZ
         MaskedOcclusionCulling* View::GetMaskedOcclusionCulling()
         {
             return m_maskedOcclusionCulling;
-        }
-
-        void View::TryCreateShaderResourceGroup()
-        {
-            if (!m_shaderResourceGroup)
-            {
-                if (auto rpiSystemInterface = RPISystemInterface::Get())
-                {
-                    if (Data::Asset<ShaderAsset> viewSrgShaderAsset = rpiSystemInterface->GetCommonShaderAssetForSrgs();
-                        viewSrgShaderAsset.IsReady())
-                    {
-                        m_shaderResourceGroup =
-                            ShaderResourceGroup::Create(viewSrgShaderAsset, rpiSystemInterface->GetViewSrgLayout()->GetName());
-                    }
-                }
-            }
-        }
-
-        void View::OnAddToRenderPipeline()
-        {
-            TryCreateShaderResourceGroup();
-            if (!m_shaderResourceGroup)
-            {
-                AZ_Error("RPI::View", false, "Shader Resource Group failed to initialize");
-            }
         }
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Tests/Mocks/MockRPISystemInterface.h
+++ b/Gems/Atom/RPI/Code/Tests/Mocks/MockRPISystemInterface.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
+
+namespace AZ::RPI
+{
+    class MockRPISystemInterface
+        : public RPISystemInterface
+    {
+    public:
+        AZ_RTTI(MockRPISystemInterface, "{76FE11F7-6454-4964-90F2-B5D1579FC1E0}");
+        
+        MOCK_METHOD0(InitializeSystemAssets, void());
+        MOCK_CONST_METHOD0(IsInitialized, bool());
+        MOCK_METHOD1(RegisterScene, void(ScenePtr scene));
+        MOCK_METHOD1(UnregisterScene, void(ScenePtr scene));
+        MOCK_CONST_METHOD0(GetDefaultScene, ScenePtr());
+        MOCK_CONST_METHOD1(GetScene, Scene*(const SceneId& sceneId));
+        MOCK_CONST_METHOD1(GetSceneByName, Scene*(const AZ::Name& name));
+        MOCK_METHOD1(GetRenderPipelineForWindow, RenderPipelinePtr(AzFramework::NativeWindowHandle windowHandle));
+        MOCK_CONST_METHOD0(GetCommonShaderAssetForSrgs, Data::Asset<ShaderAsset>());
+        MOCK_CONST_METHOD0(GetSceneSrgLayout, RHI::Ptr<RHI::ShaderResourceGroupLayout>());
+        MOCK_CONST_METHOD0(GetViewSrgLayout, RHI::Ptr<RHI::ShaderResourceGroupLayout>());
+        MOCK_METHOD0(SimulationTick, void());
+        MOCK_METHOD0(RenderTick, void());
+        MOCK_METHOD1(SetSimulationJobPolicy, void(RHI::JobPolicy jobPolicy));
+        MOCK_CONST_METHOD0(GetSimulationJobPolicy, RHI::JobPolicy());
+        MOCK_METHOD1(SetRenderPrepareJobPolicy, void(RHI::JobPolicy jobPolicy));
+        MOCK_CONST_METHOD0(GetRenderPrepareJobPolicy, RHI::JobPolicy());
+        MOCK_CONST_METHOD0(GetDescriptor, const RPISystemDescriptor&());
+        MOCK_CONST_METHOD0(GetRenderApiName, Name());
+        MOCK_CONST_METHOD0(GetCurrentTick, uint64_t());
+    };
+} // namespace AZ

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Tests/ViewportInteractionImplTests.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Tests/ViewportInteractionImplTests.cpp
@@ -16,6 +16,7 @@
 #include <AzTest/AzTest.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <Tests/Utils/Printers.h>
+#include <Atom/RPI.Public/../../../Tests/Mocks/MockRPISystemInterface.h> // TODO: fix include path
 
 namespace UnitTest
 {
@@ -33,6 +34,8 @@ namespace UnitTest
 
         void SetUp() override
         {
+            AZ::Interface<AZ::RPI::RPISystemInterface>::Register(&m_rpiSystemInterface);
+
             AZ::NameDictionary::Create();
 
             m_view = AZ::RPI::View::CreateView(AZ::Name("TestView"), AZ::RPI::View::UsageCamera);
@@ -65,10 +68,13 @@ namespace UnitTest
             m_view.reset();
 
             AZ::NameDictionary::Destroy();
+
+            AZ::Interface<AZ::RPI::RPISystemInterface>::Unregister(&m_rpiSystemInterface);
         }
 
         AZ::RPI::ViewPtr m_view;
         AZStd::unique_ptr<AtomToolsFramework::ViewportInteractionImpl> m_viewportInteractionImpl;
+        testing::NiceMock<AZ::RPI::MockRPISystemInterface> m_rpiSystemInterface;
     };
 
     // transform a point from screen space to world space, and then from world space back to screen space


### PR DESCRIPTION
This creates a mock RPISystemInterface instead of modifying the production View class to get the tests to work, as was done in #5494.