### PR TITLE
Remove 'INF' from integer widget and replace it with better formatted…

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -92,15 +92,11 @@ namespace AzToolsFramework
             {
                 toolTipString += "\n";
             }
-            toolTipString += "[";
 
             const QString minString = QLocale().toString(propertyControl->minimum());
             const QString maxString = QLocale().toString(propertyControl->maximum());
+            toolTipString += QString("[%1, %2]").arg(minString).arg(maxString);
 
-            toolTipString += minString;
-            toolTipString += ", ";
-            toolTipString += maxString;
-            toolTipString += "]";
             return true;
         }
         return false;
@@ -121,10 +117,8 @@ namespace AzToolsFramework
 
             const QString minString = QLocale().toString(propertyControl->minimum());
             const QString maxString = QLocale().toString(propertyControl->maximum());
+            toolTipString += QString("[%1, %2]").arg(minString).arg(maxString);
 
-            toolTipString += "[" + minString + ", ";
-            toolTipString += maxString;
-            toolTipString += "]";
             return true;
         }
         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/UI/PropertyEditor/PropertyQTConstants.h>
 #include <AzToolsFramework/UI/PropertyEditor/QtWidgetLimits.h>
 #include <QtWidgets/QWidget>
+#include <QLocale> 
 
 namespace AzToolsFramework
 {   

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyIntCtrlCommon.h
@@ -93,23 +93,13 @@ namespace AzToolsFramework
                 toolTipString += "\n";
             }
             toolTipString += "[";
-            if (propertyControl->minimum() <= aznumeric_cast<AZ::s64>(QtWidgetLimits<T>::Min()))
-            {
-                toolTipString += "-" + QObject::tr(PropertyQTConstant_InfinityString);
-            }
-            else
-            {
-                toolTipString += QString::number(propertyControl->minimum());
-            }
+
+            const QString minString = QLocale().toString(propertyControl->minimum());
+            const QString maxString = QLocale().toString(propertyControl->maximum());
+
+            toolTipString += minString;
             toolTipString += ", ";
-            if (propertyControl->maximum() >= aznumeric_cast<AZ::s64>(QtWidgetLimits<T>::Max()))
-            {
-                toolTipString += QObject::tr(PropertyQTConstant_InfinityString);
-            }
-            else
-            {
-                toolTipString += QString::number(propertyControl->maximum());
-            }
+            toolTipString += maxString;
             toolTipString += "]";
             return true;
         }
@@ -128,15 +118,12 @@ namespace AzToolsFramework
             {
                 toolTipString += "\n";
             }
-            toolTipString += "[" + QString::number(propertyControl->minimum()) + ", ";
-            if (propertyControl->maximum() >= aznumeric_cast<AZ::s64>(QtWidgetLimits<T>::Max()))
-            {
-                toolTipString += QObject::tr(PropertyQTConstant_InfinityString);
-            }
-            else
-            {
-                toolTipString += QString::number(propertyControl->maximum());
-            }
+
+            const QString minString = QLocale().toString(propertyControl->minimum());
+            const QString maxString = QLocale().toString(propertyControl->maximum());
+
+            toolTipString += "[" + minString + ", ";
+            toolTipString += maxString;
             toolTipString += "]";
             return true;
         }
@@ -196,7 +183,7 @@ namespace AzToolsFramework
             }
             else
             {
-                AZ_WarningOnce("AzToolsFramework", false, "Property %s: 'Min' attribute from property '%s' into widget", debugName);
+                AZ_WarningOnce("AzToolsFramework", false, "Failed to read 'Min' attribute from property '%s' into widget", debugName);
             }
         }
         else if (attrib == AZ::Edit::Attributes::Max)

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
@@ -12,7 +12,6 @@
 #include <AzCore/std/typetraits/is_signed.h>
 #include "IntegerPrimtitiveTestConfig.h"
 #include <QApplication>
-#include <QLocale.h>
 #include <sstream>
 
 namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
@@ -12,6 +12,7 @@
 #include <AzCore/std/typetraits/is_signed.h>
 #include "IntegerPrimtitiveTestConfig.h"
 #include <QApplication>
+#include <QLocale.h>
 #include <sstream>
 
 namespace UnitTest
@@ -83,18 +84,6 @@ namespace UnitTest
             widget->setMaximum(widget->maximum() - 1);
         }
 
-        static std::string GetToolTipStringAtLimits()
-        {
-            if constexpr (std::is_signed<ValueType>::value)
-            {
-                return "[-INF, INF]";
-            }
-            else
-            {
-                return "[0, INF]";
-            }
-        }
-
         void PropertyCtrlHandlersCreated()
         {
             using ::testing::Ne;
@@ -125,15 +114,19 @@ namespace UnitTest
             auto& widget = m_widget;
             auto& handler = m_handler;
             QString tooltip;
-            std::string expected;
+            std::stringstream expected;
 
             // Retrieve the tooltip string for this widget
             auto success = handler->ModifyTooltip(widget, tooltip);
-            expected = GetToolTipStringAtLimits();
+
+            const QString minString = QLocale().toString(widget->minimum());
+            const QString maxString = QLocale().toString(widget->maximum());
+
+            expected << "[" << minString.toStdString() << ", " << maxString.toStdString() << "]";
 
             // Expect the operation to be successful and a valid limit tooltip string generated
             EXPECT_TRUE(success);
-            EXPECT_STREQ(tooltip.toStdString().c_str(), expected.c_str());
+            EXPECT_STREQ(tooltip.toStdString().c_str(), expected.str().c_str());
         }
 
         void HandlerMinMaxLessLimit_ModifyHandler_ExpectSuccessAndValidLessLimitToolTipString()
@@ -149,7 +142,11 @@ namespace UnitTest
 
             // Retrieve the tooltip string for this widget
             auto success = handler->ModifyTooltip(widget, tooltip);
-            expected << "[" << widget->minimum() << ", " << widget->maximum() << "]";
+
+            const QString minString = QLocale().toString(widget->minimum());
+            const QString maxString = QLocale().toString(widget->maximum());
+
+            expected << "[" << minString.toStdString() << ", " << maxString.toStdString() << "]";
 
             // Expect the operation to be successful and a valid less than limit tooltip string generated
             EXPECT_TRUE(success);

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
@@ -113,19 +113,17 @@ namespace UnitTest
             auto& widget = m_widget;
             auto& handler = m_handler;
             QString tooltip;
-            std::stringstream expected;
 
             // Retrieve the tooltip string for this widget
             auto success = handler->ModifyTooltip(widget, tooltip);
 
             const QString minString = QLocale().toString(widget->minimum());
             const QString maxString = QLocale().toString(widget->maximum());
-
-            expected << "[" << minString.toStdString() << ", " << maxString.toStdString() << "]";
+            const AZStd::string expected = AZStd::string::format("[%d, %d]", minString.toStdString().c_str(), maxString.toStdString().c_str());
 
             // Expect the operation to be successful and a valid limit tooltip string generated
             EXPECT_TRUE(success);
-            EXPECT_STREQ(tooltip.toStdString().c_str(), expected.str().c_str());
+            EXPECT_STREQ(tooltip.toStdString().c_str(), expected.c_str());
         }
 
         void HandlerMinMaxLessLimit_ModifyHandler_ExpectSuccessAndValidLessLimitToolTipString()
@@ -134,7 +132,6 @@ namespace UnitTest
             auto& widget = m_widget;
             auto& handler = m_handler;
             QString tooltip;
-            std::stringstream expected;
 
             // That is not at the extremeties of the type range limit
             SetWidgetRangeToNonExtremeties(widget);
@@ -145,11 +142,11 @@ namespace UnitTest
             const QString minString = QLocale().toString(widget->minimum());
             const QString maxString = QLocale().toString(widget->maximum());
 
-            expected << "[" << minString.toStdString() << ", " << maxString.toStdString() << "]";
+            const AZStd::string expected = AZStd::string::format("[%d, %d]", minString.toStdString().c_str(), maxString.toStdString().c_str());
 
             // Expect the operation to be successful and a valid less than limit tooltip string generated
             EXPECT_TRUE(success);
-            EXPECT_STREQ(tooltip.toStdString().c_str(), expected.str().c_str());
+            EXPECT_STREQ(tooltip.toStdString().c_str(), expected.c_str());
         }
 
         void EmitWidgetValueChanged()

--- a/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
+++ b/Code/Framework/AzToolsFramework/Tests/PropertyIntCtrlCommonTests.h
@@ -119,7 +119,7 @@ namespace UnitTest
 
             const QString minString = QLocale().toString(widget->minimum());
             const QString maxString = QLocale().toString(widget->maximum());
-            const AZStd::string expected = AZStd::string::format("[%d, %d]", minString.toStdString().c_str(), maxString.toStdString().c_str());
+            const AZStd::string expected = AZStd::string::format("[%s, %s]", minString.toStdString().c_str(), maxString.toStdString().c_str());
 
             // Expect the operation to be successful and a valid limit tooltip string generated
             EXPECT_TRUE(success);
@@ -142,7 +142,7 @@ namespace UnitTest
             const QString minString = QLocale().toString(widget->minimum());
             const QString maxString = QLocale().toString(widget->maximum());
 
-            const AZStd::string expected = AZStd::string::format("[%d, %d]", minString.toStdString().c_str(), maxString.toStdString().c_str());
+            const AZStd::string expected = AZStd::string::format("[%s, %s]", minString.toStdString().c_str(), maxString.toStdString().c_str());
 
             // Expect the operation to be successful and a valid less than limit tooltip string generated
             EXPECT_TRUE(success);


### PR DESCRIPTION
Remove 'INF' from integer widgets and replace it with better formatted integers.
Also fixed formatted string with invalid number of parameters.
Tested signed/unsigned 8-bit, 16-bit, 32-bit and 64-bit integers.
Using QLocale to give better formatting of large integers  (adds commas)

Before. Note that the range is just [0,255] but 255 gets set to non-explicit "INF"
![image](https://user-images.githubusercontent.com/61609885/148103125-665eb043-df42-46a8-a7bc-e46c130d3f07.png)

After. (example using 32-bit signed integers)
![image](https://user-images.githubusercontent.com/61609885/148103482-2c851e3d-3cb6-48ca-865c-e87734dea26c.png)

After (8-bit signed integers)
![8 bit signed](https://user-images.githubusercontent.com/61609885/148103521-1ceacb80-043e-4135-94a7-3eee27e8badd.jpg)



Signed-off-by: mrieggeramzn <mriegger@amazon.com>