### PR TITLE
Ensure ViewPtr in ViewportInteractionImpl is updated correctly when switching cameras

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInteractionImpl.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ViewportInteractionImpl.h
@@ -10,6 +10,7 @@
 
 #include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/View.h>
+#include <Atom/RPI.Public/ViewportContextBus.h>
 #include <AzFramework/Viewport/CameraState.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
@@ -17,7 +18,9 @@ namespace AtomToolsFramework
 {
     //! A concrete implementation of the ViewportInteractionRequestBus.
     //! Primarily concerned with picking (screen to world and world to screen transformations).
-    class ViewportInteractionImpl : public AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler
+    class ViewportInteractionImpl
+        : public AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler
+        , private AZ::RPI::ViewportContextIdNotificationBus::Handler
     {
     public:
         explicit ViewportInteractionImpl(AZ::RPI::ViewPtr viewPtr);
@@ -37,6 +40,9 @@ namespace AtomToolsFramework
         AZStd::function<float()> m_deviceScalingFactorFn; //! Callback to determine the device scaling factor.
 
     private:
+        // ViewportContextIdNotificationBus overrides ...
+        void OnViewportDefaultViewChanged(AZ::RPI::ViewPtr view) override;
+
         AZ::RPI::ViewPtr m_viewPtr;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInteractionImpl.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ViewportInteractionImpl.cpp
@@ -19,10 +19,12 @@ namespace AtomToolsFramework
     void ViewportInteractionImpl::Connect(const AzFramework::ViewportId viewportId)
     {
         AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler::BusConnect(viewportId);
+        AZ::RPI::ViewportContextIdNotificationBus::Handler::BusConnect(viewportId);
     }
 
     void ViewportInteractionImpl::Disconnect()
     {
+        AZ::RPI::ViewportContextIdNotificationBus::Handler::BusDisconnect();
         AzToolsFramework::ViewportInteraction::ViewportInteractionRequestBus::Handler::BusDisconnect();
     }
 
@@ -57,5 +59,10 @@ namespace AtomToolsFramework
     float ViewportInteractionImpl::DeviceScalingFactor()
     {
         return m_deviceScalingFactorFn();
+    }
+
+    void ViewportInteractionImpl::OnViewportDefaultViewChanged(AZ::RPI::ViewPtr view)
+    {
+        m_viewPtr = AZStd::move(view);
     }
 } // namespace AtomToolsFramework


### PR DESCRIPTION
This was an oversight on my part, noticed the position returned was always that of the Editor camera

I'll add a test tomorrow but want to share this quickly for visibility