### PR TITLE
Fixed capsule auxgeom draw for lights and other aux geom issues

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomBase.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomBase.h
@@ -155,8 +155,10 @@ namespace AZ
         enum AuxGeomShapeType
         {
             ShapeType_Sphere,
+            ShapeType_Hemisphere,
             ShapeType_Cone,
             ShapeType_Cylinder,
+            ShapeType_CylinderNoEnds,       // Cylinder without disks on either end
             ShapeType_Disk,
             ShapeType_Quad,
 

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.cpp
@@ -314,15 +314,35 @@ namespace AZ
             AddShape(style, shape);
         }
 
-        void AuxGeomDrawQueue::DrawSphere(
-            const AZ::Vector3& center, 
+        Matrix3x3 CreateMatrix3x3FromDirection(const AZ::Vector3& direction)
+        {
+            Vector3 unitDirection(direction.GetNormalized());
+            Vector3 unitOrthogonal(direction.GetOrthogonalVector().GetNormalized());
+            Vector3 unitCross(unitOrthogonal.Cross(unitDirection));
+            return Matrix3x3::CreateFromColumns(unitOrthogonal, unitDirection, unitCross);
+        }
+
+        void AuxGeomDrawQueue::DrawSphere(const AZ::Vector3& center, float radius, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex)
+        {
+            DrawSphereCommon(center, AZ::Vector3::CreateAxisY(), radius, color, style, depthTest, depthWrite, faceCull, viewProjOverrideIndex, false);
+        }
+
+        void AuxGeomDrawQueue::DrawHemisphere(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex)
+        {
+            DrawSphereCommon(center, direction, radius, color, style, depthTest, depthWrite, faceCull, viewProjOverrideIndex, true);
+        }
+
+        void AuxGeomDrawQueue::DrawSphereCommon(
+            const AZ::Vector3& center,
+            const AZ::Vector3& direction,
             float radius, 
             const AZ::Color& color, 
             DrawStyle style, 
             DepthTest depthTest, 
             DepthWrite depthWrite, 
             FaceCullMode faceCull, 
-            int32_t viewProjOverrideIndex) 
+            int32_t viewProjOverrideIndex,
+            bool isHemisphere) 
         {
             if (radius <= 0.0f)
             {
@@ -330,12 +350,12 @@ namespace AZ
             }
 
             ShapeBufferEntry shape;
-            shape.m_shapeType = ShapeType_Sphere;
+            shape.m_shapeType = isHemisphere ? ShapeType_Hemisphere : ShapeType_Sphere;
             shape.m_depthRead  = ConvertRPIDepthTestFlag(depthTest);
             shape.m_depthWrite = ConvertRPIDepthWriteFlag(depthWrite);
             shape.m_faceCullMode = ConvertRPIFaceCullFlag(faceCull);
             shape.m_color = color;
-            shape.m_rotationMatrix = Matrix3x3::CreateIdentity();
+            shape.m_rotationMatrix = CreateMatrix3x3FromDirection(direction);
             shape.m_position = center;
             shape.m_scale = AZ::Vector3(radius, radius, radius);
             shape.m_pointSize = m_pointSize;
@@ -362,13 +382,9 @@ namespace AZ
             shape.m_faceCullMode = ConvertRPIFaceCullFlag(faceCull);
             shape.m_color = color;
 
-            Vector3 unitDirection(direction.GetNormalized());
-            Vector3 unitOrthogonal(direction.GetOrthogonalVector().GetNormalized());
-            Vector3 unitCross(unitOrthogonal.Cross(unitDirection));
-
             // The disk mesh is created with the top of the disk pointing along the positive Y axis. This creates a
             // rotation so that the top of the disk will point along the given direction vector.
-            shape.m_rotationMatrix = Matrix3x3::CreateFromColumns(unitOrthogonal, unitDirection, unitCross);
+            shape.m_rotationMatrix = CreateMatrix3x3FromDirection(direction);
             shape.m_position = center;
             shape.m_scale = AZ::Vector3(radius, 1.0f, radius);
             shape.m_pointSize = m_pointSize;
@@ -401,13 +417,7 @@ namespace AZ
             shape.m_faceCullMode = ConvertRPIFaceCullFlag(faceCull);
             shape.m_color = color;
 
-            Vector3 unitDirection(direction.GetNormalized());
-            Vector3 unitOrthogonal(direction.GetOrthogonalVector().GetNormalized());
-            Vector3 unitCross(unitOrthogonal.Cross(unitDirection));
-
-            // The cone mesh is created with the tip of the cone pointing along the positive Y axis. This creates a
-            // rotation so that the tip of the cone will point along the given direction vector.
-            shape.m_rotationMatrix = Matrix3x3::CreateFromColumns(unitOrthogonal, unitDirection, unitCross);
+            shape.m_rotationMatrix = CreateMatrix3x3FromDirection(direction);
             shape.m_position = center;
             shape.m_scale = AZ::Vector3(radius, height, radius);
             shape.m_pointSize = m_pointSize;
@@ -416,17 +426,30 @@ namespace AZ
             AddShape(style, shape);
         }
 
-        void AuxGeomDrawQueue::DrawCylinder(
-            const AZ::Vector3& center, 
-            const AZ::Vector3& direction, 
-            float radius, 
-            float height, 
-            const AZ::Color& color, 
-            DrawStyle style, 
-            DepthTest depthTest, 
-            DepthWrite depthWrite, 
-            FaceCullMode faceCull, 
-            int32_t viewProjOverrideIndex) 
+        void AuxGeomDrawQueue::DrawCylinder(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color,
+            DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex)
+        {
+            DrawCylinderCommon(center, direction, radius, height, color, style, depthTest, depthWrite, faceCull, viewProjOverrideIndex, true);
+        }
+
+        void AuxGeomDrawQueue::DrawCylinderNoEnds(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color,
+            DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex)
+        {
+            DrawCylinderCommon(center, direction, radius, height, color, style, depthTest, depthWrite, faceCull, viewProjOverrideIndex, false);
+        }
+
+        void AuxGeomDrawQueue::DrawCylinderCommon(
+            const AZ::Vector3& center,
+            const AZ::Vector3& direction,
+            float radius,
+            float height,
+            const AZ::Color& color,
+            DrawStyle style,
+            DepthTest depthTest,
+            DepthWrite depthWrite,
+            FaceCullMode faceCull,
+            int32_t viewProjOverrideIndex,
+            bool drawEnds)
         {
             if (radius <= 0.0f || height <= 0.0f)
             {
@@ -434,19 +457,15 @@ namespace AZ
             }
 
             ShapeBufferEntry shape;
-            shape.m_shapeType = ShapeType_Cylinder;
-            shape.m_depthRead  = ConvertRPIDepthTestFlag(depthTest);
+            shape.m_shapeType = drawEnds ? ShapeType_Cylinder : ShapeType_CylinderNoEnds;
+            shape.m_depthRead = ConvertRPIDepthTestFlag(depthTest);
             shape.m_depthWrite = ConvertRPIDepthWriteFlag(depthWrite);
             shape.m_faceCullMode = ConvertRPIFaceCullFlag(faceCull);
             shape.m_color = color;
 
-            Vector3 unitDirection(direction.GetNormalized());
-            Vector3 unitOrthogonal(direction.GetOrthogonalVector().GetNormalized());
-            Vector3 unitCross(unitOrthogonal.Cross(unitDirection));
-
             // The cylinder mesh is created with the top end cap of the cylinder facing along the positive Y axis. This creates a
             // rotation so that the top face of the cylinder will face along the given direction vector.
-            shape.m_rotationMatrix = Matrix3x3::CreateFromColumns(unitOrthogonal, unitDirection, unitCross);
+            shape.m_rotationMatrix = CreateMatrix3x3FromDirection(direction);
             shape.m_position = center;
             shape.m_scale = AZ::Vector3(radius, height, radius);
             shape.m_pointSize = m_pointSize;

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/AuxGeomDrawQueue.h
@@ -60,9 +60,11 @@ namespace AZ
             // Fixed shape draws
             void DrawQuad(float width, float height, const AZ::Matrix3x4& transform, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawSphere(const AZ::Vector3& center, float radius, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
+            void DrawHemisphere(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawDisk(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawCone(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawCylinder(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
+            void DrawCylinderNoEnds(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawAabb(const AZ::Aabb& aabb, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawAabb(const AZ::Aabb& aabb, const AZ::Matrix3x4& transform, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
             void DrawObb(const AZ::Obb& obb, const AZ::Vector3& position, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex) override;
@@ -72,6 +74,9 @@ namespace AZ
             AuxGeomBufferData* Commit();
 
         private: // functions
+
+            void DrawCylinderCommon(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex, bool drawEnds);
+            void DrawSphereCommon(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, const AZ::Color& color, DrawStyle style, DepthTest depthTest, DepthWrite depthWrite, FaceCullMode faceCull, int32_t viewProjOverrideIndex, bool isHemisphere);
 
             //! Clear the current buffers
             void ClearCurrentBufferData();

--- a/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Source/AuxGeom/FixedShapeProcessor.h
@@ -138,8 +138,8 @@ namespace AZ
                 Both,
             };
 
-            bool CreateSphereBuffersAndViews();
-            void CreateSphereMeshData(MeshData& meshData, uint32_t numRings, uint32_t numSections);
+            bool CreateSphereBuffersAndViews(AuxGeomShapeType sphereShapeType);
+            void CreateSphereMeshData(MeshData& meshData, uint32_t numRings, uint32_t numSections, AuxGeomShapeType sphereShapeType);
 
             bool CreateQuadBuffersAndViews();
             void CreateQuadMeshDataSide(MeshData& meshData, bool isUp, bool drawLines);
@@ -152,8 +152,8 @@ namespace AZ
             bool CreateConeBuffersAndViews();
             void CreateConeMeshData(MeshData& meshData, uint32_t numRings, uint32_t numSections);
 
-            bool CreateCylinderBuffersAndViews();
-            void CreateCylinderMeshData(MeshData& meshData, uint32_t numSections);
+            bool CreateCylinderBuffersAndViews(AuxGeomShapeType cylinderShapeType);
+            void CreateCylinderMeshData(MeshData& meshData, uint32_t numSections, AuxGeomShapeType cylinderShapeType);
 
             bool CreateBoxBuffersAndViews();
             void CreateBoxMeshData(MeshData& meshData);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomDraw.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/AuxGeom/AuxGeomDraw.h
@@ -147,6 +147,17 @@ namespace AZ
             //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
             virtual void DrawSphere( const AZ::Vector3& center, float radius, const AZ::Color& color, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
 
+            //! Draw a hemisphere.
+            //! @param center        The center of the sphere.
+            //! @param radius        The radius.
+            //! @param color         The color to draw the sphere.
+            //! @param style         The draw style (point, wireframe, solid, shaded etc).
+            //! @param depthTest     If depth testing should be enabled
+            //! @param depthWrite    If depth writing should be enabled
+            //! @param faceCull      Which (if any) facing triangles should be culled
+            //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
+            virtual void DrawHemisphere( const AZ::Vector3& center, const AZ::Vector3& direction, float radius, const AZ::Color& color, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
+
             //! Draw a disk.
             //! @param center        The center of the disk.
             //! @param direction     The direction vector. The disk will be orthogonal this vector.
@@ -172,7 +183,7 @@ namespace AZ
             //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
             virtual void DrawCone(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
 
-            //! Draw a cylinder.
+            //! Draw a cylinder (with flat disks on the end).
             //! @param center        The center of the base circle.
             //! @param direction     The direction vector. The top end cap of the cylinder will face along this vector.
             //! @param radius        The radius.
@@ -184,6 +195,19 @@ namespace AZ
             //! @param faceCull      Which (if any) facing triangles should be culled
             //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
             virtual void DrawCylinder(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
+
+            //! Draw a cylinder without flat disk on the end.
+            //! @param center        The center of the base circle.
+            //! @param direction     The direction vector. The top end cap of the cylinder will face along this vector.
+            //! @param radius        The radius.
+            //! @param height        The height of the cylinder.
+            //! @param color         The color to draw the cylinder.
+            //! @param style         The draw style (point, wireframe, solid, shaded etc).
+            //! @param depthTest     If depth testing should be enabled
+            //! @param depthWrite    If depth writing should be enabled
+            //! @param faceCull      Which (if any) facing triangles should be culled
+            //! @param viewProjOverrideIndex Which view projection override entry to use, -1 if unused
+            virtual void DrawCylinderNoEnds(const AZ::Vector3& center, const AZ::Vector3& direction, float radius, float height, const AZ::Color& color, DrawStyle style = DrawStyle::Shaded, DepthTest depthTest = DepthTest::On, DepthWrite depthWrite = DepthWrite::On, FaceCullMode faceCull = FaceCullMode::Back, int32_t viewProjOverrideIndex = -1) = 0;
 
             //! Draw an axis-aligned bounding box with no transform.
             //! @param aabb          The AABB (typically the bounding box of a set of world space points).

--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -1025,33 +1025,27 @@ namespace AZ::AtomBridge
         if (m_auxGeomPtr &&  radius > FLT_EPSILON &&  axis.GetLengthSq() > FLT_EPSILON)
         {
             AZ::Vector3 axisNormalized = axis.GetNormalizedEstimate();
-            SingleColorStaticSizeLineHelper<(16+1) * 5> lines; // 360/22.5 = 16, 5 possible calls to CreateArbitraryAxisArc
-            AZ::Vector3 radiusV3 = AZ::Vector3(radius);
-            float stepAngle = DegToRad(22.5f);
-            float Deg0 = DegToRad(0.0f);
 
+            const float scale = GetCurrentTransform().RetrieveScale().GetMaxElement();
+            const AZ::Vector3 worldCenter = ToWorldSpacePosition(center);
+            const AZ::Vector3 worldAxis = ToWorldSpaceVector(axis);
 
             // Draw cylinder part (or just a circle around the middle)
             if (heightStraightSection > FLT_EPSILON)
             {
-                DrawWireCylinder(center, axis, radius, heightStraightSection);
+                m_auxGeomPtr->DrawCylinderNoEnds(
+                    worldCenter,
+                    worldAxis,
+                    scale * radius,
+                    scale * heightStraightSection,
+                    m_rendState.m_color,
+                    AZ::RPI::AuxGeomDraw::DrawStyle::Line,
+                    m_rendState.m_depthTest,
+                    m_rendState.m_depthWrite,
+                    m_rendState.m_faceCullMode,
+                    m_rendState.m_viewProjOverrideIndex
+                );
             }
-            else
-            {
-                float Deg360 = DegToRad(360.0f);
-                CreateArbitraryAxisArc(
-                    lines,
-                    stepAngle,
-                    Deg0,
-                    Deg360,
-                    center,
-                    radiusV3,
-                    axisNormalized
-                    );
-            }
-
-            float Deg90 = DegToRad(90.0f);
-            float Deg180 = DegToRad(180.0f);
 
             AZ::Vector3 ortho1Normalized, ortho2Normalized;
             CalcBasisVectors(axisNormalized, ortho1Normalized, ortho2Normalized);
@@ -1059,49 +1053,29 @@ namespace AZ::AtomBridge
             AZ::Vector3 topCenter = center + centerToTopCircleCenter;
             AZ::Vector3 bottomCenter = center - centerToTopCircleCenter;
 
-            // Draw top cap as two criss-crossing 180deg arcs
-            CreateArbitraryAxisArc(
-                    lines,
-                    stepAngle,
-                    Deg90,
-                    Deg90 + Deg180,
-                    topCenter,
-                    radiusV3,
-                    ortho1Normalized
-                    );
+            m_auxGeomPtr->DrawHemisphere(
+                topCenter,
+                worldAxis,
+                scale * radius,
+                m_rendState.m_color,
+                AZ::RPI::AuxGeomDraw::DrawStyle::Line,
+                m_rendState.m_depthTest,
+                m_rendState.m_depthWrite,
+                m_rendState.m_faceCullMode,
+                m_rendState.m_viewProjOverrideIndex
+            );
 
-            CreateArbitraryAxisArc(
-                    lines,
-                    stepAngle,
-                    Deg180,
-                    Deg180 + Deg180,
-                    topCenter,
-                    radiusV3,
-                    ortho2Normalized
-                    );
-
-            // Draw bottom cap
-            CreateArbitraryAxisArc(
-                    lines,
-                    stepAngle,
-                    -Deg90,
-                    -Deg90 + Deg180,
-                    bottomCenter,
-                    radiusV3,
-                    ortho1Normalized
-                    );
-
-            CreateArbitraryAxisArc(
-                    lines,
-                    stepAngle,
-                    Deg0,
-                    Deg0 + Deg180,
-                    bottomCenter,
-                    radiusV3,
-                    ortho2Normalized
-                    );
-
-            lines.Draw(m_auxGeomPtr, m_rendState);
+            m_auxGeomPtr->DrawHemisphere(
+                bottomCenter,
+                -worldAxis,
+                scale * radius,
+                m_rendState.m_color,
+                AZ::RPI::AuxGeomDraw::DrawStyle::Line,
+                m_rendState.m_depthTest,
+                m_rendState.m_depthWrite,
+                m_rendState.m_faceCullMode,
+                m_rendState.m_viewProjOverrideIndex
+            );
         }
     }
 


### PR DESCRIPTION
- Greatly improved aux geom rendering for capsule lights
- Fixed issue with wireframe sphere (there was a ring missing close to the bottom pole, not very noticeable but fixed now)
- Added aux geom ability to draw hemispheres
- Added aux geom ability to draw open cylinders without disks at the end
- These two additions are used to draw a much better wireframe caspule

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>