### PR TITLE
Add missing `precise` attribute to depth prepass output

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/Depth/DepthPassCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/Depth/DepthPassCommon.azsli
@@ -17,7 +17,7 @@ struct VSInput
  
 struct VSDepthOutput
 {
-    float4 m_position : SV_Position;
+    precise float4 m_position : SV_Position;
 };
 
 VSDepthOutput DepthPassVS(VSInput IN)


### PR DESCRIPTION
Commit 67689d48cc0f142eccd4856b0686277b49ca42d0 enforced precision in
many vertex position outputs. This adds the attribute to the output of
the z-prepass, needed to ensure proper depth testing in the forward
passes.

Signed-off-by: Jeremy Ong <jcong@amazon.com>