### PR TITLE
[Linux] Improve thread name support

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/parallel/thread.h
+++ b/Code/Framework/AzCore/AzCore/std/parallel/thread.h
@@ -50,7 +50,7 @@ namespace AZStd
 
     struct thread_desc
     {
-        //! Debug thread name.
+        //! Debug thread name. Limited to 16 characters on Linux.
         const char*     m_name{ "AZStd::thread" };
 
         //! Thread stack size. Default is -1, which means we will use the default stack size for each platform.

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/std/parallel/internal/thread_Linux.cpp
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/std/parallel/internal/thread_Linux.cpp
@@ -6,6 +6,7 @@
  *
  */
 
+#include <AzCore/std/string/fixed_string.h>
 #include <AzCore/std/parallel/thread.h>
 
 #include <sched.h>
@@ -53,7 +54,15 @@ namespace AZStd
 
         void PostCreateThread(pthread_t tId, const char* name, int)
         {
-            pthread_setname_np(tId, name);
+            if (const int result = pthread_setname_np(tId, name); result == ERANGE)
+            {
+                // The name was too long. pthread limits the name to 16
+                // characters (including the null terminator). Let's elide the
+                // middle.
+                const auto len = strlen(name);
+                const auto elidedName = AZStd::fixed_string<15>{name, 7} + "." + AZStd::fixed_string<15>{name + len - 7, 7};
+                pthread_setname_np(tId, elidedName.c_str());
+            }
         }
 
         uint8_t GetDefaultThreadPriority()

--- a/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Network/AssetProcessorConnection.cpp
@@ -73,10 +73,10 @@ namespace AzFramework
             m_retryAfterDisconnect = false;
             m_isBusyDisconnecting = false;
 
-            m_sendThread.m_desc.m_name = "APConnection::SendThread";
+            m_sendThread.m_desc.m_name = "APConnectSend";
             m_sendThread.m_main = AZStd::bind(&AssetProcessorConnection::SendThread, this);
 
-            m_recvThread.m_desc.m_name = "APConnection::RecvThread";
+            m_recvThread.m_desc.m_name = "APConnectRecv";
             m_recvThread.m_main = AZStd::bind(&AssetProcessorConnection::RecvThread, this);
             
             // Put the AP send and receive threads on a core not shared by the main thread or render thread.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/SourceControl/PerforceComponent.cpp
@@ -80,7 +80,13 @@ namespace AzToolsFramework
 
         // set up signals before we start thread.
         m_shutdownThreadSignal = false;
-        m_WorkerThread = AZStd::thread(AZStd::bind(&PerforceComponent::ThreadWorker, this));
+        m_WorkerThread = AZStd::thread(
+            { /*m_name =*/ "Perforce worker" },
+            [this]
+            {
+                ThreadWorker();
+            }
+        );
 
         SourceControlConnectionRequestBus::Handler::BusConnect();
         SourceControlCommandBus::Handler::BusConnect();

--- a/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/AssetProcessorMessagesTests.cpp
@@ -205,7 +205,7 @@ namespace AssetProcessorMessagesTests
             AZStd::atomic_bool finished = false;
             auto start = AZStd::chrono::monotonic_clock::now();
 
-            auto thread = AZStd::thread([&finished, &func]()
+            auto thread = AZStd::thread({/*m_name =*/ "MessageTests"}, [&finished, &func]()
                 {
                     func();
                     finished = true;


### PR DESCRIPTION
pthread only supports a thread name up to 15 characters + null terminator.
Consequently, if the user code was providing a name that was too long, it
would get the default "AZStd::thread" name. This change uses an elided
name, removing characters from the middle of the name, so that it fits
within the 16 byte limit. The decision to elide the middle was made so that
threads can be named with trailing numbers, and the number will be retained
in the thread's name.

Signed-off-by: Chris Burel <burelc@amazon.com>