### PR TITLE
Bug render options

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1072,10 +1072,10 @@ namespace AzToolsFramework
             RefreshAutocompleter();
         }
 
-        // When focus is lost, clear the field if necessary
+        // When focus is lost, revert to the selected asset
         if (!focus && m_incompleteFilename)
         {
-            HandleFieldClear();
+            SetSelectedAssetID(GetCurrentAssetID());
         }
     }
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.cpp
@@ -933,6 +933,7 @@ namespace EMStudio
 
         // save the current settings and disable rendering
         m_renderOptions.SetLastUsedLayout(layout->GetName());
+        SaveRenderOptions();
         ClearViewWidgets();
         VisibilityChanged(false);
 


### PR DESCRIPTION
If a user opens multiple windows in the animation editor, and then reverts back to a single window, the previous render settings are not persistent. This fix saves the render options to resolve this.