### PR TITLE
Doubling cloth colliders

### DIFF
--- a/Gems/EMotionFX/Code/Source/Editor/ColliderContainerWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ColliderContainerWidget.cpp
@@ -691,6 +691,10 @@ namespace EMotionFX
         {
             const ActorInstance* actorInstance = actorManager->GetActorInstance(i);
             const Actor* actor = actorInstance->GetActor();
+            if (!(actorInstance->GetRender() && actorInstance->GetIsVisible() && actorInstance->GetIsOwnedByRuntime() == false))
+            {
+                continue;
+            }
             const AZStd::shared_ptr<PhysicsSetup>& physicsSetup = actor->GetPhysicsSetup();
             const Physics::CharacterColliderConfiguration* colliderConfig = physicsSetup->GetColliderConfigByType(colliderConfigType);
 


### PR DESCRIPTION
If there is only one character in the scene, click the icon on the right of Actor asset in the Actor component of the character to enter the animation editor, and select Physics to add Cloth Collider. Two Cloth Colliders are added at once.