### PR TITLE
Add CLI option to enable PIX GPU events without expressing loading the Pix runtime

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/Factory.h
@@ -112,6 +112,9 @@ namespace AZ
             //! Returns true if Pix dll is loaded
             static bool IsPixModuleLoaded();
 
+            //! Returns true if Pix GPU events should be emitted
+            static bool PixGpuEventsEnabled();
+
             //! Returns true if Warp is enabled
             static bool UsingWarpDevice();
 

--- a/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/Factory.cpp
@@ -26,6 +26,7 @@ static bool s_isRenderDocDllLoaded = false;
 #if defined(USE_PIX)
 static AZStd::unique_ptr<AZ::DynamicModuleHandle> s_pixModule;
 static bool s_isPixGpuCaptureDllLoaded = false;
+static bool s_pixGpuMarkersEnabled = false;
 #endif
 
 static bool s_usingWarpDevice = false;
@@ -62,6 +63,7 @@ namespace AZ
 #if defined(USE_RENDERDOC)
             // If RenderDoc is requested, we need to load the library as early as possible (before device queries/factories are made)
             bool enableRenderDoc = RHI::QueryCommandLineOption("enableRenderDoc");
+            s_pixGpuMarkersEnabled = s_pixGpuMarkersEnabled || enableRenderDoc;
 
             if (enableRenderDoc && AZ_TRAIT_RENDERDOC_MODULE && !s_renderDocModule)
             {
@@ -119,6 +121,8 @@ namespace AZ
 
             //Pix dll can still be injected even if we do not pass in enablePixGPU. This can be done if we launch the app from Pix.
             s_isPixGpuCaptureDllLoaded = Platform::IsPixDllInjected(AZ_TRAIT_PIX_MODULE);
+
+            s_pixGpuMarkersEnabled = s_pixGpuMarkersEnabled || RHI::QueryCommandLineOption("enablePixGpuMarkers");
 #endif
         }
 
@@ -197,6 +201,15 @@ namespace AZ
         {
 #if defined(USE_PIX)
             return s_isPixGpuCaptureDllLoaded;
+#else
+            return false;
+#endif
+        }
+
+        bool Factory::PixGpuEventsEnabled()
+        {
+#if defined(USE_PIX)
+            return s_pixGpuMarkersEnabled;
 #else
             return false;
 #endif

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.cpp
@@ -97,7 +97,7 @@ namespace AZ
             SetName(name);
 
             PIXBeginEvent(PIX_MARKER_CMDLIST_COL, name.GetCStr());
-            if (RHI::Factory::Get().IsPixModuleLoaded() || RHI::Factory::Get().IsRenderDocModuleLoaded())
+            if (RHI::Factory::Get().PixGpuEventsEnabled())
             {
                 PIXBeginEvent(GetCommandList(), PIX_MARKER_CMDLIST_COL, name.GetCStr());
             }
@@ -107,7 +107,7 @@ namespace AZ
         {
             FlushBarriers();
             PIXEndEvent();
-            if (RHI::Factory::Get().IsPixModuleLoaded() || RHI::Factory::Get().IsRenderDocModuleLoaded())
+            if (RHI::Factory::Get().PixGpuEventsEnabled())
             {
                 PIXEndEvent(GetCommandList());
             }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/Scope.cpp
@@ -311,7 +311,7 @@ namespace AZ
 
             PIXBeginEvent(0xFFFF00FF, GetId().GetCStr());
 
-            if (RHI::Factory::Get().IsPixModuleLoaded() || RHI::Factory::Get().IsRenderDocModuleLoaded())
+            if (RHI::Factory::Get().PixGpuEventsEnabled())
             {
                 PIXBeginEvent(commandList.GetCommandList(), 0xFFFF00FF, GetId().GetCStr());
             }
@@ -428,7 +428,7 @@ namespace AZ
                 }
             }
 
-            if (RHI::Factory::Get().IsPixModuleLoaded() || RHI::Factory::Get().IsRenderDocModuleLoaded())
+            if (RHI::Factory::Get().PixGpuEventsEnabled())
             {
                 PIXEndEvent(commandList.GetCommandList());
             }


### PR DESCRIPTION
Other external profilers aside from Pix (e.g. Nvidia Nsight) rely on the Pix events for instrumentation as well.

This PR adds the `--enablePixGpuMarkers` which enables Pix events without loading the Pix runtime for use with other GPU profilers.