### PR TITLE
Add a new function to DynamicDrawInterface to support submiting cached …

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h
@@ -162,6 +162,7 @@ namespace AZ
             RHI::DrawListTag GetDrawListTag();
 
             //! Create a draw srg
+            //! Note: the draw srg can only be used in the current frame. It can't be cached and used for following frames.
             Data::Instance<ShaderResourceGroup> NewDrawSrg();
 
             //! Get per context srg

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h
@@ -59,10 +59,15 @@ namespace AZ
             //! Draw a geometry to a scene with a given material
             virtual void DrawGeometry(Data::Instance<Material> material, const GeometryData& geometry, ScenePtr scene) = 0;
 
+            //! Deprecated. Please use AddDrawPacket(Scene* scene, ConstPtr<RHI::DrawPacket> drawPacket) instead
             //! Submits a DrawPacket to the renderer.
             //! Note that ownership of the DrawPacket pointer is passed to the dynamic draw system.
             //! (it will be cleaned up correctly since the DrawPacket keeps track of the allocator that was used when it was built)
             virtual void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::DrawPacket> drawPacket) = 0;
+            
+            //! Submits a DrawPacket to the scene.
+            //! The dynamic draw system will keep a reference for the DrawPacket until it's rendered.
+            virtual void AddDrawPacket(Scene* scene, ConstPtr<RHI::DrawPacket> drawPacket) = 0;
 
             //! Get DrawLists from any DynamicDrawContext which output to the specified RasterPass.
             virtual AZStd::vector<RHI::DrawListView> GetDrawListsForPass(const RasterPass* pass) = 0;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/DynamicDraw/DynamicDrawSystem.h
@@ -35,6 +35,7 @@ namespace AZ
             RHI::Ptr<DynamicBuffer> GetDynamicBuffer(uint32_t size, uint32_t alignment) override;
             void DrawGeometry(Data::Instance<Material> material, const GeometryData& geometry, ScenePtr scene) override;
             void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::DrawPacket> drawPacket) override;
+            void AddDrawPacket(Scene* scene, ConstPtr<RHI::DrawPacket> drawPacket) override;
             AZStd::vector<RHI::DrawListView> GetDrawListsForPass(const RasterPass* pass) override;
 
             // Submit draw data for selected scene and pipeline
@@ -52,7 +53,7 @@ namespace AZ
             AZStd::list<RHI::Ptr<DynamicDrawContext>> m_dynamicDrawContexts;
 
             AZStd::mutex m_mutexDrawPackets;
-            AZStd::map<Scene*, AZStd::vector<AZStd::unique_ptr<const RHI::DrawPacket>>> m_drawPackets;
+            AZStd::map<Scene*, AZStd::vector<ConstPtr<const RHI::DrawPacket>>> m_drawPackets;
         };
     }
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/DynamicDraw/DynamicDrawSystem.cpp
@@ -70,7 +70,13 @@ namespace AZ
         void DynamicDrawSystem::AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::DrawPacket> drawPacket)
         {
             AZStd::lock_guard<AZStd::mutex> lock(m_mutexDrawPackets);
-            m_drawPackets[scene].emplace_back(AZStd::move(drawPacket));
+            m_drawPackets[scene].emplace_back(ConstPtr<RHI::DrawPacket>(AZStd::move(drawPacket.get())));
+        }
+
+        void DynamicDrawSystem::AddDrawPacket(Scene* scene, ConstPtr<RHI::DrawPacket> drawPacket)
+        {
+            AZStd::lock_guard<AZStd::mutex> lock(m_mutexDrawPackets);
+            m_drawPackets[scene].emplace_back(drawPacket);
         }
 
         void DynamicDrawSystem::SubmitDrawData(Scene* scene, AZStd::vector<ViewPtr> views)


### PR DESCRIPTION
…DrawPacket

New function:
void AddDrawPacket(Scene* scene, ConstPtr<RHI::DrawPacket> drawPacket)
Deprecated function (still supported) :
void AddDrawPacket(Scene* scene, AZStd::unique_ptr<const RHI::DrawPacket> drawPacket)

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>