### PR TITLE
Move Runtime dependency on AssetBuilder from AssetProcessor.Static to…

### DIFF
--- a/Code/Tools/AssetProcessor/CMakeLists.txt
+++ b/Code/Tools/AssetProcessor/CMakeLists.txt
@@ -44,8 +44,6 @@ ly_add_target(
             AZ::AssetBuilderSDK
             AZ::AssetBuilder.Static
             ${additional_dependencies}
-    RUNTIME_DEPENDENCIES
-        AZ::AssetBuilder
 )
 
 # Aggregates all combined AssetBuilders into a single LY_ASSET_BUILDERS #define
@@ -76,6 +74,8 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AssetProcessor.Static
+    RUNTIME_DEPENDENCIES
+        AZ::AssetBuilder
 )
 
 # Adds the AssetProcessor target as a C preprocessor define so that it can be used as a Settings Registry
@@ -122,6 +122,8 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AssetProcessorBatch.Static
+    RUNTIME_DEPENDENCIES
+        AZ::AssetBuilder
 )
 
 if(LY_DEFAULT_PROJECT_PATH)


### PR DESCRIPTION
… AssetProcessor and AssetProcessorBatch.

This dependency was causing all of the asset processor modules to have to build gems, namely the unit tests which did not actually require the gems.

Signed-off-by: amzn-mike <80125227+amzn-mike@users.noreply.github.com>