### PR TITLE
Fixed logic for when to cull entities from having their viewport manipulators regenerated.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -2504,6 +2504,29 @@ namespace AzToolsFramework
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
+        // Do not create manipulators for the container entity of the focused prefab.
+        if (auto prefabFocusPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusPublicInterface>::Get())
+        {
+            AzFramework::EntityContextId editorEntityContextId = GetEntityContextId();
+            if (AZ::EntityId focusRoot = prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId);
+                focusRoot.IsValid())
+            {
+                m_selectedEntityIds.erase(focusRoot);
+            }
+        }
+
+        // Do not create manipulators for any entities marked as read only
+        if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get())
+        {
+            AZStd::erase_if(
+                m_selectedEntityIds,
+                [readOnlyEntityPublicInterface](auto entityId)
+            {
+                return readOnlyEntityPublicInterface->IsReadOnly(entityId);
+            }
+            );
+        }
+
         // note: create/destroy pattern to be addressed
         DestroyManipulators(m_entityIdManipulators);
         CreateEntityIdManipulators();
@@ -3635,29 +3658,6 @@ namespace AzToolsFramework
         m_selectedEntityIds.clear();
         m_selectedEntityIds.reserve(selectedEntityIds.size());
         AZStd::copy(selectedEntityIds.begin(), selectedEntityIds.end(), AZStd::inserter(m_selectedEntityIds, m_selectedEntityIds.end()));
-
-        // Do not create manipulators for the container entity of the focused prefab.
-        if (auto prefabFocusPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusPublicInterface>::Get())
-        {
-            AzFramework::EntityContextId editorEntityContextId = GetEntityContextId();
-            if (AZ::EntityId focusRoot = prefabFocusPublicInterface->GetFocusedPrefabContainerEntityId(editorEntityContextId);
-                focusRoot.IsValid())
-            {
-                m_selectedEntityIds.erase(focusRoot);
-            }
-        }
-
-        // Do not create manipulators for any entities marked as read only
-        if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get())
-        {
-            AZStd::erase_if(
-                m_selectedEntityIds,
-                [readOnlyEntityPublicInterface](auto entityId)
-                {
-                    return readOnlyEntityPublicInterface->IsReadOnly(entityId);
-                }
-            );
-        }
     }
 
     void EditorTransformComponentSelection::OnTransformChanged(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorTransformComponentSelection.cpp
@@ -2504,7 +2504,7 @@ namespace AzToolsFramework
     {
         AZ_PROFILE_FUNCTION(AzToolsFramework);
 
-        // Do not create manipulators for the container entity of the focused prefab.
+        // do not create manipulators for the container entity of the focused prefab.
         if (auto prefabFocusPublicInterface = AZ::Interface<AzToolsFramework::Prefab::PrefabFocusPublicInterface>::Get())
         {
             AzFramework::EntityContextId editorEntityContextId = GetEntityContextId();
@@ -2515,7 +2515,7 @@ namespace AzToolsFramework
             }
         }
 
-        // Do not create manipulators for any entities marked as read only
+        // do not create manipulators for any entities marked as read only
         if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get())
         {
             AZStd::erase_if(


### PR DESCRIPTION
There are some cases where we don't want to show the transform manipulators in the viewport for certain selected entities (focus root, and read-only entities). Previously, this culling was being done in the `RefreshSelectedEntityIds` method, but this only catches selection changes that occur outside of the viewport (e.g. selecting entities in the Entity Outliner). However, this doesn't get called if the selection was changed by the viewport itself (e.g. picking an entity by selecting it in the viewport). So, moved this logic to the `RegenerateManipulators` method so that it gets called everytime, regardless of who modified the selection.

![ReadOnlyViewportManipulatorsHidden](https://user-images.githubusercontent.com/7519264/145447856-ae4bab43-b207-436d-95e2-d362442bb1b5.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>