### PR TITLE
Force Project Manager to generate VS2019 projects on Windows

### DIFF
--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectBuilderWorker_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectBuilderWorker_windows.cpp
@@ -19,6 +19,7 @@ namespace O3DE::ProjectManager
         QString targetBuildPath = QDir(m_projectInfo.m_path).filePath(ProjectBuildPathPostfix);
 
         return AZ::Success(QStringList{ ProjectCMakeCommand,
+                                        "-G", "Visual Studio 16 2019"
                                         "-B", targetBuildPath,
                                         "-S", m_projectInfo.m_path,
                                         QString("-DLY_3RDPARTY_PATH=").append(thirdPartyPath),

--- a/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
+++ b/Code/Tools/ProjectManager/Platform/Windows/ProjectUtils_windows.cpp
@@ -77,7 +77,7 @@ namespace O3DE::ProjectManager
             if (vsWhereFile.exists() && vsWhereFile.isFile())
             {
                 QStringList vsWhereBaseArguments = QStringList{"-version",
-                                                               "16.9.2",
+                                                               "[16.9.2,17)",
                                                                "-latest",
                                                                "-requires",
                                                                "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"};


### PR DESCRIPTION
Force Project Manager to check for and generate projects with a supported version of VS 2019. 

Signed-off-by: AMZN-Phil <pconroy@amazon.com>