### PR TITLE
Add ComponentApplicationLifecycle::RegisterEvent calls to AzToolsFrameworkTests

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Main.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Main.cpp
@@ -6,17 +6,16 @@
  *
  */
 
-#include <AzTest/AzTest.h>
 #include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/Component/ComponentApplicationLifecycle.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzQtComponents/Components/StyleManager.h>
+#include <AzTest/AzTest.h>
 
 #include <QApplication>
-
-using namespace AZ;
 
 // Handle asserts
 class ToolsFrameworkHook
@@ -25,12 +24,12 @@ class ToolsFrameworkHook
 public:
     void SetupEnvironment() override
     {
-        AllocatorInstance<SystemAllocator>::Create();
+        AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
     }
 
     void TeardownEnvironment() override
     {
-        AllocatorInstance<SystemAllocator>::Destroy();
+        AZ::AllocatorInstance<AZ::SystemAllocator>::Destroy();
     }
 };
 
@@ -38,12 +37,17 @@ AZTEST_EXPORT int AZ_UNIT_TEST_HOOK_NAME(int argc, char** argv)
 {
     ::testing::InitGoogleMock(&argc, argv);
     QApplication app(argc, argv);
-    auto styleManager = AZStd::make_unique< AzQtComponents::StyleManager>(&app);
+    auto styleManager = AZStd::make_unique<AzQtComponents::StyleManager>(&app);
     AZ::IO::FixedMaxPath engineRootPath;
     {
         AZ::ComponentApplication componentApplication(argc, argv);
         auto settingsRegistry = AZ::SettingsRegistry::Get();
         settingsRegistry->Get(engineRootPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_EngineRootFolder);
+
+        AZ::ComponentApplicationLifecycle::RegisterEvent(*settingsRegistry, "SystemComponentsDeactivated");
+        AZ::ComponentApplicationLifecycle::RegisterEvent(*settingsRegistry, "ConsoleUnavailable");
+        AZ::ComponentApplicationLifecycle::RegisterEvent(*settingsRegistry, "SettingsRegistryUnavailable");
+        AZ::ComponentApplicationLifecycle::RegisterEvent(*settingsRegistry, "SystemAllocatorPendingDestruction");
     }
     styleManager->initialize(&app, engineRootPath);
     AZ::Test::printUnusedParametersWarning(argc, argv);


### PR DESCRIPTION
This

Before:
```
==================================================================
Memory: Trace::Warning
 D:/o3de-2/Code/Framework/AzCore/AzCore/Memory/AllocationRecords.cpp(412): 'void __cdecl AZ::Debug::AllocationRecords::SetMode(enum AZ::Debug::AllocationRecords::Mode)'
Memory: Records recording was disabled and now it's enabled! You might get assert when you free memory, if a you have allocations which were not recorded!
Memory: ==================================================================
ComponentApplicationLifecycle:
==================================================================
ComponentApplicationLifecycle: Trace::Warning
 D:/o3de-2/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp(33): 'bool __cdecl AZ::ComponentApplicationLifecycle::SignalEvent(class AZ::SettingsRegistryInterface &,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >)'
ComponentApplicationLifecycle: Cannot signal event ConsoleUnavailable. Name does is not a field of object "/O3DE/Application/LifecycleEvents". Please make sure the entry exists in the '<engine-root>/Registry/application_lifecycle_events.setreg" or in *.setreg within the project
ComponentApplicationLifecycle: ==================================================================
ComponentApplicationLifecycle:
==================================================================
ComponentApplicationLifecycle: Trace::Warning
 D:/o3de-2/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp(33): 'bool __cdecl AZ::ComponentApplicationLifecycle::SignalEvent(class AZ::SettingsRegistryInterface &,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >)'
ComponentApplicationLifecycle: Cannot signal event SystemComponentsDeactivated. Name does is not a field of object "/O3DE/Application/LifecycleEvents". Please make sure the entry exists in the '<engine-root>/Registry/application_lifecycle_events.setreg" or in *.setreg within the project
ComponentApplicationLifecycle: ==================================================================
ComponentApplicationLifecycle:
==================================================================
ComponentApplicationLifecycle: Trace::Warning
 D:/o3de-2/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp(33): 'bool __cdecl AZ::ComponentApplicationLifecycle::SignalEvent(class AZ::SettingsRegistryInterface &,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >)'
ComponentApplicationLifecycle: Cannot signal event SettingsRegistryUnavailable. Name does is not a field of object "/O3DE/Application/LifecycleEvents". Please make sure the entry exists in the '<engine-root>/Registry/application_lifecycle_events.setreg" or in *.setreg within the project
ComponentApplicationLifecycle: ==================================================================
ComponentApplicationLifecycle:
==================================================================
ComponentApplicationLifecycle: Trace::Warning
 D:/o3de-2/Code/Framework/AzCore/AzCore/Component/ComponentApplicationLifecycle.cpp(33): 'bool __cdecl AZ::ComponentApplicationLifecycle::SignalEvent(class AZ::SettingsRegistryInterface &,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >,class AZStd::basic_string_view<char,struct AZStd::char_traits<char> >)'
ComponentApplicationLifecycle: Cannot signal event SystemAllocatorPendingDestruction. Name does is not a field of object "/O3DE/Application/LifecycleEvents". Please make sure the entry exists in the '<engine-root>/Registry/application_lifecycle_events.setreg" or in *.setreg within the project
ComponentApplicationLifecycle: ==================================================================
```

After:

```
==================================================================
Memory: Trace::Warning
 D:/o3de-2/Code/Framework/AzCore/AzCore/Memory/AllocationRecords.cpp(412): 'void __cdecl AZ::Debug::AllocationRecords::SetMode(enum AZ::Debug::AllocationRecords::Mode)'
Memory: Records recording was disabled and now it's enabled! You might get assert when you free memory, if a you have allocations which were not recorded!
Memory: ==================================================================
```

Probably would be good to fix the memory warning too, but that can be a separate PR