### PR TITLE
Remove remote console flag suppressing game logs in GameLauncher and ServerLauncher apps

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/android/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/android/launcher.py
@@ -177,7 +177,7 @@ class AndroidLauncher(Launcher):
         if backupFiles:
             self.backup_settings()
 
-        # Base setup defaults to None
+        # None reverts to function default
         if launch_ap is None:
             launch_ap = True
 

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/android/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/android/launcher.py
@@ -163,9 +163,23 @@ class AndroidLauncher(Launcher):
 
         return True
 
-    def setup(self):
+    def setup(self, backupFiles=True, launch_ap=True, configure_settings=True):
+        """
+        Perform setup of this launcher, must be called before launching.
+        Subclasses should call its parent's setup() before calling its own code, unless it changes configuration files
+
+        :param backupFiles: Bool to backup setup files
+        :param launch_ap: Bool to launch the asset processor
+        :param configure_settings: Bool to update settings caches
+        :return: None
+        """
         # Backup
-        self.backup_settings()
+        if backupFiles:
+            self.backup_settings()
+
+        # Base setup defaults to None
+        if launch_ap is None:
+            launch_ap = True
 
         # Enable Android capabilities and verify environment is setup before continuing.
         self._is_valid_android_environment()
@@ -174,7 +188,7 @@ class AndroidLauncher(Launcher):
         # Modify and re-configure
         self.configure_settings()
         self.workspace.shader_compiler.start()
-        super(AndroidLauncher, self).setup()
+        super(AndroidLauncher, self).setup(backupFiles, launch_ap, configure_settings)
 
     def teardown(self):
         ly_test_tools.mobile.android.undo_tcp_port_changes(self._device_id)

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/base.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/base.py
@@ -75,6 +75,8 @@ class Launcher(object):
             ~/ly_test_tools/devices.ini (a.k.a. %USERPROFILE%/ly_test_tools/devices.ini)
 
         :param backupFiles: Bool to backup setup files
+        :param launch_ap: Bool to launch the asset processor
+        :param configure_settings: Bool to update settings caches
         :return: None
         """
         # Remove existing logs and dmp files before launching for self.save_project_log_files()

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
@@ -179,20 +179,20 @@ class LinuxLauncher(Launcher):
 
 class DedicatedLinuxLauncher(LinuxLauncher):
 
-    def setup(self, backupFiles=True, launch_ap=False):
+    def setup(self, backupFiles=True, launch_ap=False, configure_settings=True):
         """
         Perform setup of this launcher, must be called before launching.
         Subclasses should call its parent's setup() before calling its own code, unless it changes configuration files
 
         :param backupFiles: Bool to backup setup files
-        :param lauch_ap: Bool to lauch the asset processor
+        :param launch_ap: Bool to launch the asset processor
         :return: None
         """
         # Base setup defaults to None
         if launch_ap is None:
             launch_ap = False
 
-        super(DedicatedLinuxLauncher, self).setup(backupFiles, launch_ap)
+        super(DedicatedLinuxLauncher, self).setup(backupFiles, launch_ap, configure_settings)
 
     def binary_path(self):
         """

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
@@ -52,7 +52,7 @@ class LinuxLauncher(Launcher):
         if backupFiles:
             self.backup_settings()
 
-        # Base setup defaults to None
+        # None reverts to function default
         if launch_ap is None:
             launch_ap = True
 
@@ -192,9 +192,9 @@ class DedicatedLinuxLauncher(LinuxLauncher):
         if backupFiles:
             self.backup_settings()
 
-        # Base setup defaults to None
+        # None reverts to function default
         if launch_ap is None:
-            launch_ap = True
+            launch_ap = False
 
         super(DedicatedLinuxLauncher, self).setup(backupFiles, launch_ap, configure_settings)
 

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/linux/launcher.py
@@ -162,7 +162,7 @@ class LinuxLauncher(Launcher):
 
     def configure_settings(self):
         """
-        Configures system level settings and syncs the launcher to the targeted console IP.
+        Configures system level settings
 
         :return: None
         """
@@ -170,7 +170,6 @@ class LinuxLauncher(Launcher):
         host_ip = '127.0.0.1'
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/project_path={self.workspace.paths.project()}"')
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/remote_ip={host_ip}"')
-        self.args.append('--regset="/Amazon/AzCore/Bootstrap/wait_for_connect=1"')
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/allowed_list={host_ip}"')
 
         self.workspace.settings.modify_platform_setting("r_ShaderCompilerServer", host_ip)
@@ -186,11 +185,16 @@ class DedicatedLinuxLauncher(LinuxLauncher):
 
         :param backupFiles: Bool to backup setup files
         :param launch_ap: Bool to launch the asset processor
+        :param configure_settings: Bool to update settings caches
         :return: None
         """
+        # Backup
+        if backupFiles:
+            self.backup_settings()
+
         # Base setup defaults to None
         if launch_ap is None:
-            launch_ap = False
+            launch_ap = True
 
         super(DedicatedLinuxLauncher, self).setup(backupFiles, launch_ap, configure_settings)
 

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
@@ -169,28 +169,12 @@ class WinLauncher(Launcher):
         host_ip = '127.0.0.1'
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/project_path={self.workspace.paths.project()}"')
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/remote_ip={host_ip}"')
-        self.args.append('--regset="/Amazon/AzCore/Bootstrap/wait_for_connect=1"')
         self.args.append(f'--regset="/Amazon/AzCore/Bootstrap/allowed_list={host_ip}"')
 
         self.workspace.settings.modify_platform_setting("log_RemoteConsoleAllowedAddresses", host_ip)
 
 
 class DedicatedWinLauncher(WinLauncher):
-
-    def setup(self, backupFiles=True, launch_ap=False):
-        """
-        Perform setup of this launcher, must be called before launching.
-        Subclasses should call its parent's setup() before calling its own code, unless it changes configuration files
-
-        :param backupFiles: Bool to backup setup files
-        :param lauch_ap: Bool to lauch the asset processor
-        :return: None
-        """
-        # Base setup defaults to None
-        if launch_ap is None:
-            launch_ap = False
-
-        super(DedicatedWinLauncher, self).setup(backupFiles, launch_ap)
 
     def binary_path(self):
         """

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
@@ -52,7 +52,7 @@ class WinLauncher(Launcher):
         if backupFiles:
             self.backup_settings()
 
-        # Base setup defaults to None
+        # None reverts to function default
         if launch_ap is None:
             launch_ap = True
 
@@ -176,6 +176,26 @@ class WinLauncher(Launcher):
 
 
 class DedicatedWinLauncher(WinLauncher):
+
+    def setup(self, backupFiles=True, launch_ap=False, configure_settings=True):
+        """
+        Perform setup of this launcher, must be called before launching.
+        Subclasses should call its parent's setup() before calling its own code, unless it changes configuration files
+
+        :param backupFiles: Bool to backup setup files
+        :param launch_ap: Bool to launch the asset processor
+        :param configure_settings: Bool to update settings caches
+        :return: None
+        """
+        # Backup
+        if backupFiles:
+            self.backup_settings()
+
+        # None reverts to function default
+        if launch_ap is None:
+            launch_ap = False
+
+        super(DedicatedWinLauncher, self).setup(backupFiles, launch_ap, configure_settings)
 
     def binary_path(self):
         """

--- a/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
+++ b/Tools/LyTestTools/ly_test_tools/launchers/platforms/win/launcher.py
@@ -44,7 +44,8 @@ class WinLauncher(Launcher):
         Subclasses should call its parent's setup() before calling its own code, unless it changes configuration files
 
         :param backupFiles: Bool to backup setup files
-        :param lauch_ap: Bool to lauch the asset processor
+        :param launch_ap: Bool to lauch the asset processor
+        :param configure_settings: Bool to update settings caches
         :return: None
         """
         # Backup
@@ -58,7 +59,7 @@ class WinLauncher(Launcher):
         # Modify and re-configure
         if configure_settings:
             self.configure_settings()
-        super(WinLauncher, self).setup(backupFiles, launch_ap)
+        super(WinLauncher, self).setup(backupFiles, launch_ap, configure_settings)
 
     def launch(self):
         """
@@ -161,7 +162,7 @@ class WinLauncher(Launcher):
 
     def configure_settings(self):
         """
-        Configures system level settings and syncs the launcher to the targeted console IP.
+        Configures system level settings
 
         :return: None
         """


### PR DESCRIPTION
Removes an old flag which was suppressing writing logs to logfiles. Tests previously relied on this for logging through RC.exe, which is no longer used.

Additionally fixes some interfaces which conflicted with the parent class, which would prevent certain launchers from even starting.

Signed-off-by: sweeneys <sweeneys@amazon.com>