### PR TITLE
issue5299: Resolved via change to not disable custom window decorations.

### DIFF
--- a/Code/Tools/AssetBundler/Platform/Linux/source/utils/GUIApplicationManager_Linux.cpp
+++ b/Code/Tools/AssetBundler/Platform/Linux/source/utils/GUIApplicationManager_Linux.cpp
@@ -12,6 +12,6 @@ namespace Platform
 {
     AzQtComponents::WindowDecorationWrapper::Option GetWindowDecorationWrapperOption()
     {
-        return AzQtComponents::WindowDecorationWrapper::OptionDisabled;
+        return AzQtComponents::WindowDecorationWrapper::OptionNone;
     }
 }


### PR DESCRIPTION
Resolves ' Linux: Asset Bundler File > Close leaves a blank window' #5299 by switching from using the option to disable custom window decorations to selecting option none in the AssetBundler GUIApplicationManager_Linux.cpp file.

OptionDisabled (as previous):
![Screenshot from 2022-01-15 14-05-48](https://user-images.githubusercontent.com/980979/149632266-db1e5c1d-a5a9-45b0-aac8-6a745e9a7334.png)

OptionNone (as updated in this PR):
![Screenshot from 2022-01-15 14-10-06](https://user-images.githubusercontent.com/980979/149632283-a0c3e0ac-d4fa-426b-8c3f-632f2fb9e40a.png)

Note the title bar change. This allows file -> close to work as lines 194 through 200 of WindowDecorationWrapper.cpp:

`applyFlagsAndAttributes();`
`guest->installEventFilter(this);`
`m_titleBar->setWindowTitleOverride(guest->windowTitle());`
`updateConstraints();`

 are no longer skipped due to the if block at line 189:

`
if (m_options & OptionDisabled)
{
return;
}
`
