### PR TITLE
[Bugfix] Atom render viewport in animation editor - small fix

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -326,6 +326,9 @@ namespace EMStudio
         Camera::Configuration cameraConfig;
         cameraConfig.m_fovRadians = AZ::DegToRad(m_renderOptions->GetFOV());
         cameraConfig.m_nearClipDistance = m_renderOptions->GetNearClipPlaneDistance();
+        cameraConfig.m_farClipDistance = m_renderOptions->GetFarClipPlaneDistance();
+        cameraConfig.m_frustumWidth = DefaultFrustumDimension;
+        cameraConfig.m_frustumHeight = DefaultFrustumDimension;
 
         preset->ApplyLightingPreset(
             iblFeatureProcessor, m_skyboxFeatureProcessor, exposureControlSettingInterface, m_directionalLightFeatureProcessor,

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.h
@@ -89,6 +89,7 @@ namespace EMStudio
         AZStd::vector<AZ::Entity*> m_actorEntities;
         const RenderOptions* m_renderOptions;
 
+        const float DefaultFrustumDimension = 128.0f;
         AZStd::vector<AZ::Render::DirectionalLightFeatureProcessorInterface::LightHandle> m_lightHandles;
     };
 }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportToolBar.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportToolBar.cpp
@@ -162,6 +162,7 @@ namespace EMStudio
 
         const bool isChecked = settings.value("CameraFollowUp", false).toBool();
         m_followCharacterAction->setChecked(isChecked);
+        AnimViewportRequestBus::Broadcast(&AnimViewportRequestBus::Events::SetFollowCharacter, isChecked);
     }
 
     void AnimViewportToolBar::SaveSettings()


### PR DESCRIPTION
1. Feed the correct camera config value to light processor to avoid triggering assert 
2. When the follow mode is on, it doesn't follow the character on the start.
Signed-off-by: rhhong <rhhong@amazon.com>