### PR TITLE
Fix warnings, add branch notifier

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/NVLC.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/LightCulling/NVLC.azsli
@@ -74,7 +74,7 @@ struct TileLightData
  
 bool Light_IsInsideBin(uint package, uint bin)
 {
-    return (package & (1 << bin)) != 0;
+    return (package & (1u << bin)) != 0;
 }
 
 uint PackLightIndexWithBinMask(uint ind, uint bins)
@@ -130,7 +130,7 @@ uint NVLC_GetBin(const float viewZ, const TileLightData data)
     const float zFarCoordSystemAdjusted = data.zFar * RH_COORD_SYSTEM_REVERSE;
 
     float f = saturate( (abs(viewZCoordSystemAdjusted) - zNearCoordSystemAdjusted) / (zFarCoordSystemAdjusted - zNearCoordSystemAdjusted) );
-    float bin = min(f, 0.999999) * float(1 << data.logMaxBins);
+    float bin = min(f, 0.999999) * float(1u << data.logMaxBins);
 
     return uint(bin);
 }

--- a/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Decals.azsli
+++ b/Gems/Atom/Feature/Common/Assets/ShaderLib/Atom/Features/PBR/Decals.azsli
@@ -54,6 +54,8 @@ void ApplyDecal(uint currDecalIndex, inout Surface surface)
     localPos = mul(decalRot, localPos);
 
     float3 decalUVW = localPos * rcp(decal.m_halfSize);
+    
+    [branch]
     if(decalUVW.x >= -1.0f && decalUVW.x <= 1.0f &&
        decalUVW.y >= -1.0f && decalUVW.y <= 1.0f &&
        decalUVW.z >= -1.0f && decalUVW.z <= 1.0f)
@@ -72,6 +74,7 @@ void ApplyDecal(uint currDecalIndex, inout Surface surface)
         float2 normalMap = 0;
         // Each texture array handles a size permutation. 
         // e.g. it could be that tex array 0 handles 256x256 and tex array 1 handles 512x64, etc.
+        [branch]
         switch(textureArrayIndex)
         {
             case 0:


### PR DESCRIPTION
Fix shader compiler warnings caused by light culling.
Added [branch] to some if statements that I definitely don't want flattened

ATOM-16908

Signed-off-by: mrieggeramzn <mriegger@amazon.com>