### PR TITLE
[RHI][Vulkan][Android] Don't allow HDR profile for compressing images…

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/ASTCCompressor.cpp
@@ -78,7 +78,7 @@ namespace ImageProcessingAtom
         return true;
     }
 
-    astcenc_profile GetAstcProfile(bool isSrgb, EPixelFormat pixelFormat)
+    astcenc_profile GetAstcProfile(bool isSrgb, EPixelFormat pixelFormat, const AZStd::string& platform = "")
     {
         // select profile depends on LDR or HDR, SRGB or Linear
         //      ASTCENC_PRF_LDR
@@ -87,12 +87,13 @@ namespace ImageProcessingAtom
         //      ASTCENC_PRF_HDR
         
         auto formatInfo = CPixelFormats::GetInstance().GetPixelFormatInfo(pixelFormat);
-        bool isHDR = formatInfo->eSampleType == ESampleType::eSampleType_Half || formatInfo->eSampleType == ESampleType::eSampleType_Float;
+        bool isHDR = (formatInfo->eSampleType == ESampleType::eSampleType_Half || formatInfo->eSampleType == ESampleType::eSampleType_Float) && platform != "android";
         astcenc_profile profile;
         if (isHDR)
         {
             // HDR is not support in core vulkan 1.1 for android.
             // https://arm-software.github.io/vulkan-sdk/_a_s_t_c.html
+            // The check for isHDR takes this into account, setting false for android platform
             profile = isSrgb?ASTCENC_PRF_HDR_RGB_LDR_A:ASTCENC_PRF_HDR;
         }
         else
@@ -170,7 +171,7 @@ namespace ImageProcessingAtom
         auto dstFormatInfo = CPixelFormats::GetInstance().GetPixelFormatInfo(fmtDst);
 
         const float quality = GetAstcCompressQuality(compressOption->compressQuality);
-        const astcenc_profile profile = GetAstcProfile(srcImage->HasImageFlags(EIF_SRGBRead), fmtSrc);
+        const astcenc_profile profile = GetAstcProfile(srcImage->HasImageFlags(EIF_SRGBRead), fmtSrc, compressOption->platform);
 
         astcenc_config config;
         astcenc_error status;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/Compressor.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Compressors/Compressor.h
@@ -39,6 +39,9 @@ namespace ImageProcessingAtom
             //required for CTSquisher
             AZ::Vector3 rgbWeight = AZ::Vector3(0.3333f, 0.3334f, 0.3333f);
             bool discardAlpha = false;
+            // required for HDR profile on android vulkan 1.1 and other platform differences
+            AZStd::string platform = "";
+
         };
 
     public:

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -534,6 +534,7 @@ namespace ImageProcessingAtom
         m_image->GetCompressOption().compressQuality = quality;
         m_image->GetCompressOption().rgbWeight = m_input->m_presetSetting.GetColorWeight();
         m_image->GetCompressOption().discardAlpha = m_input->m_presetSetting.m_discardAlpha;
+        m_image->GetCompressOption().platform = m_input->m_platform;
 
         m_image->ConvertFormat(m_input->m_presetSetting.m_pixelFormat);
 


### PR DESCRIPTION
… on android due to not being supported for android Vulkan core 1.1

Signed-off-by: Peng <tonypeng@amazon.com>