### PR TITLE
Fixed the get_registration.py script to print the manifest data

### DIFF
--- a/scripts/o3de/o3de/get_registration.py
+++ b/scripts/o3de/o3de/get_registration.py
@@ -13,17 +13,22 @@ import sys
 from o3de import manifest
 
 
-def _run_get_registered(args: argparse) -> str or pathlib.Path:
+def _run_get_registered(args: argparse) -> int:
     if args.override_home_folder:
         manifest.override_home_folder = args.override_home_folder
 
-    return manifest.get_registered(args.engine_name,
-                                   args.project_name,
-                                   args.gem_name,
-                                   args.template_name,
-                                   args.default_folder,
-                                   args.repo_name,
-                                   args.restricted_name)
+    registered_path = manifest.get_registered(args.engine_name,
+                                              args.project_name,
+                                              args.gem_name,
+                                              args.template_name,
+                                              args.default_folder,
+                                              args.repo_name,
+                                              args.restricted_name)
+    # If a path has been found return 0
+    if registered_path:
+        print(registered_path)
+        return 0
+    return 1
 
 
 def add_parser_args(parser):

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -330,6 +330,11 @@ def get_engine_restricted() -> list:
 
 
 # project.json queries
+def get_project_engine_name(project_path: pathlib.Path) -> str or None:
+    project_object = get_project_json_data(project_path=project_path)
+    return project_object.get('engine', None) if project_object else None
+
+
 def get_project_gems(project_path: pathlib.Path) -> list:
     return get_gems_from_subdirectories(get_project_external_subdirectories(project_path))
 

--- a/scripts/o3de/o3de/print_registration.py
+++ b/scripts/o3de/o3de/print_registration.py
@@ -153,6 +153,21 @@ def print_engine_external_subdirectories(verbose: int) -> int:
 
 
 # Project output methods
+def print_project_engine_name(verbose: int, project_path: pathlib.Path, project_name: str) -> int:
+    project_path = get_project_path(project_path, project_name)
+    if not project_path:
+        return 1
+
+    engine_name = manifest.get_project_engine_name(project_path)
+    if engine_name:
+        print(f'Project\'s engine name:\n{engine_name}')
+        return 0
+
+    if verbose > 0:
+        logger.info(f'project.json at path "{project_path}" contains no registered "engine" field')
+    return 1
+
+
 def print_project_gems(verbose: int, project_path: pathlib.Path, project_name: str) -> int:
     project_path = get_project_path(project_path, project_name)
     if not project_path:
@@ -401,6 +416,8 @@ def _run_register_show(args: argparse) -> int:
         return print_project_templates(args.verbose, args.project_path, args.project_name)
     elif args.project_restricted:
         return print_project_restricted(args.verbose, args.project_path, args.project_name)
+    elif args.project_engine_name:
+        return print_project_engine_name(args.verbose, args.project_path, args.project_name)
 
     elif args.all_projects:
         return print_all_projects(args.verbose)
@@ -479,6 +496,9 @@ def add_parser_args(parser):
     group.add_argument('-pes', '--project-external-subdirectories', action='store_true',
                        default=False,
                        help='Returns the external subdirectories register with the project.json.')
+    group.add_argument('-pen', '--project-engine-name', action='store_true',
+                       default=False,
+                       help='Returns the "engine" name identifier registered with the project.json.')
 
     group.add_argument('-ap', '--all-projects', action='store_true', required=False,
                        default=False,


### PR DESCRIPTION
Added a --project-engine-name/-pen argument to print_registration.py to
output the engine registered with the project.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>