### PR TITLE
Fixed a bug with model previews and thumbnails.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewUtils.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SharedPreview/SharedPreviewUtils.h
@@ -21,7 +21,7 @@ namespace AZ
         namespace SharedPreviewUtils
         {
             //! Get the set of all asset types supported by the shared preview
-            AZStd::unordered_set<AZ::Uuid> GetSupportedAssetTypes();
+            AZStd::vector<AZ::Uuid> GetSupportedAssetTypes();
 
             //! Determine if a thumbnail key has an asset supported by the shared preview
             bool IsSupportedAssetType(AzToolsFramework::Thumbnailer::SharedThumbnailKey key);


### PR DESCRIPTION
A source model asset can have multiple products including models and materials.
It’s not guaranteed that the first entry in the list of products for a model asset will be a model.
In this case the first product was the default material asset.
This caused some model previews to render a gray sphere depicting the default material.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>
![image](https://user-images.githubusercontent.com/82461473/143290463-13d2fd6c-4773-461b-8f16-7bb39993d7e9.png)
![image](https://user-images.githubusercontent.com/82461473/143291213-f59e0974-7002-4af6-8284-0523830617df.png)
![image](https://user-images.githubusercontent.com/82461473/143291260-a671b58d-5a11-4c0c-be06-fb574a7cf442.png)
