### PR TITLE
A bit of Generic DOM tidying/fixup

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
@@ -77,8 +77,8 @@ namespace AZ::Dom::Utils
                     for (size_t i = 0; i < ourValues.size(); ++i)
                     {
                         const Object::EntryType& lhsChild = ourValues[i];
-                        const Object::EntryType& rhsChild = theirValues[i];
-                        if (lhsChild.first != rhsChild.first || !DeepCompareIsEqual(lhsChild.second, rhsChild.second))
+                        auto rhsIt = rhs.FindMember(lhsChild.first);
+                        if (rhsIt == rhs.MemberEnd() || !DeepCompareIsEqual(lhsChild.second, rhsIt->second))
                         {
                             return false;
                         }
@@ -144,8 +144,8 @@ namespace AZ::Dom::Utils
                     for (size_t i = 0; i < ourProperties.size(); ++i)
                     {
                         const Object::EntryType& lhsChild = ourProperties[i];
-                        const Object::EntryType& rhsChild = theirProperties[i];
-                        if (lhsChild.first != rhsChild.first || !DeepCompareIsEqual(lhsChild.second, rhsChild.second))
+                        auto rhsIt = rhs.FindMember(lhsChild.first);
+                        if (rhsIt == rhs.MemberEnd() || !DeepCompareIsEqual(lhsChild.second, rhsIt->second))
                         {
                             return false;
                         }

--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.h
@@ -268,8 +268,8 @@ namespace AZ::Dom
 
         Object::ConstIterator MemberBegin() const;
         Object::ConstIterator MemberEnd() const;
-        Object::Iterator MemberBegin();
-        Object::Iterator MemberEnd();
+        Object::Iterator MutableMemberBegin();
+        Object::Iterator MutableMemberEnd();
 
         Object::Iterator FindMutableMember(KeyType name);
         Object::Iterator FindMutableMember(AZStd::string_view name);
@@ -289,8 +289,8 @@ namespace AZ::Dom
         void RemoveMember(KeyType name);
         void RemoveMember(AZStd::string_view name);
         Object::Iterator RemoveMember(Object::Iterator pos);
-        Object::Iterator EraseMember(Object::ConstIterator pos);
-        Object::Iterator EraseMember(Object::ConstIterator first, Object::ConstIterator last);
+        Object::Iterator EraseMember(Object::Iterator pos);
+        Object::Iterator EraseMember(Object::Iterator first, Object::Iterator last);
         Object::Iterator EraseMember(KeyType name);
         Object::Iterator EraseMember(AZStd::string_view name);
 
@@ -313,15 +313,15 @@ namespace AZ::Dom
 
         Array::ConstIterator ArrayBegin() const;
         Array::ConstIterator ArrayEnd() const;
-        Array::Iterator ArrayBegin();
-        Array::Iterator ArrayEnd();
+        Array::Iterator MutableArrayBegin();
+        Array::Iterator MutableArrayEnd();
 
         Value& ArrayReserve(size_t newCapacity);
         Value& ArrayPushBack(Value value);
         Value& ArrayPopBack();
 
-        Array::Iterator ArrayErase(Array::ConstIterator pos);
-        Array::Iterator ArrayErase(Array::ConstIterator first, Array::ConstIterator last);
+        Array::Iterator ArrayErase(Array::Iterator pos);
+        Array::Iterator ArrayErase(Array::Iterator first, Array::Iterator last);
 
         Array::ContainerType& GetMutableArray();
         const Array::ContainerType& GetArray() const;

--- a/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/DOM/DomValue.h>
+#include <AzCore/Name/NameDictionary.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
+#include <Tests/DOM/DomFixtures.h>
+
+namespace AZ::Dom::Tests
+{
+    void DomTestHarness::SetUpHarness()
+    {
+        NameDictionary::Create();
+        AZ::AllocatorInstance<ValueAllocator>::Create();
+    }
+
+    void DomTestHarness::TearDownHarness()
+    {
+        AZ::AllocatorInstance<ValueAllocator>::Destroy();
+        NameDictionary::Destroy();
+    }
+
+    void DomBenchmarkFixture::SetUp(const ::benchmark::State& st)
+    {
+        UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
+        SetUpHarness();
+    }
+
+    void DomBenchmarkFixture::SetUp(::benchmark::State& st)
+    {
+        UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
+        SetUpHarness();
+    }
+
+    void DomBenchmarkFixture::TearDown(::benchmark::State& st)
+    {
+        TearDownHarness();
+        UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
+    }
+
+    void DomBenchmarkFixture::TearDown(const ::benchmark::State& st)
+    {
+        TearDownHarness();
+        UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
+    }
+
+    rapidjson::Document DomBenchmarkFixture::GenerateDomJsonBenchmarkDocument(int64_t entryCount, int64_t stringTemplateLength)
+    {
+        rapidjson::Document document;
+        document.SetObject();
+
+        AZStd::string entryTemplate;
+        while (entryTemplate.size() < static_cast<size_t>(stringTemplateLength))
+        {
+            entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
+        }
+        entryTemplate.resize(stringTemplateLength);
+        AZStd::string buffer;
+
+        auto createString = [&](int n) -> rapidjson::Value
+        {
+            buffer = AZStd::string::format("#%i %s", n, entryTemplate.c_str());
+            return rapidjson::Value(buffer.data(), static_cast<rapidjson::SizeType>(buffer.size()), document.GetAllocator());
+        };
+
+        auto createEntry = [&](int n) -> rapidjson::Value
+        {
+            rapidjson::Value entry(rapidjson::kObjectType);
+            entry.AddMember("string", createString(n), document.GetAllocator());
+            entry.AddMember("int", rapidjson::Value(n), document.GetAllocator());
+            entry.AddMember("double", rapidjson::Value(static_cast<double>(n) * 0.5), document.GetAllocator());
+            entry.AddMember("bool", rapidjson::Value(n % 2 == 0), document.GetAllocator());
+            entry.AddMember("null", rapidjson::Value(rapidjson::kNullType), document.GetAllocator());
+            return entry;
+        };
+
+        auto createArray = [&]() -> rapidjson::Value
+        {
+            rapidjson::Value array;
+            array.SetArray();
+            for (int i = 0; i < entryCount; ++i)
+            {
+                array.PushBack(createEntry(i), document.GetAllocator());
+            }
+            return array;
+        };
+
+        auto createObject = [&]() -> rapidjson::Value
+        {
+            rapidjson::Value object;
+            object.SetObject();
+            for (int i = 0; i < entryCount; ++i)
+            {
+                buffer = AZStd::string::format("Key%i", i);
+                rapidjson::Value key;
+                key.SetString(buffer.data(), static_cast<rapidjson::SizeType>(buffer.length()), document.GetAllocator());
+                object.AddMember(key.Move(), createArray(), document.GetAllocator());
+            }
+            return object;
+        };
+
+        document.SetObject();
+        document.AddMember("entries", createObject(), document.GetAllocator());
+
+        return document;
+    }
+
+    AZStd::string DomBenchmarkFixture::GenerateDomJsonBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength)
+    {
+        rapidjson::Document document = GenerateDomJsonBenchmarkDocument(entryCount, stringTemplateLength);
+
+        AZStd::string serializedJson;
+        auto result = AZ::JsonSerializationUtils::WriteJsonString(document, serializedJson);
+        AZ_Assert(result.IsSuccess(), "Failed to serialize generated JSON");
+        return serializedJson;
+    }
+
+    Value DomBenchmarkFixture::GenerateDomBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength)
+    {
+        Value root(Type::Object);
+
+        AZStd::string entryTemplate;
+        while (entryTemplate.size() < static_cast<size_t>(stringTemplateLength))
+        {
+            entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
+        }
+        entryTemplate.resize(stringTemplateLength);
+        AZStd::string buffer;
+
+        auto createString = [&](int n) -> Value
+        {
+            return Value(AZStd::string::format("#%i %s", n, entryTemplate.c_str()), true);
+        };
+
+        auto createEntry = [&](int n) -> Value
+        {
+            Value entry(Type::Object);
+            entry.AddMember("string", createString(n));
+            entry.AddMember("int", Value(n));
+            entry.AddMember("double", Value(static_cast<double>(n) * 0.5));
+            entry.AddMember("bool", Value(n % 2 == 0));
+            entry.AddMember("null", Value(Type::Null));
+            return entry;
+        };
+
+        auto createArray = [&]() -> Value
+        {
+            Value array(Type::Array);
+            for (int i = 0; i < entryCount; ++i)
+            {
+                array.ArrayPushBack(createEntry(i));
+            }
+            return array;
+        };
+
+        auto createObject = [&]() -> Value
+        {
+            Value object;
+            object.SetObject();
+            for (int i = 0; i < entryCount; ++i)
+            {
+                buffer = AZStd::string::format("Key%i", i);
+                object.AddMember(AZ::Name(buffer), createArray());
+            }
+            return object;
+        };
+
+        root["entries"] = createObject();
+
+        return root;
+    }
+
+    void DomTestFixture::SetUp()
+    {
+        UnitTest::AllocatorsFixture::SetUp();
+        SetUpHarness();
+    }
+
+    void DomTestFixture::TearDown()
+    {
+        TearDownHarness();
+        UnitTest::AllocatorsFixture::TearDown();
+    }
+} // namespace AZ::Dom::Tests

--- a/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
@@ -55,7 +55,7 @@ namespace AZ::Dom::Tests
         document.SetObject();
 
         AZStd::string entryTemplate;
-        while (entryTemplate.size() < static_cast<size_t>(stringTemplateLength))
+        while (entryTemplate.size() < aznumeric_cast<size_t>(stringTemplateLength))
         {
             entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
         }
@@ -65,7 +65,7 @@ namespace AZ::Dom::Tests
         auto createString = [&](int n) -> rapidjson::Value
         {
             buffer = AZStd::string::format("#%i %s", n, entryTemplate.c_str());
-            return rapidjson::Value(buffer.data(), static_cast<rapidjson::SizeType>(buffer.size()), document.GetAllocator());
+            return rapidjson::Value(buffer.data(), aznumeric_cast<rapidjson::SizeType>(buffer.size()), document.GetAllocator());
         };
 
         auto createEntry = [&](int n) -> rapidjson::Value
@@ -73,7 +73,7 @@ namespace AZ::Dom::Tests
             rapidjson::Value entry(rapidjson::kObjectType);
             entry.AddMember("string", createString(n), document.GetAllocator());
             entry.AddMember("int", rapidjson::Value(n), document.GetAllocator());
-            entry.AddMember("double", rapidjson::Value(static_cast<double>(n) * 0.5), document.GetAllocator());
+            entry.AddMember("double", rapidjson::Value(aznumeric_cast<double>(n) * 0.5), document.GetAllocator());
             entry.AddMember("bool", rapidjson::Value(n % 2 == 0), document.GetAllocator());
             entry.AddMember("null", rapidjson::Value(rapidjson::kNullType), document.GetAllocator());
             return entry;
@@ -98,7 +98,7 @@ namespace AZ::Dom::Tests
             {
                 buffer = AZStd::string::format("Key%i", i);
                 rapidjson::Value key;
-                key.SetString(buffer.data(), static_cast<rapidjson::SizeType>(buffer.length()), document.GetAllocator());
+                key.SetString(buffer.data(), aznumeric_cast<rapidjson::SizeType>(buffer.length()), document.GetAllocator());
                 object.AddMember(key.Move(), createArray(), document.GetAllocator());
             }
             return object;
@@ -125,7 +125,7 @@ namespace AZ::Dom::Tests
         Value root(Type::Object);
 
         AZStd::string entryTemplate;
-        while (entryTemplate.size() < static_cast<size_t>(stringTemplateLength))
+        while (entryTemplate.size() < aznumeric_cast<size_t>(stringTemplateLength))
         {
             entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
         }
@@ -142,7 +142,7 @@ namespace AZ::Dom::Tests
             Value entry(Type::Object);
             entry.AddMember("string", createString(n));
             entry.AddMember("int", Value(n));
-            entry.AddMember("double", Value(static_cast<double>(n) * 0.5));
+            entry.AddMember("double", Value(aznumeric_cast<double>(n) * 0.5));
             entry.AddMember("bool", Value(n % 2 == 0));
             entry.AddMember("null", Value(Type::Null));
             return entry;

--- a/Code/Framework/AzCore/Tests/DOM/DomFixtures.h
+++ b/Code/Framework/AzCore/Tests/DOM/DomFixtures.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/DOM/DomUtils.h>
+#include <AzCore/JSON/document.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+#define DOM_REGISTER_SERIALIZATION_BENCHMARK(BaseClass, Method)                                                                            \
+    BENCHMARK_REGISTER_F(BaseClass, Method)->Args({ 10, 5 })->Args({ 10, 500 })->Args({ 100, 5 })->Args({ 100, 500 })
+#define DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(BaseClass, Method)                                                                         \
+    DOM_REGISTER_SERIALIZATION_BENCHMARK(BaseClass, Method)->Unit(benchmark::kMillisecond);
+#define DOM_REGISTER_SERIALIZATION_BENCHMARK_NS(BaseClass, Method)                                                                         \
+    DOM_REGISTER_SERIALIZATION_BENCHMARK(BaseClass, Method)->Unit(benchmark::kNanosecond);
+
+namespace AZ::Dom::Tests
+{
+    class DomTestHarness
+    {
+    public:
+        virtual ~DomTestHarness() = default;
+
+        virtual void SetUpHarness();
+        virtual void TearDownHarness();
+    };
+
+    class DomBenchmarkFixture
+        : public DomTestHarness
+        , public UnitTest::AllocatorsBenchmarkFixture
+    {
+    public:
+        void SetUp(const ::benchmark::State& st) override;
+        void SetUp(::benchmark::State& st) override;
+        void TearDown(::benchmark::State& st) override;
+        void TearDown(const ::benchmark::State& st) override;
+
+        rapidjson::Document GenerateDomJsonBenchmarkDocument(int64_t entryCount, int64_t stringTemplateLength);
+        AZStd::string GenerateDomJsonBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength);
+        Value GenerateDomBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength);
+
+        template<class T>
+        static void TakeAndDiscardWithoutTimingDtor(T&& value, benchmark::State& state)
+        {
+            {
+                T instance = AZStd::move(value);
+                state.PauseTiming();
+            }
+            state.ResumeTiming();
+        }
+    };
+
+    class DomTestFixture
+        : public DomTestHarness
+        , public UnitTest::AllocatorsFixture
+    {
+    public:
+        void SetUp() override;
+        void TearDown() override;
+    };
+} // namespace AZ::Dom::Tests

--- a/Code/Framework/AzCore/Tests/DOM/DomJsonBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomJsonBenchmarks.cpp
@@ -16,130 +16,13 @@
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <Tests/DOM/DomFixtures.h>
 
-namespace Benchmark
+namespace AZ::Dom::Benchmark
 {
-    class DomJsonBenchmark : public UnitTest::AllocatorsBenchmarkFixture
+    class DomJsonBenchmark : public Tests::DomBenchmarkFixture
     {
-    public:
-        void SetUp(const ::benchmark::State& st) override
-        {
-            UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-            AZ::NameDictionary::Create();
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Create();
-        }
-
-        void SetUp(::benchmark::State& st) override
-        {
-            UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-            AZ::NameDictionary::Create();
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Create();
-        }
-
-        void TearDown(::benchmark::State& st) override
-        {
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Destroy();
-            AZ::NameDictionary::Destroy();
-            UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
-        }
-
-        void TearDown(const ::benchmark::State& st) override
-        {
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Destroy();
-            AZ::NameDictionary::Destroy();
-            UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
-        }
-
-        rapidjson::Document GenerateDomJsonBenchmarkDocument(int64_t entryCount, int64_t stringTemplateLength)
-        {
-            rapidjson::Document document;
-            document.SetObject();
-
-            AZStd::string entryTemplate;
-            while (entryTemplate.size() < static_cast<size_t>(stringTemplateLength))
-            {
-                entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
-            }
-            entryTemplate.resize(stringTemplateLength);
-            AZStd::string buffer;
-
-            auto createString = [&](int n) -> rapidjson::Value
-            {
-                buffer = AZStd::string::format("#%i %s", n, entryTemplate.c_str());
-                return rapidjson::Value(buffer.data(), static_cast<rapidjson::SizeType>(buffer.size()), document.GetAllocator());
-            };
-
-            auto createEntry = [&](int n) -> rapidjson::Value
-            {
-                rapidjson::Value entry(rapidjson::kObjectType);
-                entry.AddMember("string", createString(n), document.GetAllocator());
-                entry.AddMember("int", rapidjson::Value(n), document.GetAllocator());
-                entry.AddMember("double", rapidjson::Value(static_cast<double>(n) * 0.5), document.GetAllocator());
-                entry.AddMember("bool", rapidjson::Value(n % 2 == 0), document.GetAllocator());
-                entry.AddMember("null", rapidjson::Value(rapidjson::kNullType), document.GetAllocator());
-                return entry;
-            };
-
-            auto createArray = [&]() -> rapidjson::Value
-            {
-                rapidjson::Value array;
-                array.SetArray();
-                for (int i = 0; i < entryCount; ++i)
-                {
-                    array.PushBack(createEntry(i), document.GetAllocator());
-                }
-                return array;
-            };
-
-            auto createObject = [&]() -> rapidjson::Value
-            {
-                rapidjson::Value object;
-                object.SetObject();
-                for (int i = 0; i < entryCount; ++i)
-                {
-                    buffer = AZStd::string::format("Key%i", i);
-                    rapidjson::Value key;
-                    key.SetString(buffer.data(), static_cast<rapidjson::SizeType>(buffer.length()), document.GetAllocator());
-                    object.AddMember(key.Move(), createArray(), document.GetAllocator());
-                }
-                return object;
-            };
-
-            document.SetObject();
-            document.AddMember("entries", createObject(), document.GetAllocator());
-
-            return document;
-        }
-
-        AZStd::string GenerateDomJsonBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength)
-        {
-            rapidjson::Document document = GenerateDomJsonBenchmarkDocument(entryCount, stringTemplateLength);
-
-            AZStd::string serializedJson;
-            auto result = AZ::JsonSerializationUtils::WriteJsonString(document, serializedJson);
-            AZ_Assert(result.IsSuccess(), "Failed to serialize generated JSON");
-            return serializedJson;
-        }
-
-        template <class T>
-        void TakeAndDiscardWithoutTimingDtor(T&& value, benchmark::State& state)
-        {
-            {
-                T instance = AZStd::move(value);
-                state.PauseTiming();
-            }
-            state.ResumeTiming();
-        }
     };
-
-// Helper macro for registering JSON benchmarks
-#define BENCHMARK_REGISTER_JSON(BaseClass, Method)                                                                                         \
-    BENCHMARK_REGISTER_F(BaseClass, Method)                                                                                                \
-        ->Args({ 10, 5 })                                                                                                                  \
-        ->Args({ 10, 500 })                                                                                                                \
-        ->Args({ 100, 5 })                                                                                                                 \
-        ->Args({ 100, 500 })                                                                                                               \
-        ->Unit(benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToRapidjsonInPlace)(benchmark::State& state)
     {
@@ -163,7 +46,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToRapidjsonInPlace)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToRapidjsonInPlace)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToAzDomValueInPlace)(benchmark::State& state)
     {
@@ -187,7 +70,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToAzDomValueInPlace)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToAzDomValueInPlace)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToRapidjson)(benchmark::State& state)
     {
@@ -207,7 +90,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToRapidjson)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToRapidjson)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToAzDomValue)(benchmark::State& state)
     {
@@ -227,7 +110,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToAzDomValue)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToAzDomValue)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonDeserializeToRapidjson)(benchmark::State& state)
     {
@@ -243,7 +126,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonDeserializeToRapidjson)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonDeserializeToRapidjson)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonMakeComplexObject)(benchmark::State& state)
     {
@@ -254,7 +137,7 @@ namespace Benchmark
 
         state.SetItemsProcessed(state.range(0) * state.range(0) * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonMakeComplexObject)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonMakeComplexObject)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonLookupMemberByString)(benchmark::State& state)
     {
@@ -264,7 +147,9 @@ namespace Benchmark
         {
             AZStd::string key(AZStd::string::format("key%" PRId64, i));
             keys.push_back(key);
-            document.AddMember(rapidjson::Value(key.data(), static_cast<rapidjson::SizeType>(key.size()), document.GetAllocator()), rapidjson::Value(i), document.GetAllocator());
+            document.AddMember(
+                rapidjson::Value(key.data(), static_cast<rapidjson::SizeType>(key.size()), document.GetAllocator()), rapidjson::Value(i),
+                document.GetAllocator());
         }
 
         for (auto _ : state)
@@ -293,7 +178,7 @@ namespace Benchmark
         state.SetItemsProcessed(state.iterations());
     }
 
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonDeepCopy)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonDeepCopy)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonCopyAndMutate)(benchmark::State& state)
     {
@@ -309,9 +194,8 @@ namespace Benchmark
 
         state.SetItemsProcessed(state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonCopyAndMutate)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonCopyAndMutate)
 
-#undef BENCHMARK_REGISTER_JSON
-} // namespace Benchmark
+} // namespace AZ::Dom::Benchmark
 
 #endif // defined(HAVE_BENCHMARK)

--- a/Code/Framework/AzCore/Tests/DOM/DomJsonTests.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomJsonTests.cpp
@@ -13,24 +13,23 @@
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <Tests/DOM/DomFixtures.h>
 
 namespace AZ::Dom::Tests
 {
-    class DomJsonTests : public UnitTest::AllocatorsFixture
+    class DomJsonTests : public DomTestFixture
     {
     public:
         void SetUp() override
         {
-            UnitTest::AllocatorsFixture::SetUp();
-            NameDictionary::Create();
+            DomTestFixture::SetUp();
             m_document = AZStd::make_unique<rapidjson::Document>();
         }
 
         void TearDown() override
         {
             m_document.reset();
-            NameDictionary::Destroy();
-            UnitTest::AllocatorsFixture::TearDown();
+            DomTestFixture::TearDown();
         }
 
         rapidjson::Value CreateString(const AZStd::string& text)

--- a/Code/Framework/AzCore/Tests/DOM/DomValueTests.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomValueTests.cpp
@@ -15,26 +15,18 @@
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/std/numeric.h>
+#include <Tests/DOM/DomFixtures.h>
 
 namespace AZ::Dom::Tests
 {
-    class DomValueTests : public UnitTest::AllocatorsFixture
+    class DomValueTests : public DomTestFixture
     {
     public:
-        void SetUp() override
-        {
-            UnitTest::AllocatorsFixture::SetUp();
-            NameDictionary::Create();
-            AZ::AllocatorInstance<ValueAllocator>::Create();
-        }
-
         void TearDown() override
         {
             m_value = Value();
 
-            AZ::AllocatorInstance<ValueAllocator>::Destroy();
-            NameDictionary::Destroy();
-            UnitTest::AllocatorsFixture::TearDown();
+            DomTestFixture::TearDown();
         }
 
         void PerformValueChecks()

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -215,6 +215,8 @@ set(FILES
     AZStd/Variant.cpp
     AZStd/VariantSerialization.cpp
     AZStd/VectorAndArray.cpp
+    DOM/DomFixtures.cpp
+    DOM/DomFixtures.h
     DOM/DomJsonTests.cpp
     DOM/DomJsonBenchmarks.cpp
     DOM/DomValueTests.cpp


### PR DESCRIPTION
- Refactor out a test fixture for all DOM tests / benchmarks
- Optimize `GetType` implementation to not use `AZStd::variant::visit` (benchmark included to A/B the implementations)
- Tag a few more mutating Value functions with "Mutable" to avoid astonishing copy-on-writes
- Fix `Value::Accept` when called with SSO payloads
- Make `Utils::DeepCompareIsEqual` key comparison order agnostic

Benchmark results for GetType implementation:
```
DomValueBenchmark/AzDomValueGetType_UsingVariantIndex              18.2 ns         18.0 ns     40727273 items_per_second=443.667M/s
DomValueBenchmark/AzDomValueGetType_UsingVariantVisit              32.2 ns         32.2 ns     21333333 items_per_second=248.242M/s
```

Signed-off-by: Nicholas Van Sickle <nvsickle@amazon.com>