### PR TITLE
Fix Project Manager not finding CMake on Windows

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectBuilderWorker_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectBuilderWorker_linux.cpp
@@ -19,7 +19,7 @@ namespace O3DE::ProjectManager
     {
         // Attempt to use the Ninja build system if it is installed (described in the o3de documentation) if possible,
         // otherwise default to the the default for Linux (Unix Makefiles)
-        auto    whichNinjaResult = ProjectUtils::ExecuteCommandResult("which", QStringList{"ninja"}, QProcessEnvironment::systemEnvironment());
+        auto    whichNinjaResult = ProjectUtils::ExecuteCommandResult("which", QStringList{"ninja"});
         QString cmakeGenerator = (whichNinjaResult.IsSuccess()) ? "Ninja Multi-Config" : "Unix Makefiles";
         bool    compileProfileOnBuild = (whichNinjaResult.IsSuccess());
 
@@ -38,7 +38,7 @@ namespace O3DE::ProjectManager
 
     AZ::Outcome<QStringList, QString> ProjectBuilderWorker::ConstructCmakeBuildCommandArguments() const
     {
-        auto    whichNinjaResult = ProjectUtils::ExecuteCommandResult("which", QStringList{"ninja"}, QProcessEnvironment::systemEnvironment());
+        auto    whichNinjaResult = ProjectUtils::ExecuteCommandResult("which", QStringList{"ninja"});
         bool    compileProfileOnBuild = (whichNinjaResult.IsSuccess());
         QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
         QString launcherTargetName = m_projectInfo.m_projectName + ".GameLauncher";

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -19,10 +19,9 @@ namespace O3DE::ProjectManager
         // The list of clang C/C++ compiler command lines to validate on the host Linux system
         const QStringList SupportedClangVersions = {"13", "12", "11", "10", "9", "8", "7", "6.0"};
 
-        AZ::Outcome<QProcessEnvironment, QString> GetCommandLineProcessEnvironment()
+        AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment()
         {
-            QProcessEnvironment currentEnvironment(QProcessEnvironment::systemEnvironment());
-            return AZ::Success(currentEnvironment);
+            return AZ::Success();
         }
 
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform()

--- a/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
+++ b/Code/Tools/ProjectManager/Platform/Linux/ProjectUtils_linux.cpp
@@ -27,7 +27,7 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform()
         {
             // Validate that cmake is installed and is in the command line
-            auto whichCMakeResult = ProjectUtils::ExecuteCommandResult("which", QStringList{ProjectCMakeCommand}, QProcessEnvironment::systemEnvironment());
+            auto whichCMakeResult = ProjectUtils::ExecuteCommandResult("which", QStringList{ProjectCMakeCommand});
             if (!whichCMakeResult.IsSuccess())
             {
                 return AZ::Failure(QObject::tr("CMake not found. <br><br>"
@@ -38,8 +38,8 @@ namespace O3DE::ProjectManager
             // Look for the first compatible version of clang. The list below will contain the known clang compilers that have been tested for O3DE.
             for (const QString& supportClangVersion : SupportedClangVersions)
             {
-                auto whichClangResult = ProjectUtils::ExecuteCommandResult("which", QStringList{QString("clang-%1").arg(supportClangVersion)}, QProcessEnvironment::systemEnvironment());
-                auto whichClangPPResult = ProjectUtils::ExecuteCommandResult("which", QStringList{QString("clang++-%1").arg(supportClangVersion)}, QProcessEnvironment::systemEnvironment());
+                auto whichClangResult = ProjectUtils::ExecuteCommandResult("which", QStringList{QString("clang-%1").arg(supportClangVersion)});
+                auto whichClangPPResult = ProjectUtils::ExecuteCommandResult("which", QStringList{QString("clang++-%1").arg(supportClangVersion)});
                 if (whichClangResult.IsSuccess() && whichClangPPResult.IsSuccess())
                 {
                     return AZ::Success(QString("clang-%1").arg(supportClangVersion));
@@ -53,7 +53,7 @@ namespace O3DE::ProjectManager
 
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)
         {
-            AZ::Outcome processEnvResult = GetCommandLineProcessEnvironment();
+            AZ::Outcome processEnvResult = SetupCommandLineProcessEnvironment();
             if (!processEnvResult.IsSuccess())
             {
                 return AZ::Failure(processEnvResult.GetError());
@@ -67,7 +67,6 @@ namespace O3DE::ProjectManager
             }
 
             QProcess process;
-            process.setProcessEnvironment(processEnvResult.GetValue());
 
             // if the project build path is relative, it should be relative to the project path 
             process.setWorkingDirectory(projectPath);
@@ -87,7 +86,6 @@ namespace O3DE::ProjectManager
             return ExecuteCommandResultModalDialog(
                 QString("%1/python/get_python.sh").arg(engineRoot),
                 {},
-                QProcessEnvironment::systemEnvironment(),
                 QObject::tr("Running get_python script..."));
         }
 

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectBuilderWorker_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectBuilderWorker_mac.cpp
@@ -19,16 +19,14 @@ namespace O3DE::ProjectManager
     {
         AZ::Outcome<QString, QString> QueryInstalledCmakeFullPath()
         {
-            auto environmentRequest = ProjectUtils::GetCommandLineProcessEnvironment();
+            auto environmentRequest = ProjectUtils::SetupCommandLineProcessEnvironment();
             if (!environmentRequest.IsSuccess())
             {
                 return AZ::Failure(environmentRequest.GetError());
             }
-            auto currentEnvironment = environmentRequest.GetValue();
 
             auto queryCmakeInstalled = ProjectUtils::ExecuteCommandResult("which",
-                                                                          QStringList{ProjectCMakeCommand}, 
-                                                                          currentEnvironment);
+                                                                          QStringList{ProjectCMakeCommand});
             if (!queryCmakeInstalled.IsSuccess())
             {
                 return AZ::Failure(QObject::tr("Unable to detect CMake on this host."));

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -25,7 +25,8 @@ namespace O3DE::ProjectManager
             // Add that path for the command line process so that it will be able to locate
             // a home-brew installed version of CMake
             QString pathEnv = qEnvironmentVariable("PATH");
-            if (!pathEnv.contains("/usr/local/bin"))
+            QStringList pathEnvList = pathEnv.split(":");
+            if (!pathEnvList.contains("/usr/local/bin"))
             {
                 pathEnv += ":/usr/local/bin";
                 qputenv("PATH", pathEnv.toStdString().c_str());

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -18,17 +18,20 @@ namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
-        AZ::Outcome<QProcessEnvironment, QString> GetCommandLineProcessEnvironment()
+        AZ::Outcome<void, QString> GetCommandLineProcessEnvironment()
         {
             // For CMake on Mac, if its installed through home-brew, then it will be installed
             // under /usr/local/bin, which may not be in the system PATH environment. 
             // Add that path for the command line process so that it will be able to locate
             // a home-brew installed version of CMake
-            QProcessEnvironment currentEnvironment(QProcessEnvironment::systemEnvironment());
-            QString pathValue = currentEnvironment.value("PATH");
-            pathValue += ":/usr/local/bin";
-            currentEnvironment.insert("PATH", pathValue);
-            return AZ::Success(currentEnvironment);
+            QString pathEnv = qEnvironmentVariable("PATH");
+            if (!pathEnv.contains("/usr/local/bin"))
+            {
+                pathEnv += ":/usr/local/bin";
+                qputenv("PATH", pathEnv.toStdString().c_str());
+            }
+
+            return AZ::Success();
         }
 
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform()

--- a/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
+++ b/Code/Tools/ProjectManager/Platform/Mac/ProjectUtils_mac.cpp
@@ -29,7 +29,10 @@ namespace O3DE::ProjectManager
             if (!pathEnvList.contains("/usr/local/bin"))
             {
                 pathEnv += ":/usr/local/bin";
-                qputenv("PATH", pathEnv.toStdString().c_str());
+                if (!qputenv("PATH", pathEnv.toStdString().c_str()))
+                {
+                    return AZ::Failure(QObject::tr("Failed to set PATH environment variable"));
+                }
             }
 
             return AZ::Success();

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -41,7 +41,10 @@ namespace O3DE::ProjectManager
             if (!pathEnvList.contains(cmakePath.path()))
             {
                 pathEnv += ";" + cmakePath.path();
-                qputenv("Path", pathEnv.toStdString().c_str());
+                if (!qputenv("Path", pathEnv.toStdString().c_str()))
+                {
+                    return AZ::Failure(QObject::tr("Failed to set Path environment variable"));
+                }
             }
 
             return AZ::Success();

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -37,7 +37,8 @@ namespace O3DE::ProjectManager
             QDir cmakePath(engineInfo.m_path);
             cmakePath.cd("cmake/runtime/bin");
             QString pathEnv = qEnvironmentVariable("Path");
-            if (!pathEnv.contains(cmakePath.path()))
+            QStringList pathEnvList = pathEnv.split(";");
+            if (!pathEnvList.contains(cmakePath.path()))
             {
                 pathEnv += ";" + cmakePath.path();
                 qputenv("Path", pathEnv.toStdString().c_str());

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -21,7 +21,7 @@ namespace O3DE::ProjectManager
 {
     namespace ProjectUtils
     {
-        AZ::Outcome<QProcessEnvironment, QString> GetCommandLineProcessEnvironment()
+        AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment()
         {
             // Use the engine path to insert a path for cmake
             auto engineInfoResult = PythonBindingsInterface::Get()->GetEngineInfo();
@@ -31,26 +31,30 @@ namespace O3DE::ProjectManager
             }
             auto engineInfo = engineInfoResult.GetValue();
 
-            QProcessEnvironment currentEnvironment(QProcessEnvironment::systemEnvironment());
-
-            // Append cmake path to PATH incase it is missing
+            // Append cmake path to the current environment PATH incase it is missing, since if
+            // we are starting CMake itself the current application needs to find it using Path
+            // This also takes affect for all child processes.
             QDir cmakePath(engineInfo.m_path);
             cmakePath.cd("cmake/runtime/bin");
-            QString pathValue = currentEnvironment.value("PATH");
-            pathValue += ";" + cmakePath.path();
-            currentEnvironment.insert("PATH", pathValue);
-            return AZ::Success(currentEnvironment);
+            QString pathEnv = qEnvironmentVariable("Path");
+            if (!pathEnv.contains(cmakePath.path()))
+            {
+                pathEnv += ";" + cmakePath.path();
+                qputenv("Path", pathEnv.toStdString().c_str());
+            }
+
+            return AZ::Success();
         }
 
         AZ::Outcome<QString, QString> FindSupportedCompilerForPlatform()
         {
             // Validate that cmake is installed 
-            auto cmakeProcessEnvResult = GetCommandLineProcessEnvironment();
+            auto cmakeProcessEnvResult = SetupCommandLineProcessEnvironment();
             if (!cmakeProcessEnvResult.IsSuccess())
             {
                 return AZ::Failure(cmakeProcessEnvResult.GetError());
             }
-            auto cmakeVersionQueryResult = ExecuteCommandResult("cmake", QStringList{"--version"}, cmakeProcessEnvResult.GetValue());
+            auto cmakeVersionQueryResult = ExecuteCommandResult("cmake", QStringList{"--version"});
             if (!cmakeVersionQueryResult.IsSuccess())
             {
                 return AZ::Failure(QObject::tr("CMake not found. \n\n"
@@ -104,7 +108,7 @@ namespace O3DE::ProjectManager
         
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)
         {
-            AZ::Outcome processEnvResult = GetCommandLineProcessEnvironment();
+            AZ::Outcome processEnvResult = SetupCommandLineProcessEnvironment();
             if (!processEnvResult.IsSuccess())
             {
                 return AZ::Failure(processEnvResult.GetError());
@@ -118,7 +122,6 @@ namespace O3DE::ProjectManager
             }
 
             QProcess process;
-            process.setProcessEnvironment(processEnvResult.GetValue());
 
             // if the project build path is relative, it should be relative to the project path 
             process.setWorkingDirectory(projectPath);
@@ -139,7 +142,6 @@ namespace O3DE::ProjectManager
             return ExecuteCommandResultModalDialog(
                 "cmd.exe",
                 QStringList{"/c", batPath},
-                QProcessEnvironment::systemEnvironment(),
                 QObject::tr("Running get_python script..."));
         }
 
@@ -157,7 +159,7 @@ namespace O3DE::ProjectManager
                     .arg(shortcutPath)
                     .arg(targetPath)
                     .arg(arguments.join(' '));
-            auto createShortcutResult = ExecuteCommandResult(cmd, QStringList{"-Command", arg}, QProcessEnvironment::systemEnvironment());
+            auto createShortcutResult = ExecuteCommandResult(cmd, QStringList{"-Command", arg});
             if (!createShortcutResult.IsSuccess())
             {
                 return AZ::Failure(QObject::tr("Failed to create desktop shortcut %1 <br><br>"

--- a/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectBuilderWorker.cpp
@@ -117,18 +117,16 @@ namespace O3DE::ProjectManager
         // Show some kind of progress with very approximate estimates
         UpdateProgress(++m_progressEstimate);
 
-        auto currentEnvironmentRequest = ProjectUtils::GetCommandLineProcessEnvironment();
+        auto currentEnvironmentRequest = ProjectUtils::SetupCommandLineProcessEnvironment();
         if (!currentEnvironmentRequest.IsSuccess())
         {
             QStringToAZTracePrint(currentEnvironmentRequest.GetError());
             return AZ::Failure(currentEnvironmentRequest.GetError());
         }
-        QProcessEnvironment currentEnvironment = currentEnvironmentRequest.GetValue();
 
         m_configProjectProcess = new QProcess(this);
         m_configProjectProcess->setProcessChannelMode(QProcess::MergedChannels);
         m_configProjectProcess->setWorkingDirectory(m_projectInfo.m_path);
-        m_configProjectProcess->setProcessEnvironment(currentEnvironment);
 
         auto cmakeGenerateArgumentsResult = ConstructCmakeGenerateProjectArguments(engineInfo.m_thirdPartyPath);
         if (!cmakeGenerateArgumentsResult.IsSuccess())
@@ -181,7 +179,6 @@ namespace O3DE::ProjectManager
         m_buildProjectProcess = new QProcess(this);
         m_buildProjectProcess->setProcessChannelMode(QProcess::MergedChannels);
         m_buildProjectProcess->setWorkingDirectory(m_projectInfo.m_path);
-        m_buildProjectProcess->setProcessEnvironment(currentEnvironment);
 
         auto cmakeBuildArgumentsResult = ConstructCmakeBuildCommandArguments();
         if (!cmakeBuildArgumentsResult.IsSuccess())

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.cpp
@@ -520,12 +520,10 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> ExecuteCommandResultModalDialog(
             const QString& cmd,
             const QStringList& arguments,
-            const QProcessEnvironment& processEnv,
             const QString& title)
         {
             QString resultOutput;
             QProcess execProcess;
-            execProcess.setProcessEnvironment(processEnv);
             execProcess.setProcessChannelMode(QProcess::MergedChannels);
 
             QProgressDialog dialog(title, QObject::tr("Cancel"), /*minimum=*/0, /*maximum=*/0);
@@ -611,11 +609,9 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> ExecuteCommandResult(
             const QString& cmd,
             const QStringList& arguments,
-            const QProcessEnvironment& processEnv,
             int commandTimeoutSeconds /*= ProjectCommandLineTimeoutSeconds*/)
         {
             QProcess execProcess;
-            execProcess.setProcessEnvironment(processEnv);
             execProcess.setProcessChannelMode(QProcess::MergedChannels);
             execProcess.start(cmd, arguments);
             if (!execProcess.waitForStarted())

--- a/Code/Tools/ProjectManager/Source/ProjectUtils.h
+++ b/Code/Tools/ProjectManager/Source/ProjectUtils.h
@@ -47,7 +47,6 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> ExecuteCommandResult(
             const QString& cmd,
             const QStringList& arguments,
-            const QProcessEnvironment& processEnv,
             int commandTimeoutSeconds = ProjectCommandLineTimeoutSeconds);
 
         /**
@@ -61,10 +60,9 @@ namespace O3DE::ProjectManager
         AZ::Outcome<QString, QString> ExecuteCommandResultModalDialog(
             const QString& cmd,
             const QStringList& arguments,
-            const QProcessEnvironment& processEnv,
             const QString& title);
 
-        AZ::Outcome<QProcessEnvironment, QString> GetCommandLineProcessEnvironment();
+        AZ::Outcome<void, QString> SetupCommandLineProcessEnvironment();
         AZ::Outcome<QString, QString> GetProjectBuildPath(const QString& projectPath);
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath);
         AZ::Outcome<QString, QString> RunGetPythonScript(const QString& enginePath);


### PR DESCRIPTION
Fix an issue where if CMake was not pre-installed and the path added to the "Path" environment variable, then Project Manager would also not find the version that comes with the installer.

This was due to the path only being added to a QProcessEnvironment that would take affect for child processes, so the spawned process would have the path to CMake in cmake/releases/bin, but Project Manager itself would not and so not be able to find it.

Note: The only reason that we were using QProcessEnvironment was to set this additional path. Now that it is being sent on the Project Manager process, it takes affect for all spawned processes as default, so there is no need to create and pass these objects around.

Signed-off-by: AMZN-Phil <pconroy@amazon.com>