### PR TITLE
Fixed depth clipping artifacts for parallax PDO.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_DepthPass_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardPBR_DepthPass_WithPS.azsl
@@ -63,7 +63,7 @@ VSDepthOutput MainVS(VSInput IN)
 
 struct PSDepthOutput
 {
-    float m_depth : SV_Depth;
+    precise float m_depth : SV_Depth;
 };
 
 PSDepthOutput MainPS(VSDepthOutput IN, bool isFrontFace : SV_IsFrontFace)


### PR DESCRIPTION
The "precise" keyword was recently added to several shader inputs, but one was missed. This led to inconsistency between the depth and forward passes which resulted in artifacts when parallax pixel depth offset was in use. See https://github.com/o3de/o3de/pull/6536

Testing: I used AtomSampleViewer to make a local baseline of all screenshots in _fulltestsuite_.bv.lua. The only change was to the parallax test cases, which were a clear improvement.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

# screenshot_10_offsetClippingSteep
![image](https://user-images.githubusercontent.com/55155825/149056616-e4e05d7a-0add-4d2d-912e-e381ce69380d.png)

# Before
![image](https://user-images.githubusercontent.com/55155825/149056459-f0cf718f-0aeb-44bf-8f83-d11a4f7fd5df.png)

# After
![image](https://user-images.githubusercontent.com/55155825/149056477-bdddc00f-cb00-4a80-82c4-719890a867c6.png)

