### PR TITLE
Make version explorer wait on AP for dependent assets

### DIFF
--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
@@ -281,7 +281,8 @@ namespace ScriptCanvasBuilder
                 }
                 else
                 {
-                    if (AzFramework::StringFunc::Find(fileNameOnly, s_unitTestParseErrorPrefix) != AZStd::string::npos)
+                    if (!ScriptCanvas::Grammar::g_processingErrorsForUnitTestsEnabled
+                        && AzFramework::StringFunc::Find(fileNameOnly, s_unitTestParseErrorPrefix) != AZStd::string::npos)
                     {
                         response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
                     }

--- a/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverEventNodeDescriptorComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/GraphCanvas/Components/NodeDescriptors/ScriptEventReceiverEventNodeDescriptorComponent.cpp
@@ -190,7 +190,7 @@ namespace ScriptCanvasEditor
                     {
                         scriptCanvasSlot = eventHandler->GetSlot(slotId);
 
-                        int& index = (scriptCanvasSlot->IsData() && scriptCanvasSlot->IsInput()) ? paramIndex : outputIndex;
+                        int& index = (scriptCanvasSlot && scriptCanvasSlot->IsData() && scriptCanvasSlot->IsInput()) ? paramIndex : outputIndex;
 
                         if (scriptCanvasSlot && scriptCanvasSlot->IsVisible())
                         {

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/GraphUpgrade.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/GraphUpgrade.h
@@ -102,9 +102,6 @@ namespace ScriptCanvasEditor
         void Log(const char* format, ...);
 
     private:
-
-        bool m_verbose = true;
-
         StateMachine* m_stateMachine;
     };
 
@@ -363,7 +360,7 @@ namespace ScriptCanvasEditor
     template <typename Traits>
     void ScriptCanvasEditor::State<Traits>::Log(const char* format, ...)
     {
-        if (m_verbose)
+        if (GetVerbose())
         {
             char sBuffer[2048];
             va_list ArgList;

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/GraphUpgrade.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/GraphUpgrade.h
@@ -360,7 +360,7 @@ namespace ScriptCanvasEditor
     template <typename Traits>
     void ScriptCanvasEditor::State<Traits>::Log(const char* format, ...)
     {
-        if (GetVerbose())
+        if (m_stateMachine->GetVerbose())
         {
             char sBuffer[2048];
             va_list ArgList;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -1880,10 +1880,6 @@ namespace ScriptCanvasEditor
 
     void MainWindow::OnFileOpen()
     {
-        AZ::SerializeContext* serializeContext = nullptr;
-        EBUS_EVENT_RESULT(serializeContext, AZ::ComponentApplicationBus, GetSerializeContext);
-        AZ_Assert(serializeContext, "Failed to acquire application serialize context.");
-
         AZStd::string assetRoot;
         {
             AZStd::array<char, AZ::IO::MaxPathLength> assetRootChar;
@@ -1892,21 +1888,9 @@ namespace ScriptCanvasEditor
         }
 
         AZStd::string assetPath = AZStd::string::format("%s/scriptcanvas", assetRoot.c_str());
-
-        AZ::EBusAggregateResults<AZStd::vector<AZStd::string>> fileFilters;
-        AssetRegistryRequestBus::BroadcastResult(fileFilters, &AssetRegistryRequests::GetAssetHandlerFileFilters);
-
         QString filter;
 
-        AZStd::set<AZStd::string> filterSet;
-        auto aggregateFilters = fileFilters.values;
-        for (auto aggregateFilters2 : fileFilters.values)
-        {
-            for (const AZStd::string& fileFilter : aggregateFilters2)
-            {
-                filterSet.insert(fileFilter);
-            }
-        }
+        AZStd::set<AZStd::string> filterSet { ".scriptcanvas" };
 
         QStringList nameFilters;
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.cpp
@@ -189,6 +189,11 @@ namespace ScriptCanvasEditor
             OnButtonPressUpgradeImplementation(info);
         }
 
+        void Controller::OnUpgradeDependencyWaitInterval([[maybe_unused]] const SourceHandle& info)
+        {
+            AddLogEntries();
+        }
+
         void Controller::OnUpgradeModificationBegin([[maybe_unused]] const ModifyConfiguration& config, const SourceHandle& info)
         {
             for (auto* item : FindTableItems(info))

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.cpp
@@ -216,6 +216,8 @@ namespace ScriptCanvasEditor
             else
             {
                 VE_LOG("Failed to modify %s: %s", result.asset.Path().c_str(), result.errorMessage.data());
+                AZ_Warning(ScriptCanvas::k_VersionExplorerWindow.data()
+                    , false, "Failed to modify %s: %s", result.asset.Path().c_str(), result.errorMessage.data());
             }
 
             for (auto* item : FindTableItems(info))

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Controller.h
@@ -93,9 +93,10 @@ namespace ScriptCanvasEditor
                 ( const ModifyConfiguration& config
                 , const AZStd::vector<SourceHandle>& assets
                 , const AZStd::vector<size_t>& sortedOrder) override;
+            void OnUpgradeDependencyWaitInterval(const SourceHandle& info) override;
             void OnUpgradeModificationBegin(const ModifyConfiguration& config, const SourceHandle& info) override;
             void OnUpgradeModificationEnd(const ModifyConfiguration& config, const SourceHandle& info, ModificationResult result) override;
-
+            
             void SetLoggingPreferences();
             void SetSpinnerIsBusy(bool isBusy);
             void SetRowBusy(int index);

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Model.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Model.cpp
@@ -145,6 +145,7 @@ namespace ScriptCanvasEditor
             }
 
             Idle();
+            RestoreSettings();
         }
 
         void Model::OnScanComplete()
@@ -161,6 +162,7 @@ namespace ScriptCanvasEditor
                 return;
             }
 
+            CacheSettings();
             m_state = State::Scanning;
             m_log.Activate();
             m_keepEditorAlive = AZStd::make_unique<EditorKeepAlive>();

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/ModelTraits.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/ModelTraits.h
@@ -22,6 +22,7 @@ namespace ScriptCanvasEditor
             SourceHandle modifySingleAsset;
             bool backupGraphBeforeModification = false;
             bool successfulDependencyUpgradeRequired = true;
+            AZ::s32 perDependencyWaitSecondsMax = 20;
         };
 
         struct ModificationResult
@@ -98,6 +99,7 @@ namespace ScriptCanvasEditor
                 ( const ModifyConfiguration& config
                 , const AZStd::vector<SourceHandle>& assets
                 , const AZStd::vector<size_t>& sortedOrder) = 0;
+            virtual void OnUpgradeDependencyWaitInterval(const SourceHandle& info) = 0;
             virtual void OnUpgradeModificationBegin(const ModifyConfiguration& config, const SourceHandle& info) = 0;
             virtual void OnUpgradeModificationEnd(const ModifyConfiguration& config, const SourceHandle& info, ModificationResult result) = 0;
         };

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
@@ -30,38 +30,141 @@ namespace ScriptCanvasEditor
             AZ_Assert(m_config.modification, "No modification function provided");
             ModelNotificationsBus::Broadcast(&ModelNotificationsTraits::OnUpgradeBegin, modification, m_assets);
             AZ::SystemTickBus::Handler::BusConnect();
+            AzFramework::AssetSystemInfoBus::Handler::BusConnect();
+            AzFramework::AssetSystemInfoBus::Handler::BusConnect();
+            m_result.asset = m_assets[GetCurrentIndex()];
         }
 
-        size_t Modifier::GetCurrentIndex() const
+        Modifier::~Modifier()
         {
-            return m_state == State::GatheringDependencies
-                ? m_assetIndex
-                : m_dependencyOrderedAssetIndicies[m_assetIndex];
-
+            AzFramework::AssetSystemInfoBus::Handler::BusDisconnect();
+            AzFramework::AssetSystemInfoBus::Handler::BusDisconnect();
         }
 
-        AZStd::unordered_set<size_t>& Modifier::GetOrCreateDependencyIndexSet()
+        bool Modifier::AllDependenciesCleared(const AZStd::unordered_set<size_t>& dependencies) const
         {
-            auto iter = m_dependencies.find(m_assetIndex);
-            if (iter == m_dependencies.end())
+            for (auto index : dependencies)
             {
-                iter = m_dependencies.insert_or_assign(m_assetIndex, AZStd::unordered_set<size_t>()).first;
+                SourceHandle dependency = m_assets[index];
+                CompleteDescriptionInPlace(dependency);
+
+                if (dependency.Id().IsNull() || !m_assetsCompletedByAP.contains(dependency.Id()))
+                {
+                    return false;
+                }
             }
 
-            return iter->second;
+            return true;
         }
 
-        const ModificationResults& Modifier::GetResult() const
+        bool Modifier::AnyDependenciesFailed(const AZStd::unordered_set<size_t>& dependencies) const
         {
-            return m_results;
+            for (auto index : dependencies)
+            {
+                SourceHandle dependency = m_assets[index];
+                CompleteDescriptionInPlace(dependency);
+
+                if (dependency.Id().IsNull() || m_assetsFailedByAP.contains(dependency.Id()))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
-            
+
+        AZStd::sys_time_t Modifier::CalculateRemainingWaitTime(const AZStd::unordered_set<size_t>& dependencies) const
+        {
+            auto maxSeconds = AZStd::chrono::seconds(dependencies.size() * m_config.perDependencyWaitSecondsMax);
+            auto waitedSeconds = AZStd::chrono::seconds(AZStd::chrono::system_clock::now() - m_waitTimeStamp);
+            return (maxSeconds - waitedSeconds).count();
+        }
+
+        void Modifier::SourceFileChanged(AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid fileAssetId)
+        {
+            AZ_TracePrintf("SC", "received SourceFileChanged: %s", relativePath.c_str());
+            VE_LOG("received SourceFileChanged: %s", relativePath.c_str());
+        }
+
+        void Modifier::SourceFileFailed(AZStd::string relativePath, [[maybe_unused]] AZStd::string scanFolder, [[maybe_unused]] AZ::Uuid fileAssetId)
+        {
+            AZ_TracePrintf("SC", "received SourceFileFailed: %s", relativePath.c_str());
+            VE_LOG("received SourceFileFailed: %s", relativePath.c_str());
+        }
+
+        void Modifier::ProcessNotifications()
+        {
+            AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
+
+            for (const auto& assetPath : m_successNotifications)
+            {
+                VE_LOG("received AssetCompilationSuccess: %s", assetPath.c_str());
+                SourceHandle sourceHandle(nullptr, {}, assetPath.c_str());
+                CompleteDescriptionInPlace(sourceHandle);
+
+                if (m_attemptedAssets.contains(sourceHandle.Id()))
+                {
+                    m_assetsCompletedByAP.insert(sourceHandle.Id());
+                }
+            }
+
+            m_successNotifications.clear();
+
+            for (const auto& assetPath : m_failureNotifications)
+            {
+                VE_LOG("received AssetCompilationFailed: %s", assetPath.c_str());
+                SourceHandle sourceHandle(nullptr, {}, assetPath.c_str());
+                CompleteDescriptionInPlace(sourceHandle);
+
+                if (m_attemptedAssets.contains(sourceHandle.Id()))
+                {
+                    m_assetsFailedByAP.insert(sourceHandle.Id());
+                }
+            }
+
+            m_failureNotifications.clear();
+        }
+
+        void Modifier::AssetCompilationSuccess([[maybe_unused]] const AZStd::string& assetPath)
+        {
+            AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
+            // test failure path m_successNotifications.insert(assetPath);
+            m_failureNotifications.insert(assetPath);
+        }
+
+        void Modifier::AssetCompilationFailed(const AZStd::string& assetPath)
+        {
+            AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
+            m_failureNotifications.insert(assetPath);
+        }
+
+        void Modifier::CheckDependencies()
+        {
+            ModelNotificationsBus::Broadcast(&ModelNotificationsTraits::OnUpgradeModificationBegin, m_config, m_result.asset);
+
+            if (auto dependencies = GetDependencies(GetCurrentIndex()); dependencies != nullptr && !dependencies->empty())
+            {
+                VE_LOG
+                    ( "dependencies found for %s, update will wait for the AP to finish processing them"
+                    , m_result.asset.Path().c_str());
+
+                m_waitTimeStamp = AZStd::chrono::system_clock::now();
+                m_waitLogTimeStamp = AZStd::chrono::system_clock::time_point{};
+                m_modifyState = ModifyState::WaitingForDependencyProcessing;
+            }
+            else
+            {
+                m_modifyState = ModifyState::StartModification;
+            }
+        }
+
         void Modifier::GatherDependencies()
         {
             AZ::SerializeContext* serializeContext{};
             AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
             AZ_Assert(serializeContext, "SerializeContext is required to enumerate dependent assets in the ScriptCanvas file");
 
+            LoadAsset();
             bool anyFailures = false;
 
             if (m_result.asset.Get() && m_result.asset.Mod()->GetGraphData())
@@ -101,7 +204,7 @@ namespace ScriptCanvasEditor
                     , nullptr))
                 {
                     anyFailures = true;
-                        VE_LOG("Modifier: ERROR - Failed to gather dependencies from graph data: %s"
+                    VE_LOG("Modifier: ERROR - Failed to gather dependencies from graph data: %s"
                         , m_result.asset.Path().c_str())
                 }
             }
@@ -111,16 +214,40 @@ namespace ScriptCanvasEditor
                 VE_LOG("Modifier: ERROR - Failed to load asset %s for modification, even though it scanned properly"
                     , m_result.asset.Path().c_str());
             }
-            
+
             ModelNotificationsBus::Broadcast
                 ( &ModelNotificationsTraits::OnUpgradeDependenciesGathered
                 , m_result.asset
                 , anyFailures ? Result::Failure : Result::Success);
+        }
 
-            ReleaseCurrentAsset();
+        size_t Modifier::GetCurrentIndex() const
+        {
+            return m_state == State::GatheringDependencies
+                ? m_assetIndex
+                : m_dependencyOrderedAssetIndicies[m_assetIndex];
+        }
 
-            // Flush asset database events to ensure no asset references are held by closures queued on Ebuses.
-            AZ::Data::AssetManager::Instance().DispatchEvents();
+        const AZStd::unordered_set<size_t>* Modifier::GetDependencies(size_t index) const
+        {
+            auto iter = m_dependencies.find(index);
+            return iter != m_dependencies.end() ? &iter->second : nullptr;
+        }
+
+        AZStd::unordered_set<size_t>& Modifier::GetOrCreateDependencyIndexSet()
+        {
+            auto iter = m_dependencies.find(m_assetIndex);
+            if (iter == m_dependencies.end())
+            {
+                iter = m_dependencies.insert_or_assign(m_assetIndex, AZStd::unordered_set<size_t>()).first;
+            }
+
+            return iter->second;
+        }
+
+        const ModificationResults& Modifier::GetResult() const
+        {
+            return m_results;
         }
 
         void Modifier::LoadAsset()
@@ -144,7 +271,7 @@ namespace ScriptCanvasEditor
             }
             else if (m_result.asset.Describe() != result.asset.Describe())
             {
-                ReportModificationError("Received modifiction complete notification for different result");
+                ReportModificationError("Received modification complete notification for different result");
             }
             else
             {
@@ -154,9 +281,6 @@ namespace ScriptCanvasEditor
 
         void Modifier::ModifyCurrentAsset()
         {
-            m_result = {};
-            m_result.asset = m_assets[GetCurrentIndex()];
-            ModelNotificationsBus::Broadcast(&ModelNotificationsTraits::OnUpgradeModificationBegin, m_config, m_result.asset);
             LoadAsset();
 
             if (m_result.asset.IsGraphValid())
@@ -171,34 +295,55 @@ namespace ScriptCanvasEditor
             }
         }
 
-        void Modifier::ModifyNextAsset()
+        void Modifier::InitializeResult()
         {
-            ModelNotificationsBus::Broadcast
-                ( &ModelNotificationsTraits::OnUpgradeModificationEnd, m_config, m_result.asset, m_result);
-            ModificationNotificationsBus::Handler::BusDisconnect();
-            m_modifyState = ModifyState::Idle;
-            ReleaseCurrentAsset();
-            ++m_assetIndex;
             m_result = {};
+
+            if (m_assetIndex != m_assets.size())
+            {
+                m_result.asset = m_assets[GetCurrentIndex()];
+                CompleteDescriptionInPlace(m_result.asset);
+                m_attemptedAssets.insert(m_result.asset.Id());
+            }
+        }
+
+        void Modifier::NextAsset()
+        {
+            ++m_assetIndex;
+            InitializeResult();
+        }
+
+        void Modifier::NextModification()
+        {
+            ModelNotificationsBus::Broadcast( &ModelNotificationsTraits::OnUpgradeModificationEnd, m_config, m_result.asset, m_result);
+            ModificationNotificationsBus::Handler::BusDisconnect();
+            NextAsset();
+            m_fileSaveResult = {};
+            m_modifyState = ModifyState::Idle;
         }
 
         void Modifier::ReleaseCurrentAsset()
         {
             m_result.asset = m_result.asset.Describe();
+            // Flush asset database events to ensure no asset references are held by closures queued on Ebuses.
+            AZ::Data::AssetManager::Instance().DispatchEvents();
         }
 
         void Modifier::ReportModificationError(AZStd::string_view report)
         {
             m_result.errorMessage = report;
             m_results.m_failures.push_back({ m_result.asset.Describe(), report });
-            ModifyNextAsset();
+            m_assetsFailedByAP.insert(m_result.asset.Id());
+            NextModification();
         }
 
         void Modifier::ReportModificationSuccess()
         {
-            m_result.asset = m_result.asset.Describe();
+            // \note DO NOT put asset into the m_assetsCompletedByAP here. That can only be done when the message is received by the AP
             m_results.m_successes.push_back({ m_result.asset.Describe(), {} });
-            ModifyNextAsset();
+            AzFramework::AssetSystemRequestBus::Broadcast(
+                &AzFramework::AssetSystem::AssetSystemRequests::EscalateAssetByUuid, m_result.asset.Id());
+            NextModification();
         }
 
         void Modifier::ReportSaveResult()
@@ -214,9 +359,6 @@ namespace ScriptCanvasEditor
             {
                 ReportModificationError(m_fileSaveResult.fileSaveError);
             }
-
-            m_fileSaveResult = {};
-            m_modifyState = ModifyState::Idle;
         }
 
         void Modifier::OnFileSaveComplete(const FileSaveResult& result)
@@ -316,49 +458,87 @@ namespace ScriptCanvasEditor
 
                 m_assetIndex = 0;
                 m_state = State::ModifyingGraphs;
+                InitializeResult();
             }
             else
             {
                 GatherDependencies();
-                ReleaseCurrentAsset();
-                ++m_assetIndex;
+                NextAsset();
             }
         }
 
         void Modifier::TickUpdateGraph()
         {
-            if (m_assetIndex == m_assets.size())
-            {
-                VE_LOG("Modifier: Complete.");
-                AZ::SystemTickBus::Handler::BusDisconnect();
+            AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
 
-                if (m_onComplete)
+            switch (m_modifyState)
+            {
+            case ScriptCanvasEditor::VersionExplorer::Modifier::ModifyState::Idle:
+                if (m_assetIndex == m_assets.size())
                 {
-                    m_onComplete();
+                    VE_LOG("Modifier: Complete.");
+                    AZ::SystemTickBus::Handler::BusDisconnect();
+
+                    if (m_onComplete)
+                    {
+                        m_onComplete();
+                    }
                 }
+                else
+                {
+                    CheckDependencies();
+                }
+                break;
+            case ScriptCanvasEditor::VersionExplorer::Modifier::ModifyState::WaitingForDependencyProcessing:
+                WaitForDependencies();
+                break;
+            case ScriptCanvasEditor::VersionExplorer::Modifier::ModifyState::StartModification:
+                ModifyCurrentAsset();
+                break;
+            case ScriptCanvasEditor::VersionExplorer::Modifier::ModifyState::ReportResult:
+                ReportSaveResult();
+                break;
+            default:
+                break;
             }
-            else
-            {
-                AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
+        }
 
-                switch (m_modifyState)
-                {
-                case ScriptCanvasEditor::VersionExplorer::Modifier::ModifyState::Idle:
-                    ModifyCurrentAsset();
-                    break;
-                case ScriptCanvasEditor::VersionExplorer::Modifier::ModifyState::ReportResult:
-                    ReportSaveResult();
-                    break;
-                default:
-                    break;
-                }
+        void Modifier::WaitForDependencies()
+        {
+            const AZ::s32 LogPeriodSeconds = 5;
+
+            ProcessNotifications();
+
+            auto dependencies = GetDependencies(GetCurrentIndex());
+            if (dependencies == nullptr || dependencies->empty() || AllDependenciesCleared(*dependencies))
+            {
+                m_modifyState = ModifyState::StartModification;
+            }
+            else if (AnyDependenciesFailed(*dependencies))
+            {
+                ReportModificationError("A required dependency failed to update, graph cannot update.");
+            }
+            else if (AZStd::chrono::seconds(CalculateRemainingWaitTime(*dependencies)).count() < 0)
+            {
+                ReportModificationError("Dependency update time has taken too long, aborting modification.");
+            }
+            else if (AZStd::chrono::seconds(AZStd::chrono::system_clock::now() - m_waitLogTimeStamp).count() > LogPeriodSeconds)
+            {
+                m_waitLogTimeStamp = AZStd::chrono::system_clock::now();
+
+                AZ_TracePrintf
+                    ( ScriptCanvas::k_VersionExplorerWindow.data()
+                    , "Waiting for dependencies for %d more seconds: %s"
+                    , AZStd::chrono::seconds(CalculateRemainingWaitTime(*dependencies)).count()
+                    , m_result.asset.Path().c_str());
+
+                ModelNotificationsBus::Broadcast(&ModelNotificationsTraits::OnUpgradeDependencyWaitInterval, m_result.asset);
             }
         }
 
         const AZStd::unordered_set<size_t>* Modifier::Sorter::GetDependencies(size_t index) const
         {
-            auto iter = modifier->m_dependencies.find(index);
-            return iter != modifier->m_dependencies.end() ? &iter->second : nullptr;
+            return modifier->GetDependencies(index);
         }
 
         void Modifier::Sorter::Sort()
@@ -379,7 +559,7 @@ namespace ScriptCanvasEditor
             if (markedTemporary.contains(index))
             {
                 AZ_Error
-                    (ScriptCanvas::k_VersionExplorerWindow.data()
+                    ( ScriptCanvas::k_VersionExplorerWindow.data()
                     , false
                     , "Modifier: Dependency sort has failed during, circular dependency detected for Asset: %s"
                     , modifier->m_result.asset.Path().c_str());

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Modifier.cpp
@@ -128,8 +128,7 @@ namespace ScriptCanvasEditor
         void Modifier::AssetCompilationSuccess([[maybe_unused]] const AZStd::string& assetPath)
         {
             AZStd::lock_guard<AZStd::recursive_mutex> lock(m_mutex);
-            // test failure path m_successNotifications.insert(assetPath);
-            m_failureNotifications.insert(assetPath);
+            m_successNotifications.insert(assetPath);
         }
 
         void Modifier::AssetCompilationFailed(const AZStd::string& assetPath)

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Scanner.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Scanner.cpp
@@ -83,7 +83,7 @@ namespace ScriptCanvasEditor
         {
             AZStd::string name = asset.Path().c_str();
 
-            if ((m_config.filter && m_config.filter(asset) == ScanConfiguration::Filter::Exclude) || !name.contains("LY_SC_UnitTest_FunctionContainer"))
+            if (m_config.filter && m_config.filter(asset) == ScanConfiguration::Filter::Exclude)
             {
                 VE_LOG("Scanner: Excluded: %s ", ModCurrentAsset().Path().c_str());
                 m_result.m_filteredAssets.push_back(ModCurrentAsset().Describe());

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Scanner.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Scanner.cpp
@@ -81,7 +81,9 @@ namespace ScriptCanvasEditor
 
         void Scanner::FilterAsset(SourceHandle asset)
         {
-            if (m_config.filter && m_config.filter(asset) == ScanConfiguration::Filter::Exclude)
+            AZStd::string name = asset.Path().c_str();
+
+            if ((m_config.filter && m_config.filter(asset) == ScanConfiguration::Filter::Exclude) || !name.contains("LY_SC_UnitTest_FunctionContainer"))
             {
                 VE_LOG("Scanner: Excluded: %s ", ModCurrentAsset().Path().c_str());
                 m_result.m_filteredAssets.push_back(ModCurrentAsset().Describe());

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Scanner.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/Tools/UpgradeTool/Scanner.cpp
@@ -81,8 +81,6 @@ namespace ScriptCanvasEditor
 
         void Scanner::FilterAsset(SourceHandle asset)
         {
-            AZStd::string name = asset.Path().c_str();
-
             if (m_config.filter && m_config.filter(asset) == ScanConfiguration::Filter::Exclude)
             {
                 VE_LOG("Scanner: Excluded: %s ", ModCurrentAsset().Path().c_str());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -2384,9 +2384,8 @@ namespace ScriptCanvas
                         AZ_TracePrintf("ScriptCanvas", "%s", pretty.data());
                         AZ_TracePrintf("ScriptCanvas", "SubgraphInterface:");
                         AZ_TracePrintf("ScriptCanvas", ToString(m_subgraphInterface).data());
+                        AZ_TracePrintf("Script Canvas", "Parse Duration: %8.4f ms\n", m_parseDuration / 1000.0);
                     }
-
-                    AZ_TracePrintf("Script Canvas", "Parse Duration: %8.4f ms\n", m_parseDuration / 1000.0);
                 }
             }
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/PrimitivesDeclarations.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/PrimitivesDeclarations.cpp
@@ -15,6 +15,7 @@ namespace ScriptCanvas
         AZ_CVAR(bool, g_disableParseOnGraphValidation, false, {}, AZ::ConsoleFunctorFlags::Null, "In case parsing the graph is interfering with opening a graph, disable parsing on validation");
         AZ_CVAR(bool, g_printAbstractCodeModel, true, {}, AZ::ConsoleFunctorFlags::Null, "Print out the Abstract Code Model at the end of parsing for debug purposes.");
         AZ_CVAR(bool, g_printAbstractCodeModelAtPrefabTime, false, {}, AZ::ConsoleFunctorFlags::Null, "Print out the Abstract Code Model at the end of parsing (at prefab time) for debug purposes.");
+        AZ_CVAR(bool, g_processingErrorsForUnitTestsEnabled, false, {}, AZ::ConsoleFunctorFlags::Null, "Enable AP processing errors on parse failure for unit tests.");
         AZ_CVAR(bool, g_saveRawTranslationOuputToFile, true, {}, AZ::ConsoleFunctorFlags::Null, "Save out the raw result of translation for debug purposes.");
         AZ_CVAR(bool, g_saveRawTranslationOuputToFileAtPrefabTime, false, {}, AZ::ConsoleFunctorFlags::Null, "Save out the raw result of translation (at prefab time) for debug purposes.");
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/PrimitivesDeclarations.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/PrimitivesDeclarations.h
@@ -245,6 +245,7 @@ namespace ScriptCanvas
         AZ_CVAR_EXTERNED(bool, g_disableParseOnGraphValidation);
         AZ_CVAR_EXTERNED(bool, g_printAbstractCodeModel);
         AZ_CVAR_EXTERNED(bool, g_printAbstractCodeModelAtPrefabTime);
+        AZ_CVAR_EXTERNED(bool, g_processingErrorsForUnitTestsEnabled);
         AZ_CVAR_EXTERNED(bool, g_saveRawTranslationOuputToFile);
         AZ_CVAR_EXTERNED(bool, g_saveRawTranslationOuputToFileAtPrefabTime);
 


### PR DESCRIPTION
There was a subtle bug in the version explorer. Graphs that had dependencies on other graphs that would also be updated would load the outdated version of their dependency since the AP had not finished processing the new version of their dependency. This adds a step in the modification process that waits for the AP notification that the dependency has succeeded before updating the graph that is waiting.

Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>