### PR TITLE
LYN-8733 | Instantiating a Procedural Prefab puts it at the root level

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemScriptingHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemScriptingHandler.cpp
@@ -8,10 +8,12 @@
 
 #include <API/ToolsApplicationAPI.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/Entity.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzToolsFramework/ToolsComponents/EditorLockComponent.h>
+#include <AzToolsFramework/ToolsComponents/EditorVisibilityComponent.h>
 #include <Prefab/PrefabSystemComponentInterface.h>
 #include <Prefab/PrefabSystemScriptingHandler.h>
-#include <AzCore/Component/Entity.h>
 #include <Prefab/EditorPrefabComponent.h>
 #include <ToolsComponents/TransformComponent.h>
 
@@ -72,6 +74,9 @@ namespace AzToolsFramework::Prefab
             entities, commonRoot, &topLevelEntities);
 
         auto containerEntity = AZStd::make_unique<AZ::Entity>();
+        containerEntity->CreateComponent<Components::TransformComponent>();
+        containerEntity->CreateComponent<Components::EditorLockComponent>();
+        containerEntity->CreateComponent<Components::EditorVisibilityComponent>();
         containerEntity->CreateComponent<Prefab::EditorPrefabComponent>();
 
         for (AZ::Entity* entity : topLevelEntities)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -565,9 +565,7 @@ namespace AzToolsFramework
                     EditorRequestBus::BroadcastResult(position, &EditorRequestBus::Events::GetWorldPositionAtViewportCenter);
                 }
 
-                // Instantiating from context menu always puts the instance at the root level
                 auto createPrefabOutcome = s_prefabPublicInterface->InstantiatePrefab(prefabFilePath, parentId, position);
-
                 if (!createPrefabOutcome.IsSuccess())
                 {
                     WarnUserOfError("Prefab Instantiation Error",createPrefabOutcome.GetError());
@@ -594,15 +592,13 @@ namespace AzToolsFramework
                 }
                 else
                 {
-                    // otherwise return since it needs to be inside an authored prefab
-                    return;
+                    EditorRequestBus::BroadcastResult(position, &EditorRequestBus::Events::GetWorldPositionAtViewportCenter);
                 }
 
-                // Instantiating from context menu always puts the instance at the root level
                 auto createPrefabOutcome = s_prefabPublicInterface->InstantiatePrefab(prefabAssetPath, parentId, position);
                 if (!createPrefabOutcome.IsSuccess())
                 {
-                    WarnUserOfError("Prefab Instantiation Error", createPrefabOutcome.GetError());
+                    WarnUserOfError("Procedural Prefab Instantiation Error", createPrefabOutcome.GetError());
                 }
             }
         }


### PR DESCRIPTION
A couple of fixes to procedural prefab instantiation:
- Adds required editor components to the container entity of the procedural prefab (transform, visibility and lock). This issue was introduced by changes to the procprefab creation here: https://github.com/o3de/o3de/pull/4669
- Removes limitation that would cause procprefab instantiation to fail silently if no parent entity was explicitly selected. I think the assumption behind that decision is flawed, since there is currently no way to instantiate a procprefab so that it's not nested (since the level itself is a prefab).

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>