### PR TITLE
Change Vulkan RHI CommandList::SetStreamBuffers to not do 2 memory allocation per draw by using fixed_vector

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/CommandList.cpp
@@ -6,6 +6,7 @@
  *
  */
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/containers/fixed_vector.h>
 #include <AzCore/std/parallel/lock.h>
 #include <RHI/Buffer.h>
 #include <RHI/BufferView.h>
@@ -688,8 +689,8 @@ namespace AZ
             if (interval != InvalidInterval)
             {
                 uint32_t numBuffers = interval.m_max - interval.m_min + 1;
-                AZStd::vector<VkBuffer> nativeBuffers(numBuffers, VK_NULL_HANDLE);
-                AZStd::vector<VkDeviceSize> offsets(numBuffers, 0);
+                AZStd::fixed_vector<VkBuffer, RHI::Limits::Pipeline::StreamCountMax> nativeBuffers(numBuffers, VK_NULL_HANDLE);
+                AZStd::fixed_vector<VkDeviceSize, RHI::Limits::Pipeline::StreamCountMax> offsets(numBuffers, 0);
                 for (uint32_t i = 0; i < numBuffers; ++i)
                 {
                     const RHI::StreamBufferView& bufferView = streams[i + interval.m_min];


### PR DESCRIPTION
Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>