### PR TITLE
Disable invalid operations related to procedural prefabs in the Inspector

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -670,21 +670,6 @@ namespace AzToolsFramework
                 return;
             }
 
-            // Don't allow read-only entities to be re-parented at all.
-            // Also don't allow entities to be parented under read-only entities.
-            if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
-                readOnlyEntityPublicInterface->IsReadOnly(GetEntityId()) || readOnlyEntityPublicInterface->IsReadOnly(parentId))
-            {
-                return;
-            }
-
-            // Don't allow entities to be parented under closed containers.
-            if (auto containerEntityInterface = AZ::Interface<ContainerEntityInterface>::Get();
-                !containerEntityInterface->IsContainerOpen(parentId))
-            {
-                return;
-            }
-
             auto oldParentId = m_parentEntityId;
 
             bool canChangeParent = true;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -26,7 +26,9 @@
 #include <AzToolsFramework/Entity/EditorEntityTransformBus.h>
 #include <AzToolsFramework/API/EntityPropertyEditorRequestsBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <AzToolsFramework/ContainerEntity/ContainerEntityInterface.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzToolsFramework/Entity/ReadOnly/ReadOnlyEntityInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponentBus.h>
 #include <AzToolsFramework/ToolsComponents/TransformComponentSerializer.h>
@@ -35,9 +37,8 @@
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 
-#include <QMessageBox>
-
 #include <QMenu>
+#include <QMessageBox>
 
 namespace AzToolsFramework
 {
@@ -662,10 +663,24 @@ namespace AzToolsFramework
                 return;
             }
 
-
             // Prevent this from parenting to its own child. Check if this entity is in the new parent's hierarchy.
             auto potentialParentTransformComponent = GetTransformComponent(parentId);
             if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(GetEntityId()))
+            {
+                return;
+            }
+
+            // Don't allow read-only entities to be re-parented at all.
+            // Also don't allow entities to be parented under read-only entities.
+            if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
+                readOnlyEntityPublicInterface->IsReadOnly(GetEntityId()) || readOnlyEntityPublicInterface->IsReadOnly(parentId))
+            {
+                return;
+            }
+
+            // Don't allow entities to be parented under closed containers.
+            if (auto containerEntityInterface = AZ::Interface<ContainerEntityInterface>::Get();
+                !containerEntityInterface->IsContainerOpen(parentId))
             {
                 return;
             }
@@ -931,14 +946,27 @@ namespace AzToolsFramework
             {
                 return AZ::Failure(AZStd::string("You cannot set an entity's parent to itself!"));
             }
-            else
+
+            // Don't allow the change if it will result in a cycle hierarchy
+            auto potentialParentTransformComponent = GetTransformComponent(actualValue);
+            if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(GetEntityId()))
             {
-                // Don't allow the change if it will result in a cycle hierarchy
-                auto potentialParentTransformComponent = GetTransformComponent(actualValue);
-                if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(GetEntityId()))
-                {
-                    return AZ::Failure(AZStd::string("You cannot set an entity to be a child of one of its own children!"));
-                }
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of one of its own children!"));
+            }
+
+            // Don't allow read-only entities to be re-parented at all.
+            // Also don't allow entities to be parented under read-only entities.
+            if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
+                readOnlyEntityPublicInterface->IsReadOnly(GetEntityId()) || readOnlyEntityPublicInterface->IsReadOnly(actualValue))
+            {
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a read-only entity!"));
+            }
+
+            // Don't allow entities to be parented under closed containers.
+            if (auto containerEntityInterface = AZ::Interface<ContainerEntityInterface>::Get();
+                !containerEntityInterface->IsContainerOpen(actualValue))
+            {
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a closed container!"));
             }
 
             return AZ::Success();
@@ -1245,6 +1273,15 @@ namespace AzToolsFramework
 
         void TransformComponent::AddContextMenuActions(QMenu* menu)
         {
+            bool parentEntityIsReadOnly = false;
+
+            // If the parent entity is marked as read-only, don't allow actions on this transform.
+            if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
+                readOnlyEntityPublicInterface->IsReadOnly(GetEntityId()))
+            {
+                parentEntityIsReadOnly = true;
+            }
+
             if (menu)
             {
                 if (!menu->actions().empty())
@@ -1266,10 +1303,10 @@ namespace AzToolsFramework
 
                     AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);
                 });
-                resetAction->setEnabled(!m_editorTransform.m_locked);
+                resetAction->setEnabled(!m_editorTransform.m_locked && !parentEntityIsReadOnly);
 
                 QString lockString = m_editorTransform.m_locked ? "Unlock transform values" : "Lock transform values";
-                menu->addAction(lockString, [this, lockString]()
+                QAction* lockAction = menu->addAction(lockString, [this, lockString]()
                 {
                     {
                         AzToolsFramework::ScopedUndoBatch undo(lockString.toUtf8().data());
@@ -1278,6 +1315,7 @@ namespace AzToolsFramework
                     }
                     AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_AttributesAndValues);
                 });
+                lockAction->setEnabled(!parentEntityIsReadOnly);
             }
         }
     }


### PR DESCRIPTION
### Disable additional transform component context menu items that allow the user to clear the transform.
![image](https://user-images.githubusercontent.com/82231674/145642417-3d8757fb-f80d-45b8-894b-6a33cf1dc631.png)

### Prevent the user from selecting invalid entities via the entity picker (for example, reparenting entities under a procedural prefab, which is read-only).
![noReparentingViaPicker](https://user-images.githubusercontent.com/82231674/145642505-7af3c05f-9b23-440a-aa3f-02c297252e75.gif)

Fixes #6338 and #6343

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>