### PR TITLE
chore: remove duplicate instance of FancyDockingDropZoneConstants

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDocking.cpp
@@ -53,7 +53,6 @@ static void OptimizedSetParent(QWidget* widget, QWidget* parent)
 
 namespace AzQtComponents
 {
-    static const FancyDockingDropZoneConstants g_FancyDockingConstants;
 
     // Constant for the threshold in pixels for snapping to edges while dragging for docking
     static const int g_snapThresholdInPixels = 15;
@@ -155,7 +154,7 @@ namespace AzQtComponents
 
         // Timer for updating our hovered drop zone opacity
         QObject::connect(m_dropZoneHoverFadeInTimer, &QTimer::timeout, this, &FancyDocking::onDropZoneHoverFadeInUpdate);
-        m_dropZoneHoverFadeInTimer->setInterval(g_FancyDockingConstants.dropZoneHoverFadeUpdateIntervalMS);
+        m_dropZoneHoverFadeInTimer->setInterval(FancyDockingDropZoneConstants::dropZoneHoverFadeUpdateIntervalMS);
         QIcon dragIcon = QIcon(QStringLiteral(":/Cursors/Grabbing.svg"));
         m_dragCursor = QCursor(dragIcon.pixmap(16), 5, 2);
     }
@@ -333,13 +332,13 @@ namespace AzQtComponents
      */
     void FancyDocking::onDropZoneHoverFadeInUpdate()
     {
-        const qreal dropZoneHoverOpacity = g_FancyDockingConstants.dropZoneHoverFadeIncrement + m_dropZoneState.dropZoneHoverOpacity();
+        const qreal dropZoneHoverOpacity = FancyDockingDropZoneConstants::dropZoneHoverFadeIncrement + m_dropZoneState.dropZoneHoverOpacity();
 
         // Once we've reached the full drop zone opacity, cut it off in case we
         // went over and stop the timer
-        if (dropZoneHoverOpacity >= g_FancyDockingConstants.dropZoneOpacity)
+        if (dropZoneHoverOpacity >= FancyDockingDropZoneConstants::dropZoneOpacity)
         {
-            m_dropZoneState.setDropZoneHoverOpacity(g_FancyDockingConstants.dropZoneOpacity);
+            m_dropZoneState.setDropZoneHoverOpacity(FancyDockingDropZoneConstants::dropZoneOpacity);
             m_dropZoneHoverFadeInTimer->stop();
         }
         else
@@ -792,12 +791,12 @@ namespace AzQtComponents
         QPoint mainWindowTopLeft = multiscreenMapFromGlobal(mainWindow->mapToGlobal(mainWindowRect.topLeft()));
         QPoint mainWindowTopRight = multiscreenMapFromGlobal(mainWindow->mapToGlobal(mainWindowRect.topRight()));
         QPoint mainWindowBottomLeft = multiscreenMapFromGlobal(mainWindow->mapToGlobal(mainWindowRect.bottomLeft()));
-        QSize absoluteLeftRightSize(g_FancyDockingConstants.absoluteDropZoneSizeInPixels, mainWindowRect.height());
+        QSize absoluteLeftRightSize(FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels, mainWindowRect.height());
         QRect absoluteLeftDropZone(mainWindowTopLeft, absoluteLeftRightSize);
-        QRect absoluteRightDropZone(mainWindowTopRight - QPoint(g_FancyDockingConstants.absoluteDropZoneSizeInPixels, 0), absoluteLeftRightSize);
-        QSize absoluteTopBottomSize(mainWindowRect.width(), g_FancyDockingConstants.absoluteDropZoneSizeInPixels);
+        QRect absoluteRightDropZone(mainWindowTopRight - QPoint(FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels, 0), absoluteLeftRightSize);
+        QSize absoluteTopBottomSize(mainWindowRect.width(), FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels);
         QRect absoluteTopDropZone(mainWindowTopLeft, absoluteTopBottomSize);
-        QRect absoluteBottomDropZone(mainWindowBottomLeft - QPoint(0, g_FancyDockingConstants.absoluteDropZoneSizeInPixels), absoluteTopBottomSize);
+        QRect absoluteBottomDropZone(mainWindowBottomLeft - QPoint(0, FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels), absoluteTopBottomSize);
 
         // If the drop target is a main window, then we will only show the absolute
         // drop zone if the cursor is in that zone already
@@ -986,16 +985,16 @@ namespace AzQtComponents
         switch (m_dropZoneState.absoluteDropZoneArea())
         {
         case Qt::LeftDockWidgetArea:
-            dockRect.setX(dockRect.x() + g_FancyDockingConstants.absoluteDropZoneSizeInPixels);
+            dockRect.setX(dockRect.x() + FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels);
             break;
         case Qt::RightDockWidgetArea:
-            dockRect.setWidth(dockRect.width() - g_FancyDockingConstants.absoluteDropZoneSizeInPixels);
+            dockRect.setWidth(dockRect.width() - FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels);
             break;
         case Qt::TopDockWidgetArea:
-            dockRect.setY(dockRect.y() + g_FancyDockingConstants.absoluteDropZoneSizeInPixels);
+            dockRect.setY(dockRect.y() + FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels);
             break;
         case Qt::BottomDockWidgetArea:
-            dockRect.setHeight(dockRect.height() - g_FancyDockingConstants.absoluteDropZoneSizeInPixels);
+            dockRect.setHeight(dockRect.height() - FancyDockingDropZoneConstants::absoluteDropZoneSizeInPixels);
             break;
         }
 
@@ -1034,15 +1033,15 @@ namespace AzQtComponents
         // Set the drop zone width/height to the default, but if the dock widget
         // width and/or height is below the threshold, then switch to scaling them
         // down accordingly
-        int dropZoneWidth = g_FancyDockingConstants.dropZoneSizeInPixels;
-        if (dockWidth < g_FancyDockingConstants.minDockSizeBeforeDropZoneScalingInPixels)
+        int dropZoneWidth = FancyDockingDropZoneConstants::dropZoneSizeInPixels;
+        if (dockWidth < FancyDockingDropZoneConstants::minDockSizeBeforeDropZoneScalingInPixels)
         {
-            dropZoneWidth = aznumeric_cast<int>(dockWidth * g_FancyDockingConstants.dropZoneScaleFactor);
+            dropZoneWidth = aznumeric_cast<int>(dockWidth * FancyDockingDropZoneConstants::dropZoneScaleFactor);
         }
-        int dropZoneHeight = g_FancyDockingConstants.dropZoneSizeInPixels;
-        if (dockHeight < g_FancyDockingConstants.minDockSizeBeforeDropZoneScalingInPixels)
+        int dropZoneHeight = FancyDockingDropZoneConstants::dropZoneSizeInPixels;
+        if (dockHeight < FancyDockingDropZoneConstants::minDockSizeBeforeDropZoneScalingInPixels)
         {
-            dropZoneHeight = aznumeric_cast<int>(dockHeight * g_FancyDockingConstants.dropZoneScaleFactor);
+            dropZoneHeight = aznumeric_cast<int>(dockHeight * FancyDockingDropZoneConstants::dropZoneScaleFactor);
         }
 
         // Calculate the inner corners to be used when constructing the drop zone polygons
@@ -1078,7 +1077,7 @@ namespace AzQtComponents
         int innerDropZoneWidth = m_dropZoneState.innerDropZoneRect().width();
         int innerDropZoneHeight = m_dropZoneState.innerDropZoneRect().height();
         int centerDropZoneDiameter = (innerDropZoneWidth < innerDropZoneHeight) ? innerDropZoneWidth : innerDropZoneHeight;
-        centerDropZoneDiameter = aznumeric_cast<int>(centerDropZoneDiameter * g_FancyDockingConstants.centerTabDropZoneScale);
+        centerDropZoneDiameter = aznumeric_cast<int>(centerDropZoneDiameter * FancyDockingDropZoneConstants::centerTabDropZoneScale);
 
         // Setup our center tab drop zone
         const QSize centerDropZoneSize(centerDropZoneDiameter, centerDropZoneDiameter);
@@ -1986,7 +1985,7 @@ namespace AzQtComponents
             // hasn't faded in all the way yet, then ignore the drop zone area
             // which will make the widget floating
             bool modifiedKeyPressed = FancyDockingDropZoneWidget::CheckModifierKey();
-            if (modifiedKeyPressed || m_dropZoneState.dropZoneHoverOpacity() != g_FancyDockingConstants.dropZoneOpacity)
+            if (modifiedKeyPressed || m_dropZoneState.dropZoneHoverOpacity() != FancyDockingDropZoneConstants::dropZoneOpacity)
             {
                 area = Qt::NoDockWidgetArea;
             }
@@ -3026,7 +3025,7 @@ namespace AzQtComponents
         {
             bool modifiedKeyPressed = FancyDockingDropZoneWidget::CheckModifierKey();
 
-            m_ghostWidget->setWindowOpacity(modifiedKeyPressed ? 1.0f : g_FancyDockingConstants.draggingDockWidgetOpacity);
+            m_ghostWidget->setWindowOpacity(modifiedKeyPressed ? 1.0f : FancyDockingDropZoneConstants::draggingDockWidgetOpacity);
             m_ghostWidget->setPixmap(m_state.dockWidgetScreenGrab.screenGrab, m_state.placeholder(), m_state.placeholderScreen());
         }
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.cpp
@@ -19,26 +19,9 @@
 
 namespace AzQtComponents
 {
-    static const FancyDockingDropZoneConstants g_Constants;
-
-    FancyDockingDropZoneConstants::FancyDockingDropZoneConstants()
-    {
-        draggingDockWidgetOpacity = 0.6;
-        dropZoneOpacity = 0.4;
-        dropZoneSizeInPixels = 40;
-        minDockSizeBeforeDropZoneScalingInPixels = dropZoneSizeInPixels * 3;
-        dropZoneScaleFactor = 0.25;
-        centerTabDropZoneScale = 0.5;
-        centerTabIconScale = 0.5;
-        dropZoneColor = QColor(155, 155, 155);
-        dropZoneBorderColor = Qt::black;
-        dropZoneBorderInPixels = 1;
-        absoluteDropZoneSizeInPixels = 25;
-        dockingTargetDelayMS = 110;
-        dropZoneHoverFadeUpdateIntervalMS = 20;
-        dropZoneHoverFadeIncrement = dropZoneOpacity / (dockingTargetDelayMS / dropZoneHoverFadeUpdateIntervalMS);
-        centerDropZoneIconPath = QString(":/stylesheet/img/UI20/docking/tabs_icon.svg");
-    }
+    const QColor FancyDockingDropZoneConstants::dropZoneColor =  QColor(155, 155, 155);
+    const QColor FancyDockingDropZoneConstants::dropZoneBorderColor = Qt::black;
+    const QString FancyDockingDropZoneConstants::centerDropZoneIconPath = QStringLiteral(":/stylesheet/img/UI20/docking/tabs_icon.svg");
 
     FancyDockingDropZoneWidget::FancyDockingDropZoneWidget(QMainWindow* mainWindow, QWidget* coordinatesRelativeTo, QScreen* screen, FancyDockingDropZoneState* dropZoneState)
         // NOTE: this will not work with multiple monitors if this widget has a parent. The floating drop zone
@@ -154,7 +137,7 @@ namespace AzQtComponents
 
             // Draw all of the normal drop zones if they exist (if a dock widget is hovered over)
             painter.setPen(Qt::NoPen);
-            painter.setOpacity(g_Constants.dropZoneOpacity);
+            painter.setOpacity(FancyDockingDropZoneConstants::dropZoneOpacity);
             auto dropZones = m_dropZoneState->dropZones();
             for (auto it = dropZones.cbegin(); it != dropZones.cend(); ++it)
             {
@@ -189,7 +172,7 @@ namespace AzQtComponents
         // Otherwise, set the normal color
         else
         {
-            painter.setBrush(g_Constants.dropZoneColor);
+            painter.setBrush(FancyDockingDropZoneConstants::dropZoneColor);
         }
 
         // negate the window position to offset everything by that much
@@ -214,8 +197,8 @@ namespace AzQtComponents
             // Scale the tabs icon based on the drop zone size and our specified offset
             // Doing this through QIcon to make sure that SVG is rendered already in desired resolution
             const QSize& dropZoneSize = dropZoneRect.size();
-            const QSize requestedIconSize = dropZoneSize * g_Constants.centerTabIconScale;
-            const QIcon dropZoneIcon = QIcon(g_Constants.centerDropZoneIconPath);
+            const QSize requestedIconSize = dropZoneSize * FancyDockingDropZoneConstants::centerTabIconScale;
+            const QIcon dropZoneIcon = QIcon(FancyDockingDropZoneConstants::centerDropZoneIconPath);
             const QPixmap dropZonePixmap = dropZoneIcon.pixmap(requestedIconSize);
             const QSize receivedIconSize = dropZoneIcon.actualSize(requestedIconSize);
 
@@ -264,7 +247,7 @@ namespace AzQtComponents
             }
             else
             {
-                painter.setBrush(g_Constants.dropZoneColor);
+                painter.setBrush(FancyDockingDropZoneConstants::dropZoneColor);
             }
             painter.drawRect(absoluteDropZoneRect);
 
@@ -313,8 +296,8 @@ namespace AzQtComponents
         const QPoint innerBottomRight = innerDropZoneRect.bottomRight();
 
         // Draw the lines using the appropriate pen
-        QPen dropZoneBorderPen(g_Constants.dropZoneBorderColor);
-        dropZoneBorderPen.setWidth(g_Constants.dropZoneBorderInPixels);
+        QPen dropZoneBorderPen(FancyDockingDropZoneConstants::dropZoneBorderColor);
+        dropZoneBorderPen.setWidth(FancyDockingDropZoneConstants::dropZoneBorderInPixels);
         painter.setPen(dropZoneBorderPen);
         painter.setOpacity(1);
         painter.drawLine(topLeft, innerTopLeft);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.cpp
@@ -19,9 +19,6 @@
 
 namespace AzQtComponents
 {
-    const QColor FancyDockingDropZoneConstants::dropZoneColor =  QColor(155, 155, 155);
-    const QColor FancyDockingDropZoneConstants::dropZoneBorderColor = Qt::black;
-    const QString FancyDockingDropZoneConstants::centerDropZoneIconPath = QStringLiteral(":/stylesheet/img/UI20/docking/tabs_icon.svg");
 
     FancyDockingDropZoneWidget::FancyDockingDropZoneWidget(QMainWindow* mainWindow, QWidget* coordinatesRelativeTo, QScreen* screen, FancyDockingDropZoneState* dropZoneState)
         // NOTE: this will not work with multiple monitors if this widget has a parent. The floating drop zone

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.h
@@ -28,7 +28,7 @@ class QPainter;
 
 namespace AzQtComponents
 {
-    struct AZ_QT_COMPONENTS_API FancyDockingDropZoneConstants
+    namespace FancyDockingDropZoneConstants
     {
         // Constant for the opacity of the screen grab for the dock widget being dragged
         static constexpr qreal draggingDockWidgetOpacity = 0.6;
@@ -55,10 +55,10 @@ namespace AzQtComponents
         static constexpr qreal centerTabIconScale  = 0.5;
 
         // Constant for the drop zone hotspot default color
-        static const QColor dropZoneColor;
+        static const QColor dropZoneColor = QColor(155, 155, 155);
 
         // Constant for the drop zone border color
-        static const QColor dropZoneBorderColor;
+        static const QColor dropZoneBorderColor = Qt::black;
 
         // Constant for the border width in pixels separating the drop zones
         static constexpr int dropZoneBorderInPixels  = 1;
@@ -79,11 +79,7 @@ namespace AzQtComponents
         static constexpr qreal dropZoneHoverFadeIncrement = dropZoneOpacity / (dockingTargetDelayMS / dropZoneHoverFadeUpdateIntervalMS);
 
         // Constant for the path to the center drop zone tabs icon
-        static const QString centerDropZoneIconPath;
-
-        FancyDockingDropZoneConstants() = delete;
-        FancyDockingDropZoneConstants(const FancyDockingDropZoneConstants&) = delete;
-        FancyDockingDropZoneConstants& operator=(const FancyDockingDropZoneConstants&) = delete;
+        static const QString centerDropZoneIconPath = QStringLiteral(":/stylesheet/img/UI20/docking/tabs_icon.svg");
     };
 
     class FancyDockingDropZoneState

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/FancyDockingDropZoneWidget.h
@@ -31,58 +31,57 @@ namespace AzQtComponents
     struct AZ_QT_COMPONENTS_API FancyDockingDropZoneConstants
     {
         // Constant for the opacity of the screen grab for the dock widget being dragged
-        qreal draggingDockWidgetOpacity;
+        static constexpr qreal draggingDockWidgetOpacity = 0.6;
 
         // Constant for the opacity of the normal drop zones
-        qreal dropZoneOpacity;
+        static constexpr qreal dropZoneOpacity  = 0.4;
 
         // Constant for the default drop zone size (in pixels)
-        int dropZoneSizeInPixels;
+        static constexpr int dropZoneSizeInPixels  = 40;
 
         // Constant for the dock width/height size (in pixels) before we need to start
         // scaling down the drop zone sizes, or else they will overlap with the center
         // tab icon or each other
-        int minDockSizeBeforeDropZoneScalingInPixels;
+        static constexpr int minDockSizeBeforeDropZoneScalingInPixels = dropZoneSizeInPixels * 3;
 
         // Constant for the factor by which we must scale down the drop zone sizes once
         // the dock width/height size is too small
-        qreal dropZoneScaleFactor;
+        static constexpr qreal dropZoneScaleFactor  = 0.25;
 
         // Constant for the percentage to scale down the inner drop zone rectangle for the center tab drop zone
-        qreal centerTabDropZoneScale;
+        static constexpr qreal centerTabDropZoneScale  = 0.5;
 
         // Constant for the percentage to scale down the center tab drop zone for the center tab icon
-        qreal centerTabIconScale;
+        static constexpr qreal centerTabIconScale  = 0.5;
 
         // Constant for the drop zone hotspot default color
-        QColor dropZoneColor;
+        static const QColor dropZoneColor;
 
         // Constant for the drop zone border color
-        QColor dropZoneBorderColor;
+        static const QColor dropZoneBorderColor;
 
         // Constant for the border width in pixels separating the drop zones
-        int dropZoneBorderInPixels;
+        static constexpr int dropZoneBorderInPixels  = 1;
 
         // Constant for the border width in pixels separating the drop zones
-        int absoluteDropZoneSizeInPixels;
+        static constexpr int absoluteDropZoneSizeInPixels  = 25;
 
         // Constant for the delay (in milliseconds) before a drop zone becomes active
         // once it is hovered over
-        int dockingTargetDelayMS;
+        static constexpr int dockingTargetDelayMS = 110;
 
         // Constant for the rate at which we will update (fade in) the drop zone opacity
         // when hovered over (in milliseconds)
-        int dropZoneHoverFadeUpdateIntervalMS;
+        static constexpr int dropZoneHoverFadeUpdateIntervalMS  = 20;
 
         // Constant for the incremental opacity increase for the hovered drop zone
         // that will fade in to the full drop zone opacity in the desired time
-        qreal dropZoneHoverFadeIncrement;
+        static constexpr qreal dropZoneHoverFadeIncrement = dropZoneOpacity / (dockingTargetDelayMS / dropZoneHoverFadeUpdateIntervalMS);
 
         // Constant for the path to the center drop zone tabs icon
-        QString centerDropZoneIconPath;
+        static const QString centerDropZoneIconPath;
 
-        FancyDockingDropZoneConstants();
-
+        FancyDockingDropZoneConstants() = delete;
         FancyDockingDropZoneConstants(const FancyDockingDropZoneConstants&) = delete;
         FancyDockingDropZoneConstants& operator=(const FancyDockingDropZoneConstants&) = delete;
     };


### PR DESCRIPTION
these variables are fixed in place so I just declare them upfront as constexpr if its a primitive and a static const otherwise. avoides the duplicate static variables for FancyDockingDropZoneConstants.

Signed-off-by: Michael Pollind <mpollind@gmail.com>