### PR TITLE
AtomTressFX - fix bug 'Creating / Saving a prefab containing an entity with Atom Hair will crash the Editor'

### DIFF
--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.cpp
@@ -213,6 +213,8 @@ namespace AZ
                 Data::Instance<RPI::Shader> rasterShader,
                 uint32_t vertexCount, uint32_t strandsCount )
             {
+                m_initialized = false;
+
                 AZ_Assert(vertexCount <= std::numeric_limits<uint32_t>().max(), "Hair vertex count exceeds uint32_t size.");
 
                 // Create the dynamic shared buffers Srg.
@@ -608,8 +610,16 @@ namespace AZ
                 // First, Directly loading from the asset stored in the render settings.
                 if (pRenderSettings)
                 {
-                    m_baseAlbedo = RPI::StreamingImage::FindOrCreate(pRenderSettings->m_baseAlbedoAsset);
-                    m_strandAlbedo = RPI::StreamingImage::FindOrCreate(pRenderSettings->m_strandAlbedoAsset);
+                    if (pRenderSettings->m_baseAlbedoAsset)
+                    {
+                        pRenderSettings->m_baseAlbedoAsset.BlockUntilLoadComplete();
+                        m_baseAlbedo = RPI::StreamingImage::FindOrCreate(pRenderSettings->m_baseAlbedoAsset);
+                    }
+                    if (pRenderSettings->m_strandAlbedoAsset)
+                    {
+                        pRenderSettings->m_strandAlbedoAsset.BlockUntilLoadComplete();
+                        m_strandAlbedo = RPI::StreamingImage::FindOrCreate(pRenderSettings->m_strandAlbedoAsset);
+                    }
                 }
 
                 // Fallback using the texture name stored in the render settings. 
@@ -1142,7 +1152,7 @@ namespace AZ
 
                 if (!renderMaterialSrg || !simSrg)
                 {
-                    AZ_Error("Hair Gem", false, "Failed to get thre hair material Srg for the raster pass.");
+                    AZ_Error("Hair Gem", false, "Failed to get the hair material Srg for the raster pass.");
                     return false;
                 }
                 // No need to compile the simSrg since it was compiled already by the Compute pass this frame

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
@@ -110,8 +110,14 @@ namespace AZ
                     PrepareSrgDescriptors(m_dynamicBuffersDescriptors, vertexCount, strandsCount);
                 }
  
-                Data::Instance<RPI::ShaderResourceGroup> GetSimSrgForCompute() { return m_simSrgForCompute; }
-                Data::Instance<RPI::ShaderResourceGroup> GetSimSrgForRaster() { return m_simSrgForRaster; }
+                Data::Instance<RPI::ShaderResourceGroup> GetSimSrgForCompute()
+                {
+                    return m_initialized ? m_simSrgForCompute : nullptr;
+                }
+
+                Data::Instance<RPI::ShaderResourceGroup> GetSimSrgForRaster()
+                {
+                    return m_initialized ? m_simSrgForRaster : nullptr; }
 
                 bool IsInitialized() { return m_initialized;  }
 


### PR DESCRIPTION
- The crash happens due to attempt to get an instance of the hair dynamic data before it was initialized.
- This will also lock texture resource as it is trying to load / create it, making it safer to use. Following push should include async load of the asset instead as a better solution.

Signed-off-by: Adi Bar-Lev <82479970+Adi-Amazon@users.noreply.github.com>