### PR TITLE
Changing trace logger to clear log file when opened

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.cpp
@@ -73,7 +73,7 @@ namespace AzToolsFramework
         AZStd::string logPath;
         StringFunc::Path::Join(logDirectory.c_str(), logFileName.c_str(), logPath);
 
-        m_logFile.reset(aznew LogFile(logPath.c_str()));
+        m_logFile.reset(aznew LogFile(logPath.c_str(), true));
         if (m_logFile)
         {
             m_logFile->SetMachineReadable(false);
@@ -81,7 +81,7 @@ namespace AzToolsFramework
             {
                 m_logFile->AppendLog(LogFile::SEV_NORMAL, message.window.c_str(), message.message.c_str());
             }
-            m_startupLogSink = {};
+            m_startupLogSink.clear();
             m_logFile->FlushLog();
         }
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.cpp
@@ -50,7 +50,7 @@ namespace AzToolsFramework
         return false;
     }
 
-    void TraceLogger::PrepareLogFile(const AZStd::string& logFileName)
+    void TraceLogger::OpenLogFile(const AZStd::string& logFileName, bool clearLogFile)
     {
         using namespace AzFramework;
 
@@ -73,7 +73,7 @@ namespace AzToolsFramework
         AZStd::string logPath;
         StringFunc::Path::Join(logDirectory.c_str(), logFileName.c_str(), logPath);
 
-        m_logFile.reset(aznew LogFile(logPath.c_str(), true));
+        m_logFile.reset(aznew LogFile(logPath.c_str(), clearLogFile));
         if (m_logFile)
         {
             m_logFile->SetMachineReadable(false);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.h
@@ -55,7 +55,8 @@ namespace AzToolsFramework
             AZStd::string window;
             AZStd::string message;
         };
-        AZStd::vector<LogMessage> m_startupLogSink;
+
+        AZStd::list<LogMessage> m_startupLogSink;
         AZStd::unordered_set<AZStd::string> m_windowFilters;
         AZStd::unordered_set<AZStd::string> m_messageFilters;
         AZStd::unique_ptr<AzFramework::LogFile> m_logFile;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Logger/TraceLogger.h
@@ -23,7 +23,7 @@ namespace AzToolsFramework
         ~TraceLogger();
 
         //! Open log file and dump log sink into it
-        void PrepareLogFile(const AZStd::string& logFileName);
+        void OpenLogFile(const AZStd::string& logFileName, bool clearLogFile);
 
         //! Add filter to ignore messages for windows with matching names
         void AddWindowFilter(const AZStd::string& filter);

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Application/AtomToolsApplication.cpp
@@ -175,7 +175,8 @@ namespace AtomToolsFramework
 
         Base::StartCommon(systemEntity);
 
-        m_traceLogger.PrepareLogFile(GetBuildTargetName() + ".log");
+        const bool clearLogFile = GetSettingOrDefault("/O3DE/AtomToolsFramework/Application/ClearLogOnStart", false);
+        m_traceLogger.OpenLogFile(GetBuildTargetName() + ".log", clearLogFile);
 
         AzToolsFramework::AssetDatabase::AssetDatabaseRequestsBus::Handler::BusConnect();
         AzToolsFramework::AssetBrowser::AssetDatabaseLocationNotificationBus::Broadcast(


### PR DESCRIPTION
Also switched the log message sink from a vector to a list so the entire container does not have to be rebuilt every time and entry is added.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>