### PR TITLE
Pass pipeline name to post ar build sns topic

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -854,6 +854,7 @@ finally {
                     "build_number": env.BUILD_NUMBER,
                     "repository_name": env.REPOSITORY_NAME,
                     "branch_name": env.BRANCH_NAME,
+                    "pipeline_name": GetRunningPipelineName(env.JOB_NAME),
                     "build_result": "${currentBuild.currentResult}",
                     "build_failure": buildFailure,
                     "recreate_volume": env.RECREATE_VOLUME,


### PR DESCRIPTION
Pass pipeline name to post ar build sns topic.
Pipeline name is required by the lambda function to create Jira issues on nightly build failures.

Signed-off-by: Shirang Jia <shiranj@amazon.com>