### PR TITLE
LYN-3447 | Navigation Components are unusable due to missing Agent Types

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Ai/EditorNavigationAreaComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Ai/EditorNavigationAreaComponent.cpp
@@ -47,6 +47,7 @@ namespace LmbrCentral
             {
                 editContext->Class<EditorNavigationAreaComponent>("Navigation Area", "Navigation Area configuration")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AddableByUser, false)
                         ->Attribute(AZ::Edit::Attributes::Category, "AI")
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/NavigationArea.svg")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/NavigationArea.svg")

--- a/Gems/LmbrCentral/Code/Source/Ai/EditorNavigationSeedComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Ai/EditorNavigationSeedComponent.cpp
@@ -32,6 +32,7 @@ namespace LmbrCentral
                 editContext->Class<EditorNavigationSeedComponent>("Navigation Seed", "Determines reachable navigation nodes")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game", 0x232b318c))
+                        ->Attribute(AZ::Edit::Attributes::AddableByUser, false)
                         ->Attribute(AZ::Edit::Attributes::Category, "AI")
                         ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/NavigationSeed.svg")
                         ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/NavigationSeed.svg")

--- a/Gems/LmbrCentral/Code/Source/Ai/NavigationComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Ai/NavigationComponent.cpp
@@ -120,6 +120,7 @@ namespace LmbrCentral
                 editContext->Class<NavigationComponent>(
                     "Navigation", "The Navigation component provides basic pathfinding and pathfollowing services to an entity")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::AddableByUser, false)
                     ->Attribute(AZ::Edit::Attributes::Category, "AI")
                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/Navigation.svg")
                     ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/Navigation.svg")


### PR DESCRIPTION
Removing the AI navigation components from the Add Component menu in the Entity Inspector.
Note that the components are still registered, so levels using them before this change will still work as expected. This is just the least intrusive fix we can have before release, so we can start redcoding the components appropriately in development soon.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>