### PR TITLE
[development] fix for a possible MSVC compiler bug

### DIFF
--- a/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp
@@ -793,9 +793,9 @@ namespace UnitTests
 
     TEST_F(SourceFileRelocatorTest, TestInterface)
     {
-        auto* interface = AZ::Interface<ISourceFileRelocation>::Get();
+        auto* sourceFileRelocator = AZ::Interface<ISourceFileRelocation>::Get();
 
-        ASSERT_NE(interface, nullptr);
+        ASSERT_NE(sourceFileRelocator, nullptr);
     }
 
     TEST_F(SourceFileRelocatorTest, Move_Real_Succeeds)


### PR DESCRIPTION
There is a variable with the name "interface" which appears to be conflicting with the [MSVC keyword](https://docs.microsoft.com/en-us/cpp/cpp/keywords-cpp?view=msvc-170#ccli-and-ccx-keywords).  It's unclear what the exact parameters that caused the following error but it was found using Visual Studio 2019 v16.11.7 and v16.11.8, with and without unity files enabled:
```
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(796,25): error C2332: 'struct': missing tag name [D:\git\o3de\engine\build\windowsUnity\Code\Tools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          auto* interface = AZ::Interface<ISourceFileRelocation>::Get();
                          ^
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(796,25): error C2226: syntax error: unexpected type 'UnitTests::SourceFileRelocatorTest_TestInterface_Test::TestBody::<unnamed-tag>' [D:\git\o3de\engine\build\windowsU
nity\Code\Tools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          auto* interface = AZ::Interface<ISourceFileRelocation>::Get();
                          ^
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(798,9): error C2332: 'struct': missing tag name [D:\git\o3de\engine\build\windowsUnity\Code\Tools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          ASSERT_NE(interface, nullptr);
          ^
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(798,9): error C2226: syntax error: unexpected type 'UnitTests::SourceFileRelocatorTest_TestInterface_Test::TestBody::<unnamed-tag>' [D:\git\o3de\engine\build\windowsUn
ity\Code\Tools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          ASSERT_NE(interface, nullptr);
          ^
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(798,9): error C2181: illegal else without matching if [D:\git\o3de\engine\build\windowsUnity\Code\Tools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          ASSERT_NE(interface, nullptr);
          ^
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(798,9): error C2065: 'gtest_ar': undeclared identifier [D:\git\o3de\engine\build\windowsUnity\Code\Tools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          ASSERT_NE(interface, nullptr);
          ^
D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(798,9): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'testing::internal::AssertHelper' [D:\git\o3de\engine\build\windowsUnity\Code\T
ools\AssetProcessor\AssetProcessor.Tests.vcxproj]
          ASSERT_NE(interface, nullptr);
          ^
  D:/git/o3de/engine/Code/Tools/AssetProcessor/native/tests/SourceFileRelocatorTests.cpp(798,9): note: No constructor could take the source type, or constructor overload resolution was ambiguous
          ASSERT_NE(interface, nullptr);
          ^
D:\git\o3de\engine\Code\Tools\AssetProcessor\native\AssetManager/ExcludedFolderCacheInterface.h(20,9): fatal error C1903: unable to recover from previous error(s); stopping compilation [D:\git\o3de\engine\build\windowsUnity\Code\Tools\AssetProcessor\Asse
tProcessor.Tests.vcxproj]
          AZ_RTTI(ExcludedFolderCacheInterface, "{3AC471B6-C9F8-49CF-9E9D-237BDF63328C}");
          ^
  INTERNAL COMPILER ERROR in 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\CL.exe'
      Please choose the Technical Support command on the Visual C++
      Help menu, or open the Technical Support help file for more information
```

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>