### PR TITLE
Change the nvidia Aftermath integration to use c strings directly 

### DIFF
--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermath_Windows.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/NsightAftermath_Windows.cpp
@@ -53,14 +53,14 @@ namespace Aftermath
 #endif
     }
 
-    void SetAftermathEventMarker( [[maybe_unused]] void* cntxHandle, [[maybe_unused]] const AZStd::string& markerData, [[maybe_unused]] bool isAftermathInitialized)
+    void SetAftermathEventMarker( [[maybe_unused]] void* cntxHandle, [[maybe_unused]] const char* markerData, [[maybe_unused]] bool isAftermathInitialized)
     {
 #if defined(USE_NSIGHT_AFTERMATH)
         if (isAftermathInitialized)
         {
             GFSDK_Aftermath_Result result = GFSDK_Aftermath_SetEventMarker(
-                static_cast<GFSDK_Aftermath_ContextHandle>(cntxHandle), static_cast<const void*>(markerData.c_str()),
-                static_cast<unsigned int>(markerData.size()) + 1);
+                static_cast<GFSDK_Aftermath_ContextHandle>(cntxHandle), static_cast<const void*>(markerData),
+                static_cast<unsigned int>(strlen(markerData) + 1);
             AssertOnError(result);
         }
 #endif

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListBase.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListBase.cpp
@@ -85,7 +85,7 @@ namespace AZ
             return m_hardwareQueueClass;
         }
 
-        void CommandListBase::SetAftermathEventMarker(const AZStd::string& markerData)
+        void CommandListBase::SetAftermathEventMarker(const char* markerData)
         {
             auto& device = static_cast<Device&>(GetDevice());
             Aftermath::SetAftermathEventMarker(m_aftermathCommandListContext, markerData, device.IsAftermathInitialized());

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListBase.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/CommandListBase.h
@@ -52,7 +52,7 @@ namespace AZ
 
             RHI::HardwareQueueClass GetHardwareQueueClass() const;
 
-            void SetAftermathEventMarker(const AZStd::string& markerData);
+            void SetAftermathEventMarker(const char* markerData);
 
         protected:
             void Init(Device& device, RHI::HardwareQueueClass hardwareQueueClass, ID3D12CommandAllocator* commandAllocator);

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/NsightAftermath.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/NsightAftermath.h
@@ -15,6 +15,7 @@
 namespace Aftermath
 {
     void SetAftermathEventMarker(void* cntxHandle, const AZStd::string& markerData, bool isAftermathInitialized);
+    void SetAftermathEventMarker(void* cntxHandle, const char* markerData, bool isAftermathInitialized);
     bool InitializeAftermath(AZ::RHI::Ptr<ID3D12DeviceX> dx12Device);
     void* CreateAftermathContextHandle(ID3D12GraphicsCommandList* commandList, void* crashTracker);
     void OutputLastScopeExecutingOnGPU(void* crashTracker);


### PR DESCRIPTION
Avoids any cost associated with wrapping the cstring with an AZStd::string

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>