### PR TITLE
Allow InstanceDatabase<Shader> to support multiple instances with different supervariants

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Shader/Shader.h
@@ -136,11 +136,6 @@ namespace AZ
             //! This tag corresponds to the ShaderAsset object's DrawListName.
             RHI::DrawListTag GetDrawListTag() const;
 
-            //! Changes the supervariant of the shader to the specified supervariantIndex.
-            //! [GFX TODO][ATOM-15813]: this can be removed when the shader InstanceDatabase can support multiple shader
-            //! instances with different supervariants.
-            void ChangeSupervariant(SupervariantIndex supervariantIndex);
-
         private:
             explicit Shader(const SupervariantIndex& supervariantIndex) : m_supervariantIndex(supervariantIndex){};
             Shader() = delete;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderVariantAsset.h
@@ -50,6 +50,7 @@ namespace AZ
             RPI::ShaderVariantStableId GetStableId() const { return m_stableId;  }
 
             const ShaderVariantId& GetShaderVariantId() const { return m_shaderVariantId; }
+            uint32_t GetSupervariantIndex() const;
 
             //! Returns the shader stage function associated with the provided stage enum value.
             const RHI::ShaderStageFunction* GetShaderStageFunction(RHI::ShaderStage shaderStage) const;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Shader/Shader.cpp
@@ -253,6 +253,12 @@ namespace AZ
             AZ_Assert(shaderVariantAsset, "Reloaded ShaderVariantAsset is null");
             const ShaderVariantStableId stableId = shaderVariantAsset->GetStableId();
 
+            // check the supervariantIndex of the ShaderVariantAsset to make sure it matches the supervariantIndex of this shader instance
+            if (shaderVariantAsset->GetSupervariantIndex() != m_supervariantIndex.GetIndex())
+            {
+                return;
+            }
+
             // We make a copy of the updated variant because OnShaderVariantReinitialized must not be called inside
             // m_variantCacheMutex or deadlocks may occur.
             // Or if there is an error, we leave this object in its default state to indicate there was an error.

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderVariantAsset.cpp
@@ -65,6 +65,11 @@ namespace AZ
             return m_buildTimestamp;
         }
 
+        uint32_t ShaderVariantAsset::GetSupervariantIndex() const
+        {
+            return (m_assetId.m_subId >> SupervariantIndexBitPosition) & SupervariantIndexMaxValue;
+        }
+
         const RHI::ShaderStageFunction* ShaderVariantAsset::GetShaderStageFunction(RHI::ShaderStage shaderStage) const
         {
             return m_functionsByStage[static_cast<size_t>(shaderStage)].get();


### PR DESCRIPTION
Changed the Shader instanceId to the combined assetId and supervariant index.

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>