### PR TITLE
Adding TestResults to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ client*.cfg
 server*.cfg
 .mayaSwatches/
 _savebackup/
+TestResults/**
 *.swatches
 /imgui.ini
 


### PR DESCRIPTION
When running python pytest from o3de root folder to run automated tests it will generate a `TestResults` folder.

From the o3de documentation (https://www.o3de.org/docs/user-guide/testing/lytesttools/getting-started/) users can easily get to run it from o3de root. Adding `TestResults` folder to the gitignore file to avoid appearing all its files as untracked.

Signed-off-by: moraaar <moraaar@amazon.com>