### PR TITLE
CMake Xcode Generator fix

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Archive/ArchiveVars.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Archive/ArchiveVars.cpp
@@ -13,10 +13,12 @@ namespace AZ::IO
 {
     FileSearchPriority GetDefaultFileSearchPriority()
     {
-#if defined(LY_ARCHIVE_FILE_SEARCH_MODE_DEFAULT)
-        return FileSearchPriority{ LY_ARCHIVE_FILE_SEARCH_MODE_DEFAULT };
+#if defined(LY_ARCHIVE_FILE_SEARCH_MODE)
+        return FileSearchPriority{ LY_ARCHIVE_FILE_SEARCH_MODE };
 #else
-        return FileSearchPriority{};
+        return FileSearchPriority{ !ArchiveVars::IsReleaseConfig
+            ? FileSearchPriority::FileFirst
+            : FileSearchPriority::PakOnly };
 #endif
     }
 }

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -79,6 +79,7 @@ set(FILES
     CommandLine/CommandLine.h
     CommandLine/CommandRegistrationBus.h
     Debug/DebugCameraBus.h
+    feature_options.cmake
     Viewport/ViewportBus.h
     Viewport/ViewportBus.cpp
     Viewport/ViewportColors.h

--- a/Code/Framework/AzFramework/AzFramework/feature_options.cmake
+++ b/Code/Framework/AzFramework/AzFramework/feature_options.cmake
@@ -1,0 +1,13 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(LY_ARCHIVE_FILE_SEARCH_MODE "" CACHE STRING "Set the default file search mode to locate non-Pak files within the Archive System\n\
+    Valid values are:\n\
+    0 = Search FileSystem first, before searching within mounted Paks (default in debug/profile)\n\
+    1 = Search mounted Paks first, before searching FileSystem\n\
+    2 = Search only mounted Paks (default in release)\n")

--- a/Code/Framework/AzFramework/CMakeLists.txt
+++ b/Code/Framework/AzFramework/CMakeLists.txt
@@ -6,6 +6,8 @@
 #
 #
 
+include(AzFramework/feature_options.cmake)
+
 ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME})
 ly_get_list_relative_pal_filename(common_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/Common)
 
@@ -32,7 +34,7 @@ ly_add_target(
             3rdParty::lz4
 )
 
-set(LY_SEARCH_MODE_DEFINE $<$<NOT:$<STREQUAL:"${LY_ARCHIVE_FILE_SEARCH_MODE}","">>:LY_ARCHIVE_FILE_SEARCH_MODE_DEFAULT=${LY_ARCHIVE_FILE_SEARCH_MODE}>)
+set(LY_SEARCH_MODE_DEFINE $<$<BOOL:"${LY_ARCHIVE_FILE_SEARCH_MODE}">:LY_ARCHIVE_FILE_SEARCH_MODE=${LY_ARCHIVE_FILE_SEARCH_MODE}>)
 
 ly_add_source_properties(
     SOURCES

--- a/cmake/Deployment.cmake
+++ b/cmake/Deployment.cmake
@@ -10,8 +10,3 @@
 
 set(LY_ASSET_DEPLOY_MODE "LOOSE" CACHE STRING "Set the Asset deployment when deploying to the target platform (LOOSE, PAK, VFS)")
 set(LY_ASSET_OVERRIDE_PAK_FOLDER_ROOT "" CACHE STRING "Optional root path to where Pak file folders are stored. By default, blank will use a predefined 'paks' root.")
-set(LY_ARCHIVE_FILE_SEARCH_MODE "$<$<CONFIG:release>:2>" CACHE STRING "Set the default file search mode to locate non-Pak files within the Archive System\n\
-    Valid values are:\n\
-    0 = Search FileSystem first, before searching within mounted Paks\n\
-    1 = Search mounted Paks first, before searching FileSystem\n\
-    2 = Search only mounted Paks(default in release)\n")


### PR DESCRIPTION
Removed the generator expression from the `LY_ARCHIVE_FILE_SEARCH_MODE` define as Xcode doesn't support per-config per-file definitions.

Updated the #else block in ArchiveVars to default to PakOnly mode if the `LY_ARCHIVE_FILE_SEARCH_MODE` define isn't set.

Moved the the `LY_ARCHIVE_FILE_SEARCH_MODE` Cache Variable from cmake/Deployment.cmake to feature_options.cmake within the AzFramework folder.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>