### PR TITLE
Fix for GHI5848 and InstanceDataHierarchyEnumContainerTest

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -54,6 +54,7 @@
 #include <AzToolsFramework/API/ComponentEntityObjectBus.h>
 #include <AzToolsFramework/API/EditorCameraBus.h>
 #include <AzToolsFramework/API/ViewPaneOptions.h>
+#include <AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h>
 #include <AzToolsFramework/Entity/EditorEntitySearchComponent.h>
 #include <AzToolsFramework/Entity/EditorEntitySortComponent.h>
 #include <AzToolsFramework/Entity/EditorEntityModelComponent.h>
@@ -385,6 +386,7 @@ namespace AzToolsFramework
         ComponentModeFramework::ComponentModeDelegate::Reflect(context);
 
         ViewportInteraction::ViewportInteractionReflect(context);
+        ViewportEditorModeNotifications::Reflect(context);
 
         Camera::EditorCameraRequests::Reflect(context);
         AzToolsFramework::EditorTransformComponentSelectionRequests::Reflect(context);

--- a/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/InstanceDataHierarchy.cpp
@@ -710,7 +710,7 @@ namespace UnitTest
 
             auto getEnumData = [&ec](const AzToolsFramework::InstanceDataNode& node) -> Uuid
             {
-                Uuid id;
+                Uuid id = Uuid::CreateNull();
                 auto attribute = node.GetElementMetadata()->FindAttribute(AZ_CRC("EnumType"));
                 auto attributeData = azrtti_cast<AttributeData<AZ::TypeId>*>(attribute);
                 if (attributeData)


### PR DESCRIPTION
This PR addresses the Github Issue [ViewportEditorModeNotifications::Reflect method seems to not be called](https://github.com/o3de/o3de/issues/5848) and incidentally fixes the "warning as an error" issue with `InstanceDataHierarchyEnumContainerTest` that was blocking compilation of this PR.

```
Note: Google Test filter = *InstanceDataHierarchyEnumContainerTest*
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from InstanceDataHierarchyEnumContainerTest
[ RUN      ] InstanceDataHierarchyEnumContainerTest.Test
[       OK ] InstanceDataHierarchyEnumContainerTest.Test (3 ms)
[----------] 1 test from InstanceDataHierarchyEnumContainerTest (5 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (12 ms total)
[  PASSED  ] 1 test.
OKAY AzRunUnitTests() returned 0
Returning code: 0
```