### PR TITLE
fix:fragments are always reliable

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -549,7 +549,8 @@ namespace AzNetworking
                 const uint32_t nextChunkSize = AZStd::min(bytesRemaining, chunkSize);
                 chunkBuffer.CopyValues(chunkStart, nextChunkSize);
                 CorePackets::FragmentedPacket fragmentedPacket(ToSequenceId(localPacketId), fragmentedSequence, aznumeric_cast<uint8_t>(chunkIndex), aznumeric_cast<uint8_t>(numChunks), chunkBuffer);
-                const SequenceId chunkReliableId = (reliabilityType == ReliabilityType::Reliable) ? connection.m_reliableQueue.GetNextSequenceId() : InvalidSequenceId;
+                // Fragments are always reliable so original packet can be reconstructed 
+                const SequenceId chunkReliableId =  connection.m_reliableQueue.GetNextSequenceId();
                 SendPacket(connection, fragmentedPacket, chunkReliableId);
                 bytesRemaining -= nextChunkSize;
                 chunkStart += nextChunkSize;


### PR DESCRIPTION
according to the comments in the UdpNetworkInterface.h

```
//! ### Fragmentation
//! 
//! If the raw packet size exceeds the configured maximum transmission unit (MTU) then the packet is broken into
//! multiple reliable fragments to avoid fragmentation at the routing level. Fragments are always reliable so the original
//! packet can be reconstructed. Operations that alter the payload generally follow this step so that they can be
//! separately applied to the Fragments in addition to not being applied to both the original and Fragments.
```

make it reliable by default for fragments.