### PR TITLE
[Mac] Fix AssetProcessor failures on MacOS

### DIFF
--- a/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
+++ b/cmake/Platform/Mac/runtime_dependencies_mac.cmake.in
@@ -216,7 +216,7 @@ if(@target_file_dir@ MATCHES ".app/Contents/MacOS")
 
         # fixup bundle ends up removing the rpath of dxc (despite we exclude it)
         if(EXISTS "${bundle_path}/Contents/MacOS/Builders/DirectXShaderCompiler/bin/dxc-3.7")
-            execute_process(COMMAND $"{LY_INSTALL_NAME_TOOL}" -add_rpath @executable_path/../lib ${bundle_path}/Contents/MacOS/Builders/DirectXShaderCompiler/bin/dxc-3.7)
+            execute_process(COMMAND "${LY_INSTALL_NAME_TOOL}" -add_rpath @executable_path/../lib ${bundle_path}/Contents/MacOS/Builders/DirectXShaderCompiler/bin/dxc-3.7)
         endif()
 
         # misplaced .DS_Store files can cause signing to fail


### PR DESCRIPTION
Fixes https://github.com/o3de/o3de/issues/6908 
The rpath wasn't being set because of the typo and dxc wasn't able to find the dependency.

Signed-off-by: amzn-sj <srikkant@amazon.com>