### PR TITLE
[AudioSystem] ACE bug fix: Ctrl-S doesn't work correctly when a level is loaded.

### DIFF
--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorMainWindow.ui
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorMainWindow.ui
@@ -154,6 +154,9 @@
    <property name="text">
     <string>Save All</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
   </action>
   <action name="actionReload">
    <property name="icon">

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.cpp
@@ -122,27 +122,6 @@ namespace AudioControls
     }
 
     //-------------------------------------------------------------------------------------------//
-    void CAudioControlsEditorWindow::keyPressEvent(QKeyEvent* pEvent)
-    {
-        if (pEvent->key() == Qt::Key_S && pEvent->modifiers() == Qt::ControlModifier)
-        {
-            Save();
-        }
-        else if (pEvent->key() == Qt::Key_Z && (pEvent->modifiers() & Qt::ControlModifier))
-        {
-            if (pEvent->modifiers() & Qt::ShiftModifier)
-            {
-                GetIEditor()->Redo();
-            }
-            else
-            {
-                GetIEditor()->Undo();
-            }
-        }
-        QMainWindow::keyPressEvent(pEvent);
-    }
-
-    //-------------------------------------------------------------------------------------------//
     void CAudioControlsEditorWindow::closeEvent(QCloseEvent* pEvent)
     {
         if (m_pATLModel && m_pATLModel->IsDirty())

--- a/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.h
+++ b/Gems/AudioSystem/Code/Source/Editor/AudioControlsEditorWindow.h
@@ -63,7 +63,6 @@ namespace AudioControls
         void Update();
 
     protected:
-        void keyPressEvent(QKeyEvent* pEvent) override;
         void closeEvent(QCloseEvent* pEvent) override;
 
     private:


### PR DESCRIPTION
Audio Controls Editor bug fix: Ctrl-S doesn't work correctly when a level is loaded. The level is saved instead of audio controls.

This is due to how ACE handles shortcuts. It uses keyPressEvent() but in this case the keyboard event intercepted somewhere in the editor and ACE doesn't have a chance to handle it. The correct way is to use QAction with shortcut.

PR also removes unnecessary shortcut handling for the global undo/redo functionality.