### PR TITLE
Fix issues when configuring projects and gems

### DIFF
--- a/Templates/DefaultGem/Template/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/CMakeLists.txt
@@ -10,7 +10,7 @@ set(gem_path ${CMAKE_CURRENT_LIST_DIR})
 set(gem_json ${gem_path}/gem.json)
 o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${gem_restricted_path} ${gem_path} ${gem_parent_relative_path})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # project cmake for this platform.

--- a/Templates/DefaultGem/Template/Code/CMakeLists.txt
+++ b/Templates/DefaultGem/Template/Code/CMakeLists.txt
@@ -12,7 +12,7 @@
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here in our gem : Gems/${Name}/Code/Platform/<platorm_name>  or
 #            <restricted_folder>/<platform_name>/Gems/${Name}/Code
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${o3de_gem_restricted_path} ${o3de_gem_path} ${o3de_gem_name})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_name}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this gem

--- a/Templates/MinimalProject/Template/Gem/CMakeLists.txt
+++ b/Templates/MinimalProject/Template/Gem/CMakeLists.txt
@@ -16,7 +16,7 @@ o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here : ${Name}/Code/Platform/<platform_name>  or
 #            <restricted_folder>/<platform_name>/${Name}/Code
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${gem_restricted_path} ${gem_path} ${gem_parent_relative_path})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this project

--- a/cmake/3rdParty.cmake
+++ b/cmake/3rdParty.cmake
@@ -186,7 +186,7 @@ function(ly_add_external_target)
         endif()
 
         # Check if there is a pal file
-        o3de_pal_dir(pal_file ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}/${ly_add_external_target_PACKAGE}_${PAL_PLATFORM_NAME_LOWERCASE}.cmake ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+        o3de_pal_dir(pal_file ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}/${ly_add_external_target_PACKAGE}_${PAL_PLATFORM_NAME_LOWERCASE}.cmake "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
         if(NOT EXISTS ${pal_file})
             set(pal_file ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}/${ly_add_external_target_PACKAGE}_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
         endif()
@@ -357,12 +357,12 @@ endfunction()
 
 # Add the 3rdParty folder to find the modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/3rdParty)
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/3rdParty/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/3rdParty/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 list(APPEND CMAKE_MODULE_PATH ${pal_dir})
 
 if(NOT INSTALLED_ENGINE)
     # Add the 3rdParty cmake files to the IDE
     ly_include_cmake_file_list(cmake/3rdParty/cmake_files.cmake)
-    o3de_pal_dir(pal_3rdparty_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/3rdParty/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+    o3de_pal_dir(pal_3rdparty_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/3rdParty/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
     ly_include_cmake_file_list(${pal_3rdparty_dir}/cmake_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake)
 endif()

--- a/cmake/3rdParty/BuiltInPackages.cmake
+++ b/cmake/3rdParty/BuiltInPackages.cmake
@@ -12,7 +12,7 @@
 # cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
 
 #include the platform-specific 3rd party packages.
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 
 set(LY_PAL_PACKAGE_FILE_NAME ${pal_dir}/BuiltInPackages_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 include(${LY_PAL_PACKAGE_FILE_NAME})

--- a/cmake/Configurations.cmake
+++ b/cmake/Configurations.cmake
@@ -189,5 +189,5 @@ foreach(conf IN LISTS CMAKE_CONFIGURATION_TYPES)
 endforeach()
 
 # flags are defined per platform, follow platform files under Platform/<PlatformName>/Configurations_<platformname>.cmake
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 include(${pal_dir}/Configurations_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -195,6 +195,6 @@ function(ly_install_run_script SCRIPT)
 endfunction()
 
 if(LY_INSTALL_ENABLED)
-    o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+    o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
     include(${pal_dir}/Install_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 endif()

--- a/cmake/LYTestWrappers.cmake
+++ b/cmake/LYTestWrappers.cmake
@@ -141,7 +141,7 @@ function(ly_add_test)
 
     set(wrapper_file ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}/LYTestWrappers_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
     if(NOT EXISTS ${wrapper_file})
-        o3de_pal_dir(wrapper_file ${wrapper_file} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+        o3de_pal_dir(wrapper_file ${wrapper_file} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
     endif()
     include(${wrapper_file})
 

--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -11,7 +11,7 @@ set(LY_UNITY_BUILD ON CACHE BOOL "UNITY builds")
 include(CMakeFindDependencyMacro)
 include(cmake/LyAutoGen.cmake)
 
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 include(${pal_dir}/LYWrappers_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 
 # Not all platforms support unity builds

--- a/cmake/PAL.cmake
+++ b/cmake/PAL.cmake
@@ -322,9 +322,9 @@ function(ly_get_absolute_pal_filename out_name in_name)
     endif()
 
     if(${ARGC} GREATER 4)
-        o3de_pal_dir(abs_name ${in_name} ${object_restricted_path} ${object_path} ${parent_relative_path})
+        o3de_pal_dir(abs_name ${in_name} "${object_restricted_path}" "${object_path}" "${parent_relative_path}")
     else()
-        o3de_pal_dir(abs_name ${in_name} ${object_restricted_path} ${object_path})
+        o3de_pal_dir(abs_name ${in_name} "${object_restricted_path}" "${object_path}")
     endif()
     set(${out_name} ${abs_name} PARENT_SCOPE)
 endfunction()
@@ -433,7 +433,7 @@ function(ly_get_list_relative_pal_filename out_name in_name)
     set(${out_name} ${relative_name} PARENT_SCOPE)
 endfunction()
 
-o3de_pal_dir(pal_cmake_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_cmake_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 
 ly_include_cmake_file_list(${pal_cmake_dir}/platform_${PAL_PLATFORM_NAME_LOWERCASE}_files.cmake)
 

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -73,7 +73,7 @@ set(CPACK_PROJECT_CONFIG_FILE ${CPACK_SOURCE_DIR}/PackagingConfig.cmake)
 set(CPACK_AUTO_GEN_TAG ${LY_INSTALLER_AUTO_GEN_TAG})
 
 # attempt to apply platform specific settings
-o3de_pal_dir(pal_dir ${CPACK_SOURCE_DIR}/Platform/${PAL_HOST_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_dir ${CPACK_SOURCE_DIR}/Platform/${PAL_HOST_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 include(${pal_dir}/Packaging_${PAL_HOST_PLATFORM_NAME_LOWERCASE}.cmake)
 
 # if we get here and the generator hasn't been set, then a non fatal error occurred disabling packaging support

--- a/cmake/RuntimeDependencies.cmake
+++ b/cmake/RuntimeDependencies.cmake
@@ -6,6 +6,6 @@
 #
 #
 
-o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} ${O3DE_ENGINE_RESTRICTED_PATH} ${LY_ROOT_FOLDER})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Platform/${PAL_PLATFORM_NAME} "${O3DE_ENGINE_RESTRICTED_PATH}" "${LY_ROOT_FOLDER}")
 include(${pal_dir}/RuntimeDependencies_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 


### PR DESCRIPTION
The new `o3de_pal_dir` function raise errors when configuring projects/gems.

Many CMake errors are raised, but all of them seems to originate from the `o3de_pal_dir` which is invoked with incorrect arguments:
```
[cmake] CMake Error at C:/Aliens_Group/Sparky_Studios/o3de-gems/SSBehaviorTree/Code/CMakeLists.txt:21 (o3de_pal_dir):
[cmake]   o3de_pal_dir Function invoked with incorrect arguments for function named:
[cmake]   o3de_pal_dir
[cmake] 
[cmake] 
[cmake] CMake Error at C:/Aliens_Group/Sparky_Studios/o3de-gems/SSBehaviorTree/Code/CMakeLists.txt:26 (include):
[cmake]   include could not find requested file:
[cmake] 
[cmake]     C:/Aliens_Group/Sparky_Studios/o3de-gems/SSBehaviorTree/Platform/Windows/PAL_windows.cmake
```

This commit applies a simple fix to pass the last three arguments as strings.

Only files in the `cmake` and in the `Templates` directories are modified.