### PR TITLE
Remove error message from InMemorySpawnableAssetContainer

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Main_Optimized.py
@@ -54,7 +54,7 @@ class EditorSingleTest_WithFileOverrides(EditorSingleTest):
             fm._restore_file(f, file_list[f])
 
 
-# @pytest.mark.xfail(reason="Optimized tests are experimental, we will enable xfail and monitor them temporarily.")
+@pytest.mark.xfail(reason="Optimized tests are experimental, we will enable xfail and monitor them temporarily.")
 @pytest.mark.SUITE_main
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
@@ -113,6 +113,9 @@ class TestAutomationWithPrefabSystemEnabled(EditorTestSuite):
     
     class C14861504_RenderMeshAsset_WithNoPxAsset(EditorSharedTest):
         from .tests.collider import Collider_PxMeshNotAutoAssignedWhenNoPhysicsFbx as test_module
+
+    class C4976236_AddPhysxColliderComponent(EditorSharedTest):
+        from .tests.collider import Collider_AddColliderComponent as test_module
     
 
 @pytest.mark.xfail(reason="Optimized tests are experimental, we will enable xfail and monitor them temporarily.")
@@ -345,9 +348,6 @@ class TestAutomation(EditorTestSuite):
         
     class C5959809_ForceRegion_RotationalOffset(EditorSharedTest):
         from .tests.force_region import ForceRegion_RotationalOffset as test_module
-
-    class C4976236_AddPhysxColliderComponent(EditorSharedTest):
-        from .tests.collider import Collider_AddColliderComponent as test_module
 
     class C100000_RigidBody_EnablingGravityWorksPoC(EditorSharedTest):
         from .tests.rigid_body import RigidBody_EnablingGravityWorksPoC as test_module

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -440,13 +440,9 @@ class TestAutomation(TestAutomationBase):
         from .tests.material import Material_LibraryClearingAssignsDefault as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason=
-                       "Test failed due to an error message shown while in game mode: "
-                       "'(Prefab) - Invalid asset found referenced in scene while entering game mode. "
-                       "The asset was stored in an instance of Asset.'")
     def test_Collider_AddColliderComponent(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_AddColliderComponent as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @pytest.mark.xfail(
         reason="This will fail due to this issue ATOM-15487.")

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_AddColliderComponent.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/collider/Collider_AddColliderComponent.py
@@ -49,9 +49,10 @@ def Collider_AddColliderComponent():
     from editor_python_test_tools.utils import Tracer
     from editor_python_test_tools.asset_utils import Asset
     
-    helper.init_idle()
+    import editor_python_test_tools.hydra_editor_utils as hydra
+
     # 1) Load the level
-    helper.open_level("Physics", "Base")
+    hydra.open_base_level()
 
     # 2) Create test entity
     test_entity = EditorEntity.create_editor_entity("TestEntity")

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/InMemorySpawnableAssetContainer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Spawnable/InMemorySpawnableAssetContainer.cpp
@@ -235,10 +235,7 @@ namespace AzToolsFramework::Prefab::PrefabConversionUtils
 
                     if (!asset->GetId().IsValid())
                     {
-                        AZ_Error(
-                            "Prefab", false,
-                            "Invalid asset found referenced in scene while entering game mode. The asset was stored in an instance of %s.",
-                            classData->m_name);
+                        // Invalid asset found referenced in scene while entering game mode.
                         return false;
                     }
 


### PR DESCRIPTION
Related to #7431, #2532 .

Remove the error message for now based on @AMZN-koppersr 's comment on an bug ticket:
> As this seems to be down to the fact it's valid to have assets that are not set, the best way forward is to just remove those three error messages. Long term it would be good though to have a way to indicate whether or not an asset is mandatory or optional. 


Tested with the following commands:
`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Main_Optimized.py::TestAutomationWithPrefabSystemEnabled --build-directory windows_vs2019\bin\profile`

`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Periodic.py::TestAutomation::test_Collider_AddColliderComponent --build-directory windows_vs2019\bin\profile`

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>