### PR TITLE
Misc Bugfixes

### DIFF
--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/AttachmentComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Animation/AttachmentComponent.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Component/Entity.h>
-#include <MathConversion.h>
 #include <LmbrCentral/Rendering/MeshAsset.h>
 #include <LmbrCentral/Animation/AttachmentComponentBus.h>
 #include <LmbrCentral/Animation/SkeletalHierarchyRequestBus.h>

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SurfaceData/SurfaceDataMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/SurfaceData/SurfaceDataMeshComponent.cpp
@@ -17,8 +17,6 @@
 #include <SurfaceData/SurfaceDataSystemRequestBus.h>
 #include <SurfaceData/Utility/SurfaceDataUtility.h>
 
-#include <MathConversion.h>
-
 namespace SurfaceData
 {
     void SurfaceDataMeshConfig::Reflect(AZ::ReflectContext* context)

--- a/Gems/FastNoise/Code/CMakeLists.txt
+++ b/Gems/FastNoise/Code/CMakeLists.txt
@@ -18,9 +18,10 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PUBLIC
-            Legacy::CryCommon
             Gem::GradientSignal
         PRIVATE
+            AZ::AzCore
+            AZ::AzFramework
             Gem::LmbrCentral
 )
 

--- a/Gems/FastNoise/Code/CMakeLists.txt
+++ b/Gems/FastNoise/Code/CMakeLists.txt
@@ -19,8 +19,9 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PUBLIC
             Gem::GradientSignal
-        PRIVATE
+        PUBLIC
             AZ::AzCore
+        PRIVATE
             AZ::AzFramework
             Gem::LmbrCentral
 )

--- a/Gems/FastNoise/Code/Tests/FastNoiseTest.cpp
+++ b/Gems/FastNoise/Code/Tests/FastNoiseTest.cpp
@@ -7,9 +7,6 @@
  */
 
 #include <AzTest/AzTest.h>
-#include <Mocks/ICryPakMock.h>
-#include <Mocks/IConsoleMock.h>
-#include <Mocks/ISystemMock.h>
 
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/Entity.h>
@@ -101,36 +98,12 @@ public:
     void SetAdvancedMode([[maybe_unused]] bool value) override {}
 };
 
-struct MockGlobalEnvironment
-{
-    MockGlobalEnvironment()
-    {
-        m_stubEnv.pCryPak = &m_stubPak;
-        m_stubEnv.pConsole = &m_stubConsole;
-        m_stubEnv.pSystem = &m_stubSystem;
-        gEnv = &m_stubEnv;
-    }
-
-    ~MockGlobalEnvironment()
-    {
-        gEnv = nullptr;
-    }
-
-private:
-    SSystemGlobalEnvironment m_stubEnv;
-    testing::NiceMock<CryPakMock> m_stubPak;
-    testing::NiceMock<ConsoleMock> m_stubConsole;
-    testing::NiceMock<SystemMock> m_stubSystem;
-};
-
 TEST(FastNoiseTest, ComponentsWithComponentApplication)
 {
     AZ::ComponentApplication::Descriptor appDesc;
     appDesc.m_memoryBlocksByteSize = 10 * 1024 * 1024;
     appDesc.m_recordingMode = AZ::Debug::AllocationRecords::RECORD_FULL;
     appDesc.m_stackRecordLevels = 20;
-
-    MockGlobalEnvironment mocks;
 
     AZ::ComponentApplication app;
     AZ::Entity* systemEntity = app.Create(appDesc);
@@ -186,7 +159,6 @@ public:
 
     AZ::ComponentApplication m_application;
     AZ::Entity* m_systemEntity;
-    MockGlobalEnvironment m_mocks;
 };
 
 //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/CMakeLists.txt
+++ b/Gems/GradientSignal/Code/CMakeLists.txt
@@ -18,7 +18,9 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PUBLIC
-            Legacy::CryCommon
+            AZ::AzCore
+            AZ::AtomCore
+            AZ::AzFramework
             Gem::SurfaceData
             Gem::ImageProcessingAtom.Headers
         PRIVATE
@@ -40,6 +42,7 @@ ly_add_target(
             Gem::GradientSignal.Static
             Gem::LmbrCentral
         PUBLIC
+            AZ::AtomCore
             Gem::ImageProcessingAtom.Headers # Atom/ImageProcessing/PixelFormats.h is part of a header in Includes
     RUNTIME_DEPENDENCIES
         Gem::LmbrCentral
@@ -69,7 +72,9 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::LmbrCentral.Editor
             PUBLIC
                 3rdParty::Qt::Widgets
-                Legacy::CryCommon
+                AZ::AzCore
+                AZ::AtomCore
+                AZ::AzFramework
                 AZ::AzToolsFramework
                 AZ::AssetBuilderSDK
                 Gem::GradientSignal.Static
@@ -92,6 +97,8 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PRIVATE
                 Gem::GradientSignal.Editor.Static
                 Gem::LmbrCentral.Editor
+            PUBLIC
+                AZ::AtomCore
         RUNTIME_DEPENDENCIES
             Gem::LmbrCentral.Editor
     )

--- a/Gems/GradientSignal/Code/CMakeLists.txt
+++ b/Gems/GradientSignal/Code/CMakeLists.txt
@@ -23,7 +23,6 @@ ly_add_target(
             AZ::AzFramework
             Gem::SurfaceData
             Gem::ImageProcessingAtom.Headers
-        PRIVATE
             Gem::LmbrCentral
 )
 
@@ -39,10 +38,11 @@ ly_add_target(
             Include
     BUILD_DEPENDENCIES
         PRIVATE
-            Gem::GradientSignal.Static
             Gem::LmbrCentral
         PUBLIC
+            AZ::AzCore
             AZ::AtomCore
+            Gem::GradientSignal.Static
             Gem::ImageProcessingAtom.Headers # Atom/ImageProcessing/PixelFormats.h is part of a header in Includes
     RUNTIME_DEPENDENCIES
         Gem::LmbrCentral

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Util.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Util.h
@@ -14,11 +14,6 @@
 #include <AzCore/Math/Transform.h>
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
 
-namespace LmbrCentral
-{
-    class MeshAsset;
-}
-
 namespace GradientSignal
 {
     enum class WrappingType : AZ::u8

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.h
@@ -56,6 +56,7 @@ namespace LmbrCentral
         TComponent m_component;
         TConfiguration m_configuration;
         bool m_visible = true;
+        bool m_runtimeComponentActive = false;
     };
 
 } // namespace LmbrCentral

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.inl
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.inl
@@ -177,9 +177,9 @@ namespace LmbrCentral
     void EditorWrappedComponentBase<TComponent, TConfiguration>::Init()
     {
         AzToolsFramework::Components::EditorComponentBase::Init();
+        m_runtimeComponentActive = false;
         m_component.ReadInConfig(&m_configuration);
         m_component.Init();
-        m_runtimeComponentActive = false;
     }
 
     template <typename TComponent, typename TConfiguration>
@@ -209,7 +209,8 @@ namespace LmbrCentral
 
         m_runtimeComponentActive = false;
         m_component.Deactivate();
-        m_component.SetEntity(nullptr); // remove the entity association, in case the parent component is being removed, otherwise the component will be reactivated
+        // remove the entity association, in case the parent component is being removed, otherwise the component will be reactivated
+        m_component.SetEntity(nullptr); 
     }
 
     template <typename TComponent, typename TConfiguration>
@@ -227,16 +228,16 @@ namespace LmbrCentral
     {
         if (m_runtimeComponentActive)
         {
-            m_component.Deactivate();
             m_runtimeComponentActive = false;
+            m_component.Deactivate();
         }
 
         m_component.ReadInConfig(&m_configuration);
 
         if (m_visible && !m_runtimeComponentActive)
         {
-            m_runtimeComponentActive = true;
             m_component.Activate();
+            m_runtimeComponentActive = true;
         }
 
         return AZ::Edit::PropertyRefreshLevels::None;

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.inl
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.inl
@@ -222,12 +222,7 @@ namespace LmbrCentral
     template <typename TComponent, typename TConfiguration>
     AZ::u32 EditorWrappedComponentBase<TComponent, TConfiguration>::ConfigurationChanged()
     {
-        // Only call Deactivate if it's currently active.
-        if (m_component.GetEntity())
-        {
-            m_component.Deactivate();
-        }
-
+        m_component.Deactivate();
         m_component.ReadInConfig(&m_configuration);
 
         if (m_visible && m_component.GetEntity())

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.inl
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Component/EditorWrappedComponentBase.inl
@@ -222,7 +222,12 @@ namespace LmbrCentral
     template <typename TComponent, typename TConfiguration>
     AZ::u32 EditorWrappedComponentBase<TComponent, TConfiguration>::ConfigurationChanged()
     {
-        m_component.Deactivate();
+        // Only call Deactivate if it's currently active.
+        if (m_component.GetEntity())
+        {
+            m_component.Deactivate();
+        }
+
         m_component.ReadInConfig(&m_configuration);
 
         if (m_visible && m_component.GetEntity())

--- a/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshAsset.h
+++ b/Gems/LmbrCentral/Code/include/LmbrCentral/Rendering/MeshAsset.h
@@ -9,8 +9,6 @@
 
 #include <AzCore/Asset/AssetCommon.h>
 
-#include <smartptr.h>
-
 namespace LmbrCentral
 {
     class MeshAsset

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -163,8 +163,7 @@ void TerrainSystem::ClampPosition(float x, float y, AZ::Vector2& outPosition, AZ
 
 bool TerrainSystem::InWorldBounds(float x, float y) const
 {
-    const float zTestValue = m_currentSettings.m_worldBounds.GetMin().GetX() +
-        ((m_currentSettings.m_worldBounds.GetMax().GetX() - m_currentSettings.m_worldBounds.GetMin().GetX()) / 2.0f);
+    const float zTestValue = m_currentSettings.m_worldBounds.GetMin().GetZ();
     const AZ::Vector3 testValue{ x, y, zTestValue };
     if (m_currentSettings.m_worldBounds.Contains(testValue))
     {

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -80,7 +80,7 @@ void TerrainSystem::Activate()
     m_requestedSettings.m_systemActive = true;
 
     {
-        AZStd::shared_lock<AZStd::shared_mutex> lock(m_areaMutex);
+        AZStd::unique_lock<AZStd::shared_mutex> lock(m_areaMutex);
         m_registeredAreas.clear();
     }
 
@@ -109,7 +109,7 @@ void TerrainSystem::Deactivate()
     AzFramework::Terrain::TerrainDataRequestBus::Handler::BusDisconnect();
 
     {
-        AZStd::shared_lock<AZStd::shared_mutex> lock(m_areaMutex);
+        AZStd::unique_lock<AZStd::shared_mutex> lock(m_areaMutex);
         m_registeredAreas.clear();
     }
 

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -25,10 +25,12 @@ bool TerrainLayerPriorityComparator::operator()(const AZ::EntityId& layer1id, co
 {
     // Comparator for insertion/keylookup.
     // Sorts into layer/priority order, highest priority first.
-    AZ::u32 priority1 = 0, layer1 = 0;
+    AZ::u32 priority1 = 0;
+    AZ::u32 layer1 = 0;
     Terrain::TerrainSpawnerRequestBus::Event(layer1id, &Terrain::TerrainSpawnerRequestBus::Events::GetPriority, layer1, priority1);
 
-    AZ::u32 priority2 = 0, layer2 = 0;
+    AZ::u32 priority2 = 0;
+    AZ::u32 layer2 = 0;
     Terrain::TerrainSpawnerRequestBus::Event(layer2id, &Terrain::TerrainSpawnerRequestBus::Events::GetPriority, layer2, priority2);
 
     if (layer1 < layer2)

--- a/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
+++ b/Gems/Terrain/Code/Source/TerrainSystem/TerrainSystem.cpp
@@ -25,10 +25,10 @@ bool TerrainLayerPriorityComparator::operator()(const AZ::EntityId& layer1id, co
 {
     // Comparator for insertion/keylookup.
     // Sorts into layer/priority order, highest priority first.
-    AZ::u32 priority1, layer1;
+    AZ::u32 priority1 = 0, layer1 = 0;
     Terrain::TerrainSpawnerRequestBus::Event(layer1id, &Terrain::TerrainSpawnerRequestBus::Events::GetPriority, layer1, priority1);
 
-    AZ::u32 priority2, layer2;
+    AZ::u32 priority2 = 0, layer2 = 0;
     Terrain::TerrainSpawnerRequestBus::Event(layer2id, &Terrain::TerrainSpawnerRequestBus::Events::GetPriority, layer2, priority2);
 
     if (layer1 < layer2)

--- a/Gems/Vegetation/Code/CMakeLists.txt
+++ b/Gems/Vegetation/Code/CMakeLists.txt
@@ -24,6 +24,7 @@ ly_add_target(
         PRIVATE
             Gem::LmbrCentral
             Gem::SurfaceData
+            Legacy::CryCommon
         PUBLIC
             Gem::AtomLyIntegration_CommonFeatures.Static
     RUNTIME_DEPENDENCIES
@@ -72,6 +73,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PRIVATE
                 Gem::Vegetation.Static
                 AZ::AzToolsFramework
+                Legacy::CryCommon
     RUNTIME_DEPENDENCIES
         Gem::LmbrCentral.Editor
         Gem::GradientSignal.Editor

--- a/Gems/Vegetation/Code/CMakeLists.txt
+++ b/Gems/Vegetation/Code/CMakeLists.txt
@@ -44,6 +44,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             Gem::Vegetation.Static
+            Legacy::CryCommon
     RUNTIME_DEPENDENCIES
         Gem::LmbrCentral
         Gem::GradientSignal
@@ -106,6 +107,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzFrameworkTestShared
                 Gem::Vegetation.Static
                 Gem::LmbrCentral.Mocks
+                Legacy::CryCommon
     )
     ly_add_googletest(
         NAME Gem::Vegetation.Tests


### PR DESCRIPTION
Fixed the following issues:
* Changed EditorWrappedComponentBase to avoid calling Deactivate() on nested components that are already deactivated, by better tracking the active state of the nested components.
* TerrainSystem would non-deterministically match terrain areas to each other incorrectly due to uninitialized priority variables in the area priority compare function.  Because they were uninitialized, we could sometimes get both "a < b" as false and "b < a" as false due to the uninitialized priority values changing between calls, which implied equality.  With the variables initialized, areas are only equal if their IDs are equal, regardless of priority.
* TerrainSystem had a couple of shared_lock calls that should have been unique_lock calls, since the lock was being used for writing.
* TerrainSystem InWorldBounds() was comparing the X bounds vs the Z bounds, instead of using the min Z bounds value for comparing against Z bounds.  This was incorrect, and would fail whenever the X bounds didn't fall inside the Z bounds.
* FastNoise and GradientSignal had Legacy::CryCommon as a public build dependency, but really it should be a private build dependency on Vegetation.  The dependency was added to the wrong gems, and was made broader than necessary.