### PR TITLE
Parameters of LOD distance component still take effect when anim graph disabled

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleLODComponent.cpp
@@ -232,6 +232,10 @@ namespace EMotionFX
                     const float updateRateInSeconds = animGraphSampleRate > 0.0f ? 1.0f / animGraphSampleRate : 0.0f;
                     actorInstance->SetMotionSamplingRate(updateRateInSeconds);
                 }
+                else if (actorInstance->GetMotionSamplingRate() != 0)
+                {
+                    actorInstance->SetMotionSamplingRate(0);
+                }
 
                 // Disable the automatic mesh LOD level adjustment based on screen space in case a simple LOD component is present.
                 // The simple LOD component overrides the mesh LOD level and syncs the skeleton with the mesh LOD level.


### PR DESCRIPTION
Parameters of the Simple LOD distance component still take effect after Enable anim graph is disabled

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>