### PR TITLE
Fix: Param value not saving in Ragdoll window

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/JointConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/JointConfiguration.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Physics/RagdollEMotionBus.h>
 
 namespace AzPhysics
 {
@@ -38,21 +39,31 @@ namespace AzPhysics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &JointConfiguration::m_parentLocalRotation,
                         "Parent local rotation", "Parent joint frame relative to parent body.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &JointConfiguration::GetParentLocalRotationVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &JointConfiguration::m_parentLocalPosition,
                         "Parent local position", "Joint position relative to parent body.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &JointConfiguration::GetParentLocalPositionVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &JointConfiguration::m_childLocalRotation,
                         "Child local rotation", "Child joint frame relative to child body.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &JointConfiguration::GetChildLocalRotationVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &JointConfiguration::m_childLocalPosition,
                         "Child local position", "Joint position relative to child body.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &JointConfiguration::GetChildLocalPositionVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &JointConfiguration::m_startSimulationEnabled,
                         "Start simulation enabled", "When active, the joint will be enabled when the simulation begins.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &JointConfiguration::GetStartSimulationEnabledVisibility)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ;
             }
         }
+    }
+
+    void JointConfiguration::OnDataChanged()
+    {
+        Physics::RagdollEMotionNotificationBus::Broadcast(&Physics::RagdollEMotionNotificationBus::Events::OnRagdollJointLimitConfigurationChanged);
     }
 
     AZ::Crc32 JointConfiguration::GetPropertyVisibility(JointConfiguration::PropertyVisibility property) const

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/JointConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/JointConfiguration.h
@@ -31,6 +31,7 @@ namespace AzPhysics
         JointConfiguration() = default;
         virtual ~JointConfiguration() = default;
 
+        void OnDataChanged();
         // Visibility helpers for use in the Editor when reflected.
         enum PropertyVisibility : AZ::u8
         {

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/RigidBodyConfiguration.h
@@ -34,6 +34,7 @@ namespace AzPhysics
 
         MassComputeFlags GetMassComputeFlags() const;
         void SetMassComputeFlags(MassComputeFlags flags);
+        virtual void OnDataChanged(){}
 
         bool IsCCDEnabled() const;
 

--- a/Code/Framework/AzFramework/AzFramework/Physics/Ragdoll.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Ragdoll.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Physics/Ragdoll.h>
 #include <AzFramework/Physics/ClassConverters.h>
-
+#include <AzFramework/Physics/RagdollEMotionBus.h>
 
 namespace Physics
 {
@@ -46,6 +46,11 @@ namespace Physics
                 ;
             }
         }
+    }
+
+    void RagdollNodeConfiguration::OnDataChanged()
+    {
+        RagdollEMotionNotificationBus::Broadcast(&RagdollEMotionNotificationBus::Events::OnRagdollPropertiesConfigurationChanged);
     }
 
     RagdollConfiguration::RagdollConfiguration()

--- a/Code/Framework/AzFramework/AzFramework/Physics/Ragdoll.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Ragdoll.h
@@ -33,6 +33,7 @@ namespace Physics
 
         RagdollNodeConfiguration();
         RagdollNodeConfiguration(const RagdollNodeConfiguration& settings) = default;
+        void OnDataChanged() override;
 
         AZStd::shared_ptr<AzPhysics::JointConfiguration> m_jointConfig;
     };

--- a/Code/Framework/AzFramework/AzFramework/Physics/RagdollEMotionBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/RagdollEMotionBus.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/EBus/EBus.h>
+
+namespace Physics
+{
+    class RagdollEMotionNotifications : public AZ::EBusTraits
+    {
+    public:
+        virtual void OnRagdollPropertiesConfigurationChanged() = 0;
+        virtual void OnRagdollJointLimitConfigurationChanged() = 0;
+        virtual void OnRagdollColliderConfigurationChanged() = 0;
+    };
+
+    using RagdollEMotionNotificationBus = AZ::EBus<RagdollEMotionNotifications>;
+}

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
@@ -9,6 +9,7 @@
 #include "Shape.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Physics/ClassConverters.h>
+#include <AzFramework/Physics/RagdollEMotionBus.h>
 
 namespace Physics
 {
@@ -44,29 +45,39 @@ namespace Physics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isTrigger, "Trigger", "If set, this collider will act as a trigger")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::AttributesAndValues)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isSimulated, "Simulated", "If set, this collider will partake in collision in the physical simulation")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
                         ->Attribute(AZ::Edit::Attributes::ReadOnly, &ColliderConfiguration::m_isTrigger) // Trigger shapes ignore simulated flag, making it read-only in the UI.
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_isInSceneQueries, "In Scene Queries", "If set, this collider will be visible for scene queries")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetIsTriggerVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_collisionLayer, "Collision Layer", "The collision layer assigned to the collider")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetCollisionLayerVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_collisionGroupId, "Collides With", "The collision group containing the layers this collider collides with")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetCollisionLayerVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_position, "Offset", "Local offset from the rigid body")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetOffsetVisibility)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_rotation, "Rotation", "Local rotation relative to the rigid body")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetOffsetVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_materialSelection, "Physics Materials", "Select which physics materials to use for each element of this shape")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetMaterialSelectionVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_tag, "Tag", "Tag used to identify colliders from one another")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_restOffset, "Rest offset",
                         "Bodies will come to rest separated by the sum of their rest offset values (must be less than contact offset)")
                         ->Attribute(AZ::Edit::Attributes::Step, 1e-2f)
                         ->Attribute(AZ::Edit::Attributes::Max, 50.0f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnRestOffsetChanged)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_contactOffset, "Contact offset",
                         "Bodies will begin to generate contacts when within the sum of their contact offsets (must exceed rest offset)")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
@@ -74,9 +85,15 @@ namespace Physics
                         ->Attribute(AZ::Edit::Attributes::Max, 50.0f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnContactOffsetChanged)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ColliderConfiguration::OnDataChanged)
                     ;
             }
         }
+    }
+
+    void ColliderConfiguration::OnDataChanged()
+    {
+        RagdollEMotionNotificationBus::Broadcast(&RagdollEMotionNotificationBus::Events::OnRagdollColliderConfigurationChanged);
     }
 
     void ColliderConfiguration::OnRestOffsetChanged()

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
@@ -73,6 +73,7 @@ namespace Physics
     private:
         void OnRestOffsetChanged();
         void OnContactOffsetChanged();
+        void OnDataChanged();
     };
 
     struct RayCastRequest;

--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.cpp
@@ -12,6 +12,7 @@
 #include <AzFramework/Physics/PropertyTypes.h>
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzFramework/Physics/RagdollEMotionBus.h>
 
 namespace Physics
 {
@@ -43,6 +44,11 @@ namespace Physics
         }
     }
 
+    void ShapeConfiguration::OnDataChanged()
+    {
+        RagdollEMotionNotificationBus::Broadcast(&RagdollEMotionNotificationBus::Events::OnRagdollColliderConfigurationChanged);
+    }
+
     void SphereShapeConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -64,6 +70,7 @@ namespace Physics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &SphereShapeConfiguration::m_radius, "Radius", "The radius of the sphere collider")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ShapeConfiguration::OnDataChanged)
                     ;
             }
         }
@@ -95,6 +102,7 @@ namespace Physics
                     ->DataElement(AZ::Edit::UIHandlers::Default, &BoxShapeConfiguration::m_dimensions, "Dimensions", "Lengths of the box sides")
                     ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ShapeConfiguration::OnDataChanged)
                     ;
             }
         }
@@ -129,11 +137,13 @@ namespace Physics
                         ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CapsuleShapeConfiguration::OnHeightChanged)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ShapeConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CapsuleShapeConfiguration::m_radius, "Radius", "The radius of the capsule")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CapsuleShapeConfiguration::OnRadiusChanged)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::ValuesOnly)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &ShapeConfiguration::OnDataChanged)
                     ;
             }
         }

--- a/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/ShapeConfiguration.h
@@ -43,6 +43,7 @@ namespace Physics
         virtual ShapeType GetShapeType() const = 0;
 
         AZ::Vector3 m_scale = AZ::Vector3::CreateOne();
+        void OnDataChanged();
     };
 
     class SphereShapeConfiguration : public ShapeConfiguration

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -262,6 +262,7 @@ set(FILES
     Physics/CharacterBus.h
     Physics/Ragdoll.cpp
     Physics/Ragdoll.h
+    Physics/RagdollEMotionBus.h
     Physics/Utils.h
     Physics/Utils.cpp
     Physics/ClassConverters.cpp

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeWidget.cpp
@@ -105,7 +105,10 @@ namespace EMotionFX
 
         return result;
     }
-
+    RagdollNodeWidget::~RagdollNodeWidget()
+    {
+        Physics::RagdollEMotionNotificationBus::Handler::BusDisconnect();
+    }
     QWidget* RagdollNodeWidget::CreateNoSelectionWidget(QWidget* parent)
     {
         QLabel* noSelectionLabel = new QLabel("Select joints from the Skeleton Outliner and add it to the ragdoll using the right-click menu", parent);
@@ -114,6 +117,36 @@ namespace EMotionFX
         return noSelectionLabel;
     }
 
+    void RagdollNodeWidget::OnRagdollPropertiesConfigurationChanged()
+    {
+        if (m_ragdollNodeEditor->isVisible())
+        {
+            SetActorDirty();
+        }
+    }
+    void RagdollNodeWidget::OnRagdollJointLimitConfigurationChanged()
+    {
+        if (m_jointLimitWidget->isVisible())
+        {
+            SetActorDirty();
+        }
+    }
+    void RagdollNodeWidget::OnRagdollColliderConfigurationChanged()
+    {
+        if (m_collidersWidget->isVisible())
+        {
+            SetActorDirty();
+        }
+    }
+
+    void RagdollNodeWidget::SetActorDirty()
+    {
+        Actor* actor = GetActor();
+        if (actor)
+        {
+            actor->SetDirtyFlag(true);
+        }
+    }
     void RagdollNodeWidget::InternalReinit()
     {
         const QModelIndexList& selectedModelIndices = GetSelectedModelIndices();
@@ -125,6 +158,12 @@ namespace EMotionFX
             Physics::RagdollNodeConfiguration* ragdollNodeConfig = GetRagdollNodeConfig();
             if (ragdollNodeConfig)
             {
+                AzPhysics::JointConfiguration* jointLimitConfig = ragdollNodeConfig->m_jointConfig.get();
+                jointLimitConfig->SetPropertyVisibility(AzPhysics::JointConfiguration::PropertyVisibility::ParentLocalRotation, jointLimitConfig != nullptr);
+                jointLimitConfig->SetPropertyVisibility(AzPhysics::JointConfiguration::PropertyVisibility::ChildLocalRotation, jointLimitConfig != nullptr);
+
+                Physics::RagdollEMotionNotificationBus::Handler::BusConnect();
+
                 m_addColliderButton->show();
                 m_addRemoveButton->setText("Remove from ragdoll");
 

--- a/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeWidget.h
+++ b/Gems/EMotionFX/Code/Source/Editor/Plugins/Ragdoll/RagdollNodeWidget.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzFramework/Physics/Ragdoll.h>
+#include <AzFramework/Physics/RagdollEMotionBus.h>
 #include <AzQtComponents/Components/Widgets/Card.h>
 #include <AzQtComponents/Components/Widgets/CardHeader.h>
 #include <Editor/SkeletonModelJointWidget.h>
@@ -22,6 +23,7 @@ QT_FORWARD_DECLARE_CLASS(QPushButton)
 namespace Physics
 {
     class RagdollNodeConfiguration;
+    class RagdollEMotionNotifications;
 }
 
 namespace EMotionFX
@@ -47,15 +49,21 @@ namespace EMotionFX
 
     class RagdollNodeWidget
         : public SkeletonModelJointWidget
+        , private Physics::RagdollEMotionNotificationBus::Handler
     {
         Q_OBJECT //AUTOMOC
 
     public:
         RagdollNodeWidget(QWidget* parent = nullptr);
-        ~RagdollNodeWidget() = default;
+        ~RagdollNodeWidget();
 
         bool HasCopiedJointLimits() const { return !m_copiedJointLimit.empty(); }
         const AZStd::string& GetCopiedJointLimits() const { return m_copiedJointLimit; }
+
+        void SetActorDirty();
+        void OnRagdollPropertiesConfigurationChanged() override;
+        void OnRagdollJointLimitConfigurationChanged() override;
+        void OnRagdollColliderConfigurationChanged() override;
 
     public slots:
         void OnAddRemoveRagdollNode();

--- a/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorRigidBodyComponent.cpp
@@ -125,36 +125,46 @@ namespace PhysX
                         "Initial linear velocity", "Linear velocity applied when the rigid body is activated.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInitialVelocitiesVisibility)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetSpeedUnit())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_initialAngularVelocity,
                         "Initial angular velocity", "Angular velocity applied when the rigid body is activated (limited by maximum angular velocity).")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInitialVelocitiesVisibility)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetAngularVelocityUnit())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_linearDamping,
                         "Linear damping", "The rate of decay over time for linear velocity even if no forces are acting on the rigid body.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetDampingVisibility)
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_angularDamping,
                         "Angular damping", "The rate of decay over time for angular velocity even if no forces are acting on the rigid body.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetDampingVisibility)
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_sleepMinEnergy,
                         "Sleep threshold", "The rigid body can go to sleep (settle) when kinetic energy per unit mass is persistently below this value.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetSleepOptionsVisibility)
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetSleepThresholdUnit())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_startAsleep,
                         "Start asleep", "When active, the rigid body will be asleep when spawned, and wake when the body is disturbed.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetSleepOptionsVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_interpolateMotion,
                         "Interpolate motion", "When active, simulation results are interpolated resulting in smoother motion.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInterpolationVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_gravityEnabled,
                         "Gravity enabled", "When active, global gravity affects this rigid body.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetGravityVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_kinematic,
                         "Kinematic", "When active, the rigid body is not affected by gravity or other forces and is moved by script.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetKinematicVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     // Linear axis locking properties
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Linear Axis Locking")
@@ -162,12 +172,15 @@ namespace PhysX
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_lockLinearX, "Lock X",
                         "When active, forces won't create translation on the X axis of the rigid body.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_lockLinearY, "Lock Y",
                         "When active, forces won't create translation on the Y axis of the rigid body.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_lockLinearZ, "Lock Z",
                         "When active, forces won't create translation on the Z axis of the rigid body.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     // Angular axis locking properties
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Angular Axis Locking")
@@ -175,12 +188,15 @@ namespace PhysX
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_lockAngularX, "Lock X",
                         "When active, forces won't create rotation on the X axis of the rigid body.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_lockAngularY, "Lock Y",
                         "When active, forces won't create rotation on the Y axis of the rigid body.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_lockAngularZ, "Lock Z",
                         "When active, forces won't create rotation on the Z axis of the rigid body.")
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Continuous Collision Detection")
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
@@ -190,15 +206,18 @@ namespace PhysX
                         "collision detection, particularly for fast moving rigid bodies. CCD must be activated in the global PhysX preferences.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetCCDVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_ccdMinAdvanceCoefficient,
                         "Min advance coefficient", "Lower values reduce clipping but can affect simulation smoothness.")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.01f)
                         ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                         ->Attribute(AZ::Edit::Attributes::Max, 0.99f)
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::IsCCDEnabled)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_ccdFrictionEnabled,
                         "CCD friction", "When active, friction is applied when continuous collision detection (CCD) collisions are resolved.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::IsCCDEnabled)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ->ClassElement(AZ::Edit::ClassElements::Group, "") // end previous group by starting new unnamed expanded group
                         ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_maxAngularVelocity,
@@ -207,22 +226,26 @@ namespace PhysX
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetMaxVelocitiesVisibility)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetAngularVelocityUnit())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     // Mass properties
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RigidBodyConfiguration::m_computeCenterOfMass,
                         "Compute COM", "Compute the center of mass (COM) for this rigid body.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInertiaSettingsVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RigidBodyConfiguration::m_centerOfMassOffset,
                         "COM offset", "Local space offset for the center of mass (COM).")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetCoMVisibility)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetLengthUnit())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RigidBodyConfiguration::m_computeMass,
                         "Compute Mass", "When active, the mass of the rigid body is computed based on the volume and density values of its colliders.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInertiaSettingsVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &AzPhysics::RigidBodyConfiguration::m_mass,
                         "Mass", "The mass of the rigid body in kilograms. A value of 0 is treated as infinite. "
@@ -230,23 +253,27 @@ namespace PhysX
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetMassUnit())
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetMassVisibility)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RigidBodyConfiguration::m_computeInertiaTensor,
                         "Compute inertia", "When active, inertia is computed based on the mass and shape of the rigid body.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInertiaSettingsVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(Editor::InertiaHandler, &AzPhysics::RigidBodyConfiguration::m_inertiaTensor,
                         "Inertia diagonal", "Inertia diagonal elements that specify an inertia tensor; determines the "
                         "torque required to rotate the rigid body on each axis.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInertiaVisibility)
                         ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetInertiaUnit())
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
 
                     ->DataElement(AZ::Edit::UIHandlers::Default, &RigidBodyConfiguration::m_includeAllShapesInMassCalculation,
                         "Include non-simulated shapes in Mass",
                         "When active, non-simulated shapes are included in the center of mass, inertia, and mass calculations.")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &AzPhysics::RigidBodyConfiguration::GetInertiaSettingsVisibility)
                         ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &AzPhysics::RigidBodyConfiguration::OnDataChanged)
                     ;
 
                 editContext->Class<EditorRigidBodyConfiguration>(

--- a/Gems/PhysX/Code/Source/Joint/Configuration/PhysXJointConfiguration.cpp
+++ b/Gems/PhysX/Code/Source/Joint/Configuration/PhysXJointConfiguration.cpp
@@ -63,21 +63,25 @@ namespace PhysX
                     ->Attribute(AZ::Edit::Attributes::Suffix, " degrees")
                     ->Attribute(AZ::Edit::Attributes::Min, JointConstants::MinSwingLimitDegrees)
                     ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &D6JointLimitConfiguration::m_swingLimitZ, "Swing limit Z",
                         "The rotation angle limit around the joint's Z axis.")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " degrees")
                     ->Attribute(AZ::Edit::Attributes::Min, JointConstants::MinSwingLimitDegrees)
                     ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &D6JointLimitConfiguration::m_twistLimitLower, "Twist lower limit",
                         "The lower rotation angle limit around the joint's X axis.")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " degrees")
                     ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &D6JointLimitConfiguration::m_twistLimitUpper, "Twist upper limit",
                         "The upper rotation angle limit around the joint's X axis.")
                     ->Attribute(AZ::Edit::Attributes::Suffix, " degrees")
                     ->Attribute(AZ::Edit::Attributes::Min, -180.0f)
                     ->Attribute(AZ::Edit::Attributes::Max, 180.0f)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &JointConfiguration::OnDataChanged)
                 ;
             }
         }


### PR DESCRIPTION
 In the animation editor, when a parameter value is modified in the Ragdoll window, the modification cannot be saved after you click Save All.

Signed-off-by: T.J. McGrath-Daly <tj.mcgrath.daly@huawei.com>