### PR TITLE
{lyn9996} fixes for the default procedural prefab

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabBehaviorTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabBehaviorTests.cpp
@@ -348,7 +348,7 @@ namespace UnitTest
             {
                 AZ::SceneAPI::DataTypes::IMeshGroup* meshGroup = reinterpret_cast<AZ::SceneAPI::DataTypes::IMeshGroup*>(scene->GetManifest().GetValue(i).get());
                 AZStd::string groupName = meshGroup->GetName();
-                EXPECT_TRUE(groupName.starts_with("manifest_src_file_xml"));
+                EXPECT_TRUE(groupName.starts_with("default_mock_"));
             }
         }
     }

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -150,9 +150,9 @@ namespace AZ::SceneAPI::Behaviors
                 }
             }
 
-            // all mesh data nodes left in the meshIndexContainer do not have a matching TransformData node since
+            // all mesh data nodes left in the meshIndexContainer do not have a matching TransformData node
             // since the nodes have an identity transform, so map the MeshData index with an Invalid mesh index to
-            // indicate the transform should not be set
+            // indicate the transform should not be set to a default value
             for( const auto meshIndex : meshIndexContainer)
             {
                 MeshTransformPair pair{ meshIndex, Containers::SceneGraph::NodeIndex{} };
@@ -166,7 +166,7 @@ namespace AZ::SceneAPI::Behaviors
             ManifestUpdates& manifestUpdates,
             const MeshTransformMap& meshTransformMap,
             const Containers::Scene& scene,
-            AZStd::string& relativeSourcePath)
+            const AZStd::string& relativeSourcePath)
         {
             NodeEntityMap nodeEntityMap;
             const auto& graph = scene.GetGraph();
@@ -242,7 +242,8 @@ namespace AZ::SceneAPI::Behaviors
                 // assign mesh asset id hint using JSON
                 AZStd::string modelAssetPath;
                 modelAssetPath = relativeSourcePath;
-                modelAssetPath.append(meshGroupName);
+                AZ::StringFunc::Path::ReplaceFullName(modelAssetPath, meshGroupName.c_str());
+                AZ::StringFunc::Replace(modelAssetPath, "\\", "/"); // asset paths use forward slashes
 
                 auto meshAssetJson = AZStd::string::format(
                     R"JSON(

--- a/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
+++ b/Gems/SceneProcessing/Code/Source/Generation/Components/MeshOptimizer/MeshOptimizerComponent.cpp
@@ -349,7 +349,10 @@ namespace AZ::SceneGenerationComponents
                 }
 
                 const AZStd::string name =
-                    AZStd::string(graph.GetNodeName(nodeIndex).GetName(), graph.GetNodeName(nodeIndex).GetNameLength()).append(SceneAPI::Utilities::OptimizedMeshSuffix);
+                    AZStd::string(graph.GetNodeName(nodeIndex).GetName(), graph.GetNodeName(nodeIndex).GetNameLength())
+                        .append("_")
+                        .append(meshGroup.GetName())
+                        .append(SceneAPI::Utilities::OptimizedMeshSuffix);
                 if (graph.Find(name).IsValid())
                 {
                     AZ_TracePrintf(AZ::SceneAPI::Utilities::LogWindow, "Optimized mesh already exists at '%s', there must be multiple mesh groups that have selected this mesh. Skipping the additional ones.", name.c_str());

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -79,7 +79,7 @@ namespace SceneBuilder
                 m_cachedFingerprint.append(element);
             }
             // A general catch all version fingerprint. Update this to force all FBX files to recompile.
-            m_cachedFingerprint.append("Version 2");
+            m_cachedFingerprint.append("Version 3");
         }
 
         return m_cachedFingerprint.c_str();

--- a/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
+++ b/Gems/SceneProcessing/Code/Tests/MeshBuilder/MeshOptimizerComponentTests.cpp
@@ -176,7 +176,7 @@ namespace SceneProcessing
             component.OptimizeMeshes(context);
 
             AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedNodeIndex =
-                graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix));
+                graph.Find(AZStd::string("testMesh_").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix));
             ASSERT_TRUE(optimizedNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the mesh";
 
             const auto& optimizedMesh =
@@ -184,7 +184,7 @@ namespace SceneProcessing
             ASSERT_TRUE(optimizedMesh);
 
             AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedSkinDataNodeIndex =
-                graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix).append(".skinWeights"));
+                graph.Find(AZStd::string("testMesh_").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix).append(".skinWeights"));
             ASSERT_TRUE(optimizedSkinDataNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the skin data";
 
             const auto& optimizedSkinWeights =
@@ -227,7 +227,7 @@ namespace SceneProcessing
         AZ::SceneAPI::Events::GenerateSimplificationEventContext context(scene, "pc");
         component.OptimizeMeshes(context);
 
-        AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedNodeIndex = graph.Find(AZStd::string("testMesh").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix));
+        AZ::SceneAPI::Containers::SceneGraph::NodeIndex optimizedNodeIndex = graph.Find(AZStd::string("testMesh_").append(AZ::SceneAPI::Utilities::OptimizedMeshSuffix));
         ASSERT_TRUE(optimizedNodeIndex.IsValid()) << "Mesh optimizer did not add an optimized version of the mesh";
 
         const auto& optimizedMesh = AZStd::rtti_pointer_cast<AZ::SceneAPI::DataTypes::IMeshData>(graph.GetNodeContent(optimizedNodeIndex));


### PR DESCRIPTION
Fixes required to get all of the source scene asset (i.e. FBX) files to process cleaning via the Asset Processor.
Unique naming, adding transforms, blank LOD rules, and so much more!

