### PR TITLE
Wind bug

### DIFF
--- a/Gems/PhysX/Code/Source/WindProvider.cpp
+++ b/Gems/PhysX/Code/Source/WindProvider.cpp
@@ -159,6 +159,12 @@ namespace PhysX
                 AZStd::swap(m_entityTransformHandlers[index], m_entityTransformHandlers.back());
                 m_entityTransformHandlers.pop_back();
 
+                // When deleting entity from handler's m_entities, the AABB should be appended to m_pendingAabbUpdates
+                // for local wind handler to broadcast OnWindChanged to notify relative entities of wind changes in OnTick().  
+                m_pendingAabbUpdates.push_back();
+                ColliderShapeRequestBus::EventResult(m_pendingAabbUpdates.back(),
+                    entityId, &ColliderShapeRequestBus::Events::GetColliderShapeAabb);
+
                 m_changed = true;
             }
         }


### PR DESCRIPTION
When the tag of Region Force component has changedthe AABB of the component should be appended to m_pendingAabbUpdates of the local wind handler in wind bus after the wind provider delete the Force Region entity.