### PR TITLE
Adding unit tests for IndexedDataVector

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexedDataVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexedDataVector.h
@@ -57,7 +57,8 @@ namespace AZ::Render
         //! Returns the offset into the internal data vector for a given index.
         IndexType GetRawIndex(IndexType index) const;
 
-        //! Returns the public index for data given its pointer.
+        //! Returns the logical index for data given its pointer, which could passed to
+        //! GetData() to retrieve the data again.
         IndexType GetIndexForData(const DataType* data) const;
 
     private:
@@ -66,7 +67,7 @@ namespace AZ::Render
         // Indices to data and an embedded free list in the unused entries
         AZStd::vector<IndexType> m_indices;
 
-        // Map of index in m_data to the index for that data in m_indices.
+        // Map of the physical index in m_data to the logical index for that data in m_indices.
         AZStd::vector<IndexType> m_dataToIndices;
 
         // The actual data.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexedDataVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexedDataVector.h
@@ -27,31 +27,49 @@ namespace AZ::Render
         static constexpr IndexType NoFreeSlot = std::numeric_limits<IndexType>::max();
         IndexType m_firstFreeSlot = NoFreeSlot;
 
+        //! Clears all data and resets to initial state.
         void Clear();
+
+        //! Creates a new entry, default-constructs it, and returns an index that references it.
         IndexType GetFreeSlotIndex();
+
+        //! Destroys the data referenced by index and frees that index for future use.
         void RemoveIndex(IndexType index);
+
+        //! Destroys the data and related index by using a pointer to the data itself.
         void RemoveData(DataType* data);
 
+        //! Returns a reference to the data using the provided index.
         DataType& GetData(IndexType index);
         const DataType& GetData(IndexType index) const;
+
+        //! Returns a count of how many items are stored in the IndexedDataVector
         size_t GetDataCount() const;
 
+        //! Returns a reference to the internal data vector.
+        //! This vector should not be altered by calling code or the IndexedDataVector will be corrupted
         AZStd::vector<DataType>& GetDataVector();
         const AZStd::vector<DataType>& GetDataVector() const;
+        
+        //! Returns a reference to the internal vector.
+        const AZStd::vector<IndexType>& GetDataToIndexVector() const;
 
-        AZStd::vector<IndexType>& GetIndexVector();
-        const AZStd::vector<IndexType>& GetIndexVector() const;
-
+        //! Returns the offset into the internal data vector for a given index.
         IndexType GetRawIndex(IndexType index) const;
+
+        //! Returns the public index for data given its pointer.
         IndexType GetIndexForData(const DataType* data) const;
 
     private:
         constexpr static size_t InitialReservedSize = 128;
 
-        // Stores data indices and an embedded free list
+        // Indices to data and an embedded free list in the unused entries
         AZStd::vector<IndexType> m_indices;
-        // Stores the indirection index
+
+        // Map of index in m_data to the index for that data in m_indices.
         AZStd::vector<IndexType> m_dataToIndices;
+
+        // The actual data.
         AZStd::vector<DataType> m_data;
     };
 } // namespace AZ::Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexedDataVector.inl
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/IndexedDataVector.inl
@@ -125,13 +125,7 @@ namespace AZ::Render
     }
 
     template<typename DataType, typename IndexType>
-    inline AZStd::vector<IndexType>& IndexedDataVector<DataType, IndexType>::GetIndexVector()
-    {
-        return m_dataToIndices;
-    }
-
-    template<typename DataType, typename IndexType>
-    inline const AZStd::vector<IndexType>& IndexedDataVector<DataType, IndexType>::GetIndexVector() const
+    inline const AZStd::vector<IndexType>& IndexedDataVector<DataType, IndexType>::GetDataToIndexVector() const
     {
         return m_dataToIndices;
     }

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiIndexedDataVector.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Utils/MultiIndexedDataVector.h
@@ -17,7 +17,7 @@ namespace AZ
     {
         //! MultiIndexedDataVector is similar to IndexedDataVector but adds support for multiple different data vectors each containing different types
         //! i.e. structure of (N) arrays
-        //! See IndexedDataVectorTests.cpp for examples of use
+        //! See MultiIndexedDataVectorTests.cpp for examples of use
         template<typename ... Ts>
         class MultiIndexedDataVector
         {

--- a/Gems/Atom/Feature/Common/Code/Tests/IndexedDataVectorTests.cpp
+++ b/Gems/Atom/Feature/Common/Code/Tests/IndexedDataVectorTests.cpp
@@ -54,7 +54,7 @@ namespace UnitTest
         }
 
         template<typename T>
-        void ShuffleIndexedDataVector(IndexedDataVector<T> dataVector, AZStd::vector<uint16_t> indices)
+        void ShuffleIndexedDataVector(IndexedDataVector<T>& dataVector, AZStd::vector<uint16_t>& indices)
         {
             AZStd::vector<T> values;
 

--- a/Gems/Atom/Feature/Common/Code/Tests/IndexedDataVectorTests.cpp
+++ b/Gems/Atom/Feature/Common/Code/Tests/IndexedDataVectorTests.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/Component/ComponentApplication.h>
+#include <Atom/Feature/Utils/IndexedDataVector.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+    using namespace AZ;
+    using namespace AZ::Render;
+    
+    class IndexedDataVectorTests
+        : public UnitTest::AllocatorsTestFixture
+    {
+    public:
+        void SetUp() override
+        {
+            UnitTest::AllocatorsTestFixture::SetUp();
+        }
+
+        void TearDown() override
+        {
+            UnitTest::AllocatorsTestFixture::TearDown();
+        }
+
+        template<typename T>
+        IndexedDataVector<T> SetupIndexedDataVector(size_t size, T initialValue = T(0), T incrementAmount = T(1), AZStd::vector<uint16_t>* indices = nullptr)
+        {
+            IndexedDataVector<T> data;
+            T value = initialValue;
+            for (size_t i = 0; i < size; ++i)
+            {
+                uint16_t index = data.GetFreeSlotIndex();
+                EXPECT_NE(index, IndexedDataVector<int>::NoFreeSlot);
+                if (indices)
+                {
+                    indices->push_back(index);
+                }
+                if (index != IndexedDataVector<int>::NoFreeSlot)
+                {
+                    data.GetData(index) = value;
+                    value += incrementAmount;
+                }
+            }
+            return data;
+        }
+
+        template<typename T>
+        void ShuffleIndexedDataVector(IndexedDataVector<T> dataVector, AZStd::vector<uint16_t> indices)
+        {
+            AZStd::vector<T> values;
+
+            // remove every other element and store it
+            for (size_t i = 0; i < indices.size(); ++i)
+            {
+                values.push_back(dataVector.GetData(indices.at(i)));
+                dataVector.RemoveIndex(indices.at(i));
+                indices.erase(&indices.at(i));
+            }
+
+            for (T value : values)
+            {
+                uint16_t index = dataVector.GetFreeSlotIndex();
+                indices.push_back(index);
+                dataVector.GetData(index) = value;
+            }
+        }
+
+    };
+    
+    TEST_F(IndexedDataVectorTests, Construction)
+    {
+        IndexedDataVector<int> testVector;
+        uint16_t index = testVector.GetFreeSlotIndex();
+        EXPECT_NE(index, IndexedDataVector<int>::NoFreeSlot);
+    }
+    
+    TEST_F(IndexedDataVectorTests, TestInsertGetBasic)
+    {
+        constexpr size_t count = 16;
+        constexpr int initialValue = 0;
+        constexpr int increment = 1;
+
+        AZStd::vector<uint16_t> indices;
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count, initialValue, increment, &indices);
+        
+        int value = initialValue;
+        for (size_t i = 0; i < count; ++i)
+        {
+            EXPECT_EQ(testVector.GetData(indices.at(i)), value);
+            value += increment;
+        }
+    }
+    
+    TEST_F(IndexedDataVectorTests, TestInsertGetComplex)
+    {
+        constexpr size_t count = 16;
+        constexpr int initialValue = 0;
+        constexpr int increment = 1;
+
+        AZStd::vector<uint16_t> indices;
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count, initialValue, increment, &indices);
+
+        // Create a set of the data that should be in the IndexedDataVector
+        AZStd::set<int> values;
+        for (int i = 0; i < count; ++i)
+        {
+            values.emplace(initialValue + i * increment);
+        }
+
+        // Add and remove items to shuffle the underlying data
+        ShuffleIndexedDataVector(testVector, indices);
+
+        // Check to make sure all the data is still there
+        AZStd::vector<int>& underlyingVector = testVector.GetDataVector();
+        for (size_t i = 0; i < underlyingVector.size(); ++i)
+        {
+            EXPECT_TRUE(values.contains(underlyingVector.at(i)));
+        }
+    }
+
+    TEST_F(IndexedDataVectorTests, TestSize)
+    {
+        constexpr size_t count = 32;
+
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count);
+        EXPECT_EQ(testVector.GetDataCount(), count);
+    }
+
+    TEST_F(IndexedDataVectorTests, TestClear)
+    {
+        constexpr size_t count = 32;
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count);
+        testVector.Clear();
+        EXPECT_EQ(testVector.GetDataCount(), 0);
+    }
+
+    TEST_F(IndexedDataVectorTests, TestRemove)
+    {
+        constexpr size_t count = 8;
+        constexpr int initialValue = 0;
+        constexpr int increment = 8;
+
+        AZStd::vector<uint16_t> indices;
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count, initialValue, increment, &indices);
+
+        // Remove every other element by index
+        for (uint16_t i = 0; i < count; i += 2)
+        {
+            testVector.RemoveIndex(i);
+        }
+        
+        EXPECT_EQ(testVector.GetDataCount(), count / 2);
+
+        // Make sure the rest of the data is still there
+        AZStd::vector<uint16_t> remainingIndices;
+        for (size_t i = 1; i < count; i += 2)
+        {
+            int value = testVector.GetData(indices.at(i));
+            EXPECT_EQ(value, initialValue + increment * i);
+            remainingIndices.push_back(indices.at(i));
+        }
+
+        // remove the rest of the valus by value
+        for (uint16_t index : remainingIndices)
+        {
+            int* valuePtr = &testVector.GetData(index);
+            testVector.RemoveData(valuePtr);
+        }
+
+        EXPECT_EQ(testVector.GetDataCount(), 0);
+    }
+
+    TEST_F(IndexedDataVectorTests, TestIndexForData)
+    {
+        constexpr size_t count = 8;
+        constexpr int initialValue = 0;
+        constexpr int increment = 8;
+
+        AZStd::vector<uint16_t> indices;
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count, initialValue, increment, &indices);
+        
+        // Add and remove items to shuffle the underlying data
+        ShuffleIndexedDataVector(testVector, indices);
+        
+        AZStd::vector<int>& underlyingVector = testVector.GetDataVector();
+        for (size_t i = 0; i < underlyingVector.size(); ++i)
+        {
+            int value = underlyingVector.at(i);
+            uint16_t index = testVector.GetIndexForData(&underlyingVector.at(i));
+
+            // The data from GetData(index) should match for the index retrieved using GetIndexForData() for the same data.
+            EXPECT_EQ(testVector.GetData(index), value);
+        }
+    }
+    
+    TEST_F(IndexedDataVectorTests, TestRawIndex)
+    {
+        constexpr size_t count = 8;
+        constexpr int initialValue = 0;
+        constexpr int increment = 8;
+
+        AZStd::vector<uint16_t> indices;
+        IndexedDataVector<int> testVector = SetupIndexedDataVector<int>(count, initialValue, increment, &indices);
+
+        // Add and remove items to shuffle the underlying data
+        ShuffleIndexedDataVector(testVector, indices);
+        
+        AZStd::vector<int>& underlyingVector = testVector.GetDataVector();
+        for (size_t i = 0; i < indices.size(); ++i)
+        {
+            // Check that the data retrieved from GetData for a given index matches the data in the underlying vector for the raw index.
+            EXPECT_EQ(testVector.GetData(indices.at(i)), underlyingVector.at(testVector.GetRawIndex(indices.at(i))));
+        }
+
+    }
+}

--- a/Gems/Atom/Feature/Common/Code/Tests/MultiIndexedDataVectorTests.cpp
+++ b/Gems/Atom/Feature/Common/Code/Tests/MultiIndexedDataVectorTests.cpp
@@ -18,7 +18,7 @@ namespace UnitTest
     using namespace AZ;
     using namespace AZ::Render;
 
-    class IndexedDataVectorTests
+    class MultiIndexedDataVectorTests
         : public ::testing::Test
     {
     public:
@@ -58,7 +58,7 @@ namespace UnitTest
         void* m_memBlock = nullptr;
     };
 
-    TEST_F(IndexedDataVectorTests, TestInsert)
+    TEST_F(MultiIndexedDataVectorTests, TestInsert)
     {
         enum Types
         {
@@ -87,7 +87,7 @@ namespace UnitTest
         }
     }
 
-    TEST_F(IndexedDataVectorTests, TestSize)
+    TEST_F(MultiIndexedDataVectorTests, TestSize)
     {
         enum Types
         {
@@ -110,7 +110,7 @@ namespace UnitTest
         EXPECT_EQ(0, myVec.GetDataVector<IntType>().size());
     }
 
-    TEST_F(IndexedDataVectorTests, TestErase)
+    TEST_F(MultiIndexedDataVectorTests, TestErase)
     {
         enum Types
         {
@@ -153,7 +153,7 @@ namespace UnitTest
         }
     }
 
-    TEST_F(IndexedDataVectorTests, TestManyTypes)
+    TEST_F(MultiIndexedDataVectorTests, TestManyTypes)
     {
         enum Types
         {
@@ -235,14 +235,14 @@ namespace UnitTest
         }
     }
 
-    TEST_F(IndexedDataVectorTests, GetIndexForDataSimple)
+    TEST_F(MultiIndexedDataVectorTests, GetIndexForDataSimple)
     {
         AZStd::vector<uint16_t> indices;
         MultiIndexedDataVector<int32_t, float> myVec = CreateTestVector(indices);
         CheckIndexedData(myVec, indices);
     }
 
-    TEST_F(IndexedDataVectorTests, GetIndexForDataComplex)
+    TEST_F(MultiIndexedDataVectorTests, GetIndexForDataComplex)
     {
         enum Types
         {
@@ -277,7 +277,7 @@ namespace UnitTest
         CheckIndexedData(myVec, indices);
     }
 
-    TEST_F(IndexedDataVectorTests, ForEach)
+    TEST_F(MultiIndexedDataVectorTests, ForEach)
     {
         enum Types
         {

--- a/Gems/Atom/Feature/Common/Code/Tests/MultiIndexedDataVectorTests.cpp
+++ b/Gems/Atom/Feature/Common/Code/Tests/MultiIndexedDataVectorTests.cpp
@@ -19,43 +19,18 @@ namespace UnitTest
     using namespace AZ::Render;
 
     class MultiIndexedDataVectorTests
-        : public ::testing::Test
+        : public UnitTest::AllocatorsTestFixture
     {
     public:
         void SetUp() override
         {
-            CreateAllocator();
+            UnitTest::AllocatorsTestFixture::SetUp();
         }
 
         void TearDown() override
         {
-            DestroyAllocator();
+            UnitTest::AllocatorsTestFixture::TearDown();
         }
-        
-    private:
-
-        void CreateAllocator()
-        {
-            static constexpr size_t NumMBToAllocate = 1;
-            SystemAllocator::Descriptor desc;
-            desc.m_heap.m_numFixedMemoryBlocks = 1;
-            desc.m_heap.m_fixedMemoryBlocksByteSize[0] = NumMBToAllocate * 1024 * 1024;
-            m_memBlock = AZ_OS_MALLOC(
-                desc.m_heap.m_fixedMemoryBlocksByteSize[0],
-                desc.m_heap.m_memoryBlockAlignment);
-            desc.m_heap.m_fixedMemoryBlocks[0] = m_memBlock;
-
-            AllocatorInstance<AZ::SystemAllocator>::Create(desc);
-        }
-
-        void DestroyAllocator()
-        {
-            AllocatorInstance<AZ::SystemAllocator>::Destroy();
-            AZ_OS_FREE(m_memBlock);
-            m_memBlock = nullptr;
-        }
-
-        void* m_memBlock = nullptr;
     };
 
     TEST_F(MultiIndexedDataVectorTests, TestInsert)

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_tests_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_tests_files.cmake
@@ -10,6 +10,7 @@ set(FILES
     Mocks/MockMeshFeatureProcessor.h
     Tests/CommonTest.cpp
     Tests/CoreLights/ShadowmapAtlasTest.cpp
+    Tests/IndexedDataVectorTests.cpp
     Tests/MultiIndexedDataVectorTests.cpp
     Tests/IndexableListTests.cpp
     Tests/SparseVectorTests.cpp

--- a/Gems/Atom/Feature/Common/Code/atom_feature_common_tests_files.cmake
+++ b/Gems/Atom/Feature/Common/Code/atom_feature_common_tests_files.cmake
@@ -10,7 +10,7 @@ set(FILES
     Mocks/MockMeshFeatureProcessor.h
     Tests/CommonTest.cpp
     Tests/CoreLights/ShadowmapAtlasTest.cpp
-    Tests/IndexedDataVectorTests.cpp
+    Tests/MultiIndexedDataVectorTests.cpp
     Tests/IndexableListTests.cpp
     Tests/SparseVectorTests.cpp
     Tests/SkinnedMesh/SkinnedMeshDispatchItemTests.cpp


### PR DESCRIPTION
Also moving the tests for MultiIndexedDataVector currently in IndexedDataVectorTests to MultiIndexedDataVectorTests.

**Reviewer Note - File Rename**: The code in IndexedDataVectorTests is all new, don't bother looking at the comparison. The code that used to be in IndexedDataVectorTests has been moved to MultiIndexedDataVectorTests and only has minimal updates. This was done as two separate commits, so its easier to look at those individual diffs instead of the diff for the whole PR. (See d4a59a388491be7dbfd6c558704894a5377c6c81 and 4ae837410127b5428d3de8cf1ca31ceeaeee2629)