### PR TITLE
Add support for loading Png data directly from a memory buffer.

### DIFF
--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/PngFile.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/PngFile.h
@@ -53,6 +53,9 @@ namespace AZ
             //! @return the loaded PngFile or an invalid PngFile if there was an error.
             static PngFile Load(const char* path, LoadSettings loadSettings = {});
 
+            //! @return the loaded PngFile or an invalid PngFile if there was an error.
+            static PngFile LoadFromBuffer(AZStd::array_view<uint8_t> data, LoadSettings loadSettings = {});
+
             //! Create a PngFile from an RHI data buffer.
             //! @param size the dimensions of the image (m_depth is not used, assumed to be 1)
             //! @param format indicates the pixel format represented by @data. Only a limited set of formats are supported, see implementation.
@@ -83,10 +86,13 @@ namespace AZ
         private:
             AZ_DEFAULT_COPY(PngFile)
 
-                static const int HeaderSize = 8;
+            static const int HeaderSize = 8;
 
             static void DefaultErrorHandler(const char* message);
 
+            // This will load from *either* a file or an array_view, but it isn't expected for both to be valid when passed in.
+            static PngFile LoadInternal(FILE* filePtr, AZStd::array_view<uint8_t> data, LoadSettings loadSettings);
+                
             uint32_t m_width = 0;
             uint32_t m_height = 0;
             int32_t m_bitDepth = 0;

--- a/Gems/Atom/Utils/Code/Include/Atom/Utils/PngFile.h
+++ b/Gems/Atom/Utils/Code/Include/Atom/Utils/PngFile.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <AzCore/IO/GenericStreams.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/unordered_map.h>
@@ -90,8 +91,7 @@ namespace AZ
 
             static void DefaultErrorHandler(const char* message);
 
-            // This will load from *either* a file or an array_view, but it isn't expected for both to be valid when passed in.
-            static PngFile LoadInternal(FILE* filePtr, AZStd::array_view<uint8_t> data, LoadSettings loadSettings);
+            static PngFile LoadInternal(AZ::IO::GenericStream& dataStream, LoadSettings loadSettings);
                 
             uint32_t m_width = 0;
             uint32_t m_height = 0;

--- a/Gems/Atom/Utils/Code/Tests/PngFileTests.cpp
+++ b/Gems/Atom/Utils/Code/Tests/PngFileTests.cpp
@@ -311,4 +311,66 @@ namespace UnitTest
         EXPECT_TRUE(gotErrorMessage.find("PngFile is invalid") != AZStd::string::npos);
         EXPECT_FALSE(AZ::IO::FileIOBase::GetInstance()->Exists(m_tempPngFilePath.c_str()));
     }
-}
+
+    TEST_F(PngFileTests, LoadRgbFromMemoryBuffer)
+    {
+        // This is an in-memory copy of the ColorChart_rgb.png test file.
+        AZStd::fixed_vector<uint8_t, 126> pngBuffer =
+        {
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+            0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+
+            0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x02,
+            0x08, 0x02, 0x00, 0x00, 0x00, 0x12, 0x16, 0xf1,
+
+            0x4d, 0x00, 0x00, 0x00, 0x01, 0x73, 0x52, 0x47,
+            0x42, 0x00, 0xae, 0xce, 0x1c, 0xe9, 0x00, 0x00,
+
+            0x00, 0x04, 0x67, 0x41, 0x4d, 0x41, 0x00, 0x00,
+            0xb1, 0x8f, 0x0b, 0xfc, 0x61, 0x05, 0x00, 0x00,
+
+            0x00, 0x09, 0x70, 0x48, 0x59, 0x73, 0x00, 0x00,
+            0x0e, 0xc3, 0x00, 0x00, 0x0e, 0xc3, 0x01, 0xc7,
+
+            0x6f, 0xa8, 0x64, 0x00, 0x00, 0x00, 0x13, 0x49,
+            0x44, 0x41, 0x54, 0x18, 0x57, 0x63, 0xf8, 0xcf,
+
+            0xc0, 0x00, 0xc1, 0x4c, 0x10, 0xea, 0x3f, 0x03,
+            0x03, 0x00, 0x3b, 0xec, 0x05, 0xfd, 0x6a, 0x50,
+
+            0x07, 0x1f, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+            0x4e, 0x44, 0xae, 0x42, 0x60, 0x82
+        };
+
+        PngFile image = PngFile::LoadFromBuffer(pngBuffer);
+        EXPECT_TRUE(image.IsValid());
+        EXPECT_EQ(image.GetBufferFormat(), PngFile::Format::RGB);
+        EXPECT_EQ(image.GetWidth(), 3);
+        EXPECT_EQ(image.GetHeight(), 2);
+        EXPECT_EQ(image.GetBuffer().size(), 18);
+        EXPECT_EQ(Color3(image.GetBuffer().begin() + 0), Color3(255u, 0u, 0u));
+        EXPECT_EQ(Color3(image.GetBuffer().begin() + 3), Color3(0u, 255u, 0u));
+        EXPECT_EQ(Color3(image.GetBuffer().begin() + 6), Color3(0u, 0u, 255u));
+        EXPECT_EQ(Color3(image.GetBuffer().begin() + 9), Color3(255u, 255u, 0u));
+        EXPECT_EQ(Color3(image.GetBuffer().begin() + 12), Color3(0u, 255u, 255u));
+        EXPECT_EQ(Color3(image.GetBuffer().begin() + 15), Color3(255u, 0u, 255u));
+    }
+
+    TEST_F(PngFileTests, ErrorCannotLoadEmptyMemoryBuffer)
+    {
+        AZStd::vector<uint8_t> pngBuffer;
+
+        AZStd::string gotErrorMessage;
+
+        PngFile::LoadSettings loadSettings;
+        loadSettings.m_errorHandler = [&gotErrorMessage](const char* errorMessage)
+        {
+            gotErrorMessage = errorMessage;
+        };
+
+        PngFile image = PngFile::LoadFromBuffer(pngBuffer, loadSettings);
+        EXPECT_FALSE(image.IsValid());
+        EXPECT_TRUE(gotErrorMessage.find("Buffer is empty") != AZStd::string::npos);
+    }
+
+} // namespace UnitTest


### PR DESCRIPTION
Expanded the Png support in Atom Utils to allow Png data to either come from a file path or an in-memory buffer (via array_view).  Also provided a unit test to validate it.

This is needed in the use case where png data is downloaded at runtime and just needs to get immediately converted to usable pixel data without caching it to a storage device first.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>
(cherry picked from commit 6193dcf603d3c16ee193e1e6dc868bd6d04f89bc)