### PR TITLE
Fix Integer Spin Controller not sending PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -169,6 +169,10 @@ namespace AzToolsFramework
         {
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
         });
+        this->connect(newCtrl, &PropertyControl::editingFinished, this,[newCtrl]()
+        {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
+        });
         // note:  Qt automatically disconnects objects from each other when either end is destroyed, no need to worry about delete.
 
         // Set the value range to that of ValueType as clamped to the range of QtWidgetValueType

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -169,7 +169,7 @@ namespace AzToolsFramework
         {
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Events::RequestWrite, newCtrl);
         });
-        this->connect(newCtrl, &PropertyControl::editingFinished, this,[newCtrl]()
+        this->connect(newCtrl, &PropertyControl::editingFinished, this, [newCtrl]()
         {
             AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished, newCtrl);
         });

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.cpp
@@ -6,7 +6,9 @@
  *
  */
 
-#include "IntegerPrimtitiveTestConfig.h"
+#include <AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h>
+#include <AzToolsFramework/UI/PropertyEditor/QtWidgetLimits.h>
+#include <Tests/IntegerPrimtitiveTestConfig.h>
 
 namespace UnitTest
 {

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
@@ -156,6 +156,16 @@ namespace UnitTest
             EXPECT_STREQ(tooltip.toStdString().c_str(), expected.str().c_str());
         }
 
+        void EmitWidgetValueChanged()
+        {
+            emit m_widget->valueChanged(ValueType(0));
+        }
+
+        void EmitWidgetEditingFinished()
+        {
+            emit m_widget->editingFinished();
+        }
+
         AZStd::unique_ptr<QWidget> m_dummyWidget;
         AZStd::unique_ptr<HandlerAPI> m_handler;
         WidgetType* m_widget;

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntSpinCtrlTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntSpinCtrlTests.cpp
@@ -47,4 +47,71 @@ namespace UnitTest
     {
         this->HandlerMinMaxLessLimit_ModifyHandler_ExpectSuccessAndValidLessLimitToolTipString();
     }
+
+    struct PropertyEditorHandler
+        : public AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler
+    {
+        PropertyEditorHandler()
+        {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusConnect();
+        }
+
+        ~PropertyEditorHandler()
+        {
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Handler::BusDisconnect();
+        }
+
+        // AzToolsFramework::PropertyEditorGUIMessages::Bus overrides ...
+        void RequestWrite([[maybe_unused]] QWidget* editorGUI) override
+        {
+            m_requestWriteCallCount++;
+        }
+
+        void RequestRefresh([[maybe_unused]] PropertyModificationRefreshLevel level) override
+        {
+        }
+
+        void AddElementsToParentContainer(
+            [[maybe_unused]] QWidget* editorGUI,
+            [[maybe_unused]] size_t numElements,
+            [[maybe_unused]] const InstanceDataNode::FillDataClassCallback& fillDataCallback) override
+        {
+        }
+
+        void RequestPropertyNotify([[maybe_unused]] QWidget* editorGUI) override
+        {
+        }
+
+        void OnEditingFinished([[maybe_unused]]QWidget* editorGUI) override
+        {
+            m_onEditingFinishedCallCount++;
+        }
+
+        int m_requestWriteCallCount = 0;
+        int m_onEditingFinishedCallCount = 0;
+    };
+
+    TYPED_TEST(PropertySpinCtrlFixture, SpinBoxWidgetValueChangedInvokesPropertyEditorGUIMessages)
+    {
+        // setup the event handler
+        PropertyEditorHandler eventHandler;
+
+        // trigger the QT signal
+        this->EmitWidgetValueChanged();
+
+        // there should be at least 1 call to RequestWrite.
+        EXPECT_GT(eventHandler.m_requestWriteCallCount, 0);
+    }
+
+    TYPED_TEST(PropertySpinCtrlFixture, SpinBoxWidgetEditingFinishedInvokesPropertyEditorGUIMessages)
+    {
+        // setup the event handler
+        PropertyEditorHandler eventHandler;
+
+        // trigger the QT signal
+        this->EmitWidgetEditingFinished();
+
+        // there should be at least 1 call to OnEditingFinished.
+        EXPECT_GT(eventHandler.m_onEditingFinishedCallCount, 0);
+    }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -100,6 +100,7 @@ set(FILES
     Prefab/SpawnableSortEntitiesTests.cpp
     Prefab/PrefabScriptingTests.cpp
     Prefab/ProceduralPrefabAssetTests.cpp
+    PropertyIntCtrlCommonTests.cpp
     PropertyIntCtrlCommonTests.h
     PropertyIntSliderCtrlTests.cpp
     PropertyIntSpinCtrlTests.cpp


### PR DESCRIPTION
Also added tests to verify PropertyEditorGUIMessages::Bus::Handler::OnEditingFinished and PropertyEditorGUIMessages::Bus::Events::RequestWrite events are send by the int spin controls.

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>