### PR TITLE
Renamed 'Python Console' to 'Python Terminal'

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/PythonTerminal/ScriptTermDialog.h
@@ -25,7 +25,7 @@
 #endif
 
 
-#define SCRIPT_TERM_WINDOW_NAME "Python Console"
+#define SCRIPT_TERM_WINDOW_NAME "Python Terminal"
 
 class QStringListModel;
 namespace Ui {


### PR DESCRIPTION
Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>
Fixes #3503