### PR TITLE
Procedural Prefabs:  Stable transform component ID

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemScriptingHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemScriptingHandler.cpp
@@ -16,7 +16,6 @@
 #include <Prefab/PrefabSystemScriptingHandler.h>
 #include <Prefab/EditorPrefabComponent.h>
 #include <ToolsComponents/TransformComponent.h>
-#include <xxhash/xxhash.h>
 
 namespace AzToolsFramework::Prefab
 {
@@ -86,9 +85,9 @@ namespace AzToolsFramework::Prefab
             // Because procedural prefabs need to be deterministic we need to set the component ID to something unique and non-random
             // The prefab that references the proc prefab will store a patch that references the transform component by it's component ID
             // If this ID is not stable, the proc prefab will lose its position, parenting, etc data next time it is regenerated
-            auto hash = XXH64(filePath.data(), filePath.length(), 0);
+            auto hash = TypeHash64(reinterpret_cast<const uint8_t*>(filePath.data()), filePath.length(), AZ::HashValue64{0});
 
-            transformComponent->SetId(hash);
+            transformComponent->SetId(static_cast<AZ::ComponentId>(hash));
 
         }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemScriptingHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemScriptingHandler.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Utils/TypeHash.h>
 #include <AzToolsFramework/ToolsComponents/EditorLockComponent.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityComponent.h>
 #include <Prefab/PrefabSystemComponentInterface.h>

--- a/Code/Framework/AzToolsFramework/CMakeLists.txt
+++ b/Code/Framework/AzToolsFramework/CMakeLists.txt
@@ -31,7 +31,6 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             3rdParty::SQLite
-            3rdParty::xxhash
             AZ::AzCore
         PUBLIC
             3rdParty::Qt::Core

--- a/Code/Framework/AzToolsFramework/CMakeLists.txt
+++ b/Code/Framework/AzToolsFramework/CMakeLists.txt
@@ -31,6 +31,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             3rdParty::SQLite
+            3rdParty::xxhash
             AZ::AzCore
         PUBLIC
             3rdParty::Qt::Core


### PR DESCRIPTION
Updated PrefabSystemScriptingHandler::CreatePrefabTemplate to set the component ID of the created transform component to the hash of the file path.

Since Procedural Prefabs are regenerated from an FBX all the time, the component ID of the transform needs to be stable so that saved patches can still be applied.