### PR TITLE
Death test relies on an exception from occurring

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/Json/RegistrationContext.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/Json/RegistrationContext.h
@@ -45,9 +45,8 @@ namespace AZ
             }
             else
             {
-                SerializerMap::const_iterator serializerIter = m_jsonSerializers.find(typeId);
-                AZ_Assert(serializerIter != m_jsonSerializers.end(), "Attempting to unregister a serializer that has not been registered yet with typeid %s", typeId.ToString<AZStd::string>().c_str());
-                m_jsonSerializers.erase(serializerIter);
+                [[maybe_unused]] size_t erased = m_jsonSerializers.erase(typeId);
+                AZ_Assert(erased == 1, "Attempting to unregister a serializer that has not been registered yet with typeid %s", typeId.ToString<AZStd::string>().c_str());
                 return SerializerBuilder(this, m_jsonSerializers.end());
             }
         }

--- a/Code/Framework/AzCore/Tests/Serialization/Json/JsonRegistrationContextTests.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization/Json/JsonRegistrationContextTests.cpp
@@ -327,17 +327,13 @@ namespace JsonSerializationTests
         SerializerWithOneType::Unreflect(m_jsonRegistrationContext.get());
     }
 
-#if GTEST_HAS_DEATH_TEST
-    using JsonSerializationDeathTests = JsonRegistrationContextTests;
-    TEST_F(JsonSerializationDeathTests, DoubleUnregisterSerializer_Asserts)
+    TEST_F(JsonRegistrationContextTests, DoubleUnregisterSerializer_Asserts)
     {
-        ASSERT_DEATH({
-            SerializerWithOneType::Reflect(m_jsonRegistrationContext.get());
-            SerializerWithOneType::Unreflect(m_jsonRegistrationContext.get());
-            SerializerWithOneType::Unreflect(m_jsonRegistrationContext.get());
-            }, ".*"
-        );
+        SerializerWithOneType::Reflect(m_jsonRegistrationContext.get());
+        SerializerWithOneType::Unreflect(m_jsonRegistrationContext.get());
+        AZ_TEST_START_ASSERTTEST;
+        SerializerWithOneType::Unreflect(m_jsonRegistrationContext.get());
+        AZ_TEST_STOP_ASSERTTEST(1);
     }
-#endif // GTEST_HAS_DEATH_TEST
 
 } //namespace JsonSerializationTests


### PR DESCRIPTION
That exception is an access violation, which could not happen (i.e. the memory could be valid for the process). I hit this issue in another PR, the test was not dying in Jenkins.

The test doesnt have to be a death test. Also handled the situation better in the code to be able to continue in that scenario (useful for release configurations)
