### PR TITLE
Fix for bug - switch association fails

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/ATLControlsPanel.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/ATLControlsPanel.cpp
@@ -807,11 +807,11 @@ namespace AudioControls
                                     if (!pATLParent->SwitchStateConnectionCheck(pAudioSystemControl))
                                     {
                                         QMessageBox messageBox(this);
-                                        messageBox.setStandardButtons(QMessageBox::Yes);
-                                        messageBox.setDefaultButton(QMessageBox::Yes);
+                                        messageBox.setStandardButtons(QMessageBox::Ok);
+                                        messageBox.setDefaultButton(QMessageBox::Ok);
                                         messageBox.setWindowTitle("Audio Controls Editor");
                                         messageBox.setText("Not in the same switch group, connection failed.");
-                                        if (messageBox.exec() == QMessageBox::Yes)
+                                        if (messageBox.exec() == QMessageBox::Ok)
                                         {
                                             return;
                                         }

--- a/Gems/AudioSystem/Code/Source/Editor/ATLControlsPanel.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/ATLControlsPanel.cpp
@@ -802,6 +802,21 @@ namespace AudioControls
                                 {
                                     AZ::StringFunc::Path::StripExtension(sControlName);
                                 }
+                                else if (eControlType == eACET_SWITCH_STATE)
+                                {
+                                    if (!pATLParent->SwitchStateConnectionCheck(pAudioSystemControl))
+                                    {
+                                        QMessageBox messageBox(this);
+                                        messageBox.setStandardButtons(QMessageBox::Yes);
+                                        messageBox.setDefaultButton(QMessageBox::Yes);
+                                        messageBox.setWindowTitle("Audio Controls Editor");
+                                        messageBox.setText("Not in the same switch group, connection failed.");
+                                        if (messageBox.exec() == QMessageBox::Yes)
+                                        {
+                                            return;
+                                        }
+                                    }
+                                }
                                 CATLControl* pTargetControl2 = m_pTreeModel->CreateControl(eControlType, sControlName, pATLParent);
                                 if (pTargetControl2)
                                 {

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControl.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControl.cpp
@@ -368,4 +368,36 @@ namespace AudioControls
         }
     }
 
+    bool CATLControl::SwitchStateConnectionCheck(IAudioSystemControl* middlewareControl)
+    {
+        if (IAudioSystemEditor* audioSystemImpl = CAudioControlsEditorPlugin::GetImplementationManager()->GetImplementation())
+        {
+            CID parentID = middlewareControl->GetParent()->GetId();
+            EACEControlType compatibleType = audioSystemImpl->ImplTypeToATLType(middlewareControl->GetType());
+            if (compatibleType == EACEControlType::eACET_SWITCH_STATE && m_type == EACEControlType::eACET_SWITCH)
+            {
+                for (auto& child : m_children)
+                {
+                    for (int j = 0; child && j < child->ConnectionCount(); ++j)
+                    {
+                        TConnectionPtr tmpConnection = child->GetConnectionAt(j);
+                        if (tmpConnection)
+                        {
+                            IAudioSystemControl* tmpMiddlewareControl = audioSystemImpl->GetControl(tmpConnection->GetID());
+                            EACEControlType controlType = audioSystemImpl->ImplTypeToATLType(tmpMiddlewareControl->GetType());
+                            if (tmpMiddlewareControl && controlType == EACEControlType::eACET_SWITCH_STATE)
+                            {
+                                if (parentID != ACE_INVALID_CID && tmpMiddlewareControl->GetParent()->GetId() != parentID)
+                                {
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
 } // namespace AudioControls

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControl.h
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControl.h
@@ -144,6 +144,8 @@ namespace AudioControls
         void SignalConnectionAdded(IAudioSystemControl* middlewareControl);
         void SignalConnectionRemoved(IAudioSystemControl* middlewareControl);
 
+        bool SwitchStateConnectionCheck(IAudioSystemControl* middlewareControl);
+
     private:
         void SetId(CID id);
         void SetType(EACEControlType type);

--- a/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.cpp
@@ -150,6 +150,22 @@ namespace AudioControls
             }
             else
             {
+                if (m_control->GetType() == EACEControlType::eACET_SWITCH_STATE)
+                {
+                    if (!m_control->GetParent()->SwitchStateConnectionCheck(middlewareControl))
+                    {
+                        QMessageBox messageBox(this);
+                        messageBox.setStandardButtons(QMessageBox::Yes);
+                        messageBox.setDefaultButton(QMessageBox::Yes);
+                        messageBox.setWindowTitle("Audio Controls Editor");
+                        messageBox.setText("Not in the same switch group, connection failed.");
+                        if (messageBox.exec() == QMessageBox::Yes)
+                        {
+                            return;
+                        }
+                    }
+                }
+
                 connection = audioSystemImpl->CreateConnectionToControl(m_control->GetType(), middlewareControl);
                 if (connection)
                 {

--- a/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.cpp
@@ -155,11 +155,11 @@ namespace AudioControls
                     if (!m_control->GetParent()->SwitchStateConnectionCheck(middlewareControl))
                     {
                         QMessageBox messageBox(this);
-                        messageBox.setStandardButtons(QMessageBox::Yes);
-                        messageBox.setDefaultButton(QMessageBox::Yes);
+                        messageBox.setStandardButtons(QMessageBox::Ok);
+                        messageBox.setDefaultButton(QMessageBox::Ok);
                         messageBox.setWindowTitle("Audio Controls Editor");
                         messageBox.setText("Not in the same switch group, connection failed.");
-                        if (messageBox.exec() == QMessageBox::Yes)
+                        if (messageBox.exec() == QMessageBox::Ok)
                         {
                             return;
                         }


### PR DESCRIPTION
This prevents inappropriate connections being made and displays a message telling the user.

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>