### PR TITLE
Fixed range-loop-analysis warning reported as error on mac/ios

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -153,7 +153,7 @@ namespace AZ::SceneAPI::Behaviors
             // all mesh data nodes left in the meshIndexContainer do not have a matching TransformData node
             // since the nodes have an identity transform, so map the MeshData index with an Invalid mesh index to
             // indicate the transform should not be set to a default value
-            for( const auto meshIndex : meshIndexContainer)
+            for( const auto& meshIndex : meshIndexContainer)
             {
                 MeshTransformPair pair{ meshIndex, Containers::SceneGraph::NodeIndex{} };
                 meshTransformMap.emplace(MeshTransformEntry{ graph.GetNodeParent(meshIndex), AZStd::move(pair) });


### PR DESCRIPTION
````
PrefabGroupBehavior.cpp:156:29: error: loop variable 'meshIndex' of type 'const AZ::SceneAPI::Containers::SceneGraph::NodeIndex' creates a copy from type 'const AZ::SceneAPI::Containers::SceneGraph::NodeIndex' [-Werror,-Wrange-loop-analysis]
            for( const auto meshIndex : meshIndexContainer)
                            ^
PrefabGroupBehavior.cpp:156:18: note: use reference type 'const AZ::SceneAPI::Containers::SceneGraph::NodeIndex &' to prevent copying
            for( const auto meshIndex : meshIndexContainer)
                 ^~~~~~~~~~~~~~~~~~~~~~
                            &
1 error generated.
````

Signed-off-by: moraaar <moraaar@amazon.com>