### PR TITLE
Fix missing ImGui::End in multiplayer windows

### DIFF
--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugSystemComponent.cpp
@@ -386,7 +386,6 @@ namespace Multiplayer
             }
             ImGui::NewLine();
         }
-        ImGui::End();
     }
 
     void DrawMultiplayerStats()
@@ -437,7 +436,6 @@ namespace Multiplayer
             ImGui::EndTable();
             ImGui::NewLine();
         }
-        ImGui::End();
     }
 
     void MultiplayerDebugSystemComponent::OnImGuiUpdate()
@@ -448,6 +446,7 @@ namespace Multiplayer
             {
                 DrawNetworkingStats();
             }
+            ImGui::End();
         }
 
         if (m_displayMultiplayerStats)
@@ -456,6 +455,7 @@ namespace Multiplayer
             {
                 DrawMultiplayerStats();
             }
+            ImGui::End();
         }
 
         if (m_displayPerEntityStats)
@@ -473,6 +473,7 @@ namespace Multiplayer
                     m_reporter->OnImGuiUpdate();
                 }
             }
+            ImGui::End();
         }
 
         if (m_displayHierarchyDebugger)
@@ -489,6 +490,7 @@ namespace Multiplayer
                     m_hierarchyDebugger->OnImGuiUpdate();
                 }
             }
+            ImGui::End();
         }
         else
         {


### PR DESCRIPTION
Couple of missing `ImGui::End` in the multiplayer debug UI causing asserts.
Moved some already existing ones out of the functions as they need to be called even if the` ImGui::Begin` function is returning false, as per the documentation.