### PR TITLE
fixed failing periodic physx script canvas auto tests

### DIFF
--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/ScriptCanvas_CollisionEvents.ly
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_CollisionEvents/ScriptCanvas_CollisionEvents.ly
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d674eac2070ed0028ceff1e84692c9cf1f69db2192c2295b6d714670ccd50308
-size 8936
+oid sha256:82a4ffbffeee43ea4ae293080e838bbc501fe9c7c20febc2e56e745451c95df3
+size 9221

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_PostUpdateEvent/ScriptCanvas_PostUpdateEvent.ly
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_PostUpdateEvent/ScriptCanvas_PostUpdateEvent.ly
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a2c9ad554554eba1021abe0baf0b3455da1aaab2bb8331eb240f79c89031636
-size 5202
+oid sha256:3ef03f338cd867860068b5bd343f66fa9bda4f3de1662badf552f05716da35ed
+size 5161

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_PreUpdateEvent/ScriptCanvas_PreUpdateEvent.ly
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_PreUpdateEvent/ScriptCanvas_PreUpdateEvent.ly
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:982f085cfb17ce957cd1534e89a6fb5c76bcbe6936caec214ecd422b0a5dbe7b
-size 5214
+oid sha256:bf48b69c0cc2599581bd3d931d8adc6faba5d78d950c2c0946c19ec7ba7b6215
+size 5190

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_ShapeCast/ScriptCanvas_ShapeCast.ly
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_ShapeCast/ScriptCanvas_ShapeCast.ly
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3361ba7aa2faa53421d8a92ed0bb2e1747e766d93c0315484a3c85b74a6494c3
-size 8820
+oid sha256:be53bb087c53874577dad8f1fa084698c27fbad827f0ed7dc50927fb4c9d8884
+size 7748


### PR DESCRIPTION
I noticed the periodic script canvas physics automated tests were failing. It was because the Script Component no longer had the SC scripts assigned (not sure why). So i reassigned them and the tests are back to green.

Affected tests:
- ScriptCanvas_CollisionEvents
- ScriptCanvas_ShapeCast
- ScriptCanvas_PostUpdateEvent
- ScriptCanvas_PreUpdateEvent 

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>