### PR TITLE
added product dependency graphs on the asset tab of the Asset Processor

### DIFF
--- a/Code/Tools/AssetProcessor/assetprocessor_gui_files.cmake
+++ b/Code/Tools/AssetProcessor/assetprocessor_gui_files.cmake
@@ -40,6 +40,10 @@ set(FILES
     native/ui/ProductAssetTreeItemData.cpp
     native/ui/ProductAssetTreeModel.h
     native/ui/ProductAssetTreeModel.cpp
+    native/ui/ProductDependencyTreeItemData.h
+    native/ui/ProductDependencyTreeItemData.cpp
+    native/ui/ProductDependencyTreeModel.h
+    native/ui/ProductDependencyTreeModel.cpp
     native/ui/SourceAssetDetailsPanel.h
     native/ui/SourceAssetDetailsPanel.cpp
     native/ui/SourceAssetDetailsPanel.ui

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -115,6 +115,7 @@ public Q_SLOTS:
 
 protected Q_SLOTS:
     void ApplyConfig();
+
 protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
 private:
@@ -187,6 +188,8 @@ private:
 
     void ShowProductAssetContextMenu(const QPoint& pos);
     void ShowSourceAssetContextMenu(const QPoint& pos);
+    void ShowOutgoingProductDependenciesContextMenu(const QPoint& pos);
+    void ShowIncomingProductDependenciesContextMenu(const QPoint& pos);
 
     void ResetTimers();
     void CheckStartAnalysisTimers();

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include "AssetDetailsPanel.h"
+#include "ProductDependencyTreeModel.h"
 #include <AzCore/std/parallel/mutex.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <QDateTime>
@@ -57,9 +58,25 @@ namespace AssetProcessor
         }
 
         void SetScanQueueEnabled(bool enabled);
+        void SetupDependencyGraph(QTreeView* productAssetsTreeView, AZStd::shared_ptr<AssetDatabaseConnection> assetDatabaseConnection);
+
+        ProductDependencyTreeModel* GetOutgoingDependencyTreeModel() const
+        {
+            return m_outgoingDependencyTreeModel;
+        }
+
+        ProductDependencyTreeModel* GetIncomingDependencyTreeModel() const
+        {
+            return m_incomingDependencyTreeModel;
+        }
+
+        QTreeView* GetOutgoingProductDependenciesTreeView() const;
+        QTreeView* GetIncomingProductDependenciesTreeView() const;
 
     public Q_SLOTS:
         void AssetDataSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
+        void IncomingProductDependencyTreeModelReset();
+        void OutgoingProductDependencyTreeModelReset();
 
     protected:
         struct MissingDependencyScanGUIInfo
@@ -110,5 +127,8 @@ namespace AssetProcessor
         QListWidget* m_missingDependencyScanResults = nullptr;
         // The asset database connection in the AzToolsFramework namespace is read only. The AssetProcessor connection allows writing.
         AZStd::shared_ptr<AssetDatabaseConnection> m_assetDatabaseConnection;
+
+        ProductDependencyTreeModel* m_outgoingDependencyTreeModel = nullptr;
+        ProductDependencyTreeModel* m_incomingDependencyTreeModel = nullptr;
     };
 } // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.ui
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetDetailsPanel.ui
@@ -52,531 +52,678 @@
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="productPanelLayout">
-     <item>
-      <widget class="Line" name="AssetDetailsSeparator">
-       <property name="palette">
-        <palette>
-         <active>
-          <colorrole role="WindowText">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Button">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Base">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Window">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-         </active>
-         <inactive>
-          <colorrole role="WindowText">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>255</red>
-             <green>255</green>
-             <blue>255</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Button">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Base">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Window">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-         </inactive>
-         <disabled>
-          <colorrole role="WindowText">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>120</red>
-             <green>120</green>
-             <blue>120</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Button">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Base">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-          <colorrole role="Window">
-           <brush brushstyle="SolidPattern">
-            <color alpha="255">
-             <red>87</red>
-             <green>87</green>
-             <blue>87</blue>
-            </color>
-           </brush>
-          </colorrole>
-         </disabled>
-        </palette>
-       </property>
-       <property name="styleSheet">
-        <string notr="true"/>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="folderSelectedDescription">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>This folder has no additional info, select a file for details.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="MissingProductDependenciesFolderTitleLabel">
-       <property name="font">
-        <font>
-         <family>12pt</family>
-         <pointsize>8</pointsize>
-         <weight>75</weight>
-         <italic>false</italic>
-         <bold>true</bold>
-        </font>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">font: bold, 12pt;</string>
-       </property>
-       <property name="text">
-        <string>Missing Product Dependencies</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="MissingDependenciesFolderButtonsLayout">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="ProductInformationTab">
+      <attribute name="title">
+       <string>Asset Details</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="productPanelLayout">
        <item>
-        <widget class="QPushButton" name="ScanFolderButton">
-         <property name="toolTip">
-          <string>Scans all files in this folder and subfolders for missing dependencies. This may take some time.</string>
+        <widget class="Line" name="AssetDetailsSeparator">
+         <property name="palette">
+          <palette>
+           <active>
+            <colorrole role="WindowText">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>255</red>
+               <green>255</green>
+               <blue>255</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Button">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Base">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Window">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+           </active>
+           <inactive>
+            <colorrole role="WindowText">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>255</red>
+               <green>255</green>
+               <blue>255</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Button">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Base">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Window">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+           </inactive>
+           <disabled>
+            <colorrole role="WindowText">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>120</red>
+               <green>120</green>
+               <blue>120</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Button">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Base">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+            <colorrole role="Window">
+             <brush brushstyle="SolidPattern">
+              <color alpha="255">
+               <red>87</red>
+               <green>87</green>
+               <blue>87</blue>
+              </color>
+             </brush>
+            </colorrole>
+           </disabled>
+          </palette>
          </property>
-         <property name="text">
-          <string>Scan folder</string>
+         <property name="styleSheet">
+          <string notr="true"/>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Plain</enum>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="ClearScanFolderButton">
-         <property name="toolTip">
-          <string>Clears all dependency scan results for files in this folder and subfolders.</string>
+        <widget class="QLabel" name="folderSelectedDescription">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="text">
-          <string>Clear results</string>
+          <string>This folder has no additional info, select a file for details.</string>
          </property>
         </widget>
        </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QScrollArea" name="scrollArea">
-       <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
-       </property>
-       <property name="sizeAdjustPolicy">
-        <enum>QAbstractScrollArea::AdjustToContents</enum>
-       </property>
-       <property name="widgetResizable">
-        <bool>true</bool>
-       </property>
-       <widget class="QWidget" name="scrollAreaWidgetContents">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>721</width>
-          <height>756</height>
-         </rect>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <widget class="QWidget" name="verticalLayoutWidget">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>10</y>
-           <width>833</width>
-           <height>551</height>
-          </rect>
+       <item>
+        <widget class="QLabel" name="MissingProductDependenciesFolderTitleLabel">
+         <property name="font">
+          <font>
+           <family>12pt</family>
+           <pointsize>8</pointsize>
+           <weight>75</weight>
+           <italic>false</italic>
+           <bold>true</bold>
+          </font>
          </property>
-         <layout class="QVBoxLayout" name="scrollableVerticalLayout">
-          <item>
-           <layout class="QHBoxLayout" name="productAssetIdLayout">
+         <property name="styleSheet">
+          <string notr="true">font: bold, 12pt;</string>
+         </property>
+         <property name="text">
+          <string>Missing Product Dependencies</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="MissingDependenciesFolderButtonsLayout">
+         <item>
+          <widget class="QPushButton" name="ScanFolderButton">
+           <property name="toolTip">
+            <string>Scans all files in this folder and subfolders for missing dependencies. This may take some time.</string>
+           </property>
+           <property name="text">
+            <string>Scan folder</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="ClearScanFolderButton">
+           <property name="toolTip">
+            <string>Clears all dependency scan results for files in this folder and subfolders.</string>
+           </property>
+           <property name="text">
+            <string>Clear results</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QScrollArea" name="scrollArea">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QAbstractScrollArea::AdjustToContents</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="scrollAreaWidgetContents">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>699</width>
+            <height>691</height>
+           </rect>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <widget class="QWidget" name="verticalLayoutWidget">
+           <property name="geometry">
+            <rect>
+             <x>10</x>
+             <y>10</y>
+             <width>833</width>
+             <height>551</height>
+            </rect>
+           </property>
+           <layout class="QVBoxLayout" name="scrollableVerticalLayout">
             <item>
-             <widget class="QLabel" name="productAssetIdTitleLabel">
-              <property name="styleSheet">
-               <string notr="true">font: bold;</string>
-              </property>
-              <property name="text">
-               <string>Product Asset ID:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="productAssetIdLayout">
+              <item>
+               <widget class="QLabel" name="productAssetIdTitleLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: bold;</string>
+                </property>
+                <property name="text">
+                 <string>Product Asset ID:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="productAssetIdValueLabel">
+                <property name="text">
+                 <string>Product asset ID here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="productAssetIdSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QLabel" name="productAssetIdValueLabel">
-              <property name="text">
-               <string>Product asset ID here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="lastTimeProcessedLayout">
+              <item>
+               <widget class="QLabel" name="lastTimeProcessedTitleLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: bold;</string>
+                </property>
+                <property name="text">
+                 <string>Last Time Processed:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="lastTimeProcessedValueLabel">
+                <property name="text">
+                 <string>lastTimeProcessed Here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="lastTimeProcessedSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
-             <spacer name="productAssetIdSpacer">
+             <layout class="QHBoxLayout" name="jobKeyLayout">
+              <item>
+               <widget class="QLabel" name="jobKeyTitleLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: bold;</string>
+                </property>
+                <property name="text">
+                 <string>Job Key:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="jobKeyValueLabel">
+                <property name="text">
+                 <string>jobKey Here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="jobKeySpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="platformLayout">
+              <item>
+               <widget class="QLabel" name="platformTitleLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: bold;</string>
+                </property>
+                <property name="text">
+                 <string>Platform:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="platformValueLabel">
+                <property name="text">
+                 <string>platform Here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="platformSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="sourceAssetLayout">
+              <item>
+               <widget class="QLabel" name="sourceAssetTitleLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: bold;</string>
+                </property>
+                <property name="text">
+                 <string>Source Asset:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignVCenter">
+               <widget class="AssetProcessor::GoToButton" name="gotoAssetButton">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>24</width>
+                  <height>24</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="sourceAssetValueLabel">
+                <property name="text">
+                 <string>sourceAsset Here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="sourceAssetSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="Line" name="DependencySeparatorLine">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
-                <height>20</height>
+                <width>0</width>
+                <height>8</height>
                </size>
               </property>
              </spacer>
             </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="lastTimeProcessedLayout">
             <item>
-             <widget class="QLabel" name="lastTimeProcessedTitleLabel">
-              <property name="styleSheet">
-               <string notr="true">font: bold;</string>
-              </property>
-              <property name="text">
-               <string>Last Time Processed:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="OutgoingDependenciesTitleLayout">
+              <item>
+               <widget class="QLabel" name="outgoingProductDependenciesTitleLabel">
+                <property name="font">
+                 <font>
+                  <family>12pt</family>
+                  <pointsize>8</pointsize>
+                  <weight>75</weight>
+                  <italic>false</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">font: bold, 12pt;</string>
+                </property>
+                <property name="text">
+                 <string>Outgoing Product Dependencies:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="margin">
+                 <number>0</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="outgoingProductDependenciesValueLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: 12pt;</string>
+                </property>
+                <property name="text">
+                 <string>Number of outgoing product dependencies here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="outgoingDependenciesSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QLabel" name="lastTimeProcessedValueLabel">
-              <property name="text">
-               <string>lastTimeProcessed Here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="OutgoingDependenciesLayout">
+              <item>
+               <widget class="QTableWidget" name="outgoingProductDependenciesTable">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>32</height>
+                 </size>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">padding:0px</string>
+                </property>
+                <property name="verticalScrollBarPolicy">
+                 <enum>Qt::ScrollBarAlwaysOff</enum>
+                </property>
+                <property name="horizontalScrollBarPolicy">
+                 <enum>Qt::ScrollBarAlwaysOff</enum>
+                </property>
+                <property name="sizeAdjustPolicy">
+                 <enum>QAbstractScrollArea::AdjustToContents</enum>
+                </property>
+                <property name="editTriggers">
+                 <set>QAbstractItemView::NoEditTriggers</set>
+                </property>
+                <property name="showDropIndicator" stdset="0">
+                 <bool>false</bool>
+                </property>
+                <property name="dragDropOverwriteMode">
+                 <bool>false</bool>
+                </property>
+                <property name="alternatingRowColors">
+                 <bool>true</bool>
+                </property>
+                <property name="selectionMode">
+                 <enum>QAbstractItemView::SingleSelection</enum>
+                </property>
+                <property name="showGrid">
+                 <bool>false</bool>
+                </property>
+                <property name="columnCount">
+                 <number>2</number>
+                </property>
+                <attribute name="horizontalHeaderVisible">
+                 <bool>false</bool>
+                </attribute>
+                <attribute name="horizontalHeaderMinimumSectionSize">
+                 <number>24</number>
+                </attribute>
+                <attribute name="horizontalHeaderDefaultSectionSize">
+                 <number>24</number>
+                </attribute>
+                <attribute name="horizontalHeaderStretchLastSection">
+                 <bool>true</bool>
+                </attribute>
+                <attribute name="verticalHeaderVisible">
+                 <bool>false</bool>
+                </attribute>
+                <attribute name="verticalHeaderStretchLastSection">
+                 <bool>false</bool>
+                </attribute>
+                <column/>
+                <column/>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <spacer name="lastTimeProcessedSpacer">
+             <spacer name="verticalSpacer_3">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
-                <height>20</height>
+                <width>0</width>
+                <height>8</height>
                </size>
               </property>
              </spacer>
             </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="jobKeyLayout">
             <item>
-             <widget class="QLabel" name="jobKeyTitleLabel">
-              <property name="styleSheet">
-               <string notr="true">font: bold;</string>
-              </property>
-              <property name="text">
-               <string>Job Key:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="OutgoingUnmetUnmetPathDependenciesLayout">
+              <item>
+               <widget class="QLabel" name="outgoingUnmetPathProductDependenciesTitleLabel">
+                <property name="font">
+                 <font>
+                  <family>12pt</family>
+                  <pointsize>8</pointsize>
+                  <weight>75</weight>
+                  <italic>false</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">font: bold, 12pt;</string>
+                </property>
+                <property name="text">
+                 <string>Outgoing Unmet Path Product Dependencies:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="outgoingUnmetPathProductDependenciesValueLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: 12pt;</string>
+                </property>
+                <property name="text">
+                 <string>Number of dependencies here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="outgoingUnmetPathProductDependenciesSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QLabel" name="jobKeyValueLabel">
-              <property name="text">
-               <string>jobKey Here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="jobKeySpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="platformLayout">
-            <item>
-             <widget class="QLabel" name="platformTitleLabel">
-              <property name="styleSheet">
-               <string notr="true">font: bold;</string>
-              </property>
-              <property name="text">
-               <string>Platform:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="platformValueLabel">
-              <property name="text">
-               <string>platform Here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="platformSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="sourceAssetLayout">
-            <item>
-             <widget class="QLabel" name="sourceAssetTitleLabel">
-              <property name="styleSheet">
-               <string notr="true">font: bold;</string>
-              </property>
-              <property name="text">
-               <string>Source Asset:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item alignment="Qt::AlignVCenter">
-             <widget class="AssetProcessor::GoToButton" name="gotoAssetButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>24</width>
-                <height>24</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="sourceAssetValueLabel">
-              <property name="text">
-               <string>sourceAsset Here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="sourceAssetSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="Line" name="DependencySeparatorLine">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>8</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="OutgoingDependenciesTitleLayout">
-            <item>
-             <widget class="QLabel" name="outgoingProductDependenciesTitleLabel">
-              <property name="font">
-               <font>
-                <family>12pt</family>
-                <pointsize>8</pointsize>
-                <weight>75</weight>
-                <italic>false</italic>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">font: bold, 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Outgoing Product Dependencies:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="margin">
-               <number>0</number>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="outgoingProductDependenciesValueLabel">
-              <property name="styleSheet">
-               <string notr="true">font: 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Number of outgoing product dependencies here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="outgoingDependenciesSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="OutgoingDependenciesLayout">
-            <item>
-             <widget class="QTableWidget" name="outgoingProductDependenciesTable">
+             <widget class="QListWidget" name="outgoingUnmetPathProductDependenciesList">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                 <horstretch>0</horstretch>
@@ -589,8 +736,113 @@
                 <height>32</height>
                </size>
               </property>
-              <property name="styleSheet">
-               <string notr="true">padding:0px</string>
+              <property name="verticalScrollBarPolicy">
+               <enum>Qt::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="horizontalScrollBarPolicy">
+               <enum>Qt::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QAbstractScrollArea::AdjustToContents</enum>
+              </property>
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="tabKeyNavigation">
+               <bool>true</bool>
+              </property>
+              <property name="showDropIndicator" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="defaultDropAction">
+               <enum>Qt::IgnoreAction</enum>
+              </property>
+              <property name="alternatingRowColors">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>8</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="IncomingDependenciesLayout">
+              <item>
+               <widget class="QLabel" name="incomingProductDependenciesTitleLabel">
+                <property name="font">
+                 <font>
+                  <family>12pt</family>
+                  <pointsize>8</pointsize>
+                  <weight>75</weight>
+                  <italic>false</italic>
+                  <bold>true</bold>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">font: bold, 12pt;</string>
+                </property>
+                <property name="text">
+                 <string>Incoming Product Dependencies:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="incomingProductDependenciesValueLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: 12pt;</string>
+                </property>
+                <property name="text">
+                 <string>Number of incoming product dependencies here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="incomingDependenciesSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QTableWidget" name="incomingProductDependenciesTable">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>32</height>
+               </size>
               </property>
               <property name="verticalScrollBarPolicy">
                <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -644,278 +896,31 @@
               <column/>
              </widget>
             </item>
-           </layout>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>8</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="OutgoingUnmetUnmetPathDependenciesLayout">
             <item>
-             <widget class="QLabel" name="outgoingUnmetPathProductDependenciesTitleLabel">
-              <property name="font">
-               <font>
-                <family>12pt</family>
-                <pointsize>8</pointsize>
-                <weight>75</weight>
-                <italic>false</italic>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">font: bold, 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Outgoing Unmet Path Product Dependencies:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="outgoingUnmetPathProductDependenciesValueLabel">
-              <property name="styleSheet">
-               <string notr="true">font: 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Number of dependencies here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="outgoingUnmetPathProductDependenciesSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QListWidget" name="outgoingUnmetPathProductDependenciesList">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustToContents</enum>
-            </property>
-            <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="tabKeyNavigation">
-             <bool>true</bool>
-            </property>
-            <property name="showDropIndicator" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="defaultDropAction">
-             <enum>Qt::IgnoreAction</enum>
-            </property>
-            <property name="alternatingRowColors">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>0</width>
-              <height>8</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="IncomingDependenciesLayout">
-            <item>
-             <widget class="QLabel" name="incomingProductDependenciesTitleLabel">
-              <property name="font">
-               <font>
-                <family>12pt</family>
-                <pointsize>8</pointsize>
-                <weight>75</weight>
-                <italic>false</italic>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">font: bold, 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Incoming Product Dependencies:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="incomingProductDependenciesValueLabel">
-              <property name="styleSheet">
-               <string notr="true">font: 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Number of incoming product dependencies here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="incomingDependenciesSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QTableWidget" name="incomingProductDependenciesTable">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustToContents</enum>
-            </property>
-            <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="showDropIndicator" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="dragDropOverwriteMode">
-             <bool>false</bool>
-            </property>
-            <property name="alternatingRowColors">
-             <bool>true</bool>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::SingleSelection</enum>
-            </property>
-            <property name="showGrid">
-             <bool>false</bool>
-            </property>
-            <property name="columnCount">
-             <number>2</number>
-            </property>
-            <attribute name="horizontalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="horizontalHeaderMinimumSectionSize">
-             <number>24</number>
-            </attribute>
-            <attribute name="horizontalHeaderDefaultSectionSize">
-             <number>24</number>
-            </attribute>
-            <attribute name="horizontalHeaderStretchLastSection">
-             <bool>true</bool>
-            </attribute>
-            <attribute name="verticalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="verticalHeaderStretchLastSection">
-             <bool>false</bool>
-            </attribute>
-            <column/>
-            <column/>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="MissingDependenciesLayout">
-             <item>
+             <layout class="QHBoxLayout" name="MissingDependenciesLayout">
+              <item>
                <layout class="QVBoxLayout" name="supportContainer">
                 <property name="spacing">
                  <number>0</number>
                 </property>
                 <item>
                  <spacer name="verticalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Vertical</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Fixed</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>1</width>
-                   <height>2</height>
-                  </size>
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>1</width>
+                    <height>2</height>
+                   </size>
                   </property>
                  </spacer>
                 </item>
                 <item>
                  <widget class="QLabel" name="missingDependencyErrorIcon">
-                  <property name="styleSheet">
-                   <string notr="true">padding:0px</string>
-                  </property>
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                     <horstretch>0</horstretch>
@@ -937,6 +942,9 @@
                   <property name="toolTip">
                    <string>This asset has one or more missing product dependencies. Click the help button for info on how to resolve this.</string>
                   </property>
+                  <property name="styleSheet">
+                   <string notr="true">padding:0px</string>
+                  </property>
                   <property name="text">
                    <string/>
                   </property>
@@ -948,88 +956,103 @@
                   </property>
                  </widget>
                 </item>
-              </layout>
-             </item>
-            <item>
-             <widget class="QLabel" name="MissingProductDependenciesTitleLabel">
-              <property name="font">
-               <font>
-                <family>12pt</family>
-                <pointsize>8</pointsize>
-                <weight>75</weight>
-                <italic>false</italic>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="styleSheet">
-               <string notr="true">font: bold, 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Missing Product Dependencies:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="MissingProductDependenciesValueLabel">
-              <property name="styleSheet">
-               <string notr="true">font: 12pt;</string>
-              </property>
-              <property name="text">
-               <string>Number of missing product dependencies here</string>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="MissingProductDependenciesSupportContainer">
-              <property name="spacing">
-               <number>0</number>
-              </property>
+               </layout>
+              </item>
               <item>
-               <widget class="QPushButton" name="MissingProductDependenciesSupport">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+               <widget class="QLabel" name="MissingProductDependenciesTitleLabel">
+                <property name="font">
+                 <font>
+                  <family>12pt</family>
+                  <pointsize>8</pointsize>
+                  <weight>75</weight>
+                  <italic>false</italic>
+                  <bold>true</bold>
+                 </font>
                 </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>36</width>
-                  <height>12</height>
-                 </size>
+                <property name="styleSheet">
+                 <string notr="true">font: bold, 12pt;</string>
                 </property>
-                <property name="maximumSize">
-                 <size>
-                  <width>36</width>
-                  <height>12</height>
-                 </size>
+                <property name="text">
+                 <string>Missing Product Dependencies:</string>
                 </property>
-                <property name="toolTip">
-                 <string>Opens the documentation for missing dependencies in your web browser.</string>
-                </property>
-                <property name="flat">
-                 <bool>true</bool>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
               <item>
-               <spacer name="verticalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+               <widget class="QLabel" name="MissingProductDependenciesValueLabel">
+                <property name="styleSheet">
+                 <string notr="true">font: 12pt;</string>
                 </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
+                <property name="text">
+                 <string>Number of missing product dependencies here</string>
+                </property>
+                <property name="textInteractionFlags">
+                 <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="MissingProductDependenciesSupportContainer">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="MissingProductDependenciesSupport">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>36</width>
+                    <height>12</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>36</width>
+                    <height>12</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Opens the documentation for missing dependencies in your web browser.</string>
+                  </property>
+                  <property name="flat">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_6">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>1</width>
+                    <height>8</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="MissingDependenciesSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>1</width>
-                  <height>8</height>
+                  <width>40</width>
+                  <height>20</height>
                  </size>
                 </property>
                </spacer>
@@ -1037,145 +1060,204 @@
              </layout>
             </item>
             <item>
-             <spacer name="MissingDependenciesSpacer">
+             <layout class="QHBoxLayout" name="MissingDependenciesButtonsLayout">
+              <item>
+               <widget class="QPushButton" name="ScanMissingDependenciesButton">
+                <property name="toolTip">
+                 <string>Scans this file for missing dependencies. This may take some time.</string>
+                </property>
+                <property name="text">
+                 <string>Scan file</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="ClearMissingDependenciesButton">
+                <property name="toolTip">
+                 <string>Clears previous scan results for this file.</string>
+                </property>
+                <property name="text">
+                 <string>Clear results</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QTableWidget" name="MissingProductDependenciesTable">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>32</height>
+               </size>
+              </property>
+              <property name="verticalScrollBarPolicy">
+               <enum>Qt::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="horizontalScrollBarPolicy">
+               <enum>Qt::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QAbstractScrollArea::AdjustToContents</enum>
+              </property>
+              <property name="editTriggers">
+               <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="showDropIndicator" stdset="0">
+               <bool>false</bool>
+              </property>
+              <property name="dragDropOverwriteMode">
+               <bool>false</bool>
+              </property>
+              <property name="alternatingRowColors">
+               <bool>true</bool>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::SingleSelection</enum>
+              </property>
+              <property name="showGrid">
+               <bool>false</bool>
+              </property>
+              <property name="columnCount">
+               <number>3</number>
+              </property>
+              <attribute name="horizontalHeaderVisible">
+               <bool>false</bool>
+              </attribute>
+              <attribute name="horizontalHeaderCascadingSectionResizes">
+               <bool>true</bool>
+              </attribute>
+              <attribute name="horizontalHeaderMinimumSectionSize">
+               <number>24</number>
+              </attribute>
+              <attribute name="horizontalHeaderDefaultSectionSize">
+               <number>24</number>
+              </attribute>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
+              </attribute>
+              <attribute name="verticalHeaderVisible">
+               <bool>false</bool>
+              </attribute>
+              <attribute name="verticalHeaderStretchLastSection">
+               <bool>false</bool>
+              </attribute>
+              <column>
+               <property name="text">
+                <string>View</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Scan Time</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Asset</string>
+               </property>
+              </column>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_7">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
-                <height>20</height>
+                <width>20</width>
+                <height>40</height>
                </size>
               </property>
              </spacer>
             </item>
            </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="MissingDependenciesButtonsLayout">
-            <item>
-             <widget class="QPushButton" name="ScanMissingDependenciesButton">
-              <property name="toolTip">
-               <string>Scans this file for missing dependencies. This may take some time.</string>
-              </property>
-              <property name="text">
-               <string>Scan file</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="ClearMissingDependenciesButton">
-              <property name="toolTip">
-               <string>Clears previous scan results for this file.</string>
-              </property>
-              <property name="text">
-               <string>Clear results</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QTableWidget" name="MissingProductDependenciesTable">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="verticalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QAbstractScrollArea::AdjustToContents</enum>
-            </property>
-            <property name="editTriggers">
-             <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="showDropIndicator" stdset="0">
-             <bool>false</bool>
-            </property>
-            <property name="dragDropOverwriteMode">
-             <bool>false</bool>
-            </property>
-            <property name="alternatingRowColors">
-             <bool>true</bool>
-            </property>
-            <property name="selectionMode">
-             <enum>QAbstractItemView::SingleSelection</enum>
-            </property>
-            <property name="showGrid">
-             <bool>false</bool>
-            </property>
-            <property name="columnCount">
-             <number>3</number>
-            </property>
-            <attribute name="horizontalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="horizontalHeaderCascadingSectionResizes">
-             <bool>true</bool>
-            </attribute>
-            <attribute name="horizontalHeaderMinimumSectionSize">
-             <number>24</number>
-            </attribute>
-            <attribute name="horizontalHeaderDefaultSectionSize">
-             <number>24</number>
-            </attribute>
-            <attribute name="horizontalHeaderStretchLastSection">
-             <bool>true</bool>
-            </attribute>
-            <attribute name="verticalHeaderVisible">
-             <bool>false</bool>
-            </attribute>
-            <attribute name="verticalHeaderStretchLastSection">
-             <bool>false</bool>
-            </attribute>
-            <column>
-             <property name="text">
-              <string>View</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Scan Time</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Asset</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+          </widget>
+         </widget>
         </widget>
-       </widget>
-      </widget>
-     </item>
-    </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="ProductDependenciesTab">
+      <attribute name="title">
+       <string>Product Dependencies</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="ProductAssetsVerticalLayout" stretch="0,0,0,0,0">
+       <item>
+        <widget class="QLabel" name="FolderDescriptionProductDependencies">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Select an asset to view that asset's product dependency graph.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="OutgoingDescription">
+         <property name="text">
+          <string>Outgoing product dependencies are references this asset has to other assets. This tree shows this graph recursively, starting with the selected asset, then each asset it references, and each asset those assets reference.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeView" name="OutgoingProductDependenciesTreeView">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="sortingEnabled">
+          <bool>false</bool>
+         </property>
+         <attribute name="headerDefaultSectionSize">
+          <number>300</number>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="IncomingDescription">
+         <property name="text">
+          <string>Incoming product dependencies are references to this assets, from other assets. This tree shows this graph recursively, starting with the selected asset, then all assets that reference the selected asset, and all assets that reference those assets.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeView" name="IncomingProductDependenciesTreeView">
+         <property name="sortingEnabled">
+          <bool>false</bool>
+         </property>
+         <attribute name="headerDefaultSectionSize">
+          <number>300</number>
+         </attribute>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include "ProductDependencyTreeItemData.h"
+
+#include "native/utilities/assetUtils.h"
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+AZ_PUSH_DISABLE_WARNING(4127 4251 4800 4244, "-Wunknown-warning-option")
+#include <QDir>
+#include <QStack>
+AZ_POP_DISABLE_WARNING
+
+namespace AssetProcessor
+{
+    AZStd::shared_ptr<ProductDependencyTreeItemData> ProductDependencyTreeItemData::MakeShared(
+        QString name, AZStd::string productName)
+    {
+        return AZStd::make_shared<ProductDependencyTreeItemData>(name, productName);
+    }
+
+    ProductDependencyTreeItemData::ProductDependencyTreeItemData(
+        QString name, AZStd::string productName)
+        : m_name(name)
+        , m_productName(productName)
+    {
+    }
+
+    ProductDependencyTreeItem::ProductDependencyTreeItem(
+        AZStd::shared_ptr<ProductDependencyTreeItemData> data, ProductDependencyTreeItem* parentItem)
+        : m_data(data)
+        , m_parent(parentItem)
+        // QIcon is implicitily shared.
+        , m_fileIcon(QIcon(QStringLiteral(":/Gallery/Asset_File.svg")))
+    {
+    }
+
+    ProductDependencyTreeItem::~ProductDependencyTreeItem()
+    {
+    }
+
+    ProductDependencyTreeItem* ProductDependencyTreeItem::CreateChild(AZStd::shared_ptr<ProductDependencyTreeItemData> data)
+    {
+        m_childItems.emplace_back(new ProductDependencyTreeItem(data, this));
+        return m_childItems.back().get();
+    }
+
+    ProductDependencyTreeItem* ProductDependencyTreeItem::GetChild(int row) const
+    {
+        if (row < 0 || row >= getChildCount())
+        {
+            return nullptr;
+        }
+        return m_childItems.at(row).get();
+    }
+
+    void ProductDependencyTreeItem::EraseChild(ProductDependencyTreeItem* child)
+    {
+        for (auto& item : m_childItems)
+        {
+            if (item.get() == child)
+            {
+                m_childItems.erase(&item);
+                break;
+            }
+        }
+    }
+
+    int ProductDependencyTreeItem::getChildCount() const
+    {
+        return static_cast<int>(m_childItems.size());
+    }
+
+    int ProductDependencyTreeItem::GetRow() const
+    {
+        if (m_parent)
+        {
+            int index = 0;
+            for (const auto& item : m_parent->m_childItems)
+            {
+                if (item.get() == this)
+                {
+                    return index;
+                }
+                ++index;
+            }
+        }
+        return 0;
+    }
+
+    int ProductDependencyTreeItem::GetColumnCount() const
+    {
+        return static_cast<int>(ProductDependencyTreeColumns::Max);
+    }
+
+    QVariant ProductDependencyTreeItem::GetDataForColumn(int column) const
+    {
+        if (column < 0 || column >= GetColumnCount() || !m_data)
+        {
+            return QVariant();
+        }
+        switch (column)
+        {
+        case static_cast<int>(AssetTreeColumns::Name):
+            return m_data->m_name;
+        default:
+            AZ_Warning("AssetProcessor", false, "Unhandled ProductDependencyTreeItem column %d", column);
+            break;
+        }
+        return QVariant();
+    }
+
+    QIcon ProductDependencyTreeItem::GetIcon() const
+    {
+        return m_fileIcon;
+    }
+
+    ProductDependencyTreeItem* ProductDependencyTreeItem::GetParent() const
+    {
+        return m_parent;
+    }
+
+} // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.cpp
@@ -34,8 +34,6 @@ namespace AssetProcessor
         AZStd::shared_ptr<ProductDependencyTreeItemData> data, ProductDependencyTreeItem* parentItem)
         : m_data(data)
         , m_parent(parentItem)
-        // QIcon is implicitily shared.
-        , m_fileIcon(QIcon(QStringLiteral(":/Gallery/Asset_File.svg")))
     {
     }
 
@@ -112,11 +110,6 @@ namespace AssetProcessor
             break;
         }
         return QVariant();
-    }
-
-    QIcon ProductDependencyTreeItem::GetIcon() const
-    {
-        return m_fileIcon;
     }
 
     ProductDependencyTreeItem* ProductDependencyTreeItem::GetParent() const

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzCore/std/string/string.h>
+#include <AzToolsFramework/AssetDatabase/AssetDatabaseConnection.h>
+#include <QIcon>
+#include <QString>
+
+namespace AZ
+{
+    struct Uuid;
+}
+
+namespace AssetProcessor
+{
+    class ProductDependencyTreeItemData
+    {
+    public:
+        AZ_RTTI(ProductDependencyTreeItemData, "{A746FA16-7545-44FB-9454-0D64CBAA7A6E}");
+
+        static AZStd::shared_ptr<ProductDependencyTreeItemData> MakeShared(
+            QString name, AZStd::string productName);
+
+        ProductDependencyTreeItemData(
+            QString name, AZStd::string productName);
+
+        virtual ~ProductDependencyTreeItemData()
+        {
+        }
+
+        QString m_name;
+        // Product name as it exists in the database,
+        // used in the right click menu to jump to this content.
+        AZStd::string m_productName;
+    };
+
+    enum class ProductDependencyTreeColumns
+    {
+        Name,
+        Max
+    };
+    class ProductDependencyTreeItem
+    {
+    public:
+        explicit ProductDependencyTreeItem(
+            AZStd::shared_ptr<ProductDependencyTreeItemData> data, ProductDependencyTreeItem* parentItem = nullptr);
+        virtual ~ProductDependencyTreeItem();
+
+        ProductDependencyTreeItem* CreateChild(AZStd::shared_ptr<ProductDependencyTreeItemData> data);
+        ProductDependencyTreeItem* GetChild(int row) const;
+
+        void EraseChild(ProductDependencyTreeItem* child);
+
+        int getChildCount() const;
+        int GetColumnCount() const;
+        int GetRow() const;
+        QVariant GetDataForColumn(int column) const;
+        QIcon GetIcon() const;
+        ProductDependencyTreeItem* GetParent() const;
+
+        AZStd::shared_ptr<ProductDependencyTreeItemData> GetData() const
+        {
+            return m_data;
+        }
+
+
+    private:
+        AZStd::vector<AZStd::unique_ptr<ProductDependencyTreeItem>> m_childItems;
+        AZStd::shared_ptr<ProductDependencyTreeItemData> m_data;
+        ProductDependencyTreeItem* m_parent = nullptr;
+        QIcon m_fileIcon;
+    };
+} // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeItemData.h
@@ -66,7 +66,6 @@ namespace AssetProcessor
         int GetColumnCount() const;
         int GetRow() const;
         QVariant GetDataForColumn(int column) const;
-        QIcon GetIcon() const;
         ProductDependencyTreeItem* GetParent() const;
 
         AZStd::shared_ptr<ProductDependencyTreeItemData> GetData() const
@@ -79,6 +78,5 @@ namespace AssetProcessor
         AZStd::vector<AZStd::unique_ptr<ProductDependencyTreeItem>> m_childItems;
         AZStd::shared_ptr<ProductDependencyTreeItemData> m_data;
         ProductDependencyTreeItem* m_parent = nullptr;
-        QIcon m_fileIcon;
     };
 } // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "ProductDependencyTreeModel.h"
+#include "ProductDependencyTreeItemData.h"
+#include "AssetTreeItem.h"
+#include "ProductAssetTreeItemData.h"
+
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/IO/Path/Path.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <AzCore/std/smart_ptr/make_shared.h>
+
+namespace AssetProcessor
+{
+    AZ_CVAR_EXTERNED(bool, ap_disableAssetTreeView);
+
+    ProductDependencyTreeModel::ProductDependencyTreeModel(
+        AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> sharedDbConnection,
+        AssetTreeFilterModel* productFilterModel,
+        DependencyTreeType treeType,
+        QObject* parent)
+        : QAbstractItemModel(parent)
+        , m_sharedDbConnection(sharedDbConnection)
+        , m_productFilterModel(productFilterModel)
+        , m_treeType(treeType)
+    {        
+        m_root.reset(new ProductDependencyTreeItem(AZStd::make_shared<ProductDependencyTreeItemData>("", "")));
+    }
+
+    ProductDependencyTreeModel::~ProductDependencyTreeModel()
+    {
+    }
+
+    QModelIndex ProductDependencyTreeModel::index(int row, int column, const QModelIndex& parent) const
+    {
+        if (!hasIndex(row, column, parent))
+        {
+            return QModelIndex();
+        }
+
+        ProductDependencyTreeItem* parentItem = nullptr;
+
+        if (!parent.isValid())
+        {
+            parentItem = m_root.get();
+        }
+        else
+        {
+            parentItem = static_cast<ProductDependencyTreeItem*>(parent.internalPointer());
+        }
+
+        if (!parentItem)
+        {
+            return QModelIndex();
+        }
+
+        ProductDependencyTreeItem* childItem = parentItem->GetChild(row);
+
+        if (childItem)
+        {
+            QModelIndex index = createIndex(row, column, childItem);
+            Q_ASSERT(checkIndex(index));
+            return index;
+        }
+        return QModelIndex();
+    }
+
+    int ProductDependencyTreeModel::rowCount(const QModelIndex& parent) const
+    {
+        if (parent.column() > 0)
+        {
+            return 0;
+        }
+
+        ProductDependencyTreeItem* parentItem = nullptr;
+        if (!parent.isValid())
+        {
+            parentItem = m_root.get();
+        }
+        else
+        {
+            parentItem = static_cast<ProductDependencyTreeItem*>(parent.internalPointer());
+        }
+
+        if (!parentItem)
+        {
+            return 0;
+        }
+        return parentItem->getChildCount();
+    }
+
+    int ProductDependencyTreeModel::columnCount(const QModelIndex& parent) const
+    {
+        if (parent.isValid())
+        {
+            return static_cast<ProductDependencyTreeItem*>(parent.internalPointer())->GetColumnCount();
+        }
+        if (m_root)
+        {
+            return m_root->GetColumnCount();
+        }
+        return 0;
+    }
+
+    QVariant ProductDependencyTreeModel::data(const QModelIndex& index, int role) const
+    {
+        if (!index.isValid())
+        {
+            return QVariant();
+        }
+
+        ProductDependencyTreeItem* item = static_cast<ProductDependencyTreeItem*>(index.internalPointer());
+        switch (role)
+        {
+        case Qt::DisplayRole:
+            return item->GetDataForColumn(index.column());
+        case Qt::DecorationRole:
+            // Only show the icon in the name column
+            if (index.column() == static_cast<int>(AssetTreeColumns::Name))
+            {
+                return item->GetIcon();
+            }
+            break;
+        case Qt::ToolTipRole:
+            // Purposely return an empty string, so mousing over rows clear out.
+            return QString("");
+        }
+        return QVariant();
+    }
+
+    QVariant ProductDependencyTreeModel::headerData(int section, Qt::Orientation orientation, int role) const
+    {
+        if (orientation != Qt::Horizontal || role != Qt::DisplayRole)
+        {
+            return QVariant();
+        }
+        if (section < 0 || section >= static_cast<int>(ProductDependencyTreeColumns::Max))
+        {
+            return QVariant();
+        }
+
+        switch (section)
+        {
+        case static_cast<int>(ProductDependencyTreeColumns::Name):
+            switch (m_treeType)
+            {
+            case DependencyTreeType::Incoming:
+                return tr("Incoming Product Dependencies");
+            case DependencyTreeType::Outgoing:
+                return tr("Outgoing Product Dependencies");
+            default:
+                AZ_Warning("AssetProcessor", false, "Unhandled AssetTree tree type %d", m_treeType);
+                return tr("Name");
+            }
+        default:
+            AZ_Warning("AssetProcessor", false, "Unhandled AssetTree section %d", section);
+            break;
+        }
+        return QVariant();
+    }
+
+    bool ProductDependencyTreeModel::setData(const QModelIndex& /*index*/, const QVariant& /*value*/, int /*role*/)
+    {
+        return false;
+    }
+
+    Qt::ItemFlags ProductDependencyTreeModel::flags(const QModelIndex& index) const
+    {
+        return Qt::ItemIsSelectable | QAbstractItemModel::flags(index);
+    }
+
+    QModelIndex ProductDependencyTreeModel::parent(const QModelIndex& index) const
+    {
+        if (!index.isValid())
+        {
+            return QModelIndex();
+        }
+
+        ProductDependencyTreeItem* childItem = static_cast<ProductDependencyTreeItem*>(index.internalPointer());
+        ProductDependencyTreeItem* parentItem = childItem->GetParent();
+
+        if (parentItem == m_root.get() || parentItem == nullptr)
+        {
+            return QModelIndex();
+        }
+        QModelIndex parentIndex = createIndex(parentItem->GetRow(), 0, parentItem);
+        Q_ASSERT(checkIndex(parentIndex));
+        return parentIndex;
+    }
+
+    bool ProductDependencyTreeModel::hasChildren(const QModelIndex& parent) const
+    {
+        ProductDependencyTreeItem* parentItem = nullptr;
+
+        if (!parent.isValid())
+        {
+            parentItem = m_root.get();
+        }
+        else
+        {
+            parentItem = static_cast<ProductDependencyTreeItem*>(parent.internalPointer());
+        }
+
+        if (!parentItem)
+        {
+            return false;
+        }
+
+        return parentItem->getChildCount() > 0;
+    }
+
+    void ProductDependencyTreeModel::AssetDataSelectionChanged(const QItemSelection& selected, const QItemSelection& /*deselected*/)
+    {
+        // Even if multi-select is enabled, only display the first selected item.
+        if (selected.indexes().count() == 0 || !selected.indexes()[0].isValid())
+        {
+            // ResetText();
+            return;
+        }
+
+        QModelIndex productModelIndex = m_productFilterModel->mapToSource(selected.indexes()[0]);
+
+        if (!productModelIndex.isValid())
+        {
+            return;
+        }
+        const AssetTreeItem* assetTreeItem = static_cast<const AssetTreeItem*>(productModelIndex.internalPointer());
+        const AZStd::shared_ptr<const ProductAssetTreeItemData> productItemData =
+            AZStd::rtti_pointer_cast<const ProductAssetTreeItemData>(assetTreeItem->GetData());
+        beginResetModel();
+
+        m_root.reset(new ProductDependencyTreeItem(AZStd::make_shared<ProductDependencyTreeItemData>("", "")));
+        m_trackedProductIds.clear();
+
+        ProductDependencyTreeItem* parentItem = m_root.get();
+
+        // Purposely don't put the product asset database name in, so the right click menu disables. No reason to go to the root object.
+        AZStd::shared_ptr<ProductDependencyTreeItemData> productDepTreeItemData = ProductDependencyTreeItemData::MakeShared(
+            productItemData->m_name, "");
+        ProductDependencyTreeItem* productDependenciesChild = parentItem->CreateChild(productDepTreeItemData);
+        createIndex(0, 0, productDependenciesChild);
+        m_trackedProductIds.insert(productItemData->m_databaseInfo.m_productID);
+
+        switch (m_treeType)
+        {
+        case DependencyTreeType::Outgoing:
+            PopulateOutgoingProductDependencies(productDependenciesChild, productItemData->m_databaseInfo.m_productID);
+            break;
+        case DependencyTreeType::Incoming:
+            PopulateIncomingProductDependencies(productDependenciesChild, productItemData->m_databaseInfo.m_productID);
+            break;
+        }
+        endResetModel();
+    }
+
+    struct ProductDependencyChild
+    {
+        ProductDependencyChild(ProductDependencyTreeItem* treeItem, AZ::s64 productId)
+            : m_treeItem(treeItem)
+            , m_productId(productId)
+        {
+        }
+        ProductDependencyTreeItem* m_treeItem;
+        AZ::s64 m_productId;
+    };
+
+    void ProductDependencyTreeModel::PopulateIncomingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId)
+    {
+        AZ::Data::AssetId assetId;
+        m_sharedDbConnection->QueryProductByProductID(
+            parentProductId,
+            [&](AzToolsFramework::AssetDatabase::ProductDatabaseEntry& productEntry)
+            {
+                assetId.m_subId = productEntry.m_subID;
+                return true;
+            });
+
+        m_sharedDbConnection->QuerySourceByProductID(
+            parentProductId,
+            [&](AzToolsFramework::AssetDatabase::SourceDatabaseEntry& sourceEntry)
+            {
+                assetId.m_guid = sourceEntry.m_sourceGuid;
+                return true;
+            });
+
+        
+        AZStd::string platform;
+        m_sharedDbConnection->QueryJobByProductID(
+            parentProductId,
+            [&](AzToolsFramework::AssetDatabase::JobDatabaseEntry& jobEntry)
+            {
+                platform = jobEntry.m_platform;
+                return true;
+            });
+
+        
+        AZStd::vector<ProductDependencyChild> pendingChildren;
+
+        m_sharedDbConnection->QueryDirectReverseProductDependenciesBySourceGuidSubId(
+            assetId.m_guid, assetId.m_subId,
+            [&](AzToolsFramework::AssetDatabase::ProductDatabaseEntry& incomingDependency)
+            {
+                bool platformMatches = false;
+                m_sharedDbConnection->QueryJobByJobID(
+                    incomingDependency.m_jobPK,
+                    [&](AzToolsFramework::AssetDatabase::JobDatabaseEntry& jobEntry)
+                    {
+                        if (platform.compare(jobEntry.m_platform) == 0)
+                        {
+                            platformMatches = true;
+                        }
+                        return true;
+                    });
+                if (!platformMatches)
+                {
+                    return true;
+                }
+
+                AZ::IO::Path productNamePath(incomingDependency.m_productName, AZ::IO::PosixPathSeparator);
+                const AZ::IO::PathView filename = productNamePath.Filename();
+                AZStd::shared_ptr<ProductDependencyTreeItemData> productDepTreeItemData = ProductDependencyTreeItemData::MakeShared(
+                    AZ::IO::FixedMaxPathString(filename.Native()).c_str(), incomingDependency.m_productName);
+                ProductDependencyTreeItem* child = parent->CreateChild(productDepTreeItemData);
+                pendingChildren.push_back(ProductDependencyChild(child, incomingDependency.m_productID));
+                m_trackedProductIds.insert(incomingDependency.m_productID);
+
+                return true;
+            });
+
+        for (auto& child : pendingChildren)
+        {
+            PopulateIncomingProductDependencies(child.m_treeItem, child.m_productId);
+        }
+    }
+
+    void ProductDependencyTreeModel::PopulateOutgoingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId)
+    {
+        AZStd::string platform;
+        m_sharedDbConnection->QueryJobByProductID(
+            parentProductId,
+            [&](AzToolsFramework::AssetDatabase::JobDatabaseEntry& jobEntry)
+            {
+                platform = jobEntry.m_platform;
+                return true;
+            });
+
+        AZStd::vector<ProductDependencyChild> pendingChildren;
+        m_sharedDbConnection->QueryProductDependencyByProductId(
+            parentProductId,
+            [&](AzToolsFramework::AssetDatabase::ProductDependencyDatabaseEntry& dependency)
+            {
+                if (dependency.m_dependencySourceGuid.IsNull())
+                {
+                    return true;
+                }
+                m_sharedDbConnection->QueryProductBySourceGuidSubID(
+                    dependency.m_dependencySourceGuid, dependency.m_dependencySubID,
+                    [&](AzToolsFramework::AssetDatabase::ProductDatabaseEntry& product)
+                    {
+                        if (m_trackedProductIds.contains(product.m_productID))
+                        {
+                            return true;
+                        }
+                        bool platformMatches = false;
+                        m_sharedDbConnection->QueryJobByJobID(
+                            product.m_jobPK,
+                            [&](AzToolsFramework::AssetDatabase::JobDatabaseEntry& jobEntry)
+                            {
+                                if (platform.compare(jobEntry.m_platform) == 0)
+                                {
+                                    platformMatches = true;
+                                }
+                                return true;
+                            });
+                        if (!platformMatches)
+                        {
+                            return true;
+                        }
+
+                        AZ::IO::Path productNamePath(product.m_productName, AZ::IO::PosixPathSeparator);
+                        const AZ::IO::PathView filename = productNamePath.Filename();
+                        AZStd::shared_ptr<ProductDependencyTreeItemData> productDepTreeItemData = ProductDependencyTreeItemData::MakeShared(
+                            AZ::IO::FixedMaxPathString(filename.Native()).c_str(), product.m_productName);
+                        ProductDependencyTreeItem* child = parent->CreateChild(productDepTreeItemData);
+                        pendingChildren.push_back(ProductDependencyChild(child, product.m_productID));
+                        m_trackedProductIds.insert(product.m_productID);
+                        return true;
+                    });
+                return true;
+            });
+        for (auto& child : pendingChildren)
+        {
+            PopulateOutgoingProductDependencies(child.m_treeItem, child.m_productId);
+        }
+    }
+} // namespace AssetProcessor

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.cpp
@@ -30,6 +30,7 @@ namespace AssetProcessor
         , m_sharedDbConnection(sharedDbConnection)
         , m_productFilterModel(productFilterModel)
         , m_treeType(treeType)
+        , m_fileIcon(QIcon(QStringLiteral(":/Gallery/Asset_File.svg")))
     {        
         m_root.reset(new ProductDependencyTreeItem(AZStd::make_shared<ProductDependencyTreeItemData>("", "")));
     }
@@ -125,7 +126,7 @@ namespace AssetProcessor
             // Only show the icon in the name column
             if (index.column() == static_cast<int>(AssetTreeColumns::Name))
             {
-                return item->GetIcon();
+                return m_fileIcon;
             }
             break;
         case Qt::ToolTipRole:

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AssetDatabase/AssetDatabase.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzToolsFramework/API/AssetDatabaseBus.h>
+#include <native/utilities/ApplicationManagerAPI.h>
+#include <QAbstractItemModel>
+#include <QFileIconProvider>
+#include <QItemSelectionModel>
+#include "AssetTreeFilterModel.h"
+#include "ProductDependencyTreeItemData.h"
+
+namespace AssetProcessor
+{
+    class ProductDependencyTreeItemData;
+
+    enum class DependencyTreeType
+    {
+        Incoming,
+        Outgoing
+    };
+
+    class ProductDependencyTreeModel
+        : public QAbstractItemModel
+    {
+    public:
+        ProductDependencyTreeModel(
+            AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> sharedDbConnection,
+            AssetTreeFilterModel* productFilterModel,
+            DependencyTreeType treeType,
+            QObject* parent = nullptr);
+        virtual ~ProductDependencyTreeModel();
+
+        // QAbstractItemModel
+        QModelIndex index(int row, int column, const QModelIndex& parent) const override;
+
+        int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+        int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+        QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+        QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+        bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
+        QModelIndex parent(const QModelIndex& index) const override;
+        bool hasChildren(const QModelIndex& parent) const override;
+        Qt::ItemFlags flags(const QModelIndex& index) const override;
+
+    public Q_SLOTS:
+        void AssetDataSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
+    protected:
+
+        void PopulateOutgoingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId);
+        void PopulateIncomingProductDependencies(ProductDependencyTreeItem* parent, AZ::s64 parentProductId);
+
+        AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> m_sharedDbConnection;
+        AssetTreeFilterModel* m_productFilterModel = nullptr;
+        ProductDependencyTreeItem* m_currentItem = nullptr;
+        AZStd::unique_ptr<ProductDependencyTreeItem> m_root;
+        AZStd::unordered_set<AZ::s64> m_trackedProductIds;
+        DependencyTreeType m_treeType;
+    };
+}

--- a/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductDependencyTreeModel.h
@@ -63,5 +63,6 @@ namespace AssetProcessor
         AZStd::unique_ptr<ProductDependencyTreeItem> m_root;
         AZStd::unordered_set<AZ::s64> m_trackedProductIds;
         DependencyTreeType m_treeType;
+        QIcon m_fileIcon;
     };
 }

--- a/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
+++ b/Code/Tools/AssetProcessor/native/ui/style/AssetProcessor.qss
@@ -52,14 +52,24 @@ QTreeView#SourceAssetsTreeView::item,
 QTreeView#SourceAssetsTreeView::branch,
 QTreeView#ProductAssetsTreeView,
 QTreeView#ProductAssetsTreeView::item,
-QTreeView#ProductAssetsTreeView::branch {
+QTreeView#ProductAssetsTreeView::branch,
+QTreeView#OutgoingProductDependenciesTreeView,
+QTreeView#OutgoingProductDependenciesTreeView::item,
+QTreeView#OutgoingProductDependenciesTreeView::branch,
+QTreeView#IncomingProductDependenciesTreeView,
+QTreeView#IncomingProductDependenciesTreeView::item,
+QTreeView#IncomingProductDependenciesTreeView::branch {
     background-color: rgb(45,45,45);
 }
 
 QTreeView#SourceAssetsTreeView::item:hover,
 QTreeView#SourceAssetsTreeView::branch:hover,
 QTreeView#ProductAssetsTreeView::item:hover,
-QTreeView#ProductAssetsTreeView::branch:hover {
+QTreeView#ProductAssetsTreeView::branch:hover,
+QTreeView#OutgoingProductDependenciesTreeView::item:hover,
+QTreeView#OutgoingProductDependenciesTreeView::branch:hover,
+QTreeView#IncomingProductDependenciesTreeView::item:hover,
+QTreeView#IncomingProductDependenciesTreeView::branch:hover {
     background-color: rgb(60,60,60);
 }
 
@@ -68,12 +78,20 @@ QTreeView#SourceAssetsTreeView::branch:selected,
 QTreeView#SourceAssetsTreeView::item:selected:active,
 QTreeView#ProductAssetsTreeView::item:selected,
 QTreeView#ProductAssetsTreeView::branch:selected,
-QTreeView#ProductAssetsTreeView::item:selected:active {
+QTreeView#ProductAssetsTreeView::item:selected:active,
+QTreeView#OutgoingProductDependenciesTreeView::item:selected,
+QTreeView#OutgoingProductDependenciesTreeView::branch:selected,
+QTreeView#OutgoingProductDependenciesTreeView::item:selected:active,
+QTreeView#IncomingProductDependenciesTreeView::item:selected,
+QTreeView#IncomingProductDependenciesTreeView::branch:selected,
+QTreeView#IncomingProductDependenciesTreeView::item:selected:active {
     background-color: rgb(73,73,73);
 }
 
 QTreeView#SourceAssetsTreeView::item:selected:!active,
 QTreeView#ProductAssetsTreeView::item:selected:!active,
+QTreeView#OutgoingProductDependenciesTreeView::item:selected:!active,
+QTreeView#IncomingProductDependenciesTreeView::item:selected:!active,
 QTableWidget#outgoingProductDependenciesTable:item:selected:!active,
 QListWidget#outgoingUnmetPathProductDependenciesList:item:selected:!active,
 QTableWidget#incomingProductDependenciesTable:item:selected:!active,


### PR DESCRIPTION
Still needs review by the UX team, but posting this as a draft to get eyes on it.