### PR TITLE
Fix GCC Build Errors

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp
@@ -447,7 +447,7 @@ namespace AzToolsFramework
         else
         {
             loadedSuccessfully = static_cast<PrefabEditorEntityOwnershipService*>(m_entityOwnershipService.get())->LoadFromStream(
-                stream, AZStd::string_view(levelPakFile.toUtf8(), levelPakFile.size()) );
+                stream, AZStd::string_view(levelPakFile.toUtf8().constData(), levelPakFile.size()) );
 
         }
         

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/CMakeLists.txt
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/CMakeLists.txt
@@ -81,6 +81,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 Tests
         BUILD_DEPENDENCIES
             PRIVATE
+                3rdParty::Qt::Test
                 AZ::AzTest
                 AZ::AzTestShared
                 AZ::AzFrameworkTestShared

--- a/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasDeveloper/Code/CMakeLists.txt
@@ -74,6 +74,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 ${SCRIPT_CANVAS_DEV_COMMON_DEFINES}
         BUILD_DEPENDENCIES
             PRIVATE
+                3rdParty::Qt::Test
                 AZ::AzCore
                 AZ::AzFramework
                 AZ::AzToolsFramework


### PR DESCRIPTION
- Fix gcc error caused by implicit conversion of Qt::ByteArray to const char*

```
/home/ANT.AMAZON.COM/spham/github/o3de/Code/Framework/AzCore/./AzCore/std/string/string_view.h:618:13:   required by substitution of ‘template<class It, class End, class> constexpr AZStd::basic_string_view<char>::basic_string_view(It, End) [with It = QByteArray; End = int; <template-parameter-1-3> = <missing>]’
/home/ANT.AMAZON.COM/spham/github/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityContextComponent.cpp:450:86:   required from here
/home/ANT.AMAZON.COM/spham/github/o3de/Code/Framework/AzCore/./AzCore/std/concepts/concepts.h:780:48: error: ‘QByteArray::operator QNoImplicitBoolCast() const’ is private within this context
  780 |         && same_as<decltype(declval<const I>() - declval<const iter_difference_t<I>>()), I>
```

- Fix Linker errors to QtTest in **AtomToolsFramework.Tests** and **ScriptCanvasDeveloper.Editor**
ome/ANT.AMAZON.COM/spham/.o3de/3rdParty/packages/qt-5.15.2-rev6-linux/qt/include/QtTest/qtestkeyboard.h:187: undefined reference to `QTest::defaultKeyDelay()'
/usr/bin/ld: /home/xxxx/.o3de/3rdParty/packages/qt-5.15.2-rev6-linux/qt/include/QtTest/qtestkeyboard.h:188: undefined reference to `QTest::defaultKeyDelay()'
/usr/bin/ld: /home/xxxx/.o3de/3rdParty/packages/qt-5.15.2-rev6-linux/qt/include/QtTest/qtestkeyboard.h:198: undefined reference to `QTest::qWarn(char const*, char const*, int)'
/usr/bin/ld: External/AtomToolsFramework-f0ee8d08/Code/CMakeFiles/AtomToolsFramework.Tests.dir/debug/Tests/ViewportInteractionImplTests.cpp.o: in function `QTest::mouseEvent(QTest::MouseAction, QWindow*, Qt::MouseButton, QFlags<Qt::KeyboardModifier>, QPoint, int)':
```
 

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>