### PR TITLE
Add trait to enable/disable the Resource Mapping Tool

### DIFF
--- a/Gems/AWSCore/Code/CMakeLists.txt
+++ b/Gems/AWSCore/Code/CMakeLists.txt
@@ -60,6 +60,9 @@ ly_create_alias(
 )
 
 if (PAL_TRAIT_BUILD_HOST_TOOLS)
+
+    include(${CMAKE_CURRENT_SOURCE_DIR}/Platform/${PAL_PLATFORM_NAME}/PAL_traits_editor_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
+
     ly_add_target(
         NAME AWSCore.Editor.Static STATIC
         NAMESPACE Gem
@@ -97,25 +100,29 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::AWSCore.Editor.Static
     )
 
-    # This target is not a real gem module
-    # It is not meant to be loaded by the ModuleManager in C++
-    ly_add_target(
-        NAME AWSCore.ResourceMappingTool MODULE
-        NAMESPACE Gem
-        OUTPUT_SUBDIRECTORY AWSCoreEditorQtBin
-        FILES_CMAKE
-            awscore_resourcemappingtool_files.cmake
-        INCLUDE_DIRECTORIES
-            PRIVATE
-                Include/Private
-        BUILD_DEPENDENCIES
-            PRIVATE
-                Gem::AWSCore.Editor.Static
-        RUNTIME_DEPENDENCIES
-            3rdParty::pyside2
+    if (PAL_TRAIT_ENABLE_RESOURCE_MAPPING_TOOL)
 
-    )
-    ly_add_dependencies(AWSCore.Editor AWSCore.ResourceMappingTool)
+        # This target is not a real gem module
+        # It is not meant to be loaded by the ModuleManager in C++
+        ly_add_target(
+            NAME AWSCore.ResourceMappingTool MODULE
+            NAMESPACE Gem
+            OUTPUT_SUBDIRECTORY AWSCoreEditorQtBin
+            FILES_CMAKE
+                awscore_resourcemappingtool_files.cmake
+            INCLUDE_DIRECTORIES
+                PRIVATE
+                    Include/Private
+            BUILD_DEPENDENCIES
+                PRIVATE
+                    Gem::AWSCore.Editor.Static
+            RUNTIME_DEPENDENCIES
+                3rdParty::pyside2
+
+        )
+        ly_add_dependencies(AWSCore.Editor AWSCore.ResourceMappingTool)
+        
+    endif()
 
     # Builders and Tools (such as the Editor use AWSCore.Editor) use the .Editor module above.
     ly_create_alias(

--- a/Gems/AWSCore/Code/CMakeLists.txt
+++ b/Gems/AWSCore/Code/CMakeLists.txt
@@ -121,6 +121,8 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
 
         )
         ly_add_dependencies(AWSCore.Editor AWSCore.ResourceMappingTool)
+
+        ly_install_directory(DIRECTORIES Tools/ResourceMappingTool)
         
     endif()
 
@@ -199,4 +201,3 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     endif()
 endif()
 
-ly_install_directory(DIRECTORIES Tools/ResourceMappingTool)

--- a/Gems/AWSCore/Code/Platform/Linux/PAL_traits_editor_linux.cmake
+++ b/Gems/AWSCore/Code/Platform/Linux/PAL_traits_editor_linux.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_ENABLE_RESOURCE_MAPPING_TOOL TRUE)

--- a/Gems/AWSCore/Code/Platform/Mac/PAL_traits_editor_mac.cmake
+++ b/Gems/AWSCore/Code/Platform/Mac/PAL_traits_editor_mac.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_ENABLE_RESOURCE_MAPPING_TOOL FALSE)

--- a/Gems/AWSCore/Code/Platform/Windows/PAL_traits_editor_windows.cmake
+++ b/Gems/AWSCore/Code/Platform/Windows/PAL_traits_editor_windows.cmake
@@ -1,0 +1,9 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(PAL_TRAIT_ENABLE_RESOURCE_MAPPING_TOOL TRUE)


### PR DESCRIPTION
When the AWS Resource Mapping Tool was enabled for Linux, it pulled in the dependency for Pyside2 (required for the python script to work). However, Pyside2 is not supported (yet) for Mac, so we need a trait to completely skip buildint the ResourceMappingTool target on Mac

Signed-off-by: spham <82231385+spham-amzn@users.noreply.github.com>