### PR TITLE
Focus Mode | Fix flicker when holding down and dragging the focus mode icon

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.cpp
@@ -176,19 +176,6 @@ namespace AzToolsFramework
 
     void EntityOutlinerTreeView::mouseMoveEvent(QMouseEvent* event)
     {
-        if (m_queuedMouseEvent)
-        {
-            //disable selection for the pending click if the mouse moved so selection is maintained for dragging
-            QAbstractItemView::SelectionMode selectionModeBefore = selectionMode();
-            setSelectionMode(QAbstractItemView::NoSelection);
-
-            //treat this as a mouse pressed event to process everything but selection, but use the position data from the mousePress message
-            processQueuedMousePressedEvent(m_queuedMouseEvent);
-
-            //restore selection state
-            setSelectionMode(selectionModeBefore);
-        }
-
         m_mousePosition = event->pos();
         if (QModelIndex hoveredIndex = indexAt(m_mousePosition); m_currentHoveredIndex != indexAt(m_mousePosition))
         {


### PR DESCRIPTION
Removed some old code that would trigger a mouse click on mouseMove for... some reason?
I tested this and cannot find a case when that would be necessary.

Old behavior:
![image](https://user-images.githubusercontent.com/82231674/151895168-25be1ebb-434d-483b-8174-a03fa55f1979.png)

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>