### PR TITLE
[development] updated Profiler interface to allow the forwarding of format string arguments

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.h
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.h
@@ -67,8 +67,7 @@ namespace AZ::Debug
         Profiler() = default;
         virtual ~Profiler() = default;
 
-        // support for the extra macro args (e.g. format strings) will come in a later PR
-        virtual void BeginRegion(const Budget* budget, const char* eventName) = 0;
+        virtual void BeginRegion(const Budget* budget, const char* eventName, size_t eventNameArgCount, ...) = 0;
         virtual void EndRegion(const Budget* budget) = 0;
     };
 
@@ -76,12 +75,11 @@ namespace AZ::Debug
     {
     public:
         template<typename... T>
-        static void BeginRegion([[maybe_unused]] Budget* budget, [[maybe_unused]] const char* eventName, [[maybe_unused]] T const&... args);
-
-        static void EndRegion([[maybe_unused]] Budget* budget);
+        static void BeginRegion(Budget* budget, const char* eventName, T const&... args);
+        static void EndRegion(Budget* budget);
 
         template<typename... T>
-        ProfileScope(Budget* budget, char const* eventName, T const&... args);
+        ProfileScope(Budget* budget, const char* eventName, T const&... args);
 
         ~ProfileScope();
 

--- a/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
+++ b/Code/Framework/AzCore/AzCore/Debug/Profiler.inl
@@ -31,10 +31,10 @@ namespace AZ::Debug
 
             if (auto profiler = AZ::Interface<Profiler>::Get(); profiler)
             {
-                profiler->BeginRegion(budget, eventName);
+                profiler->BeginRegion(budget, eventName, sizeof...(T), args...);
             }
         }
-    #endif // #if !defined(_RELEASE)
+    #endif // !defined(_RELEASE)
     }
 
     inline void ProfileScope::EndRegion([[maybe_unused]] Budget* budget)
@@ -55,7 +55,7 @@ namespace AZ::Debug
     }
 
     template<typename... T>
-    ProfileScope::ProfileScope(Budget* budget, char const* eventName, T const&... args)
+    ProfileScope::ProfileScope(Budget* budget, const char* eventName, T const&... args)
         : m_budget{ budget }
     {
         BeginRegion(budget, eventName, args...);

--- a/Gems/Profiler/Code/Source/CpuProfilerImpl.cpp
+++ b/Gems/Profiler/Code/Source/CpuProfilerImpl.cpp
@@ -96,7 +96,7 @@ namespace Profiler
         AZ::SystemTickBus::Handler::BusDisconnect();
     }
 
-    void CpuProfilerImpl::BeginRegion(const AZ::Debug::Budget* budget, const char* eventName)
+    void CpuProfilerImpl::BeginRegion(const AZ::Debug::Budget* budget, const char* eventName, [[maybe_unused]] size_t eventNameArgCount, ...)
     {
         // Try to lock here, the shutdownMutex will only be contested when the CpuProfiler is shutting down.
         if (m_shutdownMutex.try_lock_shared())

--- a/Gems/Profiler/Code/Source/CpuProfilerImpl.h
+++ b/Gems/Profiler/Code/Source/CpuProfilerImpl.h
@@ -111,7 +111,7 @@ namespace Profiler
         void OnSystemTick() final override;
 
         //! AZ::Debug::Profiler overrides...
-        void BeginRegion(const AZ::Debug::Budget* budget, const char* eventName)  final override;
+        void BeginRegion(const AZ::Debug::Budget* budget, const char* eventName, size_t eventNameArgCount, ...) final override;
         void EndRegion(const AZ::Debug::Budget* budget) final override;
 
         //! CpuProfiler overrides...


### PR DESCRIPTION
Unlike the #7098 draft, this change is only updating the Profiler interface to forward the format string arguments.  Changes to the Profiler gem to utilize the format string arguments will come later.

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>