### PR TITLE
Fix for how viewport icons highlight (accent) when sticky select is disabled

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -897,7 +897,7 @@ namespace AzToolsFramework
         AZ::EntityId& hoveredEntityIdUnderCursor,
         const HandleAccentsContext& handleAccentsContext,
         const ViewportInteraction::MouseButtons mouseButtons,
-        const AZStd::function<void(AZ::EntityId, bool)>& setEntityHighlightedFn)
+        const AZStd::function<void(AZ::EntityId, bool)>& setEntityAccentedFn)
     {
         const bool invalidMouseButtonHeld = mouseButtons.Middle() || mouseButtons.Right();
         const bool hasSelectedEntities = handleAccentsContext.m_hasSelectedEntities;
@@ -906,19 +906,19 @@ namespace AzToolsFramework
         const bool stickySelect = handleAccentsContext.m_usingStickySelect;
         const bool canSelect = stickySelect ? !hasSelectedEntities || ctrlHeld : true;
 
-        const bool removePreviousHighlight =
+        const bool removePreviousAccent =
             (currentEntityIdUnderCursor != hoveredEntityIdUnderCursor && hoveredEntityIdUnderCursor.IsValid()) || invalidMouseButtonHeld;
-        const bool addNextHighlight = currentEntityIdUnderCursor.IsValid() && canSelect && !invalidMouseButtonHeld && !boxSelect;
+        const bool addNextAccent = currentEntityIdUnderCursor.IsValid() && canSelect && !invalidMouseButtonHeld && !boxSelect;
 
-        if (removePreviousHighlight)
+        if (removePreviousAccent)
         {
-            setEntityHighlightedFn(hoveredEntityIdUnderCursor, false);
+            setEntityAccentedFn(hoveredEntityIdUnderCursor, false);
             hoveredEntityIdUnderCursor.SetInvalid();
         }
 
-        if (addNextHighlight)
+        if (addNextAccent)
         {
-            setEntityHighlightedFn(currentEntityIdUnderCursor, true);
+            setEntityAccentedFn(currentEntityIdUnderCursor, true);
             hoveredEntityIdUnderCursor = currentEntityIdUnderCursor;
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -27,7 +27,6 @@
 #include <AzToolsFramework/Manipulators/ScaleManipulators.h>
 #include <AzToolsFramework/Manipulators/TranslationManipulators.h>
 #include <AzToolsFramework/Maths/TransformUtils.h>
-#include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabFocusInterface.h>
 #include <AzToolsFramework/Prefab/PrefabFocusPublicInterface.h>
 #include <AzToolsFramework/ToolsComponents/EditorLockComponentBus.h>
@@ -893,37 +892,34 @@ namespace AzToolsFramework
         prevModifiers = action.m_modifiers;
     }
 
-    static void HandleAccents(
-        const bool hasSelectedEntities,
-        const AZ::EntityId entityIdUnderCursor,
-        const bool ctrlHeld,
-        AZ::EntityId& hoveredEntityId,
+    void HandleAccents(
+        const AZ::EntityId currentEntityIdUnderCursor,
+        AZ::EntityId& hoveredEntityIdUnderCursor,
+        const HandleAccentsContext& handleAccentsContext,
         const ViewportInteraction::MouseButtons mouseButtons,
-        const bool usingBoxSelect)
+        const AZStd::function<void(AZ::EntityId, bool)>& setEntityHighlightedFn)
     {
-        AZ_PROFILE_FUNCTION(AzToolsFramework);
-
         const bool invalidMouseButtonHeld = mouseButtons.Middle() || mouseButtons.Right();
+        const bool hasSelectedEntities = handleAccentsContext.m_hasSelectedEntities;
+        const bool ctrlHeld = handleAccentsContext.m_ctrlHeld;
+        const bool boxSelect = handleAccentsContext.m_usingBoxSelect;
+        const bool stickySelect = handleAccentsContext.m_usingStickySelect;
+        const bool canSelect = stickySelect ? !hasSelectedEntities || ctrlHeld : true;
 
-        if ((hoveredEntityId.IsValid() && hoveredEntityId != entityIdUnderCursor) ||
-            (hasSelectedEntities && !ctrlHeld && hoveredEntityId.IsValid()) || invalidMouseButtonHeld)
+        const bool removePreviousHighlight =
+            (currentEntityIdUnderCursor != hoveredEntityIdUnderCursor && hoveredEntityIdUnderCursor.IsValid()) || invalidMouseButtonHeld;
+        const bool addNextHighlight = currentEntityIdUnderCursor.IsValid() && canSelect && !invalidMouseButtonHeld && !boxSelect;
+
+        if (removePreviousHighlight)
         {
-            if (hoveredEntityId.IsValid())
-            {
-                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetEntityHighlighted, hoveredEntityId, false);
-
-                hoveredEntityId.SetInvalid();
-            }
+            setEntityHighlightedFn(hoveredEntityIdUnderCursor, false);
+            hoveredEntityIdUnderCursor.SetInvalid();
         }
 
-        if (!invalidMouseButtonHeld && !usingBoxSelect && (!hasSelectedEntities || ctrlHeld))
+        if (addNextHighlight)
         {
-            if (entityIdUnderCursor.IsValid())
-            {
-                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetEntityHighlighted, entityIdUnderCursor, true);
-
-                hoveredEntityId = entityIdUnderCursor;
-            }
+            setEntityHighlightedFn(currentEntityIdUnderCursor, true);
+            hoveredEntityIdUnderCursor = currentEntityIdUnderCursor;
         }
     }
 
@@ -1781,7 +1777,7 @@ namespace AzToolsFramework
         const AzFramework::CameraState cameraState = GetCameraState(viewportId);
 
         const auto cursorEntityIdQuery = m_editorHelpers->FindEntityIdUnderCursor(cameraState, mouseInteraction);
-        m_cachedEntityIdUnderCursor = cursorEntityIdQuery.ContainerAncestorEntityId();
+        m_currentEntityIdUnderCursor = cursorEntityIdQuery.ContainerAncestorEntityId();
 
         const auto selectClickEvent = ClickDetectorEventFromViewportInteraction(mouseInteraction);
         m_cursorState.SetCurrentPosition(mouseInteraction.m_mouseInteraction.m_mousePick.m_screenCoordinates);
@@ -1802,7 +1798,7 @@ namespace AzToolsFramework
                         mouseInteraction.m_mouseInteraction,
                         AZ::Aabb::CreateFromMinMax(boxPosition - scaledSize, boxPosition + scaledSize)))
                 {
-                    m_cachedEntityIdUnderCursor = entityId;
+                    m_currentEntityIdUnderCursor = entityId;
                 }
             }
         }
@@ -1822,7 +1818,7 @@ namespace AzToolsFramework
             return true;
         }
 
-        const AZ::EntityId entityIdUnderCursor = m_cachedEntityIdUnderCursor;
+        const AZ::EntityId entityIdUnderCursor = m_currentEntityIdUnderCursor;
 
         if (mouseInteraction.m_mouseEvent == ViewportInteraction::MouseEvent::DoubleClick &&
             mouseInteraction.m_mouseInteraction.m_mouseButtons.Left())
@@ -3341,9 +3337,23 @@ namespace AzToolsFramework
 
         m_cursorState.Update();
 
+        bool stickySelect = false;
+        ViewportInteraction::ViewportSettingsRequestBus::EventResult(
+            stickySelect, viewportInfo.m_viewportId, &ViewportInteraction::ViewportSettingsRequestBus::Events::StickySelectEnabled);
+
+        HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = keyboardModifiers.Ctrl();
+        handleAccentsContext.m_hasSelectedEntities = !m_selectedEntityIds.empty();
+        handleAccentsContext.m_usingBoxSelect = m_boxSelect.Active();
+        handleAccentsContext.m_usingStickySelect = stickySelect;
+
         HandleAccents(
-            !m_selectedEntityIds.empty(), m_cachedEntityIdUnderCursor, keyboardModifiers.Ctrl(), m_hoveredEntityId,
-            ViewportInteraction::BuildMouseButtons(QGuiApplication::mouseButtons()), m_boxSelect.Active());
+            m_currentEntityIdUnderCursor, m_hoveredEntityId, handleAccentsContext,
+            ViewportInteraction::BuildMouseButtons(QGuiApplication::mouseButtons()),
+            [](const AZ::EntityId entityId, bool highlighted)
+            {
+                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetEntityHighlighted, entityId, highlighted);
+            });
 
         const ReferenceFrame referenceFrame = m_spaceCluster.m_spaceLock.value_or(ReferenceFrameFromModifiers(keyboardModifiers));
 
@@ -3589,7 +3599,8 @@ namespace AzToolsFramework
         if (auto prefabFocusPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusPublicInterface>::Get())
         {
             AzFramework::EntityContextId editorEntityContextId = GetEntityContextId();
-            if (AZ::EntityId focusRoot = prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId); focusRoot.IsValid())
+            if (AZ::EntityId focusRoot = prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId);
+                focusRoot.IsValid())
             {
                 m_selectedEntityIds.erase(focusRoot);
             }
@@ -3721,7 +3732,6 @@ namespace AzToolsFramework
             break;
         case ViewportEditorMode::Focus:
             {
-                
                 ViewportUi::ViewportUiRequestBus::Event(
                     ViewportUi::DefaultViewportId, &ViewportUi::ViewportUiRequestBus::Events::RemoveViewportBorder);
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -317,7 +317,7 @@ namespace AzToolsFramework
         void SetAllViewportUiVisible(bool visible);
 
         AZ::EntityId m_hoveredEntityId; //!< What EntityId is the mouse currently hovering over (if any).
-        AZ::EntityId m_cachedEntityIdUnderCursor; //!< Store the EntityId on each mouse move for use in Display.
+        AZ::EntityId m_currentEntityIdUnderCursor; //!< Store the EntityId on each mouse move for use in Display.
         AZ::EntityId m_editorCameraComponentEntityId; //!< The EditorCameraComponent EntityId if it is set.
         EntityIdSet m_selectedEntityIds; //!< Represents the current entities in the selection.
 
@@ -356,6 +356,23 @@ namespace AzToolsFramework
         SnappingCluster m_snappingCluster; //!< Related viewport ui state for aligning positions to a grid or reference frame.
         bool m_viewportUiVisible = true; //!< Used to hide/show the viewport ui elements.
     };
+
+    //! Bundles viewport state that impacts how accents are added/removed in HandleAccents.
+    struct HandleAccentsContext
+    {
+        bool m_hasSelectedEntities;
+        bool m_ctrlHeld;
+        bool m_usingBoxSelect;
+        bool m_usingStickySelect;
+    };
+
+    //! Updates whether accents (icon highlights) are added/removed for a given entity based on the cursor position.
+    void HandleAccents(
+        AZ::EntityId currentEntityIdUnderCursor,
+        AZ::EntityId& hoveredEntityIdUnderCursor,
+        const HandleAccentsContext& handleAccentsContext,
+        ViewportInteraction::MouseButtons mouseButtons,
+        const AZStd::function<void(AZ::EntityId, bool)>& setEntityHighlightedFn);
 
     //! The ETCS (EntityTransformComponentSelection) namespace contains functions and data used exclusively by
     //! the EditorTransformComponentSelection type. Functions in this namespace are exposed to facilitate testing

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.h
@@ -372,7 +372,7 @@ namespace AzToolsFramework
         AZ::EntityId& hoveredEntityIdUnderCursor,
         const HandleAccentsContext& handleAccentsContext,
         ViewportInteraction::MouseButtons mouseButtons,
-        const AZStd::function<void(AZ::EntityId, bool)>& setEntityHighlightedFn);
+        const AZStd::function<void(AZ::EntityId, bool)>& setEntityAccentedFn);
 
     //! The ETCS (EntityTransformComponentSelection) namespace contains functions and data used exclusively by
     //! the EditorTransformComponentSelection type. Functions in this namespace are exposed to facilitate testing

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -2781,4 +2781,196 @@ namespace UnitTest
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
     }
 
+    TEST(HandleAccents, CurrentValidEntityIdBecomesHoveredWithNoSelectionAndUnstickySelect)
+    {
+        namespace azvi = AzToolsFramework::ViewportInteraction;
+
+        const AZ::EntityId currentEntityId = AZ::EntityId(12345);
+        AZ::EntityId hoveredEntityEntityId;
+
+        AzToolsFramework::HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = false;
+        handleAccentsContext.m_hasSelectedEntities = false;
+        handleAccentsContext.m_usingBoxSelect = false;
+        handleAccentsContext.m_usingStickySelect = false;
+
+        bool currentEntityIdAccentAdded = false;
+        AzToolsFramework::HandleAccents(
+            currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
+            [&currentEntityIdAccentAdded, currentEntityId](const AZ::EntityId entityId, bool highlight)
+            {
+                if (entityId == currentEntityId && highlight)
+                {
+                    currentEntityIdAccentAdded = true;
+                }
+            });
+
+        using ::testing::Eq;
+        using ::testing::IsTrue;
+        EXPECT_THAT(currentEntityId, Eq(hoveredEntityEntityId));
+        EXPECT_THAT(currentEntityIdAccentAdded, IsTrue());
+    }
+
+    TEST(HandleAccents, CurrentValidEntityIdBecomesHoveredWithSelectionAndUnstickySelect)
+    {
+        namespace azvi = AzToolsFramework::ViewportInteraction;
+
+        const AZ::EntityId currentEntityId = AZ::EntityId(12345);
+        AZ::EntityId hoveredEntityEntityId;
+
+        AzToolsFramework::HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = false;
+        handleAccentsContext.m_hasSelectedEntities = true;
+        handleAccentsContext.m_usingBoxSelect = false;
+        handleAccentsContext.m_usingStickySelect = false;
+
+        bool currentEntityIdAccentAdded = false;
+        AzToolsFramework::HandleAccents(
+            currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
+            [&currentEntityIdAccentAdded, currentEntityId](const AZ::EntityId entityId, bool highlight)
+            {
+                if (entityId == currentEntityId && highlight)
+                {
+                    currentEntityIdAccentAdded = true;
+                }
+            });
+
+        using ::testing::Eq;
+        using ::testing::IsTrue;
+        EXPECT_THAT(currentEntityId, Eq(hoveredEntityEntityId));
+        EXPECT_THAT(currentEntityIdAccentAdded, IsTrue());
+    }
+
+    TEST(HandleAccents, CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionUnstickySelectAndInvalidButton)
+    {
+        namespace azvi = AzToolsFramework::ViewportInteraction;
+
+        const AZ::EntityId currentEntityId = AZ::EntityId(12345);
+        AZ::EntityId hoveredEntityEntityId = AZ::EntityId(54321);
+
+        AzToolsFramework::HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = false;
+        handleAccentsContext.m_hasSelectedEntities = false;
+        handleAccentsContext.m_usingBoxSelect = false;
+        handleAccentsContext.m_usingStickySelect = false;
+
+        bool hoveredEntityIdAccentRemoved = false;
+        AzToolsFramework::HandleAccents(
+            currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::Middle),
+            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            {
+                if (entityId == hoveredEntityEntityId && !highlight)
+                {
+                    hoveredEntityIdAccentRemoved = true;
+                }
+            });
+
+        using ::testing::Eq;
+        using ::testing::IsFalse;
+        using ::testing::IsTrue;
+        EXPECT_THAT(hoveredEntityEntityId.IsValid(), IsFalse());
+        EXPECT_THAT(hoveredEntityIdAccentRemoved, IsTrue());
+    }
+
+    TEST(HandleAccents, CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionUnstickySelectAndDoingBoxSelect)
+    {
+        namespace azvi = AzToolsFramework::ViewportInteraction;
+
+        const AZ::EntityId currentEntityId = AZ::EntityId(12345);
+        AZ::EntityId hoveredEntityEntityId = AZ::EntityId(54321);
+
+        AzToolsFramework::HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = false;
+        handleAccentsContext.m_hasSelectedEntities = false;
+        handleAccentsContext.m_usingBoxSelect = true;
+        handleAccentsContext.m_usingStickySelect = false;
+
+        bool hoveredEntityIdAccentRemoved = false;
+        AzToolsFramework::HandleAccents(
+            currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
+            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            {
+                if (entityId == hoveredEntityEntityId && !highlight)
+                {
+                    hoveredEntityIdAccentRemoved = true;
+                }
+            });
+
+        using ::testing::Eq;
+        using ::testing::IsFalse;
+        using ::testing::IsTrue;
+        EXPECT_THAT(hoveredEntityEntityId.IsValid(), IsFalse());
+        EXPECT_THAT(hoveredEntityIdAccentRemoved, IsTrue());
+    }
+
+    // mimics the mouse moving off of hovered entity onto a new entity with sticky select enabled
+    TEST(HandleAccents, CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionAndStickySelect)
+    {
+        namespace azvi = AzToolsFramework::ViewportInteraction;
+
+        const AZ::EntityId currentEntityId = AZ::EntityId(12345);
+        AZ::EntityId hoveredEntityEntityId = AZ::EntityId(54321);
+
+        AzToolsFramework::HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = false;
+        handleAccentsContext.m_hasSelectedEntities = true;
+        handleAccentsContext.m_usingBoxSelect = false;
+        handleAccentsContext.m_usingStickySelect = true;
+
+        bool hoveredEntityIdAccentRemoved = false;
+        AzToolsFramework::HandleAccents(
+            currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
+            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            {
+                if (entityId == hoveredEntityEntityId && !highlight)
+                {
+                    hoveredEntityIdAccentRemoved = true;
+                }
+            });
+
+        using ::testing::Eq;
+        using ::testing::IsFalse;
+        using ::testing::IsTrue;
+        EXPECT_THAT(hoveredEntityIdAccentRemoved, IsTrue());
+        EXPECT_THAT(hoveredEntityEntityId.IsValid(), IsFalse());
+    }
+
+    TEST(HandleAccents, CurrentValidEntityIdDoesBecomeHoveredWithSelectionAndStickySelectAndCtrl)
+    {
+        namespace azvi = AzToolsFramework::ViewportInteraction;
+
+        const AZ::EntityId currentEntityId = AZ::EntityId(12345);
+        AZ::EntityId hoveredEntityEntityId = AZ::EntityId(54321);
+
+        AzToolsFramework::HandleAccentsContext handleAccentsContext;
+        handleAccentsContext.m_ctrlHeld = true;
+        handleAccentsContext.m_hasSelectedEntities = true;
+        handleAccentsContext.m_usingBoxSelect = false;
+        handleAccentsContext.m_usingStickySelect = true;
+
+        bool currentEntityIdAccentAdded = false;
+        bool hoveredEntityIdAccentRemoved = false;
+        AzToolsFramework::HandleAccents(
+            currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
+            [&hoveredEntityIdAccentRemoved, &currentEntityIdAccentAdded, currentEntityId,
+             hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            {
+                if (entityId == currentEntityId && highlight)
+                {
+                    currentEntityIdAccentAdded = true;
+                }
+
+                if (entityId == hoveredEntityEntityId && !highlight)
+                {
+                    hoveredEntityIdAccentRemoved = true;
+                }
+            });
+
+        using ::testing::Eq;
+        using ::testing::IsFalse;
+        using ::testing::IsTrue;
+        EXPECT_THAT(currentEntityIdAccentAdded, IsTrue());
+        EXPECT_THAT(hoveredEntityIdAccentRemoved, IsTrue());
+        EXPECT_THAT(hoveredEntityEntityId, Eq(AZ::EntityId(12345)));
+    }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/EditorTransformComponentSelectionTests.cpp
@@ -2797,9 +2797,9 @@ namespace UnitTest
         bool currentEntityIdAccentAdded = false;
         AzToolsFramework::HandleAccents(
             currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
-            [&currentEntityIdAccentAdded, currentEntityId](const AZ::EntityId entityId, bool highlight)
+            [&currentEntityIdAccentAdded, currentEntityId](const AZ::EntityId entityId, const bool accent)
             {
-                if (entityId == currentEntityId && highlight)
+                if (entityId == currentEntityId && accent)
                 {
                     currentEntityIdAccentAdded = true;
                 }
@@ -2827,9 +2827,9 @@ namespace UnitTest
         bool currentEntityIdAccentAdded = false;
         AzToolsFramework::HandleAccents(
             currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
-            [&currentEntityIdAccentAdded, currentEntityId](const AZ::EntityId entityId, bool highlight)
+            [&currentEntityIdAccentAdded, currentEntityId](const AZ::EntityId entityId, const bool accent)
             {
-                if (entityId == currentEntityId && highlight)
+                if (entityId == currentEntityId && accent)
                 {
                     currentEntityIdAccentAdded = true;
                 }
@@ -2857,9 +2857,9 @@ namespace UnitTest
         bool hoveredEntityIdAccentRemoved = false;
         AzToolsFramework::HandleAccents(
             currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::Middle),
-            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, const bool accent)
             {
-                if (entityId == hoveredEntityEntityId && !highlight)
+                if (entityId == hoveredEntityEntityId && !accent)
                 {
                     hoveredEntityIdAccentRemoved = true;
                 }
@@ -2888,9 +2888,9 @@ namespace UnitTest
         bool hoveredEntityIdAccentRemoved = false;
         AzToolsFramework::HandleAccents(
             currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
-            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, const bool accent)
             {
-                if (entityId == hoveredEntityEntityId && !highlight)
+                if (entityId == hoveredEntityEntityId && !accent)
                 {
                     hoveredEntityIdAccentRemoved = true;
                 }
@@ -2920,9 +2920,9 @@ namespace UnitTest
         bool hoveredEntityIdAccentRemoved = false;
         AzToolsFramework::HandleAccents(
             currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
-            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+            [&hoveredEntityIdAccentRemoved, hoveredEntityEntityId](const AZ::EntityId entityId, const bool accent)
             {
-                if (entityId == hoveredEntityEntityId && !highlight)
+                if (entityId == hoveredEntityEntityId && !accent)
                 {
                     hoveredEntityIdAccentRemoved = true;
                 }
@@ -2953,14 +2953,14 @@ namespace UnitTest
         AzToolsFramework::HandleAccents(
             currentEntityId, hoveredEntityEntityId, handleAccentsContext, azvi::MouseButtonsFromButton(azvi::MouseButton::None),
             [&hoveredEntityIdAccentRemoved, &currentEntityIdAccentAdded, currentEntityId,
-             hoveredEntityEntityId](const AZ::EntityId entityId, bool highlight)
+             hoveredEntityEntityId](const AZ::EntityId entityId, const bool accent)
             {
-                if (entityId == currentEntityId && highlight)
+                if (entityId == currentEntityId && accent)
                 {
                     currentEntityIdAccentAdded = true;
                 }
 
-                if (entityId == hoveredEntityEntityId && !highlight)
+                if (entityId == hoveredEntityEntityId && !accent)
                 {
                     hoveredEntityIdAccentRemoved = true;
                 }


### PR DESCRIPTION
It was noticed near the end of last week that the feedback for icons (them turning yellow/orange when hovered) did not happen with a selection. This is the correct behavior when 'sticky select' is enabled (the old default) but is wrong when it's disabled. This change takes into account both stick/unsticky select and also makes the function testable with some additional coverage.

Fixes https://github.com/o3de/o3de/issues/5800

### Before

https://user-images.githubusercontent.com/82228511/142902805-30e8f9d0-f745-493b-9117-b8e96ace28ae.mp4

### After

https://user-images.githubusercontent.com/82228511/142902821-f31efc4f-511f-4499-ae7e-e829175689a9.mp4

### Tests

Note: The tests are not exhaustive but make it easy to add more should any bug be reported, this is a pretty good covering to start with.

```
[==========] Running 6 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 6 tests from HandleAccents
[ RUN      ] HandleAccents.CurrentValidEntityIdBecomesHoveredWithNoSelectionAndUnstickySelect
[       OK ] HandleAccents.CurrentValidEntityIdBecomesHoveredWithNoSelectionAndUnstickySelect (0 ms)
[ RUN      ] HandleAccents.CurrentValidEntityIdBecomesHoveredWithSelectionAndUnstickySelect
[       OK ] HandleAccents.CurrentValidEntityIdBecomesHoveredWithSelectionAndUnstickySelect (0 ms)
[ RUN      ] HandleAccents.CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionUnstickySelectAndInvalidButton
[       OK ] HandleAccents.CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionUnstickySelectAndInvalidButton (0 ms)
[ RUN      ] HandleAccents.CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionUnstickySelectAndDoingBoxSelect
[       OK ] HandleAccents.CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionUnstickySelectAndDoingBoxSelect (0 ms)
[ RUN      ] HandleAccents.CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionAndStickySelect
[       OK ] HandleAccents.CurrentValidEntityIdDoesNotBecomeHoveredWithSelectionAndStickySelect (0 ms)
[ RUN      ] HandleAccents.CurrentValidEntityIdDoesBecomeHoveredWithSelectionAndStickySelectAndCtrl
[       OK ] HandleAccents.CurrentValidEntityIdDoesBecomeHoveredWithSelectionAndStickySelectAndCtrl (0 ms)
[----------] 6 tests from HandleAccents (7 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test case ran. (11 ms total)
[  PASSED  ] 6 tests.
```