### PR TITLE
Replace old Developer Preview release name with Stable 21.11

### DIFF
--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -3834,7 +3834,7 @@ void CCryEditApp::SetEditorWindowTitle(QString sTitleStr, QString sPreTitleStr, 
     {
         if (sTitleStr.isEmpty())
         {
-            sTitleStr = QObject::tr("O3DE Editor [Developer Preview]");
+            sTitleStr = QObject::tr("O3DE Editor [Stable 21.11]");
         }
 
         if (!sPreTitleStr.isEmpty())

--- a/cmake/Platform/Windows/Packaging/Bootstrapper.wxs
+++ b/cmake/Platform/Windows/Packaging/Bootstrapper.wxs
@@ -5,7 +5,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
     xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
 
-    <Bundle Name="$(var.CPACK_PACKAGE_NAME) [Developer Preview]"
+    <Bundle Name="$(var.CPACK_PACKAGE_NAME) [Stable 21.11]"
         Version="$(var.CPACK_PACKAGE_VERSION)"
         Manufacturer="$(var.CPACK_PACKAGE_VENDOR)"
         UpgradeCode="$(var.CPACK_BOOTSTRAP_UPGRADE_GUID)"

--- a/cmake/Platform/Windows/Packaging/Shortcuts.wxs
+++ b/cmake/Platform/Windows/Packaging/Shortcuts.wxs
@@ -7,7 +7,7 @@
 
         <DirectoryRef Id="TARGETDIR">
             <Directory Id="ProgramMenuFolder">
-                <Directory Id="ApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_NAME) [Developer Preview]">
+                <Directory Id="ApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_NAME) [Stable 21.11]">
                     <Directory Id="VersionedApplicationProgramsFolder" Name="$(var.CPACK_PACKAGE_VERSION)"/>
                 </Directory>
             </Directory>


### PR DESCRIPTION
Did a search&replace on "Developer Preview" in the solution and replaced with the "Stable 21.11" denomination.

![image](https://user-images.githubusercontent.com/82231674/142485784-942eee43-2b54-4bcf-b805-0f6490806507.png)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>