### PR TITLE
Quaternion to scaled-axis angle representation (and back) helpers

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.cpp
@@ -254,12 +254,12 @@ namespace AZ
                 Method("CreateFromMatrix3x3", &Quaternion::CreateFromMatrix3x3)->
                 Method("CreateFromMatrix4x4", &Quaternion::CreateFromMatrix4x4)->
                 Method("CreateFromAxisAngle", &Quaternion::CreateFromAxisAngle)->
+                Method("CreateFromScaledAxisAngle", &Quaternion::CreateFromScaledAxisAngle)->
                 Method("CreateShortestArc", &Quaternion::CreateShortestArc)->
                 Method("CreateFromEulerAnglesDegrees", &Quaternion::CreateFromEulerAnglesDegrees)
                 ;
         }
     }
-
 
     Quaternion Quaternion::CreateFromMatrix3x3(const Matrix3x3& m)
     {
@@ -428,6 +428,26 @@ namespace AZ
         {
             outAxis.Set(0.0f, 1.0f, 0.0f);
             outAngle = 0.0f;
+        }
+    }
+
+
+    Vector3 Quaternion::ConvertToScaledAxisAngle() const
+    {
+        // Take the log of the quaternion to convert it to the exponential map
+        // and multiply it by 2.0 to bring it into the scaled axis-angle representation.
+        const AZ::Vector3 imaginary = GetImaginary();
+        const float length = imaginary.GetLength();
+        if (length < AZ::Constants::FloatEpsilon)
+        {
+            return imaginary * 2.0f;
+        }
+        else
+        {
+            const float halfAngle = acosf(AZ::GetClamp(GetW(), -1.0f, 1.0f));
+
+            // Multiply by 2.0 to convert the half angle into the full one.
+            return halfAngle * 2.0f * (imaginary / length);
         }
     }
 }

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.h
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.h
@@ -77,6 +77,9 @@ namespace AZ
 
         static Quaternion CreateFromAxisAngle(const Vector3& axis, float angle);
 
+        //! Create a quaternion from a scaled axis-angle representation.
+        static Quaternion CreateFromScaledAxisAngle(const Vector3& scaledAxisAngle);
+
         static Quaternion CreateShortestArc(const Vector3& v1, const Vector3& v2);
 
         //! Creates a quaternion using rotation in degrees about the axes. First rotated about the X axis, followed by the Y axis, then the Z axis.
@@ -230,6 +233,9 @@ namespace AZ
         //! @param[out] outAxis A Vector3 defining the rotation axis.
         //! @param[out] outAngle A float rotation angle around the axis in radians.
         void ConvertToAxisAngle(Vector3& outAxis, float& outAngle) const;
+
+        //! Convert the quaternion into scaled axis-angle representation.
+        Vector3 ConvertToScaledAxisAngle() const;
 
         //! Returns the imaginary (X/Y/Z) portion of the quaternion.
         Vector3 GetImaginary() const;

--- a/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Quaternion.inl
@@ -109,6 +109,24 @@ namespace AZ
     }
 
 
+    AZ_MATH_INLINE Quaternion Quaternion::CreateFromScaledAxisAngle(const Vector3& scaledAxisAngle)
+    {
+        const AZ::Vector3 exponentialMap = scaledAxisAngle / 2.0f;
+        const float halfAngle = exponentialMap.GetLength();
+
+        if (halfAngle < AZ::Constants::FloatEpsilon)
+        {
+            return AZ::Quaternion::CreateFromVector3AndValue(exponentialMap, 1.0f).GetNormalized();
+        }
+        else
+        {
+            float sin, cos;
+            SinCos(halfAngle, sin, cos);
+            return AZ::Quaternion::CreateFromVector3AndValue((sin / halfAngle) * exponentialMap, cos);
+        }
+    }
+
+
     AZ_MATH_INLINE void Quaternion::StoreToFloat4(float* values) const
     {
         Simd::Vec4::StoreUnaligned(values, m_value);


### PR DESCRIPTION
Direct conversion helpers for quaternion to the scaled axis-angle representation and back without the need to convert them first to the axis-angle format and manually scale (or normalize on the way back). This also avoids having to deal with the special case of an identity representation which is 0,0,0 in the scaled axis-angle format while our convention for axis-angle is 0,1,0 for the axis and 0 for the angle.

Added unit tests that check the conversion round-trips from quaternion -> (scaled) axis-angle -> quaternion as well as comparing the scaled axis-angle representations from the direct helper functions as well as the axis-angle while manually scaling/normalizing.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>