### PR TITLE
Focus Mode - Introduce API to return a list of EntityIds for all entities in the focused subtree

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeInterface.h
@@ -17,6 +17,8 @@
 
 namespace AzToolsFramework
 {
+    using EntityIdList = AZStd::vector<AZ::EntityId>;
+
     //! FocusModeInterface
     //! Interface to handle the Editor Focus Mode.
     class FocusModeInterface
@@ -35,6 +37,9 @@ namespace AzToolsFramework
         //! Returns the entity id of the root of the current Editor focus.
         //! @return The entity id of the root of the Editor focus, or an invalid entity id if no focus is set.
         virtual AZ::EntityId GetFocusRoot(AzFramework::EntityContextId entityContextId) = 0;
+
+        //! Returns a list of the ids of all the entities that are descendants of the focus root.
+        virtual EntityIdList GetFocusedEntities(AzFramework::EntityContextId entityContextId) = 0;
 
         //! Returns whether the entity id provided is part of the focused sub-tree.
         virtual bool IsInFocusSubTree(AZ::EntityId entityId) const = 0;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/FocusMode/FocusModeSystemComponent.h
@@ -11,7 +11,9 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Memory/SystemAllocator.h>
 
+#include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/FocusMode/FocusModeInterface.h>
+#include <AzToolsFramework/Prefab/PrefabPublicNotificationBus.h>
 
 namespace AzToolsFramework
 {
@@ -21,6 +23,8 @@ namespace AzToolsFramework
     class FocusModeSystemComponent final
         : public AZ::Component
         , private FocusModeInterface
+        , private EditorEntityInfoNotificationBus::Handler
+        , private Prefab::PrefabPublicNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(FocusModeSystemComponent, "{6CE522FE-2057-4794-BD05-61E04BD8EA30}");
@@ -42,10 +46,21 @@ namespace AzToolsFramework
         void SetFocusRoot(AZ::EntityId entityId) override;
         void ClearFocusRoot(AzFramework::EntityContextId entityContextId) override;
         AZ::EntityId GetFocusRoot(AzFramework::EntityContextId entityContextId) override;
+        EntityIdList GetFocusedEntities(AzFramework::EntityContextId entityContextId) override;
         bool IsInFocusSubTree(AZ::EntityId entityId) const override;
 
+        // EditorEntityInfoNotificationBus overrides ...
+        void OnEntityInfoUpdatedAddChildEnd(AZ::EntityId parentId, AZ::EntityId childId) override;
+        void OnEntityInfoUpdatedRemoveChildEnd(AZ::EntityId parentId, AZ::EntityId childId) override;
+
+        // PrefabPublicNotificationBus overrides ...
+        void OnPrefabInstancePropagationEnd() override;
+
     private:
+        void RefreshFocusedEntityIdList();
+
         AZ::EntityId m_focusRoot;
+        EntityIdList m_focusedEntityIdList;
     };
 
 } // namespace AzToolsFramework


### PR DESCRIPTION
Introduces new function in the FocusMode API to retrieve a full list of entities that are in focus.

```
//! Returns a list of the ids of all the entities that are descendants of the focus root.
virtual EntityIdList GetFocusedEntities(AzFramework::EntityContextId entityContextId) = 0;
```

The list is cached to make it possible for multiple customers to use it without additional overhead.
The handler will do its best to update the list when something changes in the editor, but on propagation we have no guarantee about the state of the scene so we have to just recreate the list from scratch.

Also adds 4 new unit tests to ensure the list is correct on regular use and after entities are added/removed

```
[ RUN      ] EditorFocusModeFixture.GetFocusedEntitiesBase
[       OK ] EditorFocusModeFixture.GetFocusedEntitiesBase (274 ms)
[ RUN      ] EditorFocusModeFixture.GetFocusedEntitiesSiblings
[       OK ] EditorFocusModeFixture.GetFocusedEntitiesSiblings (373 ms)
[ RUN      ] EditorFocusModeFixture.GetFocusedEntitiesAddEntity
[       OK ] EditorFocusModeFixture.GetFocusedEntitiesAddEntity (426 ms)
[ RUN      ] EditorFocusModeFixture.GetFocusedEntitiesRemoveEntity
[       OK ] EditorFocusModeFixture.GetFocusedEntitiesRemoveEntity (427 ms)
```

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>