### PR TITLE
Reflow Project Tiles Everytime They Are Updated

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsScreen.cpp
@@ -284,13 +284,14 @@ namespace O3DE::ProjectManager
                     {
                         currentButton = projectButtonIter.value();
                         currentButton->RestoreDefaultState();
-                        m_projectsFlowLayout->addWidget(currentButton);
                     }
                 }
 
                 // Check whether project manager has successfully built the project
                 if (currentButton)
                 {
+                    m_projectsFlowLayout->addWidget(currentButton);
+
                     bool projectBuiltSuccessfully = false;
                     SettingsInterface::Get()->GetProjectBuiltSuccessfully(projectBuiltSuccessfully, project);
 
@@ -341,6 +342,7 @@ namespace O3DE::ProjectManager
         }
 
         m_stack->setCurrentWidget(m_projectsContent);
+        m_projectsFlowLayout->update();
     }
 
     ProjectManagerScreen ProjectsScreen::GetScreenEnum()
@@ -399,7 +401,6 @@ namespace O3DE::ProjectManager
     {
         if (ProjectUtils::AddProjectDialog(this))
         {
-            ResetProjectsContent();
             emit ChangeScreenRequest(ProjectManagerScreen::Projects);
         }
     }
@@ -490,7 +491,6 @@ namespace O3DE::ProjectManager
             // Open file dialog and choose location for copied project then register copy with O3DE
             if (ProjectUtils::CopyProjectDialog(projectInfo.m_path, newProjectInfo, this))
             {
-                ResetProjectsContent();
                 emit NotifyBuildProject(newProjectInfo);
                 emit ChangeScreenRequest(ProjectManagerScreen::Projects);
             }
@@ -503,7 +503,6 @@ namespace O3DE::ProjectManager
             // Unregister Project from O3DE and reload projects
             if (ProjectUtils::UnregisterProject(projectPath))
             {
-                ResetProjectsContent();
                 emit ChangeScreenRequest(ProjectManagerScreen::Projects);
             }
         }


### PR DESCRIPTION
Removed some unnecessary `ResetProjectsContent();` because it is already called by `NotifyCurrentScreen`

![9yWcUl9sQX](https://user-images.githubusercontent.com/52797929/147505789-a1f3f490-60da-4024-a969-dce0c148830a.gif)

Signed-off-by: nggieber <52797929+AMZN-nggieber@users.noreply.github.com>

Fixes #6523 