### PR TITLE
Update default AZStd thread priority on Apple platforms.

### DIFF
--- a/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/std/parallel/internal/thread_Android.cpp
@@ -36,5 +36,12 @@ namespace AZStd
         {
             pthread_setname_np(tId, name);
         }
+
+        uint8_t GetDefaultThreadPriority()
+        {
+            // pthread priority is an integer between >=1 and <=99 (although only range 1<=>32 is guaranteed)
+            // Don't use a scheduling policy value (e.g. SCHED_OTHER or SCHED_FIFO) here.
+            return 1;
+        }
     }
 }

--- a/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/thread_Apple.cpp
+++ b/Code/Framework/AzCore/Platform/Common/Apple/AzCore/std/parallel/internal/thread_Apple.cpp
@@ -35,7 +35,7 @@ namespace AZStd
 
         void SetThreadPriority(int priority, pthread_attr_t& attr)
         {
-            if (priority == -1)
+            if (priority <= -1)
             {
                 pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
             }
@@ -58,6 +58,19 @@ namespace AZStd
                 thread_affinity_policy_data_t policyData = { cpuId };
                 thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)& policyData, 1);
             }
+        }
+
+        //////////////////////////////////////////////////////////////////////////////////
+        // Apple pthread -> NSThread quality of service level map
+        // QOS class name              | min pthread priority | max pthread priority | comment
+        // QOS_CLASS_USER_INTERACTIVE  |          38          |          47          |  Per-frame work
+        // QOS_CLASS_USER_INITIATED    |          32          |          37          |  Asynchronous / Cross frame work
+        // QOS_CLASS_DEFAULT           |          21          |          31          |  Streaming / Multiple frames deadline
+        // QOS_CLASS_UTILITY           |           5          |          20          |  Background asset download
+        // QOS_CLASS_BACKGROUN         |           0          |           4          |  Will be prevented from using whole core.
+        uint8_t GetDefaultThreadPriority()
+        {
+            return 10;
         }
     }
 }

--- a/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.cpp
+++ b/Code/Framework/AzCore/Platform/Common/UnixLike/AzCore/std/parallel/internal/thread_UnixLike.cpp
@@ -21,6 +21,7 @@ namespace AZStd
         void PreCreateSetThreadAffinity(int cpuId, pthread_attr_t& attr);
         void SetThreadPriority(int priority, pthread_attr_t& attr);
         void PostCreateThread(pthread_t tId, const char * name, int cpuId);
+        uint8_t GetDefaultThreadPriority();
     }
 
     namespace Internal
@@ -60,12 +61,13 @@ namespace AZStd
                 }
                 else
                 {
-                    priority = SCHED_OTHER;
+                    priority = Platform::GetDefaultThreadPriority();
                 }
                 if (desc->m_name)
                 {
                     name = desc->m_name;
                 }
+                ti->m_name = name;
                 cpuId = desc->m_cpuId;
 
                 pthread_attr_setdetachstate(&attr, desc->m_isJoinable ? PTHREAD_CREATE_JOINABLE : PTHREAD_CREATE_DETACHED);

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/std/parallel/internal/thread_Linux.cpp
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/std/parallel/internal/thread_Linux.cpp
@@ -55,5 +55,12 @@ namespace AZStd
         {
             pthread_setname_np(tId, name);
         }
+
+        uint8_t GetDefaultThreadPriority()
+        {
+            // pthread priority is an integer between >=1 and <=99 (although only range 1<=>32 is guaranteed)
+            // Don't use a scheduling policy value (e.g. SCHED_OTHER or SCHED_FIFO) here.
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
This change avoids AZStd threads being prevented from using 100% of a core

PAL-ified default thread priority for pthread platforms.
Fix threads not getting named on Apple platforms by setting the thread name ptr on the thread_info struct.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>