### PR TITLE
Rename sr_regset-file CVar to sr_regset_file

### DIFF
--- a/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.h
+++ b/Code/Framework/AzCore/AzCore/Settings/SettingsRegistryConsoleUtils.h
@@ -23,7 +23,7 @@ namespace AZ::SettingsRegistryConsoleUtils
     inline constexpr const char* SettingsRegistryRemove = "sr_regremove";
     inline constexpr const char* SettingsRegistryDump = "sr_regdump";
     inline constexpr const char* SettingsRegistryDumpAll = "sr_regdumpall";
-    inline constexpr const char* SettingsRegistryMergeFile = "sr_regset-file";
+    inline constexpr const char* SettingsRegistryMergeFile = "sr_regset_file";
 
     // RAII structure which owns the instances of the Settings Registry Console commands
     // registered with an AZ Console
@@ -53,7 +53,7 @@ namespace AZ::SettingsRegistryConsoleUtils
     //! "sr_regdumpall" accepts 0 arguments and dumps the entire settings registry
     //!  NOTE: this might result in a large amount of output to the console
     //!
-    //! "sr_regset-file" accepts 1 or 2 arguments - <file-path> [<anchor json path>]
+    //! "sr_regset_file" accepts 1 or 2 arguments - <file-path> [<anchor json path>]
     //!  Merges the json formatted file <file path> into the settings registry underneath the root anchor ""
     //!  or <anchor json path> if supplied
     [[nodiscard]] ConsoleFunctorHandle RegisterAzConsoleCommands(SettingsRegistryInterface& registry, AZ::IConsole& azConsole);


### PR DESCRIPTION
The Legacy Cry XConsole code validates that CVars only contain
underscore and alphanumeric characters via an Assert in `debug`
configurations.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>