### PR TITLE
Fixed issue with viewport not rendering when creating a new level

### DIFF
--- a/Code/Editor/EditorViewportWidget.cpp
+++ b/Code/Editor/EditorViewportWidget.cpp
@@ -586,6 +586,7 @@ void EditorViewportWidget::OnEditorNotifyEvent(EEditorNotifyEvent event)
         break;
 
     case eNotify_OnEndLoad:
+    case eNotify_OnEndCreate:
         UpdateScene();
         SetDefaultCamera();
         break;


### PR DESCRIPTION
Fixes #7285 

Fixed issue with the viewport not rendering after creating a new level. A performance fix was done recently to not enable the viewports render pipeline until a level has been loaded. The event being listened for `eNotify_OnEndLoad` is only sent when an existing level is loaded, not when a new one is created. So needed to add an extra case to listen for the event when a new level has been created.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>