### PR TITLE
Update default bundle size limit to fit slightly larger content.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/bundler_batch_setup_fixture.py
+++ b/AutomatedTesting/Gem/PythonTests/assetpipeline/ap_fixtures/bundler_batch_setup_fixture.py
@@ -79,7 +79,7 @@ def bundler_batch_setup_fixture(request, workspace, asset_processor, timeout) ->
                                                        workspace.asset_processor_platform)
             )
             # Useful sizes
-            self.max_bundle_size_in_mib = 5
+            self.max_bundle_size_in_mib = 35
             self.number_of_bytes_in_mib = 1024 * 1024
             self.workspace = workspace
             self.platforms = platforms
@@ -271,11 +271,13 @@ def bundler_batch_setup_fixture(request, workspace, asset_processor, timeout) ->
             for rel_path in self.get_asset_relative_paths(self.asset_info_file_result):
                 assets_from_file.append(os.path.normpath(rel_path))
 
+            expected_size = self.max_bundle_size_in_mib * self.number_of_bytes_in_mib
             # extract all files from the bundles
             for bundle in dependent_bundle_name:
                 file_info = os.stat(bundle)
                 # Verify that the size of all bundles is less than the max size specified
-                assert file_info.st_size <= (self.max_bundle_size_in_mib * self.number_of_bytes_in_mib)
+                assert file_info.st_size <= expected_size, \
+                    f"file_info.st_size {file_info.st_size} for bundle {bundle} was expected to be smaller than {expected_size}"
                 with zipfile.ZipFile(bundle) as bundle_zip:
                     bundle_zip.extractall(extract_dir)
 


### PR DESCRIPTION
Longer term we'll want to refactor these tests so they don't start failing to seemingly unrelated upstream changes, but for now this buys us time to work on other, more important things.

What happened to cause this:
The test_WindowsAndMac_BundlesAndBundleSettings_EquivalentOutput test bundles the same content in two different ways, with the final intention to compare and verify the results are the same.

It's bundling up the level levels\testdependencieslevel\testdependencieslevel.spawnable

Along the way, it verifies the bundles it gets are what it expects. One of the bundle settings it uses is a relatively small maximum bundle size of 5 mib.

Note that when we use a maximum bundle size, it's not a hard limit, it's just when we go to create a new bundle, if the current bundle size + next file would make the bundle too big, it starts a new bundle. This means you can have bundles go over the bundle size in the case where one file is larger than the bundle size limit.

Somehow, one of the files referenced from this bundle ( goegap_4k_skyboxcm.exr.streamingimage ) is now 24 MB, which is larger than the default bundle size originally used, which is why the test fails, it goes to examine the contents of the second pak file of the first bundle, and it's larger than the maximum bundle size. That's why the test is failing.

Changing this to 30 mib causes this test to continue to pass.

Signed-off-by: AMZN-stankowi <4838196+AMZN-stankowi@users.noreply.github.com>