### PR TITLE
Add additional check to ensure material library is loaded when trying to retrieve names.

### DIFF
--- a/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
@@ -864,7 +864,8 @@ namespace PhysX
         {
             if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
             {
-                if (const auto* physicsConfiguration = physicsSystem->GetConfiguration())
+                if (const auto* physicsConfiguration = physicsSystem->GetConfiguration();
+                    physicsConfiguration && physicsConfiguration->m_materialLibraryAsset)
                 {
                     const auto& materials = physicsConfiguration->m_materialLibraryAsset->GetMaterialsData();
 

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -442,6 +442,7 @@
                 "RC physmaterial": {
                     "glob": "*.physmaterial",
                     "params": "copy",
+                    "critical": "true",
                     "productAssetType": "{9E366D8C-33BB-4825-9A1F-FA3ADBE11D0F}"
                 },
                 "RC ocm": {


### PR DESCRIPTION
Adds ulterior check to ensure the PhysX material library asset is loaded correctly before trying to get materials data.

https://github.com/o3de/o3de/issues/6027

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>