### PR TITLE
Additional read-only prefab workflow changes.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.cpp
@@ -277,6 +277,8 @@ namespace AzToolsFramework
                 }
             }
 
+            bool itemWasShown = false;
+
             // Create Prefab
             {
                 if (!selectedEntities.empty())
@@ -312,33 +314,43 @@ namespace AzToolsFramework
                             QObject::connect(createAction, &QAction::triggered, createAction, [selectedEntities] {
                                 ContextMenu_CreatePrefab(selectedEntities);
                             });
+
+                            itemWasShown = true;
                         }
                     }
                 }
             }
 
             // Instantiate Prefab
+            if (!readOnlyEntityInSelection)
             {
                 QAction* instantiateAction = menu->addAction(QObject::tr("Instantiate Prefab..."));
                 instantiateAction->setToolTip(QObject::tr("Instantiates a prefab file in the scene."));
 
                 QObject::connect(
                     instantiateAction, &QAction::triggered, instantiateAction, [] { ContextMenu_InstantiatePrefab(); });
+
+                itemWasShown = true;
             }
 
             // Instantiate Procedural Prefab
-            if (AZ::Prefab::ProceduralPrefabAsset::UseProceduralPrefabs())
+            if (AZ::Prefab::ProceduralPrefabAsset::UseProceduralPrefabs() && !readOnlyEntityInSelection)
             {
                 QAction* action = menu->addAction(QObject::tr("Instantiate Procedural Prefab..."));
                 action->setToolTip(QObject::tr("Instantiates a procedural prefab file in a prefab."));
 
                 QObject::connect(
                     action, &QAction::triggered, action, [] { ContextMenu_InstantiateProceduralPrefab(); });
+
+                itemWasShown = true;
             }
 
-            menu->addSeparator();
+            if (itemWasShown)
+            {
+                menu->addSeparator();
+            }
 
-            bool itemWasShown = false;
+            itemWasShown = false;
 
             // Edit/Save Prefab
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -3240,7 +3240,7 @@ namespace AzToolsFramework
     {
         // Don't show the Toggle Pivot option if any read-only entities are in the current selection
         // We need to request the selected entities instead of just using the m_selectedEntities variable
-        // because we filter out any read-only entities from the m_selectedEntities so that the maniuplators
+        // because we filter out any read-only entities from the m_selectedEntities so that the manipulators
         // will be hidden
         EntityIdList selectedEntityIds;
         ToolsApplicationRequests::Bus::BroadcastResult(selectedEntityIds, &ToolsApplicationRequests::GetSelectedEntities);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -3238,13 +3238,34 @@ namespace AzToolsFramework
     void EditorTransformComponentSelection::PopulateEditorGlobalContextMenu(
         QMenu* menu, [[maybe_unused]] const AZ::Vector2& point, [[maybe_unused]] int flags)
     {
-        QAction* action = menu->addAction(QObject::tr(TogglePivotTitleRightClick));
-        QObject::connect(
-            action, &QAction::triggered, action,
-            [this]
+        // Don't show the Toggle Pivot option if any read-only entities are in the current selection
+        // We need to request the selected entities instead of just using the m_selectedEntities variable
+        // because we filter out any read-only entities from the m_selectedEntities so that the maniuplators
+        // will be hidden
+        EntityIdList selectedEntityIds;
+        ToolsApplicationRequests::Bus::BroadcastResult(selectedEntityIds, &ToolsApplicationRequests::GetSelectedEntities);
+
+        auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
+        bool readOnlyEntityInSelection = false;
+        for (const auto& entityId : selectedEntityIds)
+        {
+            if (readOnlyEntityPublicInterface->IsReadOnly(entityId))
+            {
+                readOnlyEntityInSelection = true;
+                break;
+            }
+        }
+
+        if (!readOnlyEntityInSelection)
+        {
+            QAction* action = menu->addAction(QObject::tr(TogglePivotTitleRightClick));
+            QObject::connect(
+                action, &QAction::triggered, action,
+                [this]
             {
                 ToggleCenterPivotSelection();
             });
+        }
     }
 
     void EditorTransformComponentSelection::BeforeEntitySelectionChanged()


### PR DESCRIPTION
Some additional read-only prefab workflow changes:
- Hide the "Toggle pivot" context menu option when there is a read-only entity in the selection
- Hide the "Instantiate Prefab" context menu option when there is a read-only entity in the selection
- Hide the "Instantiate Procedural Prefab" context menu option when there is a read-only entity in the selection

![MoreReadOnlyPrefabWorkflowChanges](https://user-images.githubusercontent.com/7519264/145264024-3349304c-53cc-47dd-8ae6-e8e9ba9eab41.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>