### PR TITLE
Workaround for Editor freeze.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/Jobs/JobManagerComponent.cpp
@@ -24,7 +24,7 @@
 
 AZ_CVAR(float, cl_jobThreadsConcurrencyRatio, 0.6f, nullptr, AZ::ConsoleFunctorFlags::Null, "Legacy Job system multiplier on the number of hw threads the machine creates at initialization");
 AZ_CVAR(uint32_t, cl_jobThreadsNumReserved, 2, nullptr, AZ::ConsoleFunctorFlags::Null, "Legacy Job system number of hardware threads that are reserved for O3DE system threads");
-AZ_CVAR(uint32_t, cl_jobThreadsMinNumber, 2, nullptr, AZ::ConsoleFunctorFlags::Null, "Legacy Job system minimum number of worker threads to create after scaling the number of hw threads");
+AZ_CVAR(uint32_t, cl_jobThreadsMinNumber, 3, nullptr, AZ::ConsoleFunctorFlags::Null, "Legacy Job system minimum number of worker threads to create after scaling the number of hw threads");
 
 namespace AZ
 {


### PR DESCRIPTION
GHI bug https://github.com/o3de/o3de/issues/5866 describes a scenario in which the Editor freezes on 6-thread CPUs.  This occurs because the Job Manager ends up with only 2 threads.  The freeze occurs when the main thread spawns a culling job and blocks on it, a Mesh Feature Processor job spawns processing jobs and blocks on them, and a Material/ShaderVariant load queues an asset load and blocks on it.  No new jobs can get started, and the main thread can't continue to process the asset load, so it freezes.
This workaround boosts the minimum number of threads from 2 to 3 by default, which fixes this specific scenario.  The longer-term fix would be to fix any jobs that block on other jobs to no longer block, so that even 1 job thread would work correctly.