### PR TITLE
Combining the original scene manifest with the new manifest

### DIFF
--- a/Gems/Blast/Editor/Scripts/blast_asset_builder.py
+++ b/Gems/Blast/Editor/Scripts/blast_asset_builder.py
@@ -15,7 +15,7 @@ manifest that writes out asset chunk data for .blast files
 import os, traceback, binascii, sys, json, pathlib
 import azlmbr.math
 import azlmbr.asset
-import azlmbr.asset.entity
+import azlmbr.entity
 import azlmbr.asset.builder
 import azlmbr.bus
 

--- a/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
+++ b/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
@@ -12,10 +12,10 @@ into a scene manifest
 This is also a SceneAPI script that executes from a foo.fbx.assetinfo scene
 manifest that writes out asset chunk data for .blast files
 """
-import os, traceback, binascii, sys, json, pathlib
+import os, traceback, binascii, sys, json, pathlib, logging
 import azlmbr.math
 import azlmbr.asset
-import azlmbr.asset.entity
+import azlmbr.entity
 import azlmbr.asset.builder
 import azlmbr.bus
 
@@ -23,6 +23,14 @@ import azlmbr.bus
 # SceneAPI Processor
 #
 blastChunksAssetType = azlmbr.math.Uuid_CreateString('{993F0B0F-37D9-48C6-9CC2-E27D3F3E343E}', 0)
+
+def log_exception_traceback():
+    """
+    Outputs an exception stacktrace.
+    """
+    data = traceback.format_exc()
+    logger = logging.getLogger('python')
+    logger.error(data)
 
 def export_chunk_asset(scene, outputDirectory, platformIdentifier, productList):
     import azlmbr.scene
@@ -97,7 +105,7 @@ def get_mesh_node_names(sceneGraph):
     return meshDataList
 
 def update_manifest(scene):
-    import uuid, os
+    import uuid, os, json
     import azlmbr.scene as sceneApi
     import azlmbr.scene.graph
     from scene_api import scene_data as sceneData
@@ -116,6 +124,9 @@ def update_manifest(scene):
         meshGroup['id'] = '{' + str(uuid.uuid5(uuid.NAMESPACE_DNS, sourceFilenameOnly + chunkPath)) + '}'
         sceneManifest.mesh_group_select_node(meshGroup, chunkPath)
 
+    # combine both scene manifests so the the OnPrepareForExport will be called
+    originalManifest = json.loads(scene.manifest.ExportToJson())
+    sceneManifest.manifest["values"].append(originalManifest["values"][0])
     return sceneManifest.export()
 
 sceneJobHandler = None

--- a/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
+++ b/Gems/Blast/Editor/Scripts/blast_chunk_processor.py
@@ -124,7 +124,7 @@ def update_manifest(scene):
         meshGroup['id'] = '{' + str(uuid.uuid5(uuid.NAMESPACE_DNS, sourceFilenameOnly + chunkPath)) + '}'
         sceneManifest.mesh_group_select_node(meshGroup, chunkPath)
 
-    # combine both scene manifests so the the OnPrepareForExport will be called
+    # combine both scene manifests so the OnPrepareForExport will be called
     originalManifest = json.loads(scene.manifest.ExportToJson())
     sceneManifest.manifest["values"].append(originalManifest["values"][0])
     return sceneManifest.export()

--- a/Gems/Blast/Editor/Scripts/bootstrap.py
+++ b/Gems/Blast/Editor/Scripts/bootstrap.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 """
 try:
     import azlmbr.asset
-    import azlmbr.asset.entity
+    import azlmbr.entity
     import azlmbr.asset.builder
     import blast_asset_builder
 except:


### PR DESCRIPTION
Combining the original scene manifest with the new manifest to allow the OnPrepareForExport to execute
Renamed 'azlmbr.asset.entity' to 'azlmbr.entity' updated as well
Results in a .blast_chunks product asset now


Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>