### PR TITLE
Lua Editor: Prev Document Tab option from the View menu is misspelled…

### DIFF
--- a/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
+++ b/Code/Tools/LuaIDE/Source/LUA/LUAEditorMainWindow.cpp
@@ -108,7 +108,7 @@ namespace LUAEditor
         m_settingsDialog = aznew LUAEditorSettingsDialog(this);
 
         actionTabForwards = new QAction(tr("Next Document Tab"), this);
-        actionTabBackwards = new QAction(tr("Prev Document Tab"), this);
+        actionTabBackwards = new QAction(tr("Previous Document Tab"), this);
 
         actionTabForwards->setShortcut(QKeySequence("Ctrl+Tab"));
         connect(actionTabForwards, SIGNAL(triggered(bool)), this, SLOT(OnTabForwards()));


### PR DESCRIPTION
… #7345

Signed-off-by: suryanshsangwan <sangwansuryansh@gmail.com>