### PR TITLE
Fix Build on Linux with Clang 13 with Debug, Profile and Release Configuration

### DIFF
--- a/Code/Editor/EditorPreferencesPageAWS.cpp
+++ b/Code/Editor/EditorPreferencesPageAWS.cpp
@@ -101,7 +101,7 @@ void CEditorPreferencesPage_AWS::SaveSettingsRegistryFile()
                 return;
             }
 
-            bool saved{};
+            [[maybe_unused]] bool saved{};
             constexpr auto configurationMode =
                 AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
             if (AZ::IO::SystemFile outputFile; outputFile.Open(resolvedPath.data(), configurationMode))

--- a/Code/Editor/Settings.cpp
+++ b/Code/Editor/Settings.cpp
@@ -1128,7 +1128,7 @@ void SEditorSettings::SaveSettingsRegistryFile()
         return;
     }
 
-    bool saved{};
+    [[maybe_unused]] bool saved{};
     constexpr auto configurationMode = AZ::IO::SystemFile::SF_OPEN_CREATE
         | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH
         | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;

--- a/Code/Editor/ViewPane.cpp
+++ b/Code/Editor/ViewPane.cpp
@@ -745,7 +745,7 @@ namespace
 
     void PySetActiveViewport(unsigned int viewportIndex)
     {
-        bool success = false;
+        [[maybe_unused]] bool success = false;
         CLayoutWnd* layout = GetIEditor()->GetViewManager()->GetLayout();
         if (layout)
         {

--- a/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Matrix3x4.cpp
@@ -25,7 +25,7 @@ namespace AZ
 
         void Matrix3x4SetRowGeneric(Matrix3x4* thisPtr, ScriptDataContext& dc)
         {
-            bool rowIsSet = false;
+            [[maybe_unused]] bool rowIsSet = false;
             if (dc.GetNumArguments() >= 5)
             {
                 if (dc.IsNumber(0))
@@ -88,7 +88,7 @@ namespace AZ
 
         void Matrix3x4SetColumnGeneric(Matrix3x4* thisPtr, ScriptDataContext& dc)
         {
-            bool columnIsSet = false;
+            [[maybe_unused]] bool columnIsSet = false;
             if (dc.GetNumArguments() >= 4)
             {
                 if (dc.IsNumber(0))
@@ -133,7 +133,7 @@ namespace AZ
 
         void Matrix3x4SetTranslationGeneric(Matrix3x4* thisPtr, ScriptDataContext& dc)
         {
-            bool translationIsSet = false;
+            [[maybe_unused]] bool translationIsSet = false;
 
             if (dc.GetNumArguments() == 3 &&
                 dc.IsNumber(0) &&

--- a/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
+++ b/Code/Framework/AzCore/AzCore/Math/Uuid.cpp
@@ -77,7 +77,7 @@ namespace AZ
 
         // check open brace
         char c = *current++;
-        bool has_open_brace = false;
+        [[maybe_unused]] bool has_open_brace = false;
         if (c == '{')
         {
             c = *current++;

--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.cpp
@@ -85,7 +85,7 @@ namespace AZ
 
     NameDictionary::~NameDictionary()
     {
-        bool leaksDetected = false;
+        [[maybe_unused]] bool leaksDetected = false;
 
         for (const auto& keyValue : m_dictionary)
         {

--- a/Code/Framework/AzCore/Tests/Name/NameTests.cpp
+++ b/Code/Framework/AzCore/Tests/Name/NameTests.cpp
@@ -642,7 +642,7 @@ namespace UnitTest
         char buffer[RandomStringBufferSize];
 
         AZStd::sys_time_t newNameTime;
-        AZStd::sys_time_t existingNameTime;
+        [[maybe_unused]] AZStd::sys_time_t existingNameTime;
         AZStd::sys_time_t stringTime;
 
         {

--- a/Code/Framework/AzFramework/AzFramework/Asset/Benchmark/BenchmarkCommands.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Asset/Benchmark/BenchmarkCommands.cpp
@@ -195,7 +195,7 @@ namespace AzFramework::AssetBenchmark
     // Console command:  Add the given list of assets to the list of assets to load with BenchmarkLoadAssetList
     void BenchmarkAddAssetsToList(const AZ::ConsoleCommandContainer& parameters)
     {
-        bool allAssetsAdded = true;
+        [[maybe_unused]] bool allAssetsAdded = true;
 
         for (auto& assetName : parameters)
         {

--- a/Code/Framework/AzFramework/Tests/CameraState.cpp
+++ b/Code/Framework/AzFramework/Tests/CameraState.cpp
@@ -81,7 +81,7 @@ namespace UnitTest
 
     TEST_P(Rotation, Permutation)
     {
-        int expectedErrors = -1;
+        [[maybe_unused]] int expectedErrors = -1;
         AZ_TEST_START_TRACE_SUPPRESSION;
 
         // Given an orientation derived from the look at points

--- a/Code/Framework/AzQtComponents/AzQtComponents/Components/StylesheetPreprocessor.cpp
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Components/StylesheetPreprocessor.cpp
@@ -134,7 +134,7 @@ namespace AzQtComponents
             QColor color;
             QString colorName(m_namedVariables.value(name));
 
-            bool colorSet = false;
+            [[maybe_unused]] bool colorSet = false;
             if (QColor::isValidColor(colorName))
             {
                 color.setNamedColor(colorName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/EntryDelegate.cpp
@@ -177,7 +177,7 @@ namespace AzToolsFramework
             auto data = index.data(AssetBrowserModel::Roles::EntryRole);
             if (data.canConvert<const AssetBrowserEntry*>())
             {
-                bool isEnabled = (option.state & QStyle::State_Enabled) != 0;
+                [[maybe_unused]] bool isEnabled = (option.state & QStyle::State_Enabled) != 0;
 
                 QStyle* style = option.widget ? option.widget->style() : QApplication::style();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -506,7 +506,7 @@ namespace AzToolsFramework
             //Remove all Links owned by the Template from TemplateToLinkIdsMap.
             Template& templateToDelete = findTemplateResult->get();
             const Template::Links& linkIdsToDelete = templateToDelete.GetLinks();
-            bool result;
+            [[maybe_unused]] bool result;
             for (auto linkId : linkIdsToDelete)
             {
                 result = RemoveLinkIdFromTemplateToLinkIdsMap(linkId);
@@ -774,7 +774,7 @@ namespace AzToolsFramework
             }
 
             Link& link = findLinkResult->get();
-            bool result;
+            [[maybe_unused]] bool result;
             result = RemoveLinkIdFromTemplateToLinkIdsMap(linkId, link);
             AZ_Assert(result,
                 "Prefab - PrefabSystemComponent::RemoveLink - "

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceTransaction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Slice/SliceTransaction.cpp
@@ -926,7 +926,7 @@ namespace AzToolsFramework
             const bool entityIsFromIgnoredSliceInstance = ignoreSliceInstance && ignoreSliceInstance->IsValid() && ignoreSliceInstance->GetReference()->GetSliceAsset().GetId() == instanceAddr.GetReference()->GetSliceAsset().GetId();
             if (!entityIsFromIgnoredSliceInstance)
             {
-                bool foundTargetAncestor = false;
+                [[maybe_unused]] bool foundTargetAncestor = false;
 
                 const AZ::SliceComponent::EntityList& entitiesInInstance = instanceAddr.GetInstance()->GetInstantiated()->m_entities;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyEnumComboBoxCtrl.cpp
@@ -45,7 +45,7 @@ namespace AzToolsFramework
     void PropertyEnumComboBoxCtrl::setValue(AZ::s64 value)
     {
         m_pComboBox->blockSignals(true);
-        bool indexWasFound = false;
+        [[maybe_unused]] bool indexWasFound = false;
         for (size_t enumValIndex = 0; enumValIndex < m_enumValues.size(); enumValIndex++)
         {
             if (m_enumValues[enumValIndex].first == value)

--- a/Code/Framework/AzToolsFramework/Tests/Slices.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Slices.cpp
@@ -430,7 +430,7 @@ namespace UnitTest
                     size_t nextIndex = 1;
                     size_t slices = 0;
                     size_t liveAllocs = 0;
-                    size_t totalAllocs = 0;
+                    [[maybe_unused]] size_t totalAllocs = 0;
 
                     auto cb = [&liveAllocs](void*, const AZ::Debug::AllocationInfo&, unsigned char)
                         {

--- a/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
+++ b/Code/Framework/GridMate/GridMate/Carrier/Carrier.cpp
@@ -1952,8 +1952,8 @@ CarrierThread::ProcessConnections()
 
         bool isHandshakeTimeOut = false;
         bool isConnectionTimeout = false;
-        bool isBadTrafficConditions = false;
-        bool isBadPackets = false;
+        [[maybe_unused]] bool isBadTrafficConditions = false;
+        [[maybe_unused]] bool isBadPackets = false;
         if (connection->m_isBadPackets)
         {
             isBadPackets = true;

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -544,7 +544,7 @@ void ApplicationManagerBase::InitConnectionManager()
             EBUS_EVENT(AssetProcessor::ConnectionBus, SendPerPlatform, 0, message, QString::fromUtf8(message.m_platform.c_str()));
         };
 
-    bool result = QObject::connect(GetAssetCatalog(), &AssetProcessor::AssetCatalog::SendAssetMessage, connectionAndChangeMessagesThreadContext, forwardMessageFunction, Qt::QueuedConnection);
+    [[maybe_unused]] bool result = QObject::connect(GetAssetCatalog(), &AssetProcessor::AssetCatalog::SendAssetMessage, connectionAndChangeMessagesThreadContext, forwardMessageFunction, Qt::QueuedConnection);
     AZ_Assert(result, "Failed to connect to AssetCatalog signal");
 
     //Application manager related stuff

--- a/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
+++ b/Code/Tools/AssetProcessor/native/utilities/BuilderManager.inl
@@ -19,7 +19,7 @@ namespace AssetProcessor
         TNetResponse netResponse;
         netRequest.m_request = request;
 
-        AZ::u32 type;
+        [[maybe_unused]] AZ::u32 type;
         QByteArray data;
         AZStd::binary_semaphore wait;
 

--- a/Code/Tools/ProjectManager/Source/Settings.cpp
+++ b/Code/Tools/ProjectManager/Source/Settings.cpp
@@ -41,7 +41,7 @@ namespace O3DE::ProjectManager
         o3deUserPath /= AZ::SettingsRegistryInterface::RegistryFolder;
         o3deUserPath /= "ProjectManager.setreg";
 
-        bool saved = false;
+        [[maybe_unused]] bool saved = false;
         constexpr auto configurationMode =
             AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
 

--- a/Code/Tools/SceneAPI/SceneBuilder/Tests/TestsMain.cpp
+++ b/Code/Tools/SceneAPI/SceneBuilder/Tests/TestsMain.cpp
@@ -25,7 +25,7 @@ protected:
 
         sceneCoreModule = AZ::DynamicModuleHandle::Create("SceneCore");
         AZ_Assert(sceneCoreModule, "SceneBuilder unit tests failed to create SceneCore module.");
-        bool loaded = sceneCoreModule->Load(false);
+        [[maybe_unused]] bool loaded = sceneCoreModule->Load(false);
         AZ_Assert(loaded, "SceneBuilder unit tests failed to load SceneCore module.");
         auto init = sceneCoreModule->GetFunction<AZ::InitializeDynamicModuleFunction>(AZ::InitializeDynamicModuleFunctionName);
         AZ_Assert(init, "SceneBuilder unit tests failed to find the initialization function the SceneCore module.");

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
@@ -223,7 +223,7 @@ namespace AWSCore
                     return;
                 }
 
-                bool saved {};
+                [[maybe_unused]] bool saved {};
                 constexpr auto configurationMode =
                     AZ::IO::SystemFile::SF_OPEN_CREATE | AZ::IO::SystemFile::SF_OPEN_CREATE_PATH | AZ::IO::SystemFile::SF_OPEN_WRITE_ONLY;
                 if (AZ::IO::SystemFile outputFile; outputFile.Open(resolvedPathAWSPreference.c_str(), configurationMode))

--- a/Gems/AssetValidation/Code/Source/AssetSystemTestCommands.cpp
+++ b/Gems/AssetValidation/Code/Source/AssetSystemTestCommands.cpp
@@ -120,9 +120,9 @@ namespace AssetValidation
             AZ::SimpleLcgRandom randomizer(seedValue);
             int lastTick = 0;
             AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>> heldAssets;
-            AZStd::size_t heldCount{ 0 };
-            AZ::u64 changeCount{ 0 };
-            AZ::u64 blockCount{ 0 };
+            [[maybe_unused]] AZStd::size_t heldCount{ 0 };
+            [[maybe_unused]] AZ::u64 changeCount{ 0 };
+            [[maybe_unused]] AZ::u64 blockCount{ 0 };
             AZ_TracePrintf("TestChangeAssets", "Beginning run with %zu assets\n", assetList.size());
             while (!forceStop && runMs < runTime)
             {

--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseProbeGridFeatureProcessor.cpp
@@ -537,7 +537,7 @@ namespace AZ
             request.m_buffer = m_boxIndexBuffer.get();
             request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, m_boxIndices.size() * sizeof(uint16_t) };
             request.m_initialData = m_boxIndices.data();
-            AZ::RHI::ResultCode result = m_bufferPool->InitBuffer(request);
+            [[maybe_unused]] AZ::RHI::ResultCode result = m_bufferPool->InitBuffer(request);
             AZ_Error("DiffuseProbeGridFeatureProcessor", result == RHI::ResultCode::Success, "Failed to initialize box index buffer - error [%d]", result);
 
             // create index buffer view

--- a/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/RayTracing/RayTracingFeatureProcessor.cpp
@@ -123,7 +123,7 @@ namespace AZ
             // create the BLAS buffers for each sub-mesh, or re-use existing BLAS objects if they were already created.
             // Note: all sub-meshes must either create new BLAS objects or re-use existing ones, otherwise it's an error (it's the same model in both cases)
             // Note: the buffer is just reserved here, the BLAS is built in the RayTracingAccelerationStructurePass
-            bool blasInstanceFound = false;
+            [[maybe_unused]] bool blasInstanceFound = false;
             for (uint32_t subMeshIndex = 0; subMeshIndex < mesh.m_subMeshes.size(); ++subMeshIndex)
             {
                 SubMesh& subMesh = mesh.m_subMeshes[subMeshIndex];

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionProbe/ReflectionProbeFeatureProcessor.cpp
@@ -397,7 +397,7 @@ namespace AZ
             request.m_buffer = m_boxIndexBuffer.get();
             request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, m_boxIndices.size() * sizeof(uint16_t) };
             request.m_initialData = m_boxIndices.data();
-            AZ::RHI::ResultCode result = m_bufferPool->InitBuffer(request);
+            [[maybe_unused]] AZ::RHI::ResultCode result = m_bufferPool->InitBuffer(request);
             AZ_Error("ReflectionProbeFeatureProcessor", result == RHI::ResultCode::Success, "Failed to initialize box index buffer - error [%d]", result);
 
             // create index buffer view

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineStateCache.cpp
@@ -364,7 +364,7 @@ namespace AZ
                 AZ_Assert(success, "PipelineStateEntry already exists in the pending cache.");
             }
 
-            ResultCode resultCode = ResultCode::InvalidArgument;
+            [[maybe_unused]] ResultCode resultCode = ResultCode::InvalidArgument;
 
             // Increment the pending compile count on the global entry, which tracks how many pipeline states
             // are currently being compiled across all threads.

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingBlas.cpp
@@ -120,7 +120,7 @@ namespace AZ
             AZ::RHI::BufferInitRequest scratchBufferRequest;
             scratchBufferRequest.m_buffer = buffers.m_scratchBuffer.get();
             scratchBufferRequest.m_descriptor = scratchBufferDescriptor;
-            RHI::ResultCode resultCode = bufferPools.GetScratchBufferPool()->InitBuffer(scratchBufferRequest);
+            [[maybe_unused]] RHI::ResultCode resultCode = bufferPools.GetScratchBufferPool()->InitBuffer(scratchBufferRequest);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "failed to create BLAS scratch buffer");
             
             BufferMemoryView* scratchMemoryView = static_cast<Buffer*>(buffers.m_scratchBuffer.get())->GetBufferMemoryView();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingPipelineState.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingPipelineState.cpp
@@ -170,7 +170,7 @@ namespace AZ
             createInfo.basePipelineHandle = nullptr;
             createInfo.basePipelineIndex = 0;
 
-            VkResult result = vkCreateRayTracingPipelinesKHR(device.GetNativeDevice(), nullptr, nullptr, 1, &createInfo, nullptr, &m_pipeline);
+            [[maybe_unused]] VkResult result = vkCreateRayTracingPipelinesKHR(device.GetNativeDevice(), nullptr, nullptr, 1, &createInfo, nullptr, &m_pipeline);
             AZ_Assert(result == VK_SUCCESS, "vkCreateRayTracingPipelinesKHR failed");
 
             // retrieve the shader handles

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingShaderTable.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingShaderTable.cpp
@@ -43,7 +43,7 @@ namespace AZ
             AZ::RHI::BufferInitRequest shaderTableBufferRequest;
             shaderTableBufferRequest.m_buffer = shaderTableBuffer.get();
             shaderTableBufferRequest.m_descriptor = shaderTableBufferDescriptor;
-            RHI::ResultCode resultCode = bufferPools.GetShaderTableBufferPool()->InitBuffer(shaderTableBufferRequest);
+            [[maybe_unused]] RHI::ResultCode resultCode = bufferPools.GetShaderTableBufferPool()->InitBuffer(shaderTableBufferRequest);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "failed to create shader table buffer");
 
             BufferMemoryView* shaderTableMemoryView = static_cast<Buffer*>(shaderTableBuffer.get())->GetBufferMemoryView();

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingTlas.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/RayTracingTlas.cpp
@@ -66,7 +66,7 @@ namespace AZ
                 AZ::RHI::BufferInitRequest tlasInstancesBufferRequest;
                 tlasInstancesBufferRequest.m_buffer = buffers.m_tlasInstancesBuffer.get();
                 tlasInstancesBufferRequest.m_descriptor = tlasInstancesBufferDescriptor;
-                RHI::ResultCode resultCode = bufferPools.GetTlasInstancesBufferPool()->InitBuffer(tlasInstancesBufferRequest);
+                [[maybe_unused]] RHI::ResultCode resultCode = bufferPools.GetTlasInstancesBufferPool()->InitBuffer(tlasInstancesBufferRequest);
                 AZ_Assert(resultCode == RHI::ResultCode::Success, "failed to create TLAS instances buffer");
                 
                 BufferMemoryView* tlasInstancesMemoryView = static_cast<Buffer*>(buffers.m_tlasInstancesBuffer.get())->GetBufferMemoryView();
@@ -160,7 +160,7 @@ namespace AZ
             AZ::RHI::BufferInitRequest scratchBufferRequest;
             scratchBufferRequest.m_buffer = buffers.m_scratchBuffer.get();
             scratchBufferRequest.m_descriptor = scratchBufferDescriptor;
-            RHI::ResultCode resultCode = bufferPools.GetScratchBufferPool()->InitBuffer(scratchBufferRequest);
+            [[maybe_unused]] RHI::ResultCode resultCode = bufferPools.GetScratchBufferPool()->InitBuffer(scratchBufferRequest);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "failed to create TLAS scratch buffer");
             
             BufferMemoryView* scratchMemoryView = static_cast<Buffer*>(buffers.m_scratchBuffer.get())->GetBufferMemoryView();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Culling.cpp
@@ -312,7 +312,7 @@ namespace AZ
 
             const View::UsageFlags viewFlags = worklistData->m_view->GetUsageFlags();
             const RHI::DrawListMask drawListMask = worklistData->m_view->GetDrawListMask();
-            uint32_t numDrawPackets = 0;
+            [[maybe_unused]] uint32_t numDrawPackets = 0;
             uint32_t numVisibleCullables = 0;
 
             AZ_Assert(worklist.size() > 0, "Received empty worklist in ProcessWorklist");

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -322,7 +322,7 @@ namespace AZ
         
         void Scene::RemoveRenderPipeline(const RenderPipelineId& pipelineId)
         {
-            bool removed = false;
+            [[maybe_unused]] bool removed = false;
             for (auto it = m_pipelines.begin(); it != m_pipelines.end(); ++it)
             {
                 if (pipelineId == (*it)->GetId())

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -123,7 +123,7 @@ namespace EMotionFX
             TargetType* targetBuffer = static_cast<TargetType*>(targetVertexAttributeLayer->GetData());
 
             // Fill the vertex attribute layer by iterating through the Atom meshes and copying over the vertex data for each.
-            size_t addedElements = 0;
+            [[maybe_unused]] size_t addedElements = 0;
             for (const AZ::RPI::ModelLodAsset::Mesh& atomMesh : sourceModelLod->GetMeshes())
             {
                 const uint32_t atomMeshVertexCount = atomMesh.GetVertexCount();

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Recorder.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Recorder.cpp
@@ -863,7 +863,7 @@ namespace EMotionFX
         }
 
         // process all objects for this frame
-        size_t totalBytesRead = 0;
+        [[maybe_unused]] size_t totalBytesRead = 0;
         const size_t numObjects = frameObjects.size();
         for (size_t a = 0; a < numObjects; ++a)
         {

--- a/Gems/GraphModel/Code/Source/Model/Node.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Node.cpp
@@ -68,7 +68,7 @@ namespace GraphModel
         CreateSlotData(m_inputEventSlots, m_inputEventSlotDefinitions);
         CreateSlotData(m_outputEventSlots, m_outputEventSlotDefinitions);
 
-        int numExtendableSlots = 0;
+        [[maybe_unused]] int numExtendableSlots = 0;
         for (auto it = m_extendableSlots.begin(); it != m_extendableSlots.end(); it++)
         {
             numExtendableSlots += aznumeric_cast<int>(it->second.size());

--- a/Gems/GraphModel/Code/Source/Model/Slot.cpp
+++ b/Gems/GraphModel/Code/Source/Model/Slot.cpp
@@ -491,7 +491,7 @@ namespace GraphModel
             // multiple supported types, Slot::GetDataType() will call GetParentNode()
             // to try and resolve its type, which will be a nullptr at this point
             // because the parent won't be valid yet
-            bool valueTypeSupported = false;
+            [[maybe_unused]] bool valueTypeSupported = false;
             DataTypePtr valueDataType = GetGraphContext()->GetDataTypeForValue(m_value);
             for (DataTypePtr dataType : GetSupportedDataTypes())
             {

--- a/Gems/LyShine/Code/Editor/PropertyHandlerEntityIdComboBox.cpp
+++ b/Gems/LyShine/Code/Editor/PropertyHandlerEntityIdComboBox.cpp
@@ -156,7 +156,7 @@ PropertyEntityIdComboBoxCtrl::PropertyEntityIdComboBoxCtrl(QWidget* pParent)
 void PropertyEntityIdComboBoxCtrl::setValue(AZ::EntityId value)
 {
     m_pComboBox->blockSignals(true);
-    bool indexWasFound = false;
+    [[maybe_unused]] bool indexWasFound = false;
     for (size_t enumValIndex = 0; enumValIndex < m_enumValues.size(); enumValIndex++)
     {
         if (m_enumValues[enumValIndex].first == value)

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -1126,7 +1126,7 @@ namespace Multiplayer
                 netBindComponent->NotifyServerMigration(GetRemoteHostId());
             }
 
-            bool didSucceed = true;
+            [[maybe_unused]] bool didSucceed = true;
             EntityMigrationMessage message;
             message.m_netEntityId = replicator->GetEntityHandle().GetNetEntityId();
             message.m_prefabEntityId = netBindComponent->GetPrefabEntityId();

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothColliders.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothColliders.cpp
@@ -72,8 +72,8 @@ namespace NvCloth
         // Maximum number of spheres and capsules is imposed by NvCloth library
         size_t sphereCount = 0;
         size_t capsuleCount = 0;
-        bool maxSphereCountReachedWarned = false;
-        bool maxCapsuleCountReachedWarned = false;
+        [[maybe_unused]] bool maxSphereCountReachedWarned = false;
+        [[maybe_unused]] bool maxCapsuleCountReachedWarned = false;
 
         AZStd::vector<SphereCollider> sphereColliders;
         AZStd::vector<CapsuleCollider> capsuleColliders;

--- a/Gems/PhysX/Code/Source/PhysXCharacters/Components/RagdollComponent.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/Components/RagdollComponent.cpp
@@ -422,7 +422,7 @@ namespace PhysX
                     return d1.m_depth < d2.m_depth;
                 });
 
-            bool massesClamped = false;
+            [[maybe_unused]] bool massesClamped = false;
             for (const auto& nodeDepth : nodeDepths)
             {
                 const size_t nodeIndex = nodeDepth.m_index;

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/ScriptEventsNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/ScriptEventsNodePaletteTreeItemTypes.cpp
@@ -145,7 +145,7 @@ namespace ScriptCanvasEditor
         ScriptEvents::ScriptEventsAsset* data = asset.GetAs<ScriptEvents::ScriptEventsAsset>();
         if (data)
         {
-            const ScriptEvents::ScriptEvent* previousDefinition = nullptr;
+            [[maybe_unused]] const ScriptEvents::ScriptEvent* previousDefinition = nullptr;
             ScriptEvents::ScriptEventsAsset* previousData = m_asset.GetAs<ScriptEvents::ScriptEventsAsset>();
             if (previousData)
             {

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainMeshManager.cpp
@@ -291,7 +291,7 @@ namespace Terrain
         modelAssetCreator.Begin(AZ::Uuid::CreateRandom());
 
         uint16_t gridSize = GridSize;
-        float gridSpacing = GridSpacing;
+        [[maybe_unused]] float gridSpacing = GridSpacing;
 
         for (uint32_t i = 0; i < AZ::RPI::ModelLodAsset::LodCountMax && gridSize > 0; ++i)
         {


### PR DESCRIPTION
When building with clang 13 (at least) on Linux in profile or release mode, the build breaks due to numerous 'write to local variable which is never used' warnings which get turned into errors (via `-Werror`). This change adds the `[[maybe_unused]]` attribute to these variables.

The warnings are generally issued because the final value of the variables are checked in `AZ_Assert` or `AZ_Warning`, but due to the build configuration being profile or release, these macros evaluate to no-ops. Therefore the compiler (rightfully) complains about the values being written (e.g. accumulation of some count), but never being read.