### PR TITLE
Handle case where engine.json missing or corrupt

### DIFF
--- a/Code/Tools/ProjectManager/Source/Application.cpp
+++ b/Code/Tools/ProjectManager/Source/Application.cpp
@@ -196,50 +196,43 @@ namespace O3DE::ProjectManager
             return true;
         }
 
-        bool forceRegistration = false;
-
-        // check if an engine with this name is already registered
+        // check if an engine with this name is already registered and has a valid engine.json
         auto existingEngineResult = m_pythonBindings->GetEngineInfo(engineInfo.m_name);
         if (existingEngineResult)
         {
-            const EngineInfo& otherEngineInfo = existingEngineResult.GetValue();
-
-            // only prompt the user about forcing registration if the other engine's engine.json exists
-            if (auto engineSettingsPath = AZ::IO::FixedMaxPath{ otherEngineInfo.m_path.toUtf8().constData() } / "engine.json";
-                AZ::IO::SystemFile::Exists(engineSettingsPath.c_str()))
+            if (!interactive)
             {
-                if (!interactive)
-                {
-                    AZ_Error("Project Manager", false, "An engine with the name %s is already registered with the path %s",
-                        engineInfo.m_name.toUtf8().constData(), engineInfo.m_path.toUtf8().constData());
-                    return false;
-                }
-
-                // get the updated engine name unless the user wants to cancel
-                bool okPressed = false;
-
-                engineInfo.m_name = QInputDialog::getText(nullptr,
-                    QObject::tr("Engine '%1' already registered").arg(engineInfo.m_name),
-                    QObject::tr("An engine named '%1' is already registered.<br /><br />"
-                                "<b>Current path</b><br />%2<br/><br />"
-                                "<b>New path</b><br />%3<br /><br />"
-                                "Press 'OK' to force registration, or provide a new engine name below.<br />"
-                                "Alternatively, press `Cancel` to close the Project Manager and resolve the issue manually.")
-                                .arg(engineInfo.m_name, otherEngineInfo.m_path, engineInfo.m_path),
-                    QLineEdit::Normal,
-                    engineInfo.m_name,
-                    &okPressed);
-
-                if (!okPressed)
-                {
-                    // user elected not to change the name or force registration
-                    return false;
-                }
+                AZ_Error("Project Manager", false, "An engine with the name %s is already registered with the path %s",
+                    engineInfo.m_name.toUtf8().constData(), engineInfo.m_path.toUtf8().constData());
+                return false;
             }
 
-            forceRegistration = true;
+            // get the updated engine name unless the user wants to cancel
+            bool okPressed = false;
+            const EngineInfo& otherEngineInfo = existingEngineResult.GetValue();
+
+            engineInfo.m_name = QInputDialog::getText(nullptr,
+                QObject::tr("Engine '%1' already registered").arg(engineInfo.m_name),
+                QObject::tr("An engine named '%1' is already registered.<br /><br />"
+                            "<b>Current path</b><br />%2<br/><br />"
+                            "<b>New path</b><br />%3<br /><br />"
+                            "Press 'OK' to force registration, or provide a new engine name below.<br />"
+                            "Alternatively, press `Cancel` to close the Project Manager and resolve the issue manually.")
+                            .arg(engineInfo.m_name, otherEngineInfo.m_path, engineInfo.m_path),
+                QLineEdit::Normal,
+                engineInfo.m_name,
+                &okPressed);
+
+            if (!okPressed)
+            {
+                // user elected not to change the name or force registration
+                return false;
+            }
         }
 
+        // always force register in case there is an engine registered in o3de_manifest.json, but
+        // the engine.json is missing or corrupt in which case GetEngineInfo() fails
+        constexpr bool forceRegistration = true;
         auto registerOutcome = m_pythonBindings->SetEngineInfo(engineInfo, forceRegistration);
         if (!registerOutcome)
         {

--- a/Code/Tools/ProjectManager/Source/Application.cpp
+++ b/Code/Tools/ProjectManager/Source/Application.cpp
@@ -202,33 +202,39 @@ namespace O3DE::ProjectManager
         auto existingEngineResult = m_pythonBindings->GetEngineInfo(engineInfo.m_name);
         if (existingEngineResult)
         {
-            if (!interactive)
-            {
-                AZ_Error("Project Manager", false, "An engine with the name %s is already registered with the path %s",
-                    engineInfo.m_name.toUtf8().constData(), engineInfo.m_path.toUtf8().constData());
-                return false;
-            }
-
-            // get the updated engine name unless the user wants to cancel
-            bool okPressed = false;
             const EngineInfo& otherEngineInfo = existingEngineResult.GetValue();
 
-            engineInfo.m_name = QInputDialog::getText(nullptr,
-                QObject::tr("Engine '%1' already registered").arg(engineInfo.m_name),
-                QObject::tr("An engine named '%1' is already registered.<br /><br />"
-                            "<b>Current path</b><br />%2<br/><br />"
-                            "<b>New path</b><br />%3<br /><br />"
-                            "Press 'OK' to force registration, or provide a new engine name below.<br />"
-                            "Alternatively, press `Cancel` to close the Project Manager and resolve the issue manually.")
-                            .arg(engineInfo.m_name, otherEngineInfo.m_path, engineInfo.m_path),
-                QLineEdit::Normal,
-                engineInfo.m_name,
-                &okPressed);
-
-            if (!okPressed)
+            // only prompt the user about forcing registration if the other engine's engine.json exists
+            if (auto engineSettingsPath = AZ::IO::FixedMaxPath{ otherEngineInfo.m_path.toUtf8().constData() } / "engine.json";
+                AZ::IO::SystemFile::Exists(engineSettingsPath.c_str()))
             {
-                // user elected not to change the name or force registration
-                return false;
+                if (!interactive)
+                {
+                    AZ_Error("Project Manager", false, "An engine with the name %s is already registered with the path %s",
+                        engineInfo.m_name.toUtf8().constData(), engineInfo.m_path.toUtf8().constData());
+                    return false;
+                }
+
+                // get the updated engine name unless the user wants to cancel
+                bool okPressed = false;
+
+                engineInfo.m_name = QInputDialog::getText(nullptr,
+                    QObject::tr("Engine '%1' already registered").arg(engineInfo.m_name),
+                    QObject::tr("An engine named '%1' is already registered.<br /><br />"
+                                "<b>Current path</b><br />%2<br/><br />"
+                                "<b>New path</b><br />%3<br /><br />"
+                                "Press 'OK' to force registration, or provide a new engine name below.<br />"
+                                "Alternatively, press `Cancel` to close the Project Manager and resolve the issue manually.")
+                                .arg(engineInfo.m_name, otherEngineInfo.m_path, engineInfo.m_path),
+                    QLineEdit::Normal,
+                    engineInfo.m_name,
+                    &okPressed);
+
+                if (!okPressed)
+                {
+                    // user elected not to change the name or force registration
+                    return false;
+                }
             }
 
             forceRegistration = true;

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -459,6 +459,13 @@ namespace O3DE::ProjectManager
             if (!pybind11::isinstance<pybind11::none>(enginePathResult))
             {
                 engineInfo = EngineInfoFromPath(enginePathResult);
+
+                // handle the case where an engine was registered but the engine.json is missing/corrupt
+                if (!engineInfo.IsValid())
+                {
+                    engineInfo.m_name = engineName;
+                    engineInfo.m_path = Py_To_String(enginePathResult); 
+                }
             }
         });
 

--- a/Code/Tools/ProjectManager/Source/PythonBindings.cpp
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.cpp
@@ -460,12 +460,8 @@ namespace O3DE::ProjectManager
             {
                 engineInfo = EngineInfoFromPath(enginePathResult);
 
-                // handle the case where an engine was registered but the engine.json is missing/corrupt
-                if (!engineInfo.IsValid())
-                {
-                    engineInfo.m_name = engineName;
-                    engineInfo.m_path = Py_To_String(enginePathResult); 
-                }
+                // it is possible an engine is registered in o3de_manifest.json but the engine.json is
+                // missing or corrupt in which case we do not consider it a registered engine
             }
         });
 

--- a/scripts/o3de/o3de/manifest.py
+++ b/scripts/o3de/o3de/manifest.py
@@ -608,7 +608,7 @@ def get_registered(engine_name: str = None,
                     except json.JSONDecodeError as e:
                         logger.warning(f'{engine_json} failed to load: {str(e)}')
                     else:
-                        this_engines_name = engine_json_data['engine_name']
+                        this_engines_name = engine_json_data.get('engine_name','')
                         if this_engines_name == engine_name:
                             return engine_path
         engines_path = json_data.get('engines_path', {})


### PR DESCRIPTION
The previous PR #6984 did not handle the case where an engine was registered but the `engine.json` file was removed or corrupt as is the case for issue #6798.

**Update**
I've pushed and tested a change so that if the other engine's `engine.json` file is missing - which is the case when uninstalled - or corrupt, we do not prompt the user.  We also force registration every time, to handle the case where the old engine.json file is corrupt.  


Prior to this fix, the following repro steps produced this error message on Project Manager start:

![image](https://user-images.githubusercontent.com/26804013/150430253-245ae164-0857-4bff-9ab6-3786a3da4e0b.png)

Repro steps:

1. Download https://o3debinaries.org/stabilization-2111RTE/Latest/Windows/o3de_installer.exe
1. Install in default location (C:/O3DE/0.0.0.0)
1. Uninstall it.
1. Install O3DE in a new location (D:/O3DE/0.0.0.0)

This fix addresses that issue so it displays the correct GUI

![image](https://user-images.githubusercontent.com/26804013/150429856-635edba3-2caf-4087-936a-95226b8907ed.png)

**Testing**
1. Changed my engine name to `o3de-sdk` to match the installer engine name and removed my current engine name and path from the `o3de_manifest.json`
1. Verified my `o3de_manifest.json` still had the `o3de-sdk` engine registered to a path that was no longer valid because I uninstalled it.
1. Ran the Project Manager and verified it detected the registered engine and popped up the correct GUI indicating the problem
1. tested with missing `engine.json`
1. tested with existing `engine.json` with valid data and corrupt data


Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>