### PR TITLE
Fix the cmake issue for AWSI automation tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/AWS/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/AWS/CMakeLists.txt
@@ -22,7 +22,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         NAME AutomatedTesting::AWSTests
         TEST_SUITE awsi
         TEST_SERIAL
-        PATH ${CMAKE_CURRENT_LIST_DIR}/${PAL_PLATFORM_NAME}/
+        PATH ${CMAKE_CURRENT_LIST_DIR}/
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessor
             AutomatedTesting.GameLauncher


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

Platform specific folder has been removed in [previous PR](https://github.com/o3de/o3de/pull/6278). Updated the CMake file for the new file path.

Verified the build locally.