### PR TITLE
Fix number argument in Project Manager notifications

### DIFF
--- a/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/GemCatalog/GemCatalogScreen.cpp
@@ -294,7 +294,7 @@ namespace O3DE::ProjectManager
             }
             else if (numChangedDependencies > 1)
             {
-                notification += tr("%1 Gem %2").arg(QString(numChangedDependencies), tr("dependencies"));
+                notification += tr("%1 Gem %2").arg(numChangedDependencies).arg(tr("dependencies"));
             }
             notification += (added ? tr(" activated") : tr(" deactivated"));
 


### PR DESCRIPTION
Number args now show correctly in gem notifications

![o3de_swHmWQ6N9P](https://user-images.githubusercontent.com/26804013/144531858-bab548d0-3345-4374-9e7f-dabaa26b2ad3.png)


Closes #6120 
Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>