### PR TITLE
Camera locking when its transform is locked

### DIFF
--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -159,11 +159,6 @@ namespace Camera
         m_isLockedFn = isLockedFunction;
     }
 
-    void CameraComponentController::SetUnpossesCurrentCameraFunction(AZStd::function<void()> unpossesCurrentCameraFunction)
-    {
-        m_unpossesCurrentCameraFn = unpossesCurrentCameraFunction;
-    }
-
     void CameraComponentController::Reflect(AZ::ReflectContext* context)
     {
         CameraComponentConfig::Reflect(context);
@@ -209,10 +204,7 @@ namespace Camera
             {
                 AZ::TransformBus::Event(m_entityId, &AZ::TransformInterface::SetWorldTM, m_atomCamera->GetCameraTransform());
             }
-            else
-            {
-                m_unpossesCurrentCameraFn();
-            }
+
         });
     }
 

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -151,12 +151,12 @@ namespace Camera
 
     void CameraComponentController::SetShouldActivateFunction(AZStd::function<bool()> shouldActivateFunction)
     {
-        m_shouldActivateFn = shouldActivateFunction;
+        m_shouldActivateFn = AZStd::move(shouldActivateFunction);
     }
 
     void CameraComponentController::SetIsLockedFunction(AZStd::function<bool()> isLockedFunction)
     {
-        m_isLockedFn = isLockedFunction;
+        m_isLockedFn = AZStd::move(isLockedFunction);
     }
 
     void CameraComponentController::Reflect(AZ::ReflectContext* context)

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -154,6 +154,11 @@ namespace Camera
         m_shouldActivateFn = shouldActivateFunction;
     }
 
+    void CameraComponentController::SetIsLockedFunction(AZStd::function<bool()> isLockedFunction)
+    {
+        m_isLockedFn = isLockedFunction;
+    }
+
     void CameraComponentController::Reflect(AZ::ReflectContext* context)
     {
         CameraComponentConfig::Reflect(context);
@@ -195,7 +200,7 @@ namespace Camera
     {
         m_onViewMatrixChanged = AZ::Event<const AZ::Matrix4x4&>::Handler([this](const AZ::Matrix4x4&)
         {
-            if (!m_updatingTransformFromEntity)
+            if (!m_updatingTransformFromEntity && !m_isLockedFn())
             {
                 AZ::TransformBus::Event(m_entityId, &AZ::TransformInterface::SetWorldTM, m_atomCamera->GetCameraTransform());
             }

--- a/Gems/Camera/Code/Source/CameraComponentController.cpp
+++ b/Gems/Camera/Code/Source/CameraComponentController.cpp
@@ -159,6 +159,11 @@ namespace Camera
         m_isLockedFn = isLockedFunction;
     }
 
+    void CameraComponentController::SetUnpossesCurrentCameraFunction(AZStd::function<void()> unpossesCurrentCameraFunction)
+    {
+        m_unpossesCurrentCameraFn = unpossesCurrentCameraFunction;
+    }
+
     void CameraComponentController::Reflect(AZ::ReflectContext* context)
     {
         CameraComponentConfig::Reflect(context);
@@ -203,6 +208,10 @@ namespace Camera
             if (!m_updatingTransformFromEntity && !m_isLockedFn())
             {
                 AZ::TransformBus::Event(m_entityId, &AZ::TransformInterface::SetWorldTM, m_atomCamera->GetCameraTransform());
+            }
+            else
+            {
+                m_unpossesCurrentCameraFn();
             }
         });
     }

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -70,6 +70,9 @@ namespace Camera
         //! Used by the Editor to disable undesirable camera changes in edit mode.
         void SetShouldActivateFunction(AZStd::function<bool()> shouldActivateFunction);
 
+        //! Defines a callback for determining whether this camera is currently locked by its transform.
+        void SetIsLockedFunction(AZStd::function<bool()> isLockedFunction);
+
         // Controller interface
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
@@ -136,5 +139,6 @@ namespace Camera
         bool m_isActiveView = false;
 
         AZStd::function<bool()> m_shouldActivateFn;
+        AZStd::function<bool()> m_isLockedFn = []{ return false; };
     };
 } // namespace Camera

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -73,6 +73,9 @@ namespace Camera
         //! Defines a callback for determining whether this camera is currently locked by its transform.
         void SetIsLockedFunction(AZStd::function<bool()> isLockedFunction);
 
+        //! Defines a callback to unposses the current camera view.
+        void SetUnpossesCurrentCameraFunction(AZStd::function<void()> unpossesCurrentCameraFunction);
+
         // Controller interface
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
@@ -140,5 +143,6 @@ namespace Camera
 
         AZStd::function<bool()> m_shouldActivateFn;
         AZStd::function<bool()> m_isLockedFn = []{ return false; };
+        AZStd::function<void()> m_unpossesCurrentCameraFn;
     };
 } // namespace Camera

--- a/Gems/Camera/Code/Source/CameraComponentController.h
+++ b/Gems/Camera/Code/Source/CameraComponentController.h
@@ -73,9 +73,6 @@ namespace Camera
         //! Defines a callback for determining whether this camera is currently locked by its transform.
         void SetIsLockedFunction(AZStd::function<bool()> isLockedFunction);
 
-        //! Defines a callback to unposses the current camera view.
-        void SetUnpossesCurrentCameraFunction(AZStd::function<void()> unpossesCurrentCameraFunction);
-
         // Controller interface
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
@@ -143,6 +140,5 @@ namespace Camera
 
         AZStd::function<bool()> m_shouldActivateFn;
         AZStd::function<bool()> m_isLockedFn = []{ return false; };
-        AZStd::function<void()> m_unpossesCurrentCameraFn;
     };
 } // namespace Camera

--- a/Gems/Camera/Code/Source/EditorCameraComponent.cpp
+++ b/Gems/Camera/Code/Source/EditorCameraComponent.cpp
@@ -18,6 +18,7 @@
 
 #include <Atom/RPI.Public/ViewportContext.h>
 #include <Atom/RPI.Public/View.h>
+#include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 
 namespace Camera
 {
@@ -39,6 +40,16 @@ namespace Camera
                 AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
                     isInGameMode, &AzToolsFramework::EditorEntityContextRequestBus::Events::IsEditorRunningGame);
                 return isInGameMode;
+            });
+
+        // Only allow our camera to move when the transform is not locked.
+        m_controller.SetIsLockedFunction([this]()
+            {
+                bool locked = false;
+                AzToolsFramework::Components::TransformComponentMessages::Bus::EventResult(
+                    locked, GetEntityId(), &AzToolsFramework::Components::TransformComponentMessages::IsTransformLocked);
+
+                return locked;
             });
 
         // Call base class activate, which in turn calls Activate on our controller.

--- a/Gems/Camera/Code/Source/EditorCameraComponent.cpp
+++ b/Gems/Camera/Code/Source/EditorCameraComponent.cpp
@@ -52,6 +52,12 @@ namespace Camera
                 return locked;
             });
 
+        //To unposses camera when we move in the viewport with the transform locked.
+        m_controller.SetUnpossesCurrentCameraFunction([]()
+            {
+                EditorCameraRequests::Bus::Broadcast(&EditorCameraRequests::SetViewFromEntityPerspective, AZ::EntityId());
+            });
+
         // Call base class activate, which in turn calls Activate on our controller.
         EditorCameraComponentBase::Activate();
 

--- a/Gems/Camera/Code/Source/EditorCameraComponent.cpp
+++ b/Gems/Camera/Code/Source/EditorCameraComponent.cpp
@@ -52,12 +52,6 @@ namespace Camera
                 return locked;
             });
 
-        //To unposses camera when we move in the viewport with the transform locked.
-        m_controller.SetUnpossesCurrentCameraFunction([]()
-            {
-                EditorCameraRequests::Bus::Broadcast(&EditorCameraRequests::SetViewFromEntityPerspective, AZ::EntityId());
-            });
-
         // Call base class activate, which in turn calls Activate on our controller.
         EditorCameraComponentBase::Activate();
 


### PR DESCRIPTION
This fixes #5477
There is some notes to this fix:
1 - When you lock the camera transform in "Be this camera" mode you can still move around but the camera transform won't be updated, once you unlock the camera transform and move while still being that camera will update its position to the current view.
2 - If you have moved while being this camera and with the transform locked, if you switch to another camera and return to the locked one will return to that camera locked transform.

Suggestions:
It would be worth thinking about having a button in the camera component that would let you recenter the current view to the camera's transform, so when you move when the transform locked you can return to the view. I've heard this from @HogJonny-AMZN and this could be expanded to a "look through entity" button that can be very useful when positioning lights in a level for example.

https://user-images.githubusercontent.com/82394219/143864719-1c2a73d0-35f6-4066-a8da-5c28e91f4f1d.mp4

 
