### PR TITLE
Fixed fbx parse issue

### DIFF
--- a/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
+++ b/Code/Tools/SceneAPI/SDKWrapper/AssImpSceneWrapper.h
@@ -10,6 +10,7 @@
 #include <assimp/Importer.hpp>
 
 struct aiScene;
+struct aiMesh;
 
 namespace AZ
 {
@@ -43,6 +44,8 @@ namespace AZ
             AZStd::pair<AxisVector, int32_t> GetFrontVectorAndSign() const;
 
             AZStd::string GetSceneFileName() const { return m_sceneFileName; }
+            void CheckTextureName();
+            aiString GetNewTextureName(const aiString& oldName, const aiMesh* pMesh);
         protected:
             const aiScene* m_assImpScene = nullptr;
             Assimp::Importer m_importer;


### PR DESCRIPTION
An FBX file fails to be parsed, and the asset builder displays a message indicating that the stream buffer fails to be added. A buffer with this streamId or name already exists.