### PR TITLE
Material Editor tests for window pane function

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
@@ -173,9 +173,11 @@ class TestMaterialEditorBasicTests(object):
             "Document saved as copy is saved with changes: True",
             "Document saved as child is saved with changes: True",
             "Save All worked as expected: True",
+            "P1: Asset Browser visibility working as expected: True",
+            "P1: Inspector visibility working as expected: True",
         ]
         unexpected_lines = [
-            "Traceback (most recent call last):"
+            # Including any lines in unexpected_lines will cause the test to run for the duration of the timeout
         ]
 
         hydra.launch_and_validate_results(

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/material_editor_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/material_editor_utils.py
@@ -125,11 +125,11 @@ def is_pane_visible(pane_name):
     """
     :return: bool
     """
-    return atomtools.AtomToolsWindowRequestBus(bus.Broadcast, "IsDockWidgetVisible", pane_name)
+    return atomtools.AtomToolsMainWindowRequestBus(bus.Broadcast, "IsDockWidgetVisible", pane_name)
 
 
 def set_pane_visibility(pane_name, value):
-    atomtools.AtomToolsWindowRequestBus(bus.Broadcast, "SetDockWidgetVisible", pane_name, value)
+    atomtools.AtomToolsMainWindowRequestBus(bus.Broadcast, "SetDockWidgetVisible", pane_name, value)
 
 
 def select_lighting_config(config_name):

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomMaterialEditor_BasicTests.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomMaterialEditor_BasicTests.py
@@ -36,6 +36,19 @@ MATERIAL_TYPE_PATH = os.path.join(
 CACHE_FILE_EXTENSION = ".azmaterial"
 
 
+def verify_pane_visibility(pane_name: str):
+    """
+    print log lines indicating Material Editor pane visibility function
+    :param pane_name: Name of the pane to be tested
+    """
+    initial_value = material_editor.is_pane_visible(pane_name)
+    material_editor.set_pane_visibility(pane_name, not initial_value)
+    result = (material_editor.is_pane_visible(pane_name) is not initial_value)
+    material_editor.set_pane_visibility(pane_name, initial_value)
+    result = result and (initial_value is material_editor.is_pane_visible(pane_name))
+    print(f"P1: {pane_name} visibility working as expected: {result}")
+
+
 def run():
     """
     Summary:
@@ -49,9 +62,12 @@ def run():
     7. Saving as a New Material
     8. Saving as a Child Material
     9. Saving all Open Materials
+    10. Verify Asset Browser pane visibility
+    11. Verify Material Inspector pane visibility
 
     Expected Result:
     All the above functions work as expected in Material Editor.
+    Pane visibility functions as expected
 
     :return: None
     """
@@ -186,6 +202,14 @@ def run():
     material_editor.set_property(document2_id, property2_name, initial_color)
     material_editor.save_all()
     material_editor.close_all_documents()
+
+    # 10) Verify Asset Browser pane visibility
+    verify_pane_visibility("Asset Browser")
+
+    # 11) Verify Material Inspector pane visibility
+    verify_pane_visibility("Inspector")
+
+    # Confirm documents closed and exit Material Editor
     material_editor.wait_for_condition(lambda:
                                        (not material_editor.is_open(document1_id)) and
                                        (not material_editor.is_open(document2_id)) and


### PR DESCRIPTION
Removes unexpected lines since these cause the material editor (ME) tests to run the duration of the timeout.
Adds tests for ME for pane visibility for inspector and asset browser. This effectively batches the tests to reduce run time. Expected lines for window pane visibility are marked P1 for priority of test.

.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py
====================================== test session starts
platform win32 -- Python 3.7.10, pytest-5.3.2, py-1.9.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 26 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py ........................... [100%]

================================= 27 passed in 81.93s (0:01:21)

Signed-off-by: Scott Murray <scottmur@amazon.com>