### PR TITLE
Atom Tools: move asset processor connection to fix thumbnails

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Application/AtomToolsApplication.h
@@ -16,7 +16,6 @@
 #include <AzCore/UserSettings/UserSettingsProvider.h>
 
 #include <AzFramework/Application/Application.h>
-#include <AzFramework/Asset/AssetSystemBus.h>
 
 #include <AzQtComponents/Application/AzQtApplication.h>
 #include <AzQtComponents/Components/StyleManager.h>
@@ -34,7 +33,6 @@ namespace AtomToolsFramework
         : public AzFramework::Application
         , public AzQtComponents::AzQtApplication
         , protected AzToolsFramework::AssetDatabase::AssetDatabaseRequestsBus::Handler
-        , protected AzFramework::AssetSystemStatusBus::Handler
         , protected AzToolsFramework::EditorPythonConsoleNotificationBus::Handler
         , protected AZ::UserSettingsOwnerRequestBus::Handler
         , protected AtomToolsMainWindowNotificationBus::Handler
@@ -78,11 +76,6 @@ namespace AtomToolsFramework
         //////////////////////////////////////////////////////////////////////////
 
         //////////////////////////////////////////////////////////////////////////
-        // AzFramework::AssetSystemStatusBus::Handler overrides...
-        void AssetSystemAvailable() override;
-        //////////////////////////////////////////////////////////////////////////
-
-        //////////////////////////////////////////////////////////////////////////
         // AZ::ComponentApplication overrides...
         void QueryApplicationType(AZ::ApplicationTypeQuery& appType) const override;
         //////////////////////////////////////////////////////////////////////////
@@ -107,6 +100,7 @@ namespace AtomToolsFramework
 
         virtual void LoadSettings();
         virtual void UnloadSettings();
+        virtual void ConnectToAssetProcessor();
         virtual void CompileCriticalAssets();
         virtual void ProcessCommandLine(const AZ::CommandLine& commandLine);
 


### PR DESCRIPTION
Thumbnails for the AtomLyIntegration common feature gem were no longer being rendered. The setup code was modified to initialize the thumbnail system after receiving a new event that critical assets finished compiling. This event was being sent and handled correctly in the main editor. This process was failing in other tools because the event was sent before systems were registered to listen for it.

To resolve the problem, atom tools application now explicitly connects to the asset processor and processes critical assets after the base application StartCommon function is called. This ensures that the connection is established and the event gets sent after all of the system components have been activated.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>