### PR TITLE
Fix compile issues blocking adoption of Pix 2108

### DIFF
--- a/Code/Editor/IEditorImpl.cpp
+++ b/Code/Editor/IEditorImpl.cpp
@@ -1445,7 +1445,7 @@ ISourceControl* CEditorImpl::GetSourceControl()
         {
             IClassDesc* pClass = classes[i];
             ISourceControl* pSCM = nullptr;
-            HRESULT hRes = pClass->QueryInterface(__uuidof(ISourceControl), (void**)&pSCM);
+            HRESULT hRes = pClass->QueryInterface(__az_uuidof(ISourceControl), (void**)&pSCM);
             if (!FAILED(hRes) && pSCM)
             {
                 m_pSourceControl = pSCM;

--- a/Code/Editor/Include/IEditorClassFactory.h
+++ b/Code/Editor/Include/IEditorClassFactory.h
@@ -31,10 +31,7 @@ struct IUnknown
 };
 #endif
 
-#ifdef __uuidof
-#undef __uuidof
-#endif
-#define __uuidof(T) T::uuid()
+#define __az_uuidof(T) T::uuid()
 
 #if defined(AZ_PLATFORM_LINUX) || defined(AZ_PLATFORM_MAC)
 
@@ -107,7 +104,7 @@ struct IClassDesc
     template<class Q>
     HRESULT STDMETHODCALLTYPE QueryInterface(Q** pp)
     {
-        return QueryInterface(__uuidof(Q), (void**)pp);
+        return QueryInterface(__az_uuidof(Q), (void**)pp);
     }
 
     //////////////////////////////////////////////////////////////////////////

--- a/Code/Editor/Include/IViewPane.h
+++ b/Code/Editor/Include/IViewPane.h
@@ -60,7 +60,7 @@ struct IViewPaneClass
     //////////////////////////////////////////////////////////////////////////
     HRESULT STDMETHODCALLTYPE QueryInterface(const IID& riid, void** ppvObj)
     {
-        if (riid == __uuidof(IViewPaneClass))
+        if (riid == __az_uuidof(IViewPaneClass))
         {
             *ppvObj = this;
             return S_OK;

--- a/Code/Editor/Plugin.cpp
+++ b/Code/Editor/Plugin.cpp
@@ -155,7 +155,7 @@ IViewPaneClass* CClassFactory::FindViewPaneClassByTitle(const char* pPaneTitle) 
     {
         IViewPaneClass* viewPane = nullptr;
         IClassDesc* desc = m_classes[i];
-        if (SUCCEEDED(desc->QueryInterface(__uuidof(IViewPaneClass), (void**)&viewPane)))
+        if (SUCCEEDED(desc->QueryInterface(__az_uuidof(IViewPaneClass), (void**)&viewPane)))
         {
             if (QString::compare(viewPane->GetPaneTitle(), pPaneTitle) == 0)
             {

--- a/Code/Editor/Plugins/PerforcePlugin/PerforceSourceControl.h
+++ b/Code/Editor/Plugins/PerforcePlugin/PerforceSourceControl.h
@@ -49,7 +49,7 @@ public:
     // from IUnknown
     HRESULT STDMETHODCALLTYPE QueryInterface(const IID& riid, void** ppvObj)
     {
-        if (riid == __uuidof(ISourceControl) /* && m_pIntegrator*/)
+        if (riid == __az_uuidof(ISourceControl) /* && m_pIntegrator*/)
         {
             *ppvObj = this;
             return S_OK;

--- a/Code/Editor/PreferencesStdPages.cpp
+++ b/Code/Editor/PreferencesStdPages.cpp
@@ -50,7 +50,7 @@ CStdPreferencesClassDesc::CStdPreferencesClassDesc()
 
 HRESULT CStdPreferencesClassDesc::QueryInterface(const IID& riid, void** ppvObj)
 {
-    if (riid == __uuidof(IPreferencesPageCreator))
+    if (riid == __az_uuidof(IPreferencesPageCreator))
     {
         *ppvObj = (IPreferencesPageCreator*)this;
         return S_OK;

--- a/Code/Editor/Util/FileUtil.cpp
+++ b/Code/Editor/Util/FileUtil.cpp
@@ -251,7 +251,7 @@ bool CFileUtil::ExtractDccFilenameFromAssetDatabase(const QString& assetFilename
 
     for (size_t i = 0; i < assetDatabasePlugins.size(); ++i)
     {
-        if (assetDatabasePlugins[i]->QueryInterface(__uuidof(IAssetItemDatabase), (void**)&pCurrentDatabaseInterface) == S_OK)
+        if (assetDatabasePlugins[i]->QueryInterface(__az_uuidof(IAssetItemDatabase), (void**)&pCurrentDatabaseInterface) == S_OK)
         {
             if (!pCurrentDatabaseInterface)
             {

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -966,18 +966,18 @@ void ApplicationManagerBase::HandleFileRelocation() const
             AZ_Printf(AssetProcessor::ConsoleChannel, "SETTING: Preview file move.  Run again with --%s to actually make changes\n", ConfirmCommand);
         }
 
-        auto* interface = AZ::Interface<AssetProcessor::ISourceFileRelocation>::Get();
+        auto* relocationInterface = AZ::Interface<AssetProcessor::ISourceFileRelocation>::Get();
 
-        if(interface)
+        if(relocationInterface)
         {
-            auto result = interface->Move(source, destination, previewOnly, allowBrokenDependencies, !leaveEmptyFolders, updateReferences, excludeMetaDataFiles);
+            auto result = relocationInterface->Move(source, destination, previewOnly, allowBrokenDependencies, !leaveEmptyFolders, updateReferences, excludeMetaDataFiles);
 
             if (result.IsSuccess())
             {
                 AssetProcessor::RelocationSuccess success = result.TakeValue();
 
                 // The report can be too long for the AZ_Printf buffer, so split it into individual lines
-                AZStd::string report = interface->BuildReport(success.m_relocationContainer, success.m_updateTasks, true, updateReferences);
+                AZStd::string report = relocationInterface->BuildReport(success.m_relocationContainer, success.m_updateTasks, true, updateReferences);
                 AZStd::vector<AZStd::string> lines;
                 AzFramework::StringFunc::Tokenize(report.c_str(), lines, "\n");
 
@@ -1051,18 +1051,18 @@ void ApplicationManagerBase::HandleFileRelocation() const
             AZ_Printf(AssetProcessor::ConsoleChannel, "SETTING: Preview file delete.  Run again with --%s to actually make changes\n", ConfirmCommand);
         }
 
-        auto* interface = AZ::Interface<AssetProcessor::ISourceFileRelocation>::Get();
+        auto* relocationInterface = AZ::Interface<AssetProcessor::ISourceFileRelocation>::Get();
 
-        if (interface)
+        if (relocationInterface)
         {
-            auto result = interface->Delete(source, previewOnly, allowBrokenDependencies, !leaveEmptyFolders, excludeMetaDataFiles);
+            auto result = relocationInterface->Delete(source, previewOnly, allowBrokenDependencies, !leaveEmptyFolders, excludeMetaDataFiles);
 
             if (result.IsSuccess())
             {
                 AssetProcessor::RelocationSuccess success = result.TakeValue();
 
                 // The report can be too long for the AZ_Printf buffer, so split it into individual lines
-                AZStd::string report = interface->BuildReport(success.m_relocationContainer, success.m_updateTasks, false, updateReferences);
+                AZStd::string report = relocationInterface->BuildReport(success.m_relocationContainer, success.m_updateTasks, false, updateReferences);
                 AZStd::vector<AZStd::string> lines;
                 AzFramework::StringFunc::Tokenize(report.c_str(), lines, "\n");
 


### PR DESCRIPTION
The primary issue was the use of the `interface` keyword (reserved by Windows) and re-defining `__uuidof` in a manner that was unnecessary.