### PR TITLE
[Mac] Fix build error caused due to exe files in Python.framework

### DIFF
--- a/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
+++ b/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
@@ -187,7 +187,7 @@ if(@target_file_dir@ MATCHES ".app/Contents/MacOS")
             )
             file(GLOB_RECURSE exe_file_list "${bundle_path}/Contents/Frameworks/Python.framework/**/*.exe")
             if(exe_file_list)
-                file(REMOVE_RECURSE "${exe_file_list}")
+                file(REMOVE_RECURSE ${exe_file_list})
             endif()
             execute_process(COMMAND "${CMAKE_COMMAND}" -E create_symlink include/python3.7m Headers
                 WORKING_DIRECTORY "${bundle_path}/Contents/Frameworks/Python.framework/Versions/3.7"


### PR DESCRIPTION
Remove quotes around list of paths

Signed-off-by: amzn-sj <srikkant@amazon.com>