### PR TITLE
Add MainPipeline to pass hierarchy for when HDR color grading component requests for the lut generation's image attachment.

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/ColorGrading/EditorHDRColorGradingComponent.cpp
@@ -199,7 +199,10 @@ namespace AZ
             }
 
             const char* LutAttachment = "LutOutput";
-            const AZStd::vector<AZStd::string> LutGenerationPassHierarchy{ "LutGenerationPass" };
+            const AZStd::vector<AZStd::string> LutGenerationPassHierarchy{
+                "MainPipeline_0",
+                "LutGenerationPass"
+            };
 
             char resolvedOutputFilePath[AZ_MAX_PATH_LEN] = { 0 };
             AZ::IO::FileIOBase::GetDirectInstance()->ResolvePath(m_currentTiffFilePath.c_str(), resolvedOutputFilePath, AZ_MAX_PATH_LEN);


### PR DESCRIPTION
Color grading component was unable to get the correct pass attachment when generating the LUT. The fix is to add the render pipeline name on the pass hierarchy request. 