### PR TITLE
fix missing include in non-unity builds

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
@@ -11,6 +11,7 @@
 #include <Atom/RHI/PoolAllocator.h>
 #include <Atom/RHI/MemoryAllocation.h>
 #include <Atom/RHI.Reflect/MemoryEnums.h>
+#include <AzCore/Debug/Profiler.h>
 
 namespace AZ
 {

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
@@ -8,6 +8,7 @@
 #include <RHI/MemoryView.h>
 
 #include <AzCore/Casting/numeric_cast.h>
+#include <AzCore/Debug/Profiler.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/string/conversions.h>
 


### PR DESCRIPTION
Signed-off-by: greerdv <greerdv@amazon.com>