### PR TITLE
Remove legacy 'CrySetFileAttributes'

### DIFF
--- a/Code/Legacy/CryCommon/WinBase.cpp
+++ b/Code/Legacy/CryCommon/WinBase.cpp
@@ -856,18 +856,4 @@ DLL_EXPORT void OutputDebugString(const char* outputString)
 
 #endif
 
-// This code does not have a long life span and will be replaced soon
-#if defined(APPLE) || defined(LINUX) || defined(DEFINE_LEGACY_CRY_FILE_OPERATIONS)
-
-bool CrySetFileAttributes(const char* lpFileName, uint32 dwFileAttributes)
-{
-    //TODO: implement
-    printf("CrySetFileAttributes not properly implemented yet\n");
-    return false;
-}
-
-
-
-#endif //defined(APPLE) || defined(LINUX)
-
 #endif // AZ_TRAIT_LEGACY_CRYCOMMON_USE_WINDOWS_STUBS

--- a/Code/Legacy/CryCommon/platform.h
+++ b/Code/Legacy/CryCommon/platform.h
@@ -336,7 +336,6 @@ void SetFlags(T& dest, U flags, bool b)
     #include AZ_RESTRICTED_FILE(platform_h)
 #endif
 
-bool   CrySetFileAttributes(const char* lpFileName, uint32 dwFileAttributes);
 threadID CryGetCurrentThreadId();
 
 #ifdef __GNUC__

--- a/Code/Legacy/CryCommon/platform_impl.cpp
+++ b/Code/Legacy/CryCommon/platform_impl.cpp
@@ -24,7 +24,6 @@
 #define PLATFORM_IMPL_H_SECTION_TRAITS 1
 #define PLATFORM_IMPL_H_SECTION_CRYLOWLATENCYSLEEP 2
 #define PLATFORM_IMPL_H_SECTION_CRYGETFILEATTRIBUTES 3
-#define PLATFORM_IMPL_H_SECTION_CRYSETFILEATTRIBUTES 4
 #define PLATFORM_IMPL_H_SECTION_CRY_FILE_ATTRIBUTE_STUBS 5
 #define PLATFORM_IMPL_H_SECTION_CRY_SYSTEM_FUNCTIONS 6
 #define PLATFORM_IMPL_H_SECTION_VIRTUAL_ALLOCATORS 7
@@ -236,22 +235,6 @@ void InitRootDir(char szExeFileName[], uint nExeSize, char szExeRootName[], uint
             }
         }
     }
-}
-
-//////////////////////////////////////////////////////////////////////////
-bool CrySetFileAttributes(const char* lpFileName, uint32 dwFileAttributes)
-{
-#if defined(AZ_RESTRICTED_PLATFORM)
-    #define AZ_RESTRICTED_SECTION PLATFORM_IMPL_H_SECTION_CRYSETFILEATTRIBUTES
-    #include AZ_RESTRICTED_FILE(platform_impl_h)
-#endif
-#if defined(AZ_RESTRICTED_SECTION_IMPLEMENTED)
-#undef AZ_RESTRICTED_SECTION_IMPLEMENTED
-#else
-    AZStd::wstring lpFileNameW;
-    AZStd::to_wstring(lpFileNameW, lpFileName);
-    return SetFileAttributes(lpFileNameW.c_str(), dwFileAttributes) != 0;
-#endif
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Code/Legacy/CrySystem/XML/xml.cpp
+++ b/Code/Legacy/CrySystem/XML/xml.cpp
@@ -1132,7 +1132,10 @@ bool CXmlNode::saveToFile(const char* fileName)
 
 bool CXmlNode::saveToFile([[maybe_unused]] const char* fileName, size_t chunkSize, AZ::IO::HandleType fileHandle)
 {
-    CrySetFileAttributes(fileName, FILE_ATTRIBUTE_NORMAL);
+    if (AZ::IO::SystemFile::Exists(fileName) && AZ::IO::SystemFile::IsWritable(fileName))
+    {
+        AZ::IO::SystemFile::SetWritable(fileName, true);
+    }
 
     if (chunkSize < 256 * 1024)   // make at least 256k
     {

--- a/Code/Legacy/CrySystem/XML/xml.cpp
+++ b/Code/Legacy/CrySystem/XML/xml.cpp
@@ -1132,7 +1132,7 @@ bool CXmlNode::saveToFile(const char* fileName)
 
 bool CXmlNode::saveToFile([[maybe_unused]] const char* fileName, size_t chunkSize, AZ::IO::HandleType fileHandle)
 {
-    if (AZ::IO::SystemFile::Exists(fileName) && AZ::IO::SystemFile::IsWritable(fileName))
+    if (AZ::IO::SystemFile::Exists(fileName) && !AZ::IO::SystemFile::IsWritable(fileName))
     {
         AZ::IO::SystemFile::SetWritable(fileName, true);
     }


### PR DESCRIPTION
Remove legacy function 'CrySetFileAttributes' and replace its only use with AZ::IO::SystemFile::* functions

**note** 
This replicates the original call to ```CrySetFileAttributes``` in ```CXmlNode::saveToFile``` by using AzCore functions, but does not fix the underlying flaw of this function. ```CXmlNode::saveToFile``` was relying on ```CrySetFileAttributes``` to make sure the file is writeable, and it wend directly to the OS (Windows) SetFileAttributes call, but the actual write uses the FileIOBase::Instance(), which is a layer above the final file system that can also handle aliases like ```@user```.  So the original logic will always silently fail on 'SetFileAttributes' on the xml files that it is writing to anyways because they mostly used aliases in the path, not actual paths.




Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>