### PR TITLE
Updating NetworkingSpawnableLibrary to Only Store Network Spawnables

### DIFF
--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerConstants.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerConstants.h
@@ -20,6 +20,7 @@ namespace Multiplayer
     constexpr AZStd::string_view MpNetworkInterfaceName("MultiplayerNetworkInterface");
     constexpr AZStd::string_view MpEditorInterfaceName("MultiplayerEditorNetworkInterface");
     constexpr AZStd::string_view LocalHost("127.0.0.1");
+    constexpr AZStd::string_view NetworkSpawnableFileExtension(".network.spawnable");
 
     constexpr uint16_t DefaultServerPort = 33450;
     constexpr uint16_t DefaultServerEditorPort = 33451;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.cpp
@@ -10,7 +10,6 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Component/ComponentApplicationLifecycle.h>
 #include <AzFramework/Spawnable/Spawnable.h>
-#include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Interface/Interface.h>
 
 namespace Multiplayer
@@ -42,7 +41,8 @@ namespace Multiplayer
 
         auto enumerateCallback = [this](const AZ::Data::AssetId id, const AZ::Data::AssetInfo& info)
         {
-            if (info.m_assetType == AZ::AzTypeInfo<AzFramework::Spawnable>::Uuid())
+            if (info.m_assetType == AZ::AzTypeInfo<AzFramework::Spawnable>::Uuid() &&
+                info.m_relativePath.ends_with(".network.spawnable"))
             {
                 ProcessSpawnableAsset(info.m_relativePath, id);
             }

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.cpp
@@ -11,6 +11,7 @@
 #include <AzCore/Component/ComponentApplicationLifecycle.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzCore/Interface/Interface.h>
+#include <Multiplayer/MultiplayerConstants.h>
 
 namespace Multiplayer
 {
@@ -42,7 +43,7 @@ namespace Multiplayer
         auto enumerateCallback = [this](const AZ::Data::AssetId id, const AZ::Data::AssetInfo& info)
         {
             if (info.m_assetType == AZ::AzTypeInfo<AzFramework::Spawnable>::Uuid() &&
-                info.m_relativePath.ends_with(".network.spawnable"))
+                info.m_relativePath.ends_with(NetworkSpawnableFileExtension))
             {
                 ProcessSpawnableAsset(info.m_relativePath, id);
             }

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.h
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.h
@@ -26,7 +26,7 @@ namespace Multiplayer
         //! INetworkSpawnableLibrary overrides.
         //! @{
         // Iterates over all assets (on-disk and in-memory) and stores any spawnables that are "network.spawnables"
-        // This allows us to look up network spawnable assets by name or id for later use
+        // This allows users to look up network spawnable assets by name or id if needed later
         void BuildSpawnablesList() override;
         void ProcessSpawnableAsset(const AZStd::string& relativePath, AZ::Data::AssetId id) override;
         AZ::Name GetSpawnableNameFromAssetId(AZ::Data::AssetId assetId) override;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.h
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkSpawnableLibrary.h
@@ -23,12 +23,15 @@ namespace Multiplayer
         NetworkSpawnableLibrary();
         ~NetworkSpawnableLibrary();
 
-        /// INetworkSpawnableLibrary overrides.
+        //! INetworkSpawnableLibrary overrides.
+        //! @{
+        // Iterates over all assets (on-disk and in-memory) and stores any spawnables that are "network.spawnables"
+        // This allows us to look up network spawnable assets by name or id for later use
         void BuildSpawnablesList() override;
         void ProcessSpawnableAsset(const AZStd::string& relativePath, AZ::Data::AssetId id) override;
         AZ::Name GetSpawnableNameFromAssetId(AZ::Data::AssetId assetId) override;
         AZ::Data::AssetId GetAssetIdByName(AZ::Name name) override;
-
+        //! @}
 
     private:
         AZStd::unordered_map<AZ::Name, AZ::Data::AssetId> m_spawnables;

--- a/Gems/Multiplayer/Code/Source/Pipeline/NetworkPrefabProcessor.cpp
+++ b/Gems/Multiplayer/Code/Source/Pipeline/NetworkPrefabProcessor.cpp
@@ -8,6 +8,7 @@
 
 #include <Multiplayer/IMultiplayerTools.h>
 #include <Multiplayer/Components/NetBindComponent.h>
+#include <Multiplayer/MultiplayerConstants.h>
 #include <Pipeline/NetworkPrefabProcessor.h>
 #include <Pipeline/NetworkSpawnableHolderComponent.h>
 
@@ -95,7 +96,7 @@ namespace Multiplayer
         using namespace AzToolsFramework::Prefab;
 
         AZStd::string uniqueName = prefab.GetName();
-        uniqueName += ".network.spawnable";
+        uniqueName += NetworkSpawnableFileExtension;
 
         auto serializer = [serializationFormat](AZStd::vector<uint8_t>& output, const ProcessedObjectStore& object) -> bool {
             AZ::IO::ByteContainerStream stream(&output);

--- a/Gems/Multiplayer/Code/Tests/PrefabProcessingTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/PrefabProcessingTests.cpp
@@ -13,6 +13,7 @@
 #include <Prefab/PrefabDomTypes.h>
 #include <Prefab/Spawnable/PrefabProcessorContext.h>
 #include <Multiplayer/Components/NetBindComponent.h>
+#include <Multiplayer/MultiplayerConstants.h>
 #include <Source/Pipeline/NetworkPrefabProcessor.h>
 
 namespace UnitTest
@@ -92,7 +93,7 @@ namespace UnitTest
 
         // Verify the name and the type of the spawnable asset 
         const AZ::Data::AssetData& spawnableAsset = processedObjects[0].GetAsset();
-        EXPECT_EQ(prefabName + ".network.spawnable", processedObjects[0].GetId());
+        EXPECT_EQ(prefabName + Multiplayer::NetworkSpawnableFileExtension.data(), processedObjects[0].GetId());
         EXPECT_EQ(spawnableAsset.GetType(), azrtti_typeid<AzFramework::Spawnable>());
 
         // Verify we have only the networked entity in the network spawnable and not the static one


### PR DESCRIPTION
Updating NetworkingSpawnableLibrary to only store network spawnables (on-disk and in-memory) instead of all spawnables.
Tested: Ran automated testing levels which require using network spawnables to properly function 

Signed-off-by: Gene Walters <genewalt@amazon.com>