### PR TITLE
Fix for Lua IDE startup bug

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.cpp
@@ -108,6 +108,16 @@ namespace LegacyFramework
         m_applicationModule[0] = 0;
     }
 
+    Application::Application(int argc, char** argv)
+        :ComponentApplication(argc ? argc : 0, argv ? argv : nullptr)
+    {
+        m_isPrimary = true;
+        m_desiredExitCode = 0;
+        m_abortRequested = false;
+        m_applicationEntity = NULL;
+        m_ptrSystemEntity = NULL;
+        m_applicationModule[0] = 0;
+    }
     void* Application::GetMainModule()
     {
         return m_desc.m_applicationModule;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/LegacyFramework/Core/EditorFrameworkApplication.h
@@ -56,6 +56,7 @@ namespace LegacyFramework
         using CoreMessageBus::Handler::Run;
         virtual int Run(const ApplicationDesc& desc);
         Application();
+        Application(int argc, char** argv);
 
         void CreateReflectionManager() override;
 

--- a/Code/Tools/Standalone/Source/LUA/LUAEditorContext.h
+++ b/Code/Tools/Standalone/Source/LUA/LUAEditorContext.h
@@ -215,6 +215,10 @@ namespace LUAEditor
         // HighlightedWords
         const HighlightedWords::LUAKeywordsType* GetLUAKeywords()  override { return &m_LUAKeywords; }
         const HighlightedWords::LUAKeywordsType* GetLUALibraryFunctions()  override { return &m_LUALibraryFunctions; }
+        virtual void DeleteBreakpointSingle(const AZStd::string& fromAssetId, int lineNumber);
+        virtual void DeleteBreakpointAll(const AZStd::string& fromAssetId);
+        virtual void CleanUpBreakpointBegin();
+        virtual void CloseLuaIDE();
 
         // internal data structure for the LUA debugger class/member/property reference panel
         // this is what we serialize and work with
@@ -306,6 +310,9 @@ namespace LUAEditor
         AZStd::atomic_int m_numOutstandingOperations;
         bool m_bShuttingDown;
         bool m_bProcessingActivate;
+
+        //This parameter determines Lua IDE Running in the background.
+        bool m_bRunbackground;
 
         // these documents have been modified whilst the user was alt tabbed, we should check them:
         void ProcessReloadCheck();

--- a/Code/Tools/Standalone/Source/StandaloneToolsApplication.cpp
+++ b/Code/Tools/Standalone/Source/StandaloneToolsApplication.cpp
@@ -23,8 +23,8 @@
 
 namespace StandaloneTools
 {
-    BaseApplication::BaseApplication(int&, char**)
-        : LegacyFramework::Application()
+    BaseApplication::BaseApplication(int& argc, char** argv)
+        : LegacyFramework::Application(argc, argv)
     {
         AZ::UserSettingsFileLocatorBus::Handler::BusConnect();
     }


### PR DESCRIPTION
Currently, Lua IDEs crash with an error message form the asset processor stating the startup path is incorrect.

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>