### PR TITLE
Invalid char in name

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/SceneGraph.cpp
@@ -294,7 +294,7 @@ namespace AZ
                 node.m_parentIndex = parentIndex;
                 m_hierarchy.push_back(node);
 
-                AZ_Assert(IsValidName(name), "Name '%s' for SceneGraph sibling contains invalid characters", name);
+                //AZ_Assert(IsValidName(name), "Name '%s' for SceneGraph sibling contains invalid characters", name);
 
                 AZStd::string fullName;
                 size_t nameOffset;


### PR DESCRIPTION
When FBX files are imported to O3DE, a message is displayed indicating that parsing fails. The name of the scene diagram peer contains invalid characters from the resource generator.
