### PR TITLE
Improve error messaging when duplicating entities before they are created

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/EditorEntityManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/EditorEntityManager.h
@@ -34,5 +34,4 @@ namespace AzToolsFramework
     private:
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
     };
-
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1158,7 +1158,8 @@ namespace AzToolsFramework
                 // Select the duplicated entities/instances
                 auto selectionUndo = aznew SelectionCommand(duplicatedEntityAndInstanceIds, "Select Duplicated Entities/Instances");
                 selectionUndo->SetParent(undoBatch.GetUndoBatch());
-                ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
+                ToolsApplicationRequestBus::Broadcast(
+                    &ToolsApplicationRequestBus::Events::SetSelectedEntities, duplicatedEntityAndInstanceIds);
             }
 
             return AZ::Success(AZStd::move(duplicatedEntityAndInstanceIds));


### PR DESCRIPTION
This is a cherry-pick of an earlier fix that was pushed to development branch: https://github.com/o3de/o3de/pull/4922/files
This prevents an assert when ctrl+D is hit very fast before the entities can be created. Instead of an assert, the change fails the action and shows an error message in the log.