### PR TITLE
Disable render pipeline for EditorViewportWidget until a level has been loaded

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -2329,15 +2329,19 @@ void EditorViewportWidget::UpdateScene()
             AZ::RPI::SceneNotificationBus::Handler::BusConnect(viewportContext->GetRenderScene()->GetId());
 
             // Don't enable the render pipeline until a level has been loaded
+            // Also show/hide the RenderViewportWidget accordingly so that we get the
+            // expected gradient background when no level is loaded
             auto renderPipeline = viewportContext->GetCurrentPipeline();
             if (renderPipeline)
             {
                 if (GetIEditor()->IsLevelLoaded())
                 {
+                    m_renderViewport->show();
                     renderPipeline->AddToRenderTick();
                 }
                 else
                 {
+                    m_renderViewport->hide();
                     renderPipeline->RemoveFromRenderTick();
                 }
             }

--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -89,6 +89,7 @@
 #include <LmbrCentral/Rendering/EditorCameraCorrectionBus.h>
 
 // Atom
+#include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/ViewportContextManager.h>
 #include <Atom/RPI.Public/ViewProviderBus.h>
@@ -584,7 +585,7 @@ void EditorViewportWidget::OnEditorNotifyEvent(EEditorNotifyEvent event)
         m_renderViewport->SetScene(nullptr);
         break;
 
-    case eNotify_OnEndSceneOpen:
+    case eNotify_OnEndLoad:
         UpdateScene();
         SetDefaultCamera();
         break;
@@ -2324,7 +2325,22 @@ void EditorViewportWidget::UpdateScene()
         {
             AZ::RPI::SceneNotificationBus::Handler::BusDisconnect();
             m_renderViewport->SetScene(mainScene);
-            AZ::RPI::SceneNotificationBus::Handler::BusConnect(m_renderViewport->GetViewportContext()->GetRenderScene()->GetId());
+            auto viewportContext = m_renderViewport->GetViewportContext();
+            AZ::RPI::SceneNotificationBus::Handler::BusConnect(viewportContext->GetRenderScene()->GetId());
+
+            // Don't enable the render pipeline until a level has been loaded
+            auto renderPipeline = viewportContext->GetCurrentPipeline();
+            if (renderPipeline)
+            {
+                if (GetIEditor()->IsLevelLoaded())
+                {
+                    renderPipeline->AddToRenderTick();
+                }
+                else
+                {
+                    renderPipeline->RemoveFromRenderTick();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Modified the `EditorViewportWidget` to disable its render pipeline until a level has been loaded to address some performance issues (e.g. Animation Editor getting < 30 FPS even with no level loaded).

Before:
- Idle no level loaded, EMFX ~28 FPS
- Rin loaded in EMFX < 5 FPS

After:
- Idle no level loaded, EMFX ~170 FPS
- in loaded in EMFX ~97 FPS

Also swapped `eNotify_OnEndSceneOpen` for `eNotify_OnEndLoad` since the latter is triggered after the former when a level is loaded, and allows the use of `GetIEditor()->IsLevelLoaded()` which is updated in between the two events being triggered.

![EMFXIdle](https://user-images.githubusercontent.com/7519264/151054973-f281ed8d-68a0-485d-ad85-629bc78f8825.png)

![EMFXRinLoaded](https://user-images.githubusercontent.com/7519264/151055860-8b7f0f4f-e03a-4135-a0af-4ffa38cd9669.png)

Also part of this change, restores the previous gradient background when no level is loaded from before:
![NoLevelLoadedGradient](https://user-images.githubusercontent.com/7519264/151072689-39720a18-8c72-46fe-80cd-d34bb21dd652.png)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>