### PR TITLE
Extra gem download failure handling

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.h
@@ -53,6 +53,7 @@ namespace O3DE::ProjectManager
 
     public slots:
         void OnGemStatusChanged(const QString& gemName, uint32_t numChangedDependencies);
+        void OnDependencyGemStatusChanged(const QString& gemName);
         void OnAddGemClicked();
         void SelectGem(const QString& gemName);
         void OnGemDownloadResult(const QString& gemName, bool succeeded = true);

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -494,14 +494,9 @@ namespace O3DE::ProjectManager
             // we need to deactivate all gems that depend on this one
             for (auto dependentModelIndex : dependentGems)
             {
-                DeactivateDependentGems(model, dependentModelIndex);
+                SetIsAdded(model, dependentModelIndex, false);
             }
 
-        }
-        else
-        {
-            // Deactivate this gem
-            SetIsAdded(model, modelIndex, false);
         }
     }
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.cpp
@@ -357,6 +357,8 @@ namespace O3DE::ProjectManager
                     if (!IsAdded(dependency))
                     {
                         numChangedDependencies++;
+                        const QString dependencyName = gemModel->GetName(dependency);
+                        gemModel->emit dependencyGemStatusChanged(dependencyName);
                     }
                 }
             }
@@ -381,6 +383,8 @@ namespace O3DE::ProjectManager
                     if (!IsAdded(dependency))
                     {
                         numChangedDependencies++;
+                        const QString dependencyName = gemModel->GetName(dependency);
+                        gemModel->emit dependencyGemStatusChanged(dependencyName);
                     }
                 }
             }
@@ -477,6 +481,28 @@ namespace O3DE::ProjectManager
             added |= modelIndex.data(RoleIsAddedDependency).toBool();
         }
         return previouslyAdded && !added;
+    }
+
+    void GemModel::DeactivateDependentGems(QAbstractItemModel& model, const QModelIndex& modelIndex)
+    {
+        GemModel* gemModel = GetSourceModel(&model);
+        AZ_Assert(gemModel, "Failed to obtain GemModel");
+
+        QVector<QModelIndex> dependentGems = gemModel->GatherDependentGems(modelIndex);
+        if (!dependentGems.isEmpty())
+        {
+            // we need to deactivate all gems that depend on this one
+            for (auto dependentModelIndex : dependentGems)
+            {
+                DeactivateDependentGems(model, dependentModelIndex);
+            }
+
+        }
+        else
+        {
+            // Deactivate this gem
+            SetIsAdded(model, modelIndex, false);
+        }
     }
 
     void GemModel::SetDownloadStatus(QAbstractItemModel& model, const QModelIndex& modelIndex, GemInfo::DownloadStatus status)

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemModel.h
@@ -99,6 +99,7 @@ namespace O3DE::ProjectManager
         static bool NeedsToBeRemoved(const QModelIndex& modelIndex, bool includeDependencies = false);
         static bool HasRequirement(const QModelIndex& modelIndex);
         static void UpdateDependencies(QAbstractItemModel& model, const QString& gemName, bool isAdded);
+        static void DeactivateDependentGems(QAbstractItemModel& model, const QModelIndex& modelIndex);
         static void SetDownloadStatus(QAbstractItemModel& model, const QModelIndex& modelIndex, GemInfo::DownloadStatus status);
 
         bool DoGemsToBeAddedHaveRequirements() const;
@@ -113,6 +114,7 @@ namespace O3DE::ProjectManager
 
     signals:
         void gemStatusChanged(const QString& gemName, uint32_t numChangedDependencies);
+        void dependencyGemStatusChanged(const QString& gemName);
 
     protected slots: 
         void OnRowsAboutToBeRemoved(const QModelIndex& parent, int first, int last);


### PR DESCRIPTION
Deactivate a gem that fails to download, along with all gems that depend on it, and also for uninstalling a gem that has dependents
Download dependency gems automatically.
Allow re-attempting a download that fails.

Signed-off-by: AMZN-Phil <pconroy@amazon.com>