### PR TITLE
Fixes #5909 hash file stats missing from AP stats log

### DIFF
--- a/Code/Tools/AssetProcessor/native/utilities/StatsCapture.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/StatsCapture.cpp
@@ -132,6 +132,12 @@ namespace AssetProcessor
             // calls PrintStat on each element in the vector.
             void PrintStatsArray(AZStd::vector<AZStd::string>& keys, int maxToPrint, const char* header)
             {
+                // don't print anything out at all, not even a header, if the keys are empty.
+                if (keys.empty())
+                {
+                    return;
+                }
+
                 if ((m_dumpHumanReadableStats)&&(header))
                 {
                     AZ_TracePrintf(AssetProcessor::ConsoleChannel,"Top %i %s\n", maxToPrint, header);

--- a/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/assetUtils.cpp
@@ -1182,7 +1182,11 @@ namespace AssetUtilities
             }
         }
 
+        // keep track of how much time we spend actually hashing files.
+        AZStd::string statName = AZStd::string::format("HashFile,%s", filePath);
+        AssetProcessor::StatsCapture::BeginCaptureStat(statName.c_str());
         hash = AssetBuilderSDK::GetFileHash(filePath, bytesReadOut, hashMsDelay);
+        AssetProcessor::StatsCapture::EndCaptureStat(statName.c_str());
         return hash;
     }
 


### PR DESCRIPTION
The root cause of this was a bad merge.  The hash stats were removed as part of a rework of the hash function merging in from a different change.

This also makes it so that it doesn't  print out the "header" of a stat section if there are no stats in that section.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>