### PR TITLE
Refactored the styling of TableView header sections

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Style.cpp
@@ -411,18 +411,6 @@ namespace AzQtComponents
             }
             break;
 
-            case CE_HeaderSection:
-            {
-                if (qobject_cast<const QHeaderView*>(widget))
-                {
-                    if (TableView::drawHeaderSection(this, option, painter, widget, m_data->tableViewConfig))
-                    {
-                        return;
-                    }
-                }
-            }
-            break;
-
             case CE_ComboBoxLabel:
             {
                 if (qobject_cast<const QComboBox*>(widget))

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.cpp
@@ -38,7 +38,6 @@ namespace AzQtComponents
         ConfigHelpers::read<qreal>(settings, QStringLiteral("FocusBorderWidth"), config.focusBorderWidth);
         ConfigHelpers::read<QColor>(settings, QStringLiteral("FocusBorderColor"), config.focusBorderColor);
         ConfigHelpers::read<QColor>(settings, QStringLiteral("FocusFillColor"), config.focusFillColor);
-        ConfigHelpers::read<QColor>(settings, QStringLiteral("HeaderFillColor"), config.headerFillColor);
         settings.endGroup();
 
         return config;
@@ -52,7 +51,6 @@ namespace AzQtComponents
         config.focusBorderWidth = 1;
         config.focusBorderColor = QStringLiteral("#94D2FF");
         config.focusFillColor = QStringLiteral("#10ffffff");
-        config.headerFillColor = QStringLiteral("#2d2d2d");
 
         return config;
     }
@@ -173,22 +171,6 @@ namespace AzQtComponents
             painter->drawRect(option->rect.left(), option->rect.top() + 1, config.borderWidth, option->rect.height() - 2);
             painter->restore();
         }
-
-        return true;
-    }
-
-    bool TableView::drawHeaderSection(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config)
-    {
-        Q_UNUSED(widget);
-        Q_UNUSED(style);
-
-        const auto headerViewOption = qstyleoption_cast<const QStyleOptionHeader*>(option);
-        if (!headerViewOption)
-        {
-            return false;
-        }
-
-        painter->fillRect(headerViewOption->rect, config.headerFillColor);
 
         return true;
     }

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.h
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.h
@@ -62,7 +62,6 @@ namespace AzQtComponents
             qreal focusBorderWidth;
             QColor focusBorderColor;
             QColor focusFillColor;
-            QColor headerFillColor;
         };
 
         /*!
@@ -93,7 +92,6 @@ namespace AzQtComponents
 
     private:
         static bool drawHeader(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config);
-        static bool drawHeaderSection(const Style* style, const QStyleOption* option, QPainter* painter, const QWidget* widget, const Config& config);
         static bool drawFrameFocusRect(const Style* style, const QStyleOption* option, QPainter* painter, const Config& config);
         static QRect itemViewItemRect(const Style* style, QStyle::SubElement element, const QStyleOptionViewItem* option, const QWidget* widget, const Config& config);
         static QSize sizeFromContents(const Style* style, QStyle::ContentsType type, const QStyleOption* option, const QSize& contentsSize, const QWidget* widget, const Config& config);

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.qss
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/Widgets/TableView.qss
@@ -66,7 +66,7 @@ QTreeView QHeaderView::section
 {
     height: 24px;
 
-    background: #444444;
+    background: #2d2d2d;
     border: none;
 
     font-size: 12px;

--- a/Code/Framework/AzQtComponents/AzQtComponents/Gallery/TableViewPage.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Gallery/TableViewPage.cpp
@@ -134,6 +134,9 @@ TableViewPage::TableViewPage(QWidget* parent)
     auto logItemDelegate = new AzToolsFramework::Logging::LogTableItemDelegate(ui->logTableView);
     ui->logTableView->setItemDelegate(logItemDelegate);
 
+    // Example of changing the header section background color
+    ui->logTableView->setStyleSheet("QHeaderView::section { background: transparent; }");
+
     ui->qTableView->setModel(logModel);
     ui->qTableView->setAlternatingRowColors(true);
     ui->qTableView->setShowGrid(false);


### PR DESCRIPTION
Refactored the styling of TableView header sections so that they can be customized through qss. Previously, we were explicitly overriding the drawing of `CE_HeaderSection` in our proxy style instead of letting Qt handle it by default. But, we were only filling the rectangle with a color, which is essentially what the default implementation does as well. So instead, I removed the custom drawing code and instead moved our default color to our `TableView.qss`, which already has an entry for how `QHeaderView::section` are to be handled, but the color was being ignored.

This will allow the user to customize the styling of TableView headers, such as the background color. I have updated the control gallery table view page with an example of overriding with a transparent background color for the header sections.

![TableViewHeaderSectionStyling](https://user-images.githubusercontent.com/7519264/150596503-f66bb695-90c2-4052-abda-db80f41a0604.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>