### PR TITLE
Only use a deterministic random when network option is enabled.

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
@@ -71,6 +71,9 @@ namespace EMotionFX
         // create the parameter value objects
         CreateParameterValues();
 
+        // Assign a unique seed for the lcg random number. Here we use the actor instance id because it guaranteed to be unique.
+        m_lcgRandom.SetSeed(actorInstance->GetID());
+
         m_animGraph->Unlock();
         GetEventManager().OnCreateAnimGraphInstance(this);
     }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphInstance.cpp
@@ -71,7 +71,7 @@ namespace EMotionFX
         // create the parameter value objects
         CreateParameterValues();
 
-        // Assign a unique seed for the lcg random number. Here we use the actor instance id because it guaranteed to be unique.
+        // Assign a unique seed for the lcg random number. Here we use the actorInstanceId because it guaranteed to be unique and available on actor instances.
         m_lcgRandom.SetSeed(actorInstance->GetID());
 
         m_animGraph->Unlock();

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
@@ -664,7 +664,16 @@ namespace EMotionFX
                 const float randomRange = previousIndexCumulativeWeight + m_motionRandomSelectionCumulativeWeights.back().second - currentIndexCumulativeWeight;
 
                 // Picking a random number between [0, randomRange)
-                const float randomValue = animGraphInstance->GetLcgRandom().GetRandomFloat() * randomRange;
+                float randomValue = 0.0f;
+                if (animGraphInstance->IsNetworkEnabled())
+                {
+                    // Using a seeded random in order to generate predictable result in network. 
+                    randomValue = animGraphInstance->GetLcgRandom().GetRandomFloat() * randomRange;
+                }
+                else
+                {
+                    randomValue = MCore::Random::RandF(0, randomRange);
+                }
                 // Remapping the value onto the existing non normalized cumulative probabilities
                 float remappedRandomValue = randomValue;
                 if (randomValue > previousIndexCumulativeWeight)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
@@ -664,16 +664,7 @@ namespace EMotionFX
                 const float randomRange = previousIndexCumulativeWeight + m_motionRandomSelectionCumulativeWeights.back().second - currentIndexCumulativeWeight;
 
                 // Picking a random number between [0, randomRange)
-                float randomValue = 0.0f;
-                if (animGraphInstance->IsNetworkEnabled())
-                {
-                    // Using a seeded random in order to generate predictable result in network. 
-                    randomValue = animGraphInstance->GetLcgRandom().GetRandomFloat() * randomRange;
-                }
-                else
-                {
-                    randomValue = MCore::Random::RandF(0, randomRange);
-                }
+                float randomValue = animGraphInstance->GetLcgRandom().GetRandomFloat() * randomRange;
                 // Remapping the value onto the existing non normalized cumulative probabilities
                 float remappedRandomValue = randomValue;
                 if (randomValue > previousIndexCumulativeWeight)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphMotionNode.cpp
@@ -664,7 +664,7 @@ namespace EMotionFX
                 const float randomRange = previousIndexCumulativeWeight + m_motionRandomSelectionCumulativeWeights.back().second - currentIndexCumulativeWeight;
 
                 // Picking a random number between [0, randomRange)
-                float randomValue = animGraphInstance->GetLcgRandom().GetRandomFloat() * randomRange;
+                const float randomValue = animGraphInstance->GetLcgRandom().GetRandomFloat() * randomRange;
                 // Remapping the value onto the existing non normalized cumulative probabilities
                 float remappedRandomValue = randomValue;
                 if (randomValue > previousIndexCumulativeWeight)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphTimeCondition.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphTimeCondition.cpp
@@ -92,8 +92,9 @@ namespace EMotionFX
             // create a randomized count down value
             if (animGraphInstance->IsNetworkEnabled())
             {
-                // using a seeded random in order to generate predictable result in network. 
-                uniqueData->m_countDownTime = MCore::Random::RandF(m_minRandomTime, m_maxRandomTime, animGraphInstance->GetLcgRandom());
+                // Using a seeded random in order to generate predictable result in network. 
+                uniqueData->m_countDownTime =
+                    m_minRandomTime + (m_maxRandomTime - m_minRandomTime) * animGraphInstance->GetLcgRandom().GetRandomFloat();
             }
             else
             {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphTimeCondition.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphTimeCondition.cpp
@@ -90,16 +90,8 @@ namespace EMotionFX
         if (m_useRandomization)
         {
             // create a randomized count down value
-            if (animGraphInstance->IsNetworkEnabled())
-            {
-                // Using a seeded random in order to generate predictable result in network. 
-                uniqueData->m_countDownTime =
-                    m_minRandomTime + (m_maxRandomTime - m_minRandomTime) * animGraphInstance->GetLcgRandom().GetRandomFloat();
-            }
-            else
-            {
-                uniqueData->m_countDownTime = MCore::Random::RandF(m_minRandomTime, m_maxRandomTime);
-            }
+            uniqueData->m_countDownTime =
+                m_minRandomTime + (m_maxRandomTime - m_minRandomTime) * animGraphInstance->GetLcgRandom().GetRandomFloat();
         }
         else
         {

--- a/Gems/EMotionFX/Code/MCore/Source/Random.h
+++ b/Gems/EMotionFX/Code/MCore/Source/Random.h
@@ -65,22 +65,6 @@ namespace MCore
         static MCORE_INLINE float RandF(float minVal, float maxVal)                                 { return minVal + (maxVal - minVal) * rand() / (float)RAND_MAX; }
 
         /**
-        * Generate a uniform random float in a range of a given minimum and maximum.
-        * @param minVal The minimum value of the range.
-        * @param maxVal The maximum value of the range.
-        * @result A uniform random floating point number in range of [min..max].
-        */
-        static MCORE_INLINE float RandF(float minVal, float maxVal, unsigned int seed) { AZ_UNUSED(seed); return minVal + (maxVal - minVal) * rand() / (float)RAND_MAX; }
-
-        /**
-        * Generate a uniform random float in a range of a given minimum and maximum.
-        * @param minVal The minimum value of the range.
-        * @param maxVal The maximum value of the range.
-        * @result A uniform random floating point number in range of [min..max].
-        */
-        static MCORE_INLINE float RandF(float minVal, float maxVal, LcgRandom& rand) { return minVal + (maxVal - minVal) * rand.GetRandomFloat(); }
-
-        /**
          * Generates a uniform random normalized direction vector, using floats.
          * @result A uniform random direction vector with a length of 1.
          */


### PR DESCRIPTION
This is a quick fix to use the rand() function instead of the seeded random generator on the motion node. This change avoid the copied anim graph instance to repeat the same sequences for picking the motions.
Later we should have a separate option for decide whether a graph should be deterministic or not and that probably should be a global network settings.

Signed-off-by: rhhong <rhhong@amazon.com>