### PR TITLE
SimpleMotion parameter issue

### DIFF
--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
@@ -307,6 +307,12 @@ namespace EMotionFX
         {
             if (m_motionInstance)
             {
+                if (time > m_motionInstance->GetDuration())
+                {
+                    AZ_Warning("EMotionFX", false, "Invalid play time: %f, The set value exceeds the maximum value.", time);
+                    return;
+                }
+
                 float delta = time - m_motionInstance->GetLastCurrentTime();
                 m_motionInstance->SetCurrentTime(time, false);
 
@@ -325,7 +331,7 @@ namespace EMotionFX
             float result = 0.0f;
             if (m_motionInstance)
             {
-                result = m_motionInstance->GetCurrentTimeNormalized();
+                result = m_motionInstance->GetCurrentTime();
             }
             return result;
         }


### PR DESCRIPTION
The playtime parameter of the Lua script node of SimpleMotion is set to 2. If the jumping animation is used, the value of the parameter obtained is less than 2.857.