### PR TITLE
Fix Prefab instance assets not preloading

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabCatchmentProcessor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabCatchmentProcessor.cpp
@@ -64,6 +64,7 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
             AZStd::move(uniqueName), context.GetSourceUuid(), AZStd::move(serializer));
         AZ_Assert(spawnable, "Failed to create a new spawnable.");
 
+        object.GetReferencedAssets() = prefab.GetReferencedAssets();
         Instance& instance = prefab.GetInstance();
         // Resolve entity aliases that store PrefabDOM information to use the spawnable instead. This is done before the entities are
         // moved from the instance as they'd otherwise can't be found.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabDocument.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabDocument.cpp
@@ -124,12 +124,22 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
         return *m_instance;
     }
 
+    AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>>& PrefabDocument::GetReferencedAssets()
+    {
+        return m_referencedAssets;
+    }
+
+    const AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>>& PrefabDocument::GetReferencedAssets() const
+    {
+        return m_referencedAssets;
+    }
+
     bool PrefabDocument::ConstructInstanceFromPrefabDom(const PrefabDom& prefab)
     {
         using namespace AzToolsFramework::Prefab;
 
         m_instance->Reset();
-        if (PrefabDomUtils::LoadInstanceFromPrefabDom(*m_instance, prefab, PrefabDomUtils::LoadFlags::AssignRandomEntityId))
+        if (PrefabDomUtils::LoadInstanceFromPrefabDom(*m_instance, prefab, m_referencedAssets, PrefabDomUtils::LoadFlags::AssignRandomEntityId))
         {
             return true;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabDocument.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/PrefabDocument.h
@@ -53,12 +53,16 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
         AzToolsFramework::Prefab::Instance& GetInstance();
         const AzToolsFramework::Prefab::Instance& GetInstance() const;
 
+        AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>>& GetReferencedAssets();
+        const AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>>& GetReferencedAssets() const;
+
     private:
         bool ConstructInstanceFromPrefabDom(const PrefabDom& prefab);
         
         mutable PrefabDom m_dom;
         AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> m_instance;
         AZStd::string m_name;
+        AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>> m_referencedAssets;
         mutable bool m_isDirty{ false };
     };
 } // namespace AzToolsFramework::Prefab::PrefabConversionUtils


### PR DESCRIPTION
PrefabCatchmentProcessor::ProcessPrefab was no longer updating the ProcessedObjectStore's referenced object list, this change exposes the referenced asset list in the new PrefabDocument API and uses them to update the referenced asset list.

Should fix https://github.com/o3de/o3de/issues/6561

Signed-off-by: Nicholas Van Sickle <nvsickle@amazon.com>