### PR TITLE
[development] fixed configure error with monolithic builds

### DIFF
--- a/Code/Tools/AWSNativeSDKInit/CMakeLists.txt
+++ b/Code/Tools/AWSNativeSDKInit/CMakeLists.txt
@@ -25,28 +25,28 @@ ly_add_target(
             AZ::AzCore
 )
 
-ly_add_target(
-    NAME AWSNativeSDKTestLibs STATIC
-    NAMESPACE AZ
-    FILES_CMAKE
-        aws_native_sdk_test_files.cmake
-    INCLUDE_DIRECTORIES
-        PUBLIC
-            include
-            tests/libs
-        PRIVATE
-            source
-    BUILD_DEPENDENCIES
-        PRIVATE
-            3rdParty::AWSNativeSDK::Core
-            AZ::AzCore
-            AZ::AzTest
-)
-
 ################################################################################
 # Tests
 ################################################################################
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
+    ly_add_target(
+        NAME AWSNativeSDKTestLibs STATIC
+        NAMESPACE AZ
+        FILES_CMAKE
+            aws_native_sdk_test_files.cmake
+        INCLUDE_DIRECTORIES
+            PUBLIC
+                include
+                tests/libs
+            PRIVATE
+                source
+        BUILD_DEPENDENCIES
+            PRIVATE
+                3rdParty::AWSNativeSDK::Core
+                AZ::AzCore
+                AZ::AzTest
+    )
+
     ly_add_target(
         NAME AWSNativeSDKInit.Tests ${PAL_TRAIT_TEST_TARGET_TYPE}
         NAMESPACE AZ


### PR DESCRIPTION
The `AWSNativeSDKTestLibs` target is now only defined when tests are enabled

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>