### PR TITLE
Fix oversight from recent change to PrefabFocusHandler internals.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -212,9 +212,17 @@ namespace AzToolsFramework::Prefab
 
     AZ::EntityId PrefabFocusHandler::GetFocusedPrefabContainerEntityId([[maybe_unused]] AzFramework::EntityContextId entityContextId) const
     {
-        return (m_focusedInstanceContainerEntityId.IsValid()
-            ? m_focusedInstanceContainerEntityId
-            : GetReferenceFromContainerEntityId(m_focusedInstanceContainerEntityId)->get().GetContainerEntityId());
+        if (m_focusedInstanceContainerEntityId.IsValid())
+        {
+            return m_focusedInstanceContainerEntityId;
+        }
+
+        if (auto instance = GetReferenceFromContainerEntityId(m_focusedInstanceContainerEntityId); instance.has_value())
+        {
+            return instance->get().GetContainerEntityId();
+        }
+
+        return AZ::EntityId();
     }
 
     bool PrefabFocusHandler::IsOwningPrefabBeingFocused(AZ::EntityId entityId) const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -212,7 +212,9 @@ namespace AzToolsFramework::Prefab
 
     AZ::EntityId PrefabFocusHandler::GetFocusedPrefabContainerEntityId([[maybe_unused]] AzFramework::EntityContextId entityContextId) const
     {
-        return m_focusedInstanceContainerEntityId;
+        return (m_focusedInstanceContainerEntityId.IsValid()
+            ? m_focusedInstanceContainerEntityId
+            : GetReferenceFromContainerEntityId(m_focusedInstanceContainerEntityId)->get().GetContainerEntityId());
     }
 
     bool PrefabFocusHandler::IsOwningPrefabBeingFocused(AZ::EntityId entityId) const


### PR DESCRIPTION
This is a regression introduced by https://github.com/o3de/o3de/pull/5762
The unit test that should have caught this was failing for unrelated reasons (unit tests don't use the Prefab EOS, but we rely on it in PrefabFocusHandler now). As such, this went unnoticed during testing yesterday.

This now fixes all checks that make sure to remove the level container from invalid operations (detach, delete).
Thanks @LB-BartoszDudzinski and @LB-KacperKapusta for picking up on the regression!

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>