### PR TITLE
Fix: AssetBrowserTest cannot be run in debug

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/UI/AssetBrowserTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/UI/AssetBrowserTests.cpp
@@ -74,10 +74,6 @@ namespace UnitTest
         AZStd::unique_ptr<AzToolsFramework::AssetBrowser::AssetBrowserFilterModel> m_filterModel;
         AZStd::unique_ptr<AzToolsFramework::AssetBrowser::AssetBrowserTableModel> m_tableModel;
 
-        AZStd::unique_ptr<QAbstractItemModelTester> m_modelTesterAssetBrowser;
-        AZStd::unique_ptr<QAbstractItemModelTester> m_modelTesterFilterModel;
-        AZStd::unique_ptr<QAbstractItemModelTester> m_modelTesterTableModel;
-
         QVector<int> m_folderIds = { 13, 14, 15 };
         QVector<int> m_sourceIDs = { 1, 2, 3, 4, 5 };
         QVector<int> m_productIDs = { 1, 2, 3, 4, 5 };
@@ -96,9 +92,6 @@ namespace UnitTest
         m_filterModel->setSourceModel(m_assetBrowserComponent->GetAssetBrowserModel());
         m_tableModel->setSourceModel(m_filterModel.get());
 
-        m_modelTesterAssetBrowser = AZStd::make_unique<QAbstractItemModelTester>(m_assetBrowserComponent->GetAssetBrowserModel());
-        m_modelTesterFilterModel = AZStd::make_unique<QAbstractItemModelTester>(m_filterModel.get());
-        m_modelTesterTableModel = AZStd::make_unique<QAbstractItemModelTester>(m_tableModel.get());
         m_searchWidget = AZStd::make_unique<AzToolsFramework::AssetBrowser::SearchWidget>();
 
         // Setup String filters
@@ -110,10 +103,6 @@ namespace UnitTest
 
     void AssetBrowserTest::TearDownEditorFixtureImpl()
     {
-        m_modelTesterAssetBrowser.reset();
-        m_modelTesterFilterModel.reset();
-        m_modelTesterTableModel.reset();
-
         m_tableModel.reset();
         m_filterModel.reset();
         m_assetBrowserComponent->Deactivate();


### PR DESCRIPTION
I have been looking into this for a while now and it has something to do with how the product addition to the AssetBrowserModel is being mocked. For now I deleted the conflicting lines that are triggering the assert so it doesn't affect productivity but I am working on a proper solution that might take a little bit more time.

I am also looking into this.
```
QSortFilterProxyModel: inconsistent changes reported by source model
```
It is some issue related to how rows are currently being removed #6404 

closes #6148
Signed-off-by: AMZN-Igarri <82394219+AMZN-Igarri@users.noreply.github.com>