### PR TITLE
sandboxing DisplayMapper P0 test for investigation

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
@@ -39,10 +39,6 @@ class TestAutomation(EditorTestSuite):
     class AtomEditorComponents_DirectionalLightAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_DirectionalLightAdded as test_module
 
-    @pytest.mark.test_case_id("C36525660")
-    class AtomEditorComponents_DisplayMapperAdded(EditorSharedTest):
-        from Atom.tests import hydra_AtomEditorComponents_DisplayMapperAdded as test_module
-
     @pytest.mark.test_case_id("C36525661")
     class AtomEditorComponents_EntityReferenceAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponents_EntityReferenceAdded as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -19,13 +19,6 @@ logger = logging.getLogger(__name__)
 TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
 
 
-class TestAtomEditorComponentsSandbox(object):
-
-    # It requires at least one test
-    def test_Dummy(self, request, editor, level, workspace, project, launcher_platform):
-        pass
-
-
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 @pytest.mark.parametrize("level", ["auto_test"])
@@ -167,10 +160,17 @@ class TestAutomation(EditorTestSuite):
 
     enable_prefab_system = False
 
+    #this test is intermittently timing out without ever having executed. sandboxing while we investigate cause.
+    @pytest.mark.test_case_id("C36525660")
+    class AtomEditorComponents_DisplayMapperAdded(EditorSharedTest):
+        from Atom.tests import hydra_AtomEditorComponents_DisplayMapperAdded as test_module
+
+    # this test causes editor to crash when using slices. once automation transitions to prefabs it should pass
     @pytest.mark.test_case_id("C36529666")
     class AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded as test_module
 
+    # this test causes editor to crash when using slices. once automation transitions to prefabs it should pass
     @pytest.mark.test_case_id("C36525660")
     class AtomEditorComponentsLevel_DisplayMapperAdded(EditorSharedTest):
         from Atom.tests import hydra_AtomEditorComponentsLevel_DisplayMapperAdded as test_module


### PR DESCRIPTION
Moving the P0 DisplayMapper component test to sandbox since it has been seen in a few timeouts for AR. We don't believe the test itself is flakey, but we are sandboxing as part of a broader investigation into why it is the suspect in more than one AR failure.
Also removed test_dummy from sandbox since it was not a valid test and caused errors for missing fixtures.

**.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py**
================================================= test session starts 
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 25 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py ..........................[100%]

============================= 26 passed in 59.35s


**.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Sandbox.py**
================================================= test session starts =================================================
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 5 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Sandbox.py ....FF  [100%]
======================================= Test failure and error troubleshooting
Use the following commands to re-run each test that failed locally
(NOTE: The 'PYTHON' or 'PYTHONPATH' environment variables need values for accurate commands):
D:\workspace\o3de\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Sandbox.py::TestAutomation::AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
D:\workspace\o3de\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Sandbox.py::TestAutomation::AtomEditorComponentsLevel_DisplayMapperAdded[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
========================== 2 failed, 4 passed, 1 warning in 193.44s (0:03:13)

Signed-off-by: Scott Murray <scottmur@amazon.com>