### PR TITLE
Bug -  association update

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1072,10 +1072,10 @@ namespace AzToolsFramework
             RefreshAutocompleter();
         }
 
-        // When focus is lost, clear the field if necessary
+        // When focus is lost, revert to the selected asset
         if (!focus && m_incompleteFilename)
         {
-            HandleFieldClear();
+            SetSelectedAssetID(GetCurrentAssetID());
         }
     }
 

--- a/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.cpp
+++ b/Gems/AudioEngineWwise/Code/Source/Editor/AudioSystemEditor_wwise.cpp
@@ -322,6 +322,10 @@ namespace AudioControls
                                 connection->m_value = value;
                                 return connection;
                             }
+                            case EACEControlType::eACET_ENVIRONMENT:
+                            {
+                                return AZStd::make_shared<IAudioConnection>(control->GetId());
+                            }
                         }
                     }
                     else
@@ -575,7 +579,7 @@ namespace AudioControls
         case eACET_SWITCH_STATE:
             return (eWCT_WWISE_SWITCH | eWCT_WWISE_GAME_STATE | eWCT_WWISE_RTPC);
         case eACET_ENVIRONMENT:
-            return (eWCT_WWISE_AUX_BUS | eWCT_WWISE_SWITCH | eWCT_WWISE_GAME_STATE | eWCT_WWISE_RTPC);
+            return (eWCT_WWISE_AUX_BUS | eWCT_WWISE_RTPC);
         case eACET_PRELOAD:
             return eWCT_WWISE_SOUND_BANK;
         }


### PR DESCRIPTION
After associating a control and clicking Save, the control disappears. This bugfix ensures the association type processing is not omitted, allowing the correct display of the association.