### PR TITLE
Remove duplicated Jenkins parameters

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -813,7 +813,7 @@ try {
                         }
                     }
 
-                    pipelineProperties.add(parameters(pipelineParameters))
+                    pipelineProperties.add(parameters(pipelineParameters.unique()))
                     properties(pipelineProperties)
 
                     // Stash the INCREMENTAL_BUILD_SCRIPT_PATH since all nodes will use it


### PR DESCRIPTION
Jenkins nightly build has duplicated parameters and duplicates need to be removed.

Signed-off-by: Shirang Jia <shiranj@amazon.com>