### PR TITLE
Move multiplayer session interface out of AzFramework library

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -165,10 +165,6 @@ set(FILES
     Logging/MissingAssetLogger.cpp
     Logging/MissingAssetLogger.h
     Logging/MissingAssetNotificationBus.h
-    Matchmaking/IMatchmakingRequests.h
-    Matchmaking/MatchmakingRequests.cpp
-    Matchmaking/MatchmakingRequests.h
-    Matchmaking/MatchmakingNotifications.h
     Scene/Scene.h
     Scene/Scene.inl
     Scene/Scene.cpp
@@ -182,13 +178,6 @@ set(FILES
     Script/ScriptDebugMsgReflection.h
     Script/ScriptRemoteDebugging.cpp
     Script/ScriptRemoteDebugging.h
-    Session/ISessionHandlingRequests.h
-    Session/ISessionRequests.h
-    Session/SessionRequests.cpp
-    Session/SessionRequests.h
-    Session/SessionConfig.cpp
-    Session/SessionConfig.h
-    Session/SessionNotifications.h
     StreamingInstall/StreamingInstall.h
     StreamingInstall/StreamingInstall.cpp
     StreamingInstall/StreamingInstallRequests.h

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/CMakeLists.txt
@@ -24,8 +24,8 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
-            AZ::AzFramework
             Gem::AWSCore
+            Gem::Multiplayer.Static
             3rdParty::AWSNativeSDK::GameLiftClient
 )
 
@@ -85,10 +85,10 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzCore
-                AZ::AzFramework
                 AZ::AzTest
                 Gem::AWSCore
                 Gem::AWSGameLift.Client.Static
+                Gem::Multiplayer.Static
                 3rdParty::AWSNativeSDK::GameLiftClient
                 AZ::AWSNativeSDKTestLibs
     )

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftAcceptMatchRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftAcceptMatchRequest.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Matchmaking/MatchmakingRequests.h>
+#include <Multiplayer/Session/MatchmakingRequests.h>
 
 namespace AWSGameLift
 {
@@ -17,10 +17,10 @@ namespace AWSGameLift
     //! Registers a player's acceptance or rejection of a proposed FlexMatch match. 
     //! AcceptMatchRequest
     struct AWSGameLiftAcceptMatchRequest
-        : public AzFramework::AcceptMatchRequest
+        : public Multiplayer::AcceptMatchRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftAcceptMatchRequest, "{8372B297-88E8-4C13-B31D-BE87236CA416}", AzFramework::AcceptMatchRequest);
+        AZ_RTTI(AWSGameLiftAcceptMatchRequest, "{8372B297-88E8-4C13-B31D-BE87236CA416}", Multiplayer::AcceptMatchRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftAcceptMatchRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftCreateSessionOnQueueRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftCreateSessionOnQueueRequest.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Session/SessionRequests.h>
+#include <Multiplayer/Session/SessionRequests.h>
 
 namespace AWSGameLift
 {
@@ -16,10 +16,10 @@ namespace AWSGameLift
     //! GameLift create session on queue request which corresponds to Amazon GameLift
     //! StartGameSessionPlacement
     struct AWSGameLiftCreateSessionOnQueueRequest
-        : public AzFramework::CreateSessionRequest
+        : public Multiplayer::CreateSessionRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftCreateSessionOnQueueRequest, "{2B99E594-CE81-4EB0-8888-74EF4242B59F}", AzFramework::CreateSessionRequest);
+        AZ_RTTI(AWSGameLiftCreateSessionOnQueueRequest, "{2B99E594-CE81-4EB0-8888-74EF4242B59F}", Multiplayer::CreateSessionRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftCreateSessionOnQueueRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftCreateSessionRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftCreateSessionRequest.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Session/SessionRequests.h>
+#include <Multiplayer/Session/SessionRequests.h>
 
 namespace AWSGameLift
 {
@@ -16,10 +16,10 @@ namespace AWSGameLift
     //! GameLift create session on fleet request which corresponds to Amazon GameLift
     //! CreateGameSessionRequest
     struct AWSGameLiftCreateSessionRequest
-        : public AzFramework::CreateSessionRequest
+        : public Multiplayer::CreateSessionRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftCreateSessionRequest, "{69612D5D-F899-4DEB-AD63-4C497ABC5C0D}", AzFramework::CreateSessionRequest);
+        AZ_RTTI(AWSGameLiftCreateSessionRequest, "{69612D5D-F899-4DEB-AD63-4C497ABC5C0D}", Multiplayer::CreateSessionRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftCreateSessionRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftJoinSessionRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftJoinSessionRequest.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Session/SessionRequests.h>
+#include <Multiplayer/Session/SessionRequests.h>
 
 namespace AWSGameLift
 {
@@ -17,10 +17,10 @@ namespace AWSGameLift
     //! Once player session has been created successfully in game session, gamelift client manager will
     //! signal Multiplayer Gem to setup networking connection.
     struct AWSGameLiftJoinSessionRequest
-        : public AzFramework::JoinSessionRequest
+        : public Multiplayer::JoinSessionRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftJoinSessionRequest, "{6EED6D15-531A-4956-90D0-2EDA31AC9CBA}", AzFramework::JoinSessionRequest);
+        AZ_RTTI(AWSGameLiftJoinSessionRequest, "{6EED6D15-531A-4956-90D0-2EDA31AC9CBA}", Multiplayer::JoinSessionRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftJoinSessionRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftMatchmakingRequestBus.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftMatchmakingRequestBus.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Matchmaking/IMatchmakingRequests.h>
+#include <Multiplayer/Session/IMatchmakingRequests.h>
 
 namespace AWSGameLift
 {
@@ -23,7 +23,7 @@ namespace AWSGameLift
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
     };
-    using AWSGameLiftMatchmakingAsyncRequestBus = AZ::EBus<AzFramework::IMatchmakingAsyncRequests, AWSGameLiftMatchmakingAsyncRequests>;
+    using AWSGameLiftMatchmakingAsyncRequestBus = AZ::EBus<Multiplayer::IMatchmakingAsyncRequests, AWSGameLiftMatchmakingAsyncRequests>;
 
     // IMatchmakingRequests EBus wrapper
     class AWSGameLiftMatchmakingRequests
@@ -34,7 +34,7 @@ namespace AWSGameLift
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
     };
-    using AWSGameLiftMatchmakingRequestBus = AZ::EBus<AzFramework::IMatchmakingRequests, AWSGameLiftMatchmakingRequests>;
+    using AWSGameLiftMatchmakingRequestBus = AZ::EBus<Multiplayer::IMatchmakingRequests, AWSGameLiftMatchmakingRequests>;
 
     //! IAWSGameLiftMatchmakingEventRequests
     //! GameLift Gem matchmaking event interfaces which is used to track matchmaking ticket event

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftSearchSessionsRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftSearchSessionsRequest.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Session/SessionRequests.h>
+#include <Multiplayer/Session/SessionRequests.h>
 
 namespace AWSGameLift
 {
@@ -16,10 +16,10 @@ namespace AWSGameLift
     //! GameLift search sessions request which corresponds to Amazon GameLift
     //! SearchSessionsRequest
     struct AWSGameLiftSearchSessionsRequest
-        : public AzFramework::SearchSessionsRequest
+        : public Multiplayer::SearchSessionsRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftSearchSessionsRequest, "{864C91C0-CA53-4585-BF07-066C0DF3E198}", AzFramework::SearchSessionsRequest);
+        AZ_RTTI(AWSGameLiftSearchSessionsRequest, "{864C91C0-CA53-4585-BF07-066C0DF3E198}", Multiplayer::SearchSessionsRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftSearchSessionsRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftSessionRequestBus.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftSessionRequestBus.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Session/ISessionRequests.h>
+#include <Multiplayer/Session/ISessionRequests.h>
 
 namespace AWSGameLift
 {
@@ -23,7 +23,7 @@ namespace AWSGameLift
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
     };
-    using AWSGameLiftSessionAsyncRequestBus = AZ::EBus<AzFramework::ISessionAsyncRequests, AWSGameLiftSessionAsyncRequests>;
+    using AWSGameLiftSessionAsyncRequestBus = AZ::EBus<Multiplayer::ISessionAsyncRequests, AWSGameLiftSessionAsyncRequests>;
 
     // ISessionRequests EBus wrapper
     class AWSGameLiftSessionRequests
@@ -34,5 +34,5 @@ namespace AWSGameLift
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
     };
-    using AWSGameLiftSessionRequestBus = AZ::EBus<AzFramework::ISessionRequests, AWSGameLiftSessionRequests>;
+    using AWSGameLiftSessionRequestBus = AZ::EBus<Multiplayer::ISessionRequests, AWSGameLiftSessionRequests>;
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftStartMatchmakingRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftStartMatchmakingRequest.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Matchmaking/MatchmakingRequests.h>
+#include <Multiplayer/Session/MatchmakingRequests.h>
 
 #include <AWSGameLiftPlayer.h>
 
@@ -21,10 +21,10 @@ namespace AWSGameLift
     //! Uses FlexMatch to create a game match for a group of players based on custom matchmaking rules
     //! StartMatchmakingRequest
     struct AWSGameLiftStartMatchmakingRequest
-        : public AzFramework::StartMatchmakingRequest
+        : public Multiplayer::StartMatchmakingRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftStartMatchmakingRequest, "{D273DF71-9C55-48C1-95F9-8D7B66B9CF3E}", AzFramework::StartMatchmakingRequest);
+        AZ_RTTI(AWSGameLiftStartMatchmakingRequest, "{D273DF71-9C55-48C1-95F9-8D7B66B9CF3E}", Multiplayer::StartMatchmakingRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftStartMatchmakingRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftStopMatchmakingRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftStopMatchmakingRequest.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Matchmaking/MatchmakingRequests.h>
+#include <Multiplayer/Session/MatchmakingRequests.h>
 
 namespace AWSGameLift
 {
@@ -17,10 +17,10 @@ namespace AWSGameLift
     //! Cancels a matchmaking ticket or match backfill ticket that is currently being processed. 
     //! StopMatchmakingRequest
     struct AWSGameLiftStopMatchmakingRequest
-        : public AzFramework::StopMatchmakingRequest
+        : public Multiplayer::StopMatchmakingRequest
     {
     public:
-        AZ_RTTI(AWSGameLiftStopMatchmakingRequest, "{2766BC03-9F84-4346-A52B-49129BBAF38B}", AzFramework::StopMatchmakingRequest);
+        AZ_RTTI(AWSGameLiftStopMatchmakingRequest, "{2766BC03-9F84-4346-A52B-49129BBAF38B}", Multiplayer::StopMatchmakingRequest);
         static void Reflect(AZ::ReflectContext* context);
 
         AWSGameLiftStopMatchmakingRequest() = default;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientLocalTicketTracker.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientLocalTicketTracker.cpp
@@ -9,8 +9,8 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/std/bind/bind.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Session/ISessionHandlingRequests.h>
-#include <AzFramework/Matchmaking/MatchmakingNotifications.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/MatchmakingNotifications.h>
 
 #include <AWSGameLiftClientLocalTicketTracker.h>
 #include <AWSGameLiftSessionConstants.h>
@@ -97,7 +97,7 @@ namespace AWSGameLift
                             AZ_TracePrintf(AWSGameLiftClientLocalTicketTrackerName,
                                 "Matchmaking ticket %s is complete.", ticket.GetTicketId().c_str());
                             RequestPlayerJoinMatch(ticket, playerId);
-                            AzFramework::MatchmakingNotificationBus::Broadcast(&AzFramework::MatchmakingNotifications::OnMatchComplete);
+                            Multiplayer::MatchmakingNotificationBus::Broadcast(&Multiplayer::MatchmakingNotifications::OnMatchComplete);
                             m_status = TicketTrackerStatus::Idle;
                             return;
                         }
@@ -107,7 +107,7 @@ namespace AWSGameLift
                         {
                             AZ_Warning(AWSGameLiftClientLocalTicketTrackerName, false, "Matchmaking ticket %s is not complete, %s",
                                 ticket.GetTicketId().c_str(), ticket.GetStatusMessage().c_str());
-                            AzFramework::MatchmakingNotificationBus::Broadcast(&AzFramework::MatchmakingNotifications::OnMatchFailure);
+                            Multiplayer::MatchmakingNotificationBus::Broadcast(&Multiplayer::MatchmakingNotifications::OnMatchFailure);
                             m_status = TicketTrackerStatus::Idle;
                             return;
                         }
@@ -115,7 +115,7 @@ namespace AWSGameLift
                         {
                             AZ_TracePrintf(AWSGameLiftClientLocalTicketTrackerName, "Matchmaking ticket %s is pending on acceptance, %s.",
                                 ticket.GetTicketId().c_str(), ticket.GetStatusMessage().c_str());
-                            AzFramework::MatchmakingNotificationBus::Broadcast(&AzFramework::MatchmakingNotifications::OnMatchAcceptance);
+                            Multiplayer::MatchmakingNotificationBus::Broadcast(&Multiplayer::MatchmakingNotifications::OnMatchAcceptance);
                         }
                         else
                         {
@@ -126,7 +126,7 @@ namespace AWSGameLift
                     else
                     {
                         AZ_Error(AWSGameLiftClientLocalTicketTrackerName, false, "Unable to find expected ticket with id %s", ticketId.c_str());
-                        AzFramework::MatchmakingNotificationBus::Broadcast(&AzFramework::MatchmakingNotifications::OnMatchError);
+                        Multiplayer::MatchmakingNotificationBus::Broadcast(&Multiplayer::MatchmakingNotifications::OnMatchError);
                     }
                 }
                 else
@@ -134,13 +134,13 @@ namespace AWSGameLift
                     AZ_Error(AWSGameLiftClientLocalTicketTrackerName, false, AWSGameLiftErrorMessageTemplate,
                         describeMatchmakingOutcome.GetError().GetExceptionName().c_str(),
                         describeMatchmakingOutcome.GetError().GetMessage().c_str());
-                    AzFramework::MatchmakingNotificationBus::Broadcast(&AzFramework::MatchmakingNotifications::OnMatchError);
+                    Multiplayer::MatchmakingNotificationBus::Broadcast(&Multiplayer::MatchmakingNotifications::OnMatchError);
                 }
             }
             else
             {
                 AZ_Error(AWSGameLiftClientLocalTicketTrackerName, false, AWSGameLiftClientMissingErrorMessage);
-                AzFramework::MatchmakingNotificationBus::Broadcast(&AzFramework::MatchmakingNotifications::OnMatchError);
+                Multiplayer::MatchmakingNotificationBus::Broadcast(&Multiplayer::MatchmakingNotifications::OnMatchError);
             }
             m_waitEvent.try_acquire_for(AZStd::chrono::milliseconds(m_pollingPeriodInMS));
         }
@@ -150,7 +150,7 @@ namespace AWSGameLift
         const Aws::GameLift::Model::MatchmakingTicket& ticket, const AZStd::string& playerId)
     {
         auto connectionInfo = ticket.GetGameSessionConnectionInfo();
-        AzFramework::SessionConnectionConfig sessionConnectionConfig;
+        Multiplayer::SessionConnectionConfig sessionConnectionConfig;
         sessionConnectionConfig.m_ipAddress = connectionInfo.GetIpAddress().c_str();
         for (auto matchedPlayer : connectionInfo.GetMatchedPlayerSessions())
         {
@@ -168,7 +168,7 @@ namespace AWSGameLift
                 "Requesting and validating player session %s to connect to the match ...",
                 sessionConnectionConfig.m_playerSessionId.c_str());
             bool result =
-                AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Get()->RequestPlayerJoinSession(sessionConnectionConfig);
+                AZ::Interface<Multiplayer::ISessionHandlingClientRequests>::Get()->RequestPlayerJoinSession(sessionConnectionConfig);
             if (result)
             {
                 AZ_TracePrintf(AWSGameLiftClientLocalTicketTrackerName,

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/Jobs/JobFunction.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
 #include <AWSCoreBus.h>
 #include <Credential/AWSCredentialBus.h>
@@ -42,32 +42,32 @@ namespace AWSGameLift
         AZ::Interface<IAWSGameLiftRequests>::Register(this);
         AWSGameLiftRequestBus::Handler::BusConnect();
 
-        AZ::Interface<AzFramework::ISessionAsyncRequests>::Register(this);
+        AZ::Interface<Multiplayer::ISessionAsyncRequests>::Register(this);
         AWSGameLiftSessionAsyncRequestBus::Handler::BusConnect();
 
-        AZ::Interface<AzFramework::ISessionRequests>::Register(this);
+        AZ::Interface<Multiplayer::ISessionRequests>::Register(this);
         AWSGameLiftSessionRequestBus::Handler::BusConnect();
 
-        AZ::Interface<AzFramework::IMatchmakingAsyncRequests>::Register(this);
+        AZ::Interface<Multiplayer::IMatchmakingAsyncRequests>::Register(this);
         AWSGameLiftMatchmakingAsyncRequestBus::Handler::BusConnect();
 
-        AZ::Interface<AzFramework::IMatchmakingRequests>::Register(this);
+        AZ::Interface<Multiplayer::IMatchmakingRequests>::Register(this);
         AWSGameLiftMatchmakingRequestBus::Handler::BusConnect();
     }
 
     void AWSGameLiftClientManager::DeactivateManager()
     {
         AWSGameLiftMatchmakingRequestBus::Handler::BusDisconnect();
-        AZ::Interface<AzFramework::IMatchmakingRequests>::Unregister(this);
+        AZ::Interface<Multiplayer::IMatchmakingRequests>::Unregister(this);
 
         AWSGameLiftMatchmakingAsyncRequestBus::Handler::BusDisconnect();
-        AZ::Interface<AzFramework::IMatchmakingAsyncRequests>::Unregister(this);
+        AZ::Interface<Multiplayer::IMatchmakingAsyncRequests>::Unregister(this);
 
         AWSGameLiftSessionRequestBus::Handler::BusDisconnect();
-        AZ::Interface<AzFramework::ISessionRequests>::Unregister(this);
+        AZ::Interface<Multiplayer::ISessionRequests>::Unregister(this);
 
         AWSGameLiftSessionAsyncRequestBus::Handler::BusDisconnect();
-        AZ::Interface<AzFramework::ISessionAsyncRequests>::Unregister(this);
+        AZ::Interface<Multiplayer::ISessionAsyncRequests>::Unregister(this);
 
         AWSGameLiftRequestBus::Handler::BusDisconnect();
         AZ::Interface<IAWSGameLiftRequests>::Unregister(this);
@@ -133,7 +133,7 @@ namespace AWSGameLift
         return AZ::Uuid::CreateRandom().ToString<AZStd::string>(includeBrackets, includeDashes);
     }
 
-    void AWSGameLiftClientManager::AcceptMatch(const AzFramework::AcceptMatchRequest& acceptMatchRequest)
+    void AWSGameLiftClientManager::AcceptMatch(const Multiplayer::AcceptMatchRequest& acceptMatchRequest)
     {
         if (AcceptMatchActivity::ValidateAcceptMatchRequest(acceptMatchRequest))
         {
@@ -143,12 +143,12 @@ namespace AWSGameLift
         }
     }
 
-    void AWSGameLiftClientManager::AcceptMatchAsync(const AzFramework::AcceptMatchRequest& acceptMatchRequest)
+    void AWSGameLiftClientManager::AcceptMatchAsync(const Multiplayer::AcceptMatchRequest& acceptMatchRequest)
     {
         if (!AcceptMatchActivity::ValidateAcceptMatchRequest(acceptMatchRequest))
         {
-            AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
-                &AzFramework::MatchmakingAsyncRequestNotifications::OnAcceptMatchAsyncComplete);
+            Multiplayer::MatchmakingAsyncRequestNotificationBus::Broadcast(
+                &Multiplayer::MatchmakingAsyncRequestNotifications::OnAcceptMatchAsyncComplete);
             return;
         }
 
@@ -161,15 +161,15 @@ namespace AWSGameLift
             {
                 AcceptMatchActivity::AcceptMatch(gameliftStartMatchmakingRequest);
 
-                AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
-                    &AzFramework::MatchmakingAsyncRequestNotifications::OnAcceptMatchAsyncComplete);
+                Multiplayer::MatchmakingAsyncRequestNotificationBus::Broadcast(
+                    &Multiplayer::MatchmakingAsyncRequestNotifications::OnAcceptMatchAsyncComplete);
             },
             true, jobContext);
 
         acceptMatchJob->Start(); 
     }
 
-    AZStd::string AWSGameLiftClientManager::CreateSession(const AzFramework::CreateSessionRequest& createSessionRequest)
+    AZStd::string AWSGameLiftClientManager::CreateSession(const Multiplayer::CreateSessionRequest& createSessionRequest)
     {
         AZStd::string result = "";
         if (CreateSessionActivity::ValidateCreateSessionRequest(createSessionRequest))
@@ -192,7 +192,7 @@ namespace AWSGameLift
         return result;
     }
 
-    void AWSGameLiftClientManager::CreateSessionAsync(const AzFramework::CreateSessionRequest& createSessionRequest)
+    void AWSGameLiftClientManager::CreateSessionAsync(const Multiplayer::CreateSessionRequest& createSessionRequest)
     {
         if (CreateSessionActivity::ValidateCreateSessionRequest(createSessionRequest))
         {
@@ -206,8 +206,8 @@ namespace AWSGameLift
                 {
                     AZStd::string result = CreateSessionActivity::CreateSession(gameliftCreateSessionRequest);
 
-                    AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                        &AzFramework::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, result);
+                    Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                        &Multiplayer::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, result);
                 },
                 true, jobContext);
             createSessionJob->Start();
@@ -224,8 +224,8 @@ namespace AWSGameLift
                 {
                     AZStd::string result = CreateSessionOnQueueActivity::CreateSessionOnQueue(gameliftCreateSessionOnQueueRequest);
 
-                    AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                        &AzFramework::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, result);
+                    Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                        &Multiplayer::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, result);
                 },
                 true, jobContext);
             createSessionOnQueueJob->Start();
@@ -233,12 +233,12 @@ namespace AWSGameLift
         else
         {
             AZ_Error(AWSGameLiftClientManagerName, false, AWSGameLiftCreateSessionRequestInvalidErrorMessage);
-            AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                &AzFramework::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, "");
+            Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                &Multiplayer::SessionAsyncRequestNotifications::OnCreateSessionAsyncComplete, "");
         }
     }
 
-    bool AWSGameLiftClientManager::JoinSession(const AzFramework::JoinSessionRequest& joinSessionRequest)
+    bool AWSGameLiftClientManager::JoinSession(const Multiplayer::JoinSessionRequest& joinSessionRequest)
     {
         bool result = false;
         if (JoinSessionActivity::ValidateJoinSessionRequest(joinSessionRequest))
@@ -252,12 +252,12 @@ namespace AWSGameLift
         return result;
     }
 
-    void AWSGameLiftClientManager::JoinSessionAsync(const AzFramework::JoinSessionRequest& joinSessionRequest)
+    void AWSGameLiftClientManager::JoinSessionAsync(const Multiplayer::JoinSessionRequest& joinSessionRequest)
     {
         if (!JoinSessionActivity::ValidateJoinSessionRequest(joinSessionRequest))
         {
-            AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                &AzFramework::SessionAsyncRequestNotifications::OnJoinSessionAsyncComplete, false);
+            Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                &Multiplayer::SessionAsyncRequestNotifications::OnJoinSessionAsyncComplete, false);
             return;
         }
 
@@ -272,8 +272,8 @@ namespace AWSGameLift
                 auto createPlayerSessionOutcome = JoinSessionActivity::CreatePlayerSession(gameliftJoinSessionRequest);
                 bool result = JoinSessionActivity::RequestPlayerJoinSession(createPlayerSessionOutcome);
 
-                AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                    &AzFramework::SessionAsyncRequestNotifications::OnJoinSessionAsyncComplete, result);
+                Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                    &Multiplayer::SessionAsyncRequestNotifications::OnJoinSessionAsyncComplete, result);
             },
             true, jobContext);
 
@@ -293,18 +293,18 @@ namespace AWSGameLift
             [this]()
             {
                 LeaveSession();
-                AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                    &AzFramework::SessionAsyncRequestNotifications::OnLeaveSessionAsyncComplete);
+                Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                    &Multiplayer::SessionAsyncRequestNotifications::OnLeaveSessionAsyncComplete);
             },
             true, jobContext);
 
         leaveSessionJob->Start();
     }
 
-    AzFramework::SearchSessionsResponse AWSGameLiftClientManager::SearchSessions(
-        const AzFramework::SearchSessionsRequest& searchSessionsRequest) const
+    Multiplayer::SearchSessionsResponse AWSGameLiftClientManager::SearchSessions(
+        const Multiplayer::SearchSessionsRequest& searchSessionsRequest) const
     {
-        AzFramework::SearchSessionsResponse response;
+        Multiplayer::SearchSessionsResponse response;
         if (SearchSessionsActivity::ValidateSearchSessionsRequest(searchSessionsRequest))
         {
             const AWSGameLiftSearchSessionsRequest& gameliftSearchSessionsRequest =
@@ -315,12 +315,12 @@ namespace AWSGameLift
         return response;
     }
 
-    void AWSGameLiftClientManager::SearchSessionsAsync(const AzFramework::SearchSessionsRequest& searchSessionsRequest) const
+    void AWSGameLiftClientManager::SearchSessionsAsync(const Multiplayer::SearchSessionsRequest& searchSessionsRequest) const
     {
         if (!SearchSessionsActivity::ValidateSearchSessionsRequest(searchSessionsRequest))
         {
-            AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                &AzFramework::SessionAsyncRequestNotifications::OnSearchSessionsAsyncComplete, AzFramework::SearchSessionsResponse());
+            Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                &Multiplayer::SessionAsyncRequestNotifications::OnSearchSessionsAsyncComplete, Multiplayer::SearchSessionsResponse());
             return;
         }
 
@@ -332,17 +332,17 @@ namespace AWSGameLift
         AZ::Job* searchSessionsJob = AZ::CreateJobFunction(
             [gameliftSearchSessionsRequest]()
             {
-                AzFramework::SearchSessionsResponse response = SearchSessionsActivity::SearchSessions(gameliftSearchSessionsRequest);
+                Multiplayer::SearchSessionsResponse response = SearchSessionsActivity::SearchSessions(gameliftSearchSessionsRequest);
 
-                AzFramework::SessionAsyncRequestNotificationBus::Broadcast(
-                    &AzFramework::SessionAsyncRequestNotifications::OnSearchSessionsAsyncComplete, response);
+                Multiplayer::SessionAsyncRequestNotificationBus::Broadcast(
+                    &Multiplayer::SessionAsyncRequestNotifications::OnSearchSessionsAsyncComplete, response);
             },
             true, jobContext);
 
         searchSessionsJob->Start(); 
     }
 
-    AZStd::string AWSGameLiftClientManager::StartMatchmaking(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest)
+    AZStd::string AWSGameLiftClientManager::StartMatchmaking(const Multiplayer::StartMatchmakingRequest& startMatchmakingRequest)
     {
         AZStd::string response;
         if (StartMatchmakingActivity::ValidateStartMatchmakingRequest(startMatchmakingRequest))
@@ -355,12 +355,12 @@ namespace AWSGameLift
         return response;
     }
 
-    void AWSGameLiftClientManager::StartMatchmakingAsync(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest)
+    void AWSGameLiftClientManager::StartMatchmakingAsync(const Multiplayer::StartMatchmakingRequest& startMatchmakingRequest)
     {
         if (!StartMatchmakingActivity::ValidateStartMatchmakingRequest(startMatchmakingRequest))
         {
-            AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
-                &AzFramework::MatchmakingAsyncRequestNotifications::OnStartMatchmakingAsyncComplete, AZStd::string{});
+            Multiplayer::MatchmakingAsyncRequestNotificationBus::Broadcast(
+                &Multiplayer::MatchmakingAsyncRequestNotifications::OnStartMatchmakingAsyncComplete, AZStd::string{});
             return;
         }
 
@@ -374,15 +374,15 @@ namespace AWSGameLift
             {
                 AZStd::string response = StartMatchmakingActivity::StartMatchmaking(gameliftStartMatchmakingRequest);
 
-                AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
-                    &AzFramework::MatchmakingAsyncRequestNotifications::OnStartMatchmakingAsyncComplete, response);
+                Multiplayer::MatchmakingAsyncRequestNotificationBus::Broadcast(
+                    &Multiplayer::MatchmakingAsyncRequestNotifications::OnStartMatchmakingAsyncComplete, response);
             },
             true, jobContext);
 
         startMatchmakingJob->Start(); 
     }
 
-    void AWSGameLiftClientManager::StopMatchmaking(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest)
+    void AWSGameLiftClientManager::StopMatchmaking(const Multiplayer::StopMatchmakingRequest& stopMatchmakingRequest)
     {
         if (StopMatchmakingActivity::ValidateStopMatchmakingRequest(stopMatchmakingRequest))
         {
@@ -393,12 +393,12 @@ namespace AWSGameLift
         }
     }
 
-    void AWSGameLiftClientManager::StopMatchmakingAsync(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest)
+    void AWSGameLiftClientManager::StopMatchmakingAsync(const Multiplayer::StopMatchmakingRequest& stopMatchmakingRequest)
     {
         if (!StopMatchmakingActivity::ValidateStopMatchmakingRequest(stopMatchmakingRequest))
         {
-            AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
-                &AzFramework::MatchmakingAsyncRequestNotifications::OnStopMatchmakingAsyncComplete);
+            Multiplayer::MatchmakingAsyncRequestNotificationBus::Broadcast(
+                &Multiplayer::MatchmakingAsyncRequestNotifications::OnStopMatchmakingAsyncComplete);
             return;
         }
 
@@ -412,8 +412,8 @@ namespace AWSGameLift
             {
                 StopMatchmakingActivity::StopMatchmaking(gameliftStopMatchmakingRequest);
 
-                AzFramework::MatchmakingAsyncRequestNotificationBus::Broadcast(
-                    &AzFramework::MatchmakingAsyncRequestNotifications::OnStopMatchmakingAsyncComplete);
+                Multiplayer::MatchmakingAsyncRequestNotificationBus::Broadcast(
+                    &Multiplayer::MatchmakingAsyncRequestNotifications::OnStopMatchmakingAsyncComplete);
             },
             true, jobContext);
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Matchmaking/MatchmakingNotifications.h>
+#include <Multiplayer/Session/MatchmakingNotifications.h>
 
 #include <Request/AWSGameLiftRequestBus.h>
 #include <Request/AWSGameLiftSessionRequestBus.h>
@@ -28,7 +28,7 @@ namespace AWSGameLift
 
     // MatchmakingNotificationBus EBus handler for scripting
     class AWSGameLiftMatchmakingNotificationBusHandler
-        : public AzFramework::MatchmakingNotificationBus::Handler
+        : public Multiplayer::MatchmakingNotificationBus::Handler
         , public AZ::BehaviorEBusHandler
     {
     public:
@@ -61,7 +61,7 @@ namespace AWSGameLift
 
     // MatchmakingAsyncRequestNotificationBus EBus handler for scripting
     class AWSGameLiftMatchmakingAsyncRequestNotificationBusHandler
-        : public AzFramework::MatchmakingAsyncRequestNotificationBus::Handler
+        : public Multiplayer::MatchmakingAsyncRequestNotificationBus::Handler
         , public AZ::BehaviorEBusHandler
     {
     public:
@@ -91,7 +91,7 @@ namespace AWSGameLift
 
     // SessionAsyncRequestNotificationBus EBus handler for scripting
     class AWSGameLiftSessionAsyncRequestNotificationBusHandler
-        : public AzFramework::SessionAsyncRequestNotificationBus::Handler
+        : public Multiplayer::SessionAsyncRequestNotificationBus::Handler
         , public AZ::BehaviorEBusHandler
     {
     public:
@@ -109,7 +109,7 @@ namespace AWSGameLift
             Call(FN_OnCreateSessionAsyncComplete, createSessionReponse);
         }
 
-        void OnSearchSessionsAsyncComplete(const AzFramework::SearchSessionsResponse& searchSessionsResponse) override
+        void OnSearchSessionsAsyncComplete(const Multiplayer::SearchSessionsResponse& searchSessionsResponse) override
         {
             Call(FN_OnSearchSessionsAsyncComplete, searchSessionsResponse);
         }
@@ -155,25 +155,25 @@ namespace AWSGameLift
         AZStd::string CreatePlayerId(bool includeBrackets, bool includeDashes) override;
 
         // AWSGameLiftMatchmakingAsyncRequestBus interface implementation
-        void AcceptMatchAsync(const AzFramework::AcceptMatchRequest& acceptMatchRequest) override;
-        void StartMatchmakingAsync(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest) override;
-        void StopMatchmakingAsync(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest) override;
+        void AcceptMatchAsync(const Multiplayer::AcceptMatchRequest& acceptMatchRequest) override;
+        void StartMatchmakingAsync(const Multiplayer::StartMatchmakingRequest& startMatchmakingRequest) override;
+        void StopMatchmakingAsync(const Multiplayer::StopMatchmakingRequest& stopMatchmakingRequest) override;
 
         // AWSGameLiftSessionAsyncRequestBus interface implementation
-        void CreateSessionAsync(const AzFramework::CreateSessionRequest& createSessionRequest) override;
-        void JoinSessionAsync(const AzFramework::JoinSessionRequest& joinSessionRequest) override;
-        void SearchSessionsAsync(const AzFramework::SearchSessionsRequest& searchSessionsRequest) const override;
+        void CreateSessionAsync(const Multiplayer::CreateSessionRequest& createSessionRequest) override;
+        void JoinSessionAsync(const Multiplayer::JoinSessionRequest& joinSessionRequest) override;
+        void SearchSessionsAsync(const Multiplayer::SearchSessionsRequest& searchSessionsRequest) const override;
         void LeaveSessionAsync() override;
 
         // AWSGameLiftMatchmakingRequestBus interface implementation
-        void AcceptMatch(const AzFramework::AcceptMatchRequest& acceptMatchRequest) override;
-        AZStd::string StartMatchmaking(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest) override;
-        void StopMatchmaking(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest) override;
+        void AcceptMatch(const Multiplayer::AcceptMatchRequest& acceptMatchRequest) override;
+        AZStd::string StartMatchmaking(const Multiplayer::StartMatchmakingRequest& startMatchmakingRequest) override;
+        void StopMatchmaking(const Multiplayer::StopMatchmakingRequest& stopMatchmakingRequest) override;
 
         // AWSGameLiftSessionRequestBus interface implementation
-        AZStd::string CreateSession(const AzFramework::CreateSessionRequest& createSessionRequest) override;
-        bool JoinSession(const AzFramework::JoinSessionRequest& joinSessionRequest) override;
-        AzFramework::SearchSessionsResponse SearchSessions(const AzFramework::SearchSessionsRequest& searchSessionsRequest) const override;
+        AZStd::string CreateSession(const Multiplayer::CreateSessionRequest& createSessionRequest) override;
+        bool JoinSession(const Multiplayer::JoinSessionRequest& joinSessionRequest) override;
+        Multiplayer::SearchSessionsResponse SearchSessions(const Multiplayer::SearchSessionsRequest& searchSessionsRequest) const override;
         void LeaveSession() override;
     };
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
 #include <AWSGameLiftClientLocalTicketTracker.h>
 #include <AWSCoreBus.h>
@@ -129,7 +129,7 @@ namespace AWSGameLift
                 ->Event("StopMatchmakingAsync", &AWSGameLiftMatchmakingAsyncRequestBus::Events::StopMatchmakingAsync,
                     { { { "StopMatchmakingRequest", "" } } });
 
-            behaviorContext->EBus<AzFramework::MatchmakingAsyncRequestNotificationBus>("AWSGameLiftMatchmakingAsyncRequestNotificationBus")
+            behaviorContext->EBus<Multiplayer::MatchmakingAsyncRequestNotificationBus>("AWSGameLiftMatchmakingAsyncRequestNotificationBus")
                 ->Attribute(AZ::Script::Attributes::Category, "AWSGameLift/Matchmaking")
                 ->Handler<AWSGameLiftMatchmakingAsyncRequestNotificationBusHandler>();
 
@@ -149,7 +149,7 @@ namespace AWSGameLift
                         { "PlayerId", "" } } })
                 ->Event("StopPolling", &AWSGameLiftMatchmakingEventRequestBus::Events::StopPolling);
 
-            behaviorContext->EBus<AzFramework::MatchmakingNotificationBus>("AWSGameLiftMatchmakingNotificationBus")
+            behaviorContext->EBus<Multiplayer::MatchmakingNotificationBus>("AWSGameLiftMatchmakingNotificationBus")
                 ->Attribute(AZ::Script::Attributes::Category, "AWSGameLift/Matchmaking")
                 ->Handler<AWSGameLiftMatchmakingNotificationBusHandler>();
         }
@@ -175,7 +175,7 @@ namespace AWSGameLift
                     { { { "SearchSessionsRequest", "" } } })
                 ->Event("LeaveSessionAsync", &AWSGameLiftSessionAsyncRequestBus::Events::LeaveSessionAsync);
 
-            behaviorContext->EBus<AzFramework::SessionAsyncRequestNotificationBus>("AWSGameLiftSessionAsyncRequestNotificationBus")
+            behaviorContext->EBus<Multiplayer::SessionAsyncRequestNotificationBus>("AWSGameLiftSessionAsyncRequestNotificationBus")
                 ->Attribute(AZ::Script::Attributes::Category, "AWSGameLift/Session")
                 ->Handler<AWSGameLiftSessionAsyncRequestNotificationBusHandler>();
 
@@ -190,10 +190,10 @@ namespace AWSGameLift
 
     void AWSGameLiftClientSystemComponent::ReflectCreateSessionRequest(AZ::ReflectContext* context)
     {
-        AzFramework::CreateSessionRequest::Reflect(context);
+        Multiplayer::CreateSessionRequest::Reflect(context);
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::CreateSessionRequest>("CreateSessionRequest")
+            behaviorContext->Class<Multiplayer::CreateSessionRequest>("CreateSessionRequest")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 // Expose base type to BehaviorContext, but hide it to be used directly
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
@@ -204,34 +204,34 @@ namespace AWSGameLift
     void AWSGameLiftClientSystemComponent::ReflectSearchSessionsResponse(AZ::ReflectContext* context)
     {
         // As it is a common response type, reflection could be moved to AzFramework to avoid duplication
-        AzFramework::SessionConfig::Reflect(context);
-        AzFramework::SearchSessionsResponse::Reflect(context);
+        Multiplayer::SessionConfig::Reflect(context);
+        Multiplayer::SearchSessionsResponse::Reflect(context);
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::SessionConfig>("SessionConfig")
+            behaviorContext->Class<Multiplayer::SessionConfig>("SessionConfig")
                 ->Attribute(AZ::Script::Attributes::Category, "Session")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
-                ->Property("CreationTime", BehaviorValueProperty(&AzFramework::SessionConfig::m_creationTime))
-                ->Property("CreatorId", BehaviorValueProperty(&AzFramework::SessionConfig::m_creatorId))
-                ->Property("CurrentPlayer", BehaviorValueProperty(&AzFramework::SessionConfig::m_currentPlayer))
-                ->Property("DnsName", BehaviorValueProperty(&AzFramework::SessionConfig::m_dnsName))
-                ->Property("IpAddress", BehaviorValueProperty(&AzFramework::SessionConfig::m_ipAddress))
-                ->Property("MaxPlayer", BehaviorValueProperty(&AzFramework::SessionConfig::m_maxPlayer))
-                ->Property("Port", BehaviorValueProperty(&AzFramework::SessionConfig::m_port))
-                ->Property("SessionId", BehaviorValueProperty(&AzFramework::SessionConfig::m_sessionId))
-                ->Property("SessionName", BehaviorValueProperty(&AzFramework::SessionConfig::m_sessionName))
-                ->Property("SessionProperties", BehaviorValueProperty(&AzFramework::SessionConfig::m_sessionProperties))
-                ->Property("MatchmakingData", BehaviorValueProperty(&AzFramework::SessionConfig::m_matchmakingData))
-                ->Property("Status", BehaviorValueProperty(&AzFramework::SessionConfig::m_status))
-                ->Property("StatusReason", BehaviorValueProperty(&AzFramework::SessionConfig::m_statusReason))
-                ->Property("TerminationTime", BehaviorValueProperty(&AzFramework::SessionConfig::m_terminationTime))
+                ->Property("CreationTime", BehaviorValueProperty(&Multiplayer::SessionConfig::m_creationTime))
+                ->Property("CreatorId", BehaviorValueProperty(&Multiplayer::SessionConfig::m_creatorId))
+                ->Property("CurrentPlayer", BehaviorValueProperty(&Multiplayer::SessionConfig::m_currentPlayer))
+                ->Property("DnsName", BehaviorValueProperty(&Multiplayer::SessionConfig::m_dnsName))
+                ->Property("IpAddress", BehaviorValueProperty(&Multiplayer::SessionConfig::m_ipAddress))
+                ->Property("MaxPlayer", BehaviorValueProperty(&Multiplayer::SessionConfig::m_maxPlayer))
+                ->Property("Port", BehaviorValueProperty(&Multiplayer::SessionConfig::m_port))
+                ->Property("SessionId", BehaviorValueProperty(&Multiplayer::SessionConfig::m_sessionId))
+                ->Property("SessionName", BehaviorValueProperty(&Multiplayer::SessionConfig::m_sessionName))
+                ->Property("SessionProperties", BehaviorValueProperty(&Multiplayer::SessionConfig::m_sessionProperties))
+                ->Property("MatchmakingData", BehaviorValueProperty(&Multiplayer::SessionConfig::m_matchmakingData))
+                ->Property("Status", BehaviorValueProperty(&Multiplayer::SessionConfig::m_status))
+                ->Property("StatusReason", BehaviorValueProperty(&Multiplayer::SessionConfig::m_statusReason))
+                ->Property("TerminationTime", BehaviorValueProperty(&Multiplayer::SessionConfig::m_terminationTime))
                 ;
-            behaviorContext->Class<AzFramework::SearchSessionsResponse>("SearchSessionsResponse")
+            behaviorContext->Class<Multiplayer::SearchSessionsResponse>("SearchSessionsResponse")
                 ->Attribute(AZ::Script::Attributes::Category, "Session")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
-                ->Property("NextToken", BehaviorValueProperty(&AzFramework::SearchSessionsResponse::m_nextToken))
-                ->Property("SessionConfigs", BehaviorValueProperty(&AzFramework::SearchSessionsResponse::m_sessionConfigs))
+                ->Property("NextToken", BehaviorValueProperty(&Multiplayer::SearchSessionsResponse::m_nextToken))
+                ->Property("SessionConfigs", BehaviorValueProperty(&Multiplayer::SearchSessionsResponse::m_sessionConfigs))
                 ;
         }
     }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.cpp
@@ -69,7 +69,7 @@ namespace AWSGameLift
             }
         }
 
-        bool ValidateAcceptMatchRequest(const AzFramework::AcceptMatchRequest& AcceptMatchRequest)
+        bool ValidateAcceptMatchRequest(const Multiplayer::AcceptMatchRequest& AcceptMatchRequest)
         {
             auto gameliftAcceptMatchRequest = azrtti_cast<const AWSGameLiftAcceptMatchRequest*>(&AcceptMatchRequest);
             bool isValid = gameliftAcceptMatchRequest &&

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftAcceptMatchActivity.h
@@ -26,6 +26,6 @@ namespace AWSGameLift
         void AcceptMatch(const AWSGameLiftAcceptMatchRequest& AcceptMatchRequest);
 
         // Validate AcceptMatchRequest and check required request parameters
-        bool ValidateAcceptMatchRequest(const AzFramework::AcceptMatchRequest& AcceptMatchRequest);
+        bool ValidateAcceptMatchRequest(const Multiplayer::AcceptMatchRequest& AcceptMatchRequest);
     } // namespace AcceptMatchActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.cpp
@@ -99,7 +99,7 @@ namespace AWSGameLift
             return result;
         }
 
-        bool ValidateCreateSessionRequest(const AzFramework::CreateSessionRequest& createSessionRequest)
+        bool ValidateCreateSessionRequest(const Multiplayer::CreateSessionRequest& createSessionRequest)
         {
             auto gameliftCreateSessionRequest = azrtti_cast<const AWSGameLiftCreateSessionRequest*>(&createSessionRequest);
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.h
@@ -25,7 +25,7 @@ namespace AWSGameLift
         AZStd::string CreateSession(const AWSGameLiftCreateSessionRequest& createSessionRequest);
 
         // Validate CreateSessionRequest and check required request parameters
-        bool ValidateCreateSessionRequest(const AzFramework::CreateSessionRequest& createSessionRequest);
+        bool ValidateCreateSessionRequest(const Multiplayer::CreateSessionRequest& createSessionRequest);
 
     } // namespace CreateSessionActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.cpp
@@ -87,7 +87,7 @@ namespace AWSGameLift
             return result;
         }
 
-        bool ValidateCreateSessionOnQueueRequest(const AzFramework::CreateSessionRequest& createSessionRequest)
+        bool ValidateCreateSessionOnQueueRequest(const Multiplayer::CreateSessionRequest& createSessionRequest)
         {
             auto gameliftCreateSessionOnQueueRequest =
                 azrtti_cast<const AWSGameLiftCreateSessionOnQueueRequest*>(&createSessionRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.h
@@ -26,7 +26,7 @@ namespace AWSGameLift
         AZStd::string CreateSessionOnQueue(const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest);
 
         // Validate CreateSessionOnQueueRequest and check required request parameters
-        bool ValidateCreateSessionOnQueueRequest(const AzFramework::CreateSessionRequest& createSessionRequest);
+        bool ValidateCreateSessionOnQueueRequest(const Multiplayer::CreateSessionRequest& createSessionRequest);
 
     } // namespace CreateSessionOnQueueActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.cpp
@@ -39,10 +39,10 @@ namespace AWSGameLift
             return request;
         }
 
-        AzFramework::SessionConnectionConfig BuildSessionConnectionConfig(
+        Multiplayer::SessionConnectionConfig BuildSessionConnectionConfig(
             const Aws::GameLift::Model::CreatePlayerSessionOutcome& createPlayerSessionOutcome)
         {
-            AzFramework::SessionConnectionConfig sessionConnectionConfig;
+            Multiplayer::SessionConnectionConfig sessionConnectionConfig;
             auto createPlayerSessionResult = createPlayerSessionOutcome.GetResult();
             // TODO: AWSNativeSDK needs to be updated to support this attribute, and it is a must have for TLS certificate enabled fleet
             //sessionConnectionConfig.m_dnsName = createPlayerSessionResult.GetPlayerSession().GetDnsName().c_str();
@@ -95,10 +95,10 @@ namespace AWSGameLift
             bool result = false;
             if (createPlayerSessionOutcome.IsSuccess())
             {
-                auto clientRequestHandler = AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Get();
+                auto clientRequestHandler = AZ::Interface<Multiplayer::ISessionHandlingClientRequests>::Get();
                 if (clientRequestHandler)
                 {
-                    AzFramework::SessionConnectionConfig sessionConnectionConfig =
+                    Multiplayer::SessionConnectionConfig sessionConnectionConfig =
                         BuildSessionConnectionConfig(createPlayerSessionOutcome);
 
                     AZ_TracePrintf(AWSGameLiftJoinSessionActivityName,
@@ -114,7 +114,7 @@ namespace AWSGameLift
             return result;
         }
 
-        bool ValidateJoinSessionRequest(const AzFramework::JoinSessionRequest& joinSessionRequest)
+        bool ValidateJoinSessionRequest(const Multiplayer::JoinSessionRequest& joinSessionRequest)
         {
             auto gameliftJoinSessionRequest = azrtti_cast<const AWSGameLiftJoinSessionRequest*>(&joinSessionRequest);
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzFramework/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
 
 #include <Request/AWSGameLiftJoinSessionRequest.h>
 
@@ -31,7 +31,7 @@ namespace AWSGameLift
             const AWSGameLiftJoinSessionRequest& joinSessionRequest);
 
         // Build session connection config by using CreatePlayerSessionOutcome
-        AzFramework::SessionConnectionConfig BuildSessionConnectionConfig(
+        Multiplayer::SessionConnectionConfig BuildSessionConnectionConfig(
             const Aws::GameLift::Model::CreatePlayerSessionOutcome& createPlayerSessionOutcome);
 
         // Create CreatePlayerSessionRequest and make a CreatePlayerSession call through GameLift client
@@ -43,7 +43,7 @@ namespace AWSGameLift
             const Aws::GameLift::Model::CreatePlayerSessionOutcome& createPlayerSessionOutcome);
 
         // Validate JoinSessionRequest and check required request parameters
-        bool ValidateJoinSessionRequest(const AzFramework::JoinSessionRequest& joinSessionRequest);
+        bool ValidateJoinSessionRequest(const Multiplayer::JoinSessionRequest& joinSessionRequest);
 
     } // namespace JoinSessionActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftLeaveSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftLeaveSessionActivity.cpp
@@ -8,7 +8,7 @@
 
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
 
 #include <Activity/AWSGameLiftLeaveSessionActivity.h>
 
@@ -18,7 +18,7 @@ namespace AWSGameLift
     {
         void LeaveSession()
         {
-            auto clientRequestHandler = AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Get();
+            auto clientRequestHandler = AZ::Interface<Multiplayer::ISessionHandlingClientRequests>::Get();
             if (clientRequestHandler)
             {
                 AZ_TracePrintf(AWSGameLiftLeaveSessionActivityName, "Requesting player to leave the current session ...");

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.cpp
@@ -8,7 +8,7 @@
 
 #include <AzCore/Interface/Interface.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
 #include <Activity/AWSGameLiftSearchSessionsActivity.h>
 #include <AWSGameLiftSessionConstants.h>
@@ -67,10 +67,10 @@ namespace AWSGameLift
             return request;
         }
 
-        AzFramework::SearchSessionsResponse SearchSessions(
+        Multiplayer::SearchSessionsResponse SearchSessions(
             const AWSGameLiftSearchSessionsRequest& searchSessionsRequest)
         {
-            AzFramework::SearchSessionsResponse response;
+            Multiplayer::SearchSessionsResponse response;
 
             auto gameliftClient = AZ::Interface<IAWSGameLiftInternalRequests>::Get()->GetGameLiftClient();
             if (!gameliftClient)
@@ -98,15 +98,15 @@ namespace AWSGameLift
             return response;
         }
 
-        AzFramework::SearchSessionsResponse ParseResponse(
+        Multiplayer::SearchSessionsResponse ParseResponse(
             const Aws::GameLift::Model::SearchGameSessionsResult& gameLiftSearchSessionsResult)
         {
-            AzFramework::SearchSessionsResponse response;
+            Multiplayer::SearchSessionsResponse response;
             response.m_nextToken = gameLiftSearchSessionsResult.GetNextToken().c_str();
 
             for (const Aws::GameLift::Model::GameSession& gameSession : gameLiftSearchSessionsResult.GetGameSessions())
             {
-                AzFramework::SessionConfig session;
+                Multiplayer::SessionConfig session;
                 session.m_creationTime = gameSession.GetCreationTime().Millis();
                 session.m_creatorId = gameSession.GetCreatorId().c_str();
                 session.m_currentPlayer = gameSession.GetCurrentPlayerSessionCount();
@@ -133,7 +133,7 @@ namespace AWSGameLift
             return response;
         };
 
-        bool ValidateSearchSessionsRequest(const AzFramework::SearchSessionsRequest& searchSessionsRequest)
+        bool ValidateSearchSessionsRequest(const Multiplayer::SearchSessionsRequest& searchSessionsRequest)
         {
             auto gameliftSearchSessionsRequest = azrtti_cast<const AWSGameLiftSearchSessionsRequest*>(&searchSessionsRequest);
             if (gameliftSearchSessionsRequest &&

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.h
@@ -25,14 +25,14 @@ namespace AWSGameLift
             const AWSGameLiftSearchSessionsRequest& searchSessionsRequest);
 
         // Create SearchGameSessionsRequest and make a SeachGameSessions call through GameLift client
-        AzFramework::SearchSessionsResponse SearchSessions(
+        Multiplayer::SearchSessionsResponse SearchSessions(
             const AWSGameLiftSearchSessionsRequest& searchSessionsRequest);
 
-        // Convert from Aws::GameLift::Model::SearchGameSessionsResult to AzFramework::SearchSessionsResponse.
-        AzFramework::SearchSessionsResponse ParseResponse(
+        // Convert from Aws::GameLift::Model::SearchGameSessionsResult to Multiplayer::SearchSessionsResponse.
+        Multiplayer::SearchSessionsResponse ParseResponse(
             const Aws::GameLift::Model::SearchGameSessionsResult& gameLiftSearchSessionsResult);
 
         // Validate SearchSessionsRequest and check required request parameters
-        bool ValidateSearchSessionsRequest(const AzFramework::SearchSessionsRequest& searchSessionsRequest);
+        bool ValidateSearchSessionsRequest(const Multiplayer::SearchSessionsRequest& searchSessionsRequest);
     } // namespace SearchSessionsActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStartMatchmakingActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStartMatchmakingActivity.cpp
@@ -110,7 +110,7 @@ namespace AWSGameLift
             return result;
         }
 
-        bool ValidateStartMatchmakingRequest(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest)
+        bool ValidateStartMatchmakingRequest(const Multiplayer::StartMatchmakingRequest& startMatchmakingRequest)
         {
             auto gameliftStartMatchmakingRequest = azrtti_cast<const AWSGameLiftStartMatchmakingRequest*>(&startMatchmakingRequest);
             bool isValid = gameliftStartMatchmakingRequest &&

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStartMatchmakingActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStartMatchmakingActivity.h
@@ -26,6 +26,6 @@ namespace AWSGameLift
         AZStd::string StartMatchmaking(const AWSGameLiftStartMatchmakingRequest& startMatchmakingRequest);
 
         // Validate StartMatchmakingRequest and check required request parameters
-        bool ValidateStartMatchmakingRequest(const AzFramework::StartMatchmakingRequest& startMatchmakingRequest);
+        bool ValidateStartMatchmakingRequest(const Multiplayer::StartMatchmakingRequest& startMatchmakingRequest);
     } // namespace StartMatchmakingActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.cpp
@@ -59,7 +59,7 @@ namespace AWSGameLift
             }
         }
 
-        bool ValidateStopMatchmakingRequest(const AzFramework::StopMatchmakingRequest& StopMatchmakingRequest)
+        bool ValidateStopMatchmakingRequest(const Multiplayer::StopMatchmakingRequest& StopMatchmakingRequest)
         {
             auto gameliftStopMatchmakingRequest = azrtti_cast<const AWSGameLiftStopMatchmakingRequest*>(&StopMatchmakingRequest);
             bool isValid = gameliftStopMatchmakingRequest && (!gameliftStopMatchmakingRequest->m_ticketId.empty());

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftStopMatchmakingActivity.h
@@ -26,6 +26,6 @@ namespace AWSGameLift
         void StopMatchmaking(const AWSGameLiftStopMatchmakingRequest& stopMatchmakingRequest);
 
         // Validate StopMatchmakingRequest and check required request parameters
-        bool ValidateStopMatchmakingRequest(const AzFramework::StopMatchmakingRequest& stopMatchmakingRequest);
+        bool ValidateStopMatchmakingRequest(const Multiplayer::StopMatchmakingRequest& stopMatchmakingRequest);
     } // namespace StopMatchmakingActivity
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftAcceptMatchRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftAcceptMatchRequest.cpp
@@ -16,11 +16,11 @@ namespace AWSGameLift
 {
     void AWSGameLiftAcceptMatchRequest::Reflect(AZ::ReflectContext* context)
     {
-        AzFramework::AcceptMatchRequest::Reflect(context);
+        Multiplayer::AcceptMatchRequest::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftAcceptMatchRequest, AzFramework::AcceptMatchRequest>()
+            serializeContext->Class<AWSGameLiftAcceptMatchRequest, Multiplayer::AcceptMatchRequest>()
                 ->Version(0);
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -33,7 +33,7 @@ namespace AWSGameLift
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::AcceptMatchRequest>("AcceptMatchRequest")
+            behaviorContext->Class<Multiplayer::AcceptMatchRequest>("AcceptMatchRequest")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 // Expose base type to BehaviorContext, but hide it to be used directly
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionOnQueueRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionOnQueueRequest.cpp
@@ -18,7 +18,7 @@ namespace AWSGameLift
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftCreateSessionOnQueueRequest, AzFramework::CreateSessionRequest>()
+            serializeContext->Class<AWSGameLiftCreateSessionOnQueueRequest, Multiplayer::CreateSessionRequest>()
                 ->Version(0)
                 ->Field("queueName", &AWSGameLiftCreateSessionOnQueueRequest::m_queueName)
                 ->Field("placementId", &AWSGameLiftCreateSessionOnQueueRequest::m_placementId)

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftCreateSessionRequest.cpp
@@ -18,7 +18,7 @@ namespace AWSGameLift
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftCreateSessionRequest, AzFramework::CreateSessionRequest>()
+            serializeContext->Class<AWSGameLiftCreateSessionRequest, Multiplayer::CreateSessionRequest>()
                 ->Version(0)
                 ->Field("aliasId", &AWSGameLiftCreateSessionRequest::m_aliasId)
                 ->Field("fleetId", &AWSGameLiftCreateSessionRequest::m_fleetId)

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftJoinSessionRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftJoinSessionRequest.cpp
@@ -15,11 +15,11 @@ namespace AWSGameLift
 {
     void AWSGameLiftJoinSessionRequest::Reflect(AZ::ReflectContext* context)
     {
-        AzFramework::JoinSessionRequest::Reflect(context);
+        Multiplayer::JoinSessionRequest::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftJoinSessionRequest, AzFramework::JoinSessionRequest>()
+            serializeContext->Class<AWSGameLiftJoinSessionRequest, Multiplayer::JoinSessionRequest>()
                 ->Version(0)
                 ;
 
@@ -34,7 +34,7 @@ namespace AWSGameLift
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::JoinSessionRequest>("JoinSessionRequest")
+            behaviorContext->Class<Multiplayer::JoinSessionRequest>("JoinSessionRequest")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 // Expose base type to BehaviorContext, but hide it to be used directly
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftSearchSessionsRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftSearchSessionsRequest.cpp
@@ -12,17 +12,17 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
 namespace AWSGameLift
 {
     void AWSGameLiftSearchSessionsRequest::Reflect(AZ::ReflectContext* context)
     {
-        AzFramework::SearchSessionsRequest::Reflect(context);
+        Multiplayer::SearchSessionsRequest::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftSearchSessionsRequest, AzFramework::SearchSessionsRequest>()
+            serializeContext->Class<AWSGameLiftSearchSessionsRequest, Multiplayer::SearchSessionsRequest>()
                 ->Version(0)
                 ->Field("aliasId", &AWSGameLiftSearchSessionsRequest::m_aliasId)
                 ->Field("fleetId", &AWSGameLiftSearchSessionsRequest::m_fleetId)
@@ -47,7 +47,7 @@ namespace AWSGameLift
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::SearchSessionsRequest>("SearchSessionsRequest")
+            behaviorContext->Class<Multiplayer::SearchSessionsRequest>("SearchSessionsRequest")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 // Expose base type to BehaviorContext, but hide it to be used directly
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftStartMatchmakingRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftStartMatchmakingRequest.cpp
@@ -16,12 +16,12 @@ namespace AWSGameLift
 {
     void AWSGameLiftStartMatchmakingRequest::Reflect(AZ::ReflectContext* context)
     {
-        AzFramework::StartMatchmakingRequest::Reflect(context);
+        Multiplayer::StartMatchmakingRequest::Reflect(context);
         AWSGameLiftPlayer::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftStartMatchmakingRequest, AzFramework::StartMatchmakingRequest>()
+            serializeContext->Class<AWSGameLiftStartMatchmakingRequest, Multiplayer::StartMatchmakingRequest>()
                 ->Version(0)
                 ->Field("configurationName", &AWSGameLiftStartMatchmakingRequest::m_configurationName)
                 ->Field("players", &AWSGameLiftStartMatchmakingRequest::m_players);
@@ -40,7 +40,7 @@ namespace AWSGameLift
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::StartMatchmakingRequest>("StartMatchmakingRequest")
+            behaviorContext->Class<Multiplayer::StartMatchmakingRequest>("StartMatchmakingRequest")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 // Expose base type to BehaviorContext, but hide it to be used directly
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftStopMatchmakingRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftStopMatchmakingRequest.cpp
@@ -16,11 +16,11 @@ namespace AWSGameLift
 {
     void AWSGameLiftStopMatchmakingRequest::Reflect(AZ::ReflectContext* context)
     {
-        AzFramework::StopMatchmakingRequest::Reflect(context);
+        Multiplayer::StopMatchmakingRequest::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<AWSGameLiftStopMatchmakingRequest, AzFramework::StopMatchmakingRequest>()
+            serializeContext->Class<AWSGameLiftStopMatchmakingRequest, Multiplayer::StopMatchmakingRequest>()
                 ->Version(0);
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
@@ -33,7 +33,7 @@ namespace AWSGameLift
 
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->Class<AzFramework::StopMatchmakingRequest>("StopMatchmakingRequest")
+            behaviorContext->Class<Multiplayer::StopMatchmakingRequest>("StopMatchmakingRequest")
                 ->Attribute(AZ::Script::Attributes::Storage, AZ::Script::Attributes::StorageType::Value)
                 // Expose base type to BehaviorContext, but hide it to be used directly
                 ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 #include <Credential/AWSCredentialBus.h>
 #include <ResourceMapping/AWSResourceMappingBus.h>
 
@@ -201,9 +201,9 @@ protected:
         return Aws::GameLift::Model::SearchGameSessionsOutcome(result);
     }
 
-    AzFramework::SearchSessionsResponse GetValidSearchSessionsResponse()
+    Multiplayer::SearchSessionsResponse GetValidSearchSessionsResponse()
     {
-        AzFramework::SessionConfig sessionConfig;
+        Multiplayer::SessionConfig sessionConfig;
         sessionConfig.m_creationTime = 0;
         sessionConfig.m_terminationTime = 0;
         sessionConfig.m_creatorId = "dummyCreatorId";
@@ -220,7 +220,7 @@ protected:
         // TODO: Update the AWS Native SDK to set the new game session attributes.
         // sessionConfig.m_dnsName = "dummyDnsName";
 
-        AzFramework::SearchSessionsResponse response;
+        Multiplayer::SearchSessionsResponse response;
         response.m_nextToken = "dummyNextToken";
         response.m_sessionConfigs = { sessionConfig };
 
@@ -344,7 +344,7 @@ TEST_F(AWSGameLiftClientManagerTest, CreateSession_CallWithoutClientSetup_GetEmp
 TEST_F(AWSGameLiftClientManagerTest, CreateSession_CallWithInvalidRequest_GetEmptyResponse)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto response = m_gameliftClientManager->CreateSession(AzFramework::CreateSessionRequest());
+    auto response = m_gameliftClientManager->CreateSession(Multiplayer::CreateSessionRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
     EXPECT_TRUE(response == "");
 }
@@ -381,7 +381,7 @@ TEST_F(AWSGameLiftClientManagerTest, CreateSessionAsync_CallWithInvalidRequest_G
     AZ_TEST_START_TRACE_SUPPRESSION;
     SessionAsyncRequestNotificationsHandlerMock sessionHandlerMock;
     EXPECT_CALL(sessionHandlerMock, OnCreateSessionAsyncComplete(AZStd::string())).Times(1);
-    m_gameliftClientManager->CreateSessionAsync(AzFramework::CreateSessionRequest());
+    m_gameliftClientManager->CreateSessionAsync(Multiplayer::CreateSessionRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }
 
@@ -513,7 +513,7 @@ TEST_F(AWSGameLiftClientManagerTest, JoinSession_CallWithoutClientSetup_GetFalse
 TEST_F(AWSGameLiftClientManagerTest, JoinSession_CallWithInvalidRequest_GetFalseResponse)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto response = m_gameliftClientManager->JoinSession(AzFramework::JoinSessionRequest());
+    auto response = m_gameliftClientManager->JoinSession(Multiplayer::JoinSessionRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
     EXPECT_FALSE(response);
 }
@@ -590,7 +590,7 @@ TEST_F(AWSGameLiftClientManagerTest, JoinSessionAsync_CallWithInvalidRequest_Get
     AZ_TEST_START_TRACE_SUPPRESSION;
     SessionAsyncRequestNotificationsHandlerMock sessionHandlerMock;
     EXPECT_CALL(sessionHandlerMock, OnJoinSessionAsyncComplete(false)).Times(1);
-    m_gameliftClientManager->JoinSessionAsync(AzFramework::JoinSessionRequest());
+    m_gameliftClientManager->JoinSessionAsync(Multiplayer::JoinSessionRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }
 
@@ -698,7 +698,7 @@ TEST_F(AWSGameLiftClientManagerTest, SearchSessions_CallWithValidRequestAndSucce
         .Times(1)
         .WillOnce(::testing::Return(outcome));
 
-    AzFramework::SearchSessionsResponse expectedResponse = GetValidSearchSessionsResponse();
+    Multiplayer::SearchSessionsResponse expectedResponse = GetValidSearchSessionsResponse();
     auto result = m_gameliftClientManager->SearchSessions(request);
     EXPECT_TRUE(result.m_sessionConfigs.size() != 0);
 }
@@ -713,7 +713,7 @@ TEST_F(AWSGameLiftClientManagerTest, SearchSessionsAsync_CallWithoutClientSetup_
 
     SessionAsyncRequestNotificationsHandlerMock sessionHandlerMock;
     EXPECT_CALL(sessionHandlerMock,
-        OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(AzFramework::SearchSessionsResponse()))).Times(1);
+        OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(Multiplayer::SearchSessionsResponse()))).Times(1);
 
     AZ_TEST_START_TRACE_SUPPRESSION;
     m_gameliftClientManager->SearchSessionsAsync(request);
@@ -725,9 +725,9 @@ TEST_F(AWSGameLiftClientManagerTest, SearchSessionsAsync_CallWithInvalidRequest_
     AZ_TEST_START_TRACE_SUPPRESSION;
     SessionAsyncRequestNotificationsHandlerMock sessionHandlerMock;
     EXPECT_CALL(sessionHandlerMock,
-        OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(AzFramework::SearchSessionsResponse()))).Times(1);
+        OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(Multiplayer::SearchSessionsResponse()))).Times(1);
 
-    m_gameliftClientManager->SearchSessionsAsync(AzFramework::SearchSessionsRequest());
+    m_gameliftClientManager->SearchSessionsAsync(Multiplayer::SearchSessionsRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }
 
@@ -746,7 +746,7 @@ TEST_F(AWSGameLiftClientManagerTest, SearchSessionsAsync_CallWithValidRequestAnd
 
     SessionAsyncRequestNotificationsHandlerMock sessionHandlerMock;
     EXPECT_CALL(sessionHandlerMock,
-        OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(AzFramework::SearchSessionsResponse()))).Times(1);
+        OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(Multiplayer::SearchSessionsResponse()))).Times(1);
 
     AZ_TEST_START_TRACE_SUPPRESSION;
     m_gameliftClientManager->SearchSessionsAsync(request);
@@ -765,7 +765,7 @@ TEST_F(AWSGameLiftClientManagerTest, SearchSessionsAsync_CallWithValidRequestAnd
         .Times(1)
         .WillOnce(::testing::Return(outcome));
 
-    AzFramework::SearchSessionsResponse expectedResponse = GetValidSearchSessionsResponse();
+    Multiplayer::SearchSessionsResponse expectedResponse = GetValidSearchSessionsResponse();
     SessionAsyncRequestNotificationsHandlerMock sessionHandlerMock;
     EXPECT_CALL(sessionHandlerMock,
         OnSearchSessionsAsyncComplete(SearchSessionsResponseMatcher(expectedResponse))).Times(1);
@@ -926,7 +926,7 @@ TEST_F(AWSGameLiftClientManagerTest, StopMatchmaking_CallWithoutClientSetup_GetE
 TEST_F(AWSGameLiftClientManagerTest, StopMatchmaking_CallWithInvalidRequest_GetError)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    m_gameliftClientManager->StopMatchmaking(AzFramework::StopMatchmakingRequest());
+    m_gameliftClientManager->StopMatchmaking(Multiplayer::StopMatchmakingRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }
 
@@ -1029,7 +1029,7 @@ TEST_F(AWSGameLiftClientManagerTest, AcceptMatch_CallWithoutClientSetup_GetError
 TEST_F(AWSGameLiftClientManagerTest, AcceptMatch_CallWithInvalidRequest_GetError)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    m_gameliftClientManager->AcceptMatch(AzFramework::AcceptMatchRequest());
+    m_gameliftClientManager->AcceptMatch(Multiplayer::AcceptMatchRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientMocks.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientMocks.h
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <AzCore/Interface/Interface.h>
-#include <AzFramework/Session/ISessionRequests.h>
-#include <AzFramework/Session/ISessionHandlingRequests.h>
-#include <AzFramework/Matchmaking/IMatchmakingRequests.h>
-#include <AzFramework/Matchmaking/MatchmakingNotifications.h>
+#include <Multiplayer/Session/ISessionRequests.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/IMatchmakingRequests.h>
+#include <Multiplayer/Session/MatchmakingNotifications.h>
 #include <AzTest/AzTest.h>
 
 #include <aws/core/auth/AWSCredentialsProvider.h>
@@ -58,17 +58,17 @@ public:
 };
 
 class MatchmakingAsyncRequestNotificationsHandlerMock
-    : public AzFramework::MatchmakingAsyncRequestNotificationBus::Handler
+    : public Multiplayer::MatchmakingAsyncRequestNotificationBus::Handler
 {
 public:
     MatchmakingAsyncRequestNotificationsHandlerMock()
     {
-        AzFramework::MatchmakingAsyncRequestNotificationBus::Handler::BusConnect();
+        Multiplayer::MatchmakingAsyncRequestNotificationBus::Handler::BusConnect();
     }
 
     ~MatchmakingAsyncRequestNotificationsHandlerMock()
     {
-        AzFramework::MatchmakingAsyncRequestNotificationBus::Handler::BusDisconnect();
+        Multiplayer::MatchmakingAsyncRequestNotificationBus::Handler::BusDisconnect();
     }
 
     MOCK_METHOD0(OnAcceptMatchAsyncComplete, void());
@@ -77,17 +77,17 @@ public:
 };
 
 class MatchmakingNotificationsHandlerMock
-    : public AzFramework::MatchmakingNotificationBus::Handler
+    : public Multiplayer::MatchmakingNotificationBus::Handler
 {
 public:
     MatchmakingNotificationsHandlerMock()
     {
-        AzFramework::MatchmakingNotificationBus::Handler::BusConnect();
+        Multiplayer::MatchmakingNotificationBus::Handler::BusConnect();
     }
 
     ~MatchmakingNotificationsHandlerMock()
     {
-        AzFramework::MatchmakingNotificationBus::Handler::BusDisconnect();
+        Multiplayer::MatchmakingNotificationBus::Handler::BusDisconnect();
     }
 
     void OnMatchAcceptance() override
@@ -117,39 +117,39 @@ public:
 };
 
 class SessionAsyncRequestNotificationsHandlerMock
-    : public AzFramework::SessionAsyncRequestNotificationBus::Handler
+    : public Multiplayer::SessionAsyncRequestNotificationBus::Handler
 {
 public:
     SessionAsyncRequestNotificationsHandlerMock()
     {
-        AzFramework::SessionAsyncRequestNotificationBus::Handler::BusConnect();
+        Multiplayer::SessionAsyncRequestNotificationBus::Handler::BusConnect();
     }
 
     ~SessionAsyncRequestNotificationsHandlerMock()
     {
-        AzFramework::SessionAsyncRequestNotificationBus::Handler::BusDisconnect();
+        Multiplayer::SessionAsyncRequestNotificationBus::Handler::BusDisconnect();
     }
 
     MOCK_METHOD1(OnCreateSessionAsyncComplete, void(const AZStd::string&));
-    MOCK_METHOD1(OnSearchSessionsAsyncComplete, void(const AzFramework::SearchSessionsResponse&));
+    MOCK_METHOD1(OnSearchSessionsAsyncComplete, void(const Multiplayer::SearchSessionsResponse&));
     MOCK_METHOD1(OnJoinSessionAsyncComplete, void(bool));
     MOCK_METHOD0(OnLeaveSessionAsyncComplete, void());
 };
 
 class SessionHandlingClientRequestsMock
-    : public AzFramework::ISessionHandlingClientRequests
+    : public Multiplayer::ISessionHandlingClientRequests
 {
 public:
     SessionHandlingClientRequestsMock()
     {
-        AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Register(this);
+        AZ::Interface<Multiplayer::ISessionHandlingClientRequests>::Register(this);
     }
 
     virtual ~SessionHandlingClientRequestsMock()
     {
-        AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Unregister(this);
+        AZ::Interface<Multiplayer::ISessionHandlingClientRequests>::Unregister(this);
     }
 
-    MOCK_METHOD1(RequestPlayerJoinSession, bool(const AzFramework::SessionConnectionConfig&));
+    MOCK_METHOD1(RequestPlayerJoinSession, bool(const Multiplayer::SessionConnectionConfig&));
     MOCK_METHOD0(RequestPlayerLeaveSession, void());
 };

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftAcceptMatchActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftAcceptMatchActivityTest.cpp
@@ -35,7 +35,7 @@ TEST_F(AWSGameLiftAcceptMatchActivityTest, BuildAWSGameLiftAcceptMatchRequest_Ca
 TEST_F(AWSGameLiftAcceptMatchActivityTest, ValidateAcceptMatchRequest_CallWithBaseType_GetFalseResult)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto result = AcceptMatchActivity::ValidateAcceptMatchRequest(AzFramework::AcceptMatchRequest());
+    auto result = AcceptMatchActivity::ValidateAcceptMatchRequest(Multiplayer::AcceptMatchRequest());
     EXPECT_FALSE(result);
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionActivityTest.cpp
@@ -39,7 +39,7 @@ TEST_F(AWSGameLiftCreateSessionActivityTest, BuildAWSGameLiftCreateGameSessionRe
 
 TEST_F(AWSGameLiftCreateSessionActivityTest, ValidateCreateSessionRequest_CallWithBaseType_GetFalseResult)
 {
-    auto result = CreateSessionActivity::ValidateCreateSessionRequest(AzFramework::CreateSessionRequest());
+    auto result = CreateSessionActivity::ValidateCreateSessionRequest(Multiplayer::CreateSessionRequest());
     EXPECT_FALSE(result);   
 }
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionOnQueueActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftCreateSessionOnQueueActivityTest.cpp
@@ -35,7 +35,7 @@ TEST_F(AWSGameLiftCreateSessionOnQueueActivityTest, BuildAWSGameLiftCreateGameSe
 
 TEST_F(AWSGameLiftCreateSessionOnQueueActivityTest, ValidateCreateSessionOnQueueRequest_CallWithBaseType_GetFalseResult)
 {
-    auto result = CreateSessionOnQueueActivity::ValidateCreateSessionOnQueueRequest(AzFramework::CreateSessionRequest());
+    auto result = CreateSessionOnQueueActivity::ValidateCreateSessionOnQueueRequest(Multiplayer::CreateSessionRequest());
     EXPECT_FALSE(result);
 }
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftJoinSessionActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftJoinSessionActivityTest.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <AzFramework/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
 
 #include <AWSGameLiftClientFixture.h>
 #include <Activity/AWSGameLiftJoinSessionActivity.h>
@@ -47,7 +47,7 @@ TEST_F(AWSGameLiftJoinSessionActivityTest, BuildSessionConnectionConfig_Call_Get
 TEST_F(AWSGameLiftJoinSessionActivityTest, ValidateJoinSessionRequest_CallWithBaseType_GetFalseResult)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto result = JoinSessionActivity::ValidateJoinSessionRequest(AzFramework::JoinSessionRequest());
+    auto result = JoinSessionActivity::ValidateJoinSessionRequest(Multiplayer::JoinSessionRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message 
     EXPECT_FALSE(result);
 }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftSearchSessionsActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftSearchSessionsActivityTest.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
 #include <Activity/AWSGameLiftSearchSessionsActivity.h>
 #include <AWSGameLiftClientFixture.h>
@@ -45,7 +45,7 @@ TEST_F(AWSGameLiftSearchSessionsActivityTest, BuildAWSGameLiftSearchGameSessions
 TEST_F(AWSGameLiftSearchSessionsActivityTest, ValidateSearchSessionsRequest_CallWithBaseType_GetFalseResult)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto result = SearchSessionsActivity::ValidateSearchSessionsRequest(AzFramework::SearchSessionsRequest());
+    auto result = SearchSessionsActivity::ValidateSearchSessionsRequest(Multiplayer::SearchSessionsRequest());
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message    
     EXPECT_FALSE(result);
 }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftStartMatchmakingActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftStartMatchmakingActivityTest.cpp
@@ -49,7 +49,7 @@ TEST_F(AWSGameLiftStartMatchmakingActivityTest, BuildAWSGameLiftStartMatchmaking
 TEST_F(AWSGameLiftStartMatchmakingActivityTest, ValidateStartMatchmakingRequest_CallWithBaseType_GetFalseResult)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto result = StartMatchmakingActivity::ValidateStartMatchmakingRequest(AzFramework::StartMatchmakingRequest());
+    auto result = StartMatchmakingActivity::ValidateStartMatchmakingRequest(Multiplayer::StartMatchmakingRequest());
     EXPECT_FALSE(result);
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftStopMatchmakingActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftStopMatchmakingActivityTest.cpp
@@ -26,7 +26,7 @@ TEST_F(AWSGameLiftStopMatchmakingActivityTest, BuildAWSGameLiftStopMatchmakingRe
 TEST_F(AWSGameLiftStopMatchmakingActivityTest, ValidateStopMatchmakingRequest_CallWithoutTicketId_GetFalseResult)
 {
     AZ_TEST_START_TRACE_SUPPRESSION;
-    auto result = StopMatchmakingActivity::ValidateStopMatchmakingRequest(AzFramework::StopMatchmakingRequest());
+    auto result = StopMatchmakingActivity::ValidateStopMatchmakingRequest(Multiplayer::StopMatchmakingRequest());
     EXPECT_FALSE(result);
     AZ_TEST_STOP_TRACE_SUPPRESSION(1); // capture 1 error message
 }

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
@@ -25,7 +25,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PRIVATE
             AZ::AzCore
-            AZ::AzFramework
+            Gem::Multiplayer.Static
             3rdParty::AWSGameLiftServerSDK
     )
 
@@ -62,8 +62,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzCore
-                AZ::AzFramework
                 AZ::AzTest
+                Gem::Multiplayer.Static
                 Gem::AWSGameLift.Server.Static
                 3rdParty::AWSGameLiftServerSDK
     )

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.h
@@ -16,8 +16,8 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
-#include <AzFramework/Session/ISessionHandlingRequests.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
 #include <AWSGameLiftPlayer.h>
 #include <Request/AWSGameLiftServerRequestBus.h>
@@ -37,7 +37,7 @@ namespace AWSGameLift
     //! Manage the server process for hosting game sessions via GameLiftServerSDK.
     class AWSGameLiftServerManager
         : public AWSGameLiftServerRequestBus::Handler
-        , public AzFramework::ISessionHandlingProviderRequests
+        , public Multiplayer::ISessionHandlingProviderRequests
     {
     public:
         static constexpr const char AWSGameLiftServerManagerName[] = "AWSGameLiftServerManager";
@@ -117,8 +117,8 @@ namespace AWSGameLift
 
         // ISessionHandlingProviderRequests interface implementation
         void HandleDestroySession() override;
-        bool ValidatePlayerJoinSession(const AzFramework::PlayerConnectionConfig& playerConnectionConfig) override;
-        void HandlePlayerLeaveSession(const AzFramework::PlayerConnectionConfig& playerConnectionConfig) override;
+        bool ValidatePlayerJoinSession(const Multiplayer::PlayerConnectionConfig& playerConnectionConfig) override;
+        void HandlePlayerLeaveSession(const Multiplayer::PlayerConnectionConfig& playerConnectionConfig) override;
         AZ::IO::Path GetExternalSessionCertificate() override;
         AZ::IO::Path GetInternalSessionCertificate() override;
 
@@ -126,7 +126,7 @@ namespace AWSGameLift
         void SetGameLiftServerSDKWrapper(AZStd::unique_ptr<GameLiftServerSDKWrapper> gameLiftServerSDKWrapper);
 
         //! Add connected player session id.
-        bool AddConnectedPlayer(const AzFramework::PlayerConnectionConfig& playerConnectionConfig);
+        bool AddConnectedPlayer(const Multiplayer::PlayerConnectionConfig& playerConnectionConfig);
 
         //! Get active server player data from lazy loaded game session for server match backfill
         AZStd::vector<AWSGameLiftPlayer> GetActiveServerMatchBackfillPlayers();
@@ -157,7 +157,7 @@ namespace AWSGameLift
         void BuildStopMatchBackfillRequest(const AZStd::string& ticketId, Aws::GameLift::Server::Model::StopMatchBackfillRequest& outRequest);
 
         //! Build session config by using AWS GameLift Server GameSession Model.
-        AzFramework::SessionConfig BuildSessionConfig(const Aws::GameLift::Server::Model::GameSession& gameSession);
+        Multiplayer::SessionConfig BuildSessionConfig(const Aws::GameLift::Server::Model::GameSession& gameSession);
 
         //! Check whether matchmaking data is in proper format
         bool IsMatchmakingDataValid();

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerManagerTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerManagerTest.cpp
@@ -11,8 +11,8 @@
 
 #include <AzCore/Interface/Interface.h>
 #include <AzFramework/IO/LocalFileIO.h>
-#include <AzFramework/Session/SessionConfig.h>
-#include <AzFramework/Session/SessionNotifications.h>
+#include <Multiplayer/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionNotifications.h>
 
 namespace UnitTest
 {
@@ -154,25 +154,25 @@ R"({
     }
 
     class SessionNotificationsHandlerMock
-        : public AzFramework::SessionNotificationBus::Handler
+        : public Multiplayer::SessionNotificationBus::Handler
     {
     public:
         SessionNotificationsHandlerMock()
         {
-            AzFramework::SessionNotificationBus::Handler::BusConnect();
+            Multiplayer::SessionNotificationBus::Handler::BusConnect();
         }
 
         ~SessionNotificationsHandlerMock()
         {
-            AzFramework::SessionNotificationBus::Handler::BusDisconnect();
+            Multiplayer::SessionNotificationBus::Handler::BusDisconnect();
         }
 
         MOCK_METHOD0(OnSessionHealthCheck, bool());
-        MOCK_METHOD1(OnCreateSessionBegin, bool(const AzFramework::SessionConfig&));
+        MOCK_METHOD1(OnCreateSessionBegin, bool(const Multiplayer::SessionConfig&));
         MOCK_METHOD0(OnCreateSessionEnd, void());
         MOCK_METHOD0(OnDestroySessionBegin, bool());
         MOCK_METHOD0(OnDestroySessionEnd, void());
-        MOCK_METHOD2(OnUpdateSessionBegin, void(const AzFramework::SessionConfig&, const AZStd::string&));
+        MOCK_METHOD2(OnUpdateSessionBegin, void(const Multiplayer::SessionConfig&, const AZStd::string&));
         MOCK_METHOD0(OnUpdateSessionEnd, void());
     };
 
@@ -255,9 +255,9 @@ R"({
     {
         m_serverManager->InitializeGameLiftServerSDK();
         m_serverManager->NotifyGameLiftProcessReady();
-        if (!AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get())
+        if (!AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get())
         {
-            AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Register(m_serverManager.get());
+            AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Register(m_serverManager.get());
         }
 
         SessionNotificationsHandlerMock handlerMock;
@@ -270,16 +270,16 @@ R"({
         m_serverManager->m_gameLiftServerSDKWrapperMockPtr->m_onProcessTerminateFunc();
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
 
-        EXPECT_FALSE(AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get());
+        EXPECT_FALSE(AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get());
     }
 
     TEST_F(GameLiftServerManagerTest, OnProcessTerminate_OnDestroySessionBeginReturnsTrue_TerminationNotificationSent)
     {
         m_serverManager->InitializeGameLiftServerSDK();
         m_serverManager->NotifyGameLiftProcessReady();
-        if (!AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get())
+        if (!AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get())
         {
-            AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Register(m_serverManager.get());
+            AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Register(m_serverManager.get());
         }
 
         SessionNotificationsHandlerMock handlerMock;
@@ -292,16 +292,16 @@ R"({
 
         m_serverManager->m_gameLiftServerSDKWrapperMockPtr->m_onProcessTerminateFunc();
 
-        EXPECT_FALSE(AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get());
+        EXPECT_FALSE(AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get());
     }
 
     TEST_F(GameLiftServerManagerTest, OnProcessTerminate_OnDestroySessionBeginReturnsTrue_TerminationNotificationSentButFail)
     {
         m_serverManager->InitializeGameLiftServerSDK();
         m_serverManager->NotifyGameLiftProcessReady();
-        if (!AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get())
+        if (!AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get())
         {
-            AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Register(m_serverManager.get());
+            AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Register(m_serverManager.get());
         }
 
         SessionNotificationsHandlerMock handlerMock;
@@ -316,7 +316,7 @@ R"({
         m_serverManager->m_gameLiftServerSDKWrapperMockPtr->m_onProcessTerminateFunc();
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
 
-        EXPECT_FALSE(AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get());
+        EXPECT_FALSE(AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get());
     }
 
     TEST_F(GameLiftServerManagerTest, OnHealthCheck_OnSessionHealthCheckReturnsTrue_CallbackFunctionReturnsTrue)
@@ -379,7 +379,7 @@ R"({
         testProperty.SetValue("testValue");
         testSession.AddGameProperties(testProperty);
         m_serverManager->m_gameLiftServerSDKWrapperMockPtr->m_onStartGameSessionFunc(testSession);
-        EXPECT_TRUE(AZ::Interface<AzFramework::ISessionHandlingProviderRequests>::Get());
+        EXPECT_TRUE(AZ::Interface<Multiplayer::ISessionHandlingProviderRequests>::Get());
         m_serverManager->HandleDestroySession();
     }
 
@@ -465,14 +465,14 @@ R"({
     TEST_F(GameLiftServerManagerTest, ValidatePlayerJoinSession_CallWithInvalidConnectionConfig_GetFalseResultAndExpectedErrorLog)
     {
         AZ_TEST_START_TRACE_SUPPRESSION;
-        auto result = m_serverManager->ValidatePlayerJoinSession(AzFramework::PlayerConnectionConfig());
+        auto result = m_serverManager->ValidatePlayerJoinSession(Multiplayer::PlayerConnectionConfig());
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         EXPECT_FALSE(result);
     }
 
     TEST_F(GameLiftServerManagerTest, ValidatePlayerJoinSession_CallWithDuplicatedConnectionId_GetFalseResultAndExpectedErrorLog)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig1;
+        Multiplayer::PlayerConnectionConfig connectionConfig1;
         connectionConfig1.m_playerConnectionId = 123;
         connectionConfig1.m_playerSessionId = "dummyPlayerSessionId1";
         GenericOutcome successOutcome(nullptr);
@@ -480,7 +480,7 @@ R"({
             .Times(1)
             .WillOnce(Return(successOutcome));
         m_serverManager->ValidatePlayerJoinSession(connectionConfig1);
-        AzFramework::PlayerConnectionConfig connectionConfig2;
+        Multiplayer::PlayerConnectionConfig connectionConfig2;
         connectionConfig2.m_playerConnectionId = 123;
         connectionConfig2.m_playerSessionId = "dummyPlayerSessionId2";
         AZ_TEST_START_TRACE_SUPPRESSION;
@@ -491,7 +491,7 @@ R"({
 
     TEST_F(GameLiftServerManagerTest, ValidatePlayerJoinSession_CallWithValidConnectionConfigButErrorOutcome_GetFalseResultAndExpectedErrorLog)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig;
+        Multiplayer::PlayerConnectionConfig connectionConfig;
         connectionConfig.m_playerConnectionId = 123;
         connectionConfig.m_playerSessionId = "dummyPlayerSessionId1";
         EXPECT_CALL(*(m_serverManager->m_gameLiftServerSDKWrapperMockPtr), AcceptPlayerSession(testing::_)).Times(1);
@@ -503,7 +503,7 @@ R"({
 
     TEST_F(GameLiftServerManagerTest, ValidatePlayerJoinSession_CallWithValidConnectionConfigAndSuccessOutcome_GetTrueResult)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig;
+        Multiplayer::PlayerConnectionConfig connectionConfig;
         connectionConfig.m_playerConnectionId = 123;
         connectionConfig.m_playerSessionId = "dummyPlayerSessionId1";
         GenericOutcome successOutcome(nullptr);
@@ -516,7 +516,7 @@ R"({
 
     TEST_F(GameLiftServerManagerTest, ValidatePlayerJoinSession_CallWithFirstErrorSecondSuccess_GetFirstFalseSecondTrueResult)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig1;
+        Multiplayer::PlayerConnectionConfig connectionConfig1;
         connectionConfig1.m_playerConnectionId = 123;
         connectionConfig1.m_playerSessionId = "dummyPlayerSessionId1";
         GenericOutcome successOutcome(nullptr);
@@ -530,7 +530,7 @@ R"({
         auto result = m_serverManager->ValidatePlayerJoinSession(connectionConfig1);
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
         EXPECT_FALSE(result);
-        AzFramework::PlayerConnectionConfig connectionConfig2;
+        Multiplayer::PlayerConnectionConfig connectionConfig2;
         connectionConfig2.m_playerConnectionId = 123;
         connectionConfig2.m_playerSessionId = "dummyPlayerSessionId2";
         result = m_serverManager->ValidatePlayerJoinSession(connectionConfig2);
@@ -549,7 +549,7 @@ R"({
         for (int index = 0; index < testThreadNumber; index++)
         {
             testThreadPool.emplace_back(AZStd::thread([&]() {
-                AzFramework::PlayerConnectionConfig connectionConfig;
+                Multiplayer::PlayerConnectionConfig connectionConfig;
                 connectionConfig.m_playerConnectionId = 123;
                 connectionConfig.m_playerSessionId = "dummyPlayerSessionId";
                 auto result = m_serverManager->ValidatePlayerJoinSession(connectionConfig);
@@ -571,19 +571,19 @@ R"({
         EXPECT_CALL(*(m_serverManager->m_gameLiftServerSDKWrapperMockPtr), RemovePlayerSession(testing::_)).Times(0);
 
         AZ_TEST_START_TRACE_SUPPRESSION;
-        m_serverManager->HandlePlayerLeaveSession(AzFramework::PlayerConnectionConfig());
+        m_serverManager->HandlePlayerLeaveSession(Multiplayer::PlayerConnectionConfig());
         AZ_TEST_STOP_TRACE_SUPPRESSION(1);
     }
 
     TEST_F(GameLiftServerManagerTest, HandlePlayerLeaveSession_CallWithNonExistentPlayerConnectionId_GetExpectedErrorLog)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig;
+        Multiplayer::PlayerConnectionConfig connectionConfig;
         connectionConfig.m_playerConnectionId = 123;
         connectionConfig.m_playerSessionId = "dummyPlayerSessionId";
         auto result = m_serverManager->AddConnectedTestPlayer(connectionConfig);
         EXPECT_TRUE(result);
 
-        AzFramework::PlayerConnectionConfig connectionConfig1;
+        Multiplayer::PlayerConnectionConfig connectionConfig1;
         connectionConfig1.m_playerConnectionId = 456;
         connectionConfig1.m_playerSessionId = "dummyPlayerSessionId";
 
@@ -596,7 +596,7 @@ R"({
 
     TEST_F(GameLiftServerManagerTest, HandlePlayerLeaveSession_CallWithValidConnectionConfigButErrorOutcome_GetExpectedErrorLog)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig;
+        Multiplayer::PlayerConnectionConfig connectionConfig;
         connectionConfig.m_playerConnectionId = 123;
         connectionConfig.m_playerSessionId = "dummyPlayerSessionId";
         auto result = m_serverManager->AddConnectedTestPlayer(connectionConfig);
@@ -615,7 +615,7 @@ R"({
 
     TEST_F(GameLiftServerManagerTest, HandlePlayerLeaveSession_CallWithValidConnectionConfigAndSuccessOutcome_RemovePlayerSessionNotificationSent)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig;
+        Multiplayer::PlayerConnectionConfig connectionConfig;
         connectionConfig.m_playerConnectionId = 123;
         connectionConfig.m_playerSessionId = "dummyPlayerSessionId";
         auto result = m_serverManager->AddConnectedTestPlayer(connectionConfig);
@@ -631,7 +631,7 @@ R"({
 
     TEST_F(GameLiftServerManagerTest, HandlePlayerLeaveSession_CallWithMultithread_OnlyOneNotificationIsSent)
     {
-        AzFramework::PlayerConnectionConfig connectionConfig;
+        Multiplayer::PlayerConnectionConfig connectionConfig;
         connectionConfig.m_playerConnectionId = 123;
         connectionConfig.m_playerSessionId = "dummyPlayerSessionId";
         auto result = m_serverManager->AddConnectedTestPlayer(connectionConfig);

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerMocks.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerMocks.h
@@ -95,7 +95,7 @@ namespace UnitTest
             UpdateGameSessionData(m_testGameSession);
         }
 
-        bool AddConnectedTestPlayer(const AzFramework::PlayerConnectionConfig& playerConnectionConfig)
+        bool AddConnectedTestPlayer(const Multiplayer::PlayerConnectionConfig& playerConnectionConfig)
         {
             return AddConnectedPlayer(playerConnectionConfig);
         }

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/IMatchmakingRequests.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/IMatchmakingRequests.h
@@ -10,9 +10,9 @@
 
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Matchmaking/MatchmakingRequests.h>
+#include <Multiplayer/Session/MatchmakingRequests.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     //! IMatchmakingRequests
     //! Pure virtual session interface class to abstract the details of session handling from application code.
@@ -87,4 +87,4 @@ namespace AzFramework
         virtual void OnStopMatchmakingAsyncComplete() = 0;
     };
     using MatchmakingAsyncRequestNotificationBus = AZ::EBus<MatchmakingAsyncRequestNotifications>;
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/ISessionHandlingRequests.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/ISessionHandlingRequests.h
@@ -12,7 +12,7 @@
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/std/string/string.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     //! SessionConnectionConfig
     //! The properties for handling join session request.
@@ -91,4 +91,4 @@ namespace AzFramework
         //!         empty string.
         virtual AZ::IO::Path GetInternalSessionCertificate() = 0;
     };
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/ISessionRequests.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/ISessionRequests.h
@@ -11,9 +11,9 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Session/SessionRequests.h>
+#include <Multiplayer/Session/SessionRequests.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     //! ISessionRequests
     //! Pure virtual session interface class to abstract the details of session handling from application code.
@@ -101,4 +101,4 @@ namespace AzFramework
         virtual void OnLeaveSessionAsyncComplete() = 0;
     };
     using SessionAsyncRequestNotificationBus = AZ::EBus<SessionAsyncRequestNotifications>;
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/MatchmakingNotifications.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/MatchmakingNotifications.h
@@ -11,7 +11,7 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/std/string/string.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     //! MatchmakingNotifications
     //! The matchmaking notifications to listen for performing required operations
@@ -43,4 +43,4 @@ namespace AzFramework
         virtual void OnMatchFailure() = 0;
     };
     using MatchmakingNotificationBus = AZ::EBus<MatchmakingNotifications>;
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/MatchmakingRequests.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/MatchmakingRequests.h
@@ -17,7 +17,7 @@ namespace AZ
     class ReflectContext;
 }
 
-namespace AzFramework
+namespace Multiplayer
 {
     //! AcceptMatchRequest
     //! The container for AcceptMatch request parameters.
@@ -64,4 +64,4 @@ namespace AzFramework
         //! A unique identifier for a matchmaking ticket
         AZStd::string m_ticketId;
     };
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/SessionConfig.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/SessionConfig.h
@@ -12,7 +12,7 @@
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/std/string/string.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     //! SessionConfig
     //! Properties describing a session.
@@ -66,4 +66,4 @@ namespace AzFramework
         //! Provides additional information about session status.
         AZStd::string m_statusReason;
     };
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/SessionNotifications.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/SessionNotifications.h
@@ -10,7 +10,7 @@
 
 #include <AzCore/EBus/EBus.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     struct SessionConfig;
 
@@ -68,4 +68,4 @@ namespace AzFramework
         virtual void OnUpdateSessionEnd() = 0;
     };
     using SessionNotificationBus = AZ::EBus<SessionNotifications>;
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Session/SessionRequests.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Session/SessionRequests.h
@@ -17,7 +17,7 @@ namespace AZ
     class ReflectContext;
 }
 
-namespace AzFramework
+namespace Multiplayer
 {
     struct SessionConfig;
 
@@ -104,4 +104,4 @@ namespace AzFramework
         //! Developer-defined information related to a player.
         AZStd::string m_playerData;
     };
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <Multiplayer/IMultiplayer.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
+#include <Multiplayer/Session/SessionNotifications.h>
 #include <Editor/MultiplayerEditorConnection.h>
 #include <NetworkTime/NetworkTime.h>
 #include <NetworkEntity/NetworkEntityManager.h>
@@ -21,8 +23,6 @@
 #include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/Threading/ThreadSafeDeque.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Session/ISessionHandlingRequests.h>
-#include <AzFramework/Session/SessionNotifications.h>
 #include <AzNetworking/ConnectionLayer/IConnectionListener.h>
 
 namespace AzFramework
@@ -41,8 +41,8 @@ namespace Multiplayer
     class MultiplayerSystemComponent final
         : public AZ::Component
         , public AZ::TickBus::Handler
-        , public AzFramework::SessionNotificationBus::Handler
-        , public AzFramework::ISessionHandlingClientRequests
+        , public SessionNotificationBus::Handler
+        , public ISessionHandlingClientRequests
         , public AzNetworking::IConnectionListener
         , public IMultiplayer
     {
@@ -63,14 +63,14 @@ namespace Multiplayer
         void Deactivate() override;
         //! @}
 
-        //! AzFramework::SessionNotificationBus::Handler overrides.
+        //! SessionNotificationBus::Handler overrides.
         //! @{
         bool OnSessionHealthCheck() override;
-        bool OnCreateSessionBegin(const AzFramework::SessionConfig& sessionConfig) override;
+        bool OnCreateSessionBegin(const SessionConfig& sessionConfig) override;
         void OnCreateSessionEnd() override;
         bool OnDestroySessionBegin() override;
         void OnDestroySessionEnd() override;
-        void OnUpdateSessionBegin(const AzFramework::SessionConfig& sessionConfig, const AZStd::string& updateReason) override;
+        void OnUpdateSessionBegin(const SessionConfig& sessionConfig, const AZStd::string& updateReason) override;
         void OnUpdateSessionEnd() override;
         //! @}
 
@@ -101,7 +101,7 @@ namespace Multiplayer
 
         //! ISessionHandlingClientRequests interface
         //! @{
-        bool RequestPlayerJoinSession(const AzFramework::SessionConnectionConfig& sessionConnectionConfig) override;
+        bool RequestPlayerJoinSession(const SessionConnectionConfig& sessionConnectionConfig) override;
         void RequestPlayerLeaveSession() override;
         //! @}
 

--- a/Gems/Multiplayer/Code/Source/Session/MatchmakingRequests.cpp
+++ b/Gems/Multiplayer/Code/Source/Session/MatchmakingRequests.cpp
@@ -9,9 +9,9 @@
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/Matchmaking/MatchmakingRequests.h>
+#include <Multiplayer/Session/MatchmakingRequests.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     void AcceptMatchRequest::Reflect(AZ::ReflectContext* context)
     {
@@ -75,4 +75,4 @@ namespace AzFramework
             }
         }
     }
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/Session/SessionConfig.cpp
+++ b/Gems/Multiplayer/Code/Source/Session/SessionConfig.cpp
@@ -8,9 +8,9 @@
 
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     void SessionConfig::Reflect(AZ::ReflectContext* context)
     {
@@ -39,35 +39,35 @@ namespace AzFramework
                 editContext->Class<SessionConfig>("SessionConfig", "Properties describing a session")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_creationTime,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_creationTime,
                         "CreationTime", "A time stamp indicating when this session was created. Format is a number expressed in Unix time as milliseconds.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_terminationTime,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_terminationTime,
                         "TerminationTime", "A time stamp indicating when this data object was terminated. Same format as creation time.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_creatorId,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_creatorId,
                         "CreatorId", "A unique identifier for a player or entity creating the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_sessionProperties,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_sessionProperties,
                         "SessionProperties", "A collection of custom properties for a session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_matchmakingData,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_matchmakingData,
                         "MatchmakingData", "The matchmaking process information that was used to create the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_sessionId,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_sessionId,
                         "SessionId", "A unique identifier for the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_sessionName,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_sessionName,
                         "SessionName", "A descriptive label that is associated with a session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_dnsName,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_dnsName,
                         "DnsName", "The DNS identifier assigned to the instance that is running the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_ipAddress,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_ipAddress,
                         "IpAddress", "The IP address of the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_port,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_port,
                         "Port", "The port number for the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_maxPlayer,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_maxPlayer,
                         "MaxPlayer", "The maximum number of players that can be connected simultaneously to the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_currentPlayer,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_currentPlayer,
                         "CurrentPlayer", "Number of players currently in the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_status,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_status,
                         "Status", "Current status of the session.")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &AzFramework::SessionConfig::m_statusReason,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &Multiplayer::SessionConfig::m_statusReason,
                         "StatusReason", "Provides additional information about session status.");
             }
         }
     }
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/Source/Session/SessionRequests.cpp
+++ b/Gems/Multiplayer/Code/Source/Session/SessionRequests.cpp
@@ -9,10 +9,10 @@
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/Session/SessionRequests.h>
-#include <AzFramework/Session/SessionConfig.h>
+#include <Multiplayer/Session/SessionRequests.h>
+#include <Multiplayer/Session/SessionConfig.h>
 
-namespace AzFramework
+namespace Multiplayer
 {
     void CreateSessionRequest::Reflect(AZ::ReflectContext* context)
     {
@@ -124,4 +124,4 @@ namespace AzFramework
             }
         }
     }
-} // namespace AzFramework
+} // namespace Multiplayer

--- a/Gems/Multiplayer/Code/multiplayer_files.cmake
+++ b/Gems/Multiplayer/Code/multiplayer_files.cmake
@@ -58,6 +58,14 @@ set(FILES
     Include/Multiplayer/NetworkTime/RewindableObject.h
     Include/Multiplayer/NetworkTime/RewindableObject.inl
     Include/Multiplayer/ReplicationWindows/IReplicationWindow.h
+    Include/Multiplayer/Session/IMatchmakingRequests.h
+    Include/Multiplayer/Session/ISessionHandlingRequests.h
+    Include/Multiplayer/Session/ISessionRequests.h
+    Include/Multiplayer/Session/MatchmakingRequests.h
+    Include/Multiplayer/Session/MatchmakingNotifications.h
+    Include/Multiplayer/Session/SessionRequests.h
+    Include/Multiplayer/Session/SessionConfig.h
+    Include/Multiplayer/Session/SessionNotifications.h
     Include/Multiplayer/AutoGen/AutoComponentTypes_Header.jinja
     Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
     Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
@@ -131,4 +139,7 @@ set(FILES
     Source/ReplicationWindows/NullReplicationWindow.h
     Source/ReplicationWindows/ServerToClientReplicationWindow.cpp
     Source/ReplicationWindows/ServerToClientReplicationWindow.h
+    Source/Session/MatchmakingRequests.cpp
+    Source/Session/SessionRequests.cpp
+    Source/Session/SessionConfig.cpp
 )


### PR DESCRIPTION
## Details
Move session interface into Multiplayer library

## Testing
Pass client and server unit test
Complete Editor test to make sure scriptcanvas node is also backward compatible
Complete local test with GameLiftLocal for create, join and leave session test case
Complete remote test with GameLift service:
1. create, join, search, and leave session test cases
2. matchmaking and backfill matchmaking test cases

## Release Note Required
Backward incompatible case:
In game c++ code, any usage of old namespace for session and matchmaking won't build

## Open Question
* Q: Re-architecture Multiplayer Static target?
Discussed with Rajiv about it, but considering we just have one gamelift use case, it is ok to use Multiplayer Static for now.
But have noticed that Multiplayer Static target has plenty dependencies, like Atom, Phyx, etc. that dedicated server provider should not care. Considering better scoping and build efficiency, it maybe a good idea to have Multiplayer Static separated into smaller scope targets. (which also provides enough flexibility and scalability as an open source engine)

Signed-off-by: onecent1101 <liug@amazon.com>