### PR TITLE
Updated AnimNode registration in LyShine and Maestro to register to a member variable map

### DIFF
--- a/Code/Editor/Lib/Tests/test_DisplaySettingsPythonBindings.cpp
+++ b/Code/Editor/Lib/Tests/test_DisplaySettingsPythonBindings.cpp
@@ -35,6 +35,11 @@ namespace DisplaySettingsPythonBindingsUnitTests
 
             m_app.Start(appDesc);
             m_app.RegisterComponentDescriptor(AzToolsFramework::DisplaySettingsPythonFuncsHandler::CreateDescriptor());
+
+            // Without this, the user settings component would attempt to save on finalize/shutdown. Since the file is
+            // shared across the whole engine, if multiple tests are run in parallel, the saving could cause a crash
+            // in the unit tests.
+            AZ::UserSettingsComponentRequestBus::Broadcast(&AZ::UserSettingsComponentRequests::DisableSaveOnFinalize);
         }
 
         void TearDown() override

--- a/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
+++ b/Code/Framework/AzCore/AzCore/std/string/fixed_string.inl
@@ -1760,7 +1760,8 @@ namespace AZStd
     template<class Element, size_t MaxElementCount, class Traits>
     struct hash<basic_fixed_string<Element, MaxElementCount, Traits>>
     {
-        inline constexpr size_t operator()(const basic_fixed_string<Element, MaxElementCount, Traits>& value) const
+        using is_transparent = void;
+        inline constexpr size_t operator()(const basic_string_view<Element, Traits>& value) const
         {
             return hash_string(value.begin(), value.length());
         }

--- a/Code/Framework/AzCore/AzCore/std/string/string.h
+++ b/Code/Framework/AzCore/AzCore/std/string/string.h
@@ -2071,9 +2071,8 @@ namespace AZStd
     template<class Element, class Traits, class Allocator>
     struct hash< basic_string< Element, Traits, Allocator> >
     {
-        typedef basic_string< Element, Traits, Allocator> argument_type;
-        typedef AZStd::size_t                           result_type;
-        inline result_type operator()(const argument_type& value) const
+        using is_transparent = void;
+        inline constexpr size_t operator()(const basic_string_view<Element, Traits>& value) const
         {
             return hash_string(value.begin(), value.length());
         }

--- a/Code/Legacy/CryCommon/IMovieSystem.h
+++ b/Code/Legacy/CryCommon/IMovieSystem.h
@@ -13,7 +13,6 @@
 #include <AzCore/Math/Crc.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/allocator_stateless.h>
 
 #include <Range.h>
 #include <AnimKey.h>
@@ -184,7 +183,7 @@ public:
 
 private:
     AnimParamType m_type;
-    AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::stateless_allocator> m_name;
+    AZStd::string m_name;
 };
 
 namespace AZStd
@@ -620,7 +619,7 @@ public:
             , valueType(_valueType)
             , flags(_flags) {};
 
-        AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::stateless_allocator> name;           // parameter name.
+        AZStd::string name;           // parameter name.
         CAnimParamType paramType;     // parameter id.
         AnimValueType valueType;       // value type, defines type of track to use for animating this parameter.
         ESupportedParamFlags flags; // combination of flags from ESupportedParamFlags.

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/SelectorImplementations.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/SelectorImplementations.h
@@ -79,7 +79,7 @@ namespace GraphCanvas
 
         private:
             AZStd::string m_value;
-            AZStd::hash<AZStd::string>::result_type m_hash;
+            size_t m_hash;
 
             friend class BasicSelectorEventHandler;
         };

--- a/Gems/LyShine/Code/Source/Animation/AnimNode.h
+++ b/Gems/LyShine/Code/Source/Animation/AnimNode.h
@@ -13,7 +13,6 @@
 
 #include <LyShine/Animation/IUiAnimation.h>
 #include "UiAnimationSystem.h"
-#include <AzCore/std/allocator_stateless.h>
 
 
 /*!
@@ -40,7 +39,7 @@ public:
             , valueType(_valueType)
             , flags(_flags) {};
 
-        AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::stateless_allocator> name;               // parameter name.
+        AZStd::string name;               // parameter name.
         CUiAnimParamType paramType;     // parameter id.
         EUiAnimValue valueType;         // value type, defines type of track to use for animating this parameter.
         ESupportedParamFlags flags;     // combination of flags from ESupportedParamFlags.

--- a/Gems/LyShine/Code/Source/Animation/UiAnimationSystem.h
+++ b/Gems/LyShine/Code/Source/Animation/UiAnimationSystem.h
@@ -14,6 +14,8 @@
 #include <AzCore/std/containers/map.h>
 #include <AzCore/Time/ITime.h>
 
+#include <CryCommon/StlUtils.h>
+
 struct PlayingUIAnimSequence
 {
     //! Sequence playing
@@ -134,11 +136,9 @@ public:
     void SerializeParamType(CUiAnimParamType& animParamType, XmlNodeRef& xmlNode, bool bLoading, const uint version) override;
     void SerializeParamData(UiAnimParamData& animParamData, XmlNodeRef& xmlNode, bool bLoading) override;
 
-    static const char* GetParamTypeName(const CUiAnimParamType& animParamType);
+    const char* GetParamTypeName(const CUiAnimParamType& animParamType);
 
     void OnCameraCut();
-
-    static void StaticInitialize();
 
     static void Reflect(AZ::SerializeContext* serializeContext);
 
@@ -186,6 +186,22 @@ private:
 
     // A sequence which turned on the early animation update last time
     uint32 m_nextSequenceId;
+
+
+    using UiAnimParamSystemString = AZStd::string;
+    template <typename KeyType, typename MappedType, typename Compare = stl::less_stricmp<KeyType>>
+    using UiAnimSystemOrderedMap = AZStd::map<KeyType, MappedType, Compare>;
+    template <typename KeyType, typename MappedType, typename Hasher = AZStd::hash<KeyType>, typename EqualKey = AZStd::equal_to<>>
+    using UiAnimSystemUnorderedMap = AZStd::unordered_map<KeyType, MappedType, Hasher, EqualKey>;
+
+    UiAnimSystemUnorderedMap<int, UiAnimParamSystemString> m_animNodeEnumToStringMap;
+    UiAnimSystemOrderedMap<UiAnimParamSystemString, EUiAnimNodeType> m_animNodeStringToEnumMap;
+
+    UiAnimSystemUnorderedMap<int, UiAnimParamSystemString> m_animParamEnumToStringMap;
+    UiAnimSystemOrderedMap<UiAnimParamSystemString, EUiAnimParamType> m_animParamStringToEnumMap;
+
+    void RegisterNodeTypes();
+    void RegisterParamTypes();
 
     void ShowPlayedSequencesDebug();
 };

--- a/Gems/LyShine/Code/Source/LyShine.cpp
+++ b/Gems/LyShine/Code/Source/LyShine.cpp
@@ -156,8 +156,6 @@ CLyShine::CLyShine([[maybe_unused]] ISystem* system)
     UiElementComponent::Initialize();
     UiCanvasComponent::Initialize();
 
-    UiAnimationSystem::StaticInitialize();
-
     AzFramework::InputChannelEventListener::Connect();
     AzFramework::InputTextEventListener::Connect();
     UiCursorBus::Handler::BusConnect();

--- a/Gems/Maestro/Code/Source/Cinematics/AnimPostFXNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/AnimPostFXNode.cpp
@@ -8,7 +8,6 @@
 
 
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/std/allocator_stateless.h>
 #include "AnimPostFXNode.h"
 #include "AnimSplineTrack.h"
 #include "CompoundSplineTrack.h"
@@ -39,7 +38,7 @@ public:
         virtual void GetDefault(bool& val) const = 0;
         virtual void GetDefault(Vec4& val) const = 0;
 
-        AZStd::basic_string<char, AZStd::char_traits<char>, AZStd::stateless_allocator> m_name;
+        AZStd::string m_name;
 
     protected:
         virtual ~CControlParamBase(){}

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.h
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.h
@@ -18,6 +18,7 @@
 
 #include <CryCommon/TimeValue.h>
 #include <CryCommon/StaticInstance.h>
+#include <CryCommon/StlUtils.h>
 
 #include "IMovieSystem.h"
 #include "IShader.h"
@@ -192,7 +193,7 @@ public:
     void SaveParamTypeToXml(const CAnimParamType& animParamType, XmlNodeRef& xmlNode) override;
     void SerializeParamType(CAnimParamType& animParamType, XmlNodeRef& xmlNode, bool bLoading, const uint version) override;
 
-    static const char* GetParamTypeName(const CAnimParamType& animParamType);
+    const char* GetParamTypeName(const CAnimParamType& animParamType);
 
     void OnCameraCut();
 
@@ -289,6 +290,23 @@ private:
     uint32 m_nextSequenceId;
 
     void ShowPlayedSequencesDebug();
+
+
+    using AnimParamSystemString = AZStd::string;
+
+    template <typename KeyType, typename MappedType, typename Compare = stl::less_stricmp<KeyType>>
+    using AnimSystemOrderedMap = AZStd::map<KeyType, MappedType, Compare>;
+    template <typename KeyType, typename MappedType, typename Hasher = AZStd::hash<KeyType>, typename EqualKey = AZStd::equal_to<>>
+    using AnimSystemUnorderedMap = AZStd::unordered_map<KeyType, MappedType, Hasher, EqualKey>;
+
+    AnimSystemUnorderedMap<AnimNodeType, AnimParamSystemString> m_animNodeEnumToStringMap;
+    AnimSystemOrderedMap<AnimParamSystemString, AnimNodeType> m_animNodeStringToEnumMap;
+
+    AnimSystemUnorderedMap<AnimParamType, AnimParamSystemString> m_animParamEnumToStringMap;
+    AnimSystemOrderedMap<AnimParamSystemString, AnimParamType> m_animParamStringToEnumMap;
+
+    void RegisterNodeTypes();
+    void RegisterParamTypes();
 
 public:
     static float m_mov_cameraPrecacheTime;

--- a/Gems/TextureAtlas/Code/Source/TextureAtlasImpl.h
+++ b/Gems/TextureAtlas/Code/Source/TextureAtlasImpl.h
@@ -33,7 +33,7 @@ namespace TextureAtlasNamespace
     struct hash_case_insensitive : public AZStd::hash<AZStd::string>
     {
         AZ_TYPE_INFO(hash_case_insensitive, "{FE0F4349-D80D-4286-8874-733966A32B29}");
-        inline result_type operator()(const AZStd::string& value) const
+        inline size_t operator()(const AZStd::string& value) const
         {
             AZStd::string lowerStr = value;
             AZStd::to_lower(lowerStr.begin(), lowerStr.end());


### PR DESCRIPTION
Updated the Maestro MovieSystem and LyShine AnimationSystem to register Anim Nodes and Anim Params into a member variable map.

Previously the registration was occurring in a global variable map inside
of Movie.cpp and UiAnimationSystem.cpp

Rolled back the changes to update the CUiAnimNode and CAnimParamType to
use the stateless allocator in their m_name string member.
This was only needed because those types were used in global memory.

Updated the string classes AZStd::hash specialization to be [transparent](https://en.cppreference.com/w/cpp/named_req/UnorderedAssociativeContainer) to allow keys which aren't off string types to be forwarded to their hashing algorithms without creation of an instance.
