### PR TITLE
Add conditional to pull LY_VERSION_BUILD_NUMBER through environment var

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -16,3 +16,8 @@ if("$ENV{O3DE_VERSION}")
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
+
+if("$ENV{O3DE_BUILD_VERSION}")
+    # Overriding through environment
+    set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
+endif()


### PR DESCRIPTION
Allows `LY_VERSION_BUILD_NUMBER` to be set by the envvar `O3DE_BUILD_VERSION`. Currently defaults to `0`

Signed-off-by: Mike Chang <changml@amazon.com>