### PR TITLE
discover build folder, don't assume or require

### DIFF
--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Editor/Scripts/bootstrap.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/Editor/Scripts/bootstrap.py
@@ -25,16 +25,6 @@ import logging as _logging
 
 
 # -------------------------------------------------------------------------
-_O3DE_RUNNING=None    
-try:
-    import azlmbr
-    _O3DE_RUNNING=True
-except:
-    _O3DE_RUNNING=False
-# ------------------------------------------------------------------------- 
-
-
-# -------------------------------------------------------------------------
 # we don't use dynaconf setting here as we might not yet have access
 # to that site-dir.
 
@@ -89,15 +79,12 @@ def get_dccsi_config(DCCSI_PATH=_DCCSI_PATH):
     return _dccsi_config
 # -------------------------------------------------------------------------
 
-# set and retreive the base env context/_settings on import
+
+# -------------------------------------------------------------------------
+# set and retreive the *basic* env context/_settings on import
 _config = get_dccsi_config()
 _settings = _config.get_config_settings()
-
-if _DCCSI_DEV_MODE:
-    _config.attach_debugger()  # attempts to start debugger
-# done with basic setup
-# --- END -----------------------------------------------------------------
-
+# -------------------------------------------------------------------------
 
 ###########################################################################
 # Main Code Block, runs this script as main (testing)
@@ -130,73 +117,81 @@ if __name__ == '__main__':
     _LOGGER = azpy.initialize_logger(_MODULENAME,
                                      log_to_file=_DCCSI_GDEBUG,
                                      default_log_level=_DCCSI_LOGLEVEL)
-    # happy print
-    _LOGGER.info(STR_CROSSBAR)
-    _LOGGER.info('~ constants.py ... Running script as __main__')
-    _LOGGER.info(STR_CROSSBAR)
-    
-    # parse the command line args
-    import argparse
-    parser = argparse.ArgumentParser(
-        description='O3DE DCCsi Boostrap (Test)',
-        epilog="Will externally test the DCCsi boostrap")
-    
-    _config = get_dccsi_config()
-    _settings = _config.get_config_settings(enable_o3de_python=True,
-                                           enable_o3de_pyside2=True)
-    parser.add_argument('-gd', '--global-debug',
-                        type=bool,
-                        required=False,
-                        help='Enables global debug flag.')
-    parser.add_argument('-dm', '--developer-mode',
-                        type=bool,
-                        required=False,
-                        help='Enables dev mode for early auto attaching debugger.')
-    parser.add_argument('-tp', '--test-pyside2',
-                        type=bool,
-                        required=False,
-                        help='Runs Qt/PySide2 tests and reports.')
-    args = parser.parse_args()
-    
-    # easy overrides
-    if args.global_debug:
-        _DCCSI_GDEBUG = True
-    if args.developer_mode:
-        _DCCSI_DEV_MODE = True
-        _config.attach_debugger()  # attempts to start debugger
-    
-    if _DCCSI_GDEBUG:
-        _LOGGER.info(f'DCCSI_PATH: {_settings.DCCSI_PATH}')
-        _LOGGER.info(f'DCCSI_G_DEBUG: {_settings.DCCSI_GDEBUG}')
-        _LOGGER.info(f'DCCSI_DEV_MODE: {_settings.DCCSI_DEV_MODE}')
-    
-        _LOGGER.info(f'DCCSI_OS_FOLDER: {_settings.DCCSI_OS_FOLDER}')
-        _LOGGER.info(f'O3DE_PROJECT: {_settings.O3DE_PROJECT}')
-        _LOGGER.info(f'O3DE_PROJECT_PATH: {_settings.O3DE_PROJECT_PATH}')
-        _LOGGER.info(f'O3DE_DEV: {_settings.O3DE_DEV}')
-        _LOGGER.info(f'O3DE_BUILD_PATH: {_settings.O3DE_BUILD_PATH}')
-        _LOGGER.info(f'O3DE_BIN_PATH: {_settings.O3DE_BIN_PATH}')
-        
-        _LOGGER.info(f'DCCSI_PATH: {_settings.DCCSI_PATH}')
-        _LOGGER.info(f'DCCSI_PYTHON_LIB_PATH: {_settings.DCCSI_PYTHON_LIB_PATH}')
-        _LOGGER.info(f'DCCSI_PY_BASE: {_settings.DCCSI_PY_BASE}')
 
-    if _DCCSI_GDEBUG or args.test_pyside2:
-        try:
-            import PySide2
-        except:
-            # set up Qt/PySide2 access and test
-            _settings = _config.get_config_settings(enable_o3de_pyside2=True)
-            import PySide2
-
-        _LOGGER.info(f'PySide2: {PySide2}')
-        _LOGGER.info(f'O3DE_BIN_PATH: {_settings.O3DE_BIN_PATH}')
-        _LOGGER.info(f'QT_PLUGIN_PATH: {_settings.QT_PLUGIN_PATH}')
-        _LOGGER.info(f'QT_QPA_PLATFORM_PLUGIN_PATH: {_settings.QT_QPA_PLATFORM_PLUGIN_PATH}')
+    if not _O3DE_RUNNING: # external tool or commandline
+        # happy print
+        _LOGGER.info(STR_CROSSBAR)
+        _LOGGER.info('~ constants.py ... Running script as __main__')
+        _LOGGER.info(STR_CROSSBAR)
         
-        _config.test_pyside2()
-       
-    if not _O3DE_RUNNING: 
-        # return
+        # parse the command line args
+        import argparse
+        parser = argparse.ArgumentParser(
+            description='O3DE DCCsi Boostrap (Test)',
+            epilog="Will externally test the DCCsi boostrap")
+
+        parser.add_argument('-gd', '--global-debug',
+                            type=bool,
+                            required=False,
+                            help='Enables global debug flag.')
+        parser.add_argument('-dm', '--developer-mode',
+                            type=bool,
+                            required=False,
+                            help='Enables dev mode for early auto attaching debugger.')
+        parser.add_argument('-tp', '--test-pyside2',
+                            type=bool,
+                            required=False,
+                            help='Runs Qt/PySide2 tests and reports.')
+        args = parser.parse_args()
+
+        # set and retreive the base env context/_settings on import
+        _config = get_dccsi_config()
+        _settings = _config.get_config_settings(enable_o3de_python=True,
+                                               enable_o3de_pyside2=True)
+
+        if _DCCSI_DEV_MODE:
+            _config.attach_debugger()  # attempts to start debugger
+        # done with basic setup
+        
+        # easy overrides
+        if args.global_debug:
+            _DCCSI_GDEBUG = True
+
+        if args.developer_mode:
+            _DCCSI_DEV_MODE = True
+            _config.attach_debugger()  # attempts to start debugger
+        
+        if _DCCSI_GDEBUG:
+            _LOGGER.info(f'DCCSI_PATH: {_settings.DCCSI_PATH}')
+            _LOGGER.info(f'DCCSI_G_DEBUG: {_settings.DCCSI_GDEBUG}')
+            _LOGGER.info(f'DCCSI_DEV_MODE: {_settings.DCCSI_DEV_MODE}')
+        
+            _LOGGER.info(f'DCCSI_OS_FOLDER: {_settings.DCCSI_OS_FOLDER}')
+            _LOGGER.info(f'O3DE_PROJECT: {_settings.O3DE_PROJECT}')
+            _LOGGER.info(f'O3DE_PROJECT_PATH: {_settings.O3DE_PROJECT_PATH}')
+            _LOGGER.info(f'O3DE_DEV: {_settings.O3DE_DEV}')
+            _LOGGER.info(f'O3DE_BUILD_PATH: {_settings.O3DE_BUILD_PATH}')
+            _LOGGER.info(f'O3DE_BIN_PATH: {_settings.O3DE_BIN_PATH}')
+            
+            _LOGGER.info(f'DCCSI_PATH: {_settings.DCCSI_PATH}')
+            _LOGGER.info(f'DCCSI_PYTHON_LIB_PATH: {_settings.DCCSI_PYTHON_LIB_PATH}')
+            _LOGGER.info(f'DCCSI_PY_BASE: {_settings.DCCSI_PY_BASE}')
+
+        if _DCCSI_GDEBUG or args.test_pyside2:
+            try:
+                import PySide2
+            except:
+                # set up Qt/PySide2 access and test
+                _settings = _config.get_config_settings(enable_o3de_pyside2=True)
+                import PySide2
+
+            _LOGGER.info(f'PySide2: {PySide2}')
+            _LOGGER.info(f'O3DE_BIN_PATH: {_settings.O3DE_BIN_PATH}')
+            _LOGGER.info(f'QT_PLUGIN_PATH: {_settings.QT_PLUGIN_PATH}')
+            _LOGGER.info(f'QT_QPA_PLATFORM_PLUGIN_PATH: {_settings.QT_QPA_PLATFORM_PLUGIN_PATH}')
+            
+            _config.test_pyside2()
+
+        # end
         sys.exit()        
 # --- END -----------------------------------------------------------------

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/config_utils.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/config_utils.py
@@ -179,6 +179,18 @@ def get_o3de_engine_root(check_stub='engine.json'):
 
 
 # -------------------------------------------------------------------------
+def get_o3de_build_path(root_directory=get_o3de_engine_root(),
+                        marker='CMakeCache.txt'):
+    """Returns a PAth for the O3DE\build root"""
+    for root, dirs, files in os.walk(root_directory):
+        if marker in files:
+            return Path(root)
+    else:
+        return None
+# -------------------------------------------------------------------------
+
+
+# -------------------------------------------------------------------------
 # settings.setenv()  # doing this will add the additional DYNACONF_ envars
 def get_dccsi_config(dccsi_dirpath=return_stub_dir()):
     """Convenience method to set and retreive settings directly from module."""
@@ -314,6 +326,11 @@ if __name__ == '__main__':
     _LOGGER.info("# {0} #".format('-' * 72))
     _LOGGER.info('~ config_utils.py ... Running script as __main__')
     _LOGGER.info("# {0} #".format('-' * 72))
+    
+    
+    _DCCSI_GDEBUG = True
+    _DCCSI_LOGLEVEL = int(10)
+    _LOGGER.setLevel(_DCCSI_LOGLEVEL)
 
     _LOGGER.info('Current Work dir: {0}'.format(os.getcwd()))
 
@@ -321,15 +338,18 @@ if __name__ == '__main__':
 
     _LOGGER.info('DCCSIG_PATH: {}'.format(return_stub_dir('dccsi_stub')))
 
-    _config = get_dccsi_config()
-    _LOGGER.info('DCCSI_CONFIG_PATH: {}'.format(_config))
-
-    _LOGGER.info('O3DE_DEV: {}'.format(get_o3de_engine_root(check_stub='engine.json')))
+    _LOGGER.info('O3DE_DEV: {}'.format(get_o3de_engine_root(check_stub='engine.json').resolve()))
+    
+    _LOGGER.info('O3DE_BUILD_PATH: {}'.format(get_o3de_build_path(get_o3de_engine_root(check_stub='engine.json').resolve(),
+                                                                  'CMakeCache.txt')))    
 
     # new o3de version
     _LOGGER.info('O3DE_PROJECT: {}'.format(get_check_global_project()))
 
     _LOGGER.info('DCCSI_PYTHON_LIB_PATH: {}'.format(bootstrap_dccsi_py_libs(return_stub_dir('dccsi_stub'))))
+
+    _config = get_dccsi_config()
+    _LOGGER.info('DCCSI_CONFIG_PATH: {}'.format(_config))
 
     # custom prompt
     sys.ps1 = "[azpy]>>"

--- a/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/constants.py
+++ b/Gems/AtomLyIntegration/TechnicalArt/DccScriptingInterface/azpy/constants.py
@@ -46,6 +46,7 @@ site.addsitedir(_DCCSIG_PATH)
 import azpy
 from azpy.env_bool import env_bool
 from azpy.config_utils import return_stub_dir
+from azpy.config_utils import get_stub_check_path
 # -------------------------------------------------------------------------
 
 
@@ -107,6 +108,7 @@ TAG_DCCSI_CONFIG = str('dccsiconfiguration.setreg')
 
 # filesystem markers, stub file names.
 STUB_O3DE_DEV = str('engine.json')
+STUB_O3DE_BUILD = str('CMakeCache.txt')
 STUB_O3DE_ROOT_DCCSI = str('dccsi_stub')
 STUB_O3DE_DCCSI_AZPY = str('dccsi_azpy_stub')
 STUB_O3DE_DCCSI_TOOLS = str('dccsi_tools_stub')
@@ -223,7 +225,9 @@ STR_QTPLUGIN_DIR = str('{0}\\bin\\profile\\EditorPlugins')
 STR_QTFORPYTHON_PATH = str('{0}\\Gems\\QtForPython\\3rdParty\\pyside2\\windows\\release')
 STR_O3DE_BIN_PATH = str('{0}\\bin\\profile')
 
-PATH_O3DE_BUILD_PATH = str('{0}\\{1}'.format(PATH_O3DE_DEV, TAG_DIR_O3DE_BUILD_FOLDER))
+STR_O3DE_BUILD_PATH = str('{0}\\{1}')
+PATH_O3DE_BUILD_PATH = STR_O3DE_BUILD_PATH.format(PATH_O3DE_DEV, TAG_DIR_O3DE_BUILD_FOLDER)
+
 PATH_QTFORPYTHON_PATH = str(STR_QTFORPYTHON_PATH.format(PATH_O3DE_DEV))
 PATH_QT_PLUGIN_PATH = str(STR_QTPLUGIN_DIR).format(PATH_O3DE_BUILD_PATH)
 PATH_O3DE_BIN_PATH = str(STR_O3DE_BIN_PATH).format(PATH_O3DE_BUILD_PATH)


### PR DESCRIPTION
Signed-off-by: Jonny Gallowy <gallowj@amazon.com>
- find the build folder via 'CMakeCache.txt' (search from root, hopefully pretty quick)
- ^ hopefully there isn't more then one, that will only find the first.
- minimize bootstrapping of DCCsi
- ^ only init basic config.py and retrieve settings, a script/util/tool can do that on a 'as needed' basis

