### PR TITLE
Bug - retarget status save

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1072,10 +1072,10 @@ namespace AzToolsFramework
             RefreshAutocompleter();
         }
 
-        // When focus is lost, clear the field if necessary
+        // When focus is lost, revert to the selected asset
         if (!focus && m_incompleteFilename)
         {
-            HandleFieldClear();
+            SetSelectedAssetID(GetCurrentAssetID());
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraph.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraph.cpp
@@ -902,6 +902,7 @@ namespace EMotionFX
 
     void AnimGraph::OnRetargetingEnabledChanged()
     {
+        SetDirtyFlag(true);
         for (AnimGraphInstance* animGraphInstance : m_animGraphInstances)
         {
             animGraphInstance->SetRetargetingEnabled(m_retarget);


### PR DESCRIPTION
When the retarget status is changed and then saved, the change is not applied. This fixes the issue by setting the dirty flag to true on change.