### PR TITLE
Empty Anim Graph

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.cpp
@@ -1105,6 +1105,10 @@ namespace EMStudio
         }
 
         delete modelItemData;
+        if (m_modelItemDataSet.empty())
+        {
+            emit RemoveAll();
+        }
     }
 
     void AnimGraphModel::OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/AnimGraphModel.h
@@ -175,6 +175,7 @@ namespace EMStudio
         // we need a way to reinit the ParameterWindow when parameter change.
         void ParametersChanged(EMotionFX::AnimGraph* animGraph);
 
+        void RemoveAll();
     private:
         void Reset();
 

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.cpp
@@ -41,6 +41,7 @@ namespace EMStudio
 
         connect(&m_plugin->GetAnimGraphModel(), &AnimGraphModel::FocusChanged, this, &NavigationLinkWidget::OnFocusChanged);
         connect(&m_plugin->GetAnimGraphModel(), &AnimGraphModel::dataChanged, this, &NavigationLinkWidget::OnDataChanged);
+        connect(&m_plugin->GetAnimGraphModel(), &AnimGraphModel::RemoveAll, this, &NavigationLinkWidget::ClearModelIndex);
     }
 
     NavigationLinkWidget::~NavigationLinkWidget()
@@ -80,6 +81,12 @@ namespace EMStudio
                 break;
             }
         }
+    }
+
+    void NavigationLinkWidget::ClearModelIndex()
+    {
+        m_modelIndexes.clear();
+        m_breadCrumbs->setCurrentPath("");
     }
 
     void NavigationLinkWidget::OnBreadCrumbsLinkClicked(const QString& linkPath, int linkIndex)

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/NavigationLinkWidget.h
@@ -34,6 +34,7 @@ namespace EMStudio
     private slots:
         void OnFocusChanged(const QModelIndex& newFocusIndex, const QModelIndex& newFocusParent, const QModelIndex& oldFocusIndex, const QModelIndex& oldFocusParent);
         void OnDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight, const QVector<int>& roles);
+        void ClearModelIndex();
         void OnBreadCrumbsLinkClicked(const QString& linkPath, int linkIndex);
 
     private:


### PR DESCRIPTION
After a workspace is created in the Animation Editor, the Anim Graph is not completely reset. The Anim Graph of the previous workspace is still retained, but the content is empty.