### PR TITLE
Some read-only prefab workflow updates.

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.h
@@ -76,6 +76,7 @@ namespace AzToolsFramework
 {
     class EditorEntityAPI;
     class EditorEntityUiInterface;
+    class ReadOnlyEntityPublicInterface;
 
     namespace AssetBrowser
     {
@@ -295,6 +296,7 @@ private:
     AzToolsFramework::EditorEntityUiInterface* m_editorEntityUiInterface = nullptr;
     AzToolsFramework::Prefab::PrefabIntegrationInterface* m_prefabIntegrationInterface = nullptr;
     AzToolsFramework::EditorEntityAPI* m_editorEntityAPI = nullptr;
+    AzToolsFramework::ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
 
     // Overrides UI styling and behavior for Layer Entities
     AzToolsFramework::LayerUiHandler m_layerUiOverrideHandler;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -25,6 +25,7 @@
 #include <AzToolsFramework/AssetBrowser/Entries/SourceAssetBrowserEntry.h>
 #include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/EditorPrefabComponent.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceEntityMapperInterface.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
@@ -140,6 +141,9 @@ namespace AzToolsFramework
                 AZ_Assert(false, "Prefab - could not get PrefabFocusPublicInterface on PrefabIntegrationManager construction.");
                 return;
             }
+
+            m_readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
+            AZ_Assert(m_readOnlyEntityPublicInterface, "Prefab - could not get ReadOnlyEntityPublicInterface on PrefabIntegrationManager construction.");
 
             // Get EditorEntityContextId
             EditorEntityContextRequestBus::BroadcastResult(s_editorEntityContextId, &EditorEntityContextRequests::GetEditorEntityContextId);
@@ -263,6 +267,16 @@ namespace AzToolsFramework
             AzFramework::ApplicationRequests::Bus::BroadcastResult(
                 prefabWipFeaturesEnabled, &AzFramework::ApplicationRequests::ArePrefabWipFeaturesEnabled);
 
+            bool readOnlyEntityInSelection = false;
+            for (const auto& entityId : selectedEntities)
+            {
+                if (m_readOnlyEntityPublicInterface->IsReadOnly(entityId))
+                {
+                    readOnlyEntityInSelection = true;
+                    break;
+                }
+            }
+
             // Create Prefab
             {
                 if (!selectedEntities.empty())
@@ -289,7 +303,8 @@ namespace AzToolsFramework
                         }
 
                         // Layers can't be in prefabs.
-                        if (!layerInSelection)
+                        // Also don't allow to create a prefab if any of the selected entities are read-only
+                        if (!layerInSelection && !readOnlyEntityInSelection)
                         {
                             QAction* createAction = menu->addAction(QObject::tr("Create Prefab..."));
                             createAction->setToolTip(QObject::tr("Creates a prefab out of the currently selected entities."));
@@ -383,14 +398,13 @@ namespace AzToolsFramework
                 menu->addSeparator();
             }
 
-            QAction* deleteAction = menu->addAction(QObject::tr("Delete"));
-            QObject::connect(deleteAction, &QAction::triggered, deleteAction, [] { ContextMenu_DeleteSelected(); });
-
-            if (selectedEntities.empty() ||
-                (selectedEntities.size() == 1 &&
-                 selectedEntities[0] == s_prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(s_editorEntityContextId)))
+            if (!selectedEntities.empty() &&
+                (selectedEntities.size() != 1 ||
+                 selectedEntities[0] != s_prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(s_editorEntityContextId)) &&
+                !readOnlyEntityInSelection)
             {
-                deleteAction->setDisabled(true);
+                QAction* deleteAction = menu->addAction(QObject::tr("Delete"));
+                QObject::connect(deleteAction, &QAction::triggered, deleteAction, [] { ContextMenu_DeleteSelected(); });
             }
 
             // Detach Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -29,6 +29,7 @@
 namespace AzToolsFramework
 {
     class ContainerEntityInterface;
+    class ReadOnlyEntityPublicInterface;
 
     namespace Prefab
     {
@@ -169,6 +170,8 @@ namespace AzToolsFramework
             static PrefabLoaderInterface* s_prefabLoaderInterface;
             static PrefabPublicInterface* s_prefabPublicInterface;
             static PrefabSystemComponentInterface* s_prefabSystemComponentInterface;
+
+            ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
         };
     }
 }


### PR DESCRIPTION
Several read-only prefab related workflow changes:
- It should not be possible to create a new entity as a child of a read-only entity
- It should not be possible to delete a direct child of a read-only entity
- It should not be possible to duplicate entities that are direct children of read-only entities
- It should not be possible to create a prefab if the selection contains a read-only entity

Also updated the "Delete" and "Duplicate" actions in the context menu to be hidden instead of just disabled.

![ReadOnlyPrefabWorkflowChanges](https://user-images.githubusercontent.com/7519264/145121291-c2b3024b-991a-44e6-b89c-77642b9cf1e8.gif)
Note: the procedural prefab is incorrectly placed at the root of the level in this gif. The build this was tested on was outdated, the issue has been fixed in latest development.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>