### PR TITLE
Script Canvas Groups

### DIFF
--- a/Code/Editor/EditorPanelUtils.cpp
+++ b/Code/Editor/EditorPanelUtils.cpp
@@ -319,8 +319,8 @@ public:
         keys.push_back(QPair<QString, QString>("Edit Menu.Duplicate", "Ctrl+D"));
         keys.push_back(QPair<QString, QString>("Edit Menu.Undo", "Ctrl+Z"));
         keys.push_back(QPair<QString, QString>("Edit Menu.Redo", "Ctrl+Shift+Z"));
-        keys.push_back(QPair<QString, QString>("Edit Menu.Group", "Ctrl+G"));
-        keys.push_back(QPair<QString, QString>("Edit Menu.Ungroup", "Ctrl+Shift+G"));
+        keys.push_back(QPair<QString, QString>("Edit Menu.Group", "Ctrl+Alt+O"));
+        keys.push_back(QPair<QString, QString>("Edit Menu.Ungroup", "Ctrl+Alt+P"));
         keys.push_back(QPair<QString, QString>("Edit Menu.Rename", "Ctrl+R"));
         keys.push_back(QPair<QString, QString>("Edit Menu.Reset", ""));
         keys.push_back(QPair<QString, QString>("Edit Menu.Edit Hotkeys", ""));

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/AssetEditorToolbar/AssetEditorToolbar.ui
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/AssetEditorToolbar/AssetEditorToolbar.ui
@@ -56,7 +56,7 @@
    <item>
     <widget class="QToolButton" name="groupNodes">
      <property name="toolTip">
-      <string>Groups the current selection in the active graph [Ctrl+Shift+G]</string>
+      <string>Groups the current selection in the active graph [Ctrl+Alt+O]</string>
      </property>
      <property name="text">
       <string>...</string>
@@ -66,14 +66,14 @@
        <normaloff>:/GraphCanvasEditorResources/group.svg</normaloff>:/GraphCanvasEditorResources/group.svg</iconset>
      </property>
      <property name="shortcut">
-      <string>Ctrl+Shift+G</string>
+      <string>Ctrl+Alt+O</string>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QToolButton" name="ungroupNodes">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ungroups the selected element in the active graph [Ctrl+Shift+H]&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>Ungroups the selected element in the active graph [Ctrl+Alt+P]</string>
      </property>
      <property name="text">
       <string>...</string>
@@ -83,7 +83,7 @@
        <normaloff>:/GraphCanvasEditorResources/ungroup.svg</normaloff>:/GraphCanvasEditorResources/ungroup.svg</iconset>
      </property>
      <property name="shortcut">
-      <string>Ctrl+Shift+H</string>
+      <string>Ctrl+Alt+P</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The Groups and Ungroups shortcut keys in Script Canvas Editor do not take effect

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>