### PR TITLE
ATOM-16854 Texture Settings dialog box crashes in the Editor

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.cpp
@@ -146,6 +146,25 @@ namespace ImageProcessingAtom
         return nullptr;
     }
 
+    AZStd::vector<AZStd::string> BuilderSettingManager::GetFileMasksForPreset(const PresetName& presetName) const
+    {
+        AZStd::vector<AZStd::string> fileMasks;
+        
+        AZStd::lock_guard<AZStd::recursive_mutex> lock(m_presetMapLock);
+        for (const auto& mapping:m_presetFilterMap)
+        {
+            for (const auto& preset : mapping.second)
+            {
+                if (preset == presetName)
+                {
+                    fileMasks.push_back(mapping.first);
+                    break;
+                }
+            }
+        }
+        return fileMasks;
+    }
+
     const BuilderSettings* BuilderSettingManager::GetBuilderSetting(const PlatformName& platform) const
     {
         auto itr = m_builderSettings.find(platform);
@@ -175,6 +194,13 @@ namespace ImageProcessingAtom
     {
         AZStd::lock_guard<AZStd::recursive_mutex> lock(m_presetMapLock);
         return m_presetFilterMap;
+    }
+
+    const AZStd::unordered_set<PresetName>& BuilderSettingManager::GetFullPresetList() const
+    {
+        AZStd::lock_guard<AZStd::recursive_mutex> lock(m_presetMapLock);
+        AZStd::string noFilter = AZStd::string();
+        return m_presetFilterMap.find(noFilter)->second;
     }
 
     const PresetName BuilderSettingManager::GetPresetNameFromId(const AZ::Uuid& presetId)

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/BuilderSettingManager.h
@@ -57,6 +57,8 @@ namespace ImageProcessingAtom
         
         const PresetSettings* GetPreset(const PresetName& presetName, const PlatformName& platform = "", AZStd::string_view* settingsFilePathOut = nullptr) const;
 
+        AZStd::vector<AZStd::string> GetFileMasksForPreset(const PresetName& presetName) const;
+
         const BuilderSettings* GetBuilderSetting(const PlatformName& platform) const;
                 
         //! Return A list of platform supported
@@ -66,6 +68,8 @@ namespace ImageProcessingAtom
         //!      @key filemask string, empty string means no filemask
         //!      @value set of preset setting names supporting the specified filemask
         const AZStd::map<FileMask, AZStd::unordered_set<PresetName>>& GetPresetFilterMap() const;
+
+        const AZStd::unordered_set<PresetName>& GetFullPresetList() const;
 
         //! Find preset name based on the preset id.
         const PresetName GetPresetNameFromId(const AZ::Uuid& presetId);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/CubemapSettings.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/CubemapSettings.h
@@ -26,19 +26,19 @@ namespace ImageProcessingAtom
         static void Reflect(AZ::ReflectContext* context);
 
         // "cm_ftype", cubemap angular filter type: gaussian, cone, disc, cosine, cosine_power, ggx
-        CubemapFilterType m_filter;
+        CubemapFilterType m_filter = CubemapFilterType::ggx;
 
         // "cm_fangle", base filter angle for cubemap filtering(degrees), 0 - disabled
-        float m_angle;
+        float m_angle = 0;
 
         // "cm_fmipangle", initial mip filter angle for cubemap filtering(degrees), 0 - disabled
-        float m_mipAngle;
+        float m_mipAngle = 0;
 
         // "cm_fmipslope", mip filter angle multiplier for cubemap filtering, 1 - default"
-        float m_mipSlope;
+        float m_mipSlope = 1;
 
         // "cm_edgefixup", cubemap edge fix-up width, 0 - disabled
-        float m_edgeFixup;
+        float m_edgeFixup = 0;
 
         // generate an IBL specular cubemap
         bool m_generateIBLSpecular = false;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/ImageProcessingDefines.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/ImageProcessingDefines.h
@@ -39,7 +39,8 @@ namespace ImageProcessingAtom
 #define STRING_OUTCOME_ERROR(error) AZ::Failure(AZStd::string(error))
 
     // Common typedefs (with dependent forward-declarations)
-    typedef AZStd::string PlatformName, FileMask;
+    typedef AZStd::string PlatformName;
+    typedef AZStd::string FileMask;
     typedef AZ::Name PresetName;
     typedef AZStd::vector<PlatformName> PlatformNameVector;
     typedef AZStd::list<PlatformName> PlatformNameList;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/EditorCommon.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Editor/EditorCommon.cpp
@@ -257,15 +257,22 @@ namespace ImageProcessingAtomEditor
             // Update input width and height if it's a cubemap
             if (presetSetting->m_cubemapSetting != nullptr)
             {
-                CubemapLayout *srcCubemap = CubemapLayout::CreateCubemapLayout(m_img);
-                if (srcCubemap == nullptr)
+                if (IsValidLatLongMap(m_img))
                 {
-                    return false;
+                    inputWidth = inputWidth/4;
                 }
-                inputWidth = srcCubemap->GetFaceSize();
+                else
+                {
+                    CubemapLayout *srcCubemap = CubemapLayout::CreateCubemapLayout(m_img);
+                    if (srcCubemap == nullptr)
+                    {
+                        return false;
+                    }
+                    inputWidth = srcCubemap->GetFaceSize();
+                    delete srcCubemap;
+                }
                 inputHeight = inputWidth;
                 outResolutionInfo.arrayCount = 6;
-                delete srcCubemap;
             }
 
             GetOutputExtent(inputWidth, inputHeight, outResolutionInfo.width, outResolutionInfo.height, outResolutionInfo.reduce, &textureSetting, presetSetting);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.h
@@ -51,9 +51,6 @@ namespace ImageProcessingAtom
     //Converts the image to a RGBA8 format that can be displayed in a preview UI.
     IImageObjectPtr ConvertImageForPreview(IImageObjectPtr image);
 
-    //Combine image with alpha image if any and output as RGBA8
-    IImageObjectPtr MergeOutputImageForPreview(IImageObjectPtr image, IImageObjectPtr alphaImage);
-
     //get output image size and mip count based on the texture setting and preset setting
 
     //other helper functions

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvertJob.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvertJob.cpp
@@ -16,28 +16,14 @@
 
 namespace ImageProcessingAtom
 {
-    IImageObjectPtr ImageConvertOutput::GetOutputImage(OutputImageType type) const
+    IImageObjectPtr ImageConvertOutput::GetOutputImage() const
     {
-        if (type < OutputImageType::Count)
-        {
-            return m_outputImage[static_cast<int>(type)];
-        }
-        else
-        {
-            return IImageObjectPtr();
-        }
+        return m_outputImage;
     }
 
-    void ImageConvertOutput::SetOutputImage(IImageObjectPtr image, OutputImageType type)
+    void ImageConvertOutput::SetOutputImage(IImageObjectPtr image)
     {
-        if (type < OutputImageType::Count)
-        {
-            m_outputImage[static_cast<int>(type)] = image;
-        }
-        else
-        {
-            AZ_Error("ImageProcess", false, "Cannot set output image to %d", type);
-        }
+        m_outputImage = image;
     }
 
     void ImageConvertOutput::SetReady(bool ready)
@@ -62,10 +48,7 @@ namespace ImageProcessingAtom
 
     void ImageConvertOutput::Reset()
     {
-        for (int i = 0; i < static_cast<int>(OutputImageType::Count); i++)
-        {
-            m_outputImage[i] = nullptr;
-        }
+        m_outputImage = nullptr;
         m_outputReady = false;
         m_progress = 0.0f;
     }
@@ -109,13 +92,12 @@ namespace ImageProcessingAtom
 
         IImageObjectPtr outputImage = m_process->GetOutputImage();
 
-        m_output->SetOutputImage(outputImage, ImageConvertOutput::Base);
-
         if (!IsJobCancelled())
         {
-            // For preview, combine image output with alpha if any
+            // convert the output image to RGBA format for preview
             m_output->SetProgress(1.0f / static_cast<float>(m_previewProcessStep));
-            m_output->SetOutputImage(outputImage, ImageConvertOutput::Preview);
+            IImageObjectPtr uncompressedImage = ConvertImageForPreview(outputImage);
+            m_output->SetOutputImage(uncompressedImage);
         }
 
         m_output->SetReady(true);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvertJob.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvertJob.h
@@ -21,16 +21,8 @@ namespace ImageProcessingAtom
     class ImageConvertOutput
     {
     public:
-        enum OutputImageType
-        {
-            Base = 0,   // Might contains alpha or not
-            Alpha,      // Separate alpha image
-            Preview,    // Combine base image with alpha if any, format RGBA8
-            Count
-        };
-
-        IImageObjectPtr GetOutputImage(OutputImageType type) const;
-        void SetOutputImage(IImageObjectPtr image, OutputImageType type);
+        IImageObjectPtr GetOutputImage() const;
+        void SetOutputImage(IImageObjectPtr image);
         void SetReady(bool ready);
         bool IsReady() const;
         float GetProgress() const;
@@ -38,7 +30,7 @@ namespace ImageProcessingAtom
         void Reset();
 
     private:
-        IImageObjectPtr m_outputImage[OutputImageType::Count];
+        IImageObjectPtr m_outputImage;
         bool m_outputReady = false;
         float m_progress = 0.0f;
     };

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImagePreview.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImagePreview.cpp
@@ -86,7 +86,7 @@ namespace ImageProcessingAtom
 
     IImageObjectPtr ImagePreview::GetOutputImage()
     {
-        return m_output.GetOutputImage(ImageConvertOutput::Preview);
+        return m_output.GetOutputImage();
     }
 
     ImagePreview::~ImagePreview()


### PR DESCRIPTION
Changes include:
-Fixed image preview issue which was trying to convert a compressed texture directly to QImage.
-Fixed texture resolution display for cubemap in texture setting editor.
-Sort the preset names in preset combo box
-Fixed a crash when showing IBLSkybox preset info in texture setting editor

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>