### PR TITLE
Fix compilation error in converting between InstanceOptionalReference and InstanceOptionalConstReference

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -222,7 +222,7 @@ namespace AzToolsFramework::Prefab
         SetInstanceContainersOpenState(m_rootAliasFocusPath, false);
 
         const RootAliasPath previousContainerRootAliasPath = m_rootAliasFocusPath;
-        const InstanceOptionalConstReference previousFocusedInstance = GetInstanceReference(previousContainerRootAliasPath);
+        const InstanceOptionalReference previousFocusedInstance = GetInstanceReference(previousContainerRootAliasPath);
 
         m_rootAliasFocusPath = focusedInstance->get().GetAbsoluteInstanceAliasPath();
         m_focusedTemplateId = focusedInstance->get().GetTemplateId();
@@ -277,7 +277,7 @@ namespace AzToolsFramework::Prefab
 
     AZ::EntityId PrefabFocusHandler::GetFocusedPrefabContainerEntityId([[maybe_unused]] AzFramework::EntityContextId entityContextId) const
     {
-        if (const InstanceOptionalConstReference instance = GetInstanceReference(m_rootAliasFocusPath); instance.has_value())
+        if (const InstanceOptionalReference instance = GetInstanceReference(m_rootAliasFocusPath); instance.has_value())
         {
             return instance->get().GetContainerEntityId();
         }


### PR DESCRIPTION
Fixes issue in nightly builds

```
[2022-02-04T08:06:01.127Z] In file included from /Users/lybuilder/workspace/o3de/build/mac/Code/Framework/AzToolsFramework/CMakeFiles/AzToolsFramework.dir/Unity/unity_31_cxx.cxx:3:
[2022-02-04T08:06:01.127Z] /Users/lybuilder/workspace/o3de/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp:225:46: error: no viable conversion from 'optional<reference_wrapper<AzToolsFramework::Prefab::Instance>>' to 'const optional<reference_wrapper<const AzToolsFramework::Prefab::Instance>>'
[2022-02-04T08:06:01.127Z]         const InstanceOptionalConstReference previousFocusedInstance = GetInstanceReference(previousContainerRootAliasPath);
[2022-02-04T08:06:01.127Z]                                              ^                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>