### PR TITLE
Fire OnEditorEntityCreated notification in SandboxIntegrationManager::CreateNewEntityAtPosition

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/AreaNodes_DependentComponentsAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/AreaNodes_DependentComponentsAdded.py
@@ -69,7 +69,7 @@ def AreaNodes_DependentComponentsAdded():
 
     # Open an existing simple level
     helper.init_idle()
-    helper.open_level("Physics", "Base")
+    helper.open_level("", "Base")
 
     # Open Landscape Canvas tool and verify
     general.open_pane('Landscape Canvas')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/TestSuite_Main_Optimized.py
@@ -12,6 +12,13 @@ import ly_test_tools.environment.file_system as file_system
 import ly_test_tools._internal.pytest_plugin as internal_plugin
 from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorSharedTest, EditorParallelTest, EditorTestSuite
 
+@pytest.mark.SUITE_periodic
+@pytest.mark.parametrize("launcher_platform", ['windows_editor'])
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+class TestAutomationWithPrefabSystemEnabled(EditorTestSuite):
+
+    class test_LandscapeCanvas_AreaNodes_DependentComponentsAdded(EditorSharedTest):
+        from .EditorScripts import AreaNodes_DependentComponentsAdded as test_module
 
 @pytest.mark.SUITE_periodic
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
@@ -25,9 +32,6 @@ class TestAutomation(EditorTestSuite):
 
     class test_LandscapeCanvas_GradientMixer_NodeConstruction(EditorSharedTest):
         from .EditorScripts import GradientMixer_NodeConstruction as test_module
-
-    class test_LandscapeCanvas_AreaNodes_DependentComponentsAdded(EditorSharedTest):
-        from .EditorScripts import AreaNodes_DependentComponentsAdded as test_module
 
     class test_LandscapeCanvas_AreaNodes_EntityCreatedOnNodeAdd(EditorSharedTest):
         from .EditorScripts import AreaNodes_EntityCreatedOnNodeAdd as test_module

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextBus.h
@@ -63,8 +63,11 @@ namespace AzToolsFramework
         /// Registers an existing set of entities with the editor context.
         virtual void AddEditorEntities(const EntityList& entities) = 0;
 
-        /// Registers an existing set of entities with the editor context.
+        /// Triggers registered callbacks for an existing set of entities with the editor context.
         virtual void HandleEntitiesAdded(const EntityList& entities) = 0;
+
+        /// Creates an editor ready entity, and sends out notification for the creation.
+        virtual void FinalizeEditorEntity(AZ::Entity* entity) = 0;
 
         /// Destroys an entity in the editor context.
         /// \return whether or not the entity was destroyed. A false return value signifies the entity did not belong to the game context.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -272,11 +272,11 @@ namespace AzToolsFramework
             return;
         }
 
-        SetupEditorEntity(entity);
-
         // Store creation undo command.
         if (m_isLegacySliceService)
         {
+            SetupEditorEntity(entity);
+
             ScopedUndoBatch undoBatch("Create Entity");
 
             EntityCreateCommand* command = aznew EntityCreateCommand(static_cast<AZ::u64>(entity->GetId()));

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -227,14 +227,8 @@ namespace AzToolsFramework
     {
         AZ::Entity* entity = CreateEntity(name);
         AZ_Assert(entity != nullptr, "Entity with name %s couldn't be created.", name);
-        if (m_isLegacySliceService)
-        {
-            FinalizeEditorEntity(entity);
-        }
-        else
-        {
-            EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnEditorEntityCreated, entity->GetId());
-        }
+        FinalizeEditorEntity(entity);
+
         return entity->GetId();
     }
 
@@ -263,14 +257,7 @@ namespace AzToolsFramework
         entity = aznew AZ::Entity(entityId, name);
         AZ_Assert(entity != nullptr, "Entity with name %s couldn't be created.", name);
         AddEntity(entity);
-        if (m_isLegacySliceService)
-        {
-            FinalizeEditorEntity(entity);
-        }
-        else
-        {
-            EditorEntityContextNotificationBus::Broadcast(&EditorEntityContextNotification::OnEditorEntityCreated, entity->GetId());
-        }
+        FinalizeEditorEntity(entity);
 
         return entity->GetId();
     }
@@ -284,9 +271,11 @@ namespace AzToolsFramework
         {
             return;
         }
+
         SetupEditorEntity(entity);
 
         // Store creation undo command.
+        if (m_isLegacySliceService)
         {
             ScopedUndoBatch undoBatch("Create Entity");
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.h
@@ -81,6 +81,7 @@ namespace AzToolsFramework
         void AddEditorEntity(AZ::Entity* entity) override;
         void AddEditorEntities(const EntityList& entities) override;
         void HandleEntitiesAdded(const EntityList& entities) override;
+        void FinalizeEditorEntity(AZ::Entity* entity) override;
         bool CloneEditorEntities(const EntityIdList& sourceEntities, 
                                  EntityList& resultEntities,
                                  AZ::SliceComponent::EntityIdToEntityIdMap& sourceToCloneEntityIdMap) override;
@@ -142,12 +143,8 @@ namespace AzToolsFramework
         }
 
     protected:
-
         void OnContextEntitiesAdded(const EntityList& entities) override;
         void OnContextEntityRemoved(const AZ::EntityId& id) override;
-
-        // Helper function for creating editor ready entities.
-        void FinalizeEditorEntity(AZ::Entity* entity);
 
         void SetupEditorEntity(AZ::Entity* entity);
         void SetupEditorEntities(const EntityList& entities);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -644,6 +644,7 @@ namespace AzToolsFramework
             entityOwningInstance.AddEntity(*entity, entityAlias);
 
             EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequestBus::Events::HandleEntitiesAdded, EntityList{entity});
+            EditorEntityContextRequestBus::Broadcast(&EditorEntityContextRequestBus::Events::FinalizeEditorEntity, entity);
 
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             transform.SetTranslation(position);


### PR DESCRIPTION
Bug fix for #6573 .

Currently if prefab system enabled, `SandboxIntegrationManager::CreateNewEntityAtPosition` will not fire `EditorEntityContextNotification::OnEditorEntityCreated` notification, causing the error in automated tests while setting prefab system enabled flag to true.

The test mentioned in #6573 with the repro steps taken passed  after the fix applied.

Tested using the following command:
`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\largeworlds\landscape_canvas\TestSuite_Periodic.py::TestAutomation::test_LandscapeCanvas_AreaNodes_DependentComponentsAdded --build-directory windows_vs2019\bin\profile`
