### PR TITLE
White box limit

### DIFF
--- a/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/Components/EditorWhiteBoxColliderComponent.cpp
@@ -73,6 +73,7 @@ namespace WhiteBox
     void EditorWhiteBoxColliderComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
     {
         incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
+        incompatible.push_back(AZ_CRC_CE("WhiteBoxColliderService"));
     }
 
     void EditorWhiteBoxColliderComponent::Activate()

--- a/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
+++ b/Gems/WhiteBox/Code/Source/EditorWhiteBoxComponent.cpp
@@ -265,6 +265,7 @@ namespace WhiteBox
     {
         incompatible.push_back(AZ_CRC_CE("NonUniformScaleService"));
         incompatible.push_back(AZ_CRC_CE("MeshService"));
+        incompatible.push_back(AZ_CRC_CE("WhiteBoxService"));
     }
 
     EditorWhiteBoxComponent::EditorWhiteBoxComponent() = default;


### PR DESCRIPTION
Limit the max number to 1 when adding white box component or white box collider component. 

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>