### PR TITLE
EMotion FX: Saving Anim Graph with CTRL+S displays unsaved changes prompt when no changes were made

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.cpp
@@ -581,6 +581,11 @@ namespace EMStudio
                 animGraph->SetFileName(filename.c_str());
             }
 
+            if (parameters.GetValueAsBool("updateDirtyFlag", this))
+            {
+                animGraph->SetDirtyFlag(false);
+            }
+
             GetMainWindow()->GetFileManager()->SourceAssetChanged(filename);
 
             // Add file in case it did not exist before (when saving it the first time).

--- a/Gems/EMotionFX/Code/Tests/UI/CanUseFileMenu.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanUseFileMenu.cpp
@@ -330,6 +330,10 @@ namespace EMotionFX
             const QString animGraphFilename = GenerateTempAnimGraphFilename();
             SaveCurrentAnimGraph(animGraphFilename);
 
+            // Pretend editing the anim graph
+            EMotionFX::AnimGraph* animGraph = m_animGraphPlugin->GetActiveAnimGraph();
+            animGraph->SetDirtyFlag(true);
+
             // Prepare a watcher to press the ok button when the SaveDirtySettingsWindow appears.
             ModalPopupHandler saveDirtyPopupHandler;
 


### PR DESCRIPTION
Saving an anim graph did not adjust the dirty flag and thus the saved changes dialog kept showing anim graphs that already saved the latest changes.

Resolves #4523

Signed-off-by: Benjamin Jillich <jillich@amazon.com>