### PR TITLE
Proc Prefabs: Remove feature toggle

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
@@ -14,8 +14,6 @@
 
 namespace AZ::Prefab
 {
-    static constexpr const char s_useProceduralPrefabsKey[] = "/O3DE/Preferences/Prefabs/UseProceduralPrefabs";
-
     // ProceduralPrefabAsset
 
     ProceduralPrefabAsset::ProceduralPrefabAsset(const AZ::Data::AssetId& assetId)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/FileFunc/FileFunc.h>
 
 namespace AZ::Prefab
@@ -58,9 +59,10 @@ namespace AZ::Prefab
 
     bool ProceduralPrefabAsset::UseProceduralPrefabs()
     {
-        bool useProceduralPrefabs = false;
-        bool result = AZ::SettingsRegistry::Get()->GetObject(useProceduralPrefabs, s_useProceduralPrefabsKey);
-        return result && useProceduralPrefabs;
+        bool prefabsEnabled = false;
+        AzFramework::ApplicationRequests::Bus::BroadcastResult(prefabsEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+
+        return prefabsEnabled;
     }
 
     // PrefabDomData

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Procedural/ProceduralPrefabAsset.cpp
@@ -60,7 +60,11 @@ namespace AZ::Prefab
     bool ProceduralPrefabAsset::UseProceduralPrefabs()
     {
         bool prefabsEnabled = false;
-        AzFramework::ApplicationRequests::Bus::BroadcastResult(prefabsEnabled, &AzFramework::ApplicationRequests::IsPrefabSystemEnabled);
+        AzFramework::ApplicationRequests::Bus::Broadcast(
+            [&prefabsEnabled](AzFramework::ApplicationRequests::Bus::Events* ebus)
+        {
+            prefabsEnabled = ebus->IsPrefabSystemEnabled();
+        });
 
         return prefabsEnabled;
     }

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -71,7 +71,7 @@ namespace SceneBuilder
                 context->EnumerateDerived(callback, azrtti_typeid<AZ::SceneAPI::SceneCore::GenerationComponent>(), azrtti_typeid<AZ::SceneAPI::SceneCore::GenerationComponent>());
                 context->EnumerateDerived(callback, azrtti_typeid<AZ::SceneAPI::SceneCore::LoadingComponent>(), azrtti_typeid<AZ::SceneAPI::SceneCore::LoadingComponent>());
             }
-            
+
             AZ::SceneAPI::SceneBuilderDependencyBus::Broadcast(&AZ::SceneAPI::SceneBuilderDependencyRequests::AddFingerprintInfo, fragments);
 
             for (const AZStd::string& element : fragments)
@@ -79,7 +79,7 @@ namespace SceneBuilder
                 m_cachedFingerprint.append(element);
             }
             // A general catch all version fingerprint. Update this to force all FBX files to recompile.
-            m_cachedFingerprint.append("Version 1");
+            m_cachedFingerprint.append("Version 2");
         }
 
         return m_cachedFingerprint.c_str();
@@ -223,7 +223,7 @@ namespace SceneBuilder
 
         // Only used during processing to redirect trace printfs with an warning or error window to the appropriate reporting function.
         TraceMessageHook messageHook;
-        
+
         // Load Scene graph and manifest from the provided path and then initialize them.
         if (m_isShuttingDown)
         {
@@ -282,9 +282,9 @@ namespace SceneBuilder
         }
         for (const AZStd::string& pathDependency : exportProduct.m_legacyPathDependencies)
         {
-            // SceneCore doesn't have access to AssetBuilderSDK, so it doesn't have access to the 
+            // SceneCore doesn't have access to AssetBuilderSDK, so it doesn't have access to the
             //  ProductPathDependency type or the ProductPathDependencyType enum. Exporters registered with the
-            //  Scene Builder should report path dependencies on source files as absolute paths, while dependencies 
+            //  Scene Builder should report path dependencies on source files as absolute paths, while dependencies
             //  on product files should be reported as relative paths.
             if (AzFramework::StringFunc::Path::IsRelative(pathDependency.c_str()))
             {
@@ -314,7 +314,7 @@ namespace SceneBuilder
         using namespace AZ::SceneAPI;
         using namespace AZ::SceneAPI::Containers;
         using namespace AZ::SceneAPI::Events;
-        
+
         AZ_TracePrintf(Utilities::LogWindow, "Loading scene.\n");
 
         SceneSerializationBus::BroadcastResult(result, &SceneSerializationBus::Events::LoadScene, request.m_fullPath, request.m_sourceFileUUID);
@@ -331,7 +331,7 @@ namespace SceneBuilder
             response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Success;
             return false; // Still return false as there's no work so should exit.
         }
-        
+
         return true;
     }
 
@@ -379,7 +379,7 @@ namespace SceneBuilder
         using namespace AZ::SceneAPI::SceneCore;
 
         AZ_Assert(scene, "Invalid scene passed for exporting.");
-        
+
         const AZStd::string& outputFolder = request.m_tempDirPath;
         const char* platformIdentifier = request.m_jobDescription.GetPlatformIdentifier().c_str();
         AZ_TraceContext("Output folder", outputFolder.c_str());


### PR DESCRIPTION
Removes the feature toggle for proc prefabs, enabling them by default whenever the prefab system is enabled.

Also version bumped the scene builder to ensure any existing procedural prefabs are rebuilt