### PR TITLE
Fix for artifact with thin-film materials and shadows

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
@@ -23,6 +23,16 @@ float3 TransmissionKernel(float t, float3 s)
     return 0.25 * (1.0 / exp(exponent) + 3.0 / exp(exponent / 3.0));
 }
 
+float ThinObjectFalloff(const float3 l, const float3 n)
+{
+    const float ndl = saturate(dot(-n, l));
+    
+    // ndl works decently well but it can produce a harsh discontinuity in the area just before 
+    // the shadow starts appearing on objects like cylinder and tubes.
+    // Smoothing out ndl does a decent enough job of removing this artifact.
+    return smoothstep(0, 1, ndl * ndl);
+}
+
 float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightIntensity, float3 dirToLight, float shadowRatio)
 {
     float3 result = float3(0.0, 0.0, 0.0);
@@ -53,8 +63,10 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
             float litRatio = 1.0 - shadowRatio;
             if (litRatio)
             {
-                result = TransmissionKernel(surface.transmission.thickness * transmissionParams.w, rcp(transmissionParams.xyz)) * 
-                    saturate(dot(-surface.normal, dirToLight)) * lightIntensity * litRatio;
+                const float t = surface.transmission.thickness * transmissionParams.w;
+                const float3 s = rcp(transmissionParams.xyz);
+                const float falloff = ThinObjectFalloff(dirToLight, surface.normal);
+                result = TransmissionKernel(t, s) * falloff * lightIntensity * litRatio;
             }
 
             break;

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/BackLighting.azsli
@@ -23,9 +23,9 @@ float3 TransmissionKernel(float t, float3 s)
     return 0.25 * (1.0 / exp(exponent) + 3.0 / exp(exponent / 3.0));
 }
 
-float ThinObjectFalloff(const float3 l, const float3 n)
+float ThinObjectFalloff(const float3 surfaceNormal, const float3 dirToLight)
 {
-    const float ndl = saturate(dot(-n, l));
+    const float ndl = saturate(dot(-surfaceNormal, dirToLight));
     
     // ndl works decently well but it can produce a harsh discontinuity in the area just before 
     // the shadow starts appearing on objects like cylinder and tubes.
@@ -63,10 +63,10 @@ float3 GetBackLighting(Surface surface, LightingData lightingData, float3 lightI
             float litRatio = 1.0 - shadowRatio;
             if (litRatio)
             {
-                const float t = surface.transmission.thickness * transmissionParams.w;
-                const float3 s = rcp(transmissionParams.xyz);
-                const float falloff = ThinObjectFalloff(dirToLight, surface.normal);
-                result = TransmissionKernel(t, s) * falloff * lightIntensity * litRatio;
+                const float thickness = surface.transmission.thickness * transmissionParams.w;
+                const float3 invScattering = rcp(transmissionParams.xyz);
+                const float falloff = ThinObjectFalloff(surface.normal, dirToLight);
+                result = TransmissionKernel(thickness, invScattering) * falloff * lightIntensity * litRatio;
             }
 
             break;


### PR DESCRIPTION
Smoothing out the ndl term does a decent enough job of fixing the visual artifact in most cases:

(Note that one material screenshot test will need updating after this PR)

ATOM-16840

### Before
![before](https://user-images.githubusercontent.com/61609885/143962091-2281d3e7-7c5f-4ff9-8ee8-eab6d2b9e79a.PNG)



### After
![after](https://user-images.githubusercontent.com/61609885/143962097-9dbb89d2-e50f-4d1a-9fce-400027b12021.PNG)


Signed-off-by: mrieggeramzn mriegger@amazon.com