### PR TITLE
bugfix: update attenuation when light intensity changed for mode Automatic

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/AreaLightComponentController.cpp
@@ -261,6 +261,11 @@ namespace AZ::Render
             m_lightShapeDelegate->SetPhotometricUnit(m_configuration.m_intensityMode);
             m_lightShapeDelegate->SetIntensity(m_configuration.m_intensity);
         }
+
+        if (m_configuration.m_attenuationRadiusMode == LightAttenuationRadiusMode::Automatic)
+        {
+            AttenuationRadiusChanged();
+        }
     }
 
     void AreaLightComponentController::ChromaChanged()


### PR DESCRIPTION
for lights in automatic mode the attenuation is updated based on intensity. would there be a sensible way to have delegates notify the AreaLightComponentController that other fields should also be updated?

REF: https://github.com/o3de/o3de/issues/6128

Signed-off-by: Michael Pollind <mpollind@gmail.com>