### PR TITLE
Fix: Special character bug

### DIFF
--- a/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
+++ b/Code/Editor/Plugins/ComponentEntityEditorPlugin/UI/Outliner/OutlinerListModel.cpp
@@ -605,6 +605,13 @@ bool OutlinerListModel::setData(const QModelIndex& index, const QVariant& value,
 
                     if (oldName != newName)
                     {
+                        QRegExp rx("[_a-zA-Z0-9-\\s]+");
+                        if (!rx.exactMatch(newName.c_str()))
+                        {
+                            QMessageBox::information(NULL, "Title", "Special characters are not allowed", QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+                            newName = oldName;
+                        }
+
                         AzToolsFramework::ScopedUndoBatch undo("Rename Entity");
 
                         entity->SetName(newName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.cpp
@@ -486,6 +486,13 @@ namespace AzToolsFramework
 
                         if (oldName != newName)
                         {
+                            QRegExp rx("[_a-zA-Z0-9-\\s]+");
+                            if (!rx.exactMatch(newName.c_str()))
+                            {
+                                QMessageBox::information(NULL, "Title", "Special characters are not allowed", QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+                                newName = oldName;
+                            }
+
                             ScopedUndoBatch undo("Rename Entity");
 
                             entity->SetName(newName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/EntityPropertyEditor.cpp
@@ -589,6 +589,10 @@ namespace AzToolsFramework
             this,
             SLOT(OnEntityNameChanged()));
 
+        QRegExp rx("[_a-zA-Z0-9-\\s]+");
+        QValidator* validator = new QRegExpValidator(rx, this);
+        m_gui->m_entityNameEditor->setValidator(validator);
+
         connect(m_gui->m_statusComboBox,
             SIGNAL(currentIndexChanged(int)),
             this,


### PR DESCRIPTION
The engine is not verified with Modules including Chinese and special characters. When saving, the log reports an error, the project exits, and the original level disappears.

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>