### PR TITLE
Fix an issue where npm is not found when running AWSI deployment script on Linux

### DIFF
--- a/scripts/build/Platform/Linux/deploy_cdk_applications.sh
+++ b/scripts/build/Platform/Linux/deploy_cdk_applications.sh
@@ -7,9 +7,6 @@
 #
 
 # Deploy the CDK applications for AWS gems (Linux only)
-# Prerequisites:
-# 1) Node.js is installed
-# 2) Node.js version >= 10.13.0, except for versions 13.0.0 - 13.6.0. A version in active long-term support is recommended.
 
 SOURCE_DIRECTORY=$(dirname "$0")
 PATH=$SOURCE_DIRECTORY/python:$PATH
@@ -70,12 +67,12 @@ echo [cdk_installation] Install the current version of nodejs
 nvm install node
 
 echo [cdk_installation] Install the latest version of CDK
-if ! sudo npm uninstall -g aws-cdk;
+if ! npm uninstall -g aws-cdk;
 then
     echo [cdk_bootstrap] Failed to uninstall the current version of CDK
     exit 1
 fi
-if ! sudo npm install -g aws-cdk@latest;
+if ! npm install -g aws-cdk@latest;
 then
     echo [cdk_bootstrap] Failed to install the latest version of CDK
     exit 1


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

- Removed the inaccurate comments since the script will install nodejs directly
- Removed sudo for the npm call since it's not needed.
- Verified on a Linux EC2 instance and in an internal fork.