### PR TITLE
Move normal map texture loads out of closest-depth search

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridDownsample.azsl
@@ -56,26 +56,27 @@ struct PSOutput
 PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
 {  
     uint2 screenCoords = IN.m_position.xy * PassSrg::m_outputImageScale;
+    uint2 closestScreenCoords = uint2(0, 0);
 
     float downsampledDepth = 0;
-    float4 downsampledEncodedNormal;
+
     for (uint y = 0; y < PassSrg::m_outputImageScale; ++y)
     {
         for (uint x = 0; x < PassSrg::m_outputImageScale; ++x)
         {
             float depth = PassSrg::m_depth.Load(screenCoords + int2(x, y), sampleIndex).r;
-            float4 encodedNormal = PassSrg::m_normal.Load(screenCoords + int2(x, y), sampleIndex);
 
             // take the closest depth sample to ensure we're getting the normal closest to the viewer 
             // (larger depth value due to reverse depth)
             if (depth > downsampledDepth)
             {
                 downsampledDepth = depth;
-                downsampledEncodedNormal = encodedNormal;
+                closestScreenCoords = uint2(x, y);
             }
         }
     }
 
+    float4 downsampledEncodedNormal = PassSrg::m_normal.Load(screenCoords + closestScreenCoords, sampleIndex);
     float3 downsampledNormal = DecodeNormalSignedOctahedron(downsampledEncodedNormal.rgb);
 
     PSOutput OUT;


### PR DESCRIPTION
~23% pass speedup due to improved L1 usage and reduced warp churn.

Before (top SOLs):

```
L1 Throughput: 75.2%
VRAM Throughput: 25.5%
```

After (top SOLs):

```
L1 Throughput: 84.1%
VRAM Throughput: 30.7%
```