### PR TITLE
Updated Entity Inspector to changed behavior when an Entity has been marked as read-only.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.hxx
@@ -62,6 +62,7 @@ namespace AzToolsFramework
     class ComponentPaletteWidget;
     class ComponentModeCollectionInterface;
     struct SourceControlFileInfo;
+    class ReadOnlyEntityPublicInterface;
 
     namespace AssetBrowser
     {
@@ -622,6 +623,9 @@ namespace AzToolsFramework
 
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
         bool m_prefabsAreEnabled = false;
+
+        ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
+        bool m_entityIsReadOnly = false;
 
         // Reordering row widgets within the RPE.
         static constexpr float MoveFadeSeconds = 0.5f;


### PR DESCRIPTION
Updated the Entity Inspector behavior to handle entities that have been marked as read-only:
- Don't allow the Entity to be renamed in the name field
- Disable the Entity activation status field
- Components show as disabled, but can be copied
- All other component actions are disabled (cut/enable/disable/paste)
- Add Component button removed

![ReadOnlyEntityInspector](https://user-images.githubusercontent.com/7519264/144663863-907d641c-8d78-4bcd-94a9-124219bebfd3.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>