### PR TITLE
Illegal exe name and version no. when opening Project Settings Tool

### DIFF
--- a/AutomatedTesting/project.json
+++ b/AutomatedTesting/project.json
@@ -7,7 +7,7 @@
     "android_settings": {
         "package_name": "com.lumberyard.yourgame",
         "version_number": 1,
-        "version_name": "1.0.0.0",
+        "version_name": "1.0.0",
         "orientation": "landscape"
     },
     "engine": "o3de"


### PR DESCRIPTION
After opening File-"Project Settings-"Project Settings Tool, the Executable Name and Version Name fields are red, and the values ​​are illegal.

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>