### PR TITLE
Added Tests for Gem Catalog Filtering

### DIFF
--- a/Code/Tools/ProjectManager/CMakeLists.txt
+++ b/Code/Tools/ProjectManager/CMakeLists.txt
@@ -92,6 +92,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzTest
                 AZ::AzFramework
                 AZ::AzFrameworkTestShared
+                AZ::AzQtComponents
                 AZ::ProjectManager.Static
     )
 

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInfo.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInfo.h
@@ -73,7 +73,7 @@ namespace O3DE::ProjectManager
 
         QString m_path;
         QString m_name = "Unknown Gem Name";
-        QString m_displayName = "Unknown Gem Name";
+        QString m_displayName;
         QString m_creator = "Unknown Creator";
         GemOrigin m_gemOrigin = Local;
         bool m_isAdded = false; //! Is the gem currently added and enabled in the project?

--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemInfo.h
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemInfo.h
@@ -76,7 +76,7 @@ namespace O3DE::ProjectManager
         QString m_displayName;
         QString m_creator = "Unknown Creator";
         GemOrigin m_gemOrigin = Local;
-        bool m_isAdded = false; //! Is the gem currently added and enabled in the project?
+        bool m_isAdded = false; //! Is the gem explicitly added (not a dependency) and enabled in the project?
         QString m_summary = "No summary provided.";
         Platforms m_platforms;
         Types m_types; //! Asset and/or Code and/or Tool

--- a/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
+++ b/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
@@ -31,7 +31,7 @@ namespace O3DE::ProjectManager
         AZStd::unique_ptr<GemModel> m_gemModel;
     };
 
-    TEST_F(GemCatalogTests, GemCatalog_Displays_But_Does_Not_Add_Dependencies)
+    TEST_F(GemCatalogTests, GemCatalog_GemWithDependencies_DisplaysButDoesNotAddDependencies)
     {
         // given 3 gems a,b,c where a depends on b which depends on c
         GemInfo gemA, gemB, gemC;
@@ -60,7 +60,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(GemModel::IsAddedDependency(indexB) && GemModel::IsAddedDependency(indexC));
         EXPECT_FALSE(GemModel::IsAdded(indexB) || GemModel::IsAdded(indexC));
 
-        QVector<QModelIndex> gemsToAdd = m_gemModel->GatherGemsToBeAdded();
+        const QVector<QModelIndex>& gemsToAdd = m_gemModel->GatherGemsToBeAdded();
         EXPECT_TRUE(gemsToAdd.size() == 1);
         EXPECT_EQ(GemModel::GetName(gemsToAdd.at(0)), gemA.m_name);
     }
@@ -126,7 +126,7 @@ namespace O3DE::ProjectManager
         QVector<int> m_gemRows;
     };
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Name_Only)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringName_ShowsNameGems)
     {
         m_proxyModel->SetSearchString("Name");
 
@@ -137,7 +137,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Display_Name_Only)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringDisplayName_ShowsDisplayNameGem)
     {
         m_proxyModel->SetSearchString("Display Name");
 
@@ -148,7 +148,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Creator_Only)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringCreator_ShowsCreatorGem)
     {
         m_proxyModel->SetSearchString("Johnathon Doe");
 
@@ -159,7 +159,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Summary_Only)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringSummary_ShowsSummaryGem)
     {
         m_proxyModel->SetSearchString("Unique Summary");
 
@@ -170,7 +170,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Features_Only)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringFeatures_ShowsFeatureGem)
     {
         m_proxyModel->SetSearchString("Creative");
 
@@ -181,7 +181,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Empty_Shows_All)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringEmpty_ShowsAll)
     {
         m_proxyModel->SetSearchString("");
 
@@ -192,7 +192,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_A_Shows_All)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringCommonCharacter_ShowsAll)
     {
         // All gems contain "a" in a searchable field so all should be shown
         m_proxyModel->SetSearchString("a");
@@ -204,7 +204,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Case_Insensitive_A_Shows_All)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringDifferentCaseCommonCharacter_ShowsAll)
     {
         // No gems contain the character "A" but search should be case insensitive
         m_proxyModel->SetSearchString("A");
@@ -216,7 +216,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Z_Shows_None)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringNoneContainCharacter_ShowsNone)
     {
         // No gems contain the character "z" or "Z" so none should be shown
         m_proxyModel->SetSearchString("z");
@@ -228,7 +228,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
     }
 
-    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_No_Token_Support)
+    TEST_F(GemCatalogSearchFilterTests, GemCatalogFilters_SearchStringPartialMatchString_ShowsNone)
     {
         // Token matching is currently not supported
         // The whole string must match a substring
@@ -295,7 +295,7 @@ namespace O3DE::ProjectManager
         QVector<QModelIndex> m_gemIndices;
     };
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Selected_Active_Expected_State)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_SelectedActiveIntialState_AddedGemsAndDependenciesAreAdded)
     {
         // Check if gems are all in expected state
         // if this test fails all other Selected/Active tests are invalid
@@ -307,7 +307,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(GemModel::IsAdded(m_gemIndices[Inactive]));
     }
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Selected_Active_No_Filter_Shows_All)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_SelectedActiveNoFilter_ShowsAll)
     {
         // Filter is clear
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
@@ -318,7 +318,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
     }
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Selected_Shown_Only)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_FilterSelected_ShowsSelectedAndDependencies)
     {
         // Check selected filter
         // Selected dependencies should also be shown
@@ -332,7 +332,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
     }
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Unselected_Shown_Only)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_FilterUnselected_ShowsUnselectedAndDependencies)
     {
         // Check unselected filter
         // Unselected dependencies should also be shown
@@ -346,7 +346,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
     }
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Un_Selected_Shows_All_Changes)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_FilterSelectedAndUnselected_ShowsAllChangesAndDependencies)
     {
         // Check both un/selected filter
         m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Both);
@@ -359,7 +359,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
     }
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Active_Shown_Only)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_FilterActive_ShowsActive)
     {
         // Check active filter
         // Active dependencies should also be shown
@@ -373,7 +373,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
     }
 
-    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Inactive_Shown_Only)
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalogFilters_FilterActive_ShowsInactive)
     {
         // Check inactive filter
         m_proxyModel->SetGemActive(GemSortFilterProxyModel::GemActive::Inactive);
@@ -433,7 +433,7 @@ namespace O3DE::ProjectManager
         QVector<int> m_gemRows;
     };
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Misc_No_Filter_Shows_All)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_MiscNoFilter_ShowsAll)
     {
         // No filter
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
@@ -441,7 +441,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Origin_Only)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterSingleOrigin_ShowsOriginMatch)
     {
         m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Open3DEngine);
 
@@ -462,7 +462,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Origin_Multiselection_Shows_All_Matches)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterMultipleOrigins_ShowsMultipleOriginMatches)
     {
         m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Open3DEngine | GemInfo::GemOrigin::Local);
 
@@ -471,7 +471,7 @@ namespace O3DE::ProjectManager
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Type_Only)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterSingleType_ShowsTypeMatch)
     {
         m_proxyModel->SetTypes(GemInfo::Type::Code);
 
@@ -492,7 +492,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Type_Multiselection_Shows_All_Matches)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterMultipleTypes_ShowsMultipleTypeMatches)
     {
         m_proxyModel->SetTypes(GemInfo::Type::Tool | GemInfo::Type::Asset);
 
@@ -501,7 +501,7 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Platform_Only)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterSinglePlatform_ShowsPlatformMatch)
     {
         m_proxyModel->SetPlatforms(GemInfo::Platform::Windows);
 
@@ -522,37 +522,37 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Platform_Multiselection_Shows_All_Matches)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterMultiplePlatforms_ShowsMultiplePlatformMatches)
     {
-        m_proxyModel->SetPlatforms(GemInfo::Platform::Windows | GemInfo::Platform::iOS);
+        m_proxyModel->SetPlatforms(GemInfo::Platform::Android | GemInfo::Platform::iOS);
 
-        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Features_Only)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterSingleFeature_ShowsFeatureMatch)
     {
-        m_proxyModel->SetFeatures({ "Framework" });
+        m_proxyModel->SetFeatures({ "Audio" });
 
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
-        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
-        m_proxyModel->SetFeatures({ "Tools", "UI" });
+        m_proxyModel->SetFeatures({ "Tools", });
 
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
 
-        m_proxyModel->SetFeatures({ "Assets", "Content", "Environment" });
+        m_proxyModel->SetFeatures({ "Environment" });
 
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Features_Multiselection_Shows_All_Matches)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterMultipleFeatures_ShowsMultipleFeatureMatches)
     {
         m_proxyModel->SetFeatures({ "Assets", "Framework" });
 
@@ -561,8 +561,9 @@ namespace O3DE::ProjectManager
         EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 
-    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Features_Must_Be_Exact_Match)
+    TEST_F(GemCatalogMiscFilterTests, GemCatalogFilters_FilterPartialMatchFeature_ShowsNone)
     {
+        // Features must be an exact match to filter by them directly
         m_proxyModel->SetFeatures({ "Frame" });
 
         EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));

--- a/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
+++ b/Code/Tools/ProjectManager/tests/GemCatalogTests.cpp
@@ -8,8 +8,8 @@
 
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzTest/Utils.h>
-#include <GemCatalog/GemModel.h>
 
+#include <GemCatalog/GemSortFilterProxyModel.h>
 
 namespace O3DE::ProjectManager
 {
@@ -17,14 +17,22 @@ namespace O3DE::ProjectManager
         : public ::UnitTest::ScopedAllocatorSetupFixture
     {
     public:
+        void SetUp() override
+        {
+            m_gemModel.reset(new GemModel());
+        }
 
-        GemCatalogTests() = default;
+        void TearDown() override
+        {
+            m_gemModel.release();
+        }
+
+    protected:
+        AZStd::unique_ptr<GemModel> m_gemModel;
     };
 
     TEST_F(GemCatalogTests, GemCatalog_Displays_But_Does_Not_Add_Dependencies)
     {
-        GemModel* gemModel = new GemModel();
-
         // given 3 gems a,b,c where a depends on b which depends on c
         GemInfo gemA, gemB, gemC;
         QModelIndex indexA, indexB, indexC;
@@ -35,30 +43,530 @@ namespace O3DE::ProjectManager
         gemA.m_dependencies = QStringList({ "b" });
         gemB.m_dependencies = QStringList({ "c" });
 
-        gemModel->AddGem(gemA);
-        indexA = gemModel->FindIndexByNameString(gemA.m_name);
+        indexA = m_gemModel->AddGem(gemA);
+        indexB = m_gemModel->AddGem(gemB);
+        indexC = m_gemModel->AddGem(gemC);
 
-        gemModel->AddGem(gemB);
-        indexB = gemModel->FindIndexByNameString(gemB.m_name);
-
-        gemModel->AddGem(gemC);
-        indexC = gemModel->FindIndexByNameString(gemC.m_name);
-
-        gemModel->UpdateGemDependencies();
+        m_gemModel->UpdateGemDependencies();
 
         EXPECT_FALSE(GemModel::IsAdded(indexA));
         EXPECT_FALSE(GemModel::IsAddedDependency(indexB) || GemModel::IsAddedDependency(indexC));
 
         // when a is added
-        GemModel::SetIsAdded(*gemModel, indexA, true);
+        GemModel::SetIsAdded(*m_gemModel, indexA, true);
 
         // expect b and c are now dependencies of an added gem but not themselves added
         // cmake will handle dependencies
         EXPECT_TRUE(GemModel::IsAddedDependency(indexB) && GemModel::IsAddedDependency(indexC));
-        EXPECT_TRUE(!GemModel::IsAdded(indexB) && !GemModel::IsAdded(indexC));
+        EXPECT_FALSE(GemModel::IsAdded(indexB) || GemModel::IsAdded(indexC));
 
-        QVector<QModelIndex> gemsToAdd = gemModel->GatherGemsToBeAdded();
+        QVector<QModelIndex> gemsToAdd = m_gemModel->GatherGemsToBeAdded();
         EXPECT_TRUE(gemsToAdd.size() == 1);
         EXPECT_EQ(GemModel::GetName(gemsToAdd.at(0)), gemA.m_name);
+    }
+
+    class GemCatalogFilterTests
+        : public GemCatalogTests 
+    {
+    public:
+        void SetUp() override
+        {
+            GemCatalogTests::SetUp(); 
+            m_proxyModel.reset(new GemSortFilterProxyModel(m_gemModel.get()));
+        }
+
+        void TearDown() override
+        {
+            m_proxyModel.release();
+            GemCatalogTests::TearDown(); 
+        }
+
+    protected:
+        AZStd::unique_ptr<GemSortFilterProxyModel> m_proxyModel;
+    };
+
+    class GemCatalogSearchFilterTests
+        : public GemCatalogFilterTests
+    {
+    public:
+        void SetUp() override
+        {
+            GemCatalogFilterTests::SetUp();
+
+            GemInfo gemfilterName, gemfilterDisplayName, gemfilterCreator, gemfilterSummary, gemfilterFeature;
+
+            gemfilterName.m_name = "Name";
+            gemfilterDisplayName.m_name = "D";
+            gemfilterCreator.m_name = "C";
+            gemfilterSummary.m_name = "S";
+            gemfilterFeature.m_name = "F";
+
+            gemfilterDisplayName.m_displayName = "Display Name";
+            gemfilterCreator.m_creator = "Johnathon Doe";
+            gemfilterSummary.m_summary = "Unique Summary";
+            gemfilterFeature.m_features.append("Creative Feature");
+
+            m_gemRows.append(m_gemModel->AddGem(gemfilterName).row());
+            m_gemRows.append(m_gemModel->AddGem(gemfilterDisplayName).row());
+            m_gemRows.append(m_gemModel->AddGem(gemfilterCreator).row());
+            m_gemRows.append(m_gemModel->AddGem(gemfilterSummary).row());
+            m_gemRows.append(m_gemModel->AddGem(gemfilterFeature).row());
+        }
+
+    protected:
+        enum RowOrder
+        {
+            Name,
+            DisplayName,
+            Creator,
+            Summary,
+            Features
+        };
+
+        QVector<int> m_gemRows;
+    };
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Name_Only)
+    {
+        m_proxyModel->SetSearchString("Name");
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Display_Name_Only)
+    {
+        m_proxyModel->SetSearchString("Display Name");
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Creator_Only)
+    {
+        m_proxyModel->SetSearchString("Johnathon Doe");
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Summary_Only)
+    {
+        m_proxyModel->SetSearchString("Unique Summary");
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Features_Only)
+    {
+        m_proxyModel->SetSearchString("Creative");
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Empty_Shows_All)
+    {
+        m_proxyModel->SetSearchString("");
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_A_Shows_All)
+    {
+        // All gems contain "a" in a searchable field so all should be shown
+        m_proxyModel->SetSearchString("a");
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Case_Insensitive_A_Shows_All)
+    {
+        // No gems contain the character "A" but search should be case insensitive
+        m_proxyModel->SetSearchString("A");
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_Z_Shows_None)
+    {
+        // No gems contain the character "z" or "Z" so none should be shown
+        m_proxyModel->SetSearchString("z");
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSearchFilterTests, GemCatalog_Filters_By_Search_String_No_Token_Support)
+    {
+        // Token matching is currently not supported
+        // The whole string must match a substring
+        m_proxyModel->SetSearchString("Name Token");
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Name], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DisplayName], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Creator], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Summary], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[Features], QModelIndex()));
+    }
+
+    class GemCatalogSelectedActiveFilterTests
+        : public GemCatalogFilterTests
+    {
+    public:
+        void SetUp() override
+        {
+            GemCatalogFilterTests::SetUp();
+
+            GemInfo gemSelected, gemSelectedDep, gemUnselected, gemUnselectedDep, gemActive, gemInactive;
+
+            gemSelected.m_name = "selected";
+            gemSelectedDep.m_name = "selectedDep";
+            gemUnselected.m_name = "unselected";
+            gemUnselectedDep.m_name = "unselectedDep";
+            gemActive.m_name = "active";
+            gemInactive.m_name = "inactive";
+
+            gemSelected.m_dependencies = QStringList({ "selectedDep" });
+            gemUnselected.m_dependencies = QStringList({ "unselectedDep" });
+
+            m_gemIndices.append(m_gemModel->AddGem(gemSelected));
+            m_gemIndices.append(m_gemModel->AddGem(gemSelectedDep));
+            m_gemIndices.append(m_gemModel->AddGem(gemUnselected));
+            m_gemIndices.append(m_gemModel->AddGem(gemUnselectedDep));
+            m_gemIndices.append(m_gemModel->AddGem(gemActive));
+            m_gemIndices.append(m_gemModel->AddGem(gemInactive));
+
+            m_gemModel->UpdateGemDependencies();
+
+            // Set intial state of catalog with the to be unselected gem currently added along with active gem
+            GemModel::SetIsAdded(*m_gemModel, m_gemIndices[Unselected], true);
+            GemModel::SetWasPreviouslyAdded(*m_gemModel, m_gemIndices[Unselected], true);
+            GemModel::SetIsAdded(*m_gemModel, m_gemIndices[Active], true);
+            GemModel::SetWasPreviouslyAdded(*m_gemModel, m_gemIndices[Active], true);
+
+            // Add selected gem and remove unselected gem
+            GemModel::SetIsAdded(*m_gemModel, m_gemIndices[Selected], true);
+            GemModel::SetIsAdded(*m_gemModel, m_gemIndices[Unselected], false);
+        }
+
+    protected:
+        enum IndexOrder
+        {
+            Selected,
+            SelectedDep,
+            Unselected,
+            UnselectedDep,
+            Active,
+            Inactive
+        };
+
+        QVector<QModelIndex> m_gemIndices;
+    };
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Selected_Active_Expected_State)
+    {
+        // Check if gems are all in expected state
+        // if this test fails all other Selected/Active tests are invalid
+        EXPECT_TRUE(GemModel::IsAdded(m_gemIndices[Selected]));
+        EXPECT_TRUE(GemModel::IsAddedDependency(m_gemIndices[SelectedDep]));
+        EXPECT_FALSE(GemModel::IsAdded(m_gemIndices[Unselected]));
+        EXPECT_FALSE(GemModel::IsAddedDependency(m_gemIndices[UnselectedDep]));
+        EXPECT_TRUE(GemModel::IsAdded(m_gemIndices[Active]));
+        EXPECT_FALSE(GemModel::IsAdded(m_gemIndices[Inactive]));
+    }
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Selected_Active_No_Filter_Shows_All)
+    {
+        // Filter is clear
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[UnselectedDep].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Active].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Selected_Shown_Only)
+    {
+        // Check selected filter
+        // Selected dependencies should also be shown
+        m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Selected);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[UnselectedDep].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Active].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Unselected_Shown_Only)
+    {
+        // Check unselected filter
+        // Unselected dependencies should also be shown
+        m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Unselected);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[UnselectedDep].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Active].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Un_Selected_Shows_All_Changes)
+    {
+        // Check both un/selected filter
+        m_proxyModel->SetGemSelected(GemSortFilterProxyModel::GemSelected::Both);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[UnselectedDep].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Active].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Active_Shown_Only)
+    {
+        // Check active filter
+        // Active dependencies should also be shown
+        m_proxyModel->SetGemActive(GemSortFilterProxyModel::GemActive::Active);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[UnselectedDep].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Active].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
+    }
+
+    TEST_F(GemCatalogSelectedActiveFilterTests, GemCatalog_Filters_By_Inactive_Shown_Only)
+    {
+        // Check inactive filter
+        m_proxyModel->SetGemActive(GemSortFilterProxyModel::GemActive::Inactive);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Selected].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[SelectedDep].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Unselected].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[UnselectedDep].row(), QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemIndices[Active].row(), QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemIndices[Inactive].row(), QModelIndex()));
+    }
+
+    class GemCatalogMiscFilterTests
+        : public GemCatalogFilterTests
+    {
+    public:
+        void SetUp() override
+        {
+            GemCatalogFilterTests::SetUp();
+
+            GemInfo gemA, gemB, gemC;
+
+            gemA.m_name = "Default Audio";
+            gemB.m_name = "Mobile UX";
+            gemC.m_name = "City Props";
+
+            gemA.m_gemOrigin = GemInfo::GemOrigin::Open3DEngine;
+            gemB.m_gemOrigin = GemInfo::GemOrigin::Local;
+            gemC.m_gemOrigin = GemInfo::GemOrigin::Remote;
+
+            gemA.m_types = GemInfo::Type::Code;
+            gemB.m_types = GemInfo::Type::Code | GemInfo::Type::Tool;
+            gemC.m_types = GemInfo::Type::Asset;
+
+            using Plat = GemInfo::Platform;
+            gemA.m_platforms = Plat::Windows;
+            gemB.m_platforms = Plat::Android | Plat::iOS;
+            gemC.m_platforms = Plat::Android | Plat::iOS | Plat::Linux | Plat::macOS | Plat::Windows; 
+
+            gemA.m_features = QStringList({ "Audio", "Framework", "SDK" });
+            gemB.m_features = QStringList({ "Framework", "Tools", "UI" });
+            gemC.m_features = QStringList({ "Assets", "Content", "Environment" });
+
+            m_gemRows.append(m_gemModel->AddGem(gemA).row());
+            m_gemRows.append(m_gemModel->AddGem(gemB).row());
+            m_gemRows.append(m_gemModel->AddGem(gemC).row());
+        }
+
+    protected:
+        enum RowOrder
+        {
+            DefaultAudio,
+            MobileUX,
+            CityProps
+        };
+
+        QVector<int> m_gemRows;
+    };
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Misc_No_Filter_Shows_All)
+    {
+        // No filter
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Origin_Only)
+    {
+        m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Open3DEngine);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Local);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Remote);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Origin_Multiselection_Shows_All_Matches)
+    {
+        m_proxyModel->SetGemOrigins(GemInfo::GemOrigin::Open3DEngine | GemInfo::GemOrigin::Local);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Type_Only)
+    {
+        m_proxyModel->SetTypes(GemInfo::Type::Code);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetTypes(GemInfo::Type::Tool);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetTypes(GemInfo::Type::Asset);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Type_Multiselection_Shows_All_Matches)
+    {
+        m_proxyModel->SetTypes(GemInfo::Type::Tool | GemInfo::Type::Asset);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Platform_Only)
+    {
+        m_proxyModel->SetPlatforms(GemInfo::Platform::Windows);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetPlatforms(GemInfo::Platform::Android);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetPlatforms(GemInfo::Platform::macOS);
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Platform_Multiselection_Shows_All_Matches)
+    {
+        m_proxyModel->SetPlatforms(GemInfo::Platform::Windows | GemInfo::Platform::iOS);
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Features_Only)
+    {
+        m_proxyModel->SetFeatures({ "Framework" });
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetFeatures({ "Tools", "UI" });
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+
+        m_proxyModel->SetFeatures({ "Assets", "Content", "Environment" });
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Features_Multiselection_Shows_All_Matches)
+    {
+        m_proxyModel->SetFeatures({ "Assets", "Framework" });
+
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_TRUE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
+    }
+
+    TEST_F(GemCatalogMiscFilterTests, GemCatalog_Filters_By_Features_Must_Be_Exact_Match)
+    {
+        m_proxyModel->SetFeatures({ "Frame" });
+
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[DefaultAudio], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[MobileUX], QModelIndex()));
+        EXPECT_FALSE(m_proxyModel->filterAcceptsRow(m_gemRows[CityProps], QModelIndex()));
     }
 }


### PR DESCRIPTION
No new bugs were found through the development of tests (besides display name being set) but it did bring to question whether the intended results from some of the filters are the most desirable. Most filters work on an or basis relative to themselves and an and basis relative to other filters. 

This is outside of the scope of this PR but it might be worth considering whether a user would prefer platform selection to work on an or basis or (as it does currently) or an and basis.Using an or basis if a user selected the Windows, Android and iOS platforms all gems that supported at least one of those platforms would be shown. Instead the user might prefer it to work on an and basis wherein only the gems that supported all of those platforms would be shown. This way the user could determine their targeted platforms and select them making it easy to see the full set of gems that are compatible with all of their target platforms.

`[----------] Global test environment tear-down
[==========] 36 tests from 7 test cases ran. (5337 ms total)
[  PASSED  ] 36 tests.`

Signed-off-by: nggieber <52797929+AMZN-nggieber@users.noreply.github.com>