### PR TITLE
Cherry-Picking 5eb058f67905c7815458fb3a2a50cb654e4a08a8 to fix PhysX Material Initialize issue

### DIFF
--- a/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.cpp
@@ -7,6 +7,8 @@
  */
 #include <AzCore/Math/MathUtils.h>
 #include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/Component/ComponentApplicationLifecycle.h>
+#include <AzCore/Asset/AssetManager.h>
 
 #include <Scene/PhysXScene.h>
 #include <System/PhysXSystem.h>
@@ -97,7 +99,20 @@ namespace PhysX
             m_systemConfig = *physXConfig;
         }
 
-        AzFramework::AssetCatalogEventBus::Handler::BusConnect();
+        // If the settings registry isn't available, something earlier in startup will report that failure.
+        if (auto* settingsRegistry = AZ::SettingsRegistry::Get();
+            settingsRegistry != nullptr)
+        {
+            // Automatically register the event if it's not registered, because
+            // this system is initialized before the settings registry has loaded the event list.
+            AZ::ComponentApplicationLifecycle::RegisterHandler(
+                *settingsRegistry, m_componentApplicationLifecycleHandler,
+                [this]([[maybe_unused]] AZStd::string_view path, [[maybe_unused]] AZ::SettingsRegistryInterface::Type type)
+                {
+                    InitializeMaterialLibrary();
+                },
+                "LegacySystemInterfaceCreated"); // LegacySystemInterfaceCreated is signaled after critical assets have been processed
+        }
 
         m_state = State::Initialized;
         m_initializeEvent.Signal(&m_systemConfig);
@@ -118,7 +133,7 @@ namespace PhysX
 
         RemoveAllScenes();
 
-        AzFramework::AssetCatalogEventBus::Handler::BusDisconnect();
+        m_componentApplicationLifecycleHandler.Disconnect();
         m_materialLibraryAssetHelper.Disconnect();
         // Clear the asset reference in deactivate. The asset system is shut down before destructors are called
         // for system components, causing any hanging asset references to become crashes on shutdown in release builds.
@@ -362,10 +377,8 @@ namespace PhysX
         return &m_systemConfig;
     }
 
-    void PhysXSystem::OnCatalogLoaded([[maybe_unused]]const char* catalogFile)
+    void PhysXSystem::InitializeMaterialLibrary()
     {
-        // now that assets can be resolved, lets load the default material library.
-        
         if (!m_systemConfig.m_materialLibraryAsset.GetId().IsValid())
         {
             m_onMaterialLibraryLoadErrorEvent.Signal(AzPhysics::SystemEvents::MaterialLibraryLoadErrorType::InvalidId);

--- a/Gems/PhysX/Code/Source/System/PhysXSystem.h
+++ b/Gems/PhysX/Code/Source/System/PhysXSystem.h
@@ -7,10 +7,9 @@
  */
 #pragma once
 
-#include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Interface/Interface.h>
-#include <AzFramework/Asset/AssetCatalogBus.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/Configuration/SystemConfiguration.h>
 
@@ -35,7 +34,6 @@ namespace PhysX
 {
     class PhysXSystem
         : public AZ::Interface<AzPhysics::SystemInterface>::Registrar
-        , private AzFramework::AssetCatalogEventBus::Handler
     {
     public:
         AZ_CLASS_ALLOCATOR_DECL;
@@ -89,10 +87,9 @@ namespace PhysX
         //! @param cookingParams The cooking params to use when setting up PhysX cooking interface. 
         void InitializePhysXSdk(const physx::PxCookingParams& cookingParams);
         void ShutdownPhysXSdk();
-        bool LoadMaterialLibrary();
 
-        // AzFramework::AssetCatalogEventBus::Handler ...
-        void OnCatalogLoaded(const char* catalogFile) override;
+        void InitializeMaterialLibrary();
+        bool LoadMaterialLibrary();
 
         PhysXSystemConfiguration m_systemConfig;
         AzPhysics::SceneConfiguration m_defaultSceneConfiguration;
@@ -145,6 +142,8 @@ namespace PhysX
             OnMaterialLibraryReloadedCallback m_onMaterialLibraryReloadedCallback;
         };
         MaterialLibraryAssetHelper m_materialLibraryAssetHelper;
+
+        AZ::SettingsRegistryInterface::NotifyEventHandler m_componentApplicationLifecycleHandler;
     };
 
     //! Helper function for getting the PhysX System interface from inside the PhysX gem.


### PR DESCRIPTION
This cherry picks the changes from PR #6168 in the development branch to have the PhysXSystem load the material library using the LegacySystemInterfaceCreated lifecycle event