### PR TITLE
Fixed tab order for default input focus on new level dialog

### DIFF
--- a/Code/Editor/NewLevelDialog.cpp
+++ b/Code/Editor/NewLevelDialog.cpp
@@ -115,7 +115,6 @@ CNewLevelDialog::~CNewLevelDialog()
 void CNewLevelDialog::OnStartup()
 {
     UpdateData(false);
-    setFocus();
 }
 
 void CNewLevelDialog::UpdateData(bool fromUi)

--- a/Code/Editor/NewLevelDialog.ui
+++ b/Code/Editor/NewLevelDialog.ui
@@ -133,6 +133,9 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>LEVEL</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Fixes #6809 

Tested new level dialog and verified the input field for the level name is now focused by default.

![NewLevelInputFieldFocus](https://user-images.githubusercontent.com/7519264/148978505-de51e765-441e-41ce-ad3d-4616b2dbf084.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>