### PR TITLE
Fix: Prevent widget color change

### DIFF
--- a/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorBaseShapeComponent.cpp
@@ -172,11 +172,13 @@ namespace LmbrCentral
 
     void EditorBaseShapeComponent::OnShapeColorChanged()
     {
-        m_shapeColor.SetA(AzFramework::ViewportColors::DeselectedColor.GetA());
+        // m_shapeColor.SetA(AzFramework::ViewportColors::DeselectedColor.GetA());
+        AZ::Color drawColor(m_shapeColor);
+        drawColor.SetA(AzFramework::ViewportColors::DeselectedColor.GetA());
 
         if (m_shapeConfig)
         {
-            m_shapeConfig->SetDrawColor(m_shapeColor);
+            m_shapeConfig->SetDrawColor(drawColor);
         }
     }
 

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorCapsuleShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorCapsuleShapeComponent.cpp
@@ -87,7 +87,7 @@ namespace LmbrCentral
             debugDisplay, [this]() { return CanDraw(); },
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
-                DrawShape(debugDisplay, { m_shapeColor, m_shapeWireColor, m_displayFilled }, m_capsuleShapeMesh);
+                DrawShape(debugDisplay, { m_capsuleShape.GetCapsuleConfiguration().GetDrawColor(), m_shapeWireColor, m_displayFilled }, m_capsuleShapeMesh);
             },
             m_capsuleShape.GetCurrentTransform());
     }

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorCylinderShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorCylinderShapeComponent.cpp
@@ -86,7 +86,7 @@ namespace LmbrCentral
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
                 DrawCylinderShape(
-                    { m_shapeColor, m_shapeWireColor, m_displayFilled },
+                    { m_cylinderShape.GetCylinderConfiguration().GetDrawColor(), m_shapeWireColor, m_displayFilled },
                     m_cylinderShape.GetCylinderConfiguration(), debugDisplay);
             },
             m_cylinderShape.GetCurrentTransform());

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorDiskShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorDiskShapeComponent.cpp
@@ -86,7 +86,7 @@ namespace LmbrCentral
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
                 DrawDiskShape(
-                    { m_shapeColor, m_shapeWireColor, m_displayFilled },
+                    { m_diskShape.GetDiskConfiguration().GetDrawColor(), m_shapeWireColor, m_displayFilled },
                     m_diskShape.GetDiskConfiguration(), debugDisplay);
             },
             m_diskShape.GetCurrentTransform());

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorPolygonPrismShapeComponent.cpp
@@ -183,7 +183,7 @@ namespace LmbrCentral
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
                 DrawPolygonPrismShape(
-                    { m_shapeColor, m_shapeWireColor, m_displayFilled },
+                    { m_polygonShapeConfig.GetDrawColor(), m_shapeWireColor, m_displayFilled },
                     m_polygonPrismMesh, debugDisplay);
 
                 debugDisplay.SetColor(m_shapeWireColor);

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorQuadShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorQuadShapeComponent.cpp
@@ -85,7 +85,7 @@ namespace LmbrCentral
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
                 DrawQuadShape(
-                    { m_shapeColor, m_shapeWireColor, m_displayFilled },
+                    { m_quadShape.GetQuadConfiguration().GetDrawColor(), m_shapeWireColor, m_displayFilled },
                     m_quadShape.GetQuadConfiguration(), debugDisplay, m_quadShape.GetCurrentNonUniformScale());
             },
             m_quadShape.GetCurrentTransform());

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorSphereShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorSphereShapeComponent.cpp
@@ -91,7 +91,7 @@ namespace LmbrCentral
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
                 DrawSphereShape(
-                    { m_shapeColor, m_shapeWireColor, m_displayFilled },
+                    { m_sphereShape.GetSphereConfiguration().GetDrawColor(), m_shapeWireColor, m_displayFilled },
                     m_sphereShape.GetSphereConfiguration(), debugDisplay);
             },
             m_sphereShape.GetCurrentTransform());

--- a/Gems/LmbrCentral/Code/Source/Shape/EditorTubeShapeComponent.cpp
+++ b/Gems/LmbrCentral/Code/Source/Shape/EditorTubeShapeComponent.cpp
@@ -143,7 +143,7 @@ namespace LmbrCentral
             debugDisplay, [this]() { return CanDraw(); },
             [this](AzFramework::DebugDisplayRequests& debugDisplay)
             {
-                DrawShape(debugDisplay, { m_shapeColor, m_shapeWireColor, m_displayFilled }, m_tubeShapeMesh);
+                DrawShape(debugDisplay, { m_tubeShapeMeshConfig.m_shapeComponentConfig.GetDrawColor(), m_shapeWireColor, m_displayFilled }, m_tubeShapeMesh);
             },
             m_tubeShape.GetCurrentTransform());
     }


### PR DESCRIPTION
When the color of a shape component changes, the color of the color widget of the component changes. To avoid this and keep the transparency of the shape, save the color with transparency and use this color when drawing

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>