### PR TITLE
Changed how pass system controls pipeline tick rate

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -450,6 +450,9 @@ namespace AZ
 
                         // Whether the pass should gather pipeline statics
                         uint64_t m_pipelineStatisticsQueryEnabled : 1;
+
+                        // Whether the pass is the root pass for a pipeline. Used to control pipeline render tick rate
+                        uint64_t m_isPipelineRoot : 1;
                     };
                     uint64_t m_allFlags = 0;
                 };

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1291,7 +1291,16 @@ namespace AZ
             AZ_PROFILE_SCOPE(RPI, "Pass::FrameBegin() - %s", m_path.GetCStr());
             AZ_RPI_BREAK_ON_TARGET_PASS;
 
-            if (!IsEnabled())
+            bool earlyOut = !IsEnabled();
+
+            // Skip if this pass is the root of the pipeline and the pipeline is set to not render
+            if (m_flags.m_isPipelineRoot)
+            {
+                AZ_RPI_PASS_ASSERT(m_pipeline != nullptr, "Pass is flagged as a pipeline root but it's pipeline pointer is invalid while trying to render");
+                earlyOut = earlyOut || m_pipeline == nullptr || m_pipeline->GetRenderMode() == RenderPipeline::RenderMode::NoRender;
+            }
+
+            if (earlyOut)
             {
                 UpdateConnectedBindings();
                 return;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RenderPipeline.cpp
@@ -103,6 +103,7 @@ namespace AZ
             pipeline->m_originalRenderSettings = desc.m_renderSettings;
             pipeline->m_activeRenderSettings = desc.m_renderSettings;
             pipeline->m_rootPass->SetRenderPipeline(pipeline);
+            pipeline->m_rootPass->m_flags.m_isPipelineRoot = true;
             pipeline->m_rootPass->ManualPipelineBuildAndInitialize();
         }
 
@@ -320,8 +321,7 @@ namespace AZ
                 // Attempt to re-create hierarchy under root pass
                 Ptr<ParentPass> newRoot = m_rootPass->Recreate();
                 newRoot->SetRenderPipeline(this);
-
-                // Manually build the pipeline
+                newRoot->m_flags.m_isPipelineRoot = true;
                 newRoot->ManualPipelineBuildAndInitialize();
 
                 // Validate the new root
@@ -482,20 +482,17 @@ namespace AZ
 
         void RenderPipeline::AddToRenderTickOnce()
         {
-            m_rootPass->SetEnabled(true);
             m_renderMode = RenderMode::RenderOnce;
         }
 
         void RenderPipeline::AddToRenderTick()
         {
-            m_rootPass->SetEnabled(true);
             m_renderMode = RenderMode::RenderEveryTick;
         }
 
         void RenderPipeline::RemoveFromRenderTick()
         {
             m_renderMode = RenderMode::NoRender;
-            m_rootPass->SetEnabled(false);
         }
 
         RenderPipeline::RenderMode RenderPipeline::GetRenderMode() const


### PR DESCRIPTION
Pipeline used to enable/disable it's pipeline pass, which would recursively enable/disable all sub-passes in that tree. Adding new control mechanism so pipelines don't have to enable/disable passes (which can happen on a per frame basis in certain tools).

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>