### PR TITLE
keyword bug fixed

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerWidget.cpp
@@ -1281,6 +1281,8 @@ void OutlinerWidget::OnSearchTextChanged(const QString& activeTextFilter)
 
     m_listModel->SearchStringChanged(filterString);
     m_proxyModel->UpdateFilter();
+
+    m_gui->m_objectTree->expandAll();
 }
 
 void OutlinerWidget::OnFilterChanged(const AzQtComponents::SearchTypeFilterList& activeTypeFilters)


### PR DESCRIPTION
In the entity outliner search box, the matching results are not expanded and displayed (prefab mode) 

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>