### PR TITLE
Lua Editor log - text ghosted

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Logging/LogPanel_Panel.cpp
@@ -840,8 +840,6 @@ namespace AzToolsFramework
                     richLabel->setTextFormat(Qt::RichText);
                 }
 
-                richLabel->setText(data);
-
                 richLabel->setGeometry(options.rect);
                 richLabel->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
                 richLabel->setPalette(options.palette);


### PR DESCRIPTION
Double-click the text in the Lua Editor log interface, and the text will appear ghosted

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>