### PR TITLE
removing compute queue flag from SSAO 

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/SsaoCompute.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/SsaoCompute.pass
@@ -50,8 +50,7 @@
                     "FilePath": "Shaders/PostProcessing/SsaoCompute.shader"
                 },
                 "Make Fullscreen Pass": true,
-                "PipelineViewTag": "MainCamera",
-                "Use Async Compute":  true
+                "PipelineViewTag": "MainCamera"
             },
             "FallbackConnections": [
                 {


### PR DESCRIPTION
removing compute queue flag from SSAO since some people are reporting crashes in the RHI

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>