### PR TITLE
[AWSMetrics] Update the auto-generated code to follow O3DE coding standard

### DIFF
--- a/Gems/AWSMetrics/Code/Source/AWSMetricsConstant.h
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsConstant.h
@@ -21,16 +21,16 @@ namespace AWSMetrics
     static constexpr char AwsMetricsAttributeKeyEventData[] = "event_data";
 
     //! Service API request and response object keys
-    static constexpr char AwsMetricsSuccessResponseRecordKeyErrorCode[] = "error_code";
-    static constexpr char AwsMetricsSuccessResponseRecordKeyResult[] = "result";
-    static constexpr char AwsMetricsSuccessResponseKeyFailedRecordCount[] = "failed_record_count";
-    static constexpr char AwsMetricsSuccessResponseKeyEvents[] = "events";
-    static constexpr char AwsMetricsSuccessResponseKeyTotal[] = "total";
-    static constexpr char AwsMetricsErrorKeyMessage[] = "message";
-    static constexpr char AwsMetricsErrorKeyType[] = "type";
-    static constexpr char AwsMetricsRequestParameterKeyEvents[] = "events";
+    static constexpr char AwsMetricsPostMetricsEventsResponseEntryKeyErrorCode[] = "error_code";
+    static constexpr char AwsMetricsPostMetricsEventsResponseEntryKeyResult[] = "result";
+    static constexpr char AwsMetricsPostMetricsEventsResponseKeyFailedRecordCount[] = "failed_record_count";
+    static constexpr char AwsMetricsPostMetricsEventsResponseKeyEvents[] = "events";
+    static constexpr char AwsMetricsPostMetricsEventsResponseKeyTotal[] = "total";
+    static constexpr char AwsMetricsPostMetricsEventsErrorKeyMessage[] = "message";
+    static constexpr char AwsMetricsPostMetricsEventsErrorKeyType[] = "type";
+    static constexpr char AwsMetricsPostMetricsEventsRequestParameterKeyEvents[] = "events";
 
-    static constexpr char AwsMetricsSuccessResponseRecordResult[] = "Ok";
+    static constexpr char AwsMetricsPostMetricsEventsResponseEntrySuccessResult[] = "Ok";
 
     //! Service API limits
     //! https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.cpp
@@ -15,56 +15,77 @@ namespace AWSMetrics
 {
     namespace ServiceAPI
     {
-        bool MetricsEventSuccessResponseRecord::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool PostMetricsEventsResponseEntry::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
-            if (strcmp(key, AwsMetricsSuccessResponseRecordKeyErrorCode) == 0) return reader.Accept(errorCode);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseEntryKeyErrorCode) == 0)
+            {
+                return reader.Accept(m_errorCode);
+            }
 
-            if (strcmp(key, AwsMetricsSuccessResponseRecordKeyResult) == 0) return reader.Accept(result);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseEntryKeyResult) == 0)
+            {
+                return reader.Accept(m_result);
+            }
 
             return reader.Ignore();
         }
 
-        bool MetricsEventSuccessResponse::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool PostMetricsEventsResponse::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
-            if (strcmp(key, AwsMetricsSuccessResponseKeyFailedRecordCount) == 0) return reader.Accept(failedRecordCount);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseKeyFailedRecordCount) == 0)
+            {
+                return reader.Accept(m_failedRecordCount);
+            }
 
-            if (strcmp(key, AwsMetricsSuccessResponseKeyEvents) == 0) return reader.Accept(events);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseKeyEvents) == 0)
+            {
+                return reader.Accept(m_responseEntries);
+            }
 
-            if (strcmp(key, AwsMetricsSuccessResponseKeyTotal) == 0) return reader.Accept(total);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseKeyTotal) == 0)
+            {
+                return reader.Accept(m_total);
+            }
 
             return reader.Ignore();
         }
 
-        bool Error::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool PostMetricsEventsError::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
-            if (strcmp(key, AwsMetricsErrorKeyMessage) == 0) return reader.Accept(message);
+            if (strcmp(key, AwsMetricsPostMetricsEventsErrorKeyMessage) == 0)
+            {
+                return reader.Accept(message);
+            }
 
-            if (strcmp(key, AwsMetricsErrorKeyType) == 0) return reader.Accept(type);
+            if (strcmp(key, AwsMetricsPostMetricsEventsErrorKeyType) == 0)
+            {
+                return reader.Accept(type);
+            }
 
             return reader.Ignore();
         }
 
-        // Generated Function Parameters
-        bool PostProducerEventsRequest::Parameters::BuildRequest(AWSCore::RequestBuilder& request)
+        // Generated request parameters
+        bool PostMetricsEventsRequest::Parameters::BuildRequest(AWSCore::RequestBuilder& request)
         {
-            bool ok = true;
+            bool buildResult = true;
+            buildResult = buildResult && request.WriteJsonBodyParameter(*this);
 
-            ok = ok && request.WriteJsonBodyParameter(*this);
-            return ok;
+            return buildResult;
         }
 
-        bool PostProducerEventsRequest::Parameters::WriteJson(AWSCore::JsonWriter& writer) const
+        bool PostMetricsEventsRequest::Parameters::WriteJson(AWSCore::JsonWriter& writer) const
         {
-            bool ok = true;
+            bool writeResult = true;
 
-            ok = ok && writer.StartObject();
+            writeResult = writeResult && writer.StartObject();
 
-            ok = ok && writer.Key(AwsMetricsRequestParameterKeyEvents);
-            ok = ok && data.SerializeToJson(writer);
+            writeResult = writeResult && writer.Key(AwsMetricsPostMetricsEventsRequestParameterKeyEvents);
+            writeResult = writeResult && m_metricsQueue.SerializeToJson(writer);
 
-            ok = ok && writer.EndObject();
+            writeResult = writeResult && writer.EndObject();
 
-            return ok;
+            return writeResult;
         }
     }
 }

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.h
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.h
@@ -16,41 +16,44 @@ namespace AWSMetrics
 {
     namespace ServiceAPI
     {
-        //! Struct for storing event record from the response.
-        struct MetricsEventSuccessResponseRecord
+        //! Response for an individual metrics event from a PostMetricsEvents request.
+        //! If the event is successfully sent to the backend, it receives an "Ok" result.
+        //! If the event fails to be sent to the backend, the result includes an error code and an "Error" result.
+        struct PostMetricsEventsResponseEntry
         {
-            //! Identify the expected property type and provide a location where the property value can be stored.
+            //! Identify the expected property type in the response entry for each individual metrics event and provide a location where the property value can be stored.
             //! @param key Name of the property.
             //! @param reader JSON reader to read the property.
             bool OnJsonKey(const char* key, AWSCore::JsonReader& reader);
 
-            AZStd::string errorCode; //!< Error code if the event is not sent successfully.
-            AZStd::string result; //!< Processing result for the input record.
+            AZStd::string m_errorCode; //!< Error code if the individual metrics event failed to be sent.
+            AZStd::string m_result; //!< Result for the processed individual metrics event. Expected value: "Error" or "Ok".
         };
 
-        using MetricsEventSuccessResponsePropertyEvents = AZStd::vector<MetricsEventSuccessResponseRecord>;
+        using PostMetricsEventsResponseEntries = AZStd::vector<PostMetricsEventsResponseEntry>;
 
-        //! Struct for storing the success response.
-        struct MetricsEventSuccessResponse
+        //! Response for all the processed metrics events from a PostMetricsEvents request.
+        struct PostMetricsEventsResponse
         {
-            //! Identify the expected property type and provide a location where the property value can be stored.
+            //! Identify the expected property type in the response and provide a location where the property value can be stored.
             //! @param key Name of the property.
             //! @param reader JSON reader to read the property.
             bool OnJsonKey(const char* key, AWSCore::JsonReader& reader);
 
-            int failedRecordCount{ 0 }; //!< Number of events that failed to be saved to metrics events stream.
-            MetricsEventSuccessResponsePropertyEvents events; //! List of input event records.
-            int total{ 0 }; //!< Total number of events that were processed in the request
+            int m_failedRecordCount{ 0 }; //!< Number of events that failed to be sent to the backend.
+            PostMetricsEventsResponseEntries m_responseEntries; //! Response list for all the processed metrics events.
+            int m_total{ 0 }; //!< Total number of events that were processed in the request.
         };
 
-        //! Struct for storing the failure response.
-        struct Error
+        //! Failure response for sending the PostMetricsEvents request.
+        struct PostMetricsEventsError
         {
-            //! Identify the expected property type and provide a location where the property value can be stored.
+            //! Identify the expected property type in the failure response and provide a location where the property value can be stored.
             //! @param key Name of the property.
             //! @param reader JSON reader to read the property.
             bool OnJsonKey(const char* key, AWSCore::JsonReader& reader);
 
+            //! Do not rename the following members since they are expected by the AWSCore dependency.
             AZStd::string message; //!< Error message.
             AZStd::string type; //!< Error type.
         };
@@ -60,7 +63,7 @@ namespace AWSMetrics
 
         //! POST request defined by api_spec.json to send metrics to the backend.
         //! The path for this service API is "/producer/events".
-        class PostProducerEventsRequest
+        class PostMetricsEventsRequest
             : public AWSCore::ServiceRequest
         {
         public:
@@ -79,14 +82,15 @@ namespace AWSMetrics
                 //! @return Whether the serialization is successful.
                 bool WriteJson(AWSCore::JsonWriter& writer) const;
 
-                MetricsQueue data; //!< Data to send via the service API request.
+                MetricsQueue m_metricsQueue; //!< Metrics events to send via the service API request.
             };
 
-            MetricsEventSuccessResponse result; //! Success response.
-            Error error; //! Failure response.
+            //! Do not rename the following members since they are expected by the AWSCore dependency.
+            PostMetricsEventsResponse result; //! Success response.
+            PostMetricsEventsError error; //! Failure response.
             Parameters parameters; //! Request parameter.
         };
 
-        using PostProducerEventsRequestJob = AWSCore::ServiceRequestJob<PostProducerEventsRequest>;
+        using PostMetricsEventsRequestJob = AWSCore::ServiceRequestJob<PostMetricsEventsRequest>;
     } // ServiceAPI
 } // AWSMetrics

--- a/Gems/AWSMetrics/Code/Source/MetricsManager.cpp
+++ b/Gems/AWSMetrics/Code/Source/MetricsManager.cpp
@@ -172,17 +172,17 @@ namespace AWSMetrics
                 if (outcome.IsSuccess())
                 {
                     // Generate response records for success call to keep consistency with the Service API response
-                    ServiceAPI::MetricsEventSuccessResponsePropertyEvents responseRecords;
+                    ServiceAPI::PostMetricsEventsResponseEntries responseEntries;
                     int numMetricsEventsInRequest = metricsQueue->GetNumMetrics();
                     for (int index = 0; index < numMetricsEventsInRequest; ++index)
                     {
-                        ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
-                        responseRecord.result = AwsMetricsSuccessResponseRecordResult;
+                        ServiceAPI::PostMetricsEventsResponseEntry responseEntry;
+                        responseEntry.m_result = AwsMetricsPostMetricsEventsResponseEntrySuccessResult;
 
-                        responseRecords.emplace_back(responseRecord);
+                        responseEntries.emplace_back(responseEntry);
                     }
 
-                    OnResponseReceived(*metricsQueue, responseRecords);
+                    OnResponseReceived(*metricsQueue, responseEntries);
 
                     AZ::TickBus::QueueFunction([requestId]()
                     {
@@ -209,19 +209,19 @@ namespace AWSMetrics
     {
         int requestId = ++m_sendMetricsId;
 
-        ServiceAPI::PostProducerEventsRequestJob* requestJob = ServiceAPI::PostProducerEventsRequestJob::Create(
-            [this, requestId](ServiceAPI::PostProducerEventsRequestJob* successJob)
+        ServiceAPI::PostMetricsEventsRequestJob* requestJob = ServiceAPI::PostMetricsEventsRequestJob::Create(
+            [this, requestId](ServiceAPI::PostMetricsEventsRequestJob* successJob)
             {
-                OnResponseReceived(successJob->parameters.data, successJob->result.events);
+                OnResponseReceived(successJob->parameters.m_metricsQueue, successJob->result.m_responseEntries);
 
                 AZ::TickBus::QueueFunction([requestId]()
                 {
                     AWSMetricsNotificationBus::Broadcast(&AWSMetricsNotifications::OnSendMetricsSuccess, requestId);
                 });
             },
-            [this, requestId](ServiceAPI::PostProducerEventsRequestJob* failedJob)
+            [this, requestId](ServiceAPI::PostMetricsEventsRequestJob* failedJob)
             {
-                OnResponseReceived(failedJob->parameters.data);
+                OnResponseReceived(failedJob->parameters.m_metricsQueue);
 
                 AZStd::string errorMessage = failedJob->error.message;
                 AZ::TickBus::QueueFunction([requestId, errorMessage]()
@@ -230,11 +230,11 @@ namespace AWSMetrics
                 });
             });
 
-        requestJob->parameters.data = AZStd::move(metricsQueue);
+        requestJob->parameters.m_metricsQueue = AZStd::move(metricsQueue);
         requestJob->Start();
     }
 
-    void MetricsManager::OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::MetricsEventSuccessResponsePropertyEvents& responseRecords)
+    void MetricsManager::OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::PostMetricsEventsResponseEntries& responseEntries)
     {
         MetricsQueue metricsEventsForRetry;
         int numMetricsEventsInRequest = metricsEventsInRequest.GetNumMetrics();
@@ -242,7 +242,7 @@ namespace AWSMetrics
         {
             MetricsEvent metricsEvent = metricsEventsInRequest[index];
 
-            if (responseRecords.size() > 0 && responseRecords[index].result == AwsMetricsSuccessResponseRecordResult)
+            if (responseEntries.size() > 0 && responseEntries[index].m_result == AwsMetricsPostMetricsEventsResponseEntrySuccessResult)
             {
                 // The metrics event is sent to the backend successfully.
                 if (metricsEvent.GetNumFailures() == 0)

--- a/Gems/AWSMetrics/Code/Source/MetricsManager.h
+++ b/Gems/AWSMetrics/Code/Source/MetricsManager.h
@@ -60,9 +60,8 @@ namespace AWSMetrics
 
         //! Update the global stats and add qualified failed metrics events back to the buffer for retry.
         //! @param metricsEventsInRequest Metrics events in the original request.
-        //! @param responseRecords Response records from the call. Each record in the list contains the result for sending the corresponding metrics event.
-        void OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::MetricsEventSuccessResponsePropertyEvents& responseRecords =
-                ServiceAPI::MetricsEventSuccessResponsePropertyEvents());
+        //! @param responseEntries Response list for all the processed metrics events.
+        void OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::PostMetricsEventsResponseEntries& responseEntries = ServiceAPI::PostMetricsEventsResponseEntries());
 
         //! Implementation for flush all metrics buffered in memory.
         void FlushMetricsAsync();

--- a/Gems/AWSMetrics/Code/Tests/AWSMetricsServiceApiTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/AWSMetricsServiceApiTest.cpp
@@ -42,43 +42,43 @@ namespace AWSMetrics
 
     TEST_F(AWSMetricsServiceApiTest, OnJsonKey_MetricsEventSuccessResponseRecord_AcceptValidKeys)
     {
-        ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
-        responseRecord.result = "ok";
+        ServiceAPI::PostMetricsEventsResponseEntry responseRecord;
+        responseRecord.m_result = "ok";
 
-        EXPECT_CALL(JsonReader, Accept(responseRecord.result)).Times(1);
-        EXPECT_CALL(JsonReader, Accept(responseRecord.errorCode)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(responseRecord.m_result)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(responseRecord.m_errorCode)).Times(1);
         EXPECT_CALL(JsonReader, Ignore()).Times(1);
 
-        responseRecord.OnJsonKey(AwsMetricsSuccessResponseRecordKeyResult, JsonReader);
-        responseRecord.OnJsonKey(AwsMetricsSuccessResponseRecordKeyErrorCode, JsonReader);
+        responseRecord.OnJsonKey(AwsMetricsPostMetricsEventsResponseEntryKeyResult, JsonReader);
+        responseRecord.OnJsonKey(AwsMetricsPostMetricsEventsResponseEntryKeyErrorCode, JsonReader);
         responseRecord.OnJsonKey("other", JsonReader);
     }
 
     TEST_F(AWSMetricsServiceApiTest, OnJsonKeyWithEvents_MetricsEventSuccessResponseRecord_AcceptValidKeys)
     {
         // Verifiy that JsonReader accepts valid JSON keys in each event record from a success reponse 
-        ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
-        responseRecord.result = "ok";
+        ServiceAPI::PostMetricsEventsResponseEntry responseRecord;
+        responseRecord.m_result = "Ok";
 
-        ServiceAPI::MetricsEventSuccessResponse response;
-        response.events.emplace_back(responseRecord);
-        response.failedRecordCount = 0;
-        response.total = 1;
+        ServiceAPI::PostMetricsEventsResponse response;
+        response.m_responseEntries.emplace_back(responseRecord);
+        response.m_failedRecordCount = 0;
+        response.m_total = 1;
 
-        EXPECT_CALL(JsonReader, Accept(response.failedRecordCount)).Times(1);
-        EXPECT_CALL(JsonReader, Accept(response.total)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(response.m_failedRecordCount)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(response.m_total)).Times(1);
         EXPECT_CALL(JsonReader, Accept(::testing::An<AWSCore::JsonArrayHandler>())).Times(1);
         EXPECT_CALL(JsonReader, Ignore()).Times(1);
 
-        response.OnJsonKey(AwsMetricsSuccessResponseKeyFailedRecordCount, JsonReader);
-        response.OnJsonKey(AwsMetricsSuccessResponseKeyTotal, JsonReader);
-        response.OnJsonKey(AwsMetricsSuccessResponseKeyEvents, JsonReader);
+        response.OnJsonKey(AwsMetricsPostMetricsEventsResponseKeyFailedRecordCount, JsonReader);
+        response.OnJsonKey(AwsMetricsPostMetricsEventsResponseKeyTotal, JsonReader);
+        response.OnJsonKey(AwsMetricsPostMetricsEventsResponseKeyEvents, JsonReader);
         response.OnJsonKey("other", JsonReader);
     }
 
     TEST_F(AWSMetricsServiceApiTest, OnJsonKey_Error_AcceptValidKeys)
     {
-        ServiceAPI::Error error;
+        ServiceAPI::PostMetricsEventsError error;
         error.message = "error message";
         error.type = "404";
 
@@ -86,16 +86,16 @@ namespace AWSMetrics
         EXPECT_CALL(JsonReader, Accept(error.type)).Times(1);
         EXPECT_CALL(JsonReader, Ignore()).Times(1);
 
-        error.OnJsonKey(AwsMetricsErrorKeyMessage, JsonReader);
-        error.OnJsonKey(AwsMetricsErrorKeyType, JsonReader);
+        error.OnJsonKey(AwsMetricsPostMetricsEventsErrorKeyMessage, JsonReader);
+        error.OnJsonKey(AwsMetricsPostMetricsEventsErrorKeyType, JsonReader);
         error.OnJsonKey("other", JsonReader);
     }
 
     TEST_F(AWSMetricsServiceApiTest, BuildRequestBody_PostProducerEventsRequest_SerializedMetricsQueue)
     {
-        ServiceAPI::PostProducerEventsRequest request;
-        request.parameters.data = MetricsQueue();
-        request.parameters.data.AddMetrics(MetricsEventBuilder().Build());
+        ServiceAPI::PostMetricsEventsRequest request;
+        request.parameters.m_metricsQueue = MetricsQueue();
+        request.parameters.m_metricsQueue.AddMetrics(MetricsEventBuilder().Build());
 
         AWSCore::RequestBuilder requestBuilder{};
         EXPECT_TRUE(request.parameters.BuildRequest(requestBuilder));
@@ -104,6 +104,6 @@ namespace AWSMetrics
 
         std::istreambuf_iterator<AZStd::string::value_type> eos;
         AZStd::string bodyString{ std::istreambuf_iterator<AZStd::string::value_type>(*bodyContent), eos };
-        EXPECT_TRUE(bodyString.contains(AZStd::string::format("{\"%s\":[{\"event_timestamp\":", AwsMetricsRequestParameterKeyEvents)));
+        EXPECT_TRUE(bodyString.contains(AZStd::string::format("{\"%s\":[{\"event_timestamp\":", AwsMetricsPostMetricsEventsRequestParameterKeyEvents)));
     }
 }

--- a/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
@@ -430,14 +430,14 @@ namespace AWSMetrics
         ReplaceLocalFileIOWithMockIO();
     }
 
-    TEST_F(MetricsManagerTest, OnResponseReceived_WithResponseRecords_RetryFailedMetrics)
+    TEST_F(MetricsManagerTest, OnResponseReceived_WithResponseEntries_RetryFailedMetrics)
     {
         // Reset the config file to change the max queue size setting.
         ResetClientConfig(false, (double)TestMetricsEventSizeInBytes * (MaxNumMetricsEvents + 1) / MbToBytes,
             DefaultFlushPeriodInSeconds, 1);
 
         MetricsQueue metricsEvents;
-        ServiceAPI::MetricsEventSuccessResponsePropertyEvents responseRecords;
+        ServiceAPI::PostMetricsEventsResponseEntries responseEntries;
         for (int index = 0; index < MaxNumMetricsEvents; ++index)
         {
             MetricsEvent newEvent;
@@ -445,19 +445,19 @@ namespace AWSMetrics
 
             metricsEvents.AddMetrics(newEvent);
 
-            ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
+            ServiceAPI::PostMetricsEventsResponseEntry responseEntry;
             if (index % 2 == 0)
             {
-                responseRecord.errorCode = "Error";
+                responseEntry.m_errorCode = "Error";
             }
             else
             {
-                responseRecord.result = "Ok";
+                responseEntry.m_result = "Ok";
             }
-            responseRecords.emplace_back(responseRecord);
+            responseEntries.emplace_back(responseEntry);
         }
 
-        m_metricsManager->OnResponseReceived(metricsEvents, responseRecords);
+        m_metricsManager->OnResponseReceived(metricsEvents, responseEntries);
 
         const GlobalStatistics& stats = m_metricsManager->GetGlobalStatistics();
         EXPECT_EQ(stats.m_numEvents, MaxNumMetricsEvents);
@@ -471,7 +471,7 @@ namespace AWSMetrics
         ASSERT_EQ(m_metricsManager->GetNumBufferedMetrics(), MaxNumMetricsEvents / 2);
     }
 
-    TEST_F(MetricsManagerTest, OnResponseReceived_NoResponseRecords_RetryAllMetrics)
+    TEST_F(MetricsManagerTest, OnResponseReceived_NoresponseEntries_RetryAllMetrics)
     {
         // Reset the config file to change the max queue size setting.
         ResetClientConfig(false, (double)TestMetricsEventSizeInBytes * (MaxNumMetricsEvents + 1) / MbToBytes,

--- a/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
@@ -471,7 +471,7 @@ namespace AWSMetrics
         ASSERT_EQ(m_metricsManager->GetNumBufferedMetrics(), MaxNumMetricsEvents / 2);
     }
 
-    TEST_F(MetricsManagerTest, OnResponseReceived_NoresponseEntries_RetryAllMetrics)
+    TEST_F(MetricsManagerTest, OnResponseReceived_NoResponseEntries_RetryAllMetrics)
     {
         // Reset the config file to change the max queue size setting.
         ResetClientConfig(false, (double)TestMetricsEventSizeInBytes * (MaxNumMetricsEvents + 1) / MbToBytes,

--- a/Gems/AWSMetrics/cdk/api_spec.json
+++ b/Gems/AWSMetrics/cdk/api_spec.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "AWSMetricsServiceApi",
         "description": "Service API for the data analytics pipeline defined by the AWS Metrics Gem",
-        "version": "1.0.0"
+        "version": "1.0.1"
     },
     "x-amazon-apigateway-request-validators": {
       "all": {

--- a/Gems/AWSMetrics/cdk/api_spec.json
+++ b/Gems/AWSMetrics/cdk/api_spec.json
@@ -68,7 +68,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/MetricsEventSuccessResponse"
+                                    "$ref": "#/components/schemas/PostMetricsEventsResponse"
                                 }
                             }
                         }
@@ -78,7 +78,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/PostMetricsEventsError"
                                 }
                             }
                         }
@@ -88,17 +88,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/PostMetricsEventsError"
                                 }
                             }
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "Internal Server PostMetricsEventsError",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/PostMetricsEventsError"
                                 }
                             }
                         }
@@ -109,7 +109,7 @@
     },
     "components": {
         "schemas": {
-            "Error": {
+            "PostMetricsEventsError": {
                 "type": "object",
                 "properties": {
                     "message": {
@@ -184,18 +184,18 @@
                     }
                 }
             },
-            "MetricsEventSuccessResponse": {
+            "PostMetricsEventsResponse": {
                 "title": "Metrics Event Success Response Schema",
                 "type": "object",
                 "properties": {
                     "failed_record_count": {
                         "type": "number",
-                        "description": "Number of events that failed to be saved to metrics events stream"
+                        "description": "Number of events that failed to be sent to the backend"
                     },
                     "events": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/MetricsEventSuccessResponseRecord"
+                            "$ref": "#/components/schemas/PostMetricsEventsResponseEntry"
                         }
                     },
                     "total": {
@@ -204,16 +204,16 @@
                     }
                 }
             },
-            "MetricsEventSuccessResponseRecord": {
+            "PostMetricsEventsResponseEntry": {
                 "type": "object",
                 "properties": {
                     "error_code": {
                         "type": "string",
-                        "description": "The error code from the metrics events stream. Value set if Result is Error"
+                        "description": "Error code if the individual metrics event failed to be sent"
                     },
                     "result": {
                         "type": "string",
-                        "description": "Processing result for the input record"
+                        "description": "Result for the processed individual metrics event. Expected value: \"Error\" or \"Ok\""
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

- Verified that all unit tests passed
- Verified that AWSMetrics end-to-end tests passed with the updated CDK application deployment
- Verified that AWSMetrics end-to-end tests passed with the old CDK application deployment (Backward compatible)