### PR TITLE
System shortcuts crash the Editor when Global Preferences are open

### DIFF
--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -112,15 +112,16 @@ void EditorPreferencesDialog::showEvent(QShowEvent* event)
     QDialog::showEvent(event);
 }
 
-void WidgetHandleKeyPressEvent(QWidget* widget, QKeyEvent* event)
+bool WidgetHandleKeyPressEvent(QKeyEvent* event)
 {
     // If the enter key is pressed during any text input, the dialog box will close
     // making it inconvenient to do multiple edits. This routine captures the
     // Key_Enter or Key_Return and clears the focus to give a visible cue that
-    // editing of that field has finished and then doesn't propogate it.
+    // editing of that field has finished and then doesn't propagate it.
     if (event->key() != Qt::Key::Key_Enter && event->key() != Qt::Key::Key_Return)
     {
-        QApplication::sendEvent(widget, event);
+        // Return false as the event was not handled
+        return false;
     }
     else
     {
@@ -128,13 +129,18 @@ void WidgetHandleKeyPressEvent(QWidget* widget, QKeyEvent* event)
         {
             editWidget->clearFocus();
         }
+
+        // We handle these events, so return true
+        return true;
     }
 }
 
-
 void EditorPreferencesDialog::keyPressEvent(QKeyEvent* event)
 {
-    WidgetHandleKeyPressEvent(this, event);
+    if(!WidgetHandleKeyPressEvent(event))
+    {
+        QDialog::keyPressEvent(event);
+    }
 }
 
 void EditorPreferencesDialog::OnTreeCurrentItemChanged()

--- a/Code/Editor/EditorPreferencesDialog.cpp
+++ b/Code/Editor/EditorPreferencesDialog.cpp
@@ -112,7 +112,7 @@ void EditorPreferencesDialog::showEvent(QShowEvent* event)
     QDialog::showEvent(event);
 }
 
-bool WidgetHandleKeyPressEvent(QKeyEvent* event)
+bool WidgetConsumesKeyPressEvent(QKeyEvent* event)
 {
     // If the enter key is pressed during any text input, the dialog box will close
     // making it inconvenient to do multiple edits. This routine captures the
@@ -120,24 +120,20 @@ bool WidgetHandleKeyPressEvent(QKeyEvent* event)
     // editing of that field has finished and then doesn't propagate it.
     if (event->key() != Qt::Key::Key_Enter && event->key() != Qt::Key::Key_Return)
     {
-        // Return false as the event was not handled
         return false;
     }
-    else
+   
+    if (QWidget* editWidget = QApplication::focusWidget())
     {
-        if (QWidget* editWidget = QApplication::focusWidget())
-        {
-            editWidget->clearFocus();
-        }
-
-        // We handle these events, so return true
-        return true;
+        editWidget->clearFocus();
     }
+
+    return true;
 }
 
 void EditorPreferencesDialog::keyPressEvent(QKeyEvent* event)
 {
-    if(!WidgetHandleKeyPressEvent(event))
+    if (!WidgetConsumesKeyPressEvent(event))
     {
         QDialog::keyPressEvent(event);
     }

--- a/Code/Editor/EditorPreferencesDialog.h
+++ b/Code/Editor/EditorPreferencesDialog.h
@@ -19,7 +19,7 @@ namespace Ui
 
 class EditorPreferencesTreeWidgetItem;
 
-void WidgetHandleKeyPressEvent(QWidget* widget, QKeyEvent* event);
+bool WidgetHandleKeyPressEvent(QKeyEvent* event);
 
 class EditorPreferencesDialog
     : public QDialog

--- a/Code/Editor/EditorPreferencesDialog.h
+++ b/Code/Editor/EditorPreferencesDialog.h
@@ -19,7 +19,7 @@ namespace Ui
 
 class EditorPreferencesTreeWidgetItem;
 
-bool WidgetHandleKeyPressEvent(QKeyEvent* event);
+bool WidgetConsumesKeyPressEvent(QKeyEvent* event);
 
 class EditorPreferencesDialog
     : public QDialog


### PR DESCRIPTION
Fixes issue introduced by a recent change to the Editor Preferences that would override key event handling to prevent the dialog from being closed when Enter is pressed on a text input. The old implementation would use sendEvent to propagate the keyPress to the parent, but in some circumstances that would result in an infinite loop.

I have changed the function to instead directly call QDialog::keyPressEvent for propagation. I verified this change prevents the infinite loop and crash when switching context with Alt+Tab or similar shortcuts.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>