### PR TITLE
Fix for GHI-4644: mesh optimization breaking skin influences

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/ISkinWeightData.h
+++ b/Code/Tools/SceneAPI/SceneCore/DataTypes/GraphData/ISkinWeightData.h
@@ -28,6 +28,12 @@ namespace AZ
                 {
                     int boneId;
                     float weight;
+
+                    bool IsClose(const Link& other, float tolerance) const
+                    {
+                        return boneId == other.boneId &&
+                            AZ::IsClose(weight, other.weight, tolerance);
+                    }
                 };
 
                 virtual ~ISkinWeightData() override = default;

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -948,19 +948,17 @@ namespace AZ
         {
             AZStd::vector<uint16_t>& skinJointIndices = productMesh.m_skinJointIndices;
             AZStd::vector<float>& skinWeights = productMesh.m_skinWeights;
-            const auto& sourceMeshData = sourceMesh.m_meshData;
 
             size_t numInfluencesAdded = 0;
             for (const auto& skinData : sourceMesh.m_skinData)
             {
-                const AZ::u32 controlPointIndex = sourceMeshData->GetControlPointIndex(static_cast<int>(vertexIndex));
-                const size_t numSkinInfluences = skinData->GetLinkCount(controlPointIndex);
+                const size_t numSkinInfluences = skinData->GetLinkCount(vertexIndex);
 
                 size_t numInfluencesExcess = 0;
 
                 for (size_t influenceIndex = 0; influenceIndex < numSkinInfluences; ++influenceIndex)
                 {
-                    const AZ::SceneAPI::DataTypes::ISkinWeightData::Link& link = skinData->GetLink(controlPointIndex, influenceIndex);
+                    const AZ::SceneAPI::DataTypes::ISkinWeightData::Link& link = skinData->GetLink(vertexIndex, influenceIndex);
 
                     const float weight = link.weight;
                     const AZStd::string& boneName = skinData->GetBoneName(link.boneId);

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.cpp
@@ -79,7 +79,7 @@ namespace AZ::MeshBuilder
 
     // optimize the weight data
     void MeshBuilderSkinningInfo::Optimize(
-        AZStd::vector<Influence>& influences, [[maybe_unused]] AZ::u32 maxNumWeightsPerVertex, [[maybe_unused]] float weightThreshold)
+        AZStd::vector<Influence>& influences, AZ::u32 maxNumWeightsPerVertex, float weightThreshold)
     {
         // gather all weights
         const size_t numInfluences = influences.size();

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.cpp
@@ -89,40 +89,16 @@ namespace AZ::MeshBuilder
     }
 
     // optimize the weight data
-    void MeshBuilderSkinningInfo::Optimize([[maybe_unused]] AZ::u32 maxNumWeightsPerVertex, [[maybe_unused]] float weightThreshold)
+    void MeshBuilderSkinningInfo::Optimize(
+        AZStd::vector<Influence>& influences, [[maybe_unused]] AZ::u32 maxNumWeightsPerVertex, [[maybe_unused]] float weightThreshold)
     {
-        AZStd::vector<Influence> influences;
-
-        // for all vertices
-        const size_t numOrgVerts = GetNumOrgVertices();
-        for (size_t v = 0; v < numOrgVerts; ++v)
+        // gather all weights
+        const size_t numInfluences = influences.size();
+        if (numInfluences > 0)
         {
-            // gather all weights
-            const size_t numInfluences = GetNumInfluences(v);
-            if (numInfluences > 0)
-            {
-                influences.resize(numInfluences);
-                for (size_t i = 0; i < numInfluences; ++i)
-                {
-                    influences[i] = GetInfluence(v, i);
-                }
-
-                // optimize the weights and sort them from big to small weight
-                OptimizeSkinningInfluences(influences, weightThreshold, maxNumWeightsPerVertex);
-                SortInfluencesByWeight(influences);
-
-                // remove all influences
-                for (size_t i = 0; i < numInfluences; ++i)
-                {
-                    RemoveInfluence(v, 0);
-                }
-
-                // re-add them
-                for (const Influence& influence : influences)
-                {
-                    AddInfluence(v, influence);
-                }
-            }
+            // optimize the weights and sort them from big to small weight
+            OptimizeSkinningInfluences(influences, weightThreshold, maxNumWeightsPerVertex);
+            SortInfluencesByWeight(influences);
         }
     }
 } // namespace AZ::MeshBuilder

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.cpp
@@ -68,17 +68,6 @@ namespace AZ::MeshBuilder
         }
     }
 
-    // sort influences on ids, from small to big
-    void MeshBuilderSkinningInfo::SortInfluencesById(AZStd::vector<Influence>& influences)
-    {
-        AZStd::sort(
-            begin(influences), end(influences),
-            [](const auto& lhs, const auto& rhs)
-            {
-                return lhs.mNodeNr <= rhs.mNodeNr;
-            });
-    }
-
     // sort influences on weights, from big to small
     void MeshBuilderSkinningInfo::SortInfluencesByWeight(AZStd::vector<Influence>& influences)
     {

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
@@ -55,8 +55,11 @@ namespace AZ::MeshBuilder
         // optimize weights
         static void OptimizeSkinningInfluences(AZStd::vector<Influence>& influences, float tolerance, size_t maxWeights);
 
+        // sort the influences, starting with the smallest id
+        static void SortInfluencesById(AZStd::vector<Influence>& influences);
+
         // sort the influences, starting with the biggest weight
-        static void SortInfluences(AZStd::vector<Influence>& influences);
+        static void SortInfluencesByWeight(AZStd::vector<Influence>& influences);
 
     private:
         AZStd::vector<AZStd::vector<Influence>> mInfluences;

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
@@ -55,9 +55,6 @@ namespace AZ::MeshBuilder
         // optimize weights
         static void OptimizeSkinningInfluences(AZStd::vector<Influence>& influences, float tolerance, size_t maxWeights);
 
-        // sort the influences, starting with the smallest id
-        static void SortInfluencesById(AZStd::vector<Influence>& influences);
-
         // sort the influences, starting with the biggest weight
         static void SortInfluencesByWeight(AZStd::vector<Influence>& influences);
 

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshBuilderSkinningInfo.h
@@ -50,7 +50,7 @@ namespace AZ::MeshBuilder
         }
 
         // optimize the weight data
-        void Optimize(AZ::u32 maxNumWeightsPerVertex = 4, float weightThreshold = 0.0001f);
+        void Optimize(AZStd::vector<Influence>& influences, AZ::u32 maxNumWeightsPerVertex = 4, float weightThreshold = 0.0001f);
 
         // optimize weights
         static void OptimizeSkinningInfluences(AZStd::vector<Influence>& influences, float tolerance, size_t maxWeights);

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
@@ -69,6 +69,10 @@ namespace AZ::MeshBuilder
 {
     using MeshBuilderVertexAttributeLayerColor = MeshBuilderVertexAttributeLayerT<AZ::SceneAPI::DataTypes::Color>;
     AZ_CLASS_ALLOCATOR_IMPL_TEMPLATE(MeshBuilderVertexAttributeLayerColor, AZ::SystemAllocator, 0)
+        
+    using MeshBuilderVertexAttributeLayerSkinInfluence = MeshBuilderVertexAttributeLayerT<AZ::SceneAPI::DataTypes::ISkinWeightData::Link>;
+    AZ_CLASS_ALLOCATOR_IMPL_TEMPLATE(MeshBuilderVertexAttributeLayerSkinInfluence, AZ::SystemAllocator, 0)
+
 } // namespace AZ::MeshBuilder
 
 namespace AZ::SceneGenerationComponents
@@ -205,7 +209,7 @@ namespace AZ::SceneGenerationComponents
         auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
         {
-            serializeContext->Class<MeshOptimizerComponent, GenerationComponent>()->Version(5);
+            serializeContext->Class<MeshOptimizerComponent, GenerationComponent>()->Version(10);
         }
     }
 
@@ -222,70 +226,24 @@ namespace AZ::SceneGenerationComponents
         }
     };
 
-    template<class MeshDataType, class SkinWeightDataView>
-    static AZStd::unique_ptr<AZ::MeshBuilder::MeshBuilderSkinningInfo> ExtractSkinningInfo(
-        const MeshDataType* meshData,
-        const SkinWeightDataView& skinWeights,
+
+    static AZStd::vector<AZ::MeshBuilder::MeshBuilderSkinningInfo::Influence> ExtractSkinningInfo(
+        const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerSkinInfluence*>& skinningInfluencesLayers,
+        const AZ::MeshBuilder::MeshBuilderVertexLookup& vertexLookup,
         AZ::u32 maxWeightsPerVertex,
-        float weightThreshold,
-        const Vector3Map<MeshDataType>& positionMap)
+        float weightThreshold)
     {
-        if (skinWeights.empty())
+        auto skinningInfo = AZStd::make_unique<AZ::MeshBuilder::MeshBuilderSkinningInfo>(aznumeric_cast<AZ::u32>(1));
+
+        AZStd::vector<AZ::MeshBuilder::MeshBuilderSkinningInfo::Influence> influences;
+        for (const auto& skinLayer : skinningInfluencesLayers)
         {
-            return {};
+            const ISkinWeightData::Link& link = skinLayer->GetVertexValue(vertexLookup.mOrgVtx, vertexLookup.mDuplicateNr);
+            influences.push_back({ aznumeric_caster(link.boneId), link.weight });
         }
 
-        const size_t usedControlPointCount = positionMap.size();
-
-        auto skinningInfo = AZStd::make_unique<AZ::MeshBuilder::MeshBuilderSkinningInfo>(aznumeric_cast<AZ::u32>(usedControlPointCount));
-
-        // A map from orgVertexNumber to an InfluenceAccumulator that is responsible for
-        // averaging the influences of any vertices that have been welded
-        AZStd::unordered_map<int, InfluenceAccumulator> influenceMap;
-
-        for (const auto& skinData : skinWeights)
-        {
-            for (size_t controlPointIndex = 0; controlPointIndex < skinData.get().GetVertexCount(); ++controlPointIndex)
-            {
-                const int usedPointIndex = meshData->GetUsedPointIndexForControlPoint(meshData->GetControlPointIndex(aznumeric_caster(controlPointIndex)));
-                const size_t linkCount = skinData.get().GetLinkCount(controlPointIndex);
-
-                if (usedPointIndex < 0 || linkCount == 0)
-                {
-                    continue;
-                }
-
-                AZ::u32 orgVertexNumber = positionMap.at(usedPointIndex);
-                const auto& [iter, didInsert] = influenceMap.try_emplace(orgVertexNumber, InfluenceAccumulator{});
-                InfluenceAccumulator& influenceAccumulatorForOrgVertexNumber = iter->second;
-                if(!didInsert)
-                {
-                    // If more than one vertex was welded, keep track of how many
-                    influenceAccumulatorForOrgVertexNumber.m_totalWeldedVertexCount += 1.0f;
-                }
-
-                for (size_t linkIndex = 0; linkIndex < linkCount; ++linkIndex)
-                {
-                    const ISkinWeightData::Link& link = skinData.get().GetLink(controlPointIndex, linkIndex);
-
-                    influenceAccumulatorForOrgVertexNumber.AddInfluence(aznumeric_caster(link.boneId), link.weight);
-                    
-                }
-            }
-        }
-
-        // Now that we've gathered and de-duplicated all the skin influences, add them
-        for (const auto& [orgVertexNumber, accumulator] : influenceMap)
-        {
-            for (const auto& [jointId, accumulatedWeight] : accumulator.m_accumulatedInfluences)
-            {
-                skinningInfo->AddInfluence(orgVertexNumber, {jointId, accumulatedWeight / accumulator.m_totalWeldedVertexCount});
-            }
-        }
-
-        skinningInfo->Optimize(maxWeightsPerVertex, weightThreshold);
-
-        return skinningInfo;
+        skinningInfo->Optimize(influences, maxWeightsPerVertex, weightThreshold);
+        return influences;
     }
 
     // Recurse through the SceneAPI's iterator types, extracting the real underlying iterator.
@@ -504,6 +462,40 @@ namespace AZ::SceneGenerationComponents
         return layers;
     };
 
+    template<class SkinWeightDataView>
+    static const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerSkinInfluence*> MakeSkinInfluenceLayers(
+        AZ::MeshBuilder::MeshBuilder& meshBuilder,
+        const SkinWeightDataView& skinWeights,
+        size_t vertexCount)
+    {
+        if (skinWeights.empty())
+        {
+            return {};
+        }
+
+        size_t maxInfluenceCount = 0;
+
+        AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerSkinInfluence*> outLayers;
+
+        // Do a pass over the skin influences, and determine the max influence count for any one vertex,
+        // which will be the number of influence layers we add
+        for (const auto& skinData : skinWeights)
+        {
+            for (size_t controlPointIndex = 0; controlPointIndex < skinData.get().GetVertexCount(); ++controlPointIndex)
+            {
+                const size_t linkCount = skinData.get().GetLinkCount(controlPointIndex);
+                maxInfluenceCount = AZStd::max(maxInfluenceCount, linkCount);
+            }
+        }
+
+        // Create the influence layers
+        for (size_t i = 0; i < maxInfluenceCount; ++i)
+        {
+            outLayers.push_back(meshBuilder.AddLayer<MeshBuilder::MeshBuilderVertexAttributeLayerSkinInfluence>(vertexCount));
+        }
+
+        return outLayers;
+    }
 
     template<class MeshDataType>
     AZStd::tuple<
@@ -529,7 +521,7 @@ namespace AZ::SceneGenerationComponents
         AZ::MeshBuilder::MeshBuilder meshBuilder(vertexCount, AZStd::numeric_limits<size_t>::max(), AZStd::numeric_limits<size_t>::max(), /*optimizeDuplicates=*/ !hasBlendShapes);
 
         // Make the layers to hold the vertex data
-        auto* orgVtxLayer = meshBuilder.AddLayer<MeshBuilder::MeshBuilderVertexAttributeLayerUInt32>(vertexCount);
+        auto* controlPointLayer = meshBuilder.AddLayer<MeshBuilder::MeshBuilderVertexAttributeLayerUInt32>(vertexCount);
         auto* posLayer = meshBuilder.AddLayer<MeshBuilder::MeshBuilderVertexAttributeLayerVector3>(vertexCount, false, true);
         auto* normalsLayer = meshBuilder.AddLayer<MeshBuilder::MeshBuilderVertexAttributeLayerVector3>(vertexCount, false, true);
 
@@ -564,6 +556,8 @@ namespace AZ::SceneGenerationComponents
         const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerVector4*> tangentLayers = makeLayersForData(tangents);
         const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerVector3*> bitangentLayers = makeLayersForData(bitangents);
         const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerColor*> vertexColorLayers = makeLayersForData(vertexColors);
+        const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerSkinInfluence*> skinningInfluencesLayers =
+            MakeSkinInfluenceLayers(meshBuilder, skinWeights, vertexCount);
 
         constexpr float positionTolerance = 0.0001f;
         Vector3Map positionMap(meshData, hasBlendShapes, positionTolerance);
@@ -576,9 +570,9 @@ namespace AZ::SceneGenerationComponents
             meshBuilder.BeginPolygon(baseMesh->GetFaceMaterialId(faceIndex));
             for (const AZ::u32 vertexIndex : meshData->GetFaceInfo(faceIndex).vertexIndex)
             {
-                const AZ::u32 orgVertexNumber = positionMap[vertexIndex];
+                const AZ::u32 controlPointVertexIndex = positionMap[vertexIndex];
 
-                orgVtxLayer->SetCurrentVertexValue(orgVertexNumber);
+                controlPointLayer->SetCurrentVertexValue(controlPointVertexIndex);
 
                 posLayer->SetCurrentVertexValue(meshData->GetPosition(vertexIndex));
                 normalsLayer->SetCurrentVertexValue(meshData->GetNormal(vertexIndex));
@@ -600,9 +594,39 @@ namespace AZ::SceneGenerationComponents
                 {
                     vertexColorLayer->SetCurrentVertexValue(vertexColorData.get().GetColor(vertexIndex));
                 }
+
+                // Initialize skin weights to 0, 0.0
+                for (auto& skinInfluenceLayer : skinningInfluencesLayers)
+                {
+                    skinInfluenceLayer->SetCurrentVertexValue(ISkinWeightData::Link{ 0, 0.0f });
+                }
+
+                bool influencesFoundForThisVertex = false;
+                // Set any real weights, if they exist
+                for (const auto& skinWeightData : skinWeights)
+                {
+                    const size_t linkCount = skinWeightData.get().GetLinkCount(vertexIndex);
+                    AZ_Assert(
+                        linkCount <= skinningInfluencesLayers.size(),
+                        "MeshOptimizer - The previously calculated maximum influence count is less than the current link count.");
+                    if (linkCount > 0)
+                    {
+                        AZ_Assert(
+                            influencesFoundForThisVertex == false,
+                            "Two different skinWeightData instances in skinWeights apply to the same vertex. "
+                            "The mesh optimizer assumes there will only ever be one skinWeightData that impacts a given vertex.");
+                        influencesFoundForThisVertex = true;
+
+                        for (size_t linkIndex = 0; linkIndex < linkCount; ++linkIndex)
+                        {
+                            const ISkinWeightData::Link& link = skinWeightData.get().GetLink(vertexIndex, linkIndex);
+                            skinningInfluencesLayers[linkIndex]->SetCurrentVertexValue(link);
+                        }
+                    }
+                }
                 AZ_POP_DISABLE_WARNING
 
-                meshBuilder.AddPolygonVertex(orgVertexNumber);
+                meshBuilder.AddPolygonVertex(controlPointVertexIndex);
             }
 
             meshBuilder.EndPolygon();
@@ -611,9 +635,10 @@ namespace AZ::SceneGenerationComponents
         const auto* skinRule = meshGroup.GetRuleContainerConst().FindFirstByType<SceneAPI::DataTypes::ISkinRule>().get();
         const AZ::u32 maxWeightsPerVertex = skinRule ? skinRule->GetMaxWeightsPerVertex() : 4;
         const float weightThreshold = skinRule ? skinRule->GetWeightThreshold() : 0.001f;
-        meshBuilder.SetSkinningInfo(ExtractSkinningInfo(meshData, skinWeights, maxWeightsPerVertex, weightThreshold, positionMap));
 
         meshBuilder.GenerateSubMeshVertexOrders();
+
+        size_t optimizedVertexCount = meshBuilder.CalcNumVertices();
 
         // Create the resulting nodes
         struct ResultingType
@@ -631,6 +656,13 @@ namespace AZ::SceneGenerationComponents
         AZStd::vector<AZStd::unique_ptr<MeshVertexTangentData>> optimizedTangents = makeSceneGraphNodesForMeshBuilderLayers<MeshVertexTangentData>(tangentLayers);
         AZStd::vector<AZStd::unique_ptr<MeshVertexBitangentData>> optimizedBitangents = makeSceneGraphNodesForMeshBuilderLayers<MeshVertexBitangentData>(bitangentLayers);
         AZStd::vector<AZStd::unique_ptr<MeshVertexColorData>> optimizedVertexColors = makeSceneGraphNodesForMeshBuilderLayers<MeshVertexColorData>(vertexColorLayers);
+        AZStd::unique_ptr<SkinWeightData> optimizedSkinWeights = nullptr;
+
+        if (!skinningInfluencesLayers.empty())
+        {
+            optimizedSkinWeights = AZStd::make_unique<SkinWeightData>();
+            optimizedSkinWeights->ResizeContainerSpace(optimizedVertexCount);
+        }
 
         // Copy node attributes
         AZStd::apply([](const auto&&... nodePairView) {
@@ -650,14 +682,16 @@ namespace AZ::SceneGenerationComponents
         for (size_t subMeshIndex = 0; subMeshIndex < meshBuilder.GetNumSubMeshes(); ++subMeshIndex)
         {
             const AZ::MeshBuilder::MeshBuilderSubMesh* subMesh = meshBuilder.GetSubMesh(subMeshIndex);
-            for (size_t vertexIndex = 0; vertexIndex < subMesh->GetNumVertices(); ++vertexIndex)
+            for (size_t subMeshVertexIndex = 0; subMeshVertexIndex < subMesh->GetNumVertices(); ++subMeshVertexIndex)
             {
-                const AZ::MeshBuilder::MeshBuilderVertexLookup& vertexLookup = subMesh->GetVertex(vertexIndex);
+                const AZ::MeshBuilder::MeshBuilderVertexLookup& vertexLookup = subMesh->GetVertex(subMeshVertexIndex);
                 optimizedMesh->AddPosition(posLayer->GetVertexValue(vertexLookup.mOrgVtx, vertexLookup.mDuplicateNr));
                 optimizedMesh->AddNormal(normalsLayer->GetVertexValue(vertexLookup.mOrgVtx, vertexLookup.mDuplicateNr));
+                
+                int modelVertexIndex = optimizedMesh->GetVertexCount() - 1;
                 optimizedMesh->SetVertexIndexToControlPointIndexMap(
-                    aznumeric_caster(optimizedMesh->GetVertexCount() - 1),
-                    orgVtxLayer->GetVertexValue(vertexLookup.mOrgVtx, vertexLookup.mDuplicateNr)
+                    modelVertexIndex,
+                    controlPointLayer->GetVertexValue(vertexLookup.mOrgVtx, vertexLookup.mDuplicateNr)
                 );
 
                 for (auto [uvLayer, optimizedUVNode] : Containers::Views::MakePairView(uvLayers, optimizedUVs))
@@ -676,6 +710,19 @@ namespace AZ::SceneGenerationComponents
                 {
                     optimizedVertexColorNode->AppendColor(vertexColorLayer->GetVertexValue(vertexLookup.mOrgVtx, vertexLookup.mDuplicateNr));
                 }
+
+                if (optimizedSkinWeights)
+                {
+                    AZStd::vector<AZ::MeshBuilder::MeshBuilderSkinningInfo::Influence> influences =
+                        ExtractSkinningInfo(skinningInfluencesLayers, vertexLookup, maxWeightsPerVertex, weightThreshold);
+
+                    for (auto influence : influences)
+                    {
+                        const int boneId =
+                            optimizedSkinWeights->GetBoneId(skinWeights[0].get().GetBoneName(aznumeric_caster(influence.mNodeNr)));
+                        optimizedSkinWeights->AppendLink(aznumeric_caster(modelVertexIndex), { boneId, influence.mWeight });
+                    }
+                }
             }
             AZStd::unordered_set<size_t> usedIndexes;
             for (size_t polygonIndex = 0; polygonIndex < subMesh->GetNumPolygons(); ++polygonIndex)
@@ -691,26 +738,6 @@ namespace AZ::SceneGenerationComponents
                 AZStd::copy(AZStd::begin(faceInfo.vertexIndex), AZStd::end(faceInfo.vertexIndex), AZStd::inserter(usedIndexes, usedIndexes.begin()));
             }
             indexOffset += static_cast<unsigned int>(usedIndexes.size());
-        }
-
-        AZStd::unique_ptr<SkinWeightData> optimizedSkinWeights;
-        if (MeshBuilder::MeshBuilderSkinningInfo* skinningInfo = meshBuilder.GetSkinningInfo())
-        {
-            optimizedSkinWeights = AZStd::make_unique<SkinWeightData>();
-
-            const size_t skinnedVertexCount = skinningInfo->GetNumOrgVertices();
-            optimizedSkinWeights->ResizeContainerSpace(skinnedVertexCount);
-
-            for (size_t vertex = 0; vertex < skinnedVertexCount; ++vertex)
-            {
-                const size_t boneCountAffectingThisVertex = skinningInfo->GetNumInfluences(vertex);
-                for (size_t influencingBone = 0; influencingBone < boneCountAffectingThisVertex; ++influencingBone)
-                {
-                    const MeshBuilder::MeshBuilderSkinningInfo::Influence& influence = skinningInfo->GetInfluence(vertex, influencingBone);
-                    const int boneId = optimizedSkinWeights->GetBoneId(skinWeights[0].get().GetBoneName(aznumeric_caster(influence.mNodeNr)));
-                    optimizedSkinWeights->AppendLink(vertex, {boneId, influence.mWeight});
-                }
-            }
         }
 
         return AZStd::make_tuple(

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
@@ -213,20 +213,6 @@ namespace AZ::SceneGenerationComponents
         }
     }
 
-    struct InfluenceAccumulator
-    {
-        AZStd::unordered_map<size_t, float> m_accumulatedInfluences;
-        float m_totalWeldedVertexCount = 1.0f;
-
-        void AddInfluence(size_t jointId, float weight)
-        {
-            //clean this up and add unit tests
-            auto iter = m_accumulatedInfluences.insert(AZStd::pair<size_t, float>(jointId, 0.0f)).first;
-            iter->second = ((iter->second * (m_totalWeldedVertexCount - 1.0f)) + weight) / m_totalWeldedVertexCount;
-        }
-    };
-
-
     static AZStd::vector<AZ::MeshBuilder::MeshBuilderSkinningInfo::Influence> ExtractSkinningInfo(
         const AZStd::vector<MeshBuilder::MeshBuilderVertexAttributeLayerSkinInfluence*>& skinningInfluencesLayers,
         const AZ::MeshBuilder::MeshBuilderVertexLookup& vertexLookup,

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
@@ -209,7 +209,7 @@ namespace AZ::SceneGenerationComponents
         auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
         {
-            serializeContext->Class<MeshOptimizerComponent, GenerationComponent>()->Version(11);
+            serializeContext->Class<MeshOptimizerComponent, GenerationComponent>()->Version(5);
         }
     }
 

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
@@ -122,7 +122,7 @@ namespace SceneProcessing
                 for (const auto& link : sourceLinks[vertexIndex])
                 {
                     // Make sure the bone is added to the skin weights
-                    skinWeights->GetBoneId(AZStd::string::format("%d", link.boneId));
+                    skinWeights->GetBoneId(AZStd::to_string(link.boneId));
 
                     skinWeights->AppendLink(vertexIndex, link);
                 }

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
@@ -35,6 +35,21 @@ namespace AZ::SceneAPI::DataTypes
     }
 }
 
+MATCHER(VectorOfLinksEq, "")
+{
+    return testing::ExplainMatchResult(
+        testing::AllOf(
+            testing::Field(&AZ::SceneData::GraphData::SkinWeightData::Link::boneId, testing::Eq(testing::get<0>(arg).boneId)),
+            testing::Field(&AZ::SceneData::GraphData::SkinWeightData::Link::weight, testing::FloatEq(testing::get<0>(arg).weight))),
+        testing::get<1>(arg), result_listener);
+}
+
+MATCHER(VectorOfVectorOfLinksEq, "")
+{
+    return testing::ExplainMatchResult(
+        testing::UnorderedPointwise(VectorOfLinksEq(), testing::get<0>(arg)), testing::get<1>(arg), result_listener);
+}
+
 namespace SceneProcessing
 {
     class VertexDeduplicationFixture
@@ -60,11 +75,12 @@ namespace SceneProcessing
         static AZStd::unique_ptr<AZ::SceneAPI::DataTypes::IMeshData> MakePlaneMesh()
         {
             // Create a simple plane with 2 triangles, 6 total vertices, 2 shared vertices
-            // 0 --- 1
-            // |   / |
-            // |  /  |
-            // | /   |
-            // 2 --- 3
+            // 0,5 --- 1
+            // | \     |
+            // |  \    |
+            // |   \   |
+            // |    \  |
+            // 4 --- 2,3
             const AZStd::array planeVertexPositions = {
                 AZ::Vector3{0.0f, 0.0f, 0.0f},
                 AZ::Vector3{0.0f, 0.0f, 1.0f},
@@ -94,7 +110,28 @@ namespace SceneProcessing
             return mesh;
         }
 
-        static AZStd::unique_ptr<AZ::SceneData::GraphData::SkinWeightData> MakeSkinData()
+        static AZStd::unique_ptr<AZ::SceneData::GraphData::SkinWeightData> MakeSkinData(
+            const AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>>& sourceLinks)
+        {
+            auto skinWeights = AZStd::make_unique<AZ::SceneData::GraphData::SkinWeightData>();
+
+            skinWeights->ResizeContainerSpace(sourceLinks.size());
+
+            for (size_t vertexIndex = 0; vertexIndex < sourceLinks.size(); ++vertexIndex)
+            {
+                for (const auto& link : sourceLinks[vertexIndex])
+                {
+                    // Make sure the bone is added to the skin weights
+                    skinWeights->GetBoneId(AZStd::string::format("%d", link.boneId));
+
+                    skinWeights->AppendLink(vertexIndex, link);
+                }
+            }
+
+            return skinWeights;
+        }
+
+        static AZStd::unique_ptr<AZ::SceneData::GraphData::SkinWeightData> MakeDuplicateSkinData()
         {
             auto skinWeights = AZStd::make_unique<AZ::SceneData::GraphData::SkinWeightData>();
 
@@ -104,14 +141,67 @@ namespace SceneProcessing
             skinWeights->GetBoneId("0");
             skinWeights->GetBoneId("1");
 
-            skinWeights->AppendLink(0, {/*.boneId=*/0, /*.weight=*/1});
-            skinWeights->AppendLink(1, {/*.boneId=*/0, /*.weight=*/1});
-            skinWeights->AppendLink(2, {/*.boneId=*/0, /*.weight=*/1});
-            skinWeights->AppendLink(3, {/*.boneId=*/1, /*.weight=*/1});
-            skinWeights->AppendLink(4, {/*.boneId=*/1, /*.weight=*/1});
-            skinWeights->AppendLink(5, {/*.boneId=*/1, /*.weight=*/1});
+            // Vertices 0,5 and 2,3 have duplicate skin data, in addition to duplicate positions
+            skinWeights->AppendLink(0, { /*.boneId=*/0, /*.weight=*/1 });
+            skinWeights->AppendLink(1, { /*.boneId=*/1, /*.weight=*/1 });
+            skinWeights->AppendLink(2, { /*.boneId=*/0, /*.weight=*/1 });
+            skinWeights->AppendLink(3, { /*.boneId=*/0, /*.weight=*/1 });
+            skinWeights->AppendLink(4, { /*.boneId=*/2, /*.weight=*/1 });
+            skinWeights->AppendLink(5, { /*.boneId=*/0, /*.weight=*/1 });
 
             return skinWeights;
+        }
+
+        static void TestSkinDuplication(
+            const AZStd::shared_ptr<AZ::SceneData::GraphData::SkinWeightData> skinData,
+            const AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>>& expectedLinks)
+        {
+            AZ::SceneAPI::Containers::Scene scene("testScene");
+            AZ::SceneAPI::Containers::SceneGraph& graph = scene.GetGraph();
+
+            const auto meshNodeIndex = graph.AddChild(graph.GetRoot(), "testMesh", MakePlaneMesh());
+            const auto skinDataNodeIndex = graph.AddChild(meshNodeIndex, "skinData", skinData);
+            graph.MakeEndPoint(skinDataNodeIndex);
+
+            // The original source mesh should have 6 vertices
+            EXPECT_EQ(
+                AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::IMeshData>(graph.GetNodeContent(meshNodeIndex))->GetVertexCount(), 6);
+
+            auto meshGroup = AZStd::make_unique<AZ::SceneAPI::SceneData::MeshGroup>();
+            meshGroup->GetSceneNodeSelectionList().AddSelectedNode("testMesh");
+            scene.GetManifest().AddEntry(AZStd::move(meshGroup));
+
+            AZ::SceneGenerationComponents::MeshOptimizerComponent component;
+            AZ::SceneAPI::Events::GenerateSimplificationEventContext context(scene, "pc");
+            component.OptimizeMeshes(context);
+
+            AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedNodeIndex =
+                graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix));
+            ASSERT_TRUE(optimizedNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the mesh";
+
+            const auto& optimizedMesh =
+                AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::IMeshData>(graph.GetNodeContent(optimizedNodeIndex));
+            ASSERT_TRUE(optimizedMesh);
+
+            AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedSkinDataNodeIndex =
+                graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix).append(".skinWeights"));
+            ASSERT_TRUE(optimizedSkinDataNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the skin data";
+
+            const auto& optimizedSkinWeights =
+                AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::ISkinWeightData>(graph.GetNodeContent(optimizedSkinDataNodeIndex));
+            ASSERT_TRUE(optimizedSkinWeights);
+
+            AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>> gotLinks(optimizedMesh->GetVertexCount());
+            for (unsigned int vertexIndex = 0; vertexIndex < optimizedMesh->GetVertexCount(); ++vertexIndex)
+            {
+                for (size_t linkIndex = 0; linkIndex < optimizedSkinWeights->GetLinkCount(vertexIndex); ++linkIndex)
+                {
+                    gotLinks[vertexIndex].emplace_back(optimizedSkinWeights->GetLink(vertexIndex, linkIndex));
+                }
+            }
+            EXPECT_THAT(gotLinks, testing::Pointwise(VectorOfVectorOfLinksEq(), expectedLinks));
+
+            EXPECT_EQ(optimizedMesh->GetVertexCount(), expectedLinks.size());
         }
 
     private:
@@ -147,75 +237,43 @@ namespace SceneProcessing
         EXPECT_EQ(optimizedMesh->GetVertexCount(), 4);
     }
 
-    MATCHER(VectorOfLinksEq, "")
+    TEST_F(VertexDeduplicationFixture, DeduplicatedVerticesKeepUniqueSkinInfluences)
     {
-        return testing::ExplainMatchResult(
-            testing::AllOf(
-                testing::Field(&AZ::SceneData::GraphData::SkinWeightData::Link::boneId, testing::Eq(testing::get<0>(arg).boneId)),
-                testing::Field(&AZ::SceneData::GraphData::SkinWeightData::Link::weight, testing::FloatEq(testing::get<0>(arg).weight))
-            ),
-            testing::get<1>(arg),
-            result_listener
-        );
-    }
-
-    MATCHER(VectorOfVectorOfLinksEq, "")
-    {
-        return testing::ExplainMatchResult(
-            testing::UnorderedPointwise(VectorOfLinksEq(), testing::get<0>(arg)),
-            testing::get<1>(arg),
-            result_listener
-        );
-    }
-
-    TEST_F(VertexDeduplicationFixture, DeduplicatedVerticesRemapSkinning)
-    {
-        AZ::SceneAPI::Containers::Scene scene("testScene");
-        AZ::SceneAPI::Containers::SceneGraph& graph = scene.GetGraph();
-
-        const auto meshNodeIndex = graph.AddChild(graph.GetRoot(), "testMesh", MakePlaneMesh());
-        const auto skinDataNodeIndex = graph.AddChild(meshNodeIndex, "skinData", MakeSkinData());
-        graph.MakeEndPoint(skinDataNodeIndex);
-
-        // The original source mesh should have 6 vertices
-        EXPECT_EQ(AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::IMeshData>(graph.GetNodeContent(meshNodeIndex))->GetVertexCount(), 6);
-
-        auto meshGroup = AZStd::make_unique<AZ::SceneAPI::SceneData::MeshGroup>();
-        meshGroup->GetSceneNodeSelectionList().AddSelectedNode("testMesh");
-        scene.GetManifest().AddEntry(AZStd::move(meshGroup));
-
-        AZ::SceneGenerationComponents::MeshOptimizerComponent component;
-        AZ::SceneAPI::Events::GenerateSimplificationEventContext context(scene, "pc");
-        component.OptimizeMeshes(context);
-
-        AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedNodeIndex = graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix));
-        ASSERT_TRUE(optimizedNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the mesh";
-
-        const auto& optimizedMesh = AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::IMeshData>(graph.GetNodeContent(optimizedNodeIndex));
-        ASSERT_TRUE(optimizedMesh);
-
-        AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedSkinDataNodeIndex = graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix).append(".skinWeights"));
-        ASSERT_TRUE(optimizedSkinDataNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the skin data";
-
-        const auto& optimizedSkinWeights = AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::ISkinWeightData>(graph.GetNodeContent(optimizedSkinDataNodeIndex));
-        ASSERT_TRUE(optimizedSkinWeights);
-
-        const AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>> expectedLinks
-        {
-            /*0*/ { {0, 0.5f}, {1, 0.5f} },
-            /*1*/ { {0, 1.0f} },
-            /*2*/ { {0, 0.5f}, {1, 0.5f} },
-            /*3*/ { {1, 1.0f} },
+        // Vertices 0,5 and 2,3 have duplicate positions, but unique links,
+        // so none of the vertices should be de-duplicated
+        // and the sourceLinks should be the same as the expected links
+        const AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>> sourceLinks{
+            /*0*/ { { 0, 1.0f } },
+            /*1*/ { { 0, 1.0f } },
+            /*2*/ { { 0, 1.0f } },
+            /*3*/ { { 1, 1.0f } },
+            /*4*/ { { 1, 1.0f } },
+            /*5*/ { { 1, 1.0f } },
         };
 
-        AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>> gotLinks(optimizedMesh->GetVertexCount());
-        for (unsigned int vertexIndex = 0; vertexIndex < optimizedMesh->GetVertexCount(); ++vertexIndex)
-        {
-            for (size_t linkIndex = 0; linkIndex < optimizedSkinWeights->GetLinkCount(vertexIndex); ++linkIndex)
-            {
-                gotLinks[vertexIndex].emplace_back(optimizedSkinWeights->GetLink(vertexIndex, linkIndex));
-            }
-        }
-        EXPECT_THAT(gotLinks, testing::Pointwise(VectorOfVectorOfLinksEq(), expectedLinks));
+        TestSkinDuplication(MakeSkinData(sourceLinks), sourceLinks);
+    }
+
+    TEST_F(VertexDeduplicationFixture, DeduplicatedVerticesDeduplicateSkinInfluences)
+    {
+        // Vertices 0,5 and 2,3 have duplicate positions, and also duplicate links,
+        // so they should be de-duplicated and the expected links
+        // should have two fewer links
+        const AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>> sourceLinks{
+            /*0*/ { { 0, 1.0f } },
+            /*1*/ { { 1, 1.0f } },
+            /*2*/ { { 0, 1.0f } },
+            /*3*/ { { 0, 1.0f } },
+            /*4*/ { { 2, 1.0f } },
+            /*5*/ { { 0, 1.0f } },
+        };
+        const AZStd::vector<AZStd::vector<AZ::SceneData::GraphData::SkinWeightData::Link>> expectedLinks{
+            /*0*/ { { 0, 1.0f } },
+            /*1*/ { { 1, 1.0f } },
+            /*2*/ { { 0, 1.0f } },
+            /*3*/ { { 2, 1.0f } },
+        };
+
+        TestSkinDuplication(MakeSkinData(sourceLinks), expectedLinks);
     }
 } // namespace SceneProcessing


### PR DESCRIPTION
This is a new branch to fix DCO validation. Originally reviewed here https://github.com/o3de/o3de/pull/6226

There are two issues that cropped up from treating skin influences separately from the rest of the vertex data

One is that the vertices are 'de-duplicated' if they have the same vertex data but unique skin influences, since the skin influences aren't part of the layer data that is used during de-duplication.

The other issue was that when vertices should legitimately be de-duplicated, the skinning info was stacking multiple copies of the same influence onto a single vertex. So if the vertex had two influences
{0, .75}
{1, .25}
The optimizer would see
{{0, .75}, {1, .25}, {0, .75}, {1, .25}, {0, .75}, {1, .25}, {0, .75}, {1, .25}}
And it would get optimized to
{0, 1.0}
because it sorts by weight, putting all the {0, .75}'s in front, then cuts the lowest weight links (which is all the {1, .25} links), then re-normalizes a vector of four {0, .75} influences to a single {0, 1.0} influence.

And the original extruding vertex on Valena is resolved