### PR TITLE
GetSurfacePoint - expose to BehaviorContext

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
@@ -14,11 +14,6 @@ namespace AzFramework::Terrain
 {
     void TerrainDataRequests::Reflect(AZ::ReflectContext* context)
     {
-        // These APIs are overloaded, so we need to define aliases for the version of the APIs that we want to use.
-        // Otherwise the BehaviorContext definition below won't compile.
-        using GetSurfacePointFuncPtr = SurfaceData::SurfacePoint (TerrainDataRequests::*)(const AZ::Vector3&, Sampler) const;
-        using GetSurfacePointFromVector2FuncPtr = SurfaceData::SurfacePoint (TerrainDataRequests::*)(const AZ::Vector2&, Sampler) const;
-
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->EBus<AzFramework::Terrain::TerrainDataRequestBus>("TerrainDataRequestBus")
@@ -33,10 +28,9 @@ namespace AzFramework::Terrain
                     &AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfaceWeightsFromVector2)
                 ->Event("GetIsHole", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetIsHole)
                 ->Event("GetIsHoleFromFloats", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetIsHoleFromFloats)
-                ->Event("GetSurfacePoint",
-                    static_cast<GetSurfacePointFuncPtr>(&AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfacePoint))
+                ->Event("GetSurfacePoint", &AzFramework::Terrain::TerrainDataRequestBus::Events::BehaviorContextGetSurfacePoint)
                 ->Event("GetSurfacePointFromVector2",
-                    static_cast<GetSurfacePointFromVector2FuncPtr>(&AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfacePointFromVector2))
+                    &AzFramework::Terrain::TerrainDataRequestBus::Events::BehaviorContextGetSurfacePointFromVector2)
                 ->Event("GetTerrainAabb", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetTerrainAabb)
                 ->Event("GetTerrainHeightQueryResolution",
                     &AzFramework::Terrain::TerrainDataRequestBus::Events::GetTerrainHeightQueryResolution)

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
@@ -14,6 +14,9 @@ namespace AzFramework::Terrain
 {
     void TerrainDataRequests::Reflect(AZ::ReflectContext* context)
     {
+        using GetSurfacePointFuncPtr = SurfaceData::SurfacePoint (TerrainDataRequests::*)(const AZ::Vector3&, Sampler) const;
+        using GetSurfacePointFromVector2FuncPtr = SurfaceData::SurfacePoint (TerrainDataRequests::*)(const AZ::Vector2&, Sampler) const;
+
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->EBus<AzFramework::Terrain::TerrainDataRequestBus>("TerrainDataRequestBus")
@@ -26,10 +29,12 @@ namespace AzFramework::Terrain
                 ->Event("GetSurfaceWeights", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfaceWeights)
                 ->Event("GetSurfaceWeightsFromVector2",
                     &AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfaceWeightsFromVector2)
+                ->Event("GetIsHole", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetIsHole)
                 ->Event("GetIsHoleFromFloats", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetIsHoleFromFloats)
-                ->Event("GetSurfacePoint", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfacePoint)
+                ->Event("GetSurfacePoint",
+                    static_cast<GetSurfacePointFuncPtr>(&AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfacePoint))
                 ->Event("GetSurfacePointFromVector2",
-                    &AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfacePointFromVector2)
+                    static_cast<GetSurfacePointFromVector2FuncPtr>(&AzFramework::Terrain::TerrainDataRequestBus::Events::GetSurfacePointFromVector2))
                 ->Event("GetTerrainAabb", &AzFramework::Terrain::TerrainDataRequestBus::Events::GetTerrainAabb)
                 ->Event("GetTerrainHeightQueryResolution",
                     &AzFramework::Terrain::TerrainDataRequestBus::Events::GetTerrainHeightQueryResolution)

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.cpp
@@ -14,6 +14,8 @@ namespace AzFramework::Terrain
 {
     void TerrainDataRequests::Reflect(AZ::ReflectContext* context)
     {
+        // These APIs are overloaded, so we need to define aliases for the version of the APIs that we want to use.
+        // Otherwise the BehaviorContext definition below won't compile.
         using GetSurfacePointFuncPtr = SurfaceData::SurfacePoint (TerrainDataRequests::*)(const AZ::Vector3&, Sampler) const;
         using GetSurfacePointFromVector2FuncPtr = SurfaceData::SurfacePoint (TerrainDataRequests::*)(const AZ::Vector2&, Sampler) const;
 

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -52,8 +52,8 @@ namespace AzFramework
             virtual void SetTerrainAabb(const AZ::Aabb& worldBounds) = 0;
 
             //! Returns terrains height in meters at location x,y.
-            //! @terrainExistsPtr: Can be nullptr. If != nullptr then, if there's no terrain at location x,y or location x,y is inside a terrain HOLE then *terrainExistsPtr will become false,
-            //!                  otherwise *terrainExistsPtr will become true.
+            //! @terrainExistsPtr: Can be nullptr. If != nullptr then, if there's no terrain at location x,y or location x,y is inside
+            //!  a terrain HOLE then *terrainExistsPtr will become false, otherwise *terrainExistsPtr will become true.
             virtual float GetHeight(const AZ::Vector3& position, Sampler sampler = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
             virtual float GetHeightFromVector2(
                 const AZ::Vector2& position, Sampler sampler = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
@@ -68,8 +68,7 @@ namespace AzFramework
 
             // Given an XY coordinate, return the surface normal.
             //! @terrainExists: Can be nullptr. If != nullptr then, if there's no terrain at location x,y or location x,y is inside a
-            //! terrain HOLE then *terrainExistsPtr will be set to false,
-            //!                  otherwise *terrainExistsPtr will be set to true.
+            //! terrain HOLE then *terrainExistsPtr will be set to false, otherwise *terrainExistsPtr will be set to true.
             virtual AZ::Vector3 GetNormal(
                 const AZ::Vector3& position, Sampler sampleFilter = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
             virtual AZ::Vector3 GetNormalFromVector2(
@@ -78,8 +77,8 @@ namespace AzFramework
                 float x, float y, Sampler sampleFilter = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
 
             //! Given an XY coordinate, return the max surface type and weight.
-            //! @terrainExists: Can be nullptr. If != nullptr then, if there's no terrain at location x,y or location x,y is inside a terrain HOLE then *terrainExistsPtr will be set to false,
-            //!                  otherwise *terrainExistsPtr will be set to true.
+            //! @terrainExists: Can be nullptr. If != nullptr then, if there's no terrain at location x,y or location x,y is inside
+            //! a terrain HOLE then *terrainExistsPtr will be set to false, otherwise *terrainExistsPtr will be set to true.
             virtual SurfaceData::SurfaceTagWeight GetMaxSurfaceWeight(
                 const AZ::Vector3& position, Sampler sampleFilter = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
             virtual SurfaceData::SurfaceTagWeight GetMaxSurfaceWeightFromVector2(
@@ -87,8 +86,8 @@ namespace AzFramework
             virtual SurfaceData::SurfaceTagWeight GetMaxSurfaceWeightFromFloats(
                 float x, float y, Sampler sampleFilter = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
 
-            //! Given an XY coordinate, return the set of surface types and weights.  The Vector3 input position version is defined to ignore
-            //! the input Z value.
+            //! Given an XY coordinate, return the set of surface types and weights. The Vector3 input position version is defined to
+            //! ignore the input Z value.
             virtual void GetSurfaceWeights(
                 const AZ::Vector3& inPosition,
                 SurfaceData::SurfaceTagWeightList& outSurfaceWeights,
@@ -106,13 +105,14 @@ namespace AzFramework
                 Sampler sampleFilter = Sampler::DEFAULT,
                 bool* terrainExistsPtr = nullptr) const = 0;
 
-            //! Convenience function for  low level systems that can't do a reverse lookup from Crc to string. Everyone else should use GetMaxSurfaceWeight or GetMaxSurfaceWeightFromFloats.
+            //! Convenience function for  low level systems that can't do a reverse lookup from Crc to string. Everyone else should use
+            //! GetMaxSurfaceWeight or GetMaxSurfaceWeightFromFloats.
             //! Not available in the behavior context.
             //! Returns nullptr if the position is inside a hole or outside of the terrain boundaries.
             virtual const char* GetMaxSurfaceName(
                 const AZ::Vector3& position, Sampler sampleFilter = Sampler::BILINEAR, bool* terrainExistsPtr = nullptr) const = 0;
 
-            //! Given an XY coordinate, return all terrain information at that location.  The Vector3 input position version is defined
+            //! Given an XY coordinate, return all terrain information at that location. The Vector3 input position version is defined
             //! to ignore the input Z value.
             virtual void GetSurfacePoint(
                 const AZ::Vector3& inPosition,
@@ -133,9 +133,9 @@ namespace AzFramework
 
         private:
             // Private variations of the GetSurfacePoint API exposed to BehaviorContext that returns a value instead of
-            // using an "out" parameter.  The "out" parameter is useful for reusing memory allocated in SurfacePoint when
+            // using an "out" parameter. The "out" parameter is useful for reusing memory allocated in SurfacePoint when
             // using the public API, but can't easily be used from Script Canvas.
-            SurfaceData::SurfacePoint GetSurfacePoint(
+            SurfaceData::SurfacePoint BehaviorContextGetSurfacePoint(
                 const AZ::Vector3& inPosition,
                 Sampler sampleFilter = Sampler::DEFAULT) const
             {
@@ -143,7 +143,7 @@ namespace AzFramework
                     GetSurfacePoint(inPosition, result, sampleFilter);
                 return result;
             }
-            SurfaceData::SurfacePoint GetSurfacePointFromVector2(
+            SurfaceData::SurfacePoint BehaviorContextGetSurfacePointFromVector2(
                 const AZ::Vector2& inPosition,
                 Sampler sampleFilter = Sampler::DEFAULT) const
             {

--- a/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Terrain/TerrainDataRequestBus.h
@@ -130,6 +130,27 @@ namespace AzFramework
                 SurfaceData::SurfacePoint& outSurfacePoint,
                 Sampler sampleFilter = Sampler::DEFAULT,
                 bool* terrainExistsPtr = nullptr) const = 0;
+
+        private:
+            // Private variations of the GetSurfacePoint API exposed to BehaviorContext that returns a value instead of
+            // using an "out" parameter.  The "out" parameter is useful for reusing memory allocated in SurfacePoint when
+            // using the public API, but can't easily be used from Script Canvas.
+            SurfaceData::SurfacePoint GetSurfacePoint(
+                const AZ::Vector3& inPosition,
+                Sampler sampleFilter = Sampler::DEFAULT) const
+            {
+                SurfaceData::SurfacePoint result;
+                    GetSurfacePoint(inPosition, result, sampleFilter);
+                return result;
+            }
+            SurfaceData::SurfacePoint GetSurfacePointFromVector2(
+                const AZ::Vector2& inPosition,
+                Sampler sampleFilter = Sampler::DEFAULT) const
+            {
+                SurfaceData::SurfacePoint result;
+                GetSurfacePointFromVector2(inPosition, result, sampleFilter);
+                return result;
+            }
         };
         using TerrainDataRequestBus = AZ::EBus<TerrainDataRequests>;
 


### PR DESCRIPTION
Fixed the way in which GetSurfacePoint is exposed to BehaviorContext so that it is functional from ScriptCanvas.

![image](https://user-images.githubusercontent.com/82224783/143961585-45c225be-2c98-4463-90e2-ec4d4a59de41.png)
