### PR TITLE
[development] added required runtime dependency Gem::PhysX.Editor to WhiteBox.Editor.Physics.Tests 

### DIFF
--- a/Gems/WhiteBox/Code/CMakeLists.txt
+++ b/Gems/WhiteBox/Code/CMakeLists.txt
@@ -198,6 +198,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     AZ::AzTestShared
                     AZ::AzManipulatorTestFramework.Static
                     Gem::WhiteBox.Editor.Static
+            RUNTIME_DEPENDENCIES
+                Gem::PhysX.Editor
         )
 
         ly_add_googletest(


### PR DESCRIPTION
Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>