### PR TITLE
[development] fixed ambiguous 'byte' type MSVC build error

### DIFF
--- a/Code/Framework/AzCore/AzCore/std/containers/span.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/span.h
@@ -189,11 +189,11 @@ namespace AZStd
     // [span.objectrep], views of object representation
     template <class ElementType, size_t Extent>
     auto as_bytes(span<ElementType, Extent> s) noexcept
-        -> span<const byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>;
+        -> span<const AZStd::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>;
 
     template <class ElementType, size_t Extent>
     auto as_writable_bytes(span<ElementType, Extent> s) noexcept
-        -> enable_if_t<!is_const_v<ElementType>, span<byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>>;
+        -> enable_if_t<!is_const_v<ElementType>, span<AZStd::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>>;
 
 } // namespace AZStd
 

--- a/Code/Framework/AzCore/AzCore/std/containers/span.inl
+++ b/Code/Framework/AzCore/AzCore/std/containers/span.inl
@@ -197,18 +197,18 @@ namespace AZStd
 
     template <class ElementType, size_t Extent>
     inline auto as_bytes(span<ElementType, Extent> s) noexcept
-        -> span<const byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>
+        -> span<const AZStd::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>
     {
-        return span<const byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>(
-            reinterpret_cast<const byte*>(s.data()), s.size_bytes());
+        return span<const AZStd::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>(
+            reinterpret_cast<const AZStd::byte*>(s.data()), s.size_bytes());
     }
 
 
     template <class ElementType, size_t Extent>
     inline auto as_writable_bytes(span<ElementType, Extent> s) noexcept
-        -> enable_if_t<!is_const_v<ElementType>, span<byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>>
+        -> enable_if_t<!is_const_v<ElementType>, span<AZStd::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>>
     {
-        return span<byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>(
-            reinterpret_cast<byte*>(s.data()), s.size_bytes());
+        return span<AZStd::byte, Extent == dynamic_extent ? dynamic_extent : sizeof(ElementType) * Extent>(
+            reinterpret_cast<AZStd::byte*>(s.data()), s.size_bytes());
     }
 } // namespace AZStd

--- a/Code/Framework/AzFramework/Tests/AssetCatalog.cpp
+++ b/Code/Framework/AzFramework/Tests/AssetCatalog.cpp
@@ -34,7 +34,6 @@
 
 #include "AZTestShared/Utils/Utils.h"
 
-using namespace AZStd;
 using namespace AZ::Data;
 
 namespace UnitTest


### PR DESCRIPTION
The recent addition of `AZStd::span` and `AZStd::byte` types seem to have broken VS 2019 16.11.8 builds due to symbol leakage when using unity files.  The following error would be produced during the building of the AzFramework.Tests target
```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared\rpcndr.h(192,14): error C2872: 'byte': ambiguous symbol [D:\git\o3de\engine\build\windowsUnityPix\Code\Framework\AzFramework
\AzFramework.Tests.vcxproj]
  typedef byte cs_byte;
               ^
  C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\shared\rpcndr.h(191,23): note: could be 'unsigned char byte'
  typedef unsigned char byte;
                        ^
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\cstddef(29,12): note: or       'std::byte'
  enum class byte : unsigned char {};
```
It was the `using namespace AZStd;` statement in the AssetCatalog tests that's the real culprit but included the full qualification of the `byte` type usage in `AZStd::span` as a precaution.

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>
