### PR TITLE
disabling unused test results jobs

### DIFF
--- a/scripts/build/Platform/Linux/build_config.json
+++ b/scripts/build/Platform/Linux/build_config.json
@@ -84,7 +84,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "all",
       "CTEST_OPTIONS": "-E (AutomatedTesting::Atom_TestSuite_Main|AutomatedTesting::TerrainTests_Main|Gem::EMotionFX.Editor.Tests) -L (SUITE_smoke|SUITE_main) -LE (REQUIRES_gpu) --no-tests=error",
-      "TEST_RESULTS": "True"
+      "TEST_RESULTS": "False"
     }
   },
   "test_profile_nounity": {
@@ -97,7 +97,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "all",
       "CTEST_OPTIONS": "-E (AutomatedTesting::Atom_TestSuite_Main|AutomatedTesting::TerrainTests_Main|Gem::EMotionFX.Editor.Tests) -L (SUITE_smoke|SUITE_main) -LE (REQUIRES_gpu) --no-tests=error",
-      "TEST_RESULTS": "True"
+      "TEST_RESULTS": "False"
     }
   },
   "asset_profile": {
@@ -146,7 +146,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_periodic",
       "CTEST_OPTIONS": "-L (SUITE_periodic) --no-tests=error",
-      "TEST_RESULTS": "True"
+      "TEST_RESULTS": "False"
     }
   },
   "sandbox_test_profile": {
@@ -182,7 +182,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
       "CTEST_OPTIONS": "-L (SUITE_benchmark) --no-tests=error",
-      "TEST_RESULTS": "True"
+      "TEST_RESULTS": "False"
     }
   },
   "release": {

--- a/scripts/build/Platform/Mac/build_config.json
+++ b/scripts/build/Platform/Mac/build_config.json
@@ -103,7 +103,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_periodic",
       "CTEST_OPTIONS": "-L \"(SUITE_periodic)\"",
-      "TEST_RESULTS": "True"
+      "TEST_RESULTS": "False"
     }
   },
   "benchmark_test_profile": {
@@ -120,7 +120,7 @@
       "CMAKE_LY_PROJECTS": "AutomatedTesting",
       "CMAKE_TARGET": "TEST_SUITE_benchmark",
       "CTEST_OPTIONS": "-L \"(SUITE_benchmark)\"",
-      "TEST_RESULTS": "True"
+      "TEST_RESULTS": "False"
     }
   },
   "release": {


### PR DESCRIPTION
These jobs do not produce test xml's so we are disabling the test results stage because they are failing. Can only test during the nightly jobs.

Signed-off-by: evanchia <evanchia@amazon.com>