### PR TITLE
Fixed critical json property.

### DIFF
--- a/Gems/Blast/AssetProcessorGemConfig.setreg
+++ b/Gems/Blast/AssetProcessorGemConfig.setreg
@@ -10,6 +10,7 @@
                 "RC blastmaterial": {
                     "glob": "*.blastmaterial",
                     "params": "copy",
+                    "critical": true,
                     "productAssetType": "{55F38C86-0767-4E7F-830A-A4BF624BE4DA}"
                 },
                 "RC blastconfiguration": {

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -442,7 +442,7 @@
                 "RC physmaterial": {
                     "glob": "*.physmaterial",
                     "params": "copy",
-                    "critical": "true",
+                    "critical": true,
                     "productAssetType": "{9E366D8C-33BB-4825-9A1F-FA3ADBE11D0F}"
                 },
                 "RC ocm": {


### PR DESCRIPTION
In order to work "critical" property needs to be without quotes.

Marking blast material library assets as criticals since it's necessary to be ready before the editor opens (same as physics materials)