### PR TITLE
Editor crashes upon adding entity to Procedural Prefab via Landscape Canvas or Track View tools

### DIFF
--- a/Code/Editor/TrackView/TrackViewDialog.cpp
+++ b/Code/Editor/TrackView/TrackViewDialog.cpp
@@ -1046,7 +1046,12 @@ void CTrackViewDialog::OnAddSequence()
             AzToolsFramework::ScopedUndoBatch undoBatch("Create TrackView Director Node");
             sequenceManager->CreateSequence(sequenceName, sequenceType);
             CTrackViewSequence* newSequence = sequenceManager->GetSequenceByName(sequenceName);
-            AZ_Assert(newSequence, "Creating new sequence failed.");
+
+            if (!newSequence)
+            {
+                return;
+            }
+            
             undoBatch.MarkEntityDirty(newSequence->GetSequenceComponentEntityId());
 
             // make it the currently selected sequence

--- a/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
+++ b/Gems/LandscapeCanvas/Code/Source/Editor/MainWindow.h
@@ -34,6 +34,8 @@
 
 namespace AzToolsFramework
 {
+    class ReadOnlyEntityPublicInterface;
+
     namespace Prefab
     {
         class PrefabFocusPublicInterface;
@@ -261,7 +263,9 @@ namespace LandscapeCanvasEditor
 
         AZ::SerializeContext* m_serializeContext = nullptr;
 
+        static AzFramework::EntityContextId s_editorEntityContextId;
         AzToolsFramework::Prefab::PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
+        AzToolsFramework::ReadOnlyEntityPublicInterface* m_readOnlyEntityPublicInterface = nullptr;
 
         bool m_ignoreGraphUpdates = false;
         bool m_prefabPropagationInProgress = false;


### PR DESCRIPTION
Adds additional checks to ensure the operation fails (as you shouldn't be able to add entities to read-only entities/prefabs) but does it gracefully and without crashing.

![trackViewAbort](https://user-images.githubusercontent.com/82231674/151081723-e3e81934-a0dd-495d-98ea-3beb61fe99bf.gif)
![landscapeCanvasAbort](https://user-images.githubusercontent.com/82231674/151081729-ef2940ba-1d11-4aac-821a-c786213df365.gif)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>