### PR TITLE
UI Editor - bugfix: prevent Anchor buttons from overlapping when shrinking layout(#5552)

### DIFF
--- a/Gems/LyShine/Code/Editor/AnchorPresetsWidget.cpp
+++ b/Gems/LyShine/Code/Editor/AnchorPresetsWidget.cpp
@@ -18,7 +18,7 @@
 #define UICANVASEDITOR_ANCHOR_ICON_PATH_SELECTED(presetIndex) (QString(":/Icons/AnchorIcon%1Selected.tif").arg(presetIndex, 2, 10, QChar('0')))
 
 #define UICANVASEDITOR_ANCHOR_WIDGET_FIXED_SIZE             (106)
-#define UICANVASEDITOR_ANCHOR_BUTTON_AND_ICON_FIXED_SIZE    (20)
+#define UICANVASEDITOR_ANCHOR_BUTTON_AND_ICON_FIXED_SIZE    (15)
 
 AnchorPresetsWidget::AnchorPresetsWidget(int defaultPresetIndex,
     PresetChanger presetChanger,
@@ -27,8 +27,6 @@ AnchorPresetsWidget::AnchorPresetsWidget(int defaultPresetIndex,
     , m_presetIndex(defaultPresetIndex)
     , m_buttons(AnchorPresets::PresetIndexCount, nullptr)
 {
-    setFixedSize(UICANVASEDITOR_ANCHOR_WIDGET_FIXED_SIZE, UICANVASEDITOR_ANCHOR_WIDGET_FIXED_SIZE);
-
     // The layout.
     QGridLayout* grid = new QGridLayout(this);
     grid->setContentsMargins(0, 0, 0, 0);
@@ -38,6 +36,7 @@ AnchorPresetsWidget::AnchorPresetsWidget(int defaultPresetIndex,
     {
         for (int presetIndex = 0; presetIndex < AnchorPresets::PresetIndexCount; ++presetIndex)
         {
+            QLayout* boxLayout = new QVBoxLayout();
             PresetButton* button = new PresetButton(UICANVASEDITOR_ANCHOR_ICON_PATH_DEFAULT(presetIndex),
                     UICANVASEDITOR_ANCHOR_ICON_PATH_HOVER(presetIndex),
                     UICANVASEDITOR_ANCHOR_ICON_PATH_SELECTED(presetIndex),
@@ -50,8 +49,9 @@ AnchorPresetsWidget::AnchorPresetsWidget(int defaultPresetIndex,
                         presetChanger(presetIndex);
                     },
                     this);
-
-            grid->addWidget(button, (presetIndex / 4), (presetIndex % 4));
+            boxLayout->addWidget(button);
+            boxLayout->setContentsMargins(4,4,4,4);
+            grid->addItem(boxLayout, (presetIndex / 4), (presetIndex % 4));
 
             m_buttons[ presetIndex ] = button;
         }

--- a/Gems/LyShine/Code/Editor/AnchorPresetsWidget.cpp
+++ b/Gems/LyShine/Code/Editor/AnchorPresetsWidget.cpp
@@ -18,7 +18,7 @@
 #define UICANVASEDITOR_ANCHOR_ICON_PATH_SELECTED(presetIndex) (QString(":/Icons/AnchorIcon%1Selected.tif").arg(presetIndex, 2, 10, QChar('0')))
 
 #define UICANVASEDITOR_ANCHOR_WIDGET_FIXED_SIZE             (106)
-#define UICANVASEDITOR_ANCHOR_BUTTON_AND_ICON_FIXED_SIZE    (15)
+#define UICANVASEDITOR_ANCHOR_BUTTON_AND_ICON_FIXED_SIZE    (20)
 
 AnchorPresetsWidget::AnchorPresetsWidget(int defaultPresetIndex,
     PresetChanger presetChanger,
@@ -50,7 +50,7 @@ AnchorPresetsWidget::AnchorPresetsWidget(int defaultPresetIndex,
                     },
                     this);
             boxLayout->addWidget(button);
-            boxLayout->setContentsMargins(4,4,4,4);
+            boxLayout->setContentsMargins(2, 2, 2, 2);
             grid->addItem(boxLayout, (presetIndex / 4), (presetIndex % 4));
 
             m_buttons[ presetIndex ] = button;

--- a/Gems/LyShine/Code/Editor/PropertiesWidget.cpp
+++ b/Gems/LyShine/Code/Editor/PropertiesWidget.cpp
@@ -49,7 +49,7 @@ PropertiesWidget::PropertiesWidget(EditorWindow* editorWindow,
         m_refreshTimer.setSingleShot(true);
     }
 
-    setMinimumWidth(250);
+    setMinimumWidth(330);
 
     ToolsApplicationEvents::Bus::Handler::BusConnect();
 }


### PR DESCRIPTION
I constrained the individual icons in a QVBoxLayout. I think I would like to have the rows constrain the container by their minimum width but that seems like a bit of a  more involved process. I can plan to do that next after this.  I increased the minimum width by a little bit so I can keep the icons the same size. 

https://user-images.githubusercontent.com/854359/142770173-5e8b8512-e668-4bab-87a0-e25a922a8606.mp4


I see the components in the entity inspector get clipped when the entity inspector is shrunk down. Properties in UI Editor is constrained by some minimum width where entries in the Entity Inspector just get clipped. 

![image](https://user-images.githubusercontent.com/854359/142755339-50dfd5f4-bc14-435d-b0ad-a977fa734983.png)

ref: https://github.com/o3de/o3de/issues/5552

Signed-off-by: Michael Pollind <mpollind@gmail.com>