### PR TITLE
Fix UI canvas save as start folder

### DIFF
--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -35,7 +35,6 @@
 #include <QUndoGroup>
 #include <QScrollBar>
 
-
 #define UICANVASEDITOR_SETTINGS_EDIT_MODE_STATE_KEY     (QString("Edit Mode State") + " " + FileHelpers::GetAbsoluteGameDir())
 #define UICANVASEDITOR_SETTINGS_EDIT_MODE_GEOM_KEY      (QString("Edit Mode Geometry") + " " + FileHelpers::GetAbsoluteGameDir())
 #define UICANVASEDITOR_SETTINGS_PREVIEW_MODE_STATE_KEY  (QString("Preview Mode State") + " " + FileHelpers::GetAbsoluteGameDir())

--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -8,6 +8,7 @@
 #include "EditorCommon.h"
 #include "CanvasHelpers.h"
 #include "AssetDropHelpers.h"
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/std/sort.h>
 #include <AzToolsFramework/API/EditorAssetSystemAPI.h>
@@ -34,8 +35,6 @@
 #include <QUndoGroup>
 #include <QScrollBar>
 
-#include <AzCore/base.h>
-#include <AzCore/IO/Path/Path.h>
 
 #define UICANVASEDITOR_SETTINGS_EDIT_MODE_STATE_KEY     (QString("Edit Mode State") + " " + FileHelpers::GetAbsoluteGameDir())
 #define UICANVASEDITOR_SETTINGS_EDIT_MODE_GEOM_KEY      (QString("Edit Mode Geometry") + " " + FileHelpers::GetAbsoluteGameDir())

--- a/Gems/LyShine/Code/Editor/EditorWindow.cpp
+++ b/Gems/LyShine/Code/Editor/EditorWindow.cpp
@@ -717,6 +717,7 @@ bool EditorWindow::SaveCanvasToXml(UiCanvasMetadata& canvasMetadata, bool forceA
         }
         // Append the default filename
         dirPath /= canvasMetadata.m_canvasDisplayName;
+        dir = QString(dirPath.c_str());
 
         QString filename = AzQtComponents::FileDialog::GetSaveFileName(nullptr,
             QString(),


### PR DESCRIPTION
When saving a UI Canvas from the UI Editor, the save as dialog behaves differently between Windows and Linux if the current Game Project does not have a 'UI' subfolder:

**Windows** The start in folder is the engine root
**Linux** The 'start in' folder is the computer root '/'

That is because the file dialog cannot use a folder that does not exist. This change will walk up the full path of the file until it (eventually) finds a valid folder, which should be the Game project folder at the very least. 
For Linux, this will reduce the chance of saving a UI Canvas outside of the game project folder

