### PR TITLE
{ghi7403} fixing Python PYI symbols on Editor start

### DIFF
--- a/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
+++ b/Gems/EditorPythonBindings/Code/Source/PythonSystemComponent.cpp
@@ -414,10 +414,10 @@ namespace EditorPythonBindings
         EditorPythonBindingsNotificationBus::Broadcast(&EditorPythonBindingsNotificationBus::Events::OnPreInitialize);
         if (StartPythonInterpreter(pythonPathStack))
         {
-            EditorPythonBindingsNotificationBus::Broadcast(&EditorPythonBindingsNotificationBus::Events::OnPostInitialize);
             // initialize internal base module and bootstrap scripts
             ExecuteByString("import azlmbr", false);
             ExecuteBootstrapScripts(pythonPathStack);
+            EditorPythonBindingsNotificationBus::Broadcast(&EditorPythonBindingsNotificationBus::Events::OnPostInitialize);
             return true;
         }
         return false;


### PR DESCRIPTION
Fixing Python PYI symbols on Editor start by processing the queue symbols
after the "azlmbr import" step since that is what queues the symbols

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>