### PR TITLE
Disable flaky HttpRequestor test

### DIFF
--- a/Gems/HttpRequestor/Code/CMakeLists.txt
+++ b/Gems/HttpRequestor/Code/CMakeLists.txt
@@ -71,5 +71,6 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     )
     ly_add_googletest(
         NAME Gem::HttpRequestor.Tests
+        TEST_SUITE sandbox
     )
 endif()


### PR DESCRIPTION
Related to: https://github.com/o3de/o3de/issues/6732

## Testing
Rebuilding the project .sln shows this test is no longer in `TEST_SUITE_main` but is part of the `TEST_SUITE_sandbox` target:

![image](https://user-images.githubusercontent.com/34254888/149231684-212c5fd5-8bf1-4b3c-a888-0dbd0b5a1a25.png)



--
Signed-off-by: allisaurus <34254888+allisaurus@users.noreply.github.com>