### PR TITLE
Fixing entity outliner order when creating prefab

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomUtils.cpp
@@ -77,8 +77,8 @@ namespace AZ::Dom::Utils
                     for (size_t i = 0; i < ourValues.size(); ++i)
                     {
                         const Object::EntryType& lhsChild = ourValues[i];
-                        const Object::EntryType& rhsChild = theirValues[i];
-                        if (lhsChild.first != rhsChild.first || !DeepCompareIsEqual(lhsChild.second, rhsChild.second))
+                        auto rhsIt = rhs.FindMember(lhsChild.first);
+                        if (rhsIt == rhs.MemberEnd() || !DeepCompareIsEqual(lhsChild.second, rhsIt->second))
                         {
                             return false;
                         }
@@ -144,8 +144,8 @@ namespace AZ::Dom::Utils
                     for (size_t i = 0; i < ourProperties.size(); ++i)
                     {
                         const Object::EntryType& lhsChild = ourProperties[i];
-                        const Object::EntryType& rhsChild = theirProperties[i];
-                        if (lhsChild.first != rhsChild.first || !DeepCompareIsEqual(lhsChild.second, rhsChild.second))
+                        auto rhsIt = rhs.FindMember(lhsChild.first);
+                        if (rhsIt == rhs.MemberEnd() || !DeepCompareIsEqual(lhsChild.second, rhsIt->second))
                         {
                             return false;
                         }

--- a/Code/Framework/AzCore/AzCore/DOM/DomValue.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomValue.h
@@ -268,8 +268,8 @@ namespace AZ::Dom
 
         Object::ConstIterator MemberBegin() const;
         Object::ConstIterator MemberEnd() const;
-        Object::Iterator MemberBegin();
-        Object::Iterator MemberEnd();
+        Object::Iterator MutableMemberBegin();
+        Object::Iterator MutableMemberEnd();
 
         Object::Iterator FindMutableMember(KeyType name);
         Object::Iterator FindMutableMember(AZStd::string_view name);
@@ -289,8 +289,8 @@ namespace AZ::Dom
         void RemoveMember(KeyType name);
         void RemoveMember(AZStd::string_view name);
         Object::Iterator RemoveMember(Object::Iterator pos);
-        Object::Iterator EraseMember(Object::ConstIterator pos);
-        Object::Iterator EraseMember(Object::ConstIterator first, Object::ConstIterator last);
+        Object::Iterator EraseMember(Object::Iterator pos);
+        Object::Iterator EraseMember(Object::Iterator first, Object::Iterator last);
         Object::Iterator EraseMember(KeyType name);
         Object::Iterator EraseMember(AZStd::string_view name);
 
@@ -313,15 +313,15 @@ namespace AZ::Dom
 
         Array::ConstIterator ArrayBegin() const;
         Array::ConstIterator ArrayEnd() const;
-        Array::Iterator ArrayBegin();
-        Array::Iterator ArrayEnd();
+        Array::Iterator MutableArrayBegin();
+        Array::Iterator MutableArrayEnd();
 
         Value& ArrayReserve(size_t newCapacity);
         Value& ArrayPushBack(Value value);
         Value& ArrayPopBack();
 
-        Array::Iterator ArrayErase(Array::ConstIterator pos);
-        Array::Iterator ArrayErase(Array::ConstIterator first, Array::ConstIterator last);
+        Array::Iterator ArrayErase(Array::Iterator pos);
+        Array::Iterator ArrayErase(Array::Iterator first, Array::Iterator last);
 
         Array::ContainerType& GetMutableArray();
         const Array::ContainerType& GetArray() const;

--- a/Code/Framework/AzCore/AzCore/std/containers/span.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/span.h
@@ -33,23 +33,24 @@ namespace AZStd
      *
      * Since the span does not copy and store any data, it is only valid as long as the data used to create it is valid.
      */
-    template <class Element>
+    template <class T>
     class span final
     {
     public:
-        using value_type = Element;
+        using element_type = T;
+        using value_type = AZStd::remove_cv_t<T>;
 
-        using pointer = value_type*;
-        using const_pointer = const value_type*;
+        using pointer = T*;
+        using const_pointer = const T*;
 
-        using reference = value_type&;
-        using const_reference = const value_type&;
+        using reference = T&;
+        using const_reference = const T&;
 
         using size_type = AZStd::size_t;
         using difference_type = AZStd::ptrdiff_t;
 
-        using iterator = value_type*;
-        using const_iterator = const value_type*;
+        using iterator = T*;
+        using const_iterator = const T*;
         using reverse_iterator = AZStd::reverse_iterator<iterator>;
         using const_reverse_iterator = AZStd::reverse_iterator<const_iterator>;
 
@@ -65,21 +66,11 @@ namespace AZStd
         // create a span to just the first element instead of an entire array.
         constexpr span(const_pointer s) = delete;
 
-        template<AZStd::size_t N>
-        constexpr span(AZStd::array<value_type, N>& data);
+        template<typename Container>
+        constexpr span(Container& data);
 
-        constexpr span(AZStd::vector<value_type>& data);
-
-        template<AZStd::size_t N>
-        constexpr span(AZStd::fixed_vector<value_type, N>& data);
-
-        template<AZStd::size_t N>
-        constexpr span(const AZStd::array<value_type, N>& data);
-
-        constexpr span(const AZStd::vector<value_type>& data);
-
-        template<AZStd::size_t N>
-        constexpr span(const AZStd::fixed_vector<value_type, N>& data);
+        template<typename Container>
+        constexpr span(const Container& data);
 
         constexpr span(const span&) = default;
 
@@ -132,6 +123,7 @@ namespace AZStd
         pointer m_begin;
         pointer m_end;
     };
+
 } // namespace AZStd
 
 #include <AzCore/std/containers/span.inl>

--- a/Code/Framework/AzCore/AzCore/std/containers/span.inl
+++ b/Code/Framework/AzCore/AzCore/std/containers/span.inl
@@ -29,42 +29,16 @@ namespace AZStd
         , m_end(last)
     { }
 
-    template <class Element>
-    template<AZStd::size_t N>
-    inline constexpr span<Element>::span(AZStd::array<Element, N>& data)
+    template<class Element>
+    template<typename Container>
+    inline constexpr span<Element>::span(Container& data)
         : m_begin(data.data())
         , m_end(m_begin + data.size())
     { }
 
-    template <class Element>
-    inline constexpr span<Element>::span(AZStd::vector<Element>& data)
-        : m_begin(data.data())
-        , m_end(m_begin + data.size())
-    { }
-
-    template <class Element>
-    template<AZStd::size_t N>
-    inline constexpr span<Element>::span(AZStd::fixed_vector<Element, N>& data)
-        : m_begin(data.data())
-        , m_end(m_begin + data.size())
-    { }
-
-    template <class Element>
-    template<AZStd::size_t N>
-    inline constexpr span<Element>::span(const AZStd::array<Element, N>& data)
-        : m_begin(data.data())
-        , m_end(m_begin + data.size())
-    { }
-
-    template <class Element>
-    inline constexpr span<Element>::span(const AZStd::vector<Element>& data)
-        : m_begin(data.data())
-        , m_end(m_begin + data.size())
-    { }
-
-    template <class Element>
-    template<AZStd::size_t N>
-    inline constexpr span<Element>::span(const AZStd::fixed_vector<Element, N>& data)
+    template<class Element>
+    template<typename Container>
+    inline constexpr span<Element>::span(const Container& data)
         : m_begin(data.data())
         , m_end(m_begin + data.size())
     { }

--- a/Code/Framework/AzCore/AzCore/std/containers/vector.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/vector.h
@@ -954,25 +954,6 @@ namespace AZStd
             return true;
         }
         /// Validates an iter iterator. Returns a combination of \ref iterator_status_flag.
-        AZ_FORCE_INLINE int     validate_iterator(const iterator& iter) const
-        {
-#ifdef AZSTD_HAS_CHECKED_ITERATORS
-            AZ_Assert(iter.m_container == this, "Iterator doesn't belong to this container");
-            pointer iterPtr = iter.m_iter;
-#else
-            pointer iterPtr = iter;
-#endif
-            if (iterPtr < m_start || iterPtr > m_last)
-            {
-                return isf_none;
-            }
-            else if (iterPtr == m_last)
-            {
-                return isf_valid;
-            }
-
-            return isf_valid | isf_can_dereference;
-        }
         AZ_FORCE_INLINE int     validate_iterator(const const_iterator& iter) const
         {
 #ifdef AZSTD_HAS_CHECKED_ITERATORS
@@ -992,7 +973,6 @@ namespace AZStd
 
             return isf_valid | isf_can_dereference;
         }
-        AZ_FORCE_INLINE int     validate_iterator(const reverse_iterator& iter) const       { return validate_iterator(iter.base()); }
         AZ_FORCE_INLINE int     validate_iterator(const const_reverse_iterator& iter) const { return validate_iterator(iter.base()); }
 
         /**

--- a/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomFixtures.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/DOM/DomValue.h>
+#include <AzCore/Name/NameDictionary.h>
+#include <AzCore/Serialization/Json/JsonUtils.h>
+#include <Tests/DOM/DomFixtures.h>
+
+namespace AZ::Dom::Tests
+{
+    void DomTestHarness::SetUpHarness()
+    {
+        NameDictionary::Create();
+        AZ::AllocatorInstance<ValueAllocator>::Create();
+    }
+
+    void DomTestHarness::TearDownHarness()
+    {
+        AZ::AllocatorInstance<ValueAllocator>::Destroy();
+        NameDictionary::Destroy();
+    }
+
+    void DomBenchmarkFixture::SetUp(const ::benchmark::State& st)
+    {
+        UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
+        SetUpHarness();
+    }
+
+    void DomBenchmarkFixture::SetUp(::benchmark::State& st)
+    {
+        UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
+        SetUpHarness();
+    }
+
+    void DomBenchmarkFixture::TearDown(::benchmark::State& st)
+    {
+        TearDownHarness();
+        UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
+    }
+
+    void DomBenchmarkFixture::TearDown(const ::benchmark::State& st)
+    {
+        TearDownHarness();
+        UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
+    }
+
+    rapidjson::Document DomBenchmarkFixture::GenerateDomJsonBenchmarkDocument(int64_t entryCount, int64_t stringTemplateLength)
+    {
+        rapidjson::Document document;
+        document.SetObject();
+
+        AZStd::string entryTemplate;
+        while (entryTemplate.size() < aznumeric_cast<size_t>(stringTemplateLength))
+        {
+            entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
+        }
+        entryTemplate.resize(stringTemplateLength);
+        AZStd::string buffer;
+
+        auto createString = [&](int n) -> rapidjson::Value
+        {
+            buffer = AZStd::string::format("#%i %s", n, entryTemplate.c_str());
+            return rapidjson::Value(buffer.data(), aznumeric_cast<rapidjson::SizeType>(buffer.size()), document.GetAllocator());
+        };
+
+        auto createEntry = [&](int n) -> rapidjson::Value
+        {
+            rapidjson::Value entry(rapidjson::kObjectType);
+            entry.AddMember("string", createString(n), document.GetAllocator());
+            entry.AddMember("int", rapidjson::Value(n), document.GetAllocator());
+            entry.AddMember("double", rapidjson::Value(aznumeric_cast<double>(n) * 0.5), document.GetAllocator());
+            entry.AddMember("bool", rapidjson::Value(n % 2 == 0), document.GetAllocator());
+            entry.AddMember("null", rapidjson::Value(rapidjson::kNullType), document.GetAllocator());
+            return entry;
+        };
+
+        auto createArray = [&]() -> rapidjson::Value
+        {
+            rapidjson::Value array;
+            array.SetArray();
+            for (int i = 0; i < entryCount; ++i)
+            {
+                array.PushBack(createEntry(i), document.GetAllocator());
+            }
+            return array;
+        };
+
+        auto createObject = [&]() -> rapidjson::Value
+        {
+            rapidjson::Value object;
+            object.SetObject();
+            for (int i = 0; i < entryCount; ++i)
+            {
+                buffer = AZStd::string::format("Key%i", i);
+                rapidjson::Value key;
+                key.SetString(buffer.data(), aznumeric_cast<rapidjson::SizeType>(buffer.length()), document.GetAllocator());
+                object.AddMember(key.Move(), createArray(), document.GetAllocator());
+            }
+            return object;
+        };
+
+        document.SetObject();
+        document.AddMember("entries", createObject(), document.GetAllocator());
+
+        return document;
+    }
+
+    AZStd::string DomBenchmarkFixture::GenerateDomJsonBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength)
+    {
+        rapidjson::Document document = GenerateDomJsonBenchmarkDocument(entryCount, stringTemplateLength);
+
+        AZStd::string serializedJson;
+        auto result = AZ::JsonSerializationUtils::WriteJsonString(document, serializedJson);
+        AZ_Assert(result.IsSuccess(), "Failed to serialize generated JSON");
+        return serializedJson;
+    }
+
+    Value DomBenchmarkFixture::GenerateDomBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength)
+    {
+        Value root(Type::Object);
+
+        AZStd::string entryTemplate;
+        while (entryTemplate.size() < aznumeric_cast<size_t>(stringTemplateLength))
+        {
+            entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
+        }
+        entryTemplate.resize(stringTemplateLength);
+        AZStd::string buffer;
+
+        auto createString = [&](int n) -> Value
+        {
+            return Value(AZStd::string::format("#%i %s", n, entryTemplate.c_str()), true);
+        };
+
+        auto createEntry = [&](int n) -> Value
+        {
+            Value entry(Type::Object);
+            entry.AddMember("string", createString(n));
+            entry.AddMember("int", Value(n));
+            entry.AddMember("double", Value(aznumeric_cast<double>(n) * 0.5));
+            entry.AddMember("bool", Value(n % 2 == 0));
+            entry.AddMember("null", Value(Type::Null));
+            return entry;
+        };
+
+        auto createArray = [&]() -> Value
+        {
+            Value array(Type::Array);
+            for (int i = 0; i < entryCount; ++i)
+            {
+                array.ArrayPushBack(createEntry(i));
+            }
+            return array;
+        };
+
+        auto createObject = [&]() -> Value
+        {
+            Value object;
+            object.SetObject();
+            for (int i = 0; i < entryCount; ++i)
+            {
+                buffer = AZStd::string::format("Key%i", i);
+                object.AddMember(AZ::Name(buffer), createArray());
+            }
+            return object;
+        };
+
+        root["entries"] = createObject();
+
+        return root;
+    }
+
+    void DomTestFixture::SetUp()
+    {
+        UnitTest::AllocatorsFixture::SetUp();
+        SetUpHarness();
+    }
+
+    void DomTestFixture::TearDown()
+    {
+        TearDownHarness();
+        UnitTest::AllocatorsFixture::TearDown();
+    }
+} // namespace AZ::Dom::Tests

--- a/Code/Framework/AzCore/Tests/DOM/DomFixtures.h
+++ b/Code/Framework/AzCore/Tests/DOM/DomFixtures.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/DOM/DomUtils.h>
+#include <AzCore/JSON/document.h>
+#include <AzCore/UnitTest/TestTypes.h>
+
+#define DOM_REGISTER_SERIALIZATION_BENCHMARK(BaseClass, Method)                                                                            \
+    BENCHMARK_REGISTER_F(BaseClass, Method)->Args({ 10, 5 })->Args({ 10, 500 })->Args({ 100, 5 })->Args({ 100, 500 })
+#define DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(BaseClass, Method)                                                                         \
+    DOM_REGISTER_SERIALIZATION_BENCHMARK(BaseClass, Method)->Unit(benchmark::kMillisecond);
+#define DOM_REGISTER_SERIALIZATION_BENCHMARK_NS(BaseClass, Method)                                                                         \
+    DOM_REGISTER_SERIALIZATION_BENCHMARK(BaseClass, Method)->Unit(benchmark::kNanosecond);
+
+namespace AZ::Dom::Tests
+{
+    class DomTestHarness
+    {
+    public:
+        virtual ~DomTestHarness() = default;
+
+        virtual void SetUpHarness();
+        virtual void TearDownHarness();
+    };
+
+    class DomBenchmarkFixture
+        : public DomTestHarness
+        , public UnitTest::AllocatorsBenchmarkFixture
+    {
+    public:
+        void SetUp(const ::benchmark::State& st) override;
+        void SetUp(::benchmark::State& st) override;
+        void TearDown(::benchmark::State& st) override;
+        void TearDown(const ::benchmark::State& st) override;
+
+        rapidjson::Document GenerateDomJsonBenchmarkDocument(int64_t entryCount, int64_t stringTemplateLength);
+        AZStd::string GenerateDomJsonBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength);
+        Value GenerateDomBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength);
+
+        template<class T>
+        static void TakeAndDiscardWithoutTimingDtor(T&& value, benchmark::State& state)
+        {
+            {
+                T instance = AZStd::move(value);
+                state.PauseTiming();
+            }
+            state.ResumeTiming();
+        }
+    };
+
+    class DomTestFixture
+        : public DomTestHarness
+        , public UnitTest::AllocatorsFixture
+    {
+    public:
+        void SetUp() override;
+        void TearDown() override;
+    };
+} // namespace AZ::Dom::Tests

--- a/Code/Framework/AzCore/Tests/DOM/DomJsonBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomJsonBenchmarks.cpp
@@ -16,130 +16,13 @@
 #include <AzCore/Name/NameDictionary.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <Tests/DOM/DomFixtures.h>
 
-namespace Benchmark
+namespace AZ::Dom::Benchmark
 {
-    class DomJsonBenchmark : public UnitTest::AllocatorsBenchmarkFixture
+    class DomJsonBenchmark : public Tests::DomBenchmarkFixture
     {
-    public:
-        void SetUp(const ::benchmark::State& st) override
-        {
-            UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-            AZ::NameDictionary::Create();
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Create();
-        }
-
-        void SetUp(::benchmark::State& st) override
-        {
-            UnitTest::AllocatorsBenchmarkFixture::SetUp(st);
-            AZ::NameDictionary::Create();
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Create();
-        }
-
-        void TearDown(::benchmark::State& st) override
-        {
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Destroy();
-            AZ::NameDictionary::Destroy();
-            UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
-        }
-
-        void TearDown(const ::benchmark::State& st) override
-        {
-            AZ::AllocatorInstance<AZ::Dom::ValueAllocator>::Destroy();
-            AZ::NameDictionary::Destroy();
-            UnitTest::AllocatorsBenchmarkFixture::TearDown(st);
-        }
-
-        rapidjson::Document GenerateDomJsonBenchmarkDocument(int64_t entryCount, int64_t stringTemplateLength)
-        {
-            rapidjson::Document document;
-            document.SetObject();
-
-            AZStd::string entryTemplate;
-            while (entryTemplate.size() < static_cast<size_t>(stringTemplateLength))
-            {
-                entryTemplate += "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
-            }
-            entryTemplate.resize(stringTemplateLength);
-            AZStd::string buffer;
-
-            auto createString = [&](int n) -> rapidjson::Value
-            {
-                buffer = AZStd::string::format("#%i %s", n, entryTemplate.c_str());
-                return rapidjson::Value(buffer.data(), static_cast<rapidjson::SizeType>(buffer.size()), document.GetAllocator());
-            };
-
-            auto createEntry = [&](int n) -> rapidjson::Value
-            {
-                rapidjson::Value entry(rapidjson::kObjectType);
-                entry.AddMember("string", createString(n), document.GetAllocator());
-                entry.AddMember("int", rapidjson::Value(n), document.GetAllocator());
-                entry.AddMember("double", rapidjson::Value(static_cast<double>(n) * 0.5), document.GetAllocator());
-                entry.AddMember("bool", rapidjson::Value(n % 2 == 0), document.GetAllocator());
-                entry.AddMember("null", rapidjson::Value(rapidjson::kNullType), document.GetAllocator());
-                return entry;
-            };
-
-            auto createArray = [&]() -> rapidjson::Value
-            {
-                rapidjson::Value array;
-                array.SetArray();
-                for (int i = 0; i < entryCount; ++i)
-                {
-                    array.PushBack(createEntry(i), document.GetAllocator());
-                }
-                return array;
-            };
-
-            auto createObject = [&]() -> rapidjson::Value
-            {
-                rapidjson::Value object;
-                object.SetObject();
-                for (int i = 0; i < entryCount; ++i)
-                {
-                    buffer = AZStd::string::format("Key%i", i);
-                    rapidjson::Value key;
-                    key.SetString(buffer.data(), static_cast<rapidjson::SizeType>(buffer.length()), document.GetAllocator());
-                    object.AddMember(key.Move(), createArray(), document.GetAllocator());
-                }
-                return object;
-            };
-
-            document.SetObject();
-            document.AddMember("entries", createObject(), document.GetAllocator());
-
-            return document;
-        }
-
-        AZStd::string GenerateDomJsonBenchmarkPayload(int64_t entryCount, int64_t stringTemplateLength)
-        {
-            rapidjson::Document document = GenerateDomJsonBenchmarkDocument(entryCount, stringTemplateLength);
-
-            AZStd::string serializedJson;
-            auto result = AZ::JsonSerializationUtils::WriteJsonString(document, serializedJson);
-            AZ_Assert(result.IsSuccess(), "Failed to serialize generated JSON");
-            return serializedJson;
-        }
-
-        template <class T>
-        void TakeAndDiscardWithoutTimingDtor(T&& value, benchmark::State& state)
-        {
-            {
-                T instance = AZStd::move(value);
-                state.PauseTiming();
-            }
-            state.ResumeTiming();
-        }
     };
-
-// Helper macro for registering JSON benchmarks
-#define BENCHMARK_REGISTER_JSON(BaseClass, Method)                                                                                         \
-    BENCHMARK_REGISTER_F(BaseClass, Method)                                                                                                \
-        ->Args({ 10, 5 })                                                                                                                  \
-        ->Args({ 10, 500 })                                                                                                                \
-        ->Args({ 100, 5 })                                                                                                                 \
-        ->Args({ 100, 500 })                                                                                                               \
-        ->Unit(benchmark::kMillisecond);
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToRapidjsonInPlace)(benchmark::State& state)
     {
@@ -163,7 +46,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToRapidjsonInPlace)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToRapidjsonInPlace)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToAzDomValueInPlace)(benchmark::State& state)
     {
@@ -187,7 +70,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToAzDomValueInPlace)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToAzDomValueInPlace)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToRapidjson)(benchmark::State& state)
     {
@@ -207,7 +90,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToRapidjson)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToRapidjson)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, AzDomDeserializeToAzDomValue)(benchmark::State& state)
     {
@@ -227,7 +110,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, AzDomDeserializeToAzDomValue)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, AzDomDeserializeToAzDomValue)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonDeserializeToRapidjson)(benchmark::State& state)
     {
@@ -243,7 +126,7 @@ namespace Benchmark
 
         state.SetBytesProcessed(serializedPayload.size() * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonDeserializeToRapidjson)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonDeserializeToRapidjson)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonMakeComplexObject)(benchmark::State& state)
     {
@@ -254,7 +137,7 @@ namespace Benchmark
 
         state.SetItemsProcessed(state.range(0) * state.range(0) * state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonMakeComplexObject)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonMakeComplexObject)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonLookupMemberByString)(benchmark::State& state)
     {
@@ -264,7 +147,9 @@ namespace Benchmark
         {
             AZStd::string key(AZStd::string::format("key%" PRId64, i));
             keys.push_back(key);
-            document.AddMember(rapidjson::Value(key.data(), static_cast<rapidjson::SizeType>(key.size()), document.GetAllocator()), rapidjson::Value(i), document.GetAllocator());
+            document.AddMember(
+                rapidjson::Value(key.data(), static_cast<rapidjson::SizeType>(key.size()), document.GetAllocator()), rapidjson::Value(i),
+                document.GetAllocator());
         }
 
         for (auto _ : state)
@@ -293,7 +178,7 @@ namespace Benchmark
         state.SetItemsProcessed(state.iterations());
     }
 
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonDeepCopy)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonDeepCopy)
 
     BENCHMARK_DEFINE_F(DomJsonBenchmark, RapidjsonCopyAndMutate)(benchmark::State& state)
     {
@@ -309,9 +194,8 @@ namespace Benchmark
 
         state.SetItemsProcessed(state.iterations());
     }
-    BENCHMARK_REGISTER_JSON(DomJsonBenchmark, RapidjsonCopyAndMutate)
+    DOM_REGISTER_SERIALIZATION_BENCHMARK_MS(DomJsonBenchmark, RapidjsonCopyAndMutate)
 
-#undef BENCHMARK_REGISTER_JSON
-} // namespace Benchmark
+} // namespace AZ::Dom::Benchmark
 
 #endif // defined(HAVE_BENCHMARK)

--- a/Code/Framework/AzCore/Tests/DOM/DomJsonTests.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomJsonTests.cpp
@@ -13,24 +13,23 @@
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <Tests/DOM/DomFixtures.h>
 
 namespace AZ::Dom::Tests
 {
-    class DomJsonTests : public UnitTest::AllocatorsFixture
+    class DomJsonTests : public DomTestFixture
     {
     public:
         void SetUp() override
         {
-            UnitTest::AllocatorsFixture::SetUp();
-            NameDictionary::Create();
+            DomTestFixture::SetUp();
             m_document = AZStd::make_unique<rapidjson::Document>();
         }
 
         void TearDown() override
         {
             m_document.reset();
-            NameDictionary::Destroy();
-            UnitTest::AllocatorsFixture::TearDown();
+            DomTestFixture::TearDown();
         }
 
         rapidjson::Value CreateString(const AZStd::string& text)

--- a/Code/Framework/AzCore/Tests/DOM/DomValueTests.cpp
+++ b/Code/Framework/AzCore/Tests/DOM/DomValueTests.cpp
@@ -15,26 +15,18 @@
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzCore/UnitTest/TestTypes.h>
 #include <AzCore/std/numeric.h>
+#include <Tests/DOM/DomFixtures.h>
 
 namespace AZ::Dom::Tests
 {
-    class DomValueTests : public UnitTest::AllocatorsFixture
+    class DomValueTests : public DomTestFixture
     {
     public:
-        void SetUp() override
-        {
-            UnitTest::AllocatorsFixture::SetUp();
-            NameDictionary::Create();
-            AZ::AllocatorInstance<ValueAllocator>::Create();
-        }
-
         void TearDown() override
         {
             m_value = Value();
 
-            AZ::AllocatorInstance<ValueAllocator>::Destroy();
-            NameDictionary::Destroy();
-            UnitTest::AllocatorsFixture::TearDown();
+            DomTestFixture::TearDown();
         }
 
         void PerformValueChecks()

--- a/Code/Framework/AzCore/Tests/azcoretests_files.cmake
+++ b/Code/Framework/AzCore/Tests/azcoretests_files.cmake
@@ -215,6 +215,8 @@ set(FILES
     AZStd/Variant.cpp
     AZStd/VariantSerialization.cpp
     AZStd/VectorAndArray.cpp
+    DOM/DomFixtures.cpp
+    DOM/DomFixtures.h
     DOM/DomJsonTests.cpp
     DOM/DomJsonBenchmarks.cpp
     DOM/DomValueTests.cpp

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -201,11 +201,8 @@ namespace AzToolsFramework
         //! Fired after the EditorEntityContext fails to export the root level slice to the game stream
         virtual void OnSaveStreamForGameFailure(AZStd::string_view /*failureString*/) {}
 
-        //! Fired when the user triggers a clone of ComponentEntity object(s), before operation begins
-        virtual void OnEntitiesAboutToBeCloned() {}
-
-        //! Fires when the user triggers a clone of ComponentEntity object(s)), after operation completes
-        virtual void OnEntitiesCloned() {}
+        //! Preserve entity order when re-parenting entities
+        virtual void ForceAddEntitiesToBack(bool /*forceAddToBack*/) {}
 
     };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityHelpers.cpp
@@ -1157,7 +1157,7 @@ namespace AzToolsFramework
 
     bool CloneInstantiatedEntities(const EntityIdSet& entitiesToClone, EntityIdSet& clonedEntities)
     {
-        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnEntitiesAboutToBeCloned);
+        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::ForceAddEntitiesToBack, true);
         ScopedUndoBatch undoBatch("Clone Selection");
 
         // Track the mapping of source to cloned entity. This both helps make sure that an entity is not accidentally
@@ -1199,7 +1199,7 @@ namespace AzToolsFramework
         // Also replace the selection with the entities that have been cloned.
         Internal::UpdateUndoStackAndSelectClonedEntities(allEntityClonesContainer.m_entities, undoBatch);
 
-        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnEntitiesCloned);
+        EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::ForceAddEntitiesToBack, false);
 
         for (const AZ::Entity* entity : allEntityClonesContainer.m_entities)
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -643,14 +643,9 @@ namespace AzToolsFramework
         }
     }
 
-    void EditorEntityModel::OnEntitiesAboutToBeCloned()
+    void EditorEntityModel::ForceAddEntitiesToBack(bool forceAddToBack)
     {
-        m_forceAddToBack = true;
-    }
-
-    void EditorEntityModel::OnEntitiesCloned()
-    {
-        m_forceAddToBack = false;
+        m_forceAddToBack = forceAddToBack;
     }
 
     void EditorEntityModel::ChildEntityOrderArrayUpdated()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.h
@@ -94,9 +94,7 @@ namespace AzToolsFramework
         void OnEntityStreamLoadBegin() override;
         void OnEntityStreamLoadSuccess() override;
         void OnEntityStreamLoadFailed() override;
-        void OnEntitiesAboutToBeCloned() override;
-        void OnEntitiesCloned() override;
-
+        void ForceAddEntitiesToBack(bool forceAddToBack) override;
 
         ////////////////////////////////////////////////
         // AzFramework::EntityContextEventBus::Handler

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -84,6 +84,7 @@ namespace AzToolsFramework
                 return AZ::Failure(findCommonRootOutcome.TakeError());
             }
 
+            // order entities by their respective position within Entity Outliner
             EditorEntitySortRequestBus::Event(
                 commonRootEntityId,
                 [&topLevelEntities](EditorEntitySortRequestBus::Events* sortRequests)
@@ -95,20 +96,6 @@ namespace AzToolsFramework
                             return sortRequests->GetChildEntityIndex(entity1->GetId()) <
                                 sortRequests->GetChildEntityIndex(entity2->GetId());
                         });
-                });
-
-            // order entities by their respective position within Entity Outliner
-            std::sort(
-                topLevelEntities.begin(), topLevelEntities.end(),
-                [&commonRootEntityId](AZ::Entity* entity1, AZ::Entity* entity2)
-                {
-                    AZ::u64 index1;
-                    EditorEntitySortRequestBus::EventResult(
-                        index1, commonRootEntityId, &EditorEntitySortRequests::GetChildEntityIndex, entity1->GetId());
-                    AZ::u64 index2;
-                    EditorEntitySortRequestBus::EventResult(
-                        index2, commonRootEntityId, &EditorEntitySortRequests::GetChildEntityIndex, entity2->GetId());
-                    return index1 < index2;
                 });
 
             AZ::EntityId containerEntityId;

--- a/Code/Tools/AWSNativeSDKInit/CMakeLists.txt
+++ b/Code/Tools/AWSNativeSDKInit/CMakeLists.txt
@@ -25,6 +25,24 @@ ly_add_target(
             AZ::AzCore
 )
 
+ly_add_target(
+    NAME AWSNativeSDKTestLibs STATIC
+    NAMESPACE AZ
+    FILES_CMAKE
+        aws_native_sdk_test_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            include
+            tests/libs
+        PRIVATE
+            source
+    BUILD_DEPENDENCIES
+        PRIVATE
+            3rdParty::AWSNativeSDK::Core
+            AZ::AzCore
+            AZ::AzTest
+)
+
 ################################################################################
 # Tests
 ################################################################################

--- a/Code/Tools/AWSNativeSDKInit/aws_native_sdk_test_files.cmake
+++ b/Code/Tools/AWSNativeSDKInit/aws_native_sdk_test_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    tests/libs/AWSNativeSDKTestManager.cpp
+    tests/libs/AWSNativeSDKTestManager.h
+)

--- a/Code/Tools/AWSNativeSDKInit/source/AWSNativeSDKInit.cpp
+++ b/Code/Tools/AWSNativeSDKInit/source/AWSNativeSDKInit.cpp
@@ -89,5 +89,4 @@ namespace AWSNativeSDKInit
         Platform::CustomizeShutdown();
 #endif // #if defined(PLATFORM_SUPPORTS_AWS_NATIVE_SDK)
     }
-
 }

--- a/Code/Tools/AWSNativeSDKInit/tests/libs/AWSNativeSDKTestManager.cpp
+++ b/Code/Tools/AWSNativeSDKInit/tests/libs/AWSNativeSDKTestManager.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+
+#include <AWSNativeSDKTestManager.h>
+
+#include <AzCore/Module/Environment.h>
+#include <AzTest/Utils.h>
+
+#include <AWSNativeSDKInit/AWSLogSystemInterface.h>
+#include <aws/core/Aws.h>
+#include <aws/core/utils/logging/AWSLogging.h>
+
+namespace AWSNativeSDKTestLibs
+{
+    AZ::EnvironmentVariable<AWSNativeSDKTestManager> AWSNativeSDKTestManager::s_sdkManager = nullptr;
+
+    AWSNativeSDKTestManager::AWSNativeSDKTestManager()
+    {
+        AZ::Test::SetEnv("AWS_DEFAULT_REGION", "us-east-1", 1);
+        m_awsSDKOptions.memoryManagementOptions.memoryManager = &m_memoryManager;
+        Aws::InitAPI(m_awsSDKOptions);
+    }
+
+    AWSNativeSDKTestManager::~AWSNativeSDKTestManager()
+    {
+        Aws::ShutdownAPI(m_awsSDKOptions);
+        AZ::Test::UnsetEnv("AWS_DEFAULT_REGION");
+    }
+
+    void AWSNativeSDKTestManager::Init()
+    {
+        s_sdkManager = AZ::Environment::CreateVariable<AWSNativeSDKTestManager>(AWSNativeSDKTestManager::SdkManagerTag);
+    }
+
+    void AWSNativeSDKTestManager::Shutdown()
+    {
+        s_sdkManager = nullptr;
+    }
+}

--- a/Code/Tools/AWSNativeSDKInit/tests/libs/AWSNativeSDKTestManager.h
+++ b/Code/Tools/AWSNativeSDKInit/tests/libs/AWSNativeSDKTestManager.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Module/Environment.h>
+#include <AzCore/PlatformIncl.h>
+
+#include <AWSNativeSDKInit/AWSMemoryInterface.h>
+
+#include <aws/core/Aws.h>
+
+namespace AWSNativeSDKTestLibs
+{
+    // Entry point for AWSNativeSDK's initialization and shutdown for test environment
+    // Use an AZ::Environment variable to enforce only one init and shutdown
+    class AWSNativeSDKTestManager
+    {
+    public:
+        static constexpr const char SdkManagerTag[] = "TestAWSSDKManager";
+
+        AWSNativeSDKTestManager();
+        ~AWSNativeSDKTestManager();
+
+        static void Init();
+        static void Shutdown();
+
+    private:
+        static AZ::EnvironmentVariable<AWSNativeSDKTestManager> s_sdkManager;
+
+        AWSNativeSDKInit::MemoryManager m_memoryManager;
+        Aws::SDKOptions m_awsSDKOptions;
+    };
+}

--- a/Gems/AWSClientAuth/Code/CMakeLists.txt
+++ b/Gems/AWSClientAuth/Code/CMakeLists.txt
@@ -106,13 +106,12 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 3rdParty::AWSNativeSDK::AWSClientAuth
                 AZ::AzCore
                 AZ::AzFramework
-                AZ::AWSNativeSDKInit
+                AZ::AWSNativeSDKTestLibs
                 Gem::AWSClientAuth.Static
                 Gem::AWSCore
                 Gem::HttpRequestor
         RUNTIME_DEPENDENCIES
             Gem::AWSCore
-            AZ::AWSNativeSDKInit
             Gem::HttpRequestor
    )
    ly_add_googletest(

--- a/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
+++ b/Gems/AWSClientAuth/Code/Tests/AWSClientAuthGemMock.h
@@ -30,7 +30,7 @@
 #include <AWSCoreBus.h>
 #include <ResourceMapping/AWSResourceMappingBus.h>
 #include <AWSClientAuthBus.h>
-#include <AWSNativeSDKInit/AWSNativeSDKInit.h>
+#include <AWSNativeSDKTestManager.h>
 #include <HttpRequestor/HttpRequestorBus.h>
 
 #include <aws/core/utils/Outcome.h>
@@ -542,7 +542,7 @@ namespace AWSClientAuthUnitTest
             m_jobContext.reset(aznew AZ::JobContext(*m_jobManager, *m_jobCancelGroup));
             AZ::JobContext::SetGlobalContext(m_jobContext.get());
 
-            AWSNativeSDKInit::InitializationManager::InitAwsApi();
+            AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Init();
             m_cognitoIdentityProviderClientMock = std::make_shared<CognitoIdentityProviderClientMock>();
             m_cognitoIdentityClientMock = std::make_shared<CognitoIdentityClientMock>();
         }
@@ -557,8 +557,7 @@ namespace AWSClientAuthUnitTest
             m_cognitoIdentityProviderClientMock.reset();
             m_cognitoIdentityClientMock.reset();
 
-            AWSNativeSDKInit::InitializationManager::Shutdown();
-
+            AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Shutdown();
 
             AZ::AllocatorInstance<AZ::ThreadPoolAllocator>::Destroy();
 

--- a/Gems/AWSCore/Code/CMakeLists.txt
+++ b/Gems/AWSCore/Code/CMakeLists.txt
@@ -163,7 +163,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
             PRIVATE
                 AZ::AzTest
                 AZ::AzFramework
-                AZ::AWSNativeSDKInit
+                AZ::AWSNativeSDKTestLibs
                 Gem::AWSCore.Static
     )
 
@@ -202,7 +202,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                     3rdParty::Qt::Gui
                     3rdParty::Qt::Widgets
                     AZ::AzTest
-                    AZ::AWSNativeSDKInit
+                    AZ::AWSNativeSDKTestLibs
                     Gem::AWSCore.Static
                     Gem::AWSCore.Editor.Static
         )

--- a/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
@@ -19,7 +19,7 @@
 #include <AzTest/AzTest.h>
 
 #include <AWSCoreSystemComponent.h>
-#include <AWSNativeSDKInit/AWSNativeSDKInit.h>
+#include <AWSNativeSDKTestManager.h>
 #include <Configuration/AWSCoreConfiguration.h>
 #include <Credential/AWSCredentialManager.h>
 #include <Framework/AWSApiJob.h>
@@ -105,7 +105,7 @@ public:
 TEST_F(AWSCoreSystemComponentTest, ComponentActivateTest)
 {
     // Shutdown SDK which is init in fixture setup step
-    AWSNativeSDKInit::InitializationManager::Shutdown();
+    AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Shutdown();
 
     EXPECT_FALSE(m_coreSystemsComponent->IsAWSApiInitialized());
 

--- a/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
+++ b/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
@@ -17,7 +17,7 @@
 #include <Framework/JsonObjectHandler.h>
 #include <Framework/JsonWriter.h>
 
-#include <AWSNativeSDKInit/AWSNativeSDKInit.h>
+#include <AWSNativeSDKTestManager.h>
 
 namespace AWSCoreTestingUtils
 {
@@ -138,7 +138,7 @@ public:
             m_app = AZStd::make_unique<AZ::ComponentApplication>();
         }
 
-        AWSNativeSDKInit::InitializationManager::InitAwsApi();
+        AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Init();
     }
 
     void TearDown() override
@@ -148,7 +148,7 @@ public:
 
     void TearDownFixture(bool mockSettingsRegistry = true) 
     {
-        AWSNativeSDKInit::InitializationManager::Shutdown();
+        AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Shutdown();
 
         if (mockSettingsRegistry)
         {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/CMakeLists.txt
@@ -90,7 +90,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 Gem::AWSCore
                 Gem::AWSGameLift.Client.Static
                 3rdParty::AWSNativeSDK::GameLiftClient
-                AZ::AWSNativeSDKInit
+                AZ::AWSNativeSDKTestLibs
     )
     # Add AWSGameLift.Client.Tests to googletest
     ly_add_googletest(

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientFixture.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientFixture.h
@@ -8,12 +8,13 @@
 
 #pragma once
 
-#include <AWSNativeSDKInit/AWSNativeSDKInit.h>
+#include <AWSNativeSDKTestManager.h>
 #include <AzCore/Jobs/JobManager.h>
 #include <AzCore/Jobs/JobManagerBus.h>
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Memory/PoolAllocator.h>
 #include <AzCore/UnitTest/TestTypes.h>
+#include <AzTest/Utils.h>
 
 class AWSGameLiftClientFixture
     : public UnitTest::ScopedAllocatorSetupFixture
@@ -38,12 +39,12 @@ public:
         m_jobContext.reset(aznew AZ::JobContext(*m_jobManager, *m_jobCancelGroup));
         AZ::JobContext::SetGlobalContext(m_jobContext.get());
 
-        AWSNativeSDKInit::InitializationManager::InitAwsApi();
+        AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Init();
     }
 
     void TearDown() override
     {
-        AWSNativeSDKInit::InitializationManager::Shutdown();
+        AWSNativeSDKTestLibs::AWSNativeSDKTestManager::Shutdown();
 
         AZ::JobContext::SetGlobalContext(nullptr);
         m_jobContext.reset();

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsConstant.h
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsConstant.h
@@ -21,16 +21,16 @@ namespace AWSMetrics
     static constexpr char AwsMetricsAttributeKeyEventData[] = "event_data";
 
     //! Service API request and response object keys
-    static constexpr char AwsMetricsSuccessResponseRecordKeyErrorCode[] = "error_code";
-    static constexpr char AwsMetricsSuccessResponseRecordKeyResult[] = "result";
-    static constexpr char AwsMetricsSuccessResponseKeyFailedRecordCount[] = "failed_record_count";
-    static constexpr char AwsMetricsSuccessResponseKeyEvents[] = "events";
-    static constexpr char AwsMetricsSuccessResponseKeyTotal[] = "total";
-    static constexpr char AwsMetricsErrorKeyMessage[] = "message";
-    static constexpr char AwsMetricsErrorKeyType[] = "type";
-    static constexpr char AwsMetricsRequestParameterKeyEvents[] = "events";
+    static constexpr char AwsMetricsPostMetricsEventsResponseEntryKeyErrorCode[] = "error_code";
+    static constexpr char AwsMetricsPostMetricsEventsResponseEntryKeyResult[] = "result";
+    static constexpr char AwsMetricsPostMetricsEventsResponseKeyFailedRecordCount[] = "failed_record_count";
+    static constexpr char AwsMetricsPostMetricsEventsResponseKeyEvents[] = "events";
+    static constexpr char AwsMetricsPostMetricsEventsResponseKeyTotal[] = "total";
+    static constexpr char AwsMetricsPostMetricsEventsErrorKeyMessage[] = "message";
+    static constexpr char AwsMetricsPostMetricsEventsErrorKeyType[] = "type";
+    static constexpr char AwsMetricsPostMetricsEventsRequestParameterKeyEvents[] = "events";
 
-    static constexpr char AwsMetricsSuccessResponseRecordResult[] = "Ok";
+    static constexpr char AwsMetricsPostMetricsEventsResponseEntrySuccessResult[] = "Ok";
 
     //! Service API limits
     //! https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.cpp
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.cpp
@@ -15,56 +15,77 @@ namespace AWSMetrics
 {
     namespace ServiceAPI
     {
-        bool MetricsEventSuccessResponseRecord::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool PostMetricsEventsResponseEntry::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
-            if (strcmp(key, AwsMetricsSuccessResponseRecordKeyErrorCode) == 0) return reader.Accept(errorCode);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseEntryKeyErrorCode) == 0)
+            {
+                return reader.Accept(m_errorCode);
+            }
 
-            if (strcmp(key, AwsMetricsSuccessResponseRecordKeyResult) == 0) return reader.Accept(result);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseEntryKeyResult) == 0)
+            {
+                return reader.Accept(m_result);
+            }
 
             return reader.Ignore();
         }
 
-        bool MetricsEventSuccessResponse::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool PostMetricsEventsResponse::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
-            if (strcmp(key, AwsMetricsSuccessResponseKeyFailedRecordCount) == 0) return reader.Accept(failedRecordCount);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseKeyFailedRecordCount) == 0)
+            {
+                return reader.Accept(m_failedRecordCount);
+            }
 
-            if (strcmp(key, AwsMetricsSuccessResponseKeyEvents) == 0) return reader.Accept(events);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseKeyEvents) == 0)
+            {
+                return reader.Accept(m_responseEntries);
+            }
 
-            if (strcmp(key, AwsMetricsSuccessResponseKeyTotal) == 0) return reader.Accept(total);
+            if (strcmp(key, AwsMetricsPostMetricsEventsResponseKeyTotal) == 0)
+            {
+                return reader.Accept(m_total);
+            }
 
             return reader.Ignore();
         }
 
-        bool Error::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool PostMetricsEventsError::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
-            if (strcmp(key, AwsMetricsErrorKeyMessage) == 0) return reader.Accept(message);
+            if (strcmp(key, AwsMetricsPostMetricsEventsErrorKeyMessage) == 0)
+            {
+                return reader.Accept(message);
+            }
 
-            if (strcmp(key, AwsMetricsErrorKeyType) == 0) return reader.Accept(type);
+            if (strcmp(key, AwsMetricsPostMetricsEventsErrorKeyType) == 0)
+            {
+                return reader.Accept(type);
+            }
 
             return reader.Ignore();
         }
 
-        // Generated Function Parameters
-        bool PostProducerEventsRequest::Parameters::BuildRequest(AWSCore::RequestBuilder& request)
+        // Generated request parameters
+        bool PostMetricsEventsRequest::Parameters::BuildRequest(AWSCore::RequestBuilder& request)
         {
-            bool ok = true;
+            bool buildResult = true;
+            buildResult = buildResult && request.WriteJsonBodyParameter(*this);
 
-            ok = ok && request.WriteJsonBodyParameter(*this);
-            return ok;
+            return buildResult;
         }
 
-        bool PostProducerEventsRequest::Parameters::WriteJson(AWSCore::JsonWriter& writer) const
+        bool PostMetricsEventsRequest::Parameters::WriteJson(AWSCore::JsonWriter& writer) const
         {
-            bool ok = true;
+            bool writeResult = true;
 
-            ok = ok && writer.StartObject();
+            writeResult = writeResult && writer.StartObject();
 
-            ok = ok && writer.Key(AwsMetricsRequestParameterKeyEvents);
-            ok = ok && data.SerializeToJson(writer);
+            writeResult = writeResult && writer.Key(AwsMetricsPostMetricsEventsRequestParameterKeyEvents);
+            writeResult = writeResult && m_metricsQueue.SerializeToJson(writer);
 
-            ok = ok && writer.EndObject();
+            writeResult = writeResult && writer.EndObject();
 
-            return ok;
+            return writeResult;
         }
     }
 }

--- a/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.h
+++ b/Gems/AWSMetrics/Code/Source/AWSMetricsServiceApi.h
@@ -16,41 +16,44 @@ namespace AWSMetrics
 {
     namespace ServiceAPI
     {
-        //! Struct for storing event record from the response.
-        struct MetricsEventSuccessResponseRecord
+        //! Response for an individual metrics event from a PostMetricsEvents request.
+        //! If the event is successfully sent to the backend, it receives an "Ok" result.
+        //! If the event fails to be sent to the backend, the result includes an error code and an "Error" result.
+        struct PostMetricsEventsResponseEntry
         {
-            //! Identify the expected property type and provide a location where the property value can be stored.
+            //! Identify the expected property type in the response entry for each individual metrics event and provide a location where the property value can be stored.
             //! @param key Name of the property.
             //! @param reader JSON reader to read the property.
             bool OnJsonKey(const char* key, AWSCore::JsonReader& reader);
 
-            AZStd::string errorCode; //!< Error code if the event is not sent successfully.
-            AZStd::string result; //!< Processing result for the input record.
+            AZStd::string m_errorCode; //!< Error code if the individual metrics event failed to be sent.
+            AZStd::string m_result; //!< Result for the processed individual metrics event. Expected value: "Error" or "Ok".
         };
 
-        using MetricsEventSuccessResponsePropertyEvents = AZStd::vector<MetricsEventSuccessResponseRecord>;
+        using PostMetricsEventsResponseEntries = AZStd::vector<PostMetricsEventsResponseEntry>;
 
-        //! Struct for storing the success response.
-        struct MetricsEventSuccessResponse
+        //! Response for all the processed metrics events from a PostMetricsEvents request.
+        struct PostMetricsEventsResponse
         {
-            //! Identify the expected property type and provide a location where the property value can be stored.
+            //! Identify the expected property type in the response and provide a location where the property value can be stored.
             //! @param key Name of the property.
             //! @param reader JSON reader to read the property.
             bool OnJsonKey(const char* key, AWSCore::JsonReader& reader);
 
-            int failedRecordCount{ 0 }; //!< Number of events that failed to be saved to metrics events stream.
-            MetricsEventSuccessResponsePropertyEvents events; //! List of input event records.
-            int total{ 0 }; //!< Total number of events that were processed in the request
+            int m_failedRecordCount{ 0 }; //!< Number of events that failed to be sent to the backend.
+            PostMetricsEventsResponseEntries m_responseEntries; //! Response list for all the processed metrics events.
+            int m_total{ 0 }; //!< Total number of events that were processed in the request.
         };
 
-        //! Struct for storing the failure response.
-        struct Error
+        //! Failure response for sending the PostMetricsEvents request.
+        struct PostMetricsEventsError
         {
-            //! Identify the expected property type and provide a location where the property value can be stored.
+            //! Identify the expected property type in the failure response and provide a location where the property value can be stored.
             //! @param key Name of the property.
             //! @param reader JSON reader to read the property.
             bool OnJsonKey(const char* key, AWSCore::JsonReader& reader);
 
+            //! Do not rename the following members since they are expected by the AWSCore dependency.
             AZStd::string message; //!< Error message.
             AZStd::string type; //!< Error type.
         };
@@ -60,7 +63,7 @@ namespace AWSMetrics
 
         //! POST request defined by api_spec.json to send metrics to the backend.
         //! The path for this service API is "/producer/events".
-        class PostProducerEventsRequest
+        class PostMetricsEventsRequest
             : public AWSCore::ServiceRequest
         {
         public:
@@ -79,14 +82,15 @@ namespace AWSMetrics
                 //! @return Whether the serialization is successful.
                 bool WriteJson(AWSCore::JsonWriter& writer) const;
 
-                MetricsQueue data; //!< Data to send via the service API request.
+                MetricsQueue m_metricsQueue; //!< Metrics events to send via the service API request.
             };
 
-            MetricsEventSuccessResponse result; //! Success response.
-            Error error; //! Failure response.
+            //! Do not rename the following members since they are expected by the AWSCore dependency.
+            PostMetricsEventsResponse result; //! Success response.
+            PostMetricsEventsError error; //! Failure response.
             Parameters parameters; //! Request parameter.
         };
 
-        using PostProducerEventsRequestJob = AWSCore::ServiceRequestJob<PostProducerEventsRequest>;
+        using PostMetricsEventsRequestJob = AWSCore::ServiceRequestJob<PostMetricsEventsRequest>;
     } // ServiceAPI
 } // AWSMetrics

--- a/Gems/AWSMetrics/Code/Source/MetricsManager.cpp
+++ b/Gems/AWSMetrics/Code/Source/MetricsManager.cpp
@@ -172,17 +172,17 @@ namespace AWSMetrics
                 if (outcome.IsSuccess())
                 {
                     // Generate response records for success call to keep consistency with the Service API response
-                    ServiceAPI::MetricsEventSuccessResponsePropertyEvents responseRecords;
+                    ServiceAPI::PostMetricsEventsResponseEntries responseEntries;
                     int numMetricsEventsInRequest = metricsQueue->GetNumMetrics();
                     for (int index = 0; index < numMetricsEventsInRequest; ++index)
                     {
-                        ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
-                        responseRecord.result = AwsMetricsSuccessResponseRecordResult;
+                        ServiceAPI::PostMetricsEventsResponseEntry responseEntry;
+                        responseEntry.m_result = AwsMetricsPostMetricsEventsResponseEntrySuccessResult;
 
-                        responseRecords.emplace_back(responseRecord);
+                        responseEntries.emplace_back(responseEntry);
                     }
 
-                    OnResponseReceived(*metricsQueue, responseRecords);
+                    OnResponseReceived(*metricsQueue, responseEntries);
 
                     AZ::TickBus::QueueFunction([requestId]()
                     {
@@ -209,19 +209,19 @@ namespace AWSMetrics
     {
         int requestId = ++m_sendMetricsId;
 
-        ServiceAPI::PostProducerEventsRequestJob* requestJob = ServiceAPI::PostProducerEventsRequestJob::Create(
-            [this, requestId](ServiceAPI::PostProducerEventsRequestJob* successJob)
+        ServiceAPI::PostMetricsEventsRequestJob* requestJob = ServiceAPI::PostMetricsEventsRequestJob::Create(
+            [this, requestId](ServiceAPI::PostMetricsEventsRequestJob* successJob)
             {
-                OnResponseReceived(successJob->parameters.data, successJob->result.events);
+                OnResponseReceived(successJob->parameters.m_metricsQueue, successJob->result.m_responseEntries);
 
                 AZ::TickBus::QueueFunction([requestId]()
                 {
                     AWSMetricsNotificationBus::Broadcast(&AWSMetricsNotifications::OnSendMetricsSuccess, requestId);
                 });
             },
-            [this, requestId](ServiceAPI::PostProducerEventsRequestJob* failedJob)
+            [this, requestId](ServiceAPI::PostMetricsEventsRequestJob* failedJob)
             {
-                OnResponseReceived(failedJob->parameters.data);
+                OnResponseReceived(failedJob->parameters.m_metricsQueue);
 
                 AZStd::string errorMessage = failedJob->error.message;
                 AZ::TickBus::QueueFunction([requestId, errorMessage]()
@@ -230,11 +230,11 @@ namespace AWSMetrics
                 });
             });
 
-        requestJob->parameters.data = AZStd::move(metricsQueue);
+        requestJob->parameters.m_metricsQueue = AZStd::move(metricsQueue);
         requestJob->Start();
     }
 
-    void MetricsManager::OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::MetricsEventSuccessResponsePropertyEvents& responseRecords)
+    void MetricsManager::OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::PostMetricsEventsResponseEntries& responseEntries)
     {
         MetricsQueue metricsEventsForRetry;
         int numMetricsEventsInRequest = metricsEventsInRequest.GetNumMetrics();
@@ -242,7 +242,7 @@ namespace AWSMetrics
         {
             MetricsEvent metricsEvent = metricsEventsInRequest[index];
 
-            if (responseRecords.size() > 0 && responseRecords[index].result == AwsMetricsSuccessResponseRecordResult)
+            if (responseEntries.size() > 0 && responseEntries[index].m_result == AwsMetricsPostMetricsEventsResponseEntrySuccessResult)
             {
                 // The metrics event is sent to the backend successfully.
                 if (metricsEvent.GetNumFailures() == 0)

--- a/Gems/AWSMetrics/Code/Source/MetricsManager.h
+++ b/Gems/AWSMetrics/Code/Source/MetricsManager.h
@@ -60,9 +60,8 @@ namespace AWSMetrics
 
         //! Update the global stats and add qualified failed metrics events back to the buffer for retry.
         //! @param metricsEventsInRequest Metrics events in the original request.
-        //! @param responseRecords Response records from the call. Each record in the list contains the result for sending the corresponding metrics event.
-        void OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::MetricsEventSuccessResponsePropertyEvents& responseRecords =
-                ServiceAPI::MetricsEventSuccessResponsePropertyEvents());
+        //! @param responseEntries Response list for all the processed metrics events.
+        void OnResponseReceived(const MetricsQueue& metricsEventsInRequest, const ServiceAPI::PostMetricsEventsResponseEntries& responseEntries = ServiceAPI::PostMetricsEventsResponseEntries());
 
         //! Implementation for flush all metrics buffered in memory.
         void FlushMetricsAsync();

--- a/Gems/AWSMetrics/Code/Tests/AWSMetricsServiceApiTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/AWSMetricsServiceApiTest.cpp
@@ -42,43 +42,43 @@ namespace AWSMetrics
 
     TEST_F(AWSMetricsServiceApiTest, OnJsonKey_MetricsEventSuccessResponseRecord_AcceptValidKeys)
     {
-        ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
-        responseRecord.result = "ok";
+        ServiceAPI::PostMetricsEventsResponseEntry responseRecord;
+        responseRecord.m_result = "ok";
 
-        EXPECT_CALL(JsonReader, Accept(responseRecord.result)).Times(1);
-        EXPECT_CALL(JsonReader, Accept(responseRecord.errorCode)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(responseRecord.m_result)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(responseRecord.m_errorCode)).Times(1);
         EXPECT_CALL(JsonReader, Ignore()).Times(1);
 
-        responseRecord.OnJsonKey(AwsMetricsSuccessResponseRecordKeyResult, JsonReader);
-        responseRecord.OnJsonKey(AwsMetricsSuccessResponseRecordKeyErrorCode, JsonReader);
+        responseRecord.OnJsonKey(AwsMetricsPostMetricsEventsResponseEntryKeyResult, JsonReader);
+        responseRecord.OnJsonKey(AwsMetricsPostMetricsEventsResponseEntryKeyErrorCode, JsonReader);
         responseRecord.OnJsonKey("other", JsonReader);
     }
 
     TEST_F(AWSMetricsServiceApiTest, OnJsonKeyWithEvents_MetricsEventSuccessResponseRecord_AcceptValidKeys)
     {
         // Verifiy that JsonReader accepts valid JSON keys in each event record from a success reponse 
-        ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
-        responseRecord.result = "ok";
+        ServiceAPI::PostMetricsEventsResponseEntry responseRecord;
+        responseRecord.m_result = "Ok";
 
-        ServiceAPI::MetricsEventSuccessResponse response;
-        response.events.emplace_back(responseRecord);
-        response.failedRecordCount = 0;
-        response.total = 1;
+        ServiceAPI::PostMetricsEventsResponse response;
+        response.m_responseEntries.emplace_back(responseRecord);
+        response.m_failedRecordCount = 0;
+        response.m_total = 1;
 
-        EXPECT_CALL(JsonReader, Accept(response.failedRecordCount)).Times(1);
-        EXPECT_CALL(JsonReader, Accept(response.total)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(response.m_failedRecordCount)).Times(1);
+        EXPECT_CALL(JsonReader, Accept(response.m_total)).Times(1);
         EXPECT_CALL(JsonReader, Accept(::testing::An<AWSCore::JsonArrayHandler>())).Times(1);
         EXPECT_CALL(JsonReader, Ignore()).Times(1);
 
-        response.OnJsonKey(AwsMetricsSuccessResponseKeyFailedRecordCount, JsonReader);
-        response.OnJsonKey(AwsMetricsSuccessResponseKeyTotal, JsonReader);
-        response.OnJsonKey(AwsMetricsSuccessResponseKeyEvents, JsonReader);
+        response.OnJsonKey(AwsMetricsPostMetricsEventsResponseKeyFailedRecordCount, JsonReader);
+        response.OnJsonKey(AwsMetricsPostMetricsEventsResponseKeyTotal, JsonReader);
+        response.OnJsonKey(AwsMetricsPostMetricsEventsResponseKeyEvents, JsonReader);
         response.OnJsonKey("other", JsonReader);
     }
 
     TEST_F(AWSMetricsServiceApiTest, OnJsonKey_Error_AcceptValidKeys)
     {
-        ServiceAPI::Error error;
+        ServiceAPI::PostMetricsEventsError error;
         error.message = "error message";
         error.type = "404";
 
@@ -86,16 +86,16 @@ namespace AWSMetrics
         EXPECT_CALL(JsonReader, Accept(error.type)).Times(1);
         EXPECT_CALL(JsonReader, Ignore()).Times(1);
 
-        error.OnJsonKey(AwsMetricsErrorKeyMessage, JsonReader);
-        error.OnJsonKey(AwsMetricsErrorKeyType, JsonReader);
+        error.OnJsonKey(AwsMetricsPostMetricsEventsErrorKeyMessage, JsonReader);
+        error.OnJsonKey(AwsMetricsPostMetricsEventsErrorKeyType, JsonReader);
         error.OnJsonKey("other", JsonReader);
     }
 
     TEST_F(AWSMetricsServiceApiTest, BuildRequestBody_PostProducerEventsRequest_SerializedMetricsQueue)
     {
-        ServiceAPI::PostProducerEventsRequest request;
-        request.parameters.data = MetricsQueue();
-        request.parameters.data.AddMetrics(MetricsEventBuilder().Build());
+        ServiceAPI::PostMetricsEventsRequest request;
+        request.parameters.m_metricsQueue = MetricsQueue();
+        request.parameters.m_metricsQueue.AddMetrics(MetricsEventBuilder().Build());
 
         AWSCore::RequestBuilder requestBuilder{};
         EXPECT_TRUE(request.parameters.BuildRequest(requestBuilder));
@@ -104,6 +104,6 @@ namespace AWSMetrics
 
         std::istreambuf_iterator<AZStd::string::value_type> eos;
         AZStd::string bodyString{ std::istreambuf_iterator<AZStd::string::value_type>(*bodyContent), eos };
-        EXPECT_TRUE(bodyString.contains(AZStd::string::format("{\"%s\":[{\"event_timestamp\":", AwsMetricsRequestParameterKeyEvents)));
+        EXPECT_TRUE(bodyString.contains(AZStd::string::format("{\"%s\":[{\"event_timestamp\":", AwsMetricsPostMetricsEventsRequestParameterKeyEvents)));
     }
 }

--- a/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
+++ b/Gems/AWSMetrics/Code/Tests/MetricsManagerTest.cpp
@@ -430,14 +430,14 @@ namespace AWSMetrics
         ReplaceLocalFileIOWithMockIO();
     }
 
-    TEST_F(MetricsManagerTest, OnResponseReceived_WithResponseRecords_RetryFailedMetrics)
+    TEST_F(MetricsManagerTest, OnResponseReceived_WithResponseEntries_RetryFailedMetrics)
     {
         // Reset the config file to change the max queue size setting.
         ResetClientConfig(false, (double)TestMetricsEventSizeInBytes * (MaxNumMetricsEvents + 1) / MbToBytes,
             DefaultFlushPeriodInSeconds, 1);
 
         MetricsQueue metricsEvents;
-        ServiceAPI::MetricsEventSuccessResponsePropertyEvents responseRecords;
+        ServiceAPI::PostMetricsEventsResponseEntries responseEntries;
         for (int index = 0; index < MaxNumMetricsEvents; ++index)
         {
             MetricsEvent newEvent;
@@ -445,19 +445,19 @@ namespace AWSMetrics
 
             metricsEvents.AddMetrics(newEvent);
 
-            ServiceAPI::MetricsEventSuccessResponseRecord responseRecord;
+            ServiceAPI::PostMetricsEventsResponseEntry responseEntry;
             if (index % 2 == 0)
             {
-                responseRecord.errorCode = "Error";
+                responseEntry.m_errorCode = "Error";
             }
             else
             {
-                responseRecord.result = "Ok";
+                responseEntry.m_result = "Ok";
             }
-            responseRecords.emplace_back(responseRecord);
+            responseEntries.emplace_back(responseEntry);
         }
 
-        m_metricsManager->OnResponseReceived(metricsEvents, responseRecords);
+        m_metricsManager->OnResponseReceived(metricsEvents, responseEntries);
 
         const GlobalStatistics& stats = m_metricsManager->GetGlobalStatistics();
         EXPECT_EQ(stats.m_numEvents, MaxNumMetricsEvents);
@@ -471,7 +471,7 @@ namespace AWSMetrics
         ASSERT_EQ(m_metricsManager->GetNumBufferedMetrics(), MaxNumMetricsEvents / 2);
     }
 
-    TEST_F(MetricsManagerTest, OnResponseReceived_NoResponseRecords_RetryAllMetrics)
+    TEST_F(MetricsManagerTest, OnResponseReceived_NoResponseEntries_RetryAllMetrics)
     {
         // Reset the config file to change the max queue size setting.
         ResetClientConfig(false, (double)TestMetricsEventSizeInBytes * (MaxNumMetricsEvents + 1) / MbToBytes,

--- a/Gems/AWSMetrics/cdk/api_spec.json
+++ b/Gems/AWSMetrics/cdk/api_spec.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "AWSMetricsServiceApi",
         "description": "Service API for the data analytics pipeline defined by the AWS Metrics Gem",
-        "version": "1.0.0"
+        "version": "1.0.1"
     },
     "x-amazon-apigateway-request-validators": {
       "all": {
@@ -68,7 +68,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/MetricsEventSuccessResponse"
+                                    "$ref": "#/components/schemas/PostMetricsEventsResponse"
                                 }
                             }
                         }
@@ -78,7 +78,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/PostMetricsEventsError"
                                 }
                             }
                         }
@@ -88,17 +88,17 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/PostMetricsEventsError"
                                 }
                             }
                         }
                     },
                     "500": {
-                        "description": "Internal Server Error",
+                        "description": "Internal Server PostMetricsEventsError",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/Error"
+                                    "$ref": "#/components/schemas/PostMetricsEventsError"
                                 }
                             }
                         }
@@ -109,7 +109,7 @@
     },
     "components": {
         "schemas": {
-            "Error": {
+            "PostMetricsEventsError": {
                 "type": "object",
                 "properties": {
                     "message": {
@@ -184,18 +184,18 @@
                     }
                 }
             },
-            "MetricsEventSuccessResponse": {
+            "PostMetricsEventsResponse": {
                 "title": "Metrics Event Success Response Schema",
                 "type": "object",
                 "properties": {
                     "failed_record_count": {
                         "type": "number",
-                        "description": "Number of events that failed to be saved to metrics events stream"
+                        "description": "Number of events that failed to be sent to the backend"
                     },
                     "events": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/MetricsEventSuccessResponseRecord"
+                            "$ref": "#/components/schemas/PostMetricsEventsResponseEntry"
                         }
                     },
                     "total": {
@@ -204,16 +204,16 @@
                     }
                 }
             },
-            "MetricsEventSuccessResponseRecord": {
+            "PostMetricsEventsResponseEntry": {
                 "type": "object",
                 "properties": {
                     "error_code": {
                         "type": "string",
-                        "description": "The error code from the metrics events stream. Value set if Result is Error"
+                        "description": "Error code if the individual metrics event failed to be sent"
                     },
                     "result": {
                         "type": "string",
-                        "description": "Processing result for the input record"
+                        "description": "Result for the processed individual metrics event. Expected value: \"Error\" or \"Ok\""
                     }
                 }
             }

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -120,7 +120,7 @@ namespace AZ
             // Register Precompiled Shader Builder
             AssetBuilderSDK::AssetBuilderDesc precompiledShaderBuilderDescriptor;
             precompiledShaderBuilderDescriptor.m_name = "Precompiled Shader Builder";
-            precompiledShaderBuilderDescriptor.m_version = 10; // ATOM-15472
+            precompiledShaderBuilderDescriptor.m_version = 11; // ATOM-15740
             precompiledShaderBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*.%s", AZ::PrecompiledShaderBuilder::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             precompiledShaderBuilderDescriptor.m_busId = azrtti_typeid<PrecompiledShaderBuilder>();
             precompiledShaderBuilderDescriptor.m_createJobFunction = AZStd::bind(&PrecompiledShaderBuilder::CreateJobs, &m_precompiledShaderBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/PrecompiledShaderBuilder.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/PrecompiledShaderBuilder.cpp
@@ -68,20 +68,23 @@ namespace AZ
             {
                 AZStd::vector<AssetBuilderSDK::JobDependency> jobDependencyList;
 
-                // setup dependencies on the root azshadervariant asset file names
-                for (const auto& rootShaderVariantAsset : precompiledShaderAsset.m_rootShaderVariantAssets)
+                // setup dependencies on the root azshadervariant asset file names, for each supervariant
+                for (const auto& supervariant : precompiledShaderAsset.m_supervariants)
                 {
-                    AZStd::string rootShaderVariantAssetPath = RPI::AssetUtils::ResolvePathReference(request.m_sourceFile.c_str(), rootShaderVariantAsset->m_rootShaderVariantAssetFileName);
-                    AssetBuilderSDK::SourceFileDependency sourceDependency;
-                    sourceDependency.m_sourceFileDependencyPath = rootShaderVariantAssetPath;
-                    response.m_sourceFileDependencyList.push_back(sourceDependency);
+                    for (const auto& rootShaderVariantAsset : supervariant->m_rootShaderVariantAssets)
+                    {
+                        AZStd::string rootShaderVariantAssetPath = RPI::AssetUtils::ResolvePathReference(request.m_sourceFile.c_str(), rootShaderVariantAsset->m_rootShaderVariantAssetFileName);
+                        AssetBuilderSDK::SourceFileDependency sourceDependency;
+                        sourceDependency.m_sourceFileDependencyPath = rootShaderVariantAssetPath;
+                        response.m_sourceFileDependencyList.push_back(sourceDependency);
 
-                    AssetBuilderSDK::JobDependency jobDependency;
-                    jobDependency.m_jobKey = "azshadervariant";
-                    jobDependency.m_platformIdentifier = platformInfo.m_identifier;
-                    jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
-                    jobDependency.m_sourceFile = sourceDependency;
-                    jobDependencyList.push_back(jobDependency);
+                        AssetBuilderSDK::JobDependency jobDependency;
+                        jobDependency.m_jobKey = "azshadervariant";
+                        jobDependency.m_platformIdentifier = platformInfo.m_identifier;
+                        jobDependency.m_type = AssetBuilderSDK::JobDependencyType::Order;
+                        jobDependency.m_sourceFile = sourceDependency;
+                        jobDependencyList.push_back(jobDependency);
+                    }
                 }
 
                 AssetBuilderSDK::JobDescriptor job;
@@ -137,33 +140,37 @@ namespace AZ
 
         AssetBuilderSDK::JobProduct jobProduct;
 
-        // load the variant product assets
+        // load the variant product assets, for each supervariant
         // these are the dependency root variant asset products that were processed prior to running this job
-        RPI::ShaderAssetCreator::ShaderRootVariantAssets rootVariantProductAssets;
-        for (AZStd::unique_ptr<RPI::RootShaderVariantAssetSourceData>& rootShaderVariantAsset : precompiledShaderAsset.m_rootShaderVariantAssets)
+        RPI::ShaderAssetCreator::ShaderSupervariants supervariants;
+        for (const auto& supervariant : precompiledShaderAsset.m_supervariants)
         {
-            // retrieve the variant asset
-            auto assetOutcome = RPI::AssetUtils::LoadAsset<RPI::ShaderVariantAsset>(request.m_fullPath, rootShaderVariantAsset->m_rootShaderVariantAssetFileName, 0);
-            if (!assetOutcome)
+            RPI::ShaderAssetCreator::ShaderRootVariantAssets rootVariantProductAssets;
+            for (const auto& rootShaderVariantAsset : supervariant->m_rootShaderVariantAssets)
             {
-                AZ_Error(PrecompiledShaderBuilderName, false, "Failed to retrieve Variant asset for file [%s]", rootShaderVariantAsset->m_rootShaderVariantAssetFileName.c_str());
-                return;
+                // retrieve the variant asset
+                auto assetOutcome = RPI::AssetUtils::LoadAsset<RPI::ShaderVariantAsset>(request.m_fullPath, rootShaderVariantAsset->m_rootShaderVariantAssetFileName, 0);
+                if (!assetOutcome)
+                {
+                    AZ_Error(PrecompiledShaderBuilderName, false, "Failed to retrieve Variant asset for file [%s]", rootShaderVariantAsset->m_rootShaderVariantAssetFileName.c_str());
+                    return;
+                }
+
+                rootVariantProductAssets.push_back(AZStd::make_pair(RHI::APIType{ rootShaderVariantAsset->m_apiName.GetCStr() }, assetOutcome.GetValue()));
+
+                AssetBuilderSDK::ProductDependency productDependency;
+                productDependency.m_dependencyId = assetOutcome.GetValue().GetId();
+                productDependency.m_flags = AZ::Data::ProductDependencyInfo::CreateFlags(AZ::Data::AssetLoadBehavior::PreLoad);
+                jobProduct.m_dependencies.push_back(productDependency);
             }
 
-            rootVariantProductAssets.push_back(AZStd::make_pair(RHI::APIType{ rootShaderVariantAsset->m_apiName.GetCStr() }, assetOutcome.GetValue()));
-
-            AssetBuilderSDK::ProductDependency productDependency;
-            productDependency.m_dependencyId = assetOutcome.GetValue().GetId();
-            productDependency.m_flags = AZ::Data::ProductDependencyInfo::CreateFlags(AZ::Data::AssetLoadBehavior::PreLoad);
-            jobProduct.m_dependencies.push_back(productDependency);
+            supervariants.push_back({ supervariant->m_name, rootVariantProductAssets });
         }
 
         // use the ShaderAssetCreator to clone the shader asset, which  will update the embedded Srg and Variant asset UUIDs
         // Note that the Srg and Variant assets do not have embedded asset references and are processed with the RC Copy functionality
         RPI::ShaderAssetCreator shaderAssetCreator;
-        shaderAssetCreator.Clone(Uuid::CreateRandom(),
-            *shaderAsset,
-            rootVariantProductAssets);
+        shaderAssetCreator.Clone(Uuid::CreateRandom(), *shaderAsset, supervariants);
 
         Data::Asset<RPI::ShaderAsset> outputShaderAsset;
         if (!shaderAssetCreator.End(outputShaderAsset))

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBlendDistance.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBlendDistance.precompiledshader
@@ -7,21 +7,28 @@
         "ShaderAssetFileName": "diffuseprobegridblenddistance.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc", 
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants":
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridblenddistance_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridblenddistance_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridblenddistance_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets":
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridblenddistance_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridblenddistance_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridblenddistance_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBlendIrradiance.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBlendIrradiance.precompiledshader
@@ -7,21 +7,28 @@
         "ShaderAssetFileName": "diffuseprobegridblendirradiance.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc", 
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants":
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridblendirradiance_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridblendirradiance_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridblendirradiance_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets":
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridblendirradiance_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridblendirradiance_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridblendirradiance_null_0.azshadervariant"
+                    }
+               ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBorderUpdateColumn.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBorderUpdateColumn.precompiledshader
@@ -5,23 +5,30 @@
     "ClassData":
     {
         "ShaderAssetFileName": "diffuseprobegridborderupdatecolumn.azshader",
-        "PlatformIdentifiers": 
+        "PlatformIdentifiers":
         [
-            "pc", "linux"
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants":
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridborderupdatecolumn_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridborderupdatecolumn_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridborderupdatecolumn_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridborderupdatecolumn_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridborderupdatecolumn_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridborderupdatecolumn_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBorderUpdateRow.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridBorderUpdateRow.precompiledshader
@@ -2,26 +2,31 @@
     "Type": "JsonSerialization",
     "Version": 1,
     "ClassName": "PrecompiledShaderAssetSourceData",
-    "ClassData":
-    {
+    "ClassData": {
         "ShaderAssetFileName": "diffuseprobegridborderupdaterow.azshader",
-        "PlatformIdentifiers": 
-        [
-            "pc", "linux"
+        "PlatformIdentifiers": [
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants": 
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridborderupdaterow_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridborderupdaterow_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridborderupdaterow_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridborderupdaterow_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridborderupdaterow_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridborderupdaterow_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridClassification.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridClassification.precompiledshader
@@ -7,21 +7,28 @@
         "ShaderAssetFileName": "diffuseprobegridclassification.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants":
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridclassification_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridclassification_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridclassification_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets":
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridclassification_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridclassification_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridclassification_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracing.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracing.precompiledshader
@@ -2,26 +2,32 @@
     "Type": "JsonSerialization",
     "Version": 1,
     "ClassName": "PrecompiledShaderAssetSourceData",
-    "ClassData":
+    "ClassData": 
     {
         "ShaderAssetFileName": "diffuseprobegridraytracing.azshader",
-        "PlatformIdentifiers": 
-        [
-            "pc", "linux"
+        "PlatformIdentifiers": [
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants": 
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracing_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracing_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracing_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracing_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracing_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracing_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingClosestHit.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingClosestHit.precompiledshader
@@ -2,26 +2,33 @@
     "Type": "JsonSerialization",
     "Version": 1,
     "ClassName": "PrecompiledShaderAssetSourceData",
-    "ClassData":
+    "ClassData": 
     {
         "ShaderAssetFileName": "diffuseprobegridraytracingclosesthit.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants": 
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracingclosesthit_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracingclosesthit_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracingclosesthit_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracingclosesthit_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracingclosesthit_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracingclosesthit_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingMiss.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRayTracingMiss.precompiledshader
@@ -2,26 +2,33 @@
     "Type": "JsonSerialization",
     "Version": 1,
     "ClassName": "PrecompiledShaderAssetSourceData",
-    "ClassData":
+    "ClassData": 
     {
         "ShaderAssetFileName": "diffuseprobegridraytracingmiss.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants": 
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracingmiss_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracingmiss_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridraytracingmiss_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracingmiss_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracingmiss_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridraytracingmiss_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRelocation.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRelocation.precompiledshader
@@ -2,26 +2,33 @@
     "Type": "JsonSerialization",
     "Version": 1,
     "ClassName": "PrecompiledShaderAssetSourceData",
-    "ClassData":
+    "ClassData": 
     {
         "ShaderAssetFileName": "diffuseprobegridrelocation.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants": 
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridrelocation_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridrelocation_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridrelocation_null_0.azshadervariant"
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridrelocation_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridrelocation_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridrelocation_null_0.azshadervariant"
+                    }
+                ]
             }
         ]
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRender.precompiledshader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/DiffuseGlobalIllumination/DiffuseProbeGridRender.precompiledshader
@@ -7,22 +7,29 @@
         "ShaderAssetFileName": "diffuseprobegridrender.azshader",
         "PlatformIdentifiers": 
         [
-            "pc", "linux"
+            "pc",
+            "linux"
         ],
-        "RootShaderVariantAssets":
+        "Supervariants": 
         [
             {
-                "APIName": "dx12",
-                "RootShaderVariantAssetFileName": "diffuseprobegridrender_dx12_0.azshadervariant"
-            },
-            {
-                "APIName": "vulkan",
-                "RootShaderVariantAssetFileName": "diffuseprobegridrender_vulkan_0.azshadervariant"
-            },
-            {
-                "APIName": "null",
-                "RootShaderVariantAssetFileName": "diffuseprobegridrender_null_0.azshadervariant"
-            }      
+                "Name": "",
+                "RootShaderVariantAssets": 
+                [
+                    {
+                        "APIName": "dx12",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridrender_dx12_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "vulkan",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridrender_vulkan_0.azshadervariant"
+                    },
+                    {
+                        "APIName": "null",
+                        "RootShaderVariantAssetFileName": "diffuseprobegridrender_null_0.azshadervariant"
+                    }
+                ]
+            }
         ]
     }
 }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.h
@@ -17,14 +17,14 @@ namespace AZ
 
     namespace RPI
     {
-        //! This asset contains is loaded from a Json file and contains information about
+        //! This asset is loaded from a Json file and contains information about
         //! precompiled shader variants and their associated API name.
-        struct RootShaderVariantAssetSourceData final
+        struct PrecompiledRootShaderVariantAssetSourceData final
             : public Data::AssetData
         {
         public:
-            AZ_RTTI(RootShaderVariantAssetSourceData, "{661EF8A7-7BAC-41B6-AD5C-C7249B2390AD}");
-            AZ_CLASS_ALLOCATOR(RootShaderVariantAssetSourceData, SystemAllocator, 0);
+            AZ_RTTI(PrecompiledRootShaderVariantAssetSourceData, "{661EF8A7-7BAC-41B6-AD5C-C7249B2390AD}");
+            AZ_CLASS_ALLOCATOR(PrecompiledRootShaderVariantAssetSourceData, SystemAllocator, 0);
 
             static void Reflect(ReflectContext* context);
 
@@ -32,7 +32,22 @@ namespace AZ
             AZStd::string m_rootShaderVariantAssetFileName;
         };
 
-        //! This asset contains is loaded from a Json file and contains information about
+        //! This asset is loaded from a Json file and contains information about
+        //! precompiled shader supervariants
+        struct PrecompiledSupervariantSourceData final
+            : public Data::AssetData
+        {
+        public:
+            AZ_RTTI(PrecompiledSupervariantSourceData, "{630BDF15-CE7C-4E2C-882E-4F7AF09C8BB6}");
+            AZ_CLASS_ALLOCATOR(PrecompiledSupervariantSourceData, SystemAllocator, 0);
+
+            static void Reflect(ReflectContext* context);
+
+            AZ::Name m_name;
+            AZStd::vector<AZStd::unique_ptr<PrecompiledRootShaderVariantAssetSourceData>> m_rootShaderVariantAssets;
+        };
+
+        //! This asset is loaded from a Json file and contains information about
         //! precompiled shader assets.
         struct PrecompiledShaderAssetSourceData final
             : public Data::AssetData
@@ -45,7 +60,7 @@ namespace AZ
 
             AZStd::string m_shaderAssetFileName;
             AZStd::vector<AZStd::string> m_platformIdentifiers;
-            AZStd::vector<AZStd::unique_ptr<RootShaderVariantAssetSourceData>> m_rootShaderVariantAssets;
+            AZStd::vector<AZStd::unique_ptr<PrecompiledSupervariantSourceData>> m_supervariants;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAssetCreator.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Shader/ShaderAssetCreator.h
@@ -75,11 +75,20 @@ namespace AZ
 
             bool End(Data::Asset<ShaderAsset>& shaderAsset);
 
-            //! Clones an existing ShaderAsset nd replaces the referenced Srg and Variant assets
-            using ShaderRootVariantAssets = AZStd::vector<AZStd::pair<AZ::Crc32, Data::Asset<RPI::ShaderVariantAsset>>>;
+            //! Clones an existing ShaderAsset and replaces the ShaderVariant assets
+            using ShaderRootVariantAssetPair = AZStd::pair<AZ::Crc32, Data::Asset<RPI::ShaderVariantAsset>>;
+            using ShaderRootVariantAssets = AZStd::vector<ShaderRootVariantAssetPair>;
+
+            struct ShaderSupervariant
+            {
+                AZ::Name m_name;
+                ShaderRootVariantAssets m_rootVariantAssets;
+            };
+            using ShaderSupervariants = AZStd::vector<ShaderSupervariant>;
+
             void Clone(const Data::AssetId& assetId,
                        const ShaderAsset& sourceShaderAsset,
-                       const ShaderRootVariantAssets& rootVariantAssets);
+                       const ShaderSupervariants& supervariants);
 
         private:
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/PrecompiledShaderAssetSourceData.cpp
@@ -14,29 +14,43 @@ namespace AZ
 {
     namespace RPI
     {
-        void RootShaderVariantAssetSourceData::Reflect(ReflectContext* context)
+        void PrecompiledRootShaderVariantAssetSourceData::Reflect(ReflectContext* context)
         {
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
-                serializeContext->Class<RootShaderVariantAssetSourceData>()
+                serializeContext->Class<PrecompiledRootShaderVariantAssetSourceData>()
                     ->Version(0)
-                    ->Field("APIName", &RootShaderVariantAssetSourceData::m_apiName)
-                    ->Field("RootShaderVariantAssetFileName", &RootShaderVariantAssetSourceData::m_rootShaderVariantAssetFileName)
+                    ->Field("APIName", &PrecompiledRootShaderVariantAssetSourceData::m_apiName)
+                    ->Field("RootShaderVariantAssetFileName", &PrecompiledRootShaderVariantAssetSourceData::m_rootShaderVariantAssetFileName)
+                    ;
+            }
+        }
+
+        void PrecompiledSupervariantSourceData::Reflect(ReflectContext* context)
+        {
+            PrecompiledRootShaderVariantAssetSourceData::Reflect(context);
+
+            if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
+            {
+                serializeContext->Class<PrecompiledSupervariantSourceData>()
+                    ->Version(0)
+                    ->Field("Name", &PrecompiledSupervariantSourceData::m_name)
+                    ->Field("RootShaderVariantAssets", &PrecompiledSupervariantSourceData::m_rootShaderVariantAssets)
                     ;
             }
         }
 
         void PrecompiledShaderAssetSourceData::Reflect(ReflectContext* context)
         {
-            RootShaderVariantAssetSourceData::Reflect(context);
+            PrecompiledSupervariantSourceData::Reflect(context);
 
             if (auto* serializeContext = azrtti_cast<SerializeContext*>(context))
             {
                 serializeContext->Class<PrecompiledShaderAssetSourceData>()
-                    ->Version(1) // ATOM-15472
+                    ->Version(2) // ATOM-15740
                     ->Field("ShaderAssetFileName", &PrecompiledShaderAssetSourceData::m_shaderAssetFileName)
                     ->Field("PlatformIdentifiers", &PrecompiledShaderAssetSourceData::m_platformIdentifiers)
-                    ->Field("RootShaderVariantAssets", &PrecompiledShaderAssetSourceData::m_rootShaderVariantAssets)
+                    ->Field("Supervariants", &PrecompiledShaderAssetSourceData::m_supervariants)
                     ;
             }
         }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Shader/ShaderAssetCreator.cpp
@@ -382,7 +382,7 @@ namespace AZ
             return EndCommon(shaderAsset);
         }
 
-        void ShaderAssetCreator::Clone(const Data::AssetId& assetId, const ShaderAsset& sourceShaderAsset, [[maybe_unused]] const ShaderRootVariantAssets& rootVariantAssets)
+        void ShaderAssetCreator::Clone(const Data::AssetId& assetId, const ShaderAsset& sourceShaderAsset, [[maybe_unused]] const ShaderSupervariants& supervariants)
         {
             BeginCommon(assetId);
 
@@ -392,38 +392,60 @@ namespace AZ
             m_asset->m_shaderOptionGroupLayout = sourceShaderAsset.m_shaderOptionGroupLayout;
             m_asset->m_buildTimestamp = sourceShaderAsset.m_buildTimestamp;
 
-            // copy root variant assets
+            // copy the perAPIShaderData
             for (auto& perAPIShaderData : sourceShaderAsset.m_perAPIShaderData)
             {
-                // find the matching ShaderVariantAsset
-                AZ::Data::Asset<ShaderVariantAsset> foundVariantAsset;
-                for (const auto& variantAsset : rootVariantAssets)
-                {
-                    if (variantAsset.first == perAPIShaderData.m_APIType)
-                    {
-                        foundVariantAsset = variantAsset.second;
-                        break;
-                    }
-                }
-            
-                if (!foundVariantAsset)
-                {
-                    ReportWarning("Failed to find variant asset for API [%d]", perAPIShaderData.m_APIType);
-                }
-            
-                m_asset->m_perAPIShaderData.push_back(perAPIShaderData);
-                if (m_asset->m_perAPIShaderData.back().m_supervariants.empty())
+                if (perAPIShaderData.m_supervariants.empty())
                 {
                     ReportWarning("Attempting to clone a shader asset that has no supervariants for API [%d]", perAPIShaderData.m_APIType);
+                    continue;
                 }
-                else
+
+                if (perAPIShaderData.m_supervariants.size() != supervariants.size())
                 {
-                    // currently we only support one supervariant when cloning
-                    // [GFX TODO][ATOM-15740] Support multiple supervariants in ShaderAssetCreator::Clone
-                    m_asset->m_perAPIShaderData.back().m_supervariants[0].m_rootShaderVariantAsset = foundVariantAsset;
+                    ReportError("Incorrect number of supervariants provided to ShaderAssetCreator::Clone");
+                    return;
+                }
+
+                m_asset->m_perAPIShaderData.push_back(perAPIShaderData);
+
+                // set the supervariants for this API
+                for (auto& supervariant : m_asset->m_perAPIShaderData.back().m_supervariants)
+                {
+                    // find the matching Supervariant by name from the incoming list
+                    ShaderSupervariants::const_iterator itFoundSuperVariant = AZStd::find_if(
+                        supervariants.begin(),
+                        supervariants.end(),
+                        [&supervariant](const ShaderSupervariant& shaderSupervariant)
+                    {
+                        return supervariant.m_name == shaderSupervariant.m_name;
+                    });
+
+                    if (itFoundSuperVariant == supervariants.end())
+                    {
+                        ReportError("Failed to find supervariant [%s]", supervariant.m_name.GetCStr());
+                        return;
+                    }
+
+                    // find the matching ShaderVariantAsset for this API
+                    ShaderRootVariantAssets::const_iterator itFoundRootShaderVariantAsset = AZStd::find_if(
+                        itFoundSuperVariant->m_rootVariantAssets.begin(),
+                        itFoundSuperVariant->m_rootVariantAssets.end(),
+                        [&perAPIShaderData](const ShaderRootVariantAssetPair& rootShaderVariantAsset)
+                    {
+                        return perAPIShaderData.m_APIType == rootShaderVariantAsset.first;
+                    });
+
+                    if (itFoundRootShaderVariantAsset == itFoundSuperVariant->m_rootVariantAssets.end())
+                    {
+                        ReportWarning("Failed to find root shader variant asset for API [%d] Supervariant [%s]", perAPIShaderData.m_APIType, supervariant.m_name.GetCStr());
+                    }
+                    else
+                    {
+                        supervariant.m_rootShaderVariantAsset = itFoundRootShaderVariantAsset->second;
+                    }
                 }
             }
-
         }
     } // namespace RPI
 } // namespace AZ

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ConstantGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ConstantGradientComponent.h
@@ -62,7 +62,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/DitherGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/DitherGradientComponent.h
@@ -77,7 +77,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -69,7 +69,7 @@ namespace GradientSignal
 
         // GradientRequestBus overrides...
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
         // AZ::Data::AssetBus overrides...
         void OnAssetReady(AZ::Data::Asset<AZ::Data::AssetData> asset) override;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/InvertGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/InvertGradientComponent.h
@@ -64,7 +64,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/LevelsGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/LevelsGradientComponent.h
@@ -69,7 +69,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/MixedGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/MixedGradientComponent.h
@@ -99,7 +99,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/PerlinGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/PerlinGradientComponent.h
@@ -70,7 +70,7 @@ namespace GradientSignal
 
         // GradientRequestBus overrides...
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     private:
         PerlinGradientConfig m_configuration;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/PosterizeGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/PosterizeGradientComponent.h
@@ -73,7 +73,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/RandomGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/RandomGradientComponent.h
@@ -61,7 +61,7 @@ namespace GradientSignal
 
         // GradientRequestBus overrides...
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     private:
         RandomGradientConfig m_configuration;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ReferenceGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ReferenceGradientComponent.h
@@ -64,7 +64,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ShapeAreaFalloffGradientComponent.h
@@ -69,7 +69,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/SmoothStepGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/SmoothStepGradientComponent.h
@@ -71,7 +71,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/SurfaceAltitudeGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/SurfaceAltitudeGradientComponent.h
@@ -90,7 +90,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/SurfaceMaskGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/SurfaceMaskGradientComponent.h
@@ -70,7 +70,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/SurfaceSlopeGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/SurfaceSlopeGradientComponent.h
@@ -92,7 +92,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
 
     protected:
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ThresholdGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ThresholdGradientComponent.h
@@ -65,7 +65,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
-        void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const override;
+        void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const override;
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const override;
 
     protected:

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientRequestBus.h
@@ -56,7 +56,7 @@ namespace GradientSignal
          * \param positions The input list of positions to query.
          * \param outValues The output list of values. This list is expected to be the same size as the positions list.
          */
-        virtual void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+        virtual void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
         {
             // Reference implementation of GetValues for any gradients that don't have their own optimized implementations.
             // This is 10%-60% faster than calling GetValue via EBus many times due to the per-call EBus overhead.

--- a/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/GradientSampler.h
@@ -33,7 +33,7 @@ namespace GradientSignal
         static void Reflect(AZ::ReflectContext* context);
 
         inline float GetValue(const GradientSampleParams& sampleParams) const;
-        inline void GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const;
+        inline void GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const;
 
         bool IsEntityInHierarchy(const AZ::EntityId& entityId) const;
 
@@ -147,7 +147,7 @@ namespace GradientSignal
         return output * m_opacity;
     }
 
-    inline void GradientSampler::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    inline void GradientSampler::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         auto ClearOutputValues = [](AZStd::span<float> outValues)
         {

--- a/Gems/GradientSignal/Code/Source/Components/ConstantGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ConstantGradientComponent.cpp
@@ -135,7 +135,7 @@ namespace GradientSignal
     }
 
     void ConstantGradientComponent::GetValues(
-        [[maybe_unused]] AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+        [[maybe_unused]] AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/DitherGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/DitherGradientComponent.cpp
@@ -264,7 +264,7 @@ namespace GradientSignal
         return GetDitherValue(scaledCoordinate, value);
     }
 
-    void DitherGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void DitherGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -219,7 +219,7 @@ namespace GradientSignal
         return 0.0f;
     }
 
-    void ImageGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void ImageGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/InvertGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/InvertGradientComponent.cpp
@@ -137,7 +137,7 @@ namespace GradientSignal
         return output;
     }
 
-    void InvertGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void InvertGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/LevelsGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/LevelsGradientComponent.cpp
@@ -185,7 +185,7 @@ namespace GradientSignal
         return output;
     }
 
-    void LevelsGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void LevelsGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/MixedGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/MixedGradientComponent.cpp
@@ -284,7 +284,7 @@ namespace GradientSignal
         return AZ::GetClamp(result, 0.0f, 1.0f);
     }
 
-    void MixedGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void MixedGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/PerlinGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/PerlinGradientComponent.cpp
@@ -203,7 +203,7 @@ namespace GradientSignal
         return 0.0f;
     }
 
-    void PerlinGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void PerlinGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/PosterizeGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/PosterizeGradientComponent.cpp
@@ -155,7 +155,7 @@ namespace GradientSignal
         return PosterizeValue(input, bands, m_configuration.m_mode);
     }
 
-    void PosterizeGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void PosterizeGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/RandomGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/RandomGradientComponent.cpp
@@ -183,7 +183,7 @@ namespace GradientSignal
         return 0.0f;
     }
 
-    void RandomGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void RandomGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/ReferenceGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ReferenceGradientComponent.cpp
@@ -134,7 +134,7 @@ namespace GradientSignal
         return m_configuration.m_gradientSampler.GetValue(sampleParams);
     }
 
-    void ReferenceGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void ReferenceGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/ShapeAreaFalloffGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ShapeAreaFalloffGradientComponent.cpp
@@ -168,7 +168,7 @@ namespace GradientSignal
         return (distance <= 0.0f) ? 1.0f : AZ::GetMax(1.0f - (distance / m_configuration.m_falloffWidth), 0.0f);
     }
 
-    void ShapeAreaFalloffGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void ShapeAreaFalloffGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/SmoothStepGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SmoothStepGradientComponent.cpp
@@ -172,7 +172,7 @@ namespace GradientSignal
         return m_configuration.m_smoothStep.GetSmoothedValue(value);
     }
 
-    void SmoothStepGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void SmoothStepGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/SurfaceAltitudeGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SurfaceAltitudeGradientComponent.cpp
@@ -211,7 +211,7 @@ namespace GradientSignal
         return CalculateAltitudeRatio(points, m_configuration.m_altitudeMin, m_configuration.m_altitudeMax);
     }
 
-    void SurfaceAltitudeGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void SurfaceAltitudeGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/SurfaceMaskGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SurfaceMaskGradientComponent.cpp
@@ -175,7 +175,7 @@ namespace GradientSignal
         return result;
     }
 
-    void SurfaceMaskGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void SurfaceMaskGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/SurfaceSlopeGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/SurfaceSlopeGradientComponent.cpp
@@ -215,7 +215,7 @@ namespace GradientSignal
         return GetSlopeRatio(points, angleMin, angleMax);
     }
 
-    void SurfaceSlopeGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void SurfaceSlopeGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/GradientSignal/Code/Source/Components/ThresholdGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ThresholdGradientComponent.cpp
@@ -141,7 +141,7 @@ namespace GradientSignal
         return (m_configuration.m_gradientSampler.GetValue(sampleParams) <= m_configuration.m_threshold) ? 0.0f : 1.0f;
     }
 
-    void ThresholdGradientComponent::GetValues(AZStd::span<AZ::Vector3> positions, AZStd::span<float> outValues) const
+    void ThresholdGradientComponent::GetValues(AZStd::span<const AZ::Vector3> positions, AZStd::span<float> outValues) const
     {
         if (positions.size() != outValues.size())
         {

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugSystemComponent.cpp
@@ -386,7 +386,6 @@ namespace Multiplayer
             }
             ImGui::NewLine();
         }
-        ImGui::End();
     }
 
     void DrawMultiplayerStats()
@@ -437,7 +436,6 @@ namespace Multiplayer
             ImGui::EndTable();
             ImGui::NewLine();
         }
-        ImGui::End();
     }
 
     void MultiplayerDebugSystemComponent::OnImGuiUpdate()
@@ -448,6 +446,7 @@ namespace Multiplayer
             {
                 DrawNetworkingStats();
             }
+            ImGui::End();
         }
 
         if (m_displayMultiplayerStats)
@@ -456,6 +455,7 @@ namespace Multiplayer
             {
                 DrawMultiplayerStats();
             }
+            ImGui::End();
         }
 
         if (m_displayPerEntityStats)
@@ -473,6 +473,7 @@ namespace Multiplayer
                     m_reporter->OnImGuiUpdate();
                 }
             }
+            ImGui::End();
         }
 
         if (m_displayHierarchyDebugger)
@@ -489,6 +490,7 @@ namespace Multiplayer
                     m_hierarchyDebugger->OnImGuiUpdate();
                 }
             }
+            ImGui::End();
         }
         else
         {


### PR DESCRIPTION
Fixes Entity Outliner order consistency when creating prefab from selected entities
Signed-off-by: Mikhail Naumov mnaumov@amazon.com

