### PR TITLE
RTE7 Team Collabration: Fix issue where the AssetProcessor would not process any engine assets

### DIFF
--- a/AutomatedTesting/Gem/AssetProcessorGemConfig.setreg
+++ b/AutomatedTesting/Gem/AssetProcessorGemConfig.setreg
@@ -3,19 +3,19 @@
         "AssetProcessor": {
             "Settings": {
                 "Exclude PythonTest Benchmark Settings Assets": {
-                    "pattern": ".*\\\\/PythonTests\\\\/.*benchmarksettings"
+                    "pattern": "(^|.+/)PythonTests/.*benchmarksettings"
                 },
                 "Exclude fbx_tests": {
-                    "pattern": ".*\\\\/fbx_tests\\\\/assets\\\\/.*"
+                    "pattern": "(^|.+/)fbx_tests/assets(/.+)$"
                 },
                 "Exclude wwise_bank_dependency_tests": {
-                    "pattern": ".*\\\\/wwise_bank_dependency_tests\\\\/assets\\\\/.*"
+                    "pattern": "(^|.+/)wwise_bank_dependency_tests/assets(/.+)$"
                 },
                 "Exclude AssetProcessorTestAssets": {
-                    "pattern": ".*\\\\/asset_processor_tests\\\\/assets\\\\/.*"
+                    "pattern": "(^|.+/)asset_processor_tests/assets(/.+)$"
                 },
                 "Exclude Restricted AssetProcessorTestAssets": {
-                    "pattern": ".*\\\\/asset_processor_tests\\\\/restricted\\\\/.*"
+                    "pattern": "(^|.+/)asset_processor_tests/restricted(/.+)$"
                 }
             }
         }

--- a/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetCatalog/AssetCatalogUnitTests.cpp
@@ -283,7 +283,7 @@ namespace AssetProcessor
 
             ExcludeAssetRecognizer excludeRecogniser;
             excludeRecogniser.m_name = "backup";
-            excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher(".*\\/savebackup\\/.*", AssetBuilderSDK::AssetBuilderPattern::Regex);
+            excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher("(^|.+/)savebackup/.*", AssetBuilderSDK::AssetBuilderPattern::Regex);
             config.AddExcludeRecognizer(excludeRecogniser);
         }
 

--- a/Code/Tools/AssetProcessor/native/tests/assetscanner/AssetScannerTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetscanner/AssetScannerTests.cpp
@@ -123,7 +123,7 @@ namespace AssetProcessor
         ExcludeAssetRecognizer excludeRecogniser;
         excludeRecogniser.m_name = "backup";
         // we are excluding all the files in the folder but not the folder itself
-        excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher(".*\\/subfolder2\\/aaa\\/.*", AssetBuilderSDK::AssetBuilderPattern::Regex);
+        excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher("(^|[^/]+/)aaa/.*", AssetBuilderSDK::AssetBuilderPattern::Regex);
         m_platformConfig.get()->AddExcludeRecognizer(excludeRecogniser);
         m_assetScanner.get()->StartScan();
 
@@ -144,7 +144,7 @@ namespace AssetProcessor
         ExcludeAssetRecognizer excludeRecogniser;
         excludeRecogniser.m_name = "backup";
         // we are excluding the complete folder here
-        excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher(".*\\/subfolder2\\/aaa", AssetBuilderSDK::AssetBuilderPattern::Regex);
+        excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher("(^|[^/]+/)aaa", AssetBuilderSDK::AssetBuilderPattern::Regex);
         m_platformConfig.get()->AddExcludeRecognizer(excludeRecogniser);
         m_assetScanner.get()->StartScan();
 

--- a/Code/Tools/AssetProcessor/native/tests/platformconfiguration/platformconfigurationtests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/platformconfiguration/platformconfigurationtests.cpp
@@ -413,6 +413,8 @@ TEST_F(PlatformConfigurationUnitTests, TestFailReadConfigFile_RegularExcludes)
     auto configRoot = AZ::IO::FileIOBase::GetInstance()->ResolvePath("@exefolder@/testdata/config_regular");
     ASSERT_TRUE(configRoot);
     UnitTestPlatformConfiguration config;
+    
+    config.AddScanFolder(ScanFolderInfo("blahblah", "Blah ScanFolder", "sf2", true, true), true);
     m_absorber.Clear();
     ASSERT_TRUE(config.InitializeFromConfigFiles(configRoot->c_str(), testExeFolder->c_str(), projectPath.c_str(), false, false));
     ASSERT_EQ(m_absorber.m_numErrorsAbsorbed, 0);

--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessorManagerUnitTests.cpp
@@ -347,7 +347,7 @@ namespace AssetProcessor
 
         ExcludeAssetRecognizer excludeRecogniser;
         excludeRecogniser.m_name = "backup";
-        excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher(".*\\/savebackup\\/.*", AssetBuilderSDK::AssetBuilderPattern::Regex);
+        excludeRecogniser.m_patternMatcher = AssetBuilderSDK::FilePatternMatcher("(^|.+/)savebackup/.*", AssetBuilderSDK::AssetBuilderPattern::Regex);
         config.AddExcludeRecognizer(excludeRecogniser);
 
         AssetProcessorManager_Test apm(&config);  // note, this will 'push' the scan folders in to the db.
@@ -1791,13 +1791,8 @@ namespace AssetProcessor
         UNIT_TEST_EXPECT_TRUE((newfingerprintForPCAfterVersionChange != fingerprintForPC) || (newfingerprintForPCAfterVersionChange != newfingerprintForPC));//Fingerprints should be different
         UNIT_TEST_EXPECT_TRUE((newfingerprintForANDROIDAfterVersionChange != fingerprintForANDROID) || (newfingerprintForANDROIDAfterVersionChange != newfingerprintForANDROID));//Fingerprints should be different
 
-        //------Test for Files which are excluded
         processResults.clear();
-        absolutePath = AssetUtilities::NormalizeFilePath(tempPath.absoluteFilePath("subfolder3/savebackup/test.txt"));
-        QMetaObject::invokeMethod(&apm, "AssessModifiedFile", Qt::QueuedConnection, Q_ARG(QString, absolutePath));
-        UNIT_TEST_EXPECT_FALSE(BlockUntil(idling, 3000)); //Processing a file that will be excluded should not cause assetprocessor manager to emit the onBecameIdle signal because its state should not change
-        UNIT_TEST_EXPECT_TRUE(processResults.size() == 0);
-
+        
         // ------------- Test querying asset status -------------------
         {
             absolutePath = tempPath.absoluteFilePath("subfolder2/folder/ship.tiff");

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1633,13 +1633,18 @@ namespace AssetProcessor
 
     bool AssetProcessor::PlatformConfiguration::IsFileExcluded(QString fileName) const
     {
-        for (const ExcludeAssetRecognizer& excludeRecognizer : m_excludeAssetRecognizers)
+        QString relPath, scanFolderName;
+        if (ConvertToRelativePath(fileName, relPath, scanFolderName))
         {
-            if (excludeRecognizer.m_patternMatcher.MatchesPath(fileName.toUtf8().constData()))
+            for (const ExcludeAssetRecognizer& excludeRecognizer : m_excludeAssetRecognizers)
             {
-                return true;
+                if (excludeRecognizer.m_patternMatcher.MatchesPath(relPath.toUtf8().constData()))
+                {
+                    return true;
+                }
             }
         }
+
         return false;
     }
 

--- a/Code/Tools/AssetProcessor/testdata/config_regular/AssetProcessorPlatformConfig.setreg
+++ b/Code/Tools/AssetProcessor/testdata/config_regular/AssetProcessorPlatformConfig.setreg
@@ -50,10 +50,10 @@
                     "order": 6000
                 },
                 "Exclude HoldFiles": {
-                    "pattern": ".*\\\\/Levels\\\\/.*_hold\\\\/.*"
+                    "pattern": "(^|.+/)Levels/.*_hold(/.*)?$"
                 },
                 "Exclude TempFiles": {
-                    "pattern": ".*\\\\/\\\\$tmp[0-9]*_.*"
+                    "pattern": "(^|.+/)\\\\$tmp[0-9]*_.*"
                 },
                 "RC i_caf": {
                     "glob": "*.i_caf",

--- a/Code/Tools/AssetProcessor/testdata/config_regular_platform_scanfolder/AssetProcessorPlatformConfig.setreg
+++ b/Code/Tools/AssetProcessor/testdata/config_regular_platform_scanfolder/AssetProcessorPlatformConfig.setreg
@@ -74,10 +74,10 @@
                     "include": "test"
                 },
                 "Exclude HoldFiles": {
-                    "pattern": ".*\\\\/Levels\\\\/.*_hold\\\\/.*"
+                    "pattern": "(^|.+/)Levels/.*_hold(/.*)?$"
                 },
                 "Exclude TempFiles": {
-                    "pattern": ".*\\\\/\\\\$tmp[0-9]*_.*"
+                    "pattern": "(^|.+/)\\\\$tmp[0-9]*_.*"
                 },
                 "RC i_caf": {
                     "glob": "*.i_caf",

--- a/Gems/AtomContent/Sponza/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Gems/AtomContent/Sponza/Registry/AssetProcessorPlatformConfig.setreg
@@ -6,7 +6,7 @@
                 // Sample Gems, Block source folders
                 // ------------------------------------------------------------------------------
                 "Exclude Work In Progress Folders": {
-                    "pattern": ".*\\\\/.[Ss]rc\\\\/.*"
+                    "pattern": "(^|.+/).[Ss]rc(/.*)?$"
                 }
             }
         }

--- a/Gems/AudioEngineWwise/AssetProcessorGemConfig.setreg
+++ b/Gems/AudioEngineWwise/AssetProcessorGemConfig.setreg
@@ -3,10 +3,10 @@
         "AssetProcessor": {
             "Settings": {
                 "Exclude AudioProject": {
-                    "pattern": ".*\\\\/Sounds\\\\/.+_project.*"
+                    "pattern": "(^|.+/)Sounds/.+_project.*"
                 },
                 "Exclude AudioTemp": {
-                    "pattern": ".*\\\\/Sounds\\\\/.+\\\\.(txt|xml|dat)"
+                    "pattern": "(^|.+/)Sounds/.+\\\\.(txt|xml|dat)"
                 },
                 "RC audio": {
                     "pattern": ".*\\\\.(wav|pcm)",

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -137,64 +137,66 @@
 
                 // Excludes files that match the pattern or glob 
                 // if you use a pattern, remember to escape your backslashes (\\)
+                // The patterns are checked against a path relative to the entry's
+                // root scan folder.
                 "Exclude _LevelBackups": {
-                    "pattern": ".*\\\\/Levels\\\\/.*\\\\/_savebackup\\\\/.*"
+                    "pattern": "(^|.+/)Levels/.*/_savebackup(/.*)?$"
                 },
                 "Exclude _LevelAutoBackups": {
-                    "pattern": ".*\\\\/Levels\\\\/.*\\\\/_autobackup\\\\/.*"
+                    "pattern": "(^|.+/)Levels/.*/_autobackup(/.*)?$"
                 },
                 "Exclude HoldFiles": {
-                    "pattern": ".*\\\\/Levels\\\\/.*_hold\\\\/.*"
+                    "pattern": "(^|.+/)Levels/.*_hold(/.*)?$"
                 },
                 // note that $ has meaning to regex, so we escape it.
                 "Exclude TempFiles": {
-                    "pattern": ".*\\\\/\\\\$tmp[0-9]*_.*"
+                    "pattern": "(^|.+/)\\\\$tmp[0-9]*_.*"
                 },
                 "Exclude TmpAnimationCompression": {
-                    "pattern": ".*\\\\/Editor\\\\/Tmp\\\\/AnimationCompression\\\\/.*"
+                    "pattern": "(^|.+/)Editor/Tmp/AnimationCompression(/.*)?$"
                 },
                 "Exclude EventLog": {
-                    "pattern": ".*\\\\/Editor\\\\/.*eventlog\\\\.xml"
+                    "pattern": "(^|.+/)Editor/.*eventlog\\\\.xml"
                 },
                 "Exclude GameGemsCode": {
-                    "pattern": ".*\\\\/Gem\\\\/Code\\\\/.*"
+                    "pattern": "(^|.+/)Gem/Code(/.*)?$"
                 },
                 "Exclude GameGemsResources": {
-                    "pattern": ".*\\\\/Gem\\\\/Resources\\\\/.*"
+                    "pattern": "(^|.+/)Gem/Resources(/.*)?$"
                 },
                 "Exclude Private Certs": {
-                    "pattern": ".*\\DynamicContent\\\\/Certificates\\\\/Private\\\\/.*"
+                    "pattern": "(^|.+/)DynamicContent/Certificates/Private(/.*)?$"
                 },
                 "Exclude CMakeLists": {
-                    "pattern": ".*\\\\/CMakeLists.txt"
+                    "pattern": "(^|.+/)CMakeLists\\\\.txt"
                 },
                 "Exclude CMakeFiles": {
-                    "pattern": ".*\\\\/.*\\\\.cmake"
+                    "pattern": "(^|.+/).+\\\\.cmake"
                 },
                 "Exclude User": {
-                    "pattern": ".*/[Uu]ser/.*"
+                    "pattern": "^[Uu]ser(/.*)?$"
                 },
                 "Exclude Build": {
-                    "pattern": ".*/[Bb]uild/.*"
+                    "pattern": "^[Bb]uild(/.*)?$"
                 },
                 "Exclude Install": {
-                    "pattern": ".*/[Ii]nstall/.*"
+                    "pattern": "^[Ii]nstall(/.*)?$"
                 },
                 "Exclude UserSettings": {
-                    "pattern": ".*/UserSettings.xml"
+                    "pattern": "(^|[^/]+/)UserSettings\\\\.xml"
                 },
 
                 // ------------------------------------------------------------------------------
                 // Large Worlds Test
                 // ------------------------------------------------------------------------------
                 "Exclude Work In Progress Folders": {
-                    "pattern": ".*\\\\/WIP\\\\/.*"
+                    "pattern": "(^|[^/]+/)WIP(/.*)?"
                 },
                 "Exclude Content Source Folders": {
-                    "pattern": ".*\\\\/CONTENT_SOURCE\\\\/.*"
+                    "pattern": "(^|[^/]+/)CONTENT_SOURCE(/.*)?"
                 },
                 "Exclude Art Source Folders": {
-                    "pattern": ".*\\\\/ArtSource\\\\/.*"
+                    "pattern": "(^|[^/]+/)ArtSource(/.*)?"
                 },
                 //------------------------------------------------------------------------------
                 // Copying Files Automatically Into the Cache


### PR DESCRIPTION
In the steps to create a distributable engine SDK along with a pre-built project as part of workflow 7, the Editor within the SDK root is asked to be launched, but the SDK root at the point is within a folder called `install`.
Previously the AssetProcessor would exclude any files that contained a directory segment with the name of "install", even if the "install" directory is outside of any ScanFolders.

The step with the issue is below
> For the convenience of the rest of your team, run the editor and supply the --project-path <project-root> to it, create a level and save it. This can be useful to confirm that when they get the engine and project there is a level they can use to make sure everything is working normally.
The <sdk-root> by is located by default at **`<engine-root>/install`**. It can be overridden at CMake configure time via the CMAKE_INSTALL_PREFIX cache variable.
`<sdk-root>: bin\Windows\profile\Default\Editor.exe --project-path <project-path>`

Following the steps would have the user launch the Editor and AssetProcessor which would work on an pre-built SDK engine that contained "install" as part of it's absolute path.
Due to AssetProcessor previously examining the absolute path of scanned files and running exclusion rules against that absolute path + the fact that the `Registry/AssetProcessorPlatformConfig.setreg` contained an exclusion rule for a path with the name "install", all the engine source assets and engine gem assets within the SDK root were excluded by the AssetProcessor

This issue was fixed in PR #4504, but the changes never made over to stabilization/2110.

fixes #6139 #3955