### PR TITLE
Atom/antonmic/pass attachment clear

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardColorResolvePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardColorResolvePass.cpp
@@ -166,7 +166,7 @@ namespace AZ
                         {
                             if (binding2.m_attachment == attachment)
                             {
-                                binding2.m_unifiedScopeDesc.m_attachmentId = nextAttachmentImage->GetAttachmentId();
+                                binding2.SetScopeDescriptorAttachmentId(nextAttachmentImage->GetAttachmentId());
                                 break;
                             }
                         }

--- a/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Checkerboard/CheckerboardPass.cpp
@@ -131,7 +131,7 @@ namespace AZ
                         {
                             if (binding.m_attachment == attachment)
                             {
-                                binding.m_unifiedScopeDesc.m_attachmentId = nextAttachment->GetAttachmentId();
+                                binding.SetScopeDescriptorAttachmentId(nextAttachment->GetAttachmentId());
                                 break;
                             }
                         }

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -129,7 +129,7 @@ namespace AZ
             RHI::AttachmentLoadStoreAction action;
             action.m_clearValue = RHI::ClearValue::CreateDepth(1.f);
             action.m_loadAction = m_clearEnabled ? RHI::AttachmentLoadAction::Clear : RHI::AttachmentLoadAction::DontCare;
-            binding.m_unifiedScopeDesc = RHI::UnifiedScopeAttachmentDescriptor(attachmentId, imageViewDescriptor, action);
+            binding.SetUnifiedScopeAttachmentDescriptor(RHI::UnifiedScopeAttachmentDescriptor(attachmentId, imageViewDescriptor, action));
 
             Base::BuildInternal();
         }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomBlurPass.cpp
@@ -155,7 +155,7 @@ namespace AZ
             RHI::ImageViewDescriptor viewDesc;
             viewDesc.m_mipSliceMin = static_cast<uint16_t>(mipLevel);
             viewDesc.m_mipSliceMax = static_cast<uint16_t>(mipLevel);
-            inBinding.m_unifiedScopeDesc.SetAsImage(viewDesc);
+            inBinding.SetImageViewDescriptor(viewDesc);
 
             pass->AddAttachmentBinding(inBinding);
 
@@ -169,7 +169,7 @@ namespace AZ
             outBinding.m_connectedBinding = isHorizontalPass ? &parentInBinding : &parentInOutBinding;
 
             // Output to the same mip level as input downsampled texture
-            outBinding.m_unifiedScopeDesc.SetAsImage(viewDesc);
+            outBinding.SetImageViewDescriptor(viewDesc);
 
             pass->AddAttachmentBinding(outBinding);
         }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomCompositePass.cpp
@@ -135,7 +135,7 @@ namespace AZ
             RHI::ImageViewDescriptor inViewDesc;
             inViewDesc.m_mipSliceMin = static_cast<uint16_t>(mipLevel);
             inViewDesc.m_mipSliceMax = static_cast<uint16_t>(mipLevel);
-            inBinding.m_unifiedScopeDesc.SetAsImage(inViewDesc);
+            inBinding.SetImageViewDescriptor(inViewDesc);
 
             pass->AddAttachmentBinding(inBinding);
 
@@ -153,7 +153,7 @@ namespace AZ
                 RHI::ImageViewDescriptor outViewDesc;
                 outViewDesc.m_mipSliceMin = static_cast<uint16_t>(mipLevel - 1);
                 outViewDesc.m_mipSliceMax = static_cast<uint16_t>(mipLevel - 1);
-                outBinding.m_unifiedScopeDesc.SetAsImage(outViewDesc);
+                outBinding.SetImageViewDescriptor(outViewDesc);
             }
             
             pass->AddAttachmentBinding(outBinding);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/BloomDownsamplePass.cpp
@@ -64,8 +64,8 @@ namespace AZ
                 RHI::ImageViewDescriptor outViewDesc;
                 outViewDesc.m_mipSliceMin = i;
                 outViewDesc.m_mipSliceMax = i;
-                outBinding.m_unifiedScopeDesc.SetAsImage(outViewDesc);
-                outBinding.m_unifiedScopeDesc.m_attachmentId = outAttachment->GetAttachmentId();
+
+                outBinding.SetUnifiedScopeAttachmentDescriptor(RHI::UnifiedScopeAttachmentDescriptor(outAttachment->GetAttachmentId(), outViewDesc));
 
                 AddAttachmentBinding(outBinding);
             }

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/TaaPass.cpp
@@ -83,11 +83,11 @@ namespace AZ::Render
         Offset offset = m_subPixelOffsets.at(m_offsetIndex);
         view->SetClipSpaceOffset(offset.m_xOffset * rcpInputSize.GetX(), offset.m_yOffset * rcpInputSize.GetY());
 
-        m_lastFrameAccumulationBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex]);
+        m_lastFrameAccumulationBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex], *this);
         m_accumulationOuptutIndex ^= 1; // swap which attachment is the output and last frame
 
         UpdateAttachmentImage(m_accumulationAttachments[m_accumulationOuptutIndex]);
-        m_outputColorBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex]);
+        m_outputColorBinding->SetAttachment(m_accumulationAttachments[m_accumulationOuptutIndex], *this);
         
         Base::FrameBeginInternal(params);
     }
@@ -135,8 +135,8 @@ namespace AZ::Render
         // ensure SRG indices are set up correctly by the pass system.
         if (m_lastFrameAccumulationBinding->m_attachment == nullptr)
         {
-            m_lastFrameAccumulationBinding->SetAttachment(m_accumulationAttachments[0]);
-            m_outputColorBinding->SetAttachment(m_accumulationAttachments[1]);
+            m_lastFrameAccumulationBinding->SetAttachment(m_accumulationAttachments[0], *this);
+            m_outputColorBinding->SetAttachment(m_accumulationAttachments[1], *this);
         }
 
         Base::BuildInternal();

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -151,12 +151,12 @@ namespace AZ
             {
                 // mip0 source input
                 RPI::PassAttachmentBinding& inputAttachmentBinding = verticalBlurChildPass->GetInputOutputBinding(0);
-                inputAttachmentBinding.SetAttachment(reflectionImageAttachment);
+                inputAttachmentBinding.SetAttachment(reflectionImageAttachment, *this);
                 inputAttachmentBinding.m_connectedBinding = &GetInputOutputBinding(0);
 
                 // mipN transient output
                 RPI::PassAttachmentBinding& outputAttachmentBinding = verticalBlurChildPass->GetInputOutputBinding(1);
-                outputAttachmentBinding.SetAttachment(transientPassAttachments[attachmentIndex]);
+                outputAttachmentBinding.SetAttachment(transientPassAttachments[attachmentIndex], *this);
 
                 // setup downsampled depth output
                 // Note: this is a vertical pass output only, and each vertical child pass writes a specific mip level
@@ -167,8 +167,8 @@ namespace AZ
                 RHI::ImageViewDescriptor downsampledDepthOutputViewDesc;
                 downsampledDepthOutputViewDesc.m_mipSliceMin = static_cast<int16_t>(mipLevel);
                 downsampledDepthOutputViewDesc.m_mipSliceMax = static_cast<int16_t>(mipLevel);
-                downsampledDepthAttachmentBinding.m_unifiedScopeDesc.SetAsImage(downsampledDepthOutputViewDesc);
-                downsampledDepthAttachmentBinding.SetAttachment(downsampledDepthImageAttachment);
+                downsampledDepthAttachmentBinding.SetImageViewDescriptor(downsampledDepthOutputViewDesc);
+                downsampledDepthAttachmentBinding.SetAttachment(downsampledDepthImageAttachment, *this);
 
                 attachmentIndex++;
             }
@@ -178,15 +178,15 @@ namespace AZ
             for (auto& horizontalBlurChildPass : m_horizontalBlurChildPasses)
             {
                 RPI::PassAttachmentBinding& inputAttachmentBinding = horizontalBlurChildPass->GetInputOutputBinding(0);
-                inputAttachmentBinding.SetAttachment(transientPassAttachments[attachmentIndex]);
+                inputAttachmentBinding.SetAttachment(transientPassAttachments[attachmentIndex], *this);
 
                 RPI::PassAttachmentBinding& outputAttachmentBinding = horizontalBlurChildPass->GetInputOutputBinding(1);
                 uint32_t mipLevel = attachmentIndex + 1;
                 RHI::ImageViewDescriptor outputViewDesc;
                 outputViewDesc.m_mipSliceMin = static_cast<int16_t>(mipLevel);
                 outputViewDesc.m_mipSliceMax = static_cast<int16_t>(mipLevel);
-                outputAttachmentBinding.m_unifiedScopeDesc.SetAsImage(outputViewDesc);
-                outputAttachmentBinding.SetAttachment(reflectionImageAttachment);
+                outputAttachmentBinding.SetImageViewDescriptor(outputViewDesc);
+                outputAttachmentBinding.SetAttachment(reflectionImageAttachment, *this);
 
                 attachmentIndex++;
             }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAttachmentReflect.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassAttachmentReflect.h
@@ -248,6 +248,9 @@ namespace AZ
 
             //! Reference to an external attachment asset, which used for imported attachment
             AssetReference m_assetRef;
+
+            //! This load store action can be used to force a clear of the attachment on it's first usage by a RenderPass in a frame 
+            RHI::AttachmentLoadStoreAction m_loadStoreAction;
         };
 
         //! A PassAttachmentDesc used for images

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/CopyPass.cpp
@@ -101,7 +101,7 @@ namespace AZ
                 m_ownedAttachments.push_back(dest);
 
                 // Set the output binding to the new attachment
-                GetOutputBinding(0).SetAttachment(dest);
+                GetOutputBinding(0).SetAttachment(dest, *this);
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/MSAAResolvePass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/MSAAResolvePass.cpp
@@ -54,7 +54,7 @@ namespace AZ
             const AZ::RPI::PassAttachmentBinding& copySource = GetInputBinding(0);
             const AZ::RPI::PassAttachmentBinding& copyDest = GetOutputBinding(0);
 
-            frameGraph.UseColorAttachment(copySource.m_unifiedScopeDesc.GetAsImage());
+            frameGraph.UseColorAttachment(copySource.GetImageScopeDescriptor());
 
             RHI::ResolveScopeAttachmentDescriptor descriptor;
             descriptor.m_attachmentId = copyDest.m_attachment->GetAttachmentId();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -421,7 +421,7 @@ namespace AZ
             attachment->m_importedResource = buffer;
             m_ownedAttachments.push_back(attachment);
 
-            localBinding->SetAttachment(attachment);
+            localBinding->SetAttachment(attachment, *this);
             localBinding->m_originalAttachment = attachment;
         }
         
@@ -453,7 +453,7 @@ namespace AZ
             attachment->m_importedResource = image;
             m_ownedAttachments.push_back(attachment);
 
-            localBinding->SetAttachment(attachment);
+            localBinding->SetAttachment(attachment, *this);
             localBinding->m_originalAttachment = attachment;
         }               
 
@@ -488,7 +488,7 @@ namespace AZ
                 AZ_RPI_PASS_ERROR(attachment, "Pass::ProcessConnection - Pass [%s] doesn't own an attachment named [%s].",
                     m_path.GetCStr(),
                     connectedSlotName.GetCStr());
-                localBinding->SetAttachment(attachment);
+                localBinding->SetAttachment(attachment, *this);
                 localBinding->m_originalAttachment = attachment;
                 return;
             }
@@ -1032,7 +1032,7 @@ namespace AZ
                 return;
             }
 
-            binding.SetAttachment(targetAttachment);
+            binding.SetAttachment(targetAttachment, *this);
         }
 
         void Pass::UpdateConnectedBindings()

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/RenderPass.cpp
@@ -223,16 +223,16 @@ namespace AZ
                 if (attachmentBinding.m_attachment != nullptr &&
                     frameGraph.GetAttachmentDatabase().IsAttachmentValid(attachmentBinding.m_attachment->GetAttachmentId()))
                 {
-                    switch (attachmentBinding.m_unifiedScopeDesc.GetType())
+                    switch (attachmentBinding.GetAttachmentType())
                     {
                     case RHI::AttachmentType::Image:
                     {
-                        frameGraph.UseAttachment(attachmentBinding.m_unifiedScopeDesc.GetAsImage(), attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
+                        frameGraph.UseAttachment(attachmentBinding.GetImageScopeDescriptor(), attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
                         break;
                     }
                     case RHI::AttachmentType::Buffer:
                     {
-                        frameGraph.UseAttachment(attachmentBinding.m_unifiedScopeDesc.GetAsBuffer(), attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
+                        frameGraph.UseAttachment(attachmentBinding.GetBufferScopeDescriptor(), attachmentBinding.GetAttachmentAccess(), attachmentBinding.m_scopeAttachmentUsage);
                         break;
                     }
                     default:
@@ -277,7 +277,7 @@ namespace AZ
                         inputIndex = imageIndex;
                     }
                     const RHI::ImageView* imageView =
-                        context.GetImageView(attachment->GetAttachmentId(), binding.m_unifiedScopeDesc.GetImageViewDescriptor(), binding.m_scopeAttachmentUsage);
+                        context.GetImageView(attachment->GetAttachmentId(), binding.GetImageViewDescriptor(), binding.m_scopeAttachmentUsage);
 
                     if (binding.m_shaderImageDimensionsNameIndex.HasName())
                     {

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleMipChainPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/DownsampleMipChainPass.cpp
@@ -124,7 +124,7 @@ namespace AZ
                     RHI::ImageViewDescriptor inViewDesc;
                     inViewDesc.m_mipSliceMin = mip;
                     inViewDesc.m_mipSliceMax = mip;
-                    inBinding.m_unifiedScopeDesc.SetAsImage(inViewDesc);
+                    inBinding.SetImageViewDescriptor(inViewDesc);
 
                     childPass->AddAttachmentBinding(inBinding);
                 }
@@ -141,7 +141,7 @@ namespace AZ
                     RHI::ImageViewDescriptor outViewDesc;
                     outViewDesc.m_mipSliceMin = mip + 1;
                     outViewDesc.m_mipSliceMax = mip + 1;
-                    outBinding.m_unifiedScopeDesc.SetAsImage(outViewDesc);
+                    outBinding.SetImageViewDescriptor(outViewDesc);
 
                     childPass->AddAttachmentBinding(outBinding);
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
@@ -203,7 +203,7 @@ namespace AZ
             if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
             {
                 serializeContext->Class<PassAttachmentDesc>()
-                    ->Version(2)    // Removing PassAttachmentArraySizeSource class
+                    ->Version(3)    // Making PassAttachment have their own load store action
                     ->Field("Name", &PassAttachmentDesc::m_name)
                     ->Field("Lifetime", &PassAttachmentDesc::m_lifetime)
                     ->Field("SizeSource", &PassAttachmentDesc::m_sizeSource)
@@ -211,6 +211,7 @@ namespace AZ
                     ->Field("FormatSource", &PassAttachmentDesc::m_formatSource)
                     ->Field("MultisampleSource", &PassAttachmentDesc::m_multisampleSource)
                     ->Field("AssetRef", &PassAttachmentDesc::m_assetRef)
+                    ->Field("LoadStoreAction", &PassSlot::m_loadStoreAction)
                     ;
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Pass/PassAttachmentReflect.cpp
@@ -211,7 +211,7 @@ namespace AZ
                     ->Field("FormatSource", &PassAttachmentDesc::m_formatSource)
                     ->Field("MultisampleSource", &PassAttachmentDesc::m_multisampleSource)
                     ->Field("AssetRef", &PassAttachmentDesc::m_assetRef)
-                    ->Field("LoadStoreAction", &PassSlot::m_loadStoreAction)
+                    ->Field("LoadStoreAction", &PassAttachmentDesc::m_loadStoreAction)
                     ;
             }
         }


### PR DESCRIPTION
Added functionality to specify a load store action directly on a pass attachment. If this action is a clear, it can override the action on the first RenderPass that used the attachment in the frame, allowing an attachment to be cleared while being passed through a disabled pass as a fallback.
This was blocking dmcdiarmid-ly