### PR TITLE
Atom Tools: disabling auto load of unused gems in some atom tools

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Util/Util.h
@@ -38,5 +38,5 @@ namespace AtomToolsFramework
     QFileInfo GetOpenFileInfo(const AZStd::vector<AZ::Data::AssetType>& assetTypes);
     QFileInfo GetUniqueFileInfo(const QString& initialPath);
     QFileInfo GetDuplicationFileInfo(const QString& initialPath);
-    bool LaunchTool(const QString& baseName, const QString& extension, const QStringList& arguments);
+    bool LaunchTool(const QString& baseName, const QStringList& arguments);
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Util/Util.cpp
@@ -168,13 +168,13 @@ namespace AtomToolsFramework
         return duplicateFileInfo;
     }
 
-    bool LaunchTool(const QString& baseName, const QString& extension, const QStringList& arguments)
+    bool LaunchTool(const QString& baseName, const QStringList& arguments)
     {
         AZ::IO::FixedMaxPath engineRoot = AZ::Utils::GetEnginePath();
         AZ_Assert(!engineRoot.empty(), "Cannot query Engine Path");
 
-        AZ::IO::FixedMaxPath launchPath = AZ::IO::FixedMaxPath(AZ::Utils::GetExecutableDirectory())
-            / (baseName + extension).toUtf8().constData();
+        AZ::IO::FixedMaxPath launchPath =
+            AZ::IO::FixedMaxPath(AZ::Utils::GetExecutableDirectory()) / (baseName + AZ_TRAIT_OS_EXECUTABLE_EXTENSION).toUtf8().constData();
 
         return QProcess::startDetached(launchPath.c_str(), arguments, engineRoot.c_str());
     }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Material/EditorMaterialSystemComponent.cpp
@@ -143,7 +143,7 @@ namespace AZ
                 arguments.append(QString("--project-path=%1").arg(projectPath.c_str()));
             }
 
-            AtomToolsFramework::LaunchTool("MaterialEditor", AZ_TRAIT_OS_EXECUTABLE_EXTENSION, arguments);
+            AtomToolsFramework::LaunchTool("MaterialEditor", arguments);
         }
 
         void EditorMaterialSystemComponent::OpenMaterialInspector(

--- a/Registry/gem_autoload.materialeditor.setreg
+++ b/Registry/gem_autoload.materialeditor.setreg
@@ -1,0 +1,69 @@
+{
+    "Amazon": {
+        "Gems": {
+            "ImGui.Editor": {
+                "AutoLoad": false
+            },
+            "Gestures.Editor": {
+                "AutoLoad": false
+            },
+            "GraphCanvas.Editor": {
+                "AutoLoad": false
+            },
+            "GraphModel.Editor": {
+                "AutoLoad": false
+            },
+            "PhysX.Editor": {
+                "AutoLoad": false
+            },
+            "PhysXDebug.Editor": {
+                "AutoLoad": false
+            },
+            "Blast.Editor": {
+                "AutoLoad": false
+            },
+            "NVCloth.Editor": {
+                "AutoLoad": false
+            },
+            "ScriptCanvas.Editor": {
+                "AutoLoad": false
+            },
+            "ScriptCanvasPhysics": {
+                "AutoLoad": false
+            },
+            "ScriptCanvasTesting.Editor": {
+                "AutoLoad": false
+            },
+            "LandscapeCanvas.Editor": {
+                "AutoLoad": false
+            },
+            "HttpRequestor.Editor": {
+                "AutoLoad": false
+            },
+            "WhiteBox.Editor": {
+                "AutoLoad": false
+            },
+            "PythonAssetBuilder.Editor": {
+                "AutoLoad": false
+            },
+            "AWSCore": {
+                "AutoLoad": false
+            },
+            "AWSCore.Editor": {
+                "AutoLoad": false
+            },
+            "AWSClientAuth": {
+                "AutoLoad": false
+            },
+            "AWSClientAuth.Editor": {
+                "AutoLoad": false
+            },
+            "AWSMetrics": {
+                "AutoLoad": false
+            },
+            "AWSMetrics.Editor": {
+                "AutoLoad": false
+            }
+        }
+    }
+}

--- a/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -1,0 +1,69 @@
+{
+    "Amazon": {
+        "Gems": {
+            "ImGui.Editor": {
+                "AutoLoad": false
+            },
+            "Gestures.Editor": {
+                "AutoLoad": false
+            },
+            "GraphCanvas.Editor": {
+                "AutoLoad": false
+            },
+            "GraphModel.Editor": {
+                "AutoLoad": false
+            },
+            "PhysX.Editor": {
+                "AutoLoad": false
+            },
+            "PhysXDebug.Editor": {
+                "AutoLoad": false
+            },
+            "Blast.Editor": {
+                "AutoLoad": false
+            },
+            "NVCloth.Editor": {
+                "AutoLoad": false
+            },
+            "ScriptCanvas.Editor": {
+                "AutoLoad": false
+            },
+            "ScriptCanvasPhysics": {
+                "AutoLoad": false
+            },
+            "ScriptCanvasTesting.Editor": {
+                "AutoLoad": false
+            },
+            "LandscapeCanvas.Editor": {
+                "AutoLoad": false
+            },
+            "HttpRequestor.Editor": {
+                "AutoLoad": false
+            },
+            "WhiteBox.Editor": {
+                "AutoLoad": false
+            },
+            "PythonAssetBuilder.Editor": {
+                "AutoLoad": false
+            },
+            "AWSCore": {
+                "AutoLoad": false
+            },
+            "AWSCore.Editor": {
+                "AutoLoad": false
+            },
+            "AWSClientAuth": {
+                "AutoLoad": false
+            },
+            "AWSClientAuth.Editor": {
+                "AutoLoad": false
+            },
+            "AWSMetrics": {
+                "AutoLoad": false
+            },
+            "AWSMetrics.Editor": {
+                "AutoLoad": false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Atom tools are set up to inherit and automatically load all of the gems used by the game project. This is a great simplification that saves us from having to manually update cmake settings for every game project to push dependencies to every tool. The tradeoff is that some dependencies will be added to certain tools that have no relevance whatsoever, potentially wasting initialization time, memory utilization, and some processing. This change follows an existing example to update a couple of tools to forego initializing unused gems. They can easily be reenabled as needed.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>