### PR TITLE
Bug motion set removal h

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/MotionSetsWindow/MotionSetWindow.cpp
@@ -1138,6 +1138,12 @@ namespace EMStudio
             for (size_t motionSetId = 0; motionSetId < numMotionSets; motionSetId++)
             {
                 EMotionFX::MotionSet* motionSet2 = EMotionFX::GetMotionManager().GetMotionSet(motionSetId);
+
+                if (motionSet2->GetIsOwnedByRuntime())
+                {
+                    continue;
+                }
+
                 if (motionSet2->FindMotionEntryById(motionEntry->GetId()))
                 {
                     numMotionSetContainsMotion++;
@@ -1146,12 +1152,6 @@ namespace EMStudio
                         break;
                     }
                 }
-            }
-
-            // If motion exists in multiple motion sets, then it should not be removed from motions window.
-            if (removeMotion && numMotionSetContainsMotion > 1)
-            {
-                continue;
             }
 
             // check the reference counter if only one reference registered
@@ -1169,6 +1169,12 @@ namespace EMStudio
                 motionIdsToRemoveString += ';';
             }
             motionIdsToRemoveString += motionEntry->GetId();
+
+            // If motion exists in multiple motion sets, then it should not be removed from motions window.
+            if (removeMotion && numMotionSetContainsMotion > 1)
+            {
+                continue;
+            }
 
             // Check if the motion is not valid, that means the motion is not loaded.
             if (removeMotion && motionEntry->GetMotion())


### PR DESCRIPTION
Previously, if a motion was used by more than one motion set, and a user tried to remove it from one of the aforementioned sets, a prompt would appear asking if the user wanted to remove the motion entirely (which was recommended). However, that action would fail completely (it wouldn't remove the motion, or remove it from the motion set). Presumably, this was to prevent loss of the motion being used by another motion set. 

This fix allows the user to select Yes, and does cause the motion to be removed from the motion set. However, it still fails to remove the motion itself in its entirety, thus protecting other motion sets from losing a access to the motion, like the original functionality did.