### PR TITLE
feat: add cursor wrap mode viewport rough implementation

### DIFF
--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -23,6 +23,7 @@ namespace SandboxEditor
     constexpr AZStd::string_view AngleSizeSetting = "/Amazon/Preferences/Editor/AngleSize";
     constexpr AZStd::string_view ShowGridSetting = "/Amazon/Preferences/Editor/ShowGrid";
     constexpr AZStd::string_view StickySelectSetting = "/Amazon/Preferences/Editor/StickySelect";
+    constexpr AZStd::string_view ManipulatorMouseWrapSetting = "/Amazon/Preferences/Editor/Manipulator/ManipulatorMouseWrapSetting";
     constexpr AZStd::string_view ManipulatorLineBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/LineBoundWidth";
     constexpr AZStd::string_view ManipulatorCircleBoundWidthSetting = "/Amazon/Preferences/Editor/Manipulator/CircleBoundWidth";
     constexpr AZStd::string_view CameraTranslateSpeedSetting = "/Amazon/Preferences/Editor/Camera/TranslateSpeed";
@@ -174,6 +175,16 @@ namespace SandboxEditor
     void SetStickySelectEnabled(const bool enabled)
     {
         AzToolsFramework::SetRegistry(StickySelectSetting, enabled);
+    }
+
+    bool ManipulatorMouseWrap()
+    {
+        return AzToolsFramework::GetRegistry(ManipulatorMouseWrapSetting, false);
+    }
+
+    void SetManipulatorMouseWrap(const bool enabled)
+    {
+        AzToolsFramework::SetRegistry(ManipulatorMouseWrapSetting, enabled);
     }
 
     float ManipulatorLineBoundWidth()

--- a/Code/Editor/EditorViewportSettings.cpp
+++ b/Code/Editor/EditorViewportSettings.cpp
@@ -182,7 +182,7 @@ namespace SandboxEditor
         return AzToolsFramework::GetRegistry(ManipulatorMouseWrapSetting, false);
     }
 
-    void SetManipulatorMouseWrap(const bool enabled)
+    void SetManipulatorMouseWrap(bool enabled)
     {
         AzToolsFramework::SetRegistry(ManipulatorMouseWrapSetting, enabled);
     }

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -52,7 +52,7 @@ namespace SandboxEditor
     SANDBOX_API void SetShowingGrid(bool showing);
 
     SANDBOX_API bool ManipulatorMouseWrap();
-    SANDBOX_API void SetManipulatorMouseWrap(const bool enabled);
+    SANDBOX_API void SetManipulatorMouseWrap(bool enabled);
 
     SANDBOX_API bool StickySelectEnabled();
     SANDBOX_API void SetStickySelectEnabled(bool enabled);

--- a/Code/Editor/EditorViewportSettings.h
+++ b/Code/Editor/EditorViewportSettings.h
@@ -51,6 +51,9 @@ namespace SandboxEditor
     SANDBOX_API bool ShowingGrid();
     SANDBOX_API void SetShowingGrid(bool showing);
 
+    SANDBOX_API bool ManipulatorMouseWrap();
+    SANDBOX_API void SetManipulatorMouseWrap(const bool enabled);
+
     SANDBOX_API bool StickySelectEnabled();
     SANDBOX_API void SetStickySelectEnabled(bool enabled);
 

--- a/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
+++ b/Code/Editor/Lib/Tests/test_ModularViewportCameraController.cpp
@@ -37,6 +37,7 @@ namespace UnitTest
         // ViewportMouseCursorRequestBus overrides ...
         void BeginCursorCapture() override;
         void EndCursorCapture() override;
+        void SetCursorMode(AzToolsFramework::CursorInputMode mode) override;
         bool IsMouseOver() const override;
         void SetOverrideCursor(AzToolsFramework::ViewportInteraction::CursorStyleOverride cursorStyleOverride) override;
         void ClearOverrideCursor() override;
@@ -54,6 +55,11 @@ namespace UnitTest
     void ViewportMouseCursorRequestImpl::EndCursorCapture()
     {
         m_inputChannelMapper->SetCursorMode(AzToolsFramework::CursorInputMode::CursorModeNone);
+    }
+
+    void ViewportMouseCursorRequestImpl::SetCursorMode(AzToolsFramework::CursorInputMode mode)
+    {
+         m_inputChannelMapper->SetCursorMode(mode);
     }
 
     bool ViewportMouseCursorRequestImpl::IsMouseOver() const

--- a/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
+++ b/Code/Editor/Lib/Tests/test_ViewportManipulatorController.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <AzCore/Settings/SettingsRegistryImpl.h>
+
 #include <AzFramework/Viewport/CameraInput.h>
 #include <AzFramework/Viewport/ViewportControllerList.h>
 #include <AzToolsFramework/Input/QtEventToAzInputMapper.h>
@@ -93,10 +95,17 @@ namespace UnitTest
             m_controllerList->RegisterViewportContext(TestViewportId);
 
             m_inputChannelMapper = AZStd::make_unique<AzToolsFramework::QtEventToAzInputMapper>(m_rootWidget.get(), TestViewportId);
+
+            m_settingsRegistry = AZStd::make_unique<AZ::SettingsRegistryImpl>();
+            AZ::SettingsRegistry::Register(m_settingsRegistry.get());
         }
 
         void TearDown() override
         {
+
+            AZ::SettingsRegistry::Unregister(m_settingsRegistry.get());
+            m_settingsRegistry.reset();
+
             m_inputChannelMapper.reset();
 
             m_controllerList->UnregisterViewportContext(TestViewportId);
@@ -111,6 +120,7 @@ namespace UnitTest
         AZStd::unique_ptr<QWidget> m_rootWidget;
         AzFramework::ViewportControllerListPtr m_controllerList;
         AZStd::unique_ptr<AzToolsFramework::QtEventToAzInputMapper> m_inputChannelMapper;
+        AZStd::unique_ptr<AZ::SettingsRegistryInterface> m_settingsRegistry;
     };
 
     TEST_F(ViewportManipulatorControllerFixture, AnEventIsNotPropagatedToTheViewportWhenAManipulatorHandlesItFirst)

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -78,7 +78,7 @@ namespace SandboxEditor
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
+                if (m_usingMouseWrap && event.m_priority == ManipulatorPriority)
                 {
                     if (m_virtualNormalizedPosition)
                     {
@@ -91,9 +91,9 @@ namespace SandboxEditor
                 }
 
                 const auto normalizedPosition = m_virtualNormalizedPosition.value_or(position->m_normalizedPosition);
-                auto screenPoint = AzFramework::ScreenPointFromVector2(AZ::Vector2(
-                    normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width),
-                    normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height)));
+                const auto screenPoint = AzFramework::ScreenPoint(
+                    aznumeric_cast<int>(normalizedPosition.GetX() * windowSize.m_width),
+                    aznumeric_cast<int>(normalizedPosition.GetY() * windowSize.m_height));
 
                 ProjectedViewportRay ray{};
                 ViewportInteractionRequestBus::EventResult(
@@ -131,8 +131,7 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Down;
                 }
-
-                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
+                if (m_usingMouseWrap && event.m_priority == ManipulatorPriority)
                 {
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
                         GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
@@ -153,7 +152,7 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Up;
                 }
-                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
+                if (m_usingMouseWrap && event.m_priority == ManipulatorPriority)
                 {
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
                         GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
@@ -235,6 +234,7 @@ namespace SandboxEditor
 
     void ViewportManipulatorControllerInstance::UpdateViewport(const AzFramework::ViewportControllerUpdateEvent& event)
     {
+        m_usingMouseWrap = SandboxEditor::ManipulatorMouseWrap();
         m_currentTime = event.m_time;
     }
 

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -19,6 +19,7 @@
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/Viewport/ViewportInteractionHelpers.h>
 #include <AzToolsFramework/Input/QtEventToAzInputMapper.h>
+#include <Editor/EditorViewportSettings.h>
 
 #include <QApplication>
 
@@ -70,14 +71,16 @@ namespace SandboxEditor
             // Cache the ray trace results when doing manipulator interaction checks, no need to recalculate after
             if (event.m_priority == ManipulatorPriority)
             {
-
                 const auto* position = event.m_inputChannel.GetCustomData<AzFramework::InputChannel::PositionData2D>();
                 AZ_Assert(position, "Expected PositionData2D but found nullptr");
 
-                if(m_captureStart) {
+                if (m_captureStart)
+                {
                     m_virtualPosition = position->m_normalizedPosition;
                     m_captureStart = false;
-                } else {
+                }
+                else
+                {
                     m_virtualPosition += position->m_normalizedPositionDelta;
                 }
 
@@ -126,10 +129,14 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Down;
                 }
+
                 m_captureStart = true;
-                AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
-                    GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
-                    AzToolsFramework::CursorInputMode::CursorModeWrapped);
+                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
+                {
+                    AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
+                        GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
+                        AzToolsFramework::CursorInputMode::CursorModeWrapped);
+                }
             }
             else if (state == InputChannel::State::Ended)
             {

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -78,17 +78,19 @@ namespace SandboxEditor
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                if (m_virtualNormalizedPosition) {
+                if (m_virtualNormalizedPosition && (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority))
+                {
                     (*m_virtualNormalizedPosition) += position->m_normalizedPositionDelta;
-                } else {
-                    m_virtualNormalizedPosition =
-                        AZStd::optional<AZ::Vector2>{position->m_normalizedPosition};
                 }
-                
+                else
+                {
+                    m_virtualNormalizedPosition = AZStd::optional<AZ::Vector2>{ position->m_normalizedPosition };
+                }
+
                 const auto normalizedPosition = m_virtualNormalizedPosition.value_or(position->m_normalizedPosition);
                 auto screenPoint = AzFramework::ScreenPointFromVector2(AZ::Vector2(
                     normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width),
-                    normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height))); 
+                    normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height)));
 
                 ProjectedViewportRay ray{};
                 ViewportInteractionRequestBus::EventResult(
@@ -127,7 +129,6 @@ namespace SandboxEditor
                     eventType = MouseEvent::Down;
                 }
 
-                m_virtualNormalizedPosition = AZStd::nullopt;
                 if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
@@ -151,6 +152,7 @@ namespace SandboxEditor
                 }
                 if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
+                    m_virtualNormalizedPosition = AZStd::nullopt;
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
                         GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
                         AzToolsFramework::CursorInputMode::CursorModeNone);

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -76,21 +76,21 @@ namespace SandboxEditor
 
                 if (m_captureStart)
                 {
-                    m_virtualPosition = position->m_normalizedPosition;
+                    m_virtualNormalizedPosition = position->m_normalizedPosition;
                     m_captureStart = false;
                 }
                 else
                 {
-                    m_virtualPosition += position->m_normalizedPositionDelta;
+                    m_virtualNormalizedPosition += position->m_normalizedPositionDelta;
                 }
 
                 AzFramework::WindowSize windowSize;
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                const auto screenPoint = AzFramework::ScreenPoint(
-                    aznumeric_cast<int>(m_virtualPosition.GetX() * windowSize.m_width),
-                    aznumeric_cast<int>(m_virtualPosition.GetY() * windowSize.m_height));
+                const auto screenPoint = AzFramework::ScreenPointFromVector2(AZ::Vector2(
+                    aznumeric_cast<int>(m_virtualNormalizedPosition.GetX() * windowSize.m_width),
+                    aznumeric_cast<int>(m_virtualNormalizedPosition.GetY() * windowSize.m_height)));
 
                 ProjectedViewportRay ray{};
                 ViewportInteractionRequestBus::EventResult(
@@ -109,7 +109,6 @@ namespace SandboxEditor
             overrideButton = mouseButton;
             if (state == InputChannel::State::Began)
             {
-                
                 m_mouseInteraction.m_mouseButtons.m_mouseButtons |= mouseButtonValue;
                 if (IsDoubleClick(mouseButton))
                 {
@@ -152,9 +151,12 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Up;
                 }
-                AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
-                    GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
-                    AzToolsFramework::CursorInputMode::CursorModeNone);
+                if (SandboxEditor::ManipulatorMouseWrap())
+                {
+                    AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
+                        GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
+                        AzToolsFramework::CursorInputMode::CursorModeNone);
+                }
             }
         }
         else if (auto keyboardModifier = Helpers::GetKeyboardModifier(event.m_inputChannel); keyboardModifier != KeyboardModifier::None)

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -78,13 +78,16 @@ namespace SandboxEditor
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                if (m_virtualNormalizedPosition && (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority))
+                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
-                    (*m_virtualNormalizedPosition) += position->m_normalizedPositionDelta;
-                }
-                else
-                {
-                    m_virtualNormalizedPosition = AZStd::optional<AZ::Vector2>{ position->m_normalizedPosition };
+                    if (m_virtualNormalizedPosition)
+                    {
+                        (*m_virtualNormalizedPosition) += position->m_normalizedPositionDelta;
+                    }
+                    else
+                    {
+                        m_virtualNormalizedPosition = { position->m_normalizedPosition };
+                    }
                 }
 
                 const auto normalizedPosition = m_virtualNormalizedPosition.value_or(position->m_normalizedPosition);
@@ -152,11 +155,11 @@ namespace SandboxEditor
                 }
                 if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
-                    m_virtualNormalizedPosition = AZStd::nullopt;
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
                         GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
                         AzToolsFramework::CursorInputMode::CursorModeNone);
                 }
+                m_virtualNormalizedPosition = AZStd::nullopt;
             }
         }
         else if (auto keyboardModifier = Helpers::GetKeyboardModifier(event.m_inputChannel); keyboardModifier != KeyboardModifier::None)

--- a/Code/Editor/ViewportManipulatorController.cpp
+++ b/Code/Editor/ViewportManipulatorController.cpp
@@ -78,7 +78,7 @@ namespace SandboxEditor
                 AzFramework::WindowRequestBus::EventResult(
                     windowSize, event.m_windowHandle, &AzFramework::WindowRequestBus::Events::GetClientAreaSize);
 
-                if (m_usingMouseWrap && event.m_priority == ManipulatorPriority)
+                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
                     if (m_virtualNormalizedPosition)
                     {
@@ -91,9 +91,9 @@ namespace SandboxEditor
                 }
 
                 const auto normalizedPosition = m_virtualNormalizedPosition.value_or(position->m_normalizedPosition);
-                const auto screenPoint = AzFramework::ScreenPoint(
-                    aznumeric_cast<int>(normalizedPosition.GetX() * windowSize.m_width),
-                    aznumeric_cast<int>(normalizedPosition.GetY() * windowSize.m_height));
+                const auto screenPoint = AzFramework::ScreenPointFromVector2(AZ::Vector2(
+                    normalizedPosition.GetX() * aznumeric_cast<float>(windowSize.m_width),
+                    normalizedPosition.GetY() * aznumeric_cast<float>(windowSize.m_height)));
 
                 ProjectedViewportRay ray{};
                 ViewportInteractionRequestBus::EventResult(
@@ -131,7 +131,7 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Down;
                 }
-                if (m_usingMouseWrap && event.m_priority == ManipulatorPriority)
+                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
                         GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
@@ -152,13 +152,13 @@ namespace SandboxEditor
                     }
                     eventType = MouseEvent::Up;
                 }
-                if (m_usingMouseWrap && event.m_priority == ManipulatorPriority)
+                if (SandboxEditor::ManipulatorMouseWrap() && event.m_priority == ManipulatorPriority)
                 {
                     AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Event(
                         GetViewportId(), &AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Events::SetCursorMode,
                         AzToolsFramework::CursorInputMode::CursorModeNone);
+                    m_virtualNormalizedPosition = AZStd::nullopt;
                 }
-                m_virtualNormalizedPosition = AZStd::nullopt;
             }
         }
         else if (auto keyboardModifier = Helpers::GetKeyboardModifier(event.m_inputChannel); keyboardModifier != KeyboardModifier::None)
@@ -234,7 +234,6 @@ namespace SandboxEditor
 
     void ViewportManipulatorControllerInstance::UpdateViewport(const AzFramework::ViewportControllerUpdateEvent& event)
     {
-        m_usingMouseWrap = SandboxEditor::ManipulatorMouseWrap();
         m_currentTime = event.m_time;
     }
 

--- a/Code/Editor/ViewportManipulatorController.h
+++ b/Code/Editor/ViewportManipulatorController.h
@@ -50,5 +50,6 @@ namespace SandboxEditor
         AZ::ScriptTimePoint m_currentTime;
         
         AZStd::optional<AZ::Vector2> m_virtualNormalizedPosition = AZStd::nullopt;
+        bool m_usingMouseWrap = false;
     };
 } // namespace SandboxEditor

--- a/Code/Editor/ViewportManipulatorController.h
+++ b/Code/Editor/ViewportManipulatorController.h
@@ -50,6 +50,6 @@ namespace SandboxEditor
         AZ::ScriptTimePoint m_currentTime;
         
         bool m_captureStart;
-        AZ::Vector2 m_virtualPosition;
+        AZ::Vector2 m_virtualNormalizedPosition;
     };
 } // namespace SandboxEditor

--- a/Code/Editor/ViewportManipulatorController.h
+++ b/Code/Editor/ViewportManipulatorController.h
@@ -13,6 +13,8 @@
 #include <AzFramework/Viewport/ViewportId.h>
 #include <AzToolsFramework/Viewport/ViewportTypes.h>
 
+#include <AzCore/Math/Vector2.h>
+
 #include <SandboxAPI.h>
 
 namespace SandboxEditor
@@ -46,5 +48,8 @@ namespace SandboxEditor
         AZStd::unordered_map<AzToolsFramework::ViewportInteraction::MouseButton, ClickEvent> m_pendingDoubleClicks;
 
         AZ::ScriptTimePoint m_currentTime;
+        
+        bool m_captureStart;
+        AZ::Vector2 m_virtualPosition;
     };
 } // namespace SandboxEditor

--- a/Code/Editor/ViewportManipulatorController.h
+++ b/Code/Editor/ViewportManipulatorController.h
@@ -50,6 +50,5 @@ namespace SandboxEditor
         AZ::ScriptTimePoint m_currentTime;
         
         AZStd::optional<AZ::Vector2> m_virtualNormalizedPosition = AZStd::nullopt;
-        bool m_usingMouseWrap = false;
     };
 } // namespace SandboxEditor

--- a/Code/Editor/ViewportManipulatorController.h
+++ b/Code/Editor/ViewportManipulatorController.h
@@ -49,7 +49,6 @@ namespace SandboxEditor
 
         AZ::ScriptTimePoint m_currentTime;
         
-        bool m_captureStart;
-        AZ::Vector2 m_virtualNormalizedPosition;
+        AZStd::optional<AZ::Vector2> m_virtualNormalizedPosition = AZStd::nullopt;
     };
 } // namespace SandboxEditor

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -31,6 +31,8 @@ namespace AzFramework
 
 namespace AzToolsFramework
 {
+    enum class CursorInputMode;
+    
     namespace ViewportInteraction
     {
         //! Result of handling mouse interaction.
@@ -323,6 +325,8 @@ namespace AzToolsFramework
             virtual void BeginCursorCapture() = 0;
             //! Restores the cursor and ends locking it in place, allowing it to be moved freely.
             virtual void EndCursorCapture() = 0;
+            //! sets the cursor mode.
+            virtual void SetCursorMode(AzToolsFramework::CursorInputMode mode) = 0;
             //! Is the mouse over the viewport.
             virtual bool IsMouseOver() const = 0;
             //! Set the cursor style override.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Viewport/ViewportMessages.h
@@ -325,7 +325,7 @@ namespace AzToolsFramework
             virtual void BeginCursorCapture() = 0;
             //! Restores the cursor and ends locking it in place, allowing it to be moved freely.
             virtual void EndCursorCapture() = 0;
-            //! sets the cursor mode.
+            //!  Sets the cursor input mode.
             virtual void SetCursorMode(AzToolsFramework::CursorInputMode mode) = 0;
             //! Is the mouse over the viewport.
             virtual bool IsMouseOver() const = 0;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/RenderViewportWidget.h
@@ -102,6 +102,7 @@ namespace AtomToolsFramework
         // AzToolsFramework::ViewportInteraction::ViewportMouseCursorRequestBus::Handler overrides ...
         void BeginCursorCapture() override;
         void EndCursorCapture() override;
+        void SetCursorMode(AzToolsFramework::CursorInputMode mode) override;
         bool IsMouseOver() const override;
         void SetOverrideCursor(AzToolsFramework::ViewportInteraction::CursorStyleOverride cursorStyleOverride) override;
         void ClearOverrideCursor() override;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/RenderViewportWidget.cpp
@@ -355,6 +355,11 @@ namespace AtomToolsFramework
         m_inputChannelMapper->SetCursorMode(AzToolsFramework::CursorInputMode::CursorModeNone);
     }
 
+    void RenderViewportWidget::SetCursorMode(AzToolsFramework::CursorInputMode mode) 
+    {
+        m_inputChannelMapper->SetCursorMode(mode);
+    }
+
     void RenderViewportWidget::SetOverrideCursor(AzToolsFramework::ViewportInteraction::CursorStyleOverride cursorStyleOverride)
     {
         m_inputChannelMapper->SetOverrideCursor(cursorStyleOverride);


### PR DESCRIPTION
rough implementation of a way to allow the cursor to wrap viewport when using manipulators. 

https://user-images.githubusercontent.com/854359/146664874-28871cab-5a39-4dfe-b466-804a14b5877a.mp4


