### PR TITLE
Add call to DisableSaveOnFinalize

### DIFF
--- a/Code/Editor/Lib/Tests/test_DisplaySettingsPythonBindings.cpp
+++ b/Code/Editor/Lib/Tests/test_DisplaySettingsPythonBindings.cpp
@@ -12,6 +12,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Debug/TraceMessageBus.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzCore/UserSettings/UserSettingsComponent.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
 #include <AzToolsFramework/Application/ToolsApplication.h>
@@ -63,6 +64,11 @@ namespace DisplaySettingsPythonBindingsUnitTests
 
             m_app.Start(appDesc);
             m_app.RegisterComponentDescriptor(AzToolsFramework::DisplaySettingsComponent::CreateDescriptor());
+
+            // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
+            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
+            // in the unit tests.
+            AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
         }
 
         void TearDown() override


### PR DESCRIPTION
This fixes a flaky test failure in `DisplaySettingsComponentFixture.DisplaySettingsComponent_ConvertToSettingsAllSet`

`DisplaySettingsComponentFixture` was missing a call to `AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);`

Related to https://github.com/o3de/o3de/issues/5718