### PR TITLE
Settings Registry: Settings changed via --regset on Editor launch are saved when the Editor is closed

### DIFF
--- a/Code/Editor/MainWindow.cpp
+++ b/Code/Editor/MainWindow.cpp
@@ -519,7 +519,7 @@ MainWindow* MainWindow::instance()
 
 void MainWindow::closeEvent(QCloseEvent* event)
 {
-    gSettings.Save();
+    gSettings.Save(true);
 
     AzFramework::SystemCursorState currentCursorState;
     bool isInGameMode = false;

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -473,7 +473,7 @@ void SEditorSettings::LoadValue(const char* sSection, const char* sKey, ESystemC
 }
 
 //////////////////////////////////////////////////////////////////////////
-void SEditorSettings::Save()
+void SEditorSettings::Save(bool isEditorClosing)
 {
     QString strStringPlaceholder;
 
@@ -640,14 +640,16 @@ void SEditorSettings::Save()
     // --- Settings Registry values
 
     // Prefab System UI
-    AzFramework::ApplicationRequests::Bus::Broadcast(
-        &AzFramework::ApplicationRequests::SetPrefabSystemEnabled, prefabSystem);
+    AzFramework::ApplicationRequests::Bus::Broadcast(&AzFramework::ApplicationRequests::SetPrefabSystemEnabled, prefabSystem);
 
     AzToolsFramework::Prefab::PrefabLoaderInterface* prefabLoaderInterface =
         AZ::Interface<AzToolsFramework::Prefab::PrefabLoaderInterface>::Get();
     prefabLoaderInterface->SetSaveAllPrefabsPreference(levelSaveSettings.saveAllPrefabsPreference);
 
-    SaveSettingsRegistryFile();
+    if (!isEditorClosing)
+    {
+        SaveSettingsRegistryFile();
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Settings.h
+++ b/Code/Editor/Settings.h
@@ -267,7 +267,7 @@ struct SANDBOX_API SEditorSettings
 AZ_POP_DISABLE_DLL_EXPORT_BASECLASS_WARNING
     SEditorSettings();
     ~SEditorSettings() = default;
-    void    Save();
+    void    Save(bool isEditorClosing = false);
     void    Load();
     void    LoadCloudSettings();
 


### PR DESCRIPTION
Preventing the prefab setting from being saved on Editor close.
This could be refactored to be more elegant, but given the current deadlines I strived to limit the blast radius.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>