### PR TITLE
[development] patch fix for launcher exit crash

### DIFF
--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -10,14 +10,17 @@
 
 #include <AzCore/Casting/numeric_cast.h>
 #include <AzCore/Component/ComponentApplicationLifecycle.h>
+#include <AzCore/Console/IConsole.h>
+#include <AzCore/Debug/BudgetTracker.h>
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/Interface/Interface.h>
 #include <AzCore/IO/Path/Path.h>
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
-#include <AzCore/Console/IConsole.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/StringFunc/StringFunc.h>
 #include <AzCore/Utils/Utils.h>
+
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzFramework/IO/RemoteStorageDrive.h>
 #include <AzFramework/Windowing/NativeWindow.h>
@@ -569,6 +572,16 @@ namespace O3DELauncher
         {
             status = ReturnCode::ErrCrySystemInterface;
         }
+
+    #if !defined(_RELEASE)
+        // until CrySystem can be removed (or made to be managed by the component application),
+        // we need to manually clear the BudgetTracker before CrySystem is unloaded so the Budget
+        // pointer(s) it has references to are cleared properly
+        if (auto budgetTracker = AZ::Interface<AZ::Debug::BudgetTracker>::Get(); budgetTracker)
+        {
+            budgetTracker->Reset();
+        }
+    #endif // !defined(_RELEASE)
 
     #if !defined(AZ_MONOLITHIC_BUILD)
         delete systemInitParams.pSystem;

--- a/Code/LauncherUnified/Launcher.cpp
+++ b/Code/LauncherUnified/Launcher.cpp
@@ -573,6 +573,8 @@ namespace O3DELauncher
             status = ReturnCode::ErrCrySystemInterface;
         }
 
+    #if !defined(AZ_MONOLITHIC_BUILD)
+
     #if !defined(_RELEASE)
         // until CrySystem can be removed (or made to be managed by the component application),
         // we need to manually clear the BudgetTracker before CrySystem is unloaded so the Budget
@@ -583,7 +585,6 @@ namespace O3DELauncher
         }
     #endif // !defined(_RELEASE)
 
-    #if !defined(AZ_MONOLITHIC_BUILD)
         delete systemInitParams.pSystem;
         crySystemLibrary.reset(nullptr);
     #endif // !defined(AZ_MONOLITHIC_BUILD)


### PR DESCRIPTION
The launcher will crash on exit due to an access violation when clearing the `BudgetTracker` after CrySystem is unloaded.  This is from a recent change to how the budget pointers are tracked making the `BudgetTracker` responsible for clearing them so the system can be re-entrant.  Unfortunately, an assumption was made that all modules that use `Budget`s are managed by the `ComponentApplication` so they can be cleared prior to being unloaded.  This is a patch to manually reset the `BudgetTracker` prior to unloading CrySystem until the legacy system can be removed (or converted to an AZ-like module).

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>