### PR TITLE
chore: add #prama once to XcbInputDeviceKeyboard

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceKeyboard.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbInputDeviceKeyboard.h
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+#pragma once
 
 #include <AzFramework/Input/Devices/Keyboard/InputDeviceKeyboard.h>
 #include <AzFramework/XcbEventHandler.h>


### PR DESCRIPTION
my build was failing with redefinition error. 

Signed-off-by: Michael Pollind <mpollind@gmail.com>