### PR TITLE
Fix editor hang on level load

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -123,11 +123,26 @@ namespace AZ
                     }
                 };
                 Job* executeGroupJob = aznew JobFunction<decltype(jobLambda)>(jobLambda, true, nullptr); // Auto-deletes
-                parentJob->StartAsChild(executeGroupJob);
+                if (parentJob)
+                {
+                    parentJob->StartAsChild(executeGroupJob);
+                }
+                else
+                {
+                    executeGroupJob->SetDependent(&jobCompletion);
+                    executeGroupJob->Start();
+                }
             }
             {
                 AZ_PROFILE_SCOPE(AzRender, "MeshFeatureProcessor: Simulate: WaitForChildren");
-                parentJob->WaitForChildren();
+                if (parentJob)
+                {
+                    parentJob->WaitForChildren();
+                }
+                else
+                {
+                    jobCompletion.StartAndWaitForCompletion();
+                }
             }
 
             m_forceRebuildDrawPackets = false;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/View.h
@@ -24,6 +24,9 @@ class MaskedOcclusionCulling;
 
 namespace AZ
 {
+    // forward declares
+    class Job;
+    class TaskGraphEvent;
     namespace  RHI
     {
         class FrameScheduler;
@@ -102,7 +105,8 @@ namespace AZ
 
             //! Finalize draw lists in this view. This function should only be called when all
             //! draw packets for current frame are added. 
-            void FinalizeDrawLists();
+            void FinalizeDrawListsJob(AZ::Job* parentJob);
+            void FinalizeDrawListsTG(AZ::TaskGraphEvent& finalizeDrawListsTGEvent);
 
             bool HasDrawListTag(RHI::DrawListTag drawListTag);
 
@@ -142,7 +146,8 @@ namespace AZ
             View(const AZ::Name& name, UsageFlags usage);
 
             //! Sorts the finalized draw lists in this view
-            void SortFinalizedDrawLists();
+            void SortFinalizedDrawListsJob(AZ::Job* parentJob);
+            void SortFinalizedDrawListsTG(AZ::TaskGraphEvent& finalizeDrawListsTGEvent);
 
             //! Sorts a drawList using the sort function from a pass with the corresponding drawListTag
             void SortDrawList(RHI::DrawList& drawList, RHI::DrawListTag tag);


### PR DESCRIPTION
Make View::SortFinalizedDrawLists use child jobs so they don't block the worker thread from doing other work while waiting.
Implement a TaskGraph version of the view draw list sort.
Fix a misc bug where the scene was waiting on a task graph event twice and so hanging.
Enable MeshFeatureProcessor::Simulate to be able to use jobs when no parent job is specified because the parent job is a task.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>