### PR TITLE
Add missing 'precise' keyword for Vertex shaders

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR_DepthPass_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR_DepthPass_WithPS.azsl
@@ -28,7 +28,7 @@ struct VSInput
  
 struct VSDepthOutput
 {
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float2 m_uv[UvSetCount] : UV1;
 
     // only used for parallax depth calculation
@@ -62,7 +62,7 @@ VSDepthOutput MainVS(VSInput IN)
 
 struct PSDepthOutput
 {
-    float m_depth : SV_Depth;
+    precise float m_depth : SV_Depth;
 };
 
 PSDepthOutput MainPS(VSDepthOutput IN, bool isFrontFace : SV_IsFrontFace)

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/EnhancedPBR_ForwardPass.azsl
@@ -67,7 +67,7 @@ struct VSInput
 struct VSOutput
 {
     // Base fields (required by the template azsli file)...
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float3 m_normal: NORMAL;
     float3 m_tangent : TANGENT; 
     float3 m_bitangent : BITANGENT; 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/Skin.azsl
@@ -86,7 +86,7 @@ struct VSInput
 struct VSOutput
 {
     // Base fields (required by the template azsli file)...
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float3 m_normal: NORMAL;
     float3 m_tangent : TANGENT; 
     float3 m_bitangent : BITANGENT; 

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_DepthPass_WithPS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_DepthPass_WithPS.azsl
@@ -41,7 +41,7 @@ struct VSInput
  
 struct VSDepthOutput
 {
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float2 m_uv[UvSetCount] : UV1;
 
     // only used for parallax depth calculation
@@ -88,7 +88,7 @@ VSDepthOutput MainVS(VSInput IN)
 
 struct PSDepthOutput
 {
-    float m_depth : SV_Depth;
+    precise float m_depth : SV_Depth;
 };
 
 PSDepthOutput MainPS(VSDepthOutput IN, bool isFrontFace : SV_IsFrontFace)

--- a/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_ForwardPass.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Materials/Types/StandardMultilayerPBR_ForwardPass.azsl
@@ -80,7 +80,7 @@ struct VSInput
 struct VSOutput
 {
     // Base fields (required by the template azsli file)...
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float3 m_normal: NORMAL;
     float3 m_tangent : TANGENT; 
     float3 m_bitangent : BITANGENT; 

--- a/Gems/Atom/TestData/TestData/Materials/Types/AutoBrick_ForwardPass.azsl
+++ b/Gems/Atom/TestData/TestData/Materials/Types/AutoBrick_ForwardPass.azsl
@@ -28,7 +28,7 @@ struct VSInput
 
 struct VSOutput
 {
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float3 m_normal: NORMAL;
     float3 m_tangent : TANGENT; 
     float3 m_bitangent : BITANGENT; 

--- a/Gems/Atom/TestData/TestData/Materials/Types/MinimalPBR_ForwardPass.azsl
+++ b/Gems/Atom/TestData/TestData/Materials/Types/MinimalPBR_ForwardPass.azsl
@@ -33,7 +33,7 @@ struct VSInput
 
 struct VSOutput
 {
-    float4 m_position : SV_Position;
+    precise linear centroid float4 m_position : SV_Position;
     float3 m_normal: NORMAL;
     float3 m_tangent : TANGENT; 
     float3 m_bitangent : BITANGENT; 


### PR DESCRIPTION
Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>