### PR TITLE
Fix a crash issue with displaying CVar help text

### DIFF
--- a/Code/Legacy/CrySystem/XConsole.cpp
+++ b/Code/Legacy/CrySystem/XConsole.cpp
@@ -1682,11 +1682,12 @@ void CXConsole::DisplayHelp(const char* help, const char* name)
     else
     {
         char* start, * pos;
-        for (pos = strstr((char*)help, "\n"), start = (char*)help; pos; start = ++pos)
+        for (pos = strstr((char*)help, "\n"), start = (char*)help; pos; )
         {
             AZStd::string s = start;
             s.resize(pos - start);
             ConsoleLogInputResponse("    $3%s", s.c_str());
+            start = ++pos;
             pos = strstr(pos, "\n");
         }
         ConsoleLogInputResponse("    $3%s", start);


### PR DESCRIPTION
Getting help from a CVar (`cvar_name ?`) would crash due to incorrect string line processing.
This code was changed to get rid of warnings about the conditional in the for-loop.  But the change ended up re-ordering statements in the loop, which then caused it to go past the end of the help string.

Signed-off-by: amzn-phist <52085794+amzn-phist@users.noreply.github.com>