### PR TITLE
Blast memory allocator must allocate with 16 byte alignment

### DIFF
--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.h
@@ -100,11 +100,14 @@ namespace Blast
         class AZBlastAllocatorCallback : public Nv::Blast::AllocatorCallback
         {
         public:
+            // Blast requires 16-byte alignment
+            static const size_t alignment = 16;
+
             void* allocate(
                 size_t size, const char* typeName, [[maybe_unused]] const char* filename,
                 [[maybe_unused]] int line) override
             {
-                return azmalloc_4(size, 0, AZ::SystemAllocator, typeName);
+                return azmalloc_4(size, alignment, AZ::SystemAllocator, typeName);
             }
 
             void deallocate(void* ptr) override


### PR DESCRIPTION
From Blast allocator documentation "Allocates size bytes of memory, which must be 16-byte aligned." https://gameworksdocs.nvidia.com/Blast/1.1/api_docs/files/class_nv_1_1_blast_1_1_allocator_callback.html

Fixes #5162

Signed-off-by: moraaar <moraaar@amazon.com>