### PR TITLE
Bug- Track View in Sequence Editor

### DIFF
--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -1261,6 +1261,11 @@ void CTrackViewDialog::OnSequenceComboBox()
         GetIEditor()->GetAnimation()->SetSequence(nullptr, false, false);
         return;
     }
+    if (sel == 0)
+    {
+        GetIEditor()->GetAnimation()->SetSequence(nullptr, false, false, true);
+        return;
+    }
 
     // Display current sequence.
     QString entityIdString = m_sequencesComboBox->currentData().toString();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1072,10 +1072,10 @@ namespace AzToolsFramework
             RefreshAutocompleter();
         }
 
-        // When focus is lost, clear the field if necessary
+        // When focus is lost, revert to the selected asset
         if (!focus && m_incompleteFilename)
         {
-            HandleFieldClear();
+            SetSelectedAssetID(GetCurrentAssetID());
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
@@ -588,6 +588,8 @@ namespace EMStudio
             {
                 return false;
             }
+
+            animGraph->SetDirtyFlag(false);
         }
 
         return saveResult;


### PR DESCRIPTION
Previously, in the Track View of the Sequence Editor, if a user selected a track, and then switched to No-Sequence, the previous track's data would be displayed. This is misleading.

This fix resolves that issue by removing the data from the Track View window, as appropriate.