### PR TITLE
Transforms lines that look like:

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/CommonFiles/Preprocessor.h
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/CommonFiles/Preprocessor.h
@@ -101,9 +101,11 @@ namespace AZ
             bool preprocessIncludedFiles = true);
 
         //! Replace all ocurrences of #line "whatever" by #line "whatwewant"
-        void MutateLineDirectivesFileOrigin(
-            AZStd::string& sourceCode,
-            AZStd::string newFileOrigin);
+        //void MutateLineDirectivesFileOrigin(
+        //    AZStd::string& sourceCode,
+        //    AZStd::string newFileOrigin);
+
+        AZStd::string TransformPathsContainingAssetProcessorTemp(const char* source);
 
         //! Binder helper to Matsui C-Pre-Processor library
         class McppBinder


### PR DESCRIPTION
into:

Basically, the idea is that if the file path contains "JobTemp-", then
it should be transformed into a relative path to guarantee deterministic
content of the preprocessed shader files and the output will be always
the same and guarantee deterministic file hashing.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>