### PR TITLE
Fix undo for create editor entity

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -261,8 +261,8 @@ namespace AzToolsFramework
             return AZ::EntityId();
         }
         entity = aznew AZ::Entity(entityId, name);
-        AddEntity(entity);
         AZ_Assert(entity != nullptr, "Entity with name %s couldn't be created.", name);
+        AddEntity(entity);
         if (m_isLegacySliceService)
         {
             FinalizeEditorEntity(entity);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -226,7 +226,15 @@ namespace AzToolsFramework
     AZ::EntityId EditorEntityContextComponent::CreateNewEditorEntity(const char* name)
     {
         AZ::Entity* entity = CreateEntity(name);
-        FinalizeEditorEntity(entity);
+        AZ_Assert(entity != nullptr, "Entity with name %s couldn't be created.", name);
+        if (m_isLegacySliceService)
+        {
+            FinalizeEditorEntity(entity);
+        }
+        else
+        {
+            EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnEditorEntityCreated, entity->GetId());
+        }
         return entity->GetId();
     }
 
@@ -254,7 +262,15 @@ namespace AzToolsFramework
         }
         entity = aznew AZ::Entity(entityId, name);
         AddEntity(entity);
-        FinalizeEditorEntity(entity);
+        AZ_Assert(entity != nullptr, "Entity with name %s couldn't be created.", name);
+        if (m_isLegacySliceService)
+        {
+            FinalizeEditorEntity(entity);
+        }
+        else
+        {
+            EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnEditorEntityCreated, entity->GetId());
+        }
 
         return entity->GetId();
     }


### PR DESCRIPTION
Same PR with the previously approved changes of https://github.com/o3de/o3de/pull/6738/commits/36140804d949d0cd1be0a4c2bb4f757d1b43074f . Creating a new PR since the commit history in previous branch got corrupted.