### PR TITLE
Fix warnings on Mac builds.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp
@@ -70,7 +70,7 @@ namespace AzToolsFramework
         for (auto& elem : m_readOnlystates)
         {
             AZ::EntityId entityId = elem.first;
-            bool wasReadOnly = m_readOnlystates[entityId];
+            bool wasReadOnly = elem.second;
             QueryReadOnlyStateForEntity(entityId);
 
             if (bool isReadOnly = m_readOnlystates[entityId]; wasReadOnly != isReadOnly)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp
@@ -52,7 +52,7 @@ namespace AzToolsFramework
 
     void ReadOnlyEntitySystemComponent::RefreshReadOnlyState(const EntityIdList& entityIds)
     {
-        for (const AZ::EntityId entityId : entityIds)
+        for (const AZ::EntityId& entityId : entityIds)
         {
             bool wasReadOnly = m_readOnlystates[entityId];
             QueryReadOnlyStateForEntity(entityId);
@@ -67,7 +67,7 @@ namespace AzToolsFramework
 
     void ReadOnlyEntitySystemComponent::RefreshReadOnlyStateForAllEntities()
     {
-        for (auto elem : m_readOnlystates)
+        for (auto& elem : m_readOnlystates)
         {
             AZ::EntityId entityId = elem.first;
             bool wasReadOnly = m_readOnlystates[entityId];


### PR DESCRIPTION
Fixes warning that fails the Mac builds after the read-only entity setup submission from yesterday:

```
2021-12-02T22:25:34.818Z] In file included from /Users/lybuilder/workspace/o3de/build/mac/Code/Framework/AzToolsFramework/CMakeFiles/AzToolsFramework.dir/Unity/unity_5_cxx.cxx:17:
[2021-12-02T22:25:34.818Z] /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp:55:33: error: loop variable 'entityId' of type 'const AZ::EntityId' creates a copy from type 'const AZ::EntityId' [-Werror,-Wrange-loop-analysis]
[2021-12-02T22:25:34.818Z]         for (const AZ::EntityId entityId : entityIds)
[2021-12-02T22:25:34.818Z]                                 ^
[2021-12-02T22:25:34.818Z] /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/ReadOnly/ReadOnlyEntitySystemComponent.cpp:55:14: note: use reference type 'const AZ::EntityId &' to prevent copying
[2021-12-02T22:25:34.818Z]         for (const AZ::EntityId entityId : entityIds)
[2021-12-02T22:25:34.818Z]              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2021-12-02T22:25:34.818Z]                                 &
[2021-12-02T22:25:34.818Z] 1 error generated.
[2021-12-02T22:25:34.818Z] 
```

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>