### PR TITLE
Check whether env variables are defined

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -12,12 +12,12 @@ set(LY_VERSION_STRING "0.0.0.0" CACHE STRING "Open 3D Engine's version")
 set(LY_VERSION_BUILD_NUMBER 0 CACHE STRING "Open 3D Engine's build number")
 set(LY_VERSION_ENGINE_NAME "o3de" CACHE STRING "Open 3D Engine's engine name")
 
-if("$ENV{O3DE_VERSION}" VERSION_GREATER "0.0.0.0")
+if(NOT "$ENV{O3DE_VERSION}" STREQUAL "")
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
 
-if("$ENV{O3DE_BUILD_VERSION}" GREATER 0)
+if(NOT "$ENV{O3DE_BUILD_VERSION}" STREQUAL "")
     # Overriding through environment
     set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
 endif()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -12,12 +12,12 @@ set(LY_VERSION_STRING "0.0.0.0" CACHE STRING "Open 3D Engine's version")
 set(LY_VERSION_BUILD_NUMBER 0 CACHE STRING "Open 3D Engine's build number")
 set(LY_VERSION_ENGINE_NAME "o3de" CACHE STRING "Open 3D Engine's engine name")
 
-if("$ENV{O3DE_VERSION}")
+if(DEFINED ENV{O3DE_VERSION})
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
 
-if("$ENV{O3DE_BUILD_VERSION}")
+if(DEFINED ENV{O3DE_BUILD_VERSION})
     # Overriding through environment
     set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
 endif()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -12,12 +12,12 @@ set(LY_VERSION_STRING "0.0.0.0" CACHE STRING "Open 3D Engine's version")
 set(LY_VERSION_BUILD_NUMBER 0 CACHE STRING "Open 3D Engine's build number")
 set(LY_VERSION_ENGINE_NAME "o3de" CACHE STRING "Open 3D Engine's engine name")
 
-if(DEFINED ENV{O3DE_VERSION})
+if("$ENV{O3DE_VERSION}" VERSION_GREATER "0.0.0.0")
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
 
-if(DEFINED ENV{O3DE_BUILD_VERSION})
+if("$ENV{O3DE_BUILD_VERSION}" GREATER 0)
     # Overriding through environment
     set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
 endif()


### PR DESCRIPTION
Check whether environment variables are defined instead of checking the env variable contents. Avoids the conditional failing with version numbers of 3 digits, such as 21.11.1.

Signed-off-by: AMZN-Phil <pconroy@amazon.com>