### PR TITLE
LYN-8837 o3de Material Editor - Texture Settings Editor - Hangs when …

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/AlbedoWithGenericAlpha.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/AlbedoWithGenericAlpha.preset
@@ -7,7 +7,7 @@
             "UUID": "{5D9ECB52-4CD9-4CB8-80E3-10CAE5EFB8A2}",
             "Name": "AlbedoWithGenericAlpha",
             "RGB_Weight": "CIEXYZ",
-            "PixelFormat": "ASTC_4x4",
+            "PixelFormat": "BC3",
             "MipMapSetting": {
                 "MipGenType": "Box"
             }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/PixelFormats.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Include/Atom/ImageProcessing/PixelFormats.h
@@ -79,6 +79,7 @@ namespace ImageProcessingAtom
     };
 
     bool IsASTCFormat(EPixelFormat fmt);
+    bool IsHDRFormat(EPixelFormat fmt);
 } // namespace ImageProcessingAtom
 
 namespace AZ

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/ImageLoaders.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/ImageLoader/ImageLoaders.cpp
@@ -8,6 +8,7 @@
 
 
 #include <ImageLoader/ImageLoaders.h>
+#include <Processing/ImageFlags.h>
 #include <Atom/ImageProcessing/ImageObject.h>
 //  warning C4251: class QT_Type needs to have dll-interface to be used by clients of class 'QT_Type'
 AZ_PUSH_DISABLE_WARNING(4251, "-Wunknown-warning-option")
@@ -26,21 +27,31 @@ namespace ImageProcessingAtom
             return nullptr;
         }
 
+        IImageObject* loadedImage = nullptr;
         if (TIFFLoader::IsExtensionSupported(ext.toUtf8()))
         {
-            return TIFFLoader::LoadImageFromTIFF(filename);
+            loadedImage = TIFFLoader::LoadImageFromTIFF(filename);
         }
         else if (DdsLoader::IsExtensionSupported(ext.toUtf8()))
         {
-            return DdsLoader::LoadImageFromFile(filename);
+            loadedImage = DdsLoader::LoadImageFromFile(filename);
         }
         else if (QtImageLoader::IsExtensionSupported(ext.toUtf8()))
         {
-            return QtImageLoader::LoadImageFromFile(filename);
+            loadedImage = QtImageLoader::LoadImageFromFile(filename);
         }
         else if (ExrLoader::IsExtensionSupported(ext.toUtf8()))
         {
-            return ExrLoader::LoadImageFromFile(filename);
+            loadedImage = ExrLoader::LoadImageFromFile(filename);
+        }
+
+        if (loadedImage)
+        {
+            if (IsHDRFormat(loadedImage->GetPixelFormat()))
+            {
+                loadedImage->AddImageFlags(EIF_HDR);
+            }
+            return loadedImage;
         }
 
         AZ_Warning("ImageProcessing", false, "No proper image loader to load file: %s", filename.c_str());

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageFlags.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageFlags.h
@@ -19,7 +19,7 @@ namespace ImageProcessingAtom
     const static AZ::u32 EIF_Decal = 0x4;  // this is usually set through the preset
     const static AZ::u32 EIF_Greyscale = 0x8;  // hint for the engine (e.g. greyscale light beams can be applied to shadow mask), can be for DXT1 because compression artfacts don't count as color
     const static AZ::u32 EIF_SupressEngineReduce = 0x10;  // info for the engine: don't reduce texture resolution on this texture
-    const static AZ::u32 EIF_UNUSED_BIT = 0x40;  // Free to use
+    const static AZ::u32 EIF_HDR = 0x40;  // the image contains HDR data
     const static AZ::u32 EIF_AttachedAlpha = 0x400;  // deprecated: info for the engine: it's a texture with attached alpha channel
     const static AZ::u32 EIF_SRGBRead = 0x800;  // info for the engine: if gamma corrected rendering is on, this texture requires SRGBRead (it's not stored in linear)
     const static AZ::u32 EIF_DontResize = 0x8000; // info for the engine: for dds textures that shouldn't be resized

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/PixelFormatInfo.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/PixelFormatInfo.cpp
@@ -52,6 +52,24 @@ namespace ImageProcessingAtom
         return false;
     }
 
+    bool IsHDRFormat(EPixelFormat fmt)
+    {
+        switch (fmt)
+        {
+        case ePixelFormat_BC6UH:
+        case ePixelFormat_R9G9B9E5:
+        case ePixelFormat_R32G32B32A32F:
+        case ePixelFormat_R32G32F:
+        case ePixelFormat_R32F:
+        case ePixelFormat_R16G16B16A16F:
+        case ePixelFormat_R16G16F:
+        case ePixelFormat_R16F:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     PixelFormatInfo::PixelFormatInfo(
         uint32_t    a_bitsPerPixel,
         uint32_t    a_Channels,


### PR DESCRIPTION
…converting texture

Fixed a editor hanging issue when preview texture with astc format (starts multiple job threads inside a job thread)
Fixed an issue of changing texture setting didn't trigger image re-process.
Fixed an issue with image asset which has texture setting may have dependency with wrong preset
Added a EIF_HDR for source image in hdr format.
Fixed astc compression issue which may wrongly compress image to HDR astc format

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>