### PR TITLE
ImGui: Added new histogram group helper

### DIFF
--- a/Gems/ImGui/Code/Include/LYImGuiUtils/HistogramGroup.h
+++ b/Gems/ImGui/Code/Include/LYImGuiUtils/HistogramGroup.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#ifdef IMGUI_ENABLED
+
+#include <AzCore/Math/Color.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/containers/unordered_map.h>
+
+#include <imgui/imgui.h>
+#include <LYImGuiUtils/HistogramContainer.h>
+
+namespace ImGui::LYImGuiUtils
+{
+    //! Helper for a group containing several histograms.
+    //! The group is shown using collapsible header.
+    class HistogramGroup
+    {
+    public:
+        HistogramGroup() = default;
+        HistogramGroup(const char* name, int histogramBinCount);
+
+        void OnImGuiUpdate();
+        void PushHistogramValue(const char* valueName, float value, const AZ::Color& color);
+
+        const char* GetName() const { return m_name.c_str(); }
+        const AZStd::string& GetNameString() const { return m_name; }
+        void SetName(AZStd::string name) { m_name = name; }
+
+        void SetHistogramBinCount(int count) { m_histogramBinCount = count; }
+
+        //! Needs to be public for l-value access for ImGui::MenuItem()
+        bool m_show = true;
+
+    private:
+        AZStd::string m_name; //< The name shown in the collapsible header.
+        int m_histogramBinCount = 100; //< The number of bins in the histogram.
+
+        using HistogramIndexByNames = AZStd::unordered_map<const char*, size_t>;
+        HistogramIndexByNames m_histogramIndexByName; //< Look-up table for the histogram index by name.
+        AZStd::vector<ImGui::LYImGuiUtils::HistogramContainer> m_histograms; //< Owns the histogram containers.
+
+        static constexpr float s_histogramHeight = 85.0f;
+    };
+} // namespace ImGui::LYImGuiUtils
+
+#endif // IMGUI_ENABLED

--- a/Gems/ImGui/Code/Source/LYImGuiUtils/HistogramGroup.cpp
+++ b/Gems/ImGui/Code/Source/LYImGuiUtils/HistogramGroup.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#ifdef IMGUI_ENABLED
+#include "LYImGuiUtils/HistogramGroup.h"
+
+namespace ImGui::LYImGuiUtils
+{
+    HistogramGroup::HistogramGroup(const char* name, int histogramBinCount)
+        : m_name(name)
+        , m_histogramBinCount(histogramBinCount)
+    {
+    }
+
+    void HistogramGroup::PushHistogramValue(const char* valueName, float value, const AZ::Color& color)
+    {
+        auto iterator = m_histogramIndexByName.find(valueName);
+        if (iterator != m_histogramIndexByName.end())
+        {
+            ImGui::LYImGuiUtils::HistogramContainer& histogramContiner = m_histograms[iterator->second];
+            histogramContiner.PushValue(value);
+            histogramContiner.SetBarLineColor(ImColor(color.GetR(), color.GetG(), color.GetB(), color.GetA()));
+        }
+        else
+        {
+            ImGui::LYImGuiUtils::HistogramContainer newHistogram;
+            newHistogram.Init(/*histogramName=*/valueName,
+                /*containerCount=*/m_histogramBinCount,
+                /*viewType=*/ImGui::LYImGuiUtils::HistogramContainer::ViewType::Histogram,
+                /*displayOverlays=*/true,
+                /*min=*/0.0f,
+                /*max=*/0.0f);
+
+            newHistogram.SetMoveDirection(ImGui::LYImGuiUtils::HistogramContainer::PushRightMoveLeft);
+            newHistogram.PushValue(value);
+
+            m_histogramIndexByName[valueName] = m_histograms.size();
+            m_histograms.push_back(newHistogram);
+        }
+    }
+
+    void HistogramGroup::OnImGuiUpdate()
+    {
+        if (!m_show)
+        {
+            return;
+        }
+
+        if (ImGui::CollapsingHeader(m_name.c_str(), ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            for (auto& histogram : m_histograms)
+            {
+                ImGui::BeginGroup();
+                {
+                    histogram.Draw(ImGui::GetColumnWidth() - 70, s_histogramHeight);
+
+                    ImGui::SameLine();
+
+                    ImGui::PushStyleColor(ImGuiCol_Text, IM_COL32(0,0,0,255));
+                    {
+                        const ImColor color = histogram.GetBarLineColor();
+                        ImGui::PushStyleColor(ImGuiCol_Button, color.Value);
+                        {
+                            const AZStd::string valueString = AZStd::string::format("%.2f", histogram.GetLastValue());
+                            ImGui::Button(valueString.c_str());
+                        }
+                        ImGui::PopStyleColor();
+                    }
+                    ImGui::PopStyleColor();
+                }
+                ImGui::EndGroup();
+            }
+        }
+    }
+} // namespace ImGui::LYImGuiUtils
+
+#endif // IMGUI_ENABLED

--- a/Gems/ImGui/Code/imgui_lyutils_static_files.cmake
+++ b/Gems/ImGui/Code/imgui_lyutils_static_files.cmake
@@ -8,7 +8,9 @@
 
 set(FILES
     Include/LYImGuiUtils/HistogramContainer.h
+    Include/LYImGuiUtils/HistogramGroup.h
     Include/LYImGuiUtils/ImGuiDrawHelpers.h
     Source/LYImGuiUtils/HistogramContainer.cpp
+    Source/LYImGuiUtils/HistogramGroup.cpp
     Source/LYImGuiUtils/ImGuiDrawHelpers.cpp
 )


### PR DESCRIPTION
* Added a helper class for a group containing several histograms.
* The group is shown using collapsible header.

![image](https://user-images.githubusercontent.com/43751992/150128176-239ddb4e-f0b7-4dba-8d3c-e12050ec5f25.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>