### PR TITLE
[Mac] Format string specifier for size_t should be %zu

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasGraphUtilities.inl
+++ b/Gems/ScriptCanvas/Code/Editor/Framework/ScriptCanvasGraphUtilities.inl
@@ -267,7 +267,7 @@ namespace ScriptCanvasEditor
 
                                 RuntimeDataOverrides dependencyRuntimeDataOverrides;
                                 dependencyRuntimeDataOverrides.m_runtimeAsset = dependency.runtimeAsset;
-                                AZStd::string dependencyHint = AZStd::string::format("dependency_%d", index);
+                                AZStd::string dependencyHint = AZStd::string::format("dependency_%zu", index);
                                 dependencyRuntimeDataOverrides.m_runtimeAsset.SetHint(dependencyHint);
                                 dependencyRuntimeDataOverrides.m_runtimeAsset.Get()->m_runtimeData.m_script.SetHint(dependencyHint);
 


### PR DESCRIPTION
Fixes this build error: `error: format specifies type 'int' but the argument has type 'size_t' (aka 'unsigned long') [-Werror,-Wformat]`

Signed-off-by: amzn-sj <srikkant@amazon.com>