### PR TITLE
Fix Network Binding Component Icon

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -39,8 +39,8 @@ namespace Multiplayer
                     "Network Binding", "The Network Binding component marks an entity as able to be replicated across the network")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "Multiplayer")
-                    ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/NetBind.png")
-                    ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/NetBind.png")
+                    ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/NetBinding.svg")
+                    ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/NetBinding.svg")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"));
             }
         }


### PR DESCRIPTION
Fix network binding component to use the new svg icons instead of png (which no longer exist).
The missing icon was causing an error in Editor: [Error] Failed to locate icon on disk: "Icons/Components/Viewport/NetBind.png"



Tested by adding a Network Binding component and seeing that there are no longer any errors, and that the icons appear.
![image](https://user-images.githubusercontent.com/32776221/147787184-71e767ed-3bae-4899-ba33-a08a7073e2d6.png)


Signed-off-by: Gene Walters <genewalt@amazon.com>