### PR TITLE
Print Entity name if Improperly Deleted

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -167,7 +167,10 @@ namespace Multiplayer
 
     void NetBindComponent::Deactivate()
     {
-        AZ_Assert(m_needsToBeStopped == false, "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.", GetEntity()->GetName().c_str());
+        AZ_Assert(
+            m_needsToBeStopped == false,
+            "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.",
+            GetEntity() ? GetEntity()->GetName().c_str() : "null");
         m_handleLocalServerRpcMessageEventHandle.Disconnect();
         if (NetworkRoleHasController(m_netEntityRole))
         {

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -167,7 +167,14 @@ namespace Multiplayer
 
     void NetBindComponent::Deactivate()
     {
-        AZ_Assert(m_needsToBeStopped == false, "Entity appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.");
+        if (m_needsToBeStopped)
+        {
+            AZ_Assert(
+                    false,
+                    "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.",
+                    GetEntity()->GetName().c_str());
+            
+        }
         m_handleLocalServerRpcMessageEventHandle.Disconnect();
         if (NetworkRoleHasController(m_netEntityRole))
         {

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -167,14 +167,7 @@ namespace Multiplayer
 
     void NetBindComponent::Deactivate()
     {
-        if (m_needsToBeStopped)
-        {
-            AZ_Assert(
-                    false,
-                    "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.",
-                    GetEntity()->GetName().c_str());
-            
-        }
+        AZ_Assert(m_needsToBeStopped == false, "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.", GetEntity()->GetName().c_str());
         m_handleLocalServerRpcMessageEventHandle.Disconnect();
         if (NetworkRoleHasController(m_netEntityRole))
         {


### PR DESCRIPTION
Improved logged to print entity name if improperly deleted; helps when debugging to find the problem entity.
Note: This hasn't been unit tested. I added this small update when running into this assert myself, but wasn't sure which entity was causing the problem.

Signed-off-by: Gene Walters <genewalt@amazon.com>