### PR TITLE
Fixes VS2022 error C5233: explicit lambda capture 'isSlash' is not used

### DIFF
--- a/Code/Tools/AssetProcessor/native/FileWatcher/FileWatcher.cpp
+++ b/Code/Tools/AssetProcessor/native/FileWatcher/FileWatcher.cpp
@@ -25,7 +25,7 @@ static bool IsSubfolder(const QString& folderA, const QString& folderB)
     using AZStd::begin;
     using AZStd::end;
 
-    constexpr auto isSlash = [](const QChar c) constexpr
+    auto isSlash = [](const QChar c) constexpr
     {
         return c == AZ::IO::WindowsPathSeparator || c == AZ::IO::PosixPathSeparator;
     };


### PR DESCRIPTION
Signed-off-by: Benjamin Jillich <jillich@amazon.com>