### PR TITLE
[AudioSystem] Allow audio engines to provide widgets for modifying connection properties.

### DIFF
--- a/Gems/AudioSystem/Code/Include/Editor/IAudioSystemEditor.h
+++ b/Gems/AudioSystem/Code/Include/Editor/IAudioSystemEditor.h
@@ -16,6 +16,8 @@
 
 #include <ACETypes.h>
 
+class QWidget;
+
 namespace AudioControls
 {
     class IAudioSystemEditor;
@@ -150,6 +152,12 @@ namespace AudioControls
 
         //! Informs the plugin that the ACE has saved the data in case it needs to do any clean up.
         virtual void DataSaved() = 0;
+
+        //! Creates a widget for modifying connection properties.
+        //! The widget must have a "PropertiesChanged()" signal.
+        //! The widget ownership transferred to the caller.
+        virtual QWidget* CreateConnectionPropertiesWidget([[maybe_unused]] const TConnectionPtr connection,
+            [[maybe_unused]] EACEControlType atlControlType) { return nullptr; }
     };
 
 } // namespace AudioControls

--- a/Gems/AudioSystem/Code/Source/Editor/ConnectionsWidget.ui
+++ b/Gems/AudioSystem/Code/Source/Editor/ConnectionsWidget.ui
@@ -16,18 +16,6 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>450</height>
-   </size>
-  </property>
-  <property name="maximumSize">
-   <size>
-    <width>16777215</width>
-    <height>450</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Inspector Panel</string>
   </property>
@@ -104,7 +92,7 @@
      <property name="frameShadow">
       <enum>QFrame::Plain</enum>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="m_connectionPropertiesLayout">
       <property name="spacing">
        <number>0</number>
       </property>

--- a/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.h
+++ b/Gems/AudioSystem/Code/Source/Editor/QConnectionsWidget.h
@@ -40,6 +40,7 @@ namespace AudioControls
         void ShowConnectionContextMenu(const QPoint& pos);
         void CurrentConnectionModified();
         void RemoveSelectedConnection();
+        void SelectedConnectionChanged();
 
     private:
         bool eventFilter(QObject* object, QEvent* event) override;
@@ -50,6 +51,8 @@ namespace AudioControls
         CATLControl* m_control;
         QColor m_notFoundColor;
         QColor m_localizedColor;
+
+        QWidget* m_connectionPropertiesWidget = nullptr;
     };
 
 } // namespace AudioControls


### PR DESCRIPTION
Useful for any audio engine implementation that relies heavily on per audio control connection properties, for example, my SoLoud library integration (https://discord.com/channels/805939474655346758/872246483523608727).