### PR TITLE
Escape % for windows batch command in palSh() function

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -42,10 +42,11 @@ def palSh(cmd, lbl = '', winSlashReplacement = true) {
     if (env.IS_UNIX) {
         sh label: lbl,
            script: cmd
-    } else if (winSlashReplacement) {
-        bat label: lbl,
-            script: cmd.replace('/','\\')
     } else {
+        if (winSlashReplacement) {
+            cmd = cmd.replace('/','\\')
+        }
+        cmd = cmd.replace('%', '%%')
         bat label: lbl,
             script: cmd
     }


### PR DESCRIPTION
Escape % for windows batch in palSh

When a branch name contains '/', env.BRANCH_NAME is URL encoded to "%2F" in Jenkinsfile, and when it's passed to Windows batch command, "%2" will be treated as special character of batch command. This will cause an issue that artifacts will be archived to the wrong S3 path when '/' is in branch name.

We need to escape "%" in Windows batch command.

Signed-off-by: Shirang Jia <shiranj@amazon.com>