### PR TITLE
corrected implementation of GetRealElapseTime

### DIFF
--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
@@ -62,6 +62,7 @@ namespace AZ
     TimeSystem::TimeSystem()
     {
         m_lastInvokedTimeUs = static_cast<TimeUs>(AZStd::GetTimeNowMicroSecond());
+        m_realLastInvokedTimeUs = static_cast<TimeUs>(AZStd::GetTimeNowMicroSecond());
         AZ::Interface<ITime>::Register(this);
         ITimeRequestBus::Handler::BusConnect();
     }
@@ -101,7 +102,11 @@ namespace AZ
 
     TimeUs TimeSystem::GetRealElapsedTimeUs() const
     {
-        return static_cast<TimeUs>(AZStd::GetTimeNowMicroSecond());
+        const TimeUs currentTime = static_cast<TimeUs>(AZStd::GetTimeNowMicroSecond());
+        m_realAccumulatedTimeUs += currentTime - m_realLastInvokedTimeUs;
+        m_realLastInvokedTimeUs = currentTime;
+
+        return m_realAccumulatedTimeUs;
     }
 
     TimeUs TimeSystem::GetSimulationTickDeltaTimeUs() const

--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
@@ -64,6 +64,14 @@ namespace AZ
         //! Mutable to allow GetElapsedTimeMs/TimeUs() to be a const functions.
         mutable TimeUs m_accumulatedTimeUs = AZ::Time::ZeroTimeUs;
 
+        //! Used to calculate the delta time between calls to GetRealElapsedTimeMs/TimeUs().
+        //! Mutable to allow GetRealElapsedTimeMs/TimeUs() to be a const functions.
+        mutable TimeUs m_realLastInvokedTimeUs = AZ::Time::ZeroTimeUs;
+
+        //! Accumulates the delta time of GetRealElapsedTimeMs/TimeUs() calls.
+        //! Mutable to allow GetRealElapsedTimeMs/TimeUs() to be a const functions.
+        mutable TimeUs m_realAccumulatedTimeUs = AZ::Time::ZeroTimeUs;
+
         //! The current game tick delta time.
         //! Can be affected by time system cvars.
         //! Updated in AdvanceTickDeltaTimes().


### PR DESCRIPTION
GetRealElapseTime now correctly calculates time from application start.

Signed-off-by: amzn-sean <75276488+amzn-sean@users.noreply.github.com>