### PR TITLE
Replace temp folder creation with solid solution

### DIFF
--- a/Gems/AWSCore/Code/CMakeLists.txt
+++ b/Gems/AWSCore/Code/CMakeLists.txt
@@ -163,6 +163,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             PRIVATE
                 AZ::AzTest
                 AZ::AzFramework
+                AZ::AzFrameworkTestShared
                 AZ::AWSNativeSDKInit
                 Gem::AWSCore.Static
     )

--- a/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
+++ b/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
@@ -13,6 +13,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzFramework/IO/LocalFileIO.h>
+#include <Tests/Utils/Utils.h>
 
 #include <Framework/JsonObjectHandler.h>
 #include <Framework/JsonWriter.h>
@@ -209,7 +210,7 @@ protected:
         return testTempDirPath;
     }
 
-    AZ::Test::ScopedAutoTempDirectory m_testTempDirectory;
+    UnitTest::ScopedTemporaryDirectory m_testTempDirectory;
     AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_settingsRegistry;
     AZStd::unique_ptr<AZ::ComponentApplication> m_app;
 };

--- a/Gems/AWSMetrics/Code/CMakeLists.txt
+++ b/Gems/AWSMetrics/Code/CMakeLists.txt
@@ -96,6 +96,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzTest
                 AZ::AzCore
                 AZ::AzFramework
+                AZ::AzFrameworkTestShared
                 Gem::AWSMetrics.Static
         RUNTIME_DEPENDENCIES
             Gem::AWSCore

--- a/Gems/AWSMetrics/Code/Tests/AWSMetricsGemMock.h
+++ b/Gems/AWSMetrics/Code/Tests/AWSMetricsGemMock.h
@@ -19,6 +19,7 @@
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzFramework/IO/LocalFileIO.h>
+#include <Tests/Utils/Utils.h>
 
 namespace AWSMetrics
 {
@@ -142,7 +143,7 @@ namespace AWSMetrics
         AZ::IO::FileIOBase* m_priorFileIO = nullptr;
         AZ::IO::FileIOBase* m_localFileIO = nullptr;
 
-        AZ::Test::ScopedAutoTempDirectory m_testDirectory;
+        UnitTest::ScopedTemporaryDirectory m_testDirectory;
         AZStd::unique_ptr<AZ::SerializeContext> m_serializeContext;
         AZStd::unique_ptr<AZ::JsonRegistrationContext> m_registrationContext;
         AZStd::unique_ptr<AZ::SettingsRegistryImpl> m_settingsRegistry;


### PR DESCRIPTION
## Details
As we see intermittent unit test failure because of temp folder creation failed, replace it with more solid solution.
Refer to https://github.com/o3de/o3de/issues/4340

More related test improvements tracked here https://github.com/o3de/o3de/issues/6783

## Testing
Run unit test locally and pass