### PR TITLE
[LYN-9039] Object stream write response change

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.h
+++ b/Code/Framework/AzCore/AzCore/Serialization/ObjectStream.h
@@ -49,14 +49,24 @@ namespace AZ
         static const AZ::Crc32 ObjectStreamWriteElementOverride = AZ_CRC("ObjectStreamWriteElementOverride", 0x35eb659f);
     }
 
+    enum class ObjectStreamWriteOverrideResponse
+    {
+        CompletedWrite,
+        FallbackToDefaultWrite,
+        AbortWrite
+    };
+    AZ_TYPE_INFO_SPECIALIZE(ObjectStreamWriteOverrideResponse, "{BDF960A8-0F18-4E9D-96DA-F800A122C42D}");
+
     ///< Callback that the object stream invokes to override saving an instance of the registered class
     ///< @param callContext EnumerateInstanceCallContext which contains the WriteElement BeingElemCB and the CloseElement EndElemCB
     ///< the callContext parameter can be passed to the SerializeContext::EnumerateInstance to continue object stream writing
     ///< @param classPtr class type which is of pointer to the type represented by the m_typeId value
     ///< @param classData reference to this instance Class Data that will be supplied to the callback
     ///< @param classElement class element pointer which contains information about the element being serialized.
-    ///< root elements do not not have a valid class element pointer
-    using ObjectStreamWriteOverrideCB = AZStd::function<void(SerializeContext::EnumerateInstanceCallContext& callContext,
+    ///<        root elements have a nullptr classElement
+    ///< @return enum to indicate that the override has saved the registered class and that the default writing should be skipped.
+    ///<         Returning false will have the WriteElement code fallback to using the default logic
+    using ObjectStreamWriteOverrideCB = AZStd::function<ObjectStreamWriteOverrideResponse(SerializeContext::EnumerateInstanceCallContext& callContext,
         const void* classPtr, const SerializeContext::ClassData& classData, const SerializeContext::ClassElement* classElement)>;
 
     AZ_TYPE_INFO_SPECIALIZE(ObjectStreamWriteOverrideCB, "{87B1A36B-8C8A-42B6-A0B5-E770D9FDBAD4}");

--- a/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
@@ -12,7 +12,7 @@
 
 namespace AZ
 {
-    enum class ObjectStreamWriteElementResponse;
+    enum class ObjectStreamWriteOverrideResponse;
 
     namespace VariantSerializationInternal
     {
@@ -482,7 +482,7 @@ namespace AZ
                 }
             }
         private:
-            static ObjectStreamWriteElementResponse ObjectStreamWriter(SerializeContext::EnumerateInstanceCallContext& callContext, const void* variantPtr,
+            static ObjectStreamWriteOverrideResponse ObjectStreamWriter(SerializeContext::EnumerateInstanceCallContext& callContext, const void* variantPtr,
                 [[maybe_unused]] const SerializeContext::ClassData& variantClassData, const SerializeContext::ClassElement* variantClassElement)
             {
                 auto alternativeVisitor = [&callContext, variantClassElement](auto&& elementAlt)
@@ -507,7 +507,7 @@ namespace AZ
                 AZStd::visit(AZStd::move(alternativeVisitor), *reinterpret_cast<const VariantType*>(variantPtr));
                 // To avoid including ObjectStream.h into this file, we static cast the value of 0
                 // to an AZ::ObjectStreamWriteElemntResponse which corresponds to the CompletedWrite enum value
-                return static_cast<AZ::ObjectStreamWriteElementResponse>(0);
+                return static_cast<AZ::ObjectStreamWriteOverrideResponse>(0);
             }
 
             VariantSerializationInternal::AZStdVariantContainer<Types...> m_variantContainer;

--- a/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/std/VariantReflection.inl
@@ -12,6 +12,8 @@
 
 namespace AZ
 {
+    enum class ObjectStreamWriteElementResponse;
+
     namespace VariantSerializationInternal
     {
         template <class ValueType>
@@ -480,7 +482,7 @@ namespace AZ
                 }
             }
         private:
-            static void ObjectStreamWriter(SerializeContext::EnumerateInstanceCallContext& callContext, const void* variantPtr,
+            static ObjectStreamWriteElementResponse ObjectStreamWriter(SerializeContext::EnumerateInstanceCallContext& callContext, const void* variantPtr,
                 [[maybe_unused]] const SerializeContext::ClassData& variantClassData, const SerializeContext::ClassElement* variantClassElement)
             {
                 auto alternativeVisitor = [&callContext, variantClassElement](auto&& elementAlt)
@@ -503,6 +505,9 @@ namespace AZ
                 };
 
                 AZStd::visit(AZStd::move(alternativeVisitor), *reinterpret_cast<const VariantType*>(variantPtr));
+                // To avoid including ObjectStream.h into this file, we static cast the value of 0
+                // to an AZ::ObjectStreamWriteElemntResponse which corresponds to the CompletedWrite enum value
+                return static_cast<AZ::ObjectStreamWriteElementResponse>(0);
             }
 
             VariantSerializationInternal::AZStdVariantContainer<Types...> m_variantContainer;

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -760,8 +760,6 @@ namespace SerializeTestClasses {
         }
 
         int m_field = 0;
-
-        static AZ::ObjectStreamWriteOverrideResponse m_response;
     };
 } //SerializeTestClasses
 

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -726,6 +726,8 @@ namespace SerializeTestClasses {
         AZ_RTTI(ElementOverrideType, "{BAA18B6C-3CB3-476C-8B41-21EA7CE1F4CF}");
         AZ_CLASS_ALLOCATOR(ElementOverrideType, AZ::SystemAllocator, 0);
 
+        virtual ~ElementOverrideType() = default;
+
         static AZ::ObjectStreamWriteOverrideResponse Writer(
             AZ::SerializeContext::EnumerateInstanceCallContext& callContext,
             const void* object,

--- a/Code/Framework/AzCore/Tests/Serialization.cpp
+++ b/Code/Framework/AzCore/Tests/Serialization.cpp
@@ -1752,11 +1752,12 @@ namespace UnitTest
         IO::ByteContainerStream<AZStd::vector<char>> stream(&buffer);
         ASSERT_TRUE(Utils::SaveObjectToStream(stream, DataStream::ST_XML, &testType, m_serializeContext.get()));
 
-        constexpr const char* expectedValue = R"(<ObjectStream version="3">
-	<Class name="ElementOverrideType" type="{BAA18B6C-3CB3-476C-8B41-21EA7CE1F4CF}">
-		<Class name="int" field="field" value="1" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>
-	</Class>
-</ObjectStream>)";
+        constexpr const char* expectedValue =
+            R"(<ObjectStream version="3">)" "\n"
+            "\t" R"(<Class name="ElementOverrideType" type="{BAA18B6C-3CB3-476C-8B41-21EA7CE1F4CF}">)" "\n"
+            "\t\t" R"(<Class name="int" field="field" value="1" type="{72039442-EB38-4D42-A1AD-CB68F7E0EEF6}"/>)" "\n"
+            "\t" R"(</Class>)" "\n"
+            R"(</ObjectStream>)";
 
         AZStd::string result(buffer.data(), stream.GetLength());
         AZ::StringFunc::TrimWhiteSpace(result, true, true);
@@ -1775,9 +1776,10 @@ namespace UnitTest
         IO::ByteContainerStream<AZStd::vector<char>> stream(&buffer);
         ASSERT_TRUE(Utils::SaveObjectToStream(stream, DataStream::ST_XML, &testType, m_serializeContext.get()));
 
-        constexpr const char* expectedValue = R"(<ObjectStream version="3">
-	<Class name="float" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>
-</ObjectStream>)";
+        constexpr const char* expectedValue =
+            R"(<ObjectStream version="3">)" "\n"
+            "\t" R"(<Class name="float" value="0.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>)" "\n"
+            R"(</ObjectStream>)";
 
         AZStd::string result(buffer.data(), stream.GetLength());
         AZ::StringFunc::TrimWhiteSpace(result, true, true);

--- a/Code/Framework/AzFramework/AzFramework/Asset/AssetBundleManifest.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/AssetBundleManifest.cpp
@@ -15,7 +15,7 @@ namespace AzFramework
 {
     // Redirects writing of the AssetBundleManifest to an older version if the bundle version
     // is not set to the current version
-    static void OldBundleManifestWriter(AZ::SerializeContext::EnumerateInstanceCallContext& callContext, const void* bundleManifestPointer,
+    static AZ::ObjectStreamWriteOverrideResponse OldBundleManifestWriter(AZ::SerializeContext::EnumerateInstanceCallContext& callContext, const void* bundleManifestPointer,
         const AZ::SerializeContext::ClassData&, const AZ::SerializeContext::ClassElement* assetBundleManifestClassElement);
 
     static bool BundleManifestVersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& rootElement);
@@ -67,7 +67,7 @@ namespace AzFramework
         return true;
     }
 
-    void OldBundleManifestWriter(AZ::SerializeContext::EnumerateInstanceCallContext& callContext, const void* bundleManifestPointer,
+    AZ::ObjectStreamWriteOverrideResponse OldBundleManifestWriter(AZ::SerializeContext::EnumerateInstanceCallContext& callContext, const void* bundleManifestPointer,
         const AZ::SerializeContext::ClassData&, const AZ::SerializeContext::ClassElement* assetBundleManifestClassElement)
     {
         // Copy the AssetBundleManifest current version instance to the AssetBundleManifest V2 instance
@@ -145,7 +145,10 @@ namespace AzFramework
             ReflectAssetBundleManifestV2(serializeContext);
             serializeContext->DisableRemoveReflection();
             AssetBundleManifest::ReflectSerialize(serializeContext);
+            return AZ::ObjectStreamWriteOverrideResponse::CompletedWrite;
         }
+
+        return AZ::ObjectStreamWriteOverrideResponse::FallbackToDefaultWrite;
     }
 
     const AZStd::vector<AZ::IO::Path>& AssetBundleManifest::GetLevelDirectories() const


### PR DESCRIPTION
Posting @lumberyard-employee-dm fix for ObjectStreamWriteElementOverride always being expected to handle serialization.  There is now a return value enum which can direct the serializer to perform default serialization.

I've included unit tests for this new functionality.

This fixes an issue with AssetBundleManifest serialization where versions <= 2 would be written out by the override but versions newer than that were expected to be written using the default serialization but weren't, resulting in an empty manifest.

Fixes LYN-9039