### PR TITLE
Updated android launcher to remove confusing branding

### DIFF
--- a/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
+++ b/Code/LauncherUnified/Platform/Android/Launcher_Android.cpp
@@ -299,7 +299,7 @@ void android_main(android_app* appState)
 {
     // Adding a start up banner so you can see when the game is starting up in amongst the logcat spam
     LOGI("****************************************************************");
-    LOGI("*             Amazon Lumberyard - Launching Game...            *");
+    LOGI("*                      Launching Game...                       *");
     LOGI("****************************************************************");
 
     // setup the system command handler which are guaranteed to be called on the same


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/5853 where launching on Android would result in a confusing message logged with conflicting branding. 

Signed-off-by: gusmccallum <gusmccallum@hotmail.com>