### PR TITLE
Minor optimizations from profiling.

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/CommandListValidator.cpp
@@ -56,7 +56,6 @@ namespace AZ
             {
                 return true;
             }
-            AZ_PROFILE_FUNCTION(RHI);
             ValidateViewContext context;
             context.m_scopeName = m_scope->GetId().GetCStr();
             context.m_srgName = shaderResourceGroup.GetName().GetCStr();

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -248,8 +248,6 @@ namespace AZ
 
         void ShaderResourceGroupPool::CompileGroupsForInterval(Interval interval)
         {
-            AZ_PROFILE_SCOPE(RHI, "CompileGroupsForInterval");
-
             AZ_Assert(m_isCompiling, "You must call CompileGroupsBegin() first!");
             AZ_Assert(
                 interval.m_max >= interval.m_min &&
@@ -259,6 +257,8 @@ namespace AZ
             for (uint32_t i = interval.m_min; i < interval.m_max; ++i)
             {
                 ShaderResourceGroup* group = m_groupsToCompile[i];
+                AZ_PROFILE_SCOPE(RHI, "CompileGroupsForInterval %s", group->GetName().GetCStr());
+
                 CompileGroupInternal(*group, group->GetData());
                 group->m_isQueuedForCompile = false;
             }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandList.h
@@ -390,7 +390,6 @@ namespace AZ
             }
 
             const PipelineLayout& pipelineLayout = pipelineState->GetPipelineLayout();
-            const RHI::PipelineLayoutDescriptor& pipelineLayoutDescriptor = pipelineLayout.GetPipelineLayoutDescriptor();
 
             // Pull from slot bindings dictated by the pipeline layout. Re-bind anything that has changed
             // at the flat index level.
@@ -499,12 +498,15 @@ namespace AZ
                     }
                 }
 
+#if defined (AZ_RHI_ENABLE_VALIDATION)
                 if (updatePipelineState || updateSRG)
                 {
+                    const RHI::PipelineLayoutDescriptor& pipelineLayoutDescriptor = pipelineLayout.GetPipelineLayoutDescriptor();
                     m_validator.ValidateShaderResourceGroup(
                         *shaderResourceGroup,
                         pipelineLayoutDescriptor.GetShaderResourceGroupBindingInfo(srgIndex));
                 }
+#endif
             }
             return true;
         }


### PR DESCRIPTION
Remove noisy profile marker in the SRG validator
Make the SRG compile marker say which srg is being compiled
Move some dx12 validation code behind the AZ_RHI_ENABLE_VALIDATION define

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>