### PR TITLE
BUGFIX improve the start up time of the atom render plugin

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -128,6 +128,7 @@ namespace EMStudio
         m_groundEntity->CreateComponent(AZ::Render::MeshComponentTypeId);
         m_groundEntity->CreateComponent(AZ::Render::MaterialComponentTypeId);
         m_groundEntity->CreateComponent(azrtti_typeid<AzFramework::TransformComponent>());
+        m_groundEntity->Init();
         m_groundEntity->Activate();
 
         Reinit();


### PR DESCRIPTION
Without init the entity first it triggers a bunch of warning and asset during activation and that slows the process down significantly. 
Signed-off-by: rhhong <rhhong@amazon.com>