### PR TITLE
 ATOM-17132 Image builder failed to build some images after preset wa…

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/TextureSettings.cpp
@@ -226,6 +226,14 @@ namespace ImageProcessingAtom
         MultiplatformTextureSettings settings;
         PlatformNameList platformsList = BuilderSettingManager::Instance()->GetPlatformList();
         PresetName suggestedPreset = BuilderSettingManager::Instance()->GetSuggestedPreset(imageFilepath);
+
+        // If the suggested preset doesn't exist (or was failed to be loaded), return empty texture settings
+        if (BuilderSettingManager::Instance()->GetPreset(suggestedPreset) == nullptr)
+        {            
+            AZ_Error("Image Processing", false, "Failed to find suggested preset [%s]", suggestedPreset.GetCStr());
+            return settings;
+        }
+
         for (PlatformName& platform : platformsList)
         {
             TextureSettings textureSettings;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/StreamingImage.cpp
@@ -143,11 +143,6 @@ namespace AZ
             RHI::ResultCode resultCode = RHI::ResultCode::Success;
             
             const ImageMipChainAsset& mipChainTailAsset = imageAsset.GetTailMipChain();
-                        
-#ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
-            m_image->SetName(Name(imageAsset.GetHint().c_str()));
-            AZ_TracePrintf("StreamingImage", "Init image [%s]\n", m_image->GetName().data());
-#endif
 
             {
                 RHI::StreamingImageInitRequest initRequest;
@@ -193,6 +188,13 @@ namespace AZ
                 m_rhiPool = rhiPool;
                 m_pool = pool;
                 m_pool->AttachImage(this);
+
+                // Set rhi image name
+                m_image->SetName(Name(m_imageAsset.GetHint()));
+                        
+#ifdef AZ_RPI_STREAMING_IMAGE_DEBUG_LOG
+                AZ_TracePrintf("StreamingImage", "Init image [%s]\n", m_image->GetName().data());
+#endif
                                 
 #if defined (AZ_RPI_STREAMING_IMAGE_HOT_RELOADING)
                 BusConnect(imageAsset.GetId());


### PR DESCRIPTION
…s fixed

The issue was because the preset reload was only happened in CreateJobs but not ProcessJobs. But these two functions might be called from different AssetBuilder. The fix is to add preset reload for Processjobs too.
There was another change to add debug device name for streaming image.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>