### PR TITLE
Atom Tools: updating gem autoload settings registry for ME and SMC to disable script canvas developer gem

### DIFF
--- a/Registry/gem_autoload.materialeditor.setreg
+++ b/Registry/gem_autoload.materialeditor.setreg
@@ -28,6 +28,9 @@
             "ScriptCanvas.Editor": {
                 "AutoLoad": false
             },
+            "ScriptCanvasDeveloper": {
+                "AutoLoad": false
+            },
             "ScriptCanvasPhysics": {
                 "AutoLoad": false
             },

--- a/Registry/gem_autoload.shadermanagementconsole.setreg
+++ b/Registry/gem_autoload.shadermanagementconsole.setreg
@@ -28,6 +28,9 @@
             "ScriptCanvas.Editor": {
                 "AutoLoad": false
             },
+            "ScriptCanvasDeveloper": {
+                "AutoLoad": false
+            },
             "ScriptCanvasPhysics": {
                 "AutoLoad": false
             },


### PR DESCRIPTION
Script canvas and related gems were already being disabled for some atom tools. The script canvas developer gem was not added initially because it’s not used in automated testing or other common projects.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>