### PR TITLE
Actor still exists after deletion

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -1179,6 +1179,12 @@ namespace AssetProcessor
                     {
                         AssetProcessor::ProcessingJobInfoBus::Broadcast(&AssetProcessor::ProcessingJobInfoBus::Events::BeginCacheFileUpdate, fullProductPath.toUtf8().data());
                         bool wasRemoved = QFile::remove(fullProductPath);
+                        if (!wasRemoved)
+                        {
+                            constexpr int DeleteRetryDelay = 10;
+                            AZStd::this_thread::sleep_for(AZStd::chrono::milliseconds(DeleteRetryDelay));
+                            wasRemoved = QFile::remove(fullProductPath);
+                        }
                         AssetProcessor::ProcessingJobInfoBus::Broadcast(&AssetProcessor::ProcessingJobInfoBus::Events::EndCacheFileUpdate, fullProductPath.toUtf8().data(), false);
                         if (!wasRemoved)
                         {


### PR DESCRIPTION
In the asset browser, select the FBX file of a character model, double-click it, and delete the Actor from the Fbx Settings page. The Actor still exists when the model is dragged to the scene. The Actor is deleted only after the engine is closed and then the Actor is opened.
After an actor is added and dragged to the scenario, when the actor is deleted, the acotr file is occupied and cannot be deleted. As a result, the AP process is not cleared and an error message is sent to the editor.