### PR TITLE
Fix missing parent class reflection for ProceduralPrefabSystemComponent

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/ProceduralPrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/ProceduralPrefabSystemComponent.cpp
@@ -24,7 +24,7 @@ namespace AzToolsFramework
         {
             if (auto serializationContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
-                serializationContext->Class<ProceduralPrefabSystemComponent>();
+                serializationContext->Class<ProceduralPrefabSystemComponent, AZ::Component>();
             }
         }
 


### PR DESCRIPTION
Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>