### PR TITLE
Fix large delta on next frame when turning t_simulationTickDeltaOverride off.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
@@ -124,14 +124,13 @@ namespace AZ
         const TimeUs currentTimeUs = static_cast<TimeUs>(AZStd::GetTimeNowMicroSecond());
 
         //real time
-        m_realTickDeltaTimeUs = currentTimeUs - m_lastRealTickTimeUs;
-        m_lastRealTickTimeUs = currentTimeUs;
+        m_realTickDeltaTimeUs = currentTimeUs - m_lastSimulationTickTimeUs;
 
         //game time
         if (m_simulationTickDeltaOverride > AZ::Time::ZeroTimeUs)
         {
             m_simulationTickDeltaTimeUs = m_simulationTickDeltaOverride;
-            m_lastSimulationTickTimeUs = m_simulationTickDeltaTimeUs;
+            m_lastSimulationTickTimeUs = currentTimeUs;
             return m_simulationTickDeltaTimeUs;
         }
 

--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
@@ -74,8 +74,7 @@ namespace AZ
         //! Updated in AdvanceTickDeltaTimes().
         TimeUs m_realTickDeltaTimeUs = AZ::Time::ZeroTimeUs;
 
-        TimeUs m_lastSimulationTickTimeUs = AZ::Time::ZeroTimeUs; //!< Used to determine the game tick delta time (affected by cvars).
-        TimeUs m_lastRealTickTimeUs = AZ::Time::ZeroTimeUs; //!< Used to determine the real game tick delta time (not affected by cvars).
+        TimeUs m_lastSimulationTickTimeUs = AZ::Time::ZeroTimeUs; //!< Used to determine the game tick delta time.
 
         TimeUs m_simulationTickDeltaOverride = AZ::Time::ZeroTimeUs; //<! Stores the TimeUs value of the t_simulationTickDeltaOverride cvar.
         TimeUs m_simulationTickLimitTimeUs = AZ::Time::ZeroTimeUs; //<! Stores the TimeUs value of the t_simulationTickRate cvar.


### PR DESCRIPTION
This was due to incorrectly setting m_lastSimulationTickTimeUs when t_simulationTickDeltaOverride was enabled to the override.
m_lastSimulationTickTimeUs is now always set to the current time so the delta calculation will always be correct.

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>