### PR TITLE
Fix several Prefab outliner ordering issues

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EntityOutliner_EntityOrdering.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EntityOutliner_EntityOrdering.py
@@ -95,7 +95,8 @@ def EntityOutliner_EntityOrdering():
         entity_outliner_model.dropMimeData(
             mime_data, QtCore.Qt.MoveAction, target_row, 0, target_index.parent()
         )
-        QtWidgets.QApplication.processEvents()
+        # Wait after move to let events (i.e. prefab propagation) process
+        general.idle_wait(1.0)
 
     # Move an entity before another entity in the order by dragging the source above the target
     move_entity_before = lambda source_name, target_name: _move_entity(

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EntityOutliner_EntityOrdering.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EntityOutliner_EntityOrdering.py
@@ -119,24 +119,24 @@ def EntityOutliner_EntityOrdering():
 
         # Our new entity should be given a name with a number automatically
         new_entity = f"Entity{i+1}"
-        # The new entity should be added to the top of its parent entity
-        expected_order = [new_entity] + expected_order
+        # The new entity should be added to the bottom of its parent entity
+        expected_order = expected_order + [new_entity]
 
         verify_entities_sorted(expected_order)
 
-    # 3) Move "Entity1" to the top of the order
-    move_entity_before("Entity1", "Entity5")
-    expected_order = ["Entity1", "Entity5", "Entity4", "Entity3", "Entity2"]
+    # 3) Move "Entity5" to the top of the order
+    move_entity_before("Entity5", "Entity1")
+    expected_order = ["Entity5", "Entity1", "Entity2", "Entity3", "Entity4"]
     verify_entities_sorted(expected_order)
 
-    # 4) Move "Entity4" to the bottom of the order
-    move_entity_after("Entity4", "Entity2")
-    expected_order = ["Entity1", "Entity5", "Entity3", "Entity2", "Entity4"]
+    # 4) Move "Entity2" to the bottom of the order
+    move_entity_after("Entity2", "Entity4")
+    expected_order = ["Entity5", "Entity1", "Entity3", "Entity4", "Entity2"]
     verify_entities_sorted(expected_order)
 
     # 5) Add another new entity, ensure the rest of the order is unchanged
     create_entity()
-    expected_order = ["Entity6", "Entity1", "Entity5", "Entity3", "Entity2", "Entity4"]
+    expected_order = ["Entity5", "Entity1", "Entity3", "Entity4", "Entity2", "Entity6"]
     verify_entities_sorted(expected_order)
 
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -233,12 +233,14 @@ namespace AzToolsFramework
         , m_isInIsolationMode(false)
     {
         ToolsApplicationRequests::Bus::Handler::BusConnect();
+        AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusConnect();
 
         m_undoCache.RegisterToUndoCacheInterface();
     }
 
     ToolsApplication::~ToolsApplication()
     {
+        AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler::BusDisconnect();
         ToolsApplicationRequests::Bus::Handler::BusDisconnect();
         Stop();
     }
@@ -558,6 +560,12 @@ namespace AzToolsFramework
     void ToolsApplication::MarkEntitySelected(AZ::EntityId entityId)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
+
+        if (m_freezeSelectionUpdates)
+        {
+            return;
+        }
+
         AZ_Assert(entityId.IsValid(), "Invalid entity Id being marked as selected.");
 
         EntityIdList::iterator foundIter = AZStd::find(m_selectedEntities.begin(), m_selectedEntities.end(), entityId);
@@ -576,6 +584,11 @@ namespace AzToolsFramework
     void ToolsApplication::MarkEntitiesSelected(const EntityIdList& entitiesToSelect)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
+
+        if (m_freezeSelectionUpdates)
+        {
+            return;
+        }
 
         EntityIdList entitiesSelected;
         entitiesSelected.reserve(entitiesToSelect.size());
@@ -600,6 +613,12 @@ namespace AzToolsFramework
     void ToolsApplication::MarkEntityDeselected(AZ::EntityId entityId)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
+
+        if (m_freezeSelectionUpdates)
+        {
+            return;
+        }
+
         auto foundIter = AZStd::find(m_selectedEntities.begin(), m_selectedEntities.end(), entityId);
         if (foundIter != m_selectedEntities.end())
         {
@@ -616,6 +635,11 @@ namespace AzToolsFramework
     void ToolsApplication::MarkEntitiesDeselected(const EntityIdList& entitiesToDeselect)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
+
+        if (m_freezeSelectionUpdates)
+        {
+            return;
+        }
 
         ToolsApplicationEvents::Bus::Broadcast(&ToolsApplicationEvents::BeforeEntitySelectionChanged);
 
@@ -670,6 +694,11 @@ namespace AzToolsFramework
     void ToolsApplication::SetSelectedEntities(const EntityIdList& selectedEntities)
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
+
+        if (m_freezeSelectionUpdates)
+        {
+            return;
+        }
 
         // We're setting the selection set as a batch from an external caller.
         // * Filter out any unselectable entities
@@ -1548,6 +1577,16 @@ namespace AzToolsFramework
 #endif
             m_currentBatchUndo = nullptr;
         }
+    }
+
+    void ToolsApplication::OnPrefabInstancePropagationBegin()
+    {
+        m_freezeSelectionUpdates = true;
+    }
+
+    void ToolsApplication::OnPrefabInstancePropagationEnd()
+    {
+        m_freezeSelectionUpdates = false;
     }
 
     void ToolsApplication::CreateUndosForDirtyEntities()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.h
@@ -16,6 +16,7 @@
 #include <AzToolsFramework/API/EditorEntityAPI.h>
 #include <AzToolsFramework/Application/EditorEntityManager.h>
 #include <AzToolsFramework/Commands/PreemptiveUndoCache.h>
+#include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 
 #pragma once
 
@@ -29,6 +30,7 @@ namespace AzToolsFramework
     class ToolsApplication
         : public AzFramework::Application
         , public ToolsApplicationRequests::Bus::Handler
+        , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
     {
     public:
         AZ_RTTI(ToolsApplication, "{2895561E-BE90-4CC3-8370-DD46FCF74C01}", AzFramework::Application);
@@ -169,6 +171,14 @@ namespace AzToolsFramework
         };
         //////////////////////////////////////////////////////////////////////////
 
+        //////////////////////////////////////////////////////////////////////////
+        // PrefabPublicNotificationBus::Handler
+
+        void OnPrefabInstancePropagationBegin() override;
+        void OnPrefabInstancePropagationEnd() override;
+
+        //////////////////////////////////////////////////////////////////////////
+
         void CreateUndosForDirtyEntities();
         void ConsistencyCheckUndoCache();
         AZ::Aabb                            m_selectionBounds;
@@ -181,6 +191,7 @@ namespace AzToolsFramework
         bool                                m_isDuringUndoRedo;
         bool                                m_isInIsolationMode;
         EntityIdSet                         m_isolatedEntityIdSet;
+        bool                                m_freezeSelectionUpdates = false;
 
         EditorEntityAPI* m_editorEntityAPI = nullptr;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
@@ -383,7 +383,7 @@ namespace AzToolsFramework
                 }
             }
 
-            AZStd::sort(children.begin(), children.end(), [this](AZ::EntityId lhs, AZ::EntityId rhs)
+            AZStd::sort(children.begin(), children.end(), [](AZ::EntityId lhs, AZ::EntityId rhs)
             {
                 return GetEntityById(lhs)->GetName() < GetEntityById(rhs)->GetName();
             });

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
@@ -8,11 +8,17 @@
 #include "EditorEntitySortComponent.h"
 #include "EditorEntityInfoBus.h"
 #include "EditorEntityHelpers.h"
+#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/std/sort.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
+#include <AzToolsFramework/Prefab/PrefabPublicRequestBus.h>
+#include <AzToolsFramework/Undo/UndoSystem.h>
+#include <AzCore/Serialization/Json/RegistrationContext.h>
+#include <AzToolsFramework/Entity/EditorEntitySortComponentSerializer.h>
 
 static_assert(sizeof(AZ::u64) == sizeof(AZ::EntityId), "We use AZ::EntityId for Persistent ID, which is a u64 under the hood. These must be the same size otherwise the persistent id will have to be rewritten");
 
@@ -50,6 +56,12 @@ namespace AzToolsFramework
                         ->Attribute(AZ::Edit::Attributes::SliceFlags, AZ::Edit::SliceFlags::HideOnAdd | AZ::Edit::SliceFlags::PushWhenHidden | AZ::Edit::SliceFlags::DontGatherReference)
                         ;
                 }
+            }
+
+            AZ::JsonRegistrationContext* jsonRegistration = azrtti_cast<AZ::JsonRegistrationContext*>(context);
+            if (jsonRegistration)
+            {
+                jsonRegistration->Serializer<JsonEditorEntitySortComponentSerializer>()->HandlesType<EditorEntitySortComponent>();
             }
         }
 
@@ -167,9 +179,6 @@ namespace AzToolsFramework
                 }
 
                 MarkDirtyAndSendChangedEvent();
-
-                // Use the ToolsApplication to mark the entity dirty, this will only do something if we already have an undo batch
-                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::AddDirtyEntity, GetEntityId());
                 
                 return true;
             }
@@ -187,6 +196,10 @@ namespace AzToolsFramework
             else
             {
                 EntityOrderArray::iterator insertPosition = GetFirstSelectedEntityPosition();
+                if (insertPosition != m_childEntityOrderArray.end())
+                {
+                    ++insertPosition;
+                }
                 retval = AddChildEntityInternal(entityId, false, insertPosition);
             }
 
@@ -219,9 +232,6 @@ namespace AzToolsFramework
                 RebuildEntityOrderCache();
 
                 MarkDirtyAndSendChangedEvent();
-
-                // Use the ToolsApplication to mark the entity dirty, this will only do something if we already have an undo batch
-                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::AddDirtyEntity, GetEntityId());
 
                 return true;
             }
@@ -272,6 +282,8 @@ namespace AzToolsFramework
         void EditorEntitySortComponent::OnPrefabInstancePropagationEnd()
         {
             m_ignoreIncomingOrderChanges = false;
+
+            SanitizeOrderEntryArray();
         }
 
         void EditorEntitySortComponent::MarkDirtyAndSendChangedEvent()
@@ -279,6 +291,9 @@ namespace AzToolsFramework
             // mark the order as dirty before sending the ChildEntityOrderArrayUpdated event in order for PrepareSave to be properly handled in the case 
             // one of the event listeners needs to build the InstanceDataHierarchy
             m_entityOrderIsDirty = true;
+
+            // Use the ToolsApplication to mark the entity dirty, this will only do something if we already have an undo batch
+            ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::AddDirtyEntity, GetEntityId());
 
             // Force an immediate update for prefabs, which won't receive PrepareSave
             bool isPrefabEnabled = false;
@@ -308,9 +323,8 @@ namespace AzToolsFramework
                 isPrefabEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
             if (isPrefabEnabled)
             {
-                PostLoad();
+                m_shouldSanityCheckStateAfterPropagation = true;
             }
-
             // Send out that the order for our entity is now updated
             EditorEntitySortNotificationBus::Event(GetEntityId(), &EditorEntitySortNotificationBus::Events::ChildEntityOrderArrayUpdated);
         }
@@ -331,6 +345,71 @@ namespace AzToolsFramework
             for (size_t entityIndex = 0; entityIndex < m_childEntityOrderArray.size(); ++entityIndex)
             {
                 m_childEntityOrderEntryArray.push_back({ m_childEntityOrderArray[entityIndex], entityIndex });
+            }
+
+            m_entityOrderIsDirty = false;
+        }
+
+        void EditorEntitySortComponent::SanitizeOrderEntryArray()
+        {
+            bool shouldEmitDirtyState = false;
+
+            // Remove invalid entries that point at non-existent entities
+            for (auto it = m_childEntityOrderArray.begin(); it != m_childEntityOrderArray.end();)
+            {
+                if (!it->IsValid() || GetEntityById(*it) == nullptr)
+                {
+                    it = m_childEntityOrderArray.erase(it);
+                    shouldEmitDirtyState = true;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+
+            // Append any missing children
+            EntityIdList children;
+            AZ::TransformBus::EventResult(children, GetEntityId(), &AZ::TransformBus::Events::GetChildren);
+            for (auto it = m_childEntityOrderArray.begin(); it != m_childEntityOrderArray.end(); ++it)
+            {
+                if (auto removedChildrenIt = AZStd::remove(children.begin(), children.end(), *it); removedChildrenIt != children.end())
+                {
+                    children.erase(removedChildrenIt);
+                }
+            }
+
+            AZStd::sort(children.begin(), children.end(), [this](AZ::EntityId lhs, AZ::EntityId rhs)
+            {
+                return GetEntityById(lhs)->GetName() < GetEntityById(rhs)->GetName();
+            });
+
+            if (!children.empty())
+            {
+                shouldEmitDirtyState = true;
+                EntityOrderArray::iterator insertPosition = GetFirstSelectedEntityPosition();
+                if (insertPosition != m_childEntityOrderArray.end())
+                {
+                    ++insertPosition;
+                }
+                m_childEntityOrderArray.insert(insertPosition, children.begin(), children.end());
+            }
+
+            // Clear out the vector to be rebuilt from persistent id
+            m_childEntityOrderEntryArray.resize(m_childEntityOrderArray.size());
+            for (size_t i = 0; i < m_childEntityOrderArray.size(); ++i)
+            {
+                m_childEntityOrderEntryArray[i] = {
+                    m_childEntityOrderArray[i],
+                    static_cast<AZ::u64>(i)
+                };
+            }
+
+            RebuildEntityOrderCache();
+
+            if (shouldEmitDirtyState)
+            {
+                ToolsApplicationRequests::Bus::Broadcast(&ToolsApplicationRequests::Bus::Events::AddDirtyEntity, GetEntityId());
             }
 
             m_entityOrderIsDirty = false;
@@ -383,7 +462,7 @@ namespace AzToolsFramework
                 firstSelectedEntityPos = selectedEntityPos < firstSelectedEntityPos ? selectedEntityPos : firstSelectedEntityPos;
             }
 
-            return firstSelectedEntityPos == m_childEntityOrderArray.end() ? m_childEntityOrderArray.begin() : firstSelectedEntityPos;
+            return firstSelectedEntityPos;
         }
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.cpp
@@ -283,7 +283,11 @@ namespace AzToolsFramework
         {
             m_ignoreIncomingOrderChanges = false;
 
-            SanitizeOrderEntryArray();
+            if (m_shouldSanityCheckStateAfterPropagation)
+            {
+                SanitizeOrderEntryArray();
+                m_shouldSanityCheckStateAfterPropagation = false;
+            }
         }
 
         void EditorEntitySortComponent::MarkDirtyAndSendChangedEvent()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponent.h
@@ -23,6 +23,8 @@ namespace AzToolsFramework
             , public EditorEntityContextNotificationBus::Handler
             , public AzToolsFramework::Prefab::PrefabPublicNotificationBus::Handler
         {
+            friend class JsonEditorEntitySortComponentSerializer;
+
         public:
             AZ_COMPONENT(EditorEntitySortComponent, "{6EA1E03D-68B2-466D-97F7-83998C8C27F0}", EditorComponentBase);
 
@@ -63,6 +65,8 @@ namespace AzToolsFramework
             // Serialization events
             void PrepareSave();
             void PostLoad();
+
+            void SanitizeOrderEntryArray();
 
             class EntitySortSerializationEvents
                 : public AZ::SerializeContext::IEventHandler
@@ -112,6 +116,7 @@ namespace AzToolsFramework
 
             bool m_entityOrderIsDirty = true; ///< This flag indicates our stored serialization order data is out of date and must be rebuilt before serialization occurs
             bool m_ignoreIncomingOrderChanges = false; ///< This is set when prefab propagation occurs so that non-authored order changes can be ignored
+            bool m_shouldSanityCheckStateAfterPropagation = false; //< This is set after activation, to queue a cleanup of any invalid state after the next prefab propagation.
         };
     }
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponentSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponentSerializer.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/Json/JsonSerializationResult.h>
+#include <AzCore/std/sort.h>
+#include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
+#include <AzToolsFramework/Entity/EditorEntitySortComponentSerializer.h>
+
+namespace AzToolsFramework::Components
+{
+    AZ_CLASS_ALLOCATOR_IMPL(JsonEditorEntitySortComponentSerializer, AZ::SystemAllocator, 0);
+
+    AZ::JsonSerializationResult::Result JsonEditorEntitySortComponentSerializer::Load(
+        void* outputValue,
+        [[maybe_unused]] const AZ::Uuid& outputValueTypeId,
+        const rapidjson::Value& inputValue,
+        AZ::JsonDeserializerContext& context)
+    {
+        namespace JSR = AZ::JsonSerializationResult;
+
+        AZ_Assert(
+            azrtti_typeid<EditorEntitySortComponent>() == outputValueTypeId,
+            "Unable to deserialize EditorEntitySortComponent from json because the provided type is %s.",
+            outputValueTypeId.ToString<AZStd::string>().c_str());
+
+        EditorEntitySortComponent* sortComponentInstance = reinterpret_cast<EditorEntitySortComponent*>(outputValue);
+        AZ_Assert(sortComponentInstance, "Output value for JsonEditorEntitySortComponentSerializer can't be null.");
+
+        JSR::ResultCode result(JSR::Tasks::ReadField);
+        {
+            JSR::ResultCode componentIdLoadResult = ContinueLoadingFromJsonObjectField(
+                &sortComponentInstance->m_id, azrtti_typeid<decltype(sortComponentInstance->m_id)>(), inputValue,
+                "Id", context);
+
+            result.Combine(componentIdLoadResult);
+        }
+
+        {
+            sortComponentInstance->m_childEntityOrderArray.clear();
+            JSR::ResultCode enryLoadResult = ContinueLoadingFromJsonObjectField(
+                &sortComponentInstance->m_childEntityOrderArray,
+                azrtti_typeid<decltype(sortComponentInstance->m_childEntityOrderArray)>(), inputValue, "Child Entity Order",
+                context);
+
+            // Migrate ChildEntityOrderEntryArray -> ChildEntityOrderArray
+            if (sortComponentInstance->m_childEntityOrderArray.empty())
+            {
+                enryLoadResult = ContinueLoadingFromJsonObjectField(
+                    &sortComponentInstance->m_childEntityOrderEntryArray,
+                    azrtti_typeid<decltype(sortComponentInstance->m_childEntityOrderEntryArray)>(), inputValue,
+                    "ChildEntityOrderEntryArray", context);
+
+                AZStd::sort(
+                    sortComponentInstance->m_childEntityOrderEntryArray.begin(),
+                    sortComponentInstance->m_childEntityOrderEntryArray.end(),
+                    [](const EditorEntitySortComponent::EntityOrderEntry& lhs,
+                       const EditorEntitySortComponent::EntityOrderEntry& rhs) -> bool
+                    {
+                        return lhs.m_sortIndex < rhs.m_sortIndex;
+                    });
+
+                // Sort by index and copy to the order array, any duplicates or invalid entries will be cleaned up by the sanitization pass
+                sortComponentInstance->m_childEntityOrderArray.resize(sortComponentInstance->m_childEntityOrderEntryArray.size());
+                for (size_t i = 0; i < sortComponentInstance->m_childEntityOrderEntryArray.size(); ++i)
+                {
+                    sortComponentInstance->m_childEntityOrderArray[i] = sortComponentInstance->m_childEntityOrderEntryArray[i].m_entityId;
+                }
+            }
+
+            sortComponentInstance->RebuildEntityOrderCache();
+
+            result.Combine(enryLoadResult);
+        }
+
+        return context.Report(
+            result,
+            result.GetProcessing() != JSR::Processing::Halted ? "Successfully loaded EditorEntitySortComponent information."
+                                                              : "Failed to load EditorEntitySortComponent information.");
+    }
+
+    AZ::JsonSerializationResult::Result JsonEditorEntitySortComponentSerializer::Store(
+        rapidjson::Value& outputValue,
+        const void* inputValue,
+        const void* defaultValue,
+        [[maybe_unused]] const AZ::Uuid& valueTypeId,
+        AZ::JsonSerializerContext& context)
+    {
+        namespace JSR = AZ::JsonSerializationResult;
+
+        AZ_Assert(
+            azrtti_typeid<EditorEntitySortComponent>() == valueTypeId,
+            "Unable to Serialize EditorEntitySortComponent because the provided type is %s.",
+            valueTypeId.ToString<AZStd::string>().c_str());
+
+        const EditorEntitySortComponent* sortComponentInstance = reinterpret_cast<const EditorEntitySortComponent*>(inputValue);
+        AZ_Assert(sortComponentInstance, "Input value for JsonEditorEntitySortComponentSerializer can't be null.");
+        const EditorEntitySortComponent* defaultsortComponentInstance =
+            reinterpret_cast<const EditorEntitySortComponent*>(defaultValue);
+
+        JSR::ResultCode result(JSR::Tasks::WriteValue);
+        {
+            AZ::ScopedContextPath subPathName(context, "m_id");
+            const AZ::ComponentId* componentId = &sortComponentInstance->m_id;
+            const AZ::ComponentId* defaultComponentId =
+                defaultsortComponentInstance ? &defaultsortComponentInstance->m_id : nullptr;
+
+            JSR::ResultCode resultComponentId = ContinueStoringToJsonObjectField(
+                outputValue, "Id", componentId, defaultComponentId, azrtti_typeid<decltype(sortComponentInstance->m_id)>(),
+                context);
+
+            result.Combine(resultComponentId);
+        }
+
+        {
+            AZ::ScopedContextPath subPathName(context, "m_childEntityOrderArray");
+            const EntityOrderArray* childEntityOrderArray = &sortComponentInstance->m_childEntityOrderArray;
+            const EntityOrderArray* defaultChildEntityOrderArray =
+                defaultsortComponentInstance ? &defaultsortComponentInstance->m_childEntityOrderArray : nullptr;
+
+            JSR::ResultCode resultParentEntityId = ContinueStoringToJsonObjectField(
+                outputValue, "Child Entity Order", childEntityOrderArray, defaultChildEntityOrderArray,
+                azrtti_typeid<decltype(sortComponentInstance->m_childEntityOrderArray)>(), context);
+
+            result.Combine(resultParentEntityId);
+        }
+
+        return context.Report(
+            result,
+            result.GetProcessing() != JSR::Processing::Halted ? "Successfully stored EditorEntitySortComponent information."
+                                                              : "Failed to store EditorEntitySortComponent information.");
+    }
+} // namespace AzToolsFramework::Components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponentSerializer.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntitySortComponentSerializer.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/Serialization/Json/BaseJsonSerializer.h>
+
+namespace AzToolsFramework::Components
+{
+    class JsonEditorEntitySortComponentSerializer
+        : public AZ::BaseJsonSerializer
+    {
+    public:
+        AZ_RTTI(JsonEditorEntitySortComponentSerializer, "{5104782E-B34F-4D87-B1DF-BDFB1AF20D58}", BaseJsonSerializer);
+        AZ_CLASS_ALLOCATOR_DECL;
+
+        AZ::JsonSerializationResult::Result Load(
+            void* outputValue, const AZ::Uuid& outputValueTypeId, const rapidjson::Value& inputValue,
+            AZ::JsonDeserializerContext& context) override;
+
+        AZ::JsonSerializationResult::Result Store(
+            rapidjson::Value& outputValue, const void* inputValue, const void* defaultValue, const AZ::Uuid& valueTypeId,
+            AZ::JsonSerializerContext& context) override;
+    };
+} // namespace AzToolsFramework::Components

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -20,6 +20,7 @@
 #include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/Template/Template.h>
+#include <AzToolsFramework/Prefab/PrefabPublicRequestBus.h>
 
 namespace AzToolsFramework
 {
@@ -244,10 +245,10 @@ namespace AzToolsFramework
                             selectedEntityIds.erase(entityIdIterator--);
                         }
                     }
-                    ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
 
-                    // Notify Propagation has ended
+                    // Notify Propagation has ended, then update selection (which is frozen during propagation, so this order matters)
                     PrefabPublicNotificationBus::Broadcast(&PrefabPublicNotifications::OnPrefabInstancePropagationEnd);
+                    ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetSelectedEntities, selectedEntityIds);
                 }
 
                 m_updatingTemplateInstancesInQueue = false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -29,8 +29,8 @@ namespace AzToolsFramework
             inline static const char* EntitiesName = "Entities";
             inline static const char* ContainerEntityName = "ContainerEntity";
             inline static const char* ComponentsName = "Components";
-            inline static const char* EntityOrderFieldName = "Child Entity Order";
-            inline static const char* TypeFieldName = "$type";
+            inline static const char* EntityOrderName = "Child Entity Order";
+            inline static const char* TypeName = "$type";
 
             /**
             * Find Prefab value from given parent value and target value's name.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -28,6 +28,9 @@ namespace AzToolsFramework
             inline static const char* EntityIdName = "Id";
             inline static const char* EntitiesName = "Entities";
             inline static const char* ContainerEntityName = "ContainerEntity";
+            inline static const char* ComponentsName = "Components";
+            inline static const char* EntityOrderFieldName = "Child Entity Order";
+            inline static const char* TypeFieldName = "$type";
 
             /**
             * Find Prefab value from given parent value and target value's name.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -710,8 +710,6 @@ namespace AzToolsFramework
                 bool isNewParentOwnedByDifferentInstance = false;
 
                 AzFramework::EntityContextId editorEntityContextId = AzToolsFramework::GetEntityContextId();
-                AZ::EntityId focusedInstanceContainerEntityId =
-                    m_prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId);
 
                 bool isInFocusTree = m_prefabFocusPublicInterface->IsOwningPrefabInFocusHierarchy(entityId);
                 bool isOwnedByFocusedPrefabInstance = m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/JSON/stringbuffer.h>
 #include <AzCore/JSON/writer.h>
+#include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Utils/TypeHash.h>
 
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
@@ -29,6 +30,7 @@
 #include <AzToolsFramework/Prefab/PrefabUndo.h>
 #include <AzToolsFramework/Prefab/PrefabUndoHelpers.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
+#include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
 
 #include <QString>
 
@@ -595,8 +597,9 @@ namespace AzToolsFramework
             
             Instance& entityOwningInstance = owningInstanceOfParentEntity->get();
 
-            PrefabDom instanceDomBeforeUpdate;
-            m_instanceToTemplateInterface->GenerateDomForInstance(instanceDomBeforeUpdate, entityOwningInstance);
+            // Get the comparison instance directly from the template, as that's what we'll be applying our patch to
+            const PrefabDom& instanceDomBeforeUpdate =
+                m_prefabSystemComponentInterface->FindTemplateDom(entityOwningInstance.GetTemplateId());
 
             ScopedUndoBatch undoBatch("Add Entity");
 
@@ -674,6 +677,13 @@ namespace AzToolsFramework
                 bool isInstanceContainerEntity = IsInstanceContainerEntity(entityId) && !IsLevelInstanceContainerEntity(entityId);
                 bool isNewParentOwnedByDifferentInstance = false;
 
+                AzFramework::EntityContextId editorEntityContextId = AzToolsFramework::GetEntityContextId();
+                AZ::EntityId focusedInstanceContainerEntityId =
+                    m_prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId);
+
+                bool isInFocusTree = m_prefabFocusPublicInterface->IsOwningPrefabInFocusHierarchy(entityId);
+                bool isOwnedByFocusedPrefabInstance = m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId);
+
                 if (beforeParentId != afterParentId)
                 {
                     // If the entity parent changed, verify if the owning instance changed too
@@ -727,7 +737,7 @@ namespace AzToolsFramework
                     }
                 }
 
-                if (isInstanceContainerEntity)
+                if (isInFocusTree && !isOwnedByFocusedPrefabInstance)
                 {
                     if (isNewParentOwnedByDifferentInstance)
                     {
@@ -1653,6 +1663,144 @@ namespace AzToolsFramework
             return true;
         }
 
+        void PrefabPublicHandler::AddNewEntityToSortOrder(
+            Instance& owningInstance,
+            PrefabDom& domToAddEntityUnder,
+            const EntityAlias& parentEntityAlias,
+            const EntityAlias& entityToAddAlias)
+        {
+            // Find the parent entity to get its sort order component
+            auto findParentEntity = [&]() -> rapidjson::Value*
+            {
+                if (auto containerEntityIter = domToAddEntityUnder.FindMember(PrefabDomUtils::ContainerEntityName);
+                    containerEntityIter != domToAddEntityUnder.MemberEnd())
+                {
+                    if (parentEntityAlias == containerEntityIter->value[PrefabDomUtils::EntityIdName].GetString())
+                    {
+                        return &containerEntityIter->value;
+                    }
+                }
+
+                if (auto entitiesIter = domToAddEntityUnder.FindMember(PrefabDomUtils::EntitiesName);
+                    entitiesIter != domToAddEntityUnder.MemberEnd())
+                {
+                    for (auto entityIter = entitiesIter->value.MemberBegin(); entityIter != entitiesIter->value.MemberEnd(); ++entityIter)
+                    {
+                        if (parentEntityAlias == entityIter->value[PrefabDomUtils::EntityIdName].GetString())
+                        {
+                            return &entityIter->value;
+                        }
+                    }
+                }
+
+                return nullptr;
+            };
+
+            rapidjson::Value* parentEntityValue = findParentEntity();
+            if (parentEntityValue == nullptr)
+            {
+                return;
+            }
+
+            // Get the list of selected entitie, we'll insert our duplicated entities after the last selected
+            // siblign in their parent's list, e.g. for:
+            // - Entity1
+            // - Entity2 (selected)
+            // - Entity3
+            // - Entity4 (selected)
+            // - Entity5
+            // Our duplicate selection command would create duplicate Entity2 and Entity4 and insert them after Entity4:
+            // - Entity1
+            // - Entity2
+            // - Entity3
+            // - Entity4
+            // - Entity2 (new, selected after duplicate)
+            // - Entity4 (new, selected after duplicate)
+            // - Entity5
+            AzToolsFramework::EntityIdList selectedEntities;
+            AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(
+                selectedEntities, &AzToolsFramework::ToolsApplicationRequests::GetSelectedEntities);
+
+            // Find the EditorEntitySortComponent DOM
+            auto componentsIter = parentEntityValue->FindMember(PrefabDomUtils::ComponentsName);
+            if (componentsIter == parentEntityValue->MemberEnd())
+            {
+                return;
+            }
+
+            for (auto componentIter = componentsIter->value.MemberBegin(); componentIter != componentIter->value.MemberEnd();
+                 ++componentIter)
+            {
+                // Check the component type
+                auto typeFieldIter = componentIter->value.FindMember(PrefabDomUtils::TypeFieldName);
+                if (typeFieldIter == componentIter->value.MemberEnd())
+                {
+                    continue;
+                }
+
+                AZ::JsonDeserializerSettings jsonDeserializerSettings;
+                AZ::Uuid typeId = AZ::Uuid::CreateNull();
+                AZ::JsonSerialization::LoadTypeId(typeId, typeFieldIter->value);
+
+                if (typeId != azrtti_typeid<Components::EditorEntitySortComponent>())
+                {
+                    continue;
+                }
+
+                // Check for the entity order field
+                auto orderMembersIter = componentIter->value.FindMember(PrefabDomUtils::EntityOrderFieldName);
+                if (orderMembersIter == componentIter->value.MemberEnd() || !orderMembersIter->value.IsArray())
+                {
+                    continue;
+                }
+
+                // Scan for the last selected entity in the list (if any) to determine where to add our entries
+                rapidjson::Value newOrder(rapidjson::kArrayType);
+                auto insertValuesAfter = orderMembersIter->value.End();
+                for (auto orderMemberIter = orderMembersIter->value.Begin(); orderMemberIter != orderMembersIter->value.End();
+                     ++orderMemberIter)
+                {
+                    if (!orderMemberIter->IsString())
+                    {
+                        continue;
+                    }
+                    const char* value = orderMemberIter->GetString();
+                    for (AZ::EntityId selectedEntity : selectedEntities)
+                    {
+                        auto alias = owningInstance.GetEntityAlias(selectedEntity);
+                        if (alias.has_value() && alias.value().get() == value)
+                        {
+                            insertValuesAfter = orderMemberIter;
+                            break;
+                        }
+                    }
+                }
+
+                // Construct our new array with the new order - insertion may happen at end, so check for that in the loop itself
+                for (auto orderMemberIter = orderMembersIter->value.Begin();; ++orderMemberIter)
+                {
+                    if (orderMemberIter != orderMembersIter->value.End())
+                    {
+                        newOrder.PushBack(orderMemberIter->Move(), domToAddEntityUnder.GetAllocator());
+                    }
+                    if (orderMemberIter == insertValuesAfter)
+                    {
+                        newOrder.PushBack(
+                            rapidjson::Value(entityToAddAlias.c_str(), domToAddEntityUnder.GetAllocator()),
+                            domToAddEntityUnder.GetAllocator());
+                    }
+                    if (orderMemberIter == orderMembersIter->value.End())
+                    {
+                        break;
+                    }
+                }
+
+                // Replace the order with our newly constructed one
+                orderMembersIter->value.Swap(newOrder);
+                break;
+            }
+        }
+
         void PrefabPublicHandler::DuplicateNestedEntitiesInInstance(Instance& commonOwningInstance,
             const AZStd::vector<AZ::Entity*>& entities, PrefabDom& domToAddDuplicatedEntitiesUnder,
             EntityIdList& duplicatedEntityIds, AZStd::unordered_map<EntityAlias, EntityAlias>& oldAliasToNewAliasMap)
@@ -1709,6 +1857,25 @@ namespace AzToolsFramework
                 // Create the new Entity DOM from parsing the JSON string
                 PrefabDom entityDomAfter(&domToAddDuplicatedEntitiesUnder.GetAllocator());
                 entityDomAfter.Parse(newEntityDomString.toUtf8().constData());
+
+                EntityAlias parentEntityAlias;
+                if (auto componentsIter = entityDomAfter.FindMember(PrefabDomUtils::ComponentsName);
+                    componentsIter != entityDomAfter.MemberEnd())
+                {
+                    for (auto componentIter = componentsIter->value.MemberBegin(); componentIter != componentIter->value.MemberEnd() && parentEntityAlias.empty();
+                         ++componentIter)
+                    {
+                        if (auto parentEntityIter = componentIter->value.FindMember("Parent Entity");
+                            parentEntityIter != componentIter->value.MemberEnd())
+                        {
+                            parentEntityAlias = parentEntityIter->value.GetString();
+                            break;
+                        }
+                    }
+                }
+
+                // Insert our entity into its parent's sort order
+                AddNewEntityToSortOrder(commonOwningInstance, domToAddDuplicatedEntitiesUnder, parentEntityAlias, newEntityAlias);
 
                 // Add the new Entity DOM to the Entities member of the instance
                 rapidjson::Value aliasName(newEntityAlias.c_str(), static_cast<rapidjson::SizeType>(newEntityAlias.length()), domToAddDuplicatedEntitiesUnder.GetAllocator());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1734,8 +1734,8 @@ namespace AzToolsFramework
                 return;
             }
 
-            // Get the list of selected entitie, we'll insert our duplicated entities after the last selected
-            // siblign in their parent's list, e.g. for:
+            // Get the list of selected entities, we'll insert our duplicated entities after the last selected
+            // sibling in their parent's list, e.g. for:
             // - Entity1
             // - Entity2 (selected)
             // - Entity3

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -709,8 +709,6 @@ namespace AzToolsFramework
                 bool isInstanceContainerEntity = IsInstanceContainerEntity(entityId) && !IsLevelInstanceContainerEntity(entityId);
                 bool isNewParentOwnedByDifferentInstance = false;
 
-                AzFramework::EntityContextId editorEntityContextId = AzToolsFramework::GetEntityContextId();
-
                 bool isInFocusTree = m_prefabFocusPublicInterface->IsOwningPrefabInFocusHierarchy(entityId);
                 bool isOwnedByFocusedPrefabInstance = m_prefabFocusPublicInterface->IsOwningPrefabBeingFocused(entityId);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1732,7 +1732,7 @@ namespace AzToolsFramework
                  ++componentIter)
             {
                 // Check the component type
-                auto typeFieldIter = componentIter->value.FindMember(PrefabDomUtils::TypeFieldName);
+                auto typeFieldIter = componentIter->value.FindMember(PrefabDomUtils::TypeName);
                 if (typeFieldIter == componentIter->value.MemberEnd())
                 {
                     continue;
@@ -1748,7 +1748,7 @@ namespace AzToolsFramework
                 }
 
                 // Check for the entity order field
-                auto orderMembersIter = componentIter->value.FindMember(PrefabDomUtils::EntityOrderFieldName);
+                auto orderMembersIter = componentIter->value.FindMember(PrefabDomUtils::EntityOrderName);
                 if (orderMembersIter == componentIter->value.MemberEnd() || !orderMembersIter->value.IsArray())
                 {
                     continue;
@@ -1865,6 +1865,23 @@ namespace AzToolsFramework
                     for (auto componentIter = componentsIter->value.MemberBegin(); componentIter != componentIter->value.MemberEnd() && parentEntityAlias.empty();
                          ++componentIter)
                     {
+                        // Check the component type
+                        auto typeFieldIter = componentIter->value.FindMember(PrefabDomUtils::TypeName);
+                        if (typeFieldIter == componentIter->value.MemberEnd())
+                        {
+                            continue;
+                        }
+
+                        AZ::JsonDeserializerSettings jsonDeserializerSettings;
+                        AZ::Uuid typeId = AZ::Uuid::CreateNull();
+                        AZ::JsonSerialization::LoadTypeId(typeId, typeFieldIter->value);
+
+                        // Prefabs get serialized with the Editor transform component type, check for that
+                        if (typeId != azrtti_typeid<Components::TransformComponent>())
+                        {
+                            continue;
+                        }
+
                         if (auto parentEntityIter = componentIter->value.FindMember("Parent Entity");
                             parentEntityIter != componentIter->value.MemberEnd())
                         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -78,6 +78,8 @@ namespace AzToolsFramework
 
             InstanceOptionalReference GetOwnerInstanceByEntityId(AZ::EntityId entityId) const;
             bool EntitiesBelongToSameInstance(const EntityIdList& entityIds) const;
+            void AddNewEntityToSortOrder(Instance& owningInstance, PrefabDom& domToAddEntityUnder,
+                const EntityAlias& parentEntityAlias, const EntityAlias& entityToAddAlias);
 
             /**
              * Duplicate a list of entities owned by a common owning instance by directly

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -1599,7 +1599,6 @@ namespace AzToolsFramework
         for (size_t entityIndex = 1; entityIndex < m_selectedEntityIds.size(); ++entityIndex)
         {
             entity = GetSelectedEntityById(m_selectedEntityIds[entityIndex]);
-            AZ_Assert(entity, "Entity id selected for display but no such entity exists");
             if (!entity)
             {
                 continue;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -147,6 +147,8 @@ set(FILES
     Entity/EditorEntitySortBus.h
     Entity/EditorEntitySortComponent.cpp
     Entity/EditorEntitySortComponent.h
+    Entity/EditorEntitySortComponentSerializer.cpp
+    Entity/EditorEntitySortComponentSerializer.h
     Entity/EditorEntityTransformBus.h
     Entity/PrefabEditorEntityOwnershipInterface.h
     Entity/PrefabEditorEntityOwnershipService.h


### PR DESCRIPTION
This change does a few things to address instability in entity order when prefabs are enabled:
- Changes ordering behavior on entity add to always be "insert after the last selected sibling of the new entity, or at the end if there is no selected sibling"
- Adds some logic to ensure selection stays frozen during prefab propagation to allow this behavior to be used
- Alters delta generation in `PrefabPublicHandler::CreateEntity` to use the template instead of reserializing the DOM - this avoids a whole bunch of patching issues caused by EditorEntitySortComponent doing post-hoc order fix-up and should generally be safer/faster as we're producing patches for the actual target for those patches
- Because the duplicate action is DOM-driven, and there's some thorniness around making changes that will affect the template during propagation, this adds `PrefabPublicHandler::AddNewEntityToSortOrder` to directly patch the DOM for the duplicate case

Two bits of this come from patches from the incredibly helpful @AMZN-daimini
- Alters `PrefabPublicHandler::GenerateUndoNodesForEntityChangeAndUpdateCache` behavior for determining what's an override: we now check to see if we're part of the current focused instance but *not* owned by the focus instance directly. This lets entity order for nested prefabs get saved to the owning prefab instead of as an override. I'm putting this up for discussion without a feature flag gating it, but we may wish to make this a toggle or disable it outright for stabilization (in which case entity order won't be saved to the owning prefab)
- Adds a custom serializer for EditorEntitySortComponent. This isn't strictly necessary now, but it was very useful for debugging and ended up receiving much more manual testing its migration path and save/load path more than I've tested without using the serializer.

General functionality demo, note that the newly duplicated instances don't always get selected - this is an unrelated bug:

![ordering1](https://user-images.githubusercontent.com/760096/142426227-8d2df518-5389-4bbf-ac16-7e7049a93b47.gif)

Prefab ordering demo:
![ordering2](https://user-images.githubusercontent.com/760096/142426387-1ff22681-98ba-4239-a828-89c25eb89f33.gif)

Signed-off-by: Nicholas Van Sickle <nvsickle@amazon.com>