### PR TITLE
Atom/mriegger/overflow

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
@@ -315,11 +315,6 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
         lightingOutput.m_diffuseColor.w = -1; // Disable subsurface scattering
     }
 
-    if (lightingData.tileIterator.m_overflow)
-    {
-        lightingOutput.m_diffuseColor = lightingOutput.m_specularColor = float4(1,0,0,1);
-    }
-
     return lightingOutput;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_ForwardPass.azsl
@@ -315,6 +315,11 @@ PbrLightingOutput ForwardPassPS_Common(VSOutput IN, bool isFrontFace, out float 
         lightingOutput.m_diffuseColor.w = -1; // Disable subsurface scattering
     }
 
+    if (lightingData.tileIterator.m_overflow)
+    {
+        lightingOutput.m_diffuseColor = lightingOutput.m_specularColor = float4(1,0,0,1);
+    }
+
     return lightingOutput;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/LightCullingTileIterator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/LightCullingTileIterator.azsli
@@ -55,7 +55,9 @@ class LightCullingTileIterator
 
     uint m_readIndex;
     uint m_value;   
-    // true if there are too many lights / decals assigned to this particular screen tile 
+
+    // true if the maximum number of lights per tile is exceeded
+    // lights will probably flicker if this happens
     bool m_overflow;
     StructuredBuffer<uint> m_lightListRemapped;
 };

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/LightCullingTileIterator.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/LightCullingTileIterator.azsli
@@ -27,6 +27,7 @@ class LightCullingTileIterator
         tileLightDataTex.GetDimensions(tileWidth, tileHeight);
                     
         TileLightData tileLightData = Tile_UnpackData(tileLightDataTex[tileId]);
+        m_overflow = tileLightData.overflow;
         uint bin = NVLC_GetBin(viewz, tileLightData); 
         m_readIndex = ((tileId.y * tileWidth + tileId.x) * NVLC_MAX_BINS + bin) * NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN; 
         m_value = 0;               
@@ -53,6 +54,8 @@ class LightCullingTileIterator
     }
 
     uint m_readIndex;
-    uint m_value;    
+    uint m_value;   
+    // true if there are too many lights / decals assigned to this particular screen tile 
+    bool m_overflow;
     StructuredBuffer<uint> m_lightListRemapped;
 };

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/NVLC.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/NVLC.azsli
@@ -67,6 +67,8 @@ struct TileLightData
     // If there is a pixel of opaque geometry there, we mark a bit in this bin.
     uint mask;
     uint logMaxBins;
+    // true if there are too many lights or decals assigned to this tile
+    bool overflow;    
 };
 
  
@@ -115,7 +117,8 @@ TileLightData Tile_UnpackData(uint4 pack)
     data.zFar               = asfloat( pack.y | NVLC_BINS_MASK );
     data.mask               = pack.z;
     data.logMaxBins         = pack.y & NVLC_BINS_MASK;
-
+    // unpack the "lights overflowed" bit
+    data.overflow           = pack.w >> 31; 
     return data;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.azsl
@@ -6,16 +6,17 @@
  *
  */
 
-// The heatmap will change color as the light count increases up to TileCountMax, at which point and beyond it will be white.
+// The heatmap will change color as the light count increases up to TileCountMax
 static const int TileCountMax = 75;
+static const int OverflowDisplayNumber = 999;
 
 
-
-static const float3 BARELY_USED_COLOR = float3(0.05, 0.05, 0.20);
-static const float3 LIGHTLY_USED_COLOR = float3(0.05, 0.05, 0.60);
-static const float3 MODERATELY_USED_COLOR = float3(0.05, 0.60, 0.05);
-static const float3 HEAVILY_USED_COLOR = float3(1.00, 1.00, 0.05);
-static const float3 OVER_USED_COLOR = float3(1.00, 0.05, 0.05);
+static const float3 BarelyUsedColor = float3(0.05, 0.05, 0.20);
+static const float3 LightlyUsedColor = float3(0.05, 0.05, 0.60);
+static const float3 ModeratelyUsedColor = float3(0.05, 0.60, 0.05);
+static const float3 HeavilyUsedColor = float3(1.00, 1.00, 0.05);
+static const float3 OverUsedColor = float3(1.00, 0.05, 0.05);
+static const float3 OverflowColor = float3(1.0, 1.0, 1.0);
 
 
 #include <Atom/Features/SrgSemantics.azsli>
@@ -174,30 +175,33 @@ uint PrintNumbersInsideTile(uint x, uint2 origin, uint2 uv, uint scale)
 }
    
 
-float3 ComputeTileColor(uint2 uv, uint print_me, uint maximum)
+float3 ComputeTileColor(const uint2 uv, const uint print_me, const bool overflow)
 {
     int2 local_uv = int2( uv % uint2(TILE_DIM_X, TILE_DIM_Y) );
 
-    float x = float(print_me) / float(maximum);
+    float x = float(print_me) / float(TileCountMax);
     x = sqrt(x);
     x = saturate(x);
 
     float3 color;
 
-    if( x <= 0.0 )
+    if (overflow)
+    {
+        color = OverflowColor;
+    }
+    else if( x <= 0.0 )
     {
         color = float3(0.0, 0.0, 0.0);        
     }
     else if( x >= 1.0 )
     {
-        color = float3(1.0, 1.0, 1.0);    
+        color = OverUsedColor;
     }
     else
     {
-        color = lerp(BARELY_USED_COLOR, LIGHTLY_USED_COLOR, saturate((x - 0.00) * 4.0));
-        color = lerp(color, MODERATELY_USED_COLOR, saturate((x - 0.25) * 4.0));
-        color = lerp(color, HEAVILY_USED_COLOR, saturate((x - 0.50) * 4.0));
-        color = lerp(color, OVER_USED_COLOR, saturate((x - 0.75) * 4.0));
+        color = lerp(BarelyUsedColor, LightlyUsedColor, saturate((x - 0.00) * 4.0));
+        color = lerp(color, ModeratelyUsedColor, saturate((x - 0.33) * 4.0));
+        color = lerp(color, HeavilyUsedColor, saturate((x - 0.66) * 4.0));
     }
 
     float border = (local_uv.x == TILE_DIM_X - 1 || local_uv.y == TILE_DIM_Y - 1) ? 1.0 : 0.0;
@@ -229,12 +233,15 @@ PSOutput MainPS(VSOutput IN)
     const uint2 tileId = ComputeTileId(IN.m_position.xy);
     
     const uint tileLightDataW = PassSrg::m_tileLightData[tileId].w;
+
+    // check to see if we are overflowing the number of lights per tile
+    // expect the lighting to flicker if this happens
     const bool overflow = (tileLightDataW >> 31);    
 
     // We subtract NUM_LIGHT_TYPES because it includes termination markers
-    const uint lightCount = overflow ? NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN : tileLightDataW - NUM_LIGHT_TYPES;
+    const uint lightCount = overflow ? OverflowDisplayNumber : tileLightDataW - NUM_LIGHT_TYPES;
 
-    const float3 tileColor = ComputeTileColor(IN.m_position.xy, lightCount, TileCountMax);
+    const float3 tileColor = ComputeTileColor(IN.m_position.xy, lightCount, overflow);
                              
     PSOutput OUT;
     OUT.m_color.rgb = tileColor; 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.azsl
@@ -11,12 +11,12 @@ static const int TileCountMax = 75;
 static const int OverflowDisplayNumber = 999;
 
 
-static const float3 BarelyUsedColor = float3(0.05, 0.05, 0.20);
-static const float3 LightlyUsedColor = float3(0.05, 0.05, 0.60);
-static const float3 ModeratelyUsedColor = float3(0.05, 0.60, 0.05);
-static const float3 HeavilyUsedColor = float3(1.00, 1.00, 0.05);
-static const float3 OverUsedColor = float3(1.00, 0.05, 0.05);
-static const float3 OverflowColor = float3(1.0, 1.0, 1.0);
+static const float3 BarelyUsedColor = float3(0.05, 0.05, 0.20);         // Deep dark blue
+static const float3 LightlyUsedColor = float3(0.05, 0.05, 0.60);        // Deep blue
+static const float3 ModeratelyUsedColor = float3(0.05, 0.60, 0.05);     // Green
+static const float3 HeavilyUsedColor = float3(1.00, 1.00, 0.05);        // Yellow
+static const float3 OverUsedColor = float3(1.00, 0.05, 0.05);           // Red
+static const float3 OverflowColor = float3(1.0, 1.0, 1.0);              // White
 
 
 #include <Atom/Features/SrgSemantics.azsli>

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingHeatmap.azsl
@@ -226,12 +226,15 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 
 PSOutput MainPS(VSOutput IN)
 {
-    uint2 tileId = ComputeTileId(IN.m_position.xy);
+    const uint2 tileId = ComputeTileId(IN.m_position.xy);
     
-    // We subtract NUM_LIGHT_TYPES because it includes termination markers
-    uint lightCount = PassSrg::m_tileLightData[tileId].w - NUM_LIGHT_TYPES;
+    const uint tileLightDataW = PassSrg::m_tileLightData[tileId].w;
+    const bool overflow = (tileLightDataW >> 31);    
 
-    float3 tileColor = ComputeTileColor(IN.m_position.xy, lightCount, TileCountMax);
+    // We subtract NUM_LIGHT_TYPES because it includes termination markers
+    const uint lightCount = overflow ? NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN : tileLightDataW - NUM_LIGHT_TYPES;
+
+    const float3 tileColor = ComputeTileColor(IN.m_position.xy, lightCount, TileCountMax);
                              
     PSOutput OUT;
     OUT.m_color.rgb = tileColor; 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingRemap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingRemap.azsl
@@ -145,7 +145,8 @@ void WriteTileLightData(const uint groupIndex, const uint3 groupID, const uint l
         uint4 tileLightData = PassSrg::m_tileLightData[groupID.xy];
         // Used for the heatmap
         tileLightData.w = lightsInWorstBin;
-	// pack a "lights have overflowed bit" into this uint
+        
+        // pack a "lights have overflowed bit" into this uint
         tileLightData.w |= overflow ? (1 << 31) : 0;
 
         PassSrg::m_tileLightData[groupID.xy] = tileLightData;    
@@ -194,7 +195,9 @@ void MainCS(
     GroupMemoryBarrierWithGroupSync();
 
     uint totalLights = PassSrg::m_lightCount.Load(uint3(groupID.xy, 0)).x;
-    bool overflow = totalLights > (NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN - 1);
+    
+    // expect flickering if the max number of lights per tile is exceeded
+    const bool overflow = totalLights > (NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN - 1);
     totalLights = min(totalLights, NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN - 1);
 
     AssignLightsToSharedMemoryBins(groupIndex, groupID, totalLights);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingRemap.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/LightCulling/LightCullingRemap.azsl
@@ -138,17 +138,18 @@ uint CalculateNumLightsInWorstBin(uint groupIndex, uint3 groupID, uint baseBin, 
     return lightsInWorstBin;
 }
 
-void WriteTileLightData(uint groupIndex, uint3 groupID, uint lightsInWorstBin)
+void WriteTileLightData(const uint groupIndex, const uint3 groupID, const uint lightsInWorstBin, const bool overflow)
 {
     if (groupIndex == 0)
     {
         uint4 tileLightData = PassSrg::m_tileLightData[groupID.xy];
-
         // Used for the heatmap
         tileLightData.w = lightsInWorstBin;
+	// pack a "lights have overflowed bit" into this uint
+        tileLightData.w |= overflow ? (1 << 31) : 0;
 
         PassSrg::m_tileLightData[groupID.xy] = tileLightData;    
-    }
+    } 
 }
 
 void WriteEndOfList(uint groupIndex, uint writeIndices[NVLC_MAX_BINS])
@@ -193,6 +194,7 @@ void MainCS(
     GroupMemoryBarrierWithGroupSync();
 
     uint totalLights = PassSrg::m_lightCount.Load(uint3(groupID.xy, 0)).x;
+    bool overflow = totalLights > (NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN - 1);
     totalLights = min(totalLights, NVLC_MAX_POSSIBLE_LIGHTS_PER_BIN - 1);
 
     AssignLightsToSharedMemoryBins(groupIndex, groupID, totalLights);
@@ -207,5 +209,5 @@ void MainCS(
 
     uint lightsInWorstBin = CalculateNumLightsInWorstBin(groupIndex, groupID, baseBin, writeIndices);
     WriteEndOfList(groupIndex, writeIndices);
-    WriteTileLightData(groupIndex, groupID, lightsInWorstBin);
+    WriteTileLightData(groupIndex, groupID, lightsInWorstBin, overflow);
 }


### PR DESCRIPTION
Adding a way to detect when the light culling system overflows the number of lights per 16x16 screen tile. Basically I am encoding an "is overflowed" bit in the tile light data, and modified the light culling heatmap to make it obvious.

I change the tile color to white and set it to 999 to indicate overflow
I also make this variable available in the TileLightIterator so I could change the screen color to red or something if wanted.

![overflow](https://user-images.githubusercontent.com/61609885/144529612-bd80cff3-4794-4c34-a278-89ad76516ac1.PNG)


ATOM-16867
