### PR TITLE
Fix for gizmo axis text not displaying correctly on high dpi screens

### DIFF
--- a/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
+++ b/Gems/AtomLyIntegration/AtomBridge/Code/Source/AtomDebugDisplayViewportInterface.cpp
@@ -1353,9 +1353,8 @@ namespace AZ::AtomBridge
         // if 2d draw need to project pos to screen first
         AzFramework::TextDrawParameters params;
         AZ::RPI::ViewportContextPtr viewportContext = GetViewportContext();
-        const auto dpiScaleFactor = viewportContext->GetDpiScalingFactor();
         params.m_drawViewportId = viewportContext->GetId(); // get the viewport ID so default viewport works
-        params.m_position = AZ::Vector3(x * dpiScaleFactor, y * dpiScaleFactor, 1.0f);
+        params.m_position = AZ::Vector3(x, y, 1.0f);
         params.m_color = m_rendState.m_color;
         params.m_scale = AZ::Vector2(size);
         params.m_hAlign = center ? AzFramework::TextHorizontalAlignment::Center : AzFramework::TextHorizontalAlignment::Left; //! Horizontal text alignment


### PR DESCRIPTION
I noticed this text was not display correctly on high-dpi screens and was showing up on regular displays.

I think this fix was added a while back but the dpi scaling must have been addressed at a more fundamental level so this wound up being applied twice.

Before:
![image](https://user-images.githubusercontent.com/82228511/142420556-6d23e852-90ad-4982-a297-31c83c6a9e03.png)

After:
![image](https://user-images.githubusercontent.com/82228511/142420435-63bdcb67-7e0b-446c-8792-17c07147dd8a.png)
