### PR TITLE
Removing PythonAssetBuilderSystemComponent from GetRequiredSystemComponents

### DIFF
--- a/Gems/PythonAssetBuilder/Code/Source/PythonAssetBuilderModule.cpp
+++ b/Gems/PythonAssetBuilder/Code/Source/PythonAssetBuilderModule.cpp
@@ -34,9 +34,7 @@ namespace PythonAssetBuilder
         // Add required SystemComponents to the SystemEntity.
         AZ::ComponentTypeList GetRequiredSystemComponents() const override
         {
-            return AZ::ComponentTypeList {
-                azrtti_typeid<PythonAssetBuilderSystemComponent>(),
-            };
+            return AZ::ComponentTypeList{};
         }
     };
 }


### PR DESCRIPTION
This change was prompted by the Python asset builder activating in the material editor and asset processor, leading to conflicts as both initialized, started Python, spamming the console window and log with warnings while trying to save module symbol information.

Because PythonAssetBuilderSystemComponent also has a SystemComponentTag attribute declaring it as an AssetBuilder, it will still be discovered and automatically added to the asset builder.

Removing it from GetRequiredSystemComponents will stop the component from activating outside of the asset builder.