### PR TITLE
Make SC User data slots proper, immutable variable references

### DIFF
--- a/Gems/GraphCanvas/Code/Include/GraphCanvas/Components/Connections/ConnectionFilters/DataConnectionFilters.h
+++ b/Gems/GraphCanvas/Code/Include/GraphCanvas/Components/Connections/ConnectionFilters/DataConnectionFilters.h
@@ -97,7 +97,7 @@ namespace GraphCanvas
                         // Only want to try to convert to references when we have no connections
                         if (!hasConnections)
                         {
-                            DataSlotRequestBus::EventResult(acceptConnection, sourceEndpoint.GetSlotId(), &DataSlotRequests::CanConvertToReference);
+                            DataSlotRequestBus::EventResult(acceptConnection, sourceEndpoint.GetSlotId(), &DataSlotRequests::CanConvertToReference, false);
                         }
                     }
                     else if (targetType == DataSlotType::Value)
@@ -115,7 +115,7 @@ namespace GraphCanvas
                         // Only want to try to convert to references when we have no connections
                         if (!hasConnections)
                         {
-                            DataSlotRequestBus::EventResult(acceptConnection, targetEndpoint.GetSlotId(), &DataSlotRequests::CanConvertToReference);
+                            DataSlotRequestBus::EventResult(acceptConnection, targetEndpoint.GetSlotId(), &DataSlotRequests::CanConvertToReference, false);
                         }
                     }
                     else if (sourceType == DataSlotType::Value)

--- a/Gems/GraphCanvas/Code/Source/Components/Connections/DataConnections/DataConnectionComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Connections/DataConnections/DataConnectionComponent.cpp
@@ -92,7 +92,7 @@ namespace GraphCanvas
                 }
                 else if (sourceSlotType == DataSlotType::Reference)
                 {
-                    DataSlotRequestBus::EventResult(converted, GetTargetSlotId(), &DataSlotRequests::ConvertToReference);
+                    DataSlotRequestBus::EventResult(converted, GetTargetSlotId(), &DataSlotRequests::ConvertToReference, false);
                 }
             }
             else if (m_dragContext == DragContext::MoveSource)
@@ -103,7 +103,7 @@ namespace GraphCanvas
                 }
                 else if (targetSlotType == DataSlotType::Reference)
                 {
-                    DataSlotRequestBus::EventResult(converted, GetSourceSlotId(), &DataSlotRequests::ConvertToReference);
+                    DataSlotRequestBus::EventResult(converted, GetSourceSlotId(), &DataSlotRequests::ConvertToReference, false);
                 }
             }
             else if (m_dragContext == DragContext::TryConnection)

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotComponent.cpp
@@ -294,9 +294,9 @@ namespace GraphCanvas
         }
     }
 
-    bool DataSlotComponent::ConvertToReference()
+    bool DataSlotComponent::ConvertToReference(bool isNewSlot)
     {
-        if (CanConvertToReference())
+        if (CanConvertToReference(isNewSlot))
         {
             AZ::EntityId nodeId = GetNode();
             GraphId graphId;
@@ -307,7 +307,7 @@ namespace GraphCanvas
                 ScopedGraphUndoBlocker undoBlocker(graphId);
 
                 bool convertedToReference = false;
-                GraphModelRequestBus::EventResult(convertedToReference, graphId, &GraphModelRequests::ConvertSlotToReference, Endpoint(nodeId, GetEntityId()));
+                GraphModelRequestBus::EventResult(convertedToReference, graphId, &GraphModelRequests::ConvertSlotToReference, Endpoint(nodeId, GetEntityId()), isNewSlot);
 
                 if (convertedToReference)
                 {
@@ -326,8 +326,9 @@ namespace GraphCanvas
         return m_dataSlotType == DataSlotType::Reference;
     }
 
-    bool DataSlotComponent::CanConvertToReference() const
+    bool DataSlotComponent::CanConvertToReference([[maybe_unused]] bool isNewSlot) const
     {
+        // #sc_user_slot_variable_ux  make sure this can be converted to reference, or created as one
         bool canToggleReference = false;        
 
         if (m_canConvertSlotTypes && DataSlotUtils::IsValueDataSlotType(m_dataSlotType) && !HasConnections())
@@ -336,7 +337,7 @@ namespace GraphCanvas
             GraphId graphId;
 
             SceneMemberRequestBus::EventResult(graphId, nodeId, &SceneMemberRequests::GetScene);            
-            GraphModelRequestBus::EventResult(canToggleReference, graphId, &GraphModelRequests::CanConvertSlotToReference, Endpoint(nodeId, GetEntityId()));
+            GraphModelRequestBus::EventResult(canToggleReference, graphId, &GraphModelRequests::CanConvertSlotToReference, Endpoint(nodeId, GetEntityId()), isNewSlot);
         }
 
         return canToggleReference;

--- a/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Slots/Data/DataSlotComponent.h
@@ -47,8 +47,8 @@ namespace GraphCanvas
         ////
 
         // DataSlotRequestBus
-        bool ConvertToReference() override;
-        bool CanConvertToReference() const override;
+        bool ConvertToReference(bool isNewSlot = false) override;
+        bool CanConvertToReference(bool isNewSlot = false) const override;
 
         bool ConvertToValue() override;
         bool CanConvertToValue() const override;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/Data/DataSlotBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Slots/Data/DataSlotBus.h
@@ -70,8 +70,8 @@ namespace GraphCanvas
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
         using BusIdType = AZ::EntityId;
 
-        virtual bool ConvertToReference() = 0;
-        virtual bool CanConvertToReference() const = 0;
+        virtual bool ConvertToReference(bool isNewSlot = false) = 0;
+        virtual bool CanConvertToReference(bool isNewSlot = false) const = 0;
 
         virtual bool ConvertToValue() = 0;
         virtual bool CanConvertToValue() const = 0;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Editor/GraphModelBus.h
@@ -125,12 +125,12 @@ namespace GraphCanvas
             return false;
         }
 
-        virtual bool ConvertSlotToReference([[maybe_unused]] const Endpoint& endpoint)
+        virtual bool ConvertSlotToReference([[maybe_unused]] const Endpoint& endpoint, [[maybe_unused]] bool isNewSlot)
         {
             return false;
         }
 
-        virtual bool CanConvertSlotToReference([[maybe_unused]] const Endpoint& endpoint)
+        virtual bool CanConvertSlotToReference([[maybe_unused]] const Endpoint& endpoint, [[maybe_unused]] bool isNewSlot)
         {
             return false;
         }
@@ -145,12 +145,13 @@ namespace GraphCanvas
             return false;
         }
 
-        virtual bool CanPromoteToVariable([[maybe_unused]] const Endpoint& endpoint) const
+        virtual bool CanPromoteToVariable([[maybe_unused]] const Endpoint& endpoint, [[maybe_unused]] bool isNewSlot = false) const
         {
             return false;
         }
 
-        virtual bool PromoteToVariableAction([[maybe_unused]] const Endpoint& endpoint)
+        virtual bool PromoteToVariableAction([[maybe_unused]] const Endpoint& endpoint
+            , [[maybe_unused]] bool isNewSlot)
         {
             return false;
         }

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/SlotMenuActions/SlotContextMenuActions.cpp
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Widgets/EditorContextMenu/ContextMenuActions/SlotMenuActions/SlotContextMenuActions.cpp
@@ -258,7 +258,7 @@ namespace GraphCanvas
                 if (DataSlotUtils::IsValueDataSlotType(dataSlotType))
                 {
                     setText("Convert to Reference");
-                    DataSlotRequestBus::EventResult(canToggleState, targetId, &DataSlotRequests::CanConvertToReference);
+                    DataSlotRequestBus::EventResult(canToggleState, targetId, &DataSlotRequests::CanConvertToReference, false);
                 }
                 else
                 {
@@ -291,7 +291,7 @@ namespace GraphCanvas
 
         if (DataSlotUtils::IsValueDataSlotType(dataSlotType))
         {
-            DataSlotRequestBus::EventResult(toggledState, targetId, &DataSlotRequests::ConvertToReference);
+            DataSlotRequestBus::EventResult(toggledState, targetId, &DataSlotRequests::ConvertToReference, false);
         }
         else
         {
@@ -345,14 +345,14 @@ namespace GraphCanvas
 
                     if (DataSlotUtils::IsValueDataSlotType(dataSlotType))
                     {
-                        DataSlotRequestBus::EventResult(enableAction, targetId, &DataSlotRequests::CanConvertToReference);
+                        DataSlotRequestBus::EventResult(enableAction, targetId, &DataSlotRequests::CanConvertToReference, false);
 
                         if (enableAction)
                         {
                             Endpoint endpoint;
                             SlotRequestBus::EventResult(endpoint, targetId, &SlotRequests::GetEndpoint);
 
-                            GraphModelRequestBus::EventResult(enableAction, graphId, &GraphModelRequests::CanPromoteToVariable, endpoint);
+                            GraphModelRequestBus::EventResult(enableAction, graphId, &GraphModelRequests::CanPromoteToVariable, endpoint, false);
                         }
                     }
                 }
@@ -371,7 +371,7 @@ namespace GraphCanvas
         SlotRequestBus::EventResult(endpoint, targetId, &SlotRequests::GetEndpoint);
 
         bool promotedElement = false;
-        GraphModelRequestBus::EventResult(promotedElement, graphId, &GraphModelRequests::PromoteToVariableAction, endpoint);
+        GraphModelRequestBus::EventResult(promotedElement, graphId, &GraphModelRequests::PromoteToVariableAction, endpoint, false);
 
         if (promotedElement)
         {

--- a/Gems/GraphModel/Code/Tests/MockGraphCanvas.cpp
+++ b/Gems/GraphModel/Code/Tests/MockGraphCanvas.cpp
@@ -94,12 +94,12 @@ namespace MockGraphCanvasServices
         GraphCanvas::DataSlotRequestBus::Handler::BusDisconnect();
     }
 
-    bool MockDataSlotComponent::ConvertToReference()
+    bool MockDataSlotComponent::ConvertToReference([[maybe_unused]] bool isNewSlot = false)
     {
         return false;
     }
 
-    bool MockDataSlotComponent::CanConvertToReference() const
+    bool MockDataSlotComponent::CanConvertToReference([[maybe_unused]] bool isNewSlot = false) const
     {
         return false;
     }

--- a/Gems/GraphModel/Code/Tests/MockGraphCanvas.h
+++ b/Gems/GraphModel/Code/Tests/MockGraphCanvas.h
@@ -72,8 +72,8 @@ namespace MockGraphCanvasServices
         void Deactivate() override;
 
         // GraphCanvas::DataSlotRequestBus overrides ...
-        bool ConvertToReference() override;
-        bool CanConvertToReference() const override;
+        bool ConvertToReference(bool isNewSlot = false) override;
+        bool CanConvertToReference(bool isNewSlot = false) const override;
         bool ConvertToValue() override;
         bool CanConvertToValue() const override;
         bool IsUserSlot() const override;

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1142,7 +1142,7 @@ namespace ScriptCanvasEditor
             {
                 if (slot->IsVariableReference())
                 {
-                    return true;
+                    return !slot->IsUserAdded();
                 }
                 else
                 {
@@ -1254,7 +1254,7 @@ namespace ScriptCanvasEditor
             return nullptr;
         }
 
-        if (slot->IsVariableReference())
+        if (slot->IsVariableReference() && !slot->IsUserAdded())
         {
             ScriptCanvasVariableReferenceDataInterface* dataInterface = aznew ScriptCanvasVariableReferenceDataInterface(&m_variableDataModel, GetScriptCanvasId(), scriptCanvasNodeId, scriptCanvasSlotId);
             GraphCanvas::NodePropertyDisplay* dataDisplay = nullptr;

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -674,7 +674,6 @@ namespace ScriptCanvasEditor
 
                             if (variable)
                             {
-                                // functions 2.0 set variable scope to function 
                                 if (variable->GetScope() != ScriptCanvas::VariableFlags::Scope::Function)
                                 {
                                     variable->SetScope(ScriptCanvas::VariableFlags::Scope::Function);

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorGraph.h
@@ -175,12 +175,12 @@ namespace ScriptCanvasEditor
         void RemoveSlot(const GraphCanvas::Endpoint& endpoint) override;
         bool IsSlotRemovable(const GraphCanvas::Endpoint& endpoint) const override;
 
-        bool ConvertSlotToReference(const GraphCanvas::Endpoint& endpoint) override;
-        bool CanConvertSlotToReference(const GraphCanvas::Endpoint& endpoint) override;
+        bool ConvertSlotToReference(const GraphCanvas::Endpoint& endpoint, bool isNewSlot = false) override;
+        bool CanConvertSlotToReference(const GraphCanvas::Endpoint& endpoint, bool isNewSlot = false) override;
         GraphCanvas::CanHandleMimeEventOutcome CanHandleReferenceMimeEvent(const GraphCanvas::Endpoint& endpoint, const QMimeData* mimeData) override;
         bool HandleReferenceMimeEvent(const GraphCanvas::Endpoint& endpoint, const QMimeData* mimeData) override;
-        bool CanPromoteToVariable(const GraphCanvas::Endpoint& endpoint) const override;
-        bool PromoteToVariableAction(const GraphCanvas::Endpoint& endpoint) override;
+        bool CanPromoteToVariable(const GraphCanvas::Endpoint& endpoint, bool isNewSlot = false) const override;
+        bool PromoteToVariableAction(const GraphCanvas::Endpoint& endpoint, bool isNewSlot = false) override;
         bool SynchronizeReferences(const GraphCanvas::Endpoint& sourceEndpoint, const GraphCanvas::Endpoint& targetEndpoint) override;
 
         bool ConvertSlotToValue(const GraphCanvas::Endpoint& endpoint) override;

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/MainWindow.cpp
@@ -3873,7 +3873,9 @@ namespace ScriptCanvasEditor
         contextMenu.AddMenuAction(aznew ConvertReferenceToVariableNodeAction(&contextMenu));
         contextMenu.AddMenuAction(aznew ExposeSlotMenuAction(&contextMenu));
         contextMenu.AddMenuAction(aznew CreateAzEventHandlerSlotMenuAction(&contextMenu));
-        contextMenu.AddMenuAction(aznew SetDataSlotTypeMenuAction(&contextMenu));
+
+        // disabling until references can be changed
+        // contextMenu.AddMenuAction(aznew SetDataSlotTypeMenuAction(&contextMenu));
 
         return HandleContextMenu(contextMenu, slotId, screenPoint, scenePoint);
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptCanvasContextMenus.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Windows/ScriptCanvasContextMenus.cpp
@@ -516,7 +516,7 @@ namespace ScriptCanvasEditor
             GraphCanvas::SlotRequestBus::EventResult(endpoint, slotId2, &GraphCanvas::SlotRequests::GetEndpoint);
 
             bool promotedElement = false;
-            GraphCanvas::GraphModelRequestBus::EventResult(promotedElement, graphId2, &GraphCanvas::GraphModelRequests::PromoteToVariableAction, endpoint);
+            GraphCanvas::GraphModelRequestBus::EventResult(promotedElement, graphId2, &GraphCanvas::GraphModelRequests::PromoteToVariableAction, endpoint, false);
 
             if (promotedElement)
             {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAssetHandler.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Asset/RuntimeAssetHandler.cpp
@@ -100,12 +100,18 @@ namespace ScriptCanvas
     {
         RuntimeAsset* runtimeAsset = asset.GetAs<RuntimeAsset>();
         AZ_Assert(runtimeAsset, "This should be a Script Canvas runtime asset, as this is the only type we process!");
+
         if (runtimeAsset && m_serializeContext)
         {
             stream->Seek(0U, AZ::IO::GenericStream::ST_SEEK_BEGIN);
-            bool loadSuccess = AZ::Utils::LoadObjectFromStreamInPlace(*stream, runtimeAsset->m_runtimeData, m_serializeContext, AZ::ObjectStream::FilterDescriptor(assetLoadFilterCB));
+            const bool loadSuccess = AZ::Utils::LoadObjectFromStreamInPlace(*stream, runtimeAsset->m_runtimeData
+                , m_serializeContext, AZ::ObjectStream::FilterDescriptor(assetLoadFilterCB));
+            AZ_Error("ScriptCanvas", loadSuccess, "ScriptCanvas failed to load runtime asset: %s - %s"
+                , asset.GetHint().c_str(), asset.GetId().ToString<AZStd::string>().c_str());
+
             return loadSuccess ? AZ::Data::AssetHandler::LoadResult::LoadComplete : AZ::Data::AssetHandler::LoadResult::Error;
         }
+
         return AZ::Data::AssetHandler::LoadResult::Error;
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -2577,11 +2577,11 @@ namespace ScriptCanvas
         }
     }
 
-    bool Node::ConvertSlotToReference(const SlotId& slotId)
+    bool Node::ConvertSlotToReference(const SlotId& slotId, bool isNewSlot)
     {
         Slot* slot = GetSlot(slotId);
 
-        if (slot && slot->ConvertToReference())
+        if (slot && slot->ConvertToReference(isNewSlot))
         {
             InitializeVariableReference((*slot), {});
             return true;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
@@ -498,7 +498,7 @@ namespace ScriptCanvas
         void SanityCheckDynamicDisplay();
         void SanityCheckDynamicDisplay(ExploredDynamicGroupCache& exploredGroupCache);
 
-        bool ConvertSlotToReference(const SlotId& slotId);
+        bool ConvertSlotToReference(const SlotId& slotId, bool isNewSlot = false);
         bool ConvertSlotToValue(const SlotId& slotId);
 
         NamedEndpoint CreateNamedEndpoint(SlotId slotId) const;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -460,14 +460,15 @@ namespace ScriptCanvas
             && GetDataType() != Data::Type::BehaviorContextObject(GraphScopedVariableId::TYPEINFO_Uuid());
     }
 
-    bool Slot::CanConvertToReference() const
-    {        
-        return !m_isUserAdded && CanConvertTypes() && !m_isVariableReference && !m_node->HasConnectedNodes((*this));
+    bool Slot::CanConvertToReference(bool isNewSlot) const
+    {
+        // #sc_user_slot_variable_ux  make sure this can be converted to reference, or created as one
+        return (!m_isUserAdded || isNewSlot) && CanConvertTypes() && !m_isVariableReference && !m_node->HasConnectedNodes((*this));
     }
 
-    bool Slot::ConvertToReference()
+    bool Slot::ConvertToReference(bool isNewSlot)
     {
-        if (CanConvertToReference())
+        if (CanConvertToReference(isNewSlot))
         {
             m_isVariableReference = true;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -147,8 +147,8 @@ namespace ScriptCanvas
         bool CanConvertToValue() const;
         bool ConvertToValue();
 
-        bool CanConvertToReference() const;
-        bool ConvertToReference();
+        bool CanConvertToReference(bool isNewSlot = false) const;
+        bool ConvertToReference(bool isNewSlot = false);
         void SetVariableReference(const VariableId& variableId);
         const VariableId& GetVariableReference() const;
         GraphVariable* GetVariable() const;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Grammar/AbstractCodeModel.cpp
@@ -237,7 +237,7 @@ namespace ScriptCanvas
 
                 if (auto datum = variablePair.second.GetDatum())
                 {
-                    // #functions2 slot<->variable consider getting all variables from the UX variable manager, or from the ACM and looking them up in the variable manager for ordering
+                    // #sc_user_slot_variable_ux consider getting all variables from the UX variable manager, or from the ACM and looking them up in the variable manager for ordering
                     m_sourceVariableByDatum.insert(AZStd::make_pair(datum, &variablePair.second));
                 }
 
@@ -248,7 +248,7 @@ namespace ScriptCanvas
                 auto datum = sourceVariable->GetDatum();
                 AZ_Assert(datum != nullptr, "the datum must be valid");
 
-                // #functions2 slot<->variable check to verify if it is a member variable
+                // #sc_user_slot_variable_ux check to verify if it is a member variable
                 auto variable = sourceVariable->GetScope() == VariableFlags::Scope::Graph
                     ? AddMemberVariable(*datum, sourceVariable->GetVariableName(), sourceVariable->GetVariableId())
                     : AddVariable(*datum, sourceVariable->GetVariableName(), sourceVariable->GetVariableId());
@@ -1671,7 +1671,7 @@ namespace ScriptCanvas
 
                     if (returnValue.second->m_source->m_sourceSlotId == slot->GetId())
                     {
-                        // #functions2 slot<->variable determine if the root or the function call should be passed in here...the slot/node lead to the user call on the thread, but it may not even be created yet
+                        // #sc_user_slot_variable_ux determine if the root or the function call should be passed in here...the slot/node lead to the user call on the thread, but it may not even be created yet
                         return AZStd::make_pair(root, returnValue.second->m_source);
                     }
                 }
@@ -4644,7 +4644,7 @@ namespace ScriptCanvas
 
         void AbstractCodeModel::ParseNodelingVariables(const Node& node, NodelingType nodelingType)
         {
-            // #functions2 slot<->variable adjust once datums are more coordinated
+            // #sc_user_slot_variable_ux adjust once datums are more coordinated
             auto createVariablesSlots = [&](AZStd::unordered_map<const Slot*, VariablePtr>& variablesBySlots, const AZStd::vector<const Slot*>& slots, bool slotHasDatum)
             {
                 for (const auto& slot : slots)
@@ -4660,7 +4660,7 @@ namespace ScriptCanvas
                             return;
                         }
 
-                        // #functions2 slot<->variable consider getting all variables from the UX variable manager, or from the ACM and looking them up in the variable manager for ordering
+                        // #sc_user_slot_variable_ux consider getting all variables from the UX variable manager, or from the ACM and looking them up in the variable manager for ordering
 //                         auto iter = m_sourceVariableByDatum.find(variableDatum);
 //                         if (iter == m_sourceVariableByDatum.end())
 //                         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariableManagerComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Variable/GraphVariableManagerComponent.cpp
@@ -220,7 +220,7 @@ namespace ScriptCanvas
         return AZ::Success(newId);
     }
 
-    // #functions2 slot<->variable add this to the graph, using the old datum
+    // #sc_user_slot_variable_ux add this to the graph, using the old datum
     AZ::Outcome<VariableId, AZStd::string> GraphVariableManagerComponent::AddVariable(AZStd::string_view name, const Datum& value, bool functionScope)
     {
         if (FindVariable(name))

--- a/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_PromotedUserVariables.scriptcanvas
+++ b/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_PromotedUserVariables.scriptcanvas
@@ -1,0 +1,858 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "ScriptCanvasData",
+    "ClassData": {
+        "m_scriptCanvas": {
+            "Id": {
+                "id": 8475300026301128284
+            },
+            "Name": "Script Canvas Graph",
+            "Components": {
+                "Component_[11907165653188402756]": {
+                    "$type": "EditorGraphVariableManagerComponent",
+                    "Id": 11907165653188402756
+                },
+                "Component_[3578973614457412392]": {
+                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "Id": 3578973614457412392,
+                    "m_graphData": {
+                        "m_nodes": [
+                            {
+                                "Id": {
+                                    "id": 16019084446641
+                                },
+                                "Name": "SC-Node(Start)",
+                                "Components": {
+                                    "Component_[1767232296153779726]": {
+                                        "$type": "Start",
+                                        "Id": 1767232296153779726,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{635D7286-4B19-44D4-8F5E-1B4A0CF85C9E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled when the entity that owns this graph is fully activated.",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 7910364941488
+                                },
+                                "Name": "SC-Node(Mark Complete)",
+                                "Components": {
+                                    "Component_[1885955816756801547]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 1885955816756801547,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{31ABE549-E2E3-440E-884C-9F7FD4185C1D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId: 0",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{4FFA1776-D933-4475-BB3C-5BD7FAD47E2B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F8687B16-9C64-4B5E-B000-035D9B3712EF}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{0E8012D1-A36B-4BCC-86C9-7D4F93816923}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 4276206253
+                                                }
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Mark Complete",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{31ABE549-E2E3-440E-884C-9F7FD4185C1D}"
+                                            },
+                                            {
+                                                "m_id": "{4FFA1776-D933-4475-BB3C-5BD7FAD47E2B}"
+                                            }
+                                        ],
+                                        "prettyClassName": "Unit Testing"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 16611789933489
+                                },
+                                "Name": "SC-Node(Expect Equal)",
+                                "Components": {
+                                    "Component_[6935885723653735789]": {
+                                        "$type": "MethodOverloaded",
+                                        "Id": 6935885723653735789,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{E2AB1183-3D7C-479C-88D5-8C90042F9D3F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId: 0",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{8D954D4E-D65E-47E4-8979-BAE900582B38}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Candidate",
+                                                "toolTip": "left of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{17DA7626-AA06-4574-8F27-9DE230F03639}"
+                                                },
+                                                "DynamicTypeOverride": 1,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "OverloadContract"
+                                                    }
+                                                ],
+                                                "slotName": "Reference",
+                                                "toolTip": "right of ==",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{B442C3D0-F6F5-4689-982B-67CDF723D505}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Report",
+                                                "toolTip": "additional notes for the test report",
+                                                "DisplayDataType": {
+                                                    "m_type": 5
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{33531BA3-2152-4F66-BFDA-CEAC2EB631C7}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A8A9AB24-E5B2-4947-85CC-F87AD9F97FEB}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 4276206253
+                                                }
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Candidate"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 7.0,
+                                                "label": "Reference"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "",
+                                                "label": "Report"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "Expect Equal",
+                                        "className": "Unit Testing",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{E2AB1183-3D7C-479C-88D5-8C90042F9D3F}"
+                                            },
+                                            {
+                                                "m_id": "{8D954D4E-D65E-47E4-8979-BAE900582B38}"
+                                            },
+                                            {
+                                                "m_id": "{17DA7626-AA06-4574-8F27-9DE230F03639}"
+                                            },
+                                            {
+                                                "m_id": "{B442C3D0-F6F5-4689-982B-67CDF723D505}"
+                                            }
+                                        ],
+                                        "orderedInputSlotIds": [
+                                            {
+                                                "m_id": "{E2AB1183-3D7C-479C-88D5-8C90042F9D3F}"
+                                            },
+                                            {
+                                                "m_id": "{8D954D4E-D65E-47E4-8979-BAE900582B38}"
+                                            },
+                                            {
+                                                "m_id": "{17DA7626-AA06-4574-8F27-9DE230F03639}"
+                                            },
+                                            {
+                                                "m_id": "{B442C3D0-F6F5-4689-982B-67CDF723D505}"
+                                            }
+                                        ],
+                                        "outputSlotIds": [
+                                            {}
+                                        ]
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 15443558828977
+                                },
+                                "Name": "FunctionCallNode",
+                                "Components": {
+                                    "Component_[9383725529787702808]": {
+                                        "$type": "FunctionCallNode",
+                                        "Id": 9383725529787702808,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{32BD3CC0-AA44-4B1F-966D-4FF1561E4BC5}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "IncrementNumber",
+                                                "DisplayGroup": {
+                                                    "Value": 921414446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{EBE31443-CFB9-41B1-8DBA-127DB07A405A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "IncrementMe",
+                                                "DisplayGroup": {
+                                                    "Value": 921414446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{7FDF8233-D26E-4EBE-9D68-1074FD9B9999}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "DisplayGroup": {
+                                                    "Value": 921414446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{3A29CBC7-A727-4DBD-8319-0D31D299A9F0}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Incremented",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 2732307328
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 6.0,
+                                                "label": "IncrementMe"
+                                            }
+                                        ],
+                                        "m_sourceId": "{5F36B80D-9546-478E-AD33-BF4AFEC8FF01}",
+                                        "m_asset": {
+                                            "assetId": {
+                                                "guid": "{35A24A1D-57B7-5B0A-89C9-8BBA7657ECA5}",
+                                                "subId": 3756448882
+                                            },
+                                            "assetHint": "scriptcanvas/unittests/ly_sc_unittest_promoteduservariablesfunction.scriptcanvas_fn_compiled"
+                                        },
+                                        "m_slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{32BD3CC0-AA44-4B1F-966D-4FF1561E4BC5}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{EBE31443-CFB9-41B1-8DBA-127DB07A405A}"
+                                                            },
+                                                            "_interfaceSourceId": {
+                                                                "m_id": "{55F1434B-40C1-40AA-91C8-A65D6F2AFDC3}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{7FDF8233-D26E-4EBE-9D68-1074FD9B9999}"
+                                                            },
+                                                            "_name": "Out",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{3A29CBC7-A727-4DBD-8319-0D31D299A9F0}"
+                                                                    },
+                                                                    "_interfaceSourceId": {
+                                                                        "m_id": "{81088CD0-BC45-4EB8-A823-DE442BF0541C}"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "_interfaceSourceId": "{E9A0BF28-5910-4B0B-B82F-6519BCC1A33A}"
+                                                        }
+                                                    ],
+                                                    "_parsedName": "IncrementNumber_scvm",
+                                                    "_interfaceSourceId": "{5F36B80D-9546-478E-AD33-BF4AFEC8FF01}"
+                                                }
+                                            ]
+                                        },
+                                        "m_slotExecutionMapSourceInterface": {
+                                            "ins": [
+                                                {
+                                                    "displayName": "IncrementNumber",
+                                                    "parsedName": "IncrementNumber_scvm",
+                                                    "inputs": [
+                                                        {
+                                                            "displayName": "IncrementMe",
+                                                            "parsedName": "IncrementMe_scvm_1",
+                                                            "datum": {
+                                                                "scriptCanvasType": {
+                                                                    "m_type": 3
+                                                                },
+                                                                "isNullPointer": false,
+                                                                "$type": "double",
+                                                                "value": 0.0
+                                                            },
+                                                            "sourceID": {
+                                                                "m_id": "{55F1434B-40C1-40AA-91C8-A65D6F2AFDC3}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "outs": [
+                                                        {
+                                                            "displayName": "Out",
+                                                            "parsedName": "Out",
+                                                            "outputs": [
+                                                                {
+                                                                    "displayName": "Incremented",
+                                                                    "parsedName": "Incremented_scvm_1",
+                                                                    "type": {
+                                                                        "m_type": 3
+                                                                    },
+                                                                    "sourceID": {
+                                                                        "m_id": "{81088CD0-BC45-4EB8-A823-DE442BF0541C}"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "sourceID": "{E9A0BF28-5910-4B0B-B82F-6519BCC1A33A}"
+                                                        }
+                                                    ],
+                                                    "isPure": true,
+                                                    "sourceID": "{5F36B80D-9546-478E-AD33-BF4AFEC8FF01}"
+                                                }
+                                            ],
+                                            "outKeys": [
+                                                {
+                                                    "Value": 3119148441
+                                                }
+                                            ],
+                                            "namespacePath": [
+                                                "scriptcanvas",
+                                                "unittests",
+                                                "ly_sc_unittest_promoteduservariablesfunction_vm"
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ],
+                        "m_connections": [
+                            {
+                                "Id": {
+                                    "id": 16482940914609
+                                },
+                                "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(Function Call Node: IncrementNumber)",
+                                "Components": {
+                                    "Component_[1325606044371455697]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 1325606044371455697,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 16019084446641
+                                            },
+                                            "slotId": {
+                                                "m_id": "{635D7286-4B19-44D4-8F5E-1B4A0CF85C9E}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 15443558828977
+                                            },
+                                            "slotId": {
+                                                "m_id": "{32BD3CC0-AA44-4B1F-966D-4FF1561E4BC5}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 17672646855601
+                                },
+                                "Name": "srcEndpoint=(Function Call Node: Out), destEndpoint=(Expect Equal: In)",
+                                "Components": {
+                                    "Component_[553888750995224414]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 553888750995224414,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 15443558828977
+                                            },
+                                            "slotId": {
+                                                "m_id": "{7FDF8233-D26E-4EBE-9D68-1074FD9B9999}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 16611789933489
+                                            },
+                                            "slotId": {
+                                                "m_id": "{33531BA3-2152-4F66-BFDA-CEAC2EB631C7}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 18003359337393
+                                },
+                                "Name": "srcEndpoint=(Function Call Node: Incremented), destEndpoint=(Expect Equal: Candidate)",
+                                "Components": {
+                                    "Component_[6929789752232921563]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 6929789752232921563,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 15443558828977
+                                            },
+                                            "slotId": {
+                                                "m_id": "{3A29CBC7-A727-4DBD-8319-0D31D299A9F0}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 16611789933489
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8D954D4E-D65E-47E4-8979-BAE900582B38}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 8902502386864
+                                },
+                                "Name": "srcEndpoint=(Expect Equal: Out), destEndpoint=(Mark Complete: In)",
+                                "Components": {
+                                    "Component_[11962156650601495433]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 11962156650601495433,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 16611789933489
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A8A9AB24-E5B2-4947-85CC-F87AD9F97FEB}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 7910364941488
+                                            },
+                                            "slotId": {
+                                                "m_id": "{F8687B16-9C64-4B5E-B000-035D9B3712EF}"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "m_assetType": "{1D497BC7-F97F-0000-80C2-359B6A010000}",
+                    "versionData": {
+                        "_grammarVersion": 1,
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
+                    },
+                    "GraphCanvasData": [
+                        {
+                            "Key": {
+                                "id": 7910364941488
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            620.0,
+                                            320.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{69405A2B-8669-41A0-9660-74C8ECCE8B84}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 15443558828977
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            100.0,
+                                            100.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{61B5E23D-2C56-4183-9606-AC0A4B788B7E}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 16019084446641
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -80.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{A7B4E93B-07A1-43DC-BE07-4DC5A1D64352}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 16611789933489
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            300.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{5EDF60ED-BF05-4AC4-85D9-5988FFE7C2A7}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 8475300026301128284
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
+                                        "$type": "SceneComponentSaveData"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "StatisticsHelper": {
+                        "InstanceCounter": [
+                            {
+                                "Key": 4053150093067829293,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 4199610336680704683,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 6740857896271713458,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 10204019744198319120,
+                                "Value": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_PromotedUserVariablesFunction.scriptcanvas
+++ b/Gems/ScriptCanvasTesting/Assets/ScriptCanvas/UnitTests/LY_SC_UnitTest_PromotedUserVariablesFunction.scriptcanvas
@@ -1,0 +1,1100 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "ScriptCanvasData",
+    "ClassData": {
+        "m_scriptCanvas": {
+            "Id": {
+                "id": 8918912361393065975
+            },
+            "Name": "Script Canvas Graph",
+            "Components": {
+                "Component_[14098532328271403379]": {
+                    "$type": "EditorGraphVariableManagerComponent",
+                    "Id": 14098532328271403379,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{55F1434B-40C1-40AA-91C8-A65D6F2AFDC3}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 3
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "double",
+                                        "value": 0.0
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{55F1434B-40C1-40AA-91C8-A65D6F2AFDC3}"
+                                    },
+                                    "VariableName": "IncrementMe",
+                                    "Scope": 1
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{71AAA826-F605-4EA7-8445-76CBCE253BE0}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 0
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "bool",
+                                        "value": false
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{71AAA826-F605-4EA7-8445-76CBCE253BE0}"
+                                    },
+                                    "VariableName": "OnlyOne",
+                                    "Scope": 1
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{793CF8BD-AF82-484E-AFD3-54EA328D9663}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 0
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "bool",
+                                        "value": false,
+                                        "label": "alsoTwo"
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{793CF8BD-AF82-484E-AFD3-54EA328D9663}"
+                                    },
+                                    "VariableName": "alsoTwo",
+                                    "Scope": 1
+                                }
+                            },
+                            {
+                                "Key": {
+                                    "m_id": "{81088CD0-BC45-4EB8-A823-DE442BF0541C}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 3
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "double",
+                                        "value": 0.0,
+                                        "label": "Incremented"
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{81088CD0-BC45-4EB8-A823-DE442BF0541C}"
+                                    },
+                                    "VariableName": "Incremented",
+                                    "Scope": 1
+                                }
+                            }
+                        ]
+                    }
+                },
+                "Component_[2840022707551160176]": {
+                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "Id": 2840022707551160176,
+                    "m_graphData": {
+                        "m_nodes": [
+                            {
+                                "Id": {
+                                    "id": 7454919658417
+                                },
+                                "Name": "SC Node(SetVariable)",
+                                "Components": {
+                                    "Component_[13386694676262750118]": {
+                                        "$type": "SetVariableNode",
+                                        "Id": 13386694676262750118,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{22483279-E500-40D5-A61B-2C78DAC3319A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the variable referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{17296A41-81F9-444D-BA2E-B8DAD7C62B10}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced variable has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{8D9CBBAD-5F75-4397-8139-B7FE79C48DFD}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A21214FF-8D17-48B1-9A29-E805230F8942}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Number"
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{81088CD0-BC45-4EB8-A823-DE442BF0541C}"
+                                        },
+                                        "m_variableDataInSlotId": {
+                                            "m_id": "{8D9CBBAD-5F75-4397-8139-B7FE79C48DFD}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{A21214FF-8D17-48B1-9A29-E805230F8942}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 3946110127280
+                                },
+                                "Name": "SC Node(GetVariable)",
+                                "Components": {
+                                    "Component_[14162979093169706711]": {
+                                        "$type": "GetVariableNode",
+                                        "Id": 14162979093169706711,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{D0D0EC9C-927F-42DB-AD22-412F374326CD}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "When signaled sends the property referenced by this node to a Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{484C5712-DB44-4A98-8199-11E47AC3D837}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "toolTip": "Signaled after the referenced property has been pushed to the Data Output slot",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{71712AB8-E5BC-42EC-A07E-733D0D36F830}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "m_variableId": {
+                                            "m_id": "{55F1434B-40C1-40AA-91C8-A65D6F2AFDC3}"
+                                        },
+                                        "m_variableDataOutSlotId": {
+                                            "m_id": "{71712AB8-E5BC-42EC-A07E-733D0D36F830}"
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5620968623025
+                                },
+                                "Name": "SC-Node(FunctionDefinitionNode)",
+                                "Components": {
+                                    "Component_[15563419574622171620]": {
+                                        "$type": "FunctionDefinitionNode",
+                                        "Id": 15563419574622171620,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{8362D954-5F68-4DAB-94B3-1EFA2B2774FB}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "DisplayGroupConnectedSlotLimitContract",
+                                                        "limit": 1,
+                                                        "displayGroup": "NodelingSlotDisplayGroup",
+                                                        "errorMessage": "Execution nodes can only be connected to either the Input or Output, and not both at the same time."
+                                                    },
+                                                    {
+                                                        "$type": "DisallowReentrantExecutionContract"
+                                                    }
+                                                ],
+                                                "slotName": " ",
+                                                "DisplayGroup": {
+                                                    "Value": 3992535411
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{8F6E144D-A6A4-4A5D-8D47-D4FB5E165EAC}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "DisplayGroupConnectedSlotLimitContract",
+                                                        "limit": 1,
+                                                        "displayGroup": "NodelingSlotDisplayGroup",
+                                                        "errorMessage": "Execution nodes can only be connected to either the Input or Output, and not both at the same time."
+                                                    }
+                                                ],
+                                                "slotName": " ",
+                                                "DisplayGroup": {
+                                                    "Value": 3992535411
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{67EC591D-BB4D-4D92-8FBE-617561EFD79D}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Incremented",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 452080683
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{81088CD0-BC45-4EB8-A823-DE442BF0541C}"
+                                                },
+                                                "IsUserAdded": true
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Incremented"
+                                            }
+                                        ],
+                                        "m_displayName": "Out",
+                                        "m_identifier": "{E9A0BF28-5910-4B0B-B82F-6519BCC1A33A}",
+                                        "m_isExecutionEntry": false
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 4731910392753
+                                },
+                                "Name": "SC-Node(FunctionDefinitionNode)",
+                                "Components": {
+                                    "Component_[18278450953448842587]": {
+                                        "$type": "FunctionDefinitionNode",
+                                        "Id": 18278450953448842587,
+                                        "Slots": [
+                                            {
+                                                "isVisibile": false,
+                                                "id": {
+                                                    "m_id": "{52C8B76A-CC38-4358-9971-02B6F7E05030}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "DisplayGroupConnectedSlotLimitContract",
+                                                        "limit": 1,
+                                                        "displayGroup": "NodelingSlotDisplayGroup",
+                                                        "errorMessage": "Execution nodes can only be connected to either the Input or Output, and not both at the same time."
+                                                    },
+                                                    {
+                                                        "$type": "DisallowReentrantExecutionContract"
+                                                    }
+                                                ],
+                                                "slotName": " ",
+                                                "DisplayGroup": {
+                                                    "Value": 3992535411
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{4C0849D0-627F-41BA-A8EE-A201074D5E52}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "DisplayGroupConnectedSlotLimitContract",
+                                                        "limit": 1,
+                                                        "displayGroup": "NodelingSlotDisplayGroup",
+                                                        "errorMessage": "Execution nodes can only be connected to either the Input or Output, and not both at the same time."
+                                                    }
+                                                ],
+                                                "slotName": " ",
+                                                "DisplayGroup": {
+                                                    "Value": 3992535411
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{CFDCE169-7DE0-4DD9-A599-F0EA7360CF8A}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "IncrementMe",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 452080683
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{55F1434B-40C1-40AA-91C8-A65D6F2AFDC3}"
+                                                },
+                                                "IsUserAdded": true
+                                            }
+                                        ],
+                                        "m_displayName": "IncrementNumber",
+                                        "m_identifier": "{5F36B80D-9546-478E-AD33-BF4AFEC8FF01}"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 8502891678641
+                                },
+                                "Name": "SC-Node(OperatorAdd)",
+                                "Components": {
+                                    "Component_[6948954108967528756]": {
+                                        "$type": "OperatorAdd",
+                                        "Id": 6948954108967528756,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{4546CCB4-B493-435F-BAEC-B76996DBDC8F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{52C93C3F-A8DC-47E5-98A6-5B6A15C83F92}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{9D5A6AF3-99FE-4449-83DD-261AF2107F36}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 11
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{440FC98B-34B5-418A-9000-6E8B6BFBFDC7}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 11
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Number",
+                                                "toolTip": "An operand to use in performing the specified Operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A0113449-B8EA-441F-871E-A34F10A281AF}"
+                                                },
+                                                "DynamicTypeOverride": 3,
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    },
+                                                    {
+                                                        "$type": "MathOperatorContract",
+                                                        "NativeTypes": [
+                                                            {
+                                                                "m_type": 3
+                                                            },
+                                                            {
+                                                                "m_type": 6
+                                                            },
+                                                            {
+                                                                "m_type": 8
+                                                            },
+                                                            {
+                                                                "m_type": 9
+                                                            },
+                                                            {
+                                                                "m_type": 10
+                                                            },
+                                                            {
+                                                                "m_type": 11
+                                                            },
+                                                            {
+                                                                "m_type": 12
+                                                            },
+                                                            {
+                                                                "m_type": 14
+                                                            },
+                                                            {
+                                                                "m_type": 15
+                                                            }
+                                                        ]
+                                                    }
+                                                ],
+                                                "slotName": "Result",
+                                                "toolTip": "The result of the specified operation",
+                                                "DisplayDataType": {
+                                                    "m_type": 3
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DynamicGroup": {
+                                                    "Value": 1114760223
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Number"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 1.0,
+                                                "label": "Number"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        ],
+                        "m_connections": [
+                            {
+                                "Id": {
+                                    "id": 11118526761905
+                                },
+                                "Name": "srcEndpoint=(Add (+): Result), destEndpoint=(Set Variable: Number)",
+                                "Components": {
+                                    "Component_[4894099700298815938]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 4894099700298815938,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 8502891678641
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A0113449-B8EA-441F-871E-A34F10A281AF}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 7454919658417
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8D9CBBAD-5F75-4397-8139-B7FE79C48DFD}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 11466419112881
+                                },
+                                "Name": "srcEndpoint=(Add (+): Out), destEndpoint=(Set Variable: In)",
+                                "Components": {
+                                    "Component_[17374411643043616824]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17374411643043616824,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 8502891678641
+                                            },
+                                            "slotId": {
+                                                "m_id": "{52C93C3F-A8DC-47E5-98A6-5B6A15C83F92}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 7454919658417
+                                            },
+                                            "slotId": {
+                                                "m_id": "{22483279-E500-40D5-A61B-2C78DAC3319A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 11857261136817
+                                },
+                                "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(New Output:  )",
+                                "Components": {
+                                    "Component_[13113299305621275439]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 13113299305621275439,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 7454919658417
+                                            },
+                                            "slotId": {
+                                                "m_id": "{17296A41-81F9-444D-BA2E-B8DAD7C62B10}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 5620968623025
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8362D954-5F68-4DAB-94B3-1EFA2B2774FB}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 4817988488368
+                                },
+                                "Name": "srcEndpoint=(IncrementNumber:  ), destEndpoint=(Get Variable: In)",
+                                "Components": {
+                                    "Component_[2259136399829712910]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2259136399829712910,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 4731910392753
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4C0849D0-627F-41BA-A8EE-A201074D5E52}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 3946110127280
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D0D0EC9C-927F-42DB-AD22-412F374326CD}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5084276460720
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Add (+): Number)",
+                                "Components": {
+                                    "Component_[10085458428308435370]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 10085458428308435370,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3946110127280
+                                            },
+                                            "slotId": {
+                                                "m_id": "{71712AB8-E5BC-42EC-A07E-733D0D36F830}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 8502891678641
+                                            },
+                                            "slotId": {
+                                                "m_id": "{9D5A6AF3-99FE-4449-83DD-261AF2107F36}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 5423578877104
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Add (+): In)",
+                                "Components": {
+                                    "Component_[4574112699302556330]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 4574112699302556330,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 3946110127280
+                                            },
+                                            "slotId": {
+                                                "m_id": "{484C5712-DB44-4A98-8199-11E47AC3D837}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 8502891678641
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4546CCB4-B493-435F-BAEC-B76996DBDC8F}"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "m_assetType": "{003738F8-FA01-0000-7300-000000000000}",
+                    "versionData": {
+                        "_grammarVersion": 1,
+                        "_runtimeVersion": 1,
+                        "_fileVersion": 1
+                    },
+                    "m_variableCounter": 4,
+                    "GraphCanvasData": [
+                        {
+                            "Key": {
+                                "id": 3946110127280
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            140.0,
+                                            -140.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D085EC42-2893-4FFF-BF65-5A7BDBAA7CC7}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 4731910392753
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "NodelingTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -260.0,
+                                            -240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".nodeling"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{DF821D33-9967-4B89-BA06-C2B8116DF1AB}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 5620968623025
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "NodelingTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            640.0,
+                                            160.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".nodeling"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{462CEE46-FA16-4DE3-B00C-236F49976D74}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 7454919658417
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            660.0,
+                                            -160.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{54BBBFA0-B4C7-4FA4-BE92-51E9FA1A422B}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 8502891678641
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            320.0,
+                                            60.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{AE983459-5498-46B7-A50B-7DF0A9D9886D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 8918912361393065975
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
+                                        "$type": "SceneComponentSaveData",
+                                        "ViewParams": {
+                                            "Scale": 0.85,
+                                            "AnchorX": -196.4705810546875,
+                                            "AnchorY": -303.5294189453125
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "StatisticsHelper": {
+                        "InstanceCounter": [
+                            {
+                                "Key": 1244476766431948410,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 7011818094993955847,
+                                "Value": 2
+                            },
+                            {
+                                "Key": 8876278780785933991,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 11663418749378679464,
+                                "Value": 1
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_RuntimeInterpreted.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Tests/ScriptCanvas_RuntimeInterpreted.cpp
@@ -935,3 +935,8 @@ TEST_F(ScriptCanvasTestFixture, InterpretedExecutionOutPerformance)
 {
     RunUnitTestGraph("LY_SC_UnitTest_ExecutionOutPerformance", ExecutionMode::Interpreted);
 }
+
+TEST_F(ScriptCanvasTestFixture, PromotedUserVariables)
+{
+    RunUnitTestGraph("LY_SC_UnitTest_PromotedUserVariables", ExecutionMode::Interpreted);
+}


### PR DESCRIPTION
Previously, adding user data slots added a variable in the manager pane for convenience, however, the relationship between the two datums was not discoverable programmatically leading to bugs and errors in the script canvas editor and runtime. This corrects that by making user data slots into a well formed reference slot to the new convenience variable.

closes https://github.com/o3de/o3de/issues/3042
closes https://github.com/o3de/o3de/issues/3879