### PR TITLE
Fix failing scene compilations on Linux

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabBehaviorTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabBehaviorTests.cpp
@@ -138,14 +138,17 @@ namespace UnitTest
             return true;
         }
 
-        AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> CreateMockScene()
+        AZStd::shared_ptr<AZ::SceneAPI::Containers::Scene> CreateMockScene(
+            const AZStd::string manifestFilename = "ManifestFilename",
+            const AZStd::string sourceFileName = "Source",
+            const AZStd::string watchFolder = "WatchFolder")
         {
             using namespace AZ::SceneAPI;
 
             auto scene = AZStd::make_shared<Containers::Scene>("mock_scene");
-            scene->SetManifestFilename("ManifestFilename");
-            scene->SetSource("Source", AZ::Uuid::CreateRandom());
-            scene->SetWatchFolder("WatchFolder");
+            scene->SetManifestFilename(manifestFilename);
+            scene->SetSource(sourceFileName, AZ::Uuid::CreateRandom());
+            scene->SetWatchFolder(watchFolder);
 
             /*---------------------------------------\
                         Root
@@ -319,18 +322,35 @@ namespace UnitTest
         using namespace AZ::SceneAPI;
         using namespace AZ::SceneAPI::Events;
 
-        auto scene = CreateMockScene();
+        #if defined(AZ_PLATFORM_WINDOWS)
+        auto scene = CreateMockScene("Manifest", "C:/o3de/watchfolder/manifest_src_file.xml", "C:/o3de/watchfolder");
+        #else
+        auto scene = CreateMockScene("Manifest", "//o3de/watchfolder/manifest_src_file.xml", "//o3de/watchfolder");
+        #endif
         AssetImportRequest::ManifestAction action = AssetImportRequest::ManifestAction::ConstructDefault;
         AssetImportRequest::RequestingApplication requester = {};
 
         Behaviors::PrefabGroupBehavior prefabGroupBehavior;
         ProcessingResult result = ProcessingResult::Failure;
         AssetImportRequestBus::BroadcastResult(result, &AssetImportRequestBus::Events::UpdateManifest, *scene, action, requester);
+
         EXPECT_EQ(result, ProcessingResult::Success);
         EXPECT_EQ(scene->GetManifest().GetEntryCount(), 3);
+
         EXPECT_TRUE(azrtti_istypeof<AZ::SceneAPI::DataTypes::IMeshGroup>(scene->GetManifest().GetValue(0).get()));
         EXPECT_TRUE(azrtti_istypeof<AZ::SceneAPI::DataTypes::IMeshGroup>(scene->GetManifest().GetValue(1).get()));
         EXPECT_TRUE(azrtti_istypeof<AZ::SceneAPI::DataTypes::IPrefabGroup>(scene->GetManifest().GetValue(2).get()));
+
+        // The mesh group names are expected to be just the file name relative to the watch folder and not any absolute path
+        for (size_t i = 0; i < scene->GetManifest().GetEntryCount(); i++)
+        {
+            if (azrtti_istypeof<AZ::SceneAPI::DataTypes::IMeshGroup>(scene->GetManifest().GetValue(i).get()))
+            {
+                AZ::SceneAPI::DataTypes::IMeshGroup* meshGroup = reinterpret_cast<AZ::SceneAPI::DataTypes::IMeshGroup*>(scene->GetManifest().GetValue(i).get());
+                AZStd::string groupName = meshGroup->GetName();
+                EXPECT_TRUE(groupName.starts_with("manifest_src_file_xml"));
+            }
+        }
     }
 
     TEST_F(PrefabBehaviorTests, PrefabBehavior_UpdateManifest_ToggleWorks)

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabBehaviorTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabBehaviorTests.cpp
@@ -322,10 +322,10 @@ namespace UnitTest
         using namespace AZ::SceneAPI;
         using namespace AZ::SceneAPI::Events;
 
-        #if defined(AZ_PLATFORM_WINDOWS)
-        auto scene = CreateMockScene("Manifest", "C:/o3de/watchfolder/manifest_src_file.xml", "C:/o3de/watchfolder");
+        #if AZ_TRAIT_OS_USE_WINDOWS_FILE_PATHS
+        auto scene = CreateMockScene("Manifest", "C:/o3de/watch.folder/manifest_src_file.xml", "C:/o3de/watch.folder");
         #else
-        auto scene = CreateMockScene("Manifest", "//o3de/watchfolder/manifest_src_file.xml", "//o3de/watchfolder");
+        auto scene = CreateMockScene("Manifest", "//o3de/watch.folder/manifest_src_file.xml", "//o3de/watch.folder");
         #endif
         AssetImportRequest::ManifestAction action = AssetImportRequest::ManifestAction::ConstructDefault;
         AssetImportRequest::RequestingApplication requester = {};

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -400,10 +400,10 @@ namespace AZ::SceneAPI::Behaviors
 
         // compute the filenames of the scene file
         AZStd::string relativeSourcePath = scene.GetSourceFilename();
-        AZ::StringFunc::Replace(relativeSourcePath, ".", "_");
         // the watch folder and forward slash is used to in the asset hint path of the file
         AZStd::string watchFolder = scene.GetWatchFolder() + "/";
         AZ::StringFunc::Replace(relativeSourcePath, watchFolder.c_str(), "");
+        AZ::StringFunc::Replace(relativeSourcePath, ".", "_");
         AZStd::string filenameOnly{ relativeSourcePath };
         AZ::StringFunc::Path::GetFileName(filenameOnly.c_str(), filenameOnly);
         AZ::StringFunc::Path::ReplaceExtension(filenameOnly, "prefab");


### PR DESCRIPTION
On my Linux machine, the full path to O3DE has a subdirectory that has a '.' in it. (i.e. /home/s.pham/github/o3de for example). In these situations, UpdateManifest call for the PrefabGroupBehavior is attempting to derive a filename based on the full path. In order to get the relative path, it substitutes out the watch folder. But the substitution happens after the attempted substitution of the '.' for the file extension, so the intermediate original full path will be substituted too. In that scenario, it will not be able to substitute out the watch folder since it wont match, resulting in the 'relativeSourcePath' being the (incorrect) absolute path.

The fix is simply to move the '.' extension substitution AFTER the watch folder substitution. Long term, this should be use the AZCore Path functionality to do path manipulation.


Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>