### PR TITLE
Cherry pick changes to 2111RTE for installer version build number

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -16,3 +16,8 @@ if("$ENV{O3DE_VERSION}")
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
+
+if("$ENV{O3DE_BUILD_VERSION}")
+    # Overriding through environment
+    set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
+endif()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -12,12 +12,12 @@ set(LY_VERSION_STRING "0.0.0.0" CACHE STRING "Open 3D Engine's version")
 set(LY_VERSION_BUILD_NUMBER 0 CACHE STRING "Open 3D Engine's build number")
 set(LY_VERSION_ENGINE_NAME "o3de" CACHE STRING "Open 3D Engine's engine name")
 
-if("$ENV{O3DE_VERSION}" VERSION_GREATER "0.0.0.0")
+if(NOT "$ENV{O3DE_VERSION}" STREQUAL "")
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
 
-if("$ENV{O3DE_BUILD_VERSION}" GREATER 0)
+if(NOT "$ENV{O3DE_BUILD_VERSION}" STREQUAL "")
     # Overriding through environment
     set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
 endif()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -12,12 +12,12 @@ set(LY_VERSION_STRING "0.0.0.0" CACHE STRING "Open 3D Engine's version")
 set(LY_VERSION_BUILD_NUMBER 0 CACHE STRING "Open 3D Engine's build number")
 set(LY_VERSION_ENGINE_NAME "o3de" CACHE STRING "Open 3D Engine's engine name")
 
-if("$ENV{O3DE_VERSION}")
+if(DEFINED ENV{O3DE_VERSION})
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
 
-if("$ENV{O3DE_BUILD_VERSION}")
+if(DEFINED ENV{O3DE_BUILD_VERSION})
     # Overriding through environment
     set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
 endif()

--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -12,12 +12,12 @@ set(LY_VERSION_STRING "0.0.0.0" CACHE STRING "Open 3D Engine's version")
 set(LY_VERSION_BUILD_NUMBER 0 CACHE STRING "Open 3D Engine's build number")
 set(LY_VERSION_ENGINE_NAME "o3de" CACHE STRING "Open 3D Engine's engine name")
 
-if(DEFINED ENV{O3DE_VERSION})
+if("$ENV{O3DE_VERSION}" VERSION_GREATER "0.0.0.0")
     # Overriding through environment
     set(LY_VERSION_STRING "$ENV{O3DE_VERSION}")
 endif()
 
-if(DEFINED ENV{O3DE_BUILD_VERSION})
+if("$ENV{O3DE_BUILD_VERSION}" GREATER 0)
     # Overriding through environment
     set(LY_VERSION_BUILD_NUMBER "$ENV{O3DE_BUILD_VERSION}")
 endif()


### PR DESCRIPTION
Cherry pick changes to stabilization/2111RTE to allow setting the build number as part of a version by forcing a string check and allowing Jenkins to set LY_VERSION_BUILD_NUMBER (and in turn O3DEBuildNumber in engine.json) for installer builds. This is required for an installer build from this branch to have a build number appended to the version, for example 21.11.1.