### PR TITLE
change default color picker input color space to SRGB

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Utils/EditorLightingPreset.cpp
@@ -72,7 +72,7 @@ namespace AZ
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &LightConfig::m_direction, "Direction", "")
                         ->DataElement(Edit::UIHandlers::Color, &LightConfig::m_color, "Color", "Color of the light")
-                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetLinearRgbEditorConfig())
+                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetRgbEditorConfig())
                         ->DataElement(Edit::UIHandlers::Default, &LightConfig::m_intensity, "Intensity", "Intensity of the light in the set photometric unit.")
 
                         ->ClassElement(AZ::Edit::ClassElements::Group, "Shadow")

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Common/ColorUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Edit/Common/ColorUtils.h
@@ -19,6 +19,8 @@ namespace AZ
             //[GFX TODO][ATOM-4462] Replace this to use data driven color management system
             //! Return a ColorEditorConfiguration for editing a Linear sRGB color in sRGB space.
             AzToolsFramework::ColorEditorConfiguration GetLinearRgbEditorConfig();
+            //! Return a ColorEditorConfiguration for editing a sRGB color in sRGB space.
+            AzToolsFramework::ColorEditorConfiguration GetRgbEditorConfig();
 
         } // namespace PropertyColorConfigs
     } // namespace RPI

--- a/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/ColorUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Edit/Common/ColorUtils.cpp
@@ -14,14 +14,14 @@ namespace AZ
     {
         namespace ColorUtils
         {
+            enum ColorSpace : uint32_t
+            {
+                LinearSRGB,
+                SRGB
+            };
+
             AzToolsFramework::ColorEditorConfiguration GetLinearRgbEditorConfig()
             {
-                enum ColorSpace : uint32_t
-                {
-                    LinearSRGB,
-                    SRGB
-                };
-                
                 AzToolsFramework::ColorEditorConfiguration configuration;
                 configuration.m_colorPickerDialogConfiguration = AzQtComponents::ColorPicker::Configuration::RGB;
 
@@ -55,6 +55,15 @@ namespace AZ
                         return color;
                     }
                 };
+
+                return configuration;
+            }
+
+            AzToolsFramework::ColorEditorConfiguration GetRgbEditorConfig()
+            {
+                AzToolsFramework::ColorEditorConfiguration configuration = GetLinearRgbEditorConfig();
+
+                configuration.m_propertyColorSpaceId = ColorSpace::SRGB;
 
                 return configuration;
             }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/DynamicProperty/DynamicProperty.cpp
@@ -160,7 +160,7 @@ namespace AtomToolsFramework
                 ApplyRangeEditDataAttributes<float>();
                 break;
             case DynamicPropertyType::Color:
-                AddEditDataAttribute(AZ_CRC("ColorEditorConfiguration", 0xc8b9510e), AZ::RPI::ColorUtils::GetLinearRgbEditorConfig());
+                AddEditDataAttribute(AZ_CRC("ColorEditorConfiguration", 0xc8b9510e), AZ::RPI::ColorUtils::GetRgbEditorConfig());
                 break;
             case DynamicPropertyType::Enum:
                 m_editData.m_elementId = AZ::Edit::UIHandlers::ComboBox;

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorAreaLightComponent.cpp
@@ -75,7 +75,7 @@ namespace AZ
                         ->DataElement(Edit::UIHandlers::Color, &AreaLightComponentConfig::m_color, "Color", "Color of the light")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::LightTypeIsSelected)
-                            ->Attribute("ColorEditorConfiguration", RPI::ColorUtils::GetLinearRgbEditorConfig())
+                            ->Attribute("ColorEditorConfiguration", RPI::ColorUtils::GetRgbEditorConfig())
                         ->DataElement(Edit::UIHandlers::ComboBox, &AreaLightComponentConfig::m_intensityMode, "Intensity mode", "Allows specifying which photometric unit to work in.")
                             ->Attribute(AZ::Edit::Attributes::EnumValues, &AreaLightComponentConfig::GetValidPhotometricUnits)
                             ->Attribute(Edit::Attributes::Visibility, &AreaLightComponentConfig::LightTypeIsSelected)

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/CoreLights/EditorDirectionalLightComponent.cpp
@@ -59,7 +59,7 @@ namespace AZ
                         ->ClassElement(Edit::ClassElements::EditorData, "")
                         ->DataElement(Edit::UIHandlers::Color, &DirectionalLightComponentConfig::m_color, "Color", "Color of the light")
                             ->Attribute(Edit::Attributes::ChangeNotify, Edit::PropertyRefreshLevels::ValuesOnly)
-                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetLinearRgbEditorConfig())
+                            ->Attribute("ColorEditorConfiguration", AZ::RPI::ColorUtils::GetRgbEditorConfig())
                         ->DataElement(Edit::UIHandlers::ComboBox, &DirectionalLightComponentConfig::m_intensityMode, "Intensity mode", "Allows specifying light values in lux or Ev100")
                             ->EnumAttribute(PhotometricUnit::Lux, "Lux")
                             ->EnumAttribute(PhotometricUnit::Ev100Illuminance, "Ev100")


### PR DESCRIPTION
Ensures that the RGB values shown in the color picker match those being set in the component inspector. UX approved.

Signed-off-by: sphrose <82213493+sphrose@users.noreply.github.com>