### PR TITLE
Various Vulkan fixes 

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/SMAAEdgeDetection.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SMAAEdgeDetection.pass
@@ -15,7 +15,12 @@
                 {
                     "Name": "InputDepth",
                     "SlotType": "Input",
-                    "ScopeAttachmentUsage": "Shader"
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "AspectFlags": [
+                            "Depth"
+                        ]
+                    }
                 },
                 {
                     "Name": "OutputEdgeDetectionResult",

--- a/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/PostProcessing/ViewSrg.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderResourceGroups/PostProcessing/ViewSrg.azsli
@@ -26,8 +26,9 @@ partial ShaderResourceGroup ViewSrg
 
         // circle of confusion to screen ratio;
         float m_cocToScreenRatio;
+        [[pad_to(16)]]
     };
-
+     
     DepthOfFieldData m_dof;
     
     struct ExposureControlParameters

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -127,7 +127,7 @@ namespace AZ
             {
                 RHI::Size mipSize = imageSize.GetReducedMip(mip);
 
-                RHI::ImageBindFlags imageBindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
+                RHI::ImageBindFlags imageBindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead;
                 auto transientImageDesc = RHI::ImageDescriptor::Create2D(imageBindFlags, mipSize.m_width, mipSize.m_height, RHI::Format::R16G16B16A16_FLOAT);
 
                 RPI::PassAttachment* transientPassAttachment = aznew RPI::PassAttachment();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/DescriptorSetLayout.h
@@ -76,7 +76,7 @@ namespace AZ
             const AZStd::vector<VkDescriptorBindingFlags>& GetNativeBindingFlags() const;
             const RHI::ShaderResourceGroupLayout* GetShaderResourceGroupLayout() const;
 
-            static const uint32_t MaxUnboundedArrayDescriptors = (1024 * 1024 * 2); // 2M
+            static const uint32_t MaxUnboundedArrayDescriptors = 900000; //Using this number as it needs to be less than maxDescriptorSetSampledImages limit of 1048576
             bool GetHasUnboundedArray() const { return m_hasUnboundedArray; }
 
         private:


### PR DESCRIPTION
- Swapchain related fix for UI editor (only tested Windows)
  -  Object of type VkQueue is simultaneously used in the main thread and the queue thread. Pushed the swapchain invalidation to the presentation queue thread

- Added padding for DepthOfFieldData to ensure it is 16 byte aligned
- Added aspect flag for SMAAEdgeDetectionTemplate pass
- Reduced MaxUnboundedArrayDescriptors so that it is under the maxDescriptorSetSampledImages limit
- Added CopyRead flag for ReflectionScreenSpaceBlurPass related transient resources.