### PR TITLE
Added preset for converting gsi images

### DIFF
--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
@@ -6,7 +6,7 @@
         "DefaultPreset": {
             "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
             "Name": "GSI",
-            "OutputTypeHandling": "UseInputFormatAndBitDepth",
+            "OutputTypeHandling": "UseInputFormat",
             "IsPowerOf2": true,
             "MipMapSetting": {
                 "MipGenType": "Box"
@@ -16,7 +16,7 @@
             "android": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "OutputTypeHandling": "UseInputFormatAndBitDepth",
+                "OutputTypeHandling": "UseInputFormat",
                 "MaxTextureSize": 2048,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
@@ -26,7 +26,7 @@
             "ios": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "OutputTypeHandling": "UseInputFormatAndBitDepth",
+                "OutputTypeHandling": "UseInputFormat",
                 "MaxTextureSize": 2048,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
@@ -36,7 +36,7 @@
             "mac": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "OutputTypeHandling": "UseInputFormatAndBitDepth",
+                "OutputTypeHandling": "UseInputFormat",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -45,7 +45,7 @@
             "provo": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "OutputTypeHandling": "UseInputFormatAndBitDepth",
+                "OutputTypeHandling": "UseInputFormat",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
@@ -1,0 +1,66 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "MultiplatformPresetSettings",
+    "ClassData": {
+        "DefaultPreset": {
+            "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
+            "Name": "GSI",
+            "PixelFormat": "R8G8B8A8",
+            "UncompressedAutoPick": true,
+            "DiscardAlpha": true,
+            "IsPowerOf2": true,
+            "MipMapSetting": {
+                "MipGenType": "Box"
+            }
+        },
+        "PlatformsPresets": {
+            "android": {
+                "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
+                "Name": "GSI",
+                "PixelFormat": "R8G8B8A8",
+                "UncompressedAutoPick": true,
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "ios": {
+                "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
+                "Name": "GSI",
+                "PixelFormat": "R8G8B8A8",
+                "UncompressedAutoPick": true,
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "mac": {
+                "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
+                "Name": "GSI",
+                "PixelFormat": "R8G8B8A8",
+                "UncompressedAutoPick": true,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "provo": {
+                "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
+                "Name": "GSI",
+                "PixelFormat": "R8G8B8A8",
+                "UncompressedAutoPick": true,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
@@ -6,7 +6,7 @@
         "DefaultPreset": {
             "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
             "Name": "GSI",
-            "UncompressedAutoPick": true,
+            "OutputTypeHandling": "UseInputFormatAndBitDepth",
             "IsPowerOf2": true,
             "MipMapSetting": {
                 "MipGenType": "Box"
@@ -16,7 +16,7 @@
             "android": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "UncompressedAutoPick": true,
+                "OutputTypeHandling": "UseInputFormatAndBitDepth",
                 "MaxTextureSize": 2048,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
@@ -26,7 +26,7 @@
             "ios": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "UncompressedAutoPick": true,
+                "OutputTypeHandling": "UseInputFormatAndBitDepth",
                 "MaxTextureSize": 2048,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
@@ -36,7 +36,7 @@
             "mac": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "UncompressedAutoPick": true,
+                "OutputTypeHandling": "UseInputFormatAndBitDepth",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -45,7 +45,7 @@
             "provo": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "UncompressedAutoPick": true,
+                "OutputTypeHandling": "UseInputFormatAndBitDepth",
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI.preset
@@ -6,9 +6,7 @@
         "DefaultPreset": {
             "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
             "Name": "GSI",
-            "PixelFormat": "R8G8B8A8",
             "UncompressedAutoPick": true,
-            "DiscardAlpha": true,
             "IsPowerOf2": true,
             "MipMapSetting": {
                 "MipGenType": "Box"
@@ -18,10 +16,8 @@
             "android": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "PixelFormat": "R8G8B8A8",
                 "UncompressedAutoPick": true,
                 "MaxTextureSize": 2048,
-                "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -30,10 +26,8 @@
             "ios": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "PixelFormat": "R8G8B8A8",
                 "UncompressedAutoPick": true,
                 "MaxTextureSize": 2048,
-                "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -42,9 +36,7 @@
             "mac": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "PixelFormat": "R8G8B8A8",
                 "UncompressedAutoPick": true,
-                "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"
@@ -53,9 +45,7 @@
             "provo": {
                 "UUID": "{C5E76E09-39FA-411F-B2E2-15B47BB6AB5F}",
                 "Name": "GSI",
-                "PixelFormat": "R8G8B8A8",
                 "UncompressedAutoPick": true,
-                "DiscardAlpha": true,
                 "IsPowerOf2": true,
                 "MipMapSetting": {
                     "MipGenType": "Box"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI16.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI16.preset
@@ -1,0 +1,61 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "MultiplatformPresetSettings",
+    "ClassData": {
+        "DefaultPreset": {
+            "UUID": "{181FE328-5408-4722-895F-1BB61803997B}",
+            "Name": "GSI16",
+            "PixelFormat": "R16",
+            "DiscardAlpha": true,
+            "IsPowerOf2": true,
+            "MipMapSetting": {
+                "MipGenType": "Box"
+            }
+        },
+        "PlatformsPresets": {
+            "android": {
+                "UUID": "{181FE328-5408-4722-895F-1BB61803997B}",
+                "Name": "GSI16",
+                "PixelFormat": "R16",
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "ios": {
+                "UUID": "{181FE328-5408-4722-895F-1BB61803997B}",
+                "Name": "GSI16",
+                "PixelFormat": "R16",
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "mac": {
+                "UUID": "{181FE328-5408-4722-895F-1BB61803997B}",
+                "Name": "GSI16",
+                "PixelFormat": "R16",
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "provo": {
+                "UUID": "{181FE328-5408-4722-895F-1BB61803997B}",
+                "Name": "GSI16",
+                "PixelFormat": "R16",
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI32.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI32.preset
@@ -1,0 +1,61 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "MultiplatformPresetSettings",
+    "ClassData": {
+        "DefaultPreset": {
+            "UUID": "{604FB174-7165-4F6E-889A-3B91DEC9311C}",
+            "Name": "GSI32",
+            "PixelFormat": "R32",
+            "DiscardAlpha": true,
+            "IsPowerOf2": true,
+            "MipMapSetting": {
+                "MipGenType": "Box"
+            }
+        },
+        "PlatformsPresets": {
+            "android": {
+                "UUID": "{604FB174-7165-4F6E-889A-3B91DEC9311C}",
+                "Name": "GSI32",
+                "PixelFormat": "R32",
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "ios": {
+                "UUID": "{604FB174-7165-4F6E-889A-3B91DEC9311C}",
+                "Name": "GSI32",
+                "PixelFormat": "R32",
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "mac": {
+                "UUID": "{604FB174-7165-4F6E-889A-3B91DEC9311C}",
+                "Name": "GSI32",
+                "PixelFormat": "R32",
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "provo": {
+                "UUID": "{604FB174-7165-4F6E-889A-3B91DEC9311C}",
+                "Name": "GSI32",
+                "PixelFormat": "R32",
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI8.preset
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/GSI8.preset
@@ -1,0 +1,61 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "MultiplatformPresetSettings",
+    "ClassData": {
+        "DefaultPreset": {
+            "UUID": "{84B1FE72-AD1A-4E50-83CC-4253ABA59733}",
+            "Name": "GSI8",
+            "PixelFormat": "R8",
+            "DiscardAlpha": true,
+            "IsPowerOf2": true,
+            "MipMapSetting": {
+                "MipGenType": "Box"
+            }
+        },
+        "PlatformsPresets": {
+            "android": {
+                "UUID": "{84B1FE72-AD1A-4E50-83CC-4253ABA59733}",
+                "Name": "GSI8",
+                "PixelFormat": "R8",
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "ios": {
+                "UUID": "{84B1FE72-AD1A-4E50-83CC-4253ABA59733}",
+                "Name": "GSI8",
+                "PixelFormat": "R8",
+                "MaxTextureSize": 2048,
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "mac": {
+                "UUID": "{84B1FE72-AD1A-4E50-83CC-4253ABA59733}",
+                "Name": "GSI8",
+                "PixelFormat": "R8",
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            },
+            "provo": {
+                "UUID": "{84B1FE72-AD1A-4E50-83CC-4253ABA59733}",
+                "Name": "GSI8",
+                "PixelFormat": "R8",
+                "DiscardAlpha": true,
+                "IsPowerOf2": true,
+                "MipMapSetting": {
+                    "MipGenType": "Box"
+                }
+            }
+        }
+    }
+}

--- a/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Assets/Config/ImageBuilder.settings
@@ -146,7 +146,11 @@
             // decal
             "_decal": [ "Decal_AlbedoWithOpacity" ],
             // ui
-            "_ui": [ "UserInterface_Compressed","UserInterface_Lossless" ]
+            "_ui": [ "UserInterface_Compressed","UserInterface_Lossless" ],
+            "_gsi": [ "GSI" ],
+            "_gsi8": [ "GSI8" ],
+            "_gsi16": [ "GSI16" ],
+            "_gsi32": [ "GSI32" ]
         },
         "DefaultPreset": "Albedo",
         "DefaultPresetAlpha": "AlbedoWithGenericAlpha"

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
@@ -134,8 +134,8 @@ namespace ImageProcessingAtom
                 ;
 
             serialize->Enum<OutputTypeHandling>()
-                ->Value("Default", OutputTypeHandling::USE_SPECIFIED_OUTPUT_TYPE)
-                ->Value("UseInputFormatAndBitDepth", OutputTypeHandling::USE_INPUT_FORMAT_AND_BIT_DEPTH)
+                ->Value("Default", OutputTypeHandling::UseSpecifiedOutputType)
+                ->Value("UseInputFormat", OutputTypeHandling::UseInputFormat)
                 ;
         }
     }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
@@ -50,7 +50,9 @@ namespace ImageProcessingAtom
                 ->Field("NumberResidentMips", &PresetSettings::m_numResidentMips)
                 ->Field("Swizzle", &PresetSettings::m_swizzle)
                 ->Field("CubemapSettings", &PresetSettings::m_cubemapSetting)
-                ->Field("MipMapSetting", &PresetSettings::m_mipmapSetting);
+                ->Field("MipMapSetting", &PresetSettings::m_mipmapSetting)
+                ->Field("UncompressedAutoPick", &PresetSettings::m_uncompressedAutoPick)
+                ;
 
             serialize->Enum<RGBWeight>()
                 ->Value("Uniform", RGBWeight::uniform)
@@ -200,7 +202,9 @@ namespace ImageProcessingAtom
             m_glossFromNormals == other.m_glossFromNormals &&
             m_swizzle == other.m_swizzle &&
             m_isMipRenormalize == other.m_isMipRenormalize &&
-            m_numResidentMips == other.m_numResidentMips;
+            m_numResidentMips == other.m_numResidentMips &&
+            m_uncompressedAutoPick == other.m_uncompressedAutoPick
+            ;
     }
 
     void PresetSettings::DeepCopyMembers(const PresetSettings& other)
@@ -237,6 +241,7 @@ namespace ImageProcessingAtom
             m_swizzle = other.m_swizzle;
             m_isMipRenormalize = other.m_isMipRenormalize;
             m_numResidentMips = other.m_numResidentMips;
+            m_uncompressedAutoPick = other.m_uncompressedAutoPick;
         }
     }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.cpp
@@ -51,7 +51,7 @@ namespace ImageProcessingAtom
                 ->Field("Swizzle", &PresetSettings::m_swizzle)
                 ->Field("CubemapSettings", &PresetSettings::m_cubemapSetting)
                 ->Field("MipMapSetting", &PresetSettings::m_mipmapSetting)
-                ->Field("UncompressedAutoPick", &PresetSettings::m_uncompressedAutoPick)
+                ->Field("OutputTypeHandling", &PresetSettings::m_outputTypeHandling)
                 ;
 
             serialize->Enum<RGBWeight>()
@@ -132,6 +132,11 @@ namespace ImageProcessingAtom
                 ->Value("R32", EPixelFormat::ePixelFormat_R32)
                 ->Value("Unknown", EPixelFormat::ePixelFormat_Unknown)
                 ;
+
+            serialize->Enum<OutputTypeHandling>()
+                ->Value("Default", OutputTypeHandling::USE_SPECIFIED_OUTPUT_TYPE)
+                ->Value("UseInputFormatAndBitDepth", OutputTypeHandling::USE_INPUT_FORMAT_AND_BIT_DEPTH)
+                ;
         }
     }
 
@@ -203,7 +208,7 @@ namespace ImageProcessingAtom
             m_swizzle == other.m_swizzle &&
             m_isMipRenormalize == other.m_isMipRenormalize &&
             m_numResidentMips == other.m_numResidentMips &&
-            m_uncompressedAutoPick == other.m_uncompressedAutoPick
+            m_outputTypeHandling == other.m_outputTypeHandling
             ;
     }
 
@@ -241,7 +246,7 @@ namespace ImageProcessingAtom
             m_swizzle = other.m_swizzle;
             m_isMipRenormalize = other.m_isMipRenormalize;
             m_numResidentMips = other.m_numResidentMips;
-            m_uncompressedAutoPick = other.m_uncompressedAutoPick;
+            m_outputTypeHandling = other.m_outputTypeHandling;
         }
     }
 

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.h
@@ -28,8 +28,8 @@ namespace ImageProcessingAtom
         //! Custom overrides for how to handle the output format
         enum OutputTypeHandling
         {
-            USE_SPECIFIED_OUTPUT_TYPE = 0,
-            USE_INPUT_FORMAT_AND_BIT_DEPTH
+            UseSpecifiedOutputType = 0,
+            UseInputFormat
         };
 
         PresetSettings();
@@ -111,7 +111,7 @@ namespace ImageProcessingAtom
         AZStd::string m_swizzle;
 
         //! Controls how the output type format is derived
-        OutputTypeHandling m_outputTypeHandling = USE_SPECIFIED_OUTPUT_TYPE;
+        OutputTypeHandling m_outputTypeHandling = UseSpecifiedOutputType;
 
     protected:
         void DeepCopyMembers(const PresetSettings& other);

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.h
@@ -25,6 +25,13 @@ namespace ImageProcessingAtom
         AZ_TYPE_INFO(PresetSettings, "{4F4DEC5C-48DD-40FD-97B4-5FB6FC7242E9}");
         AZ_CLASS_ALLOCATOR(PresetSettings, AZ::SystemAllocator, 0);
 
+        //! Custom overrides for how to handle the output format
+        enum OutputTypeHandling
+        {
+            USE_SPECIFIED_OUTPUT_TYPE = 0,
+            USE_INPUT_FORMAT_AND_BIT_DEPTH
+        };
+
         PresetSettings();
         PresetSettings(const PresetSettings& other);
         PresetSettings& operator= (const PresetSettings& other);
@@ -103,9 +110,8 @@ namespace ImageProcessingAtom
         //"swizzle". need to be 4 character and each character need to be one of "rgba01"
         AZStd::string m_swizzle;
 
-        //! Convert to an uncompressed pixel format that automatically picks a preferred pixel
-        //! format based on the source input
-        bool m_uncompressedAutoPick = false;
+        //! Controls how the output type format is derived
+        OutputTypeHandling m_outputTypeHandling = USE_SPECIFIED_OUTPUT_TYPE;
 
     protected:
         void DeepCopyMembers(const PresetSettings& other);
@@ -140,3 +146,10 @@ namespace ImageProcessingAtom
     };
     
 } // namespace ImageProcessingAtom
+
+namespace AZ
+{
+    // Bind enums with uuids. Required for named enum support.
+    // Note: AZ_TYPE_INFO_SPECIALIZE has to be declared in AZ namespace
+    AZ_TYPE_INFO_SPECIALIZE(ImageProcessingAtom::PresetSettings::OutputTypeHandling, "{F919ECB6-BF80-4BEF-9E72-EA76504EBE9D}");
+}

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.h
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/BuilderSettings/PresetSettings.h
@@ -103,6 +103,10 @@ namespace ImageProcessingAtom
         //"swizzle". need to be 4 character and each character need to be one of "rgba01"
         AZStd::string m_swizzle;
 
+        //! Convert to an uncompressed pixel format that automatically picks a preferred pixel
+        //! format based on the source input
+        bool m_uncompressedAutoPick = false;
+
     protected:
         void DeepCopyMembers(const PresetSettings& other);
     };

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -537,19 +537,19 @@ namespace ImageProcessingAtom
 
         // Convert to a pixel format based on the desired handling
         // The default behavior will choose the output format specified by the preset
+        EPixelFormat outputFormat;
         switch (m_input->m_presetSetting.m_outputTypeHandling)
         {
-        case PresetSettings::OutputTypeHandling::USE_INPUT_FORMAT_AND_BIT_DEPTH:
-            {
-                EPixelFormat sourceInputFormat = m_input->m_inputImage->GetPixelFormat();
-                m_image->ConvertFormat(sourceInputFormat);
-            }
+        case PresetSettings::OutputTypeHandling::UseInputFormat:
+            outputFormat = m_input->m_inputImage->GetPixelFormat();
             break;
-        case PresetSettings::OutputTypeHandling::USE_SPECIFIED_OUTPUT_TYPE:
+        case PresetSettings::OutputTypeHandling::UseSpecifiedOutputType:
         default:
-            m_image->ConvertFormat(m_input->m_presetSetting.m_pixelFormat);
+            outputFormat = m_input->m_presetSetting.m_pixelFormat;
             break;
         }
+
+        m_image->ConvertFormat(outputFormat);
 
         return true;
     }

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -535,17 +535,20 @@ namespace ImageProcessingAtom
         m_image->GetCompressOption().rgbWeight = m_input->m_presetSetting.GetColorWeight();
         m_image->GetCompressOption().discardAlpha = m_input->m_presetSetting.m_discardAlpha;
 
-        // If the m_uncompressedAutoPick flag is set, then let the converter pick
-        // a pixel format that best matches the source input format
-        if (m_input->m_presetSetting.m_uncompressedAutoPick)
+        // Convert to a pixel format based on the desired handling
+        // The default behavior will choose the output format specified by the preset
+        switch (m_input->m_presetSetting.m_outputTypeHandling)
         {
-            EPixelFormat sourceInputFormat = m_input->m_inputImage->GetPixelFormat();
-            m_image->ConvertFormat(sourceInputFormat);
-        }
-        // Otherwise, convert to the pixel format specified by the preset that was chosen
-        else
-        {
+        case PresetSettings::OutputTypeHandling::USE_INPUT_FORMAT_AND_BIT_DEPTH:
+            {
+                EPixelFormat sourceInputFormat = m_input->m_inputImage->GetPixelFormat();
+                m_image->ConvertFormat(sourceInputFormat);
+            }
+            break;
+        case PresetSettings::OutputTypeHandling::USE_SPECIFIED_OUTPUT_TYPE:
+        default:
             m_image->ConvertFormat(m_input->m_presetSetting.m_pixelFormat);
+            break;
         }
 
         return true;

--- a/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
+++ b/Gems/Atom/Asset/ImageProcessingAtom/Code/Source/Processing/ImageConvert.cpp
@@ -535,7 +535,18 @@ namespace ImageProcessingAtom
         m_image->GetCompressOption().rgbWeight = m_input->m_presetSetting.GetColorWeight();
         m_image->GetCompressOption().discardAlpha = m_input->m_presetSetting.m_discardAlpha;
 
-        m_image->ConvertFormat(m_input->m_presetSetting.m_pixelFormat);
+        // If the m_uncompressedAutoPick flag is set, then let the converter pick
+        // a pixel format that best matches the source input format
+        if (m_input->m_presetSetting.m_uncompressedAutoPick)
+        {
+            EPixelFormat sourceInputFormat = m_input->m_inputImage->GetPixelFormat();
+            m_image->ConvertFormat(sourceInputFormat);
+        }
+        // Otherwise, convert to the pixel format specified by the preset that was chosen
+        else
+        {
+            m_image->ConvertFormat(m_input->m_presetSetting.m_pixelFormat);
+        }
 
         return true;
     }


### PR DESCRIPTION
Added preset config for converting gradient signal images (GSI) to the expected pixel format.

Currently, there is a separate builder process to produce single channel, uncompressed formats for images ending in the "_gsi" suffix, but this goes to a custom asset data `ImageAsset`. Instead of having a separate asset type, we want to utilize the standard `StreamingImageAsset` for image gradients. In order for this to happen. We needed to be able to convert the input image to an uncompressed format with matching bit depth and number of channels. The existing preset configs only allowed you to specify a single destination pixel format, so I've added a new enum, `OutputTypeHandling`. The default will still choose the single output format based on the preset. There is an additional value which will do a best match to the input format and bit depth. Since the default is the current behavior, all existing presets will be unaffected.

In order to give the user further control, I've actually added 4 presets based on the following file masks:
- _gsi (This file mask matches our existing gradient signal images, and any content that users had authored based on the previous system, and will produced a best match uncompressed format)
- _gsi8 (This will produce a single channel R8 pixel format)
- _gsi16 (This will produce a single channel R16 pixel format)
- _gsi32 (This will produce a single channel R32 pixel format)

Since these are new file masks for the preset settings, all pre-existing images with the "_gsi" suffix will automatically get re-compiled (which is what we want), but any other image formats will remain untouched. This way, we don't need to bump the version number of the image builder, which would cause all of our image assets to be re-compiled.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>