### PR TITLE
chore[EmotionFX]: replace usage of SafeNormalize

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Rendering/Common/RenderUtil.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Rendering/Common/RenderUtil.cpp
@@ -688,7 +688,7 @@ namespace MCommon
                 const AZ::Vector3       nodeWorldPos        = pose->GetWorldSpaceTransform(jointIndex).m_position;
                 const AZ::Vector3       parentWorldPos      = pose->GetWorldSpaceTransform(parentIndex).m_position;
                 const AZ::Vector3       bone                = parentWorldPos - nodeWorldPos;
-                const AZ::Vector3       boneDirection       = MCore::SafeNormalize(bone);
+                const AZ::Vector3       boneDirection       = bone.GetNormalizedSafe();
                 const float             boneLength          = MCore::SafeLength(bone);
                 const float             boneScale           = GetBoneScale(actorInstance, joint);
                 const float             parentBoneScale     = GetBoneScale(actorInstance, skeleton->GetNode(parentIndex));

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeFootIKNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeFootIKNode.cpp
@@ -258,9 +258,9 @@ namespace EMotionFX
     // Calculate the matrix to rotate the solve plane.
     void BlendTreeFootIKNode::CalculateMatrix(const AZ::Vector3& goal, const AZ::Vector3& bendDir, AZ::Matrix3x3* outForward)
     {
-        const AZ::Vector3 x = MCore::SafeNormalize(goal);
+        const AZ::Vector3 x = goal.GetNormalizedSafe();
         const float dot = bendDir.Dot(x);
-        const AZ::Vector3 y = MCore::SafeNormalize(bendDir - (dot * x));
+        const AZ::Vector3 y = (bendDir - (dot * x)).GetNormalizedSafe();
         const AZ::Vector3 z = x.Cross(y);
         outForward->SetRow(0, x);
         outForward->SetRow(1, y);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTwoLinkIKNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTwoLinkIKNode.cpp
@@ -189,11 +189,11 @@ namespace EMotionFX
     void BlendTreeTwoLinkIKNode::CalculateMatrix(const AZ::Vector3& goal, const AZ::Vector3& bendDir, AZ::Matrix3x3* outForward)
     {
         // the inverse matrix defines a coordinate system whose x axis contains P, so X = unit(P).
-        const AZ::Vector3 x = MCore::SafeNormalize(goal);
+        const AZ::Vector3 x = goal.GetNormalizedSafe(); 
 
         // the y axis of the inverse is perpendicular to P, so Y = unit( D - X(D . X) ).
         const float dot = bendDir.Dot(x);
-        const AZ::Vector3 y = MCore::SafeNormalize(bendDir - (dot * x));
+        const AZ::Vector3 y = (bendDir - (dot * x)).GetNormalizedSafe();
 
         // the z axis of the inverse is perpendicular to both X and Y, so Z = X x Y.
         const AZ::Vector3 z = x.Cross(y);
@@ -372,11 +372,11 @@ namespace EMotionFX
         if (m_relativeBendDir && !m_extractBendDir)
         {
             bendDir = actorInstance->GetWorldSpaceTransform().m_rotation.TransformVector(bendDir);
-            bendDir = MCore::SafeNormalize(bendDir);
+            bendDir.NormalizeSafe();
         }
         else
         {
-            bendDir = MCore::SafeNormalize(bendDir);
+            bendDir.NormalizeSafe();
         }
 
         // if end node rotation is enabled
@@ -470,8 +470,8 @@ namespace EMotionFX
         // calculate the differences between the current forward vector and the new one after IK
         AZ::Vector3 oldForward = globalTransformB.m_position - globalTransformA.m_position;
         AZ::Vector3 newForward = midPos - globalTransformA.m_position;
-        oldForward = MCore::SafeNormalize(oldForward);
-        newForward = MCore::SafeNormalize(newForward);
+        oldForward.NormalizeSafe();
+        newForward.NormalizeSafe();
 
         // perform a delta rotation to rotate into the new direction after IK
         float dotProduct = oldForward.Dot(newForward);
@@ -499,9 +499,8 @@ namespace EMotionFX
             oldForward = endEffectorNodePos - globalTransformB.m_position;
         }
 
-        oldForward = MCore::SafeNormalize(oldForward);
-        newForward = goal - globalTransformB.m_position;
-        newForward = MCore::SafeNormalize(newForward);
+        oldForward.NormalizeSafe();
+        newForward = (goal - globalTransformB.m_position).GetNormalizedSafe();
 
         // calculate the delta rotation
         dotProduct = oldForward.Dot(newForward);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -581,8 +581,8 @@ namespace EMotionFX
                     &curTangent, &curBitangent);
 
                 // normalize the vectors
-                curTangent = MCore::SafeNormalize(curTangent);
-                curBitangent = MCore::SafeNormalize(curBitangent);
+                curTangent.NormalizeSafe();
+                curBitangent.NormalizeSafe();
 
                 // store the tangents in the orgTangents array
                 const AZ::Vector4 vec4Tangent(curTangent.GetX(), curTangent.GetY(), curTangent.GetZ(), 1.0f);
@@ -605,7 +605,7 @@ namespace EMotionFX
         {
             // get the normal
             AZ::Vector3 normal(normals[i]);
-            normal = MCore::SafeNormalize(normal);
+            normal.NormalizeSafe();
 
             // get the tangent
             AZ::Vector3 tangent = AZ::Vector3(orgTangents[i].GetX(), orgTangents[i].GetY(), orgTangents[i].GetZ());
@@ -631,7 +631,7 @@ namespace EMotionFX
 
             // Gram-Schmidt orthogonalize
             AZ::Vector3 fixedTangent = tangent - (normal * normal.Dot(tangent));
-            fixedTangent = MCore::SafeNormalize(fixedTangent);
+            fixedTangent.NormalizeSafe();
 
             // calculate handedness
             const AZ::Vector3 crossResult = normal.Cross(tangent);
@@ -1671,7 +1671,7 @@ namespace EMotionFX
                     const AZ::Vector3& posA = positions[ indexA ];
                     const AZ::Vector3& posB = positions[ indexB ];
                     const AZ::Vector3& posC = positions[ indexC ];
-                    AZ::Vector3 faceNormal = MCore::SafeNormalize((posB - posA).Cross(posC - posB));
+                    AZ::Vector3 faceNormal = (posB - posA).Cross(posC - posB).GetNormalizedSafe();
 
                     // store the tangents in the orgTangents array
                     smoothNormals[ orgVerts[indexA] ] += faceNormal;
@@ -1684,7 +1684,7 @@ namespace EMotionFX
             // normalize
             for (uint32 i = 0; i < m_numOrgVerts; ++i)
             {
-                smoothNormals[i] = MCore::SafeNormalize(smoothNormals[i]);
+                smoothNormals[i].NormalizeSafe();
             }
 
             for (uint32 i = 0; i < m_numVertices; ++i)
@@ -1721,7 +1721,7 @@ namespace EMotionFX
                     const AZ::Vector3& posA = positions[ indexA ];
                     const AZ::Vector3& posB = positions[ indexB ];
                     const AZ::Vector3& posC = positions[ indexC ];
-                    AZ::Vector3 faceNormal = MCore::SafeNormalize((posB - posA).Cross(posC - posB));
+                    AZ::Vector3 faceNormal = (posB - posA).Cross(posC - posB).GetNormalizedSafe();
 
                     // store the tangents in the orgTangents array
                     normals[indexA] = normals[indexA] + faceNormal;
@@ -1734,7 +1734,7 @@ namespace EMotionFX
             // normalize the normals
             for (uint32 i = 0; i < m_numVertices; ++i)
             {
-                normals[i] = MCore::SafeNormalize(normals[i]);
+                normals[i].NormalizeSafe();
             }
         }
     }

--- a/Gems/EMotionFX/Code/MCore/Source/Vector.h
+++ b/Gems/EMotionFX/Code/MCore/Source/Vector.h
@@ -17,12 +17,14 @@
 
 namespace MCore
 {
+    //! @deprecated Use AZ::Vector3::NormalizeSafeWithLength()
     inline float SafeLength(const AZ::Vector3& rhs)
     {
         const float lenSq = rhs.Dot(rhs);
         return (lenSq > FLT_EPSILON) ? sqrtf(lenSq) : 0.0f;
     }
 
+    //! @deprecated Use AZ::Vector3::GetNormalizedSafe()
     inline AZ::Vector3 SafeNormalize(const AZ::Vector3& rhs)
     {
         AZ::Vector3 result(0.0f);
@@ -43,6 +45,7 @@ namespace MCore
         return AZ::Vector3(vec.GetX() - fac * n.GetX(), vec.GetY() - fac * n.GetY(), vec.GetZ() - fac * n.GetZ());
     }
 
+    //! @deprecated Use AZ::Vector3::Project()
     MCORE_INLINE AZ::Vector3 Projected(const AZ::Vector3& vec, const AZ::Vector3& projectOnto)
     {
         AZ::Vector3 result = projectOnto;
@@ -60,6 +63,7 @@ namespace MCore
                 (MCore::Math::Abs(val.GetX() - val.GetZ()) < MCore::Math::epsilon));
     }
 
+    //! @deprecated Use AZ::Vector3::Lerp()
     template <>
     MCORE_INLINE AZ::Vector3 LinearInterpolate(const AZ::Vector3& source, const AZ::Vector3& target, float timeValue)
     {


### PR DESCRIPTION
a safeNormalize method already exists. make sense to already use the existing implementation under Vector3. 

ref: https://github.com/o3de/o3de/pull/6433

Signed-off-by: Michael Pollind <mpollind@gmail.com>
