### PR TITLE
Prefabs UX | Fixes issue with painters being saved and not restored

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -306,41 +306,37 @@ namespace AzToolsFramework
         {
             // Only show the close icon if the prefab is expanded.
             // This allows the prefab container to be opened if it was collapsed during propagation.
-            if (!isExpanded)
+            if (isExpanded)
             {
-                return;
-            }
+                // Use the same color as the background.
+                QColor backgroundColor = m_backgroundColor;
+                if (isSelected)
+                {
+                    backgroundColor = m_backgroundSelectedColor;
+                }
+                else if (isHovered)
+                {
+                    backgroundColor = m_backgroundHoverColor;
+                }
 
-            // Use the same color as the background.
-            QColor backgroundColor = m_backgroundColor;
-            if (isSelected)
-            {
-                backgroundColor = m_backgroundSelectedColor;
-            }
-            else if (isHovered)
-            {
-                backgroundColor = m_backgroundHoverColor;
-            }
+                // Paint a rect to cover up the expander.
+                QRect rect = QRect(0, 0, 16, 16);
+                rect.translate(option.rect.topLeft() + offset);
+                painter->fillRect(rect, backgroundColor);
 
-            // Paint a rect to cover up the expander.
-            QRect rect = QRect(0, 0, 16, 16);
-            rect.translate(option.rect.topLeft() + offset);
-            painter->fillRect(rect, backgroundColor);
-
-            // Paint the icon.
-            QIcon closeIcon = QIcon(m_prefabEditCloseIconPath);
-            painter->drawPixmap(option.rect.topLeft() + offset, closeIcon.pixmap(iconSize));
+                // Paint the icon.
+                QIcon closeIcon = QIcon(m_prefabEditCloseIconPath);
+                painter->drawPixmap(option.rect.topLeft() + offset, closeIcon.pixmap(iconSize));
+            }
         }
         else
         {
             // Only show the edit icon on hover.
-            if (!isHovered)
+            if (isHovered)
             {
-                return;
+                QIcon openIcon = QIcon(m_prefabEditOpenIconPath);
+                painter->drawPixmap(option.rect.topLeft() + offset, openIcon.pixmap(iconSize));
             }
-
-            QIcon openIcon = QIcon(m_prefabEditOpenIconPath);
-            painter->drawPixmap(option.rect.topLeft() + offset, openIcon.pixmap(iconSize));
         }
 
         painter->restore();


### PR DESCRIPTION
Fixes small issue that would result in a lot of warnings being printed out to the VS output.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>