### PR TITLE
Fix for bug in entity outliner search box

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -1088,6 +1088,8 @@ namespace AzToolsFramework
 
         m_listModel->SearchStringChanged(filterString);
         m_proxyModel->UpdateFilter();
+
+        m_gui->m_objectTree->expandAll();
     }
 
     void EntityOutlinerWidget::OnFilterChanged(const AzQtComponents::SearchTypeFilterList& activeTypeFilters)


### PR DESCRIPTION
In the entity outliner search box, the matching results are not expanded and displayed (slice mode)

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>