### PR TITLE
Removed chatty profile markers.

### DIFF
--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/MemorySubAllocator.h
@@ -100,7 +100,6 @@ namespace AZ
         template <class Traits>
         typename MemorySubAllocator<Traits>::memory_allocation MemorySubAllocator<Traits>::Allocate(size_t sizeInBytes, size_t alignmentInBytes)
         {
-            AZ_PROFILE_FUNCTION(RHI);
             if (RHI::AlignUp(sizeInBytes, alignmentInBytes) > m_descriptor.m_capacityInBytes)
             {
                 return memory_allocation();

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -257,7 +257,6 @@ namespace AZ
             for (uint32_t i = interval.m_min; i < interval.m_max; ++i)
             {
                 ShaderResourceGroup* group = m_groupsToCompile[i];
-                AZ_PROFILE_SCOPE(RHI, "CompileGroupsForInterval %s", group->GetName().GetCStr());
 
                 CompileGroupInternal(*group, group->GetData());
                 group->m_isQueuedForCompile = false;

--- a/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ShaderResourceGroupPool.cpp
@@ -257,6 +257,7 @@ namespace AZ
             for (uint32_t i = interval.m_min; i < interval.m_max; ++i)
             {
                 ShaderResourceGroup* group = m_groupsToCompile[i];
+                AZ_PROFILE_SCOPE(RHI, "CompileGroupsForInterval %s", group->GetName().GetCStr());
 
                 CompileGroupInternal(*group, group->GetData());
                 group->m_isQueuedForCompile = false;

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/MemoryView.cpp
@@ -57,8 +57,6 @@ namespace AZ
 
         CpuVirtualAddress MemoryView::Map(RHI::HostMemoryAccess hostAccess) const
         {
-            AZ_PROFILE_FUNCTION(RHI);
-
             CpuVirtualAddress cpuAddress = nullptr;
             D3D12_RANGE readRange = {};
             if (hostAccess == RHI::HostMemoryAccess::Read)

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/ShaderResourceGroup.cpp
@@ -74,8 +74,6 @@ namespace AZ
 
         RHI::ResultCode ShaderResourceGroup::Init(ShaderAsset& shaderAsset, const SupervariantIndex& supervariantIndex, const AZ::Name& srgName)
         {
-            AZ_PROFILE_FUNCTION(RPI);
-
             const auto& lay = shaderAsset.FindShaderResourceGroupLayout(srgName, supervariantIndex);
             m_layout = lay.get();
             


### PR DESCRIPTION
These 4 markers removed tens of thousands of events, which reduced an example capture from 1685 ms to 1614 ms and made it far more readable.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com

![before](https://user-images.githubusercontent.com/82224783/147259691-cbd3a7a9-27a9-4221-808e-2991f15fa57b.png)
![after](https://user-images.githubusercontent.com/82224783/147259702-a1874a8f-fa8e-447c-b16c-622778bb9d40.png)
>