### PR TITLE
EBS snapshot Jenkinsfile fix

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -845,8 +845,10 @@ try {
                     // Stash the INCREMENTAL_BUILD_SCRIPT_PATH and EBS_SNAPSHOT_SCRIPT_PATH since all nodes will use it
                     stash name: 'incremental_build_script',
                           includes: INCREMENTAL_BUILD_SCRIPT_PATH
-                    stash name: 'ebs_snapshot_script',
+                    if (fileExists(EBS_SNAPSHOT_SCRIPT_PATH)) {
+                        stash name: 'ebs_snapshot_script',
                           includes: EBS_SNAPSHOT_SCRIPT_PATH
+                    }
                  }
             }
         }


### PR DESCRIPTION
Resolves https://github.com/o3de/o3de/issues/7175 by checking for the existence of the ebs_snapshot file before attempting to stash it.