### PR TITLE
Fix Visual Studio requirements text and doc link

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -107,7 +107,7 @@ namespace O3DE::ProjectManager
 
             return AZ::Failure(QObject::tr("Visual Studio 2019 version 16.9.2 or higher not found.<br><br>"
                 "A compatible version of Visual Studio is required to build this project.<br>"
-                " Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual Studio requirements</a> for more information."));
+                "Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual Studio requirements</a> for more information."));
         }
 
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -106,10 +106,8 @@ namespace O3DE::ProjectManager
             }
 
             return AZ::Failure(QObject::tr("Visual Studio 2019 version 16.9.2 or higher not found.<br><br>"
-                "Visual Studio 2019 is required to build this project."
-                " Install any edition of <a href='https://visualstudio.microsoft.com/downloads/'>Visual Studio 2019</a>"
-                " or update to a newer version before proceeding to the next step."
-                " While installing configure Visual Studio with these <a href='https://o3de.org/docs/welcome-guide/setup/requirements/#visual-studio-configuration'>workloads</a>."));
+                "A compatible version of Visual Studio is required to build this project.<br>"
+                " Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual Studio requirements</a> for more information."));
         }
 
         AZ::Outcome<void, QString> OpenCMakeGUI(const QString& projectPath)


### PR DESCRIPTION
The current Visual Studio requirements direct the user to a Microsoft page we have no control over that promotes Visual Studio 2022 and makes it difficult to find the Visual Studio 2019 install.  This change, directs the user to the O3DE docs where we can provide the user with correct information and links.

```
A compatible version of Visual Studio is required to build this project.
Refer to the <a href='https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio'>Visual Studio requirements</a> for more information.
```

I have confirmed the URL (https://o3de.org/docs/welcome-guide/requirements/#microsoft-visual-studio) with @erickson-doug 

![image](https://user-images.githubusercontent.com/26804013/145489248-2e8ea403-4521-4f77-9a72-93f2d0c63636.png)

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>