### PR TITLE
Improved image gradient GetValue(s) performance by using cached image data

### DIFF
--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPIUtils.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/RPIUtils.h
@@ -60,6 +60,11 @@ namespace AZ
         //! Same as above. Provided as a convenience when all arguments of the 'numthreads' attributes should be assigned to RHI::DispatchDirect::m_threadsPerGroup* variables.
         AZ::Outcome<void, AZStd::string> GetComputeShaderNumThreads(const Data::Asset<ShaderAsset>& shaderAsset, RHI::DispatchDirect& dispatchDirect);
 
+        //! Get single image pixel value from raw image data
+        //! This assumes the imageData is not empty
+        template<typename T>
+        T GetImageDataPixelValue(AZStd::span<const uint8_t> imageData, const AZ::RHI::ImageDescriptor& imageDescriptor, uint32_t x, uint32_t y, uint32_t componentIndex = 0);
+
         //! Get single image pixel value for specified mip and slice
         template<typename T>
         T GetSubImagePixelValue(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, uint32_t x, uint32_t y, uint32_t componentIndex = 0, uint32_t mip = 0, uint32_t slice = 0);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPIUtils.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPIUtils.cpp
@@ -232,16 +232,12 @@ namespace AZ
                 }
             }
 
-            template<typename T>
-            T GetSubImagePixelValueInternal(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, uint32_t x, uint32_t y, uint32_t componentIndex, uint32_t mip, uint32_t slice)
+            size_t GetImageDataIndex(const AZ::RHI::ImageDescriptor& imageDescriptor, uint32_t x, uint32_t y, uint32_t componentIndex)
             {
-                AZStd::array values{ aznumeric_cast<T>(0) };
+                auto width = imageDescriptor.m_size.m_width;
+                const uint32_t numComponents = AZ::RHI::GetFormatComponentCount(imageDescriptor.m_format);
 
-                auto topLeft = AZStd::make_pair(x, y);
-                auto bottomRight = AZStd::make_pair(x + 1, y + 1);
-                GetSubImagePixelValues(imageAsset, topLeft, bottomRight, AZStd::span<T>(values), componentIndex, mip, slice);
-
-                return values[0];
+                return (y * width + x) * numComponents + componentIndex;
             }
         }
 
@@ -448,21 +444,59 @@ namespace AZ
         }
 
         template<>
+        float GetImageDataPixelValue<float>(AZStd::span<const uint8_t> imageData, const AZ::RHI::ImageDescriptor& imageDescriptor, uint32_t x, uint32_t y, uint32_t componentIndex)
+        {
+            size_t imageDataIndex = Internal::GetImageDataIndex(imageDescriptor, x, y, componentIndex);
+            return Internal::RetrieveFloatValue(imageData.data(), imageDataIndex, imageDescriptor.m_format);
+        }
+
+        template<>
+        AZ::u32 GetImageDataPixelValue<AZ::u32>(AZStd::span<const uint8_t> imageData, const AZ::RHI::ImageDescriptor& imageDescriptor, uint32_t x, uint32_t y, uint32_t componentIndex)
+        {
+            size_t imageDataIndex = Internal::GetImageDataIndex(imageDescriptor, x, y, componentIndex);
+            return Internal::RetrieveUintValue(imageData.data(), imageDataIndex, imageDescriptor.m_format);
+        }
+
+        template<>
+        AZ::s32 GetImageDataPixelValue<AZ::s32>(AZStd::span<const uint8_t> imageData, const AZ::RHI::ImageDescriptor& imageDescriptor, uint32_t x, uint32_t y, uint32_t componentIndex)
+        {
+            size_t imageDataIndex = Internal::GetImageDataIndex(imageDescriptor, x, y, componentIndex);
+            return Internal::RetrieveIntValue(imageData.data(), imageDataIndex, imageDescriptor.m_format);
+        }
+
+        template<typename T>
+        T GetSubImagePixelValueInternal(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, uint32_t x, uint32_t y, uint32_t componentIndex, uint32_t mip, uint32_t slice)
+        {
+            if (!imageAsset.IsReady())
+            {
+                return aznumeric_cast<T>(0);
+            }
+
+            auto imageData = imageAsset->GetSubImageData(mip, slice);
+            if (imageData.empty())
+            {
+                return aznumeric_cast<T>(0);
+            }
+
+            return GetImageDataPixelValue<T>(imageData, imageAsset->GetImageDescriptor(), x, y, componentIndex);
+        }
+
+        template<>
         float GetSubImagePixelValue<float>(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, uint32_t x, uint32_t y, uint32_t componentIndex, uint32_t mip, uint32_t slice)
         {
-            return Internal::GetSubImagePixelValueInternal<float>(imageAsset, x, y, componentIndex, mip, slice);
+            return GetSubImagePixelValueInternal<float>(imageAsset, x, y, componentIndex, mip, slice);
         }
 
         template<>
         AZ::u32 GetSubImagePixelValue<AZ::u32>(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, uint32_t x, uint32_t y, uint32_t componentIndex, uint32_t mip, uint32_t slice)
         {
-            return Internal::GetSubImagePixelValueInternal<AZ::u32>(imageAsset, x, y, componentIndex, mip, slice);
+            return GetSubImagePixelValueInternal<AZ::u32>(imageAsset, x, y, componentIndex, mip, slice);
         }
 
         template<>
         AZ::s32 GetSubImagePixelValue<AZ::s32>(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, uint32_t x, uint32_t y, uint32_t componentIndex, uint32_t mip, uint32_t slice)
         {
-            return Internal::GetSubImagePixelValueInternal<AZ::s32>(imageAsset, x, y, componentIndex, mip, slice);
+            return GetSubImagePixelValueInternal<AZ::s32>(imageAsset, x, y, componentIndex, mip, slice);
         }
 
         bool GetSubImagePixelValues(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, AZStd::pair<uint32_t, uint32_t> topLeft, AZStd::pair<uint32_t, uint32_t> bottomRight, AZStd::span<float> outValues, uint32_t componentIndex, uint32_t mip, uint32_t slice)
@@ -478,16 +512,14 @@ namespace AZ
                 return false;
             }
 
-            const AZ::RHI::ImageDescriptor imageDescriptor = imageAsset->GetImageDescriptor();
-            auto width = imageDescriptor.m_size.m_width;
-            const uint32_t numComponents = AZ::RHI::GetFormatComponentCount(imageDescriptor.m_format);
+            const AZ::RHI::ImageDescriptor& imageDescriptor = imageAsset->GetImageDescriptor();
 
             size_t outValuesIndex = 0;
             for (uint32_t y = topLeft.second; y < bottomRight.second; ++y)
             {
                 for (uint32_t x = topLeft.first; x < bottomRight.first; ++x)
                 {
-                    size_t imageDataIndex = (y * width + x) * numComponents + componentIndex;
+                    size_t imageDataIndex = Internal::GetImageDataIndex(imageDescriptor, x, y, componentIndex);
 
                     auto& outValue = outValues[outValuesIndex++];
                     outValue = Internal::RetrieveFloatValue(imageData.data(), imageDataIndex, imageDescriptor.m_format);
@@ -510,16 +542,14 @@ namespace AZ
                 return false;
             }
 
-            const AZ::RHI::ImageDescriptor imageDescriptor = imageAsset->GetImageDescriptor();
-            auto width = imageDescriptor.m_size.m_width;
-            const uint32_t numComponents = AZ::RHI::GetFormatComponentCount(imageDescriptor.m_format);
+            const AZ::RHI::ImageDescriptor& imageDescriptor = imageAsset->GetImageDescriptor();
 
             size_t outValuesIndex = 0;
             for (uint32_t y = topLeft.second; y < bottomRight.second; ++y)
             {
                 for (uint32_t x = topLeft.first; x < bottomRight.first; ++x)
                 {
-                    size_t imageDataIndex = (y * width + x) * numComponents + componentIndex;
+                    size_t imageDataIndex = Internal::GetImageDataIndex(imageDescriptor, x, y, componentIndex);
 
                     auto& outValue = outValues[outValuesIndex++];
                     outValue = Internal::RetrieveUintValue(imageData.data(), imageDataIndex, imageDescriptor.m_format);
@@ -542,16 +572,14 @@ namespace AZ
                 return false;
             }
 
-            const AZ::RHI::ImageDescriptor imageDescriptor = imageAsset->GetImageDescriptor();
-            auto width = imageDescriptor.m_size.m_width;
-            const uint32_t numComponents = AZ::RHI::GetFormatComponentCount(imageDescriptor.m_format);
+            const AZ::RHI::ImageDescriptor& imageDescriptor = imageAsset->GetImageDescriptor();
 
             size_t outValuesIndex = 0;
             for (uint32_t y = topLeft.second; y < bottomRight.second; ++y)
             {
                 for (uint32_t x = topLeft.first; x < bottomRight.first; ++x)
                 {
-                    size_t imageDataIndex = (y * width + x) * numComponents + componentIndex;
+                    size_t imageDataIndex = Internal::GetImageDataIndex(imageDescriptor, x, y, componentIndex);
 
                     auto& outValue = outValues[outValuesIndex++];
                     outValue = Internal::RetrieveIntValue(imageData.data(), imageDataIndex, imageDescriptor.m_format);

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Components/ImageGradientComponent.h
@@ -98,6 +98,8 @@ namespace GradientSignal
 
         void SetupDependencies();
 
+        void GetSubImageData();
+
         // ImageGradientRequestBus overrides...
         AZStd::string GetImageAssetPath() const override;
         void SetImageAssetPath(const AZStd::string& assetPath) override;
@@ -113,5 +115,6 @@ namespace GradientSignal
         LmbrCentral::DependencyMonitor m_dependencyMonitor;
         mutable AZStd::shared_mutex m_imageMutex;
         GradientTransform m_gradientTransform;
+        AZStd::span<const uint8_t> m_imageData;
     };
 }

--- a/Gems/GradientSignal/Code/Include/GradientSignal/ImageAsset.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/ImageAsset.h
@@ -62,6 +62,6 @@ namespace GradientSignal
         }
     };
 
-    float GetValueFromImageAsset(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, const AZ::Vector3& uvw, float tilingX, float tilingY, float defaultValue);
+    float GetValueFromImageAsset(AZStd::span<const uint8_t> imageData, const AZ::RHI::ImageDescriptor& imageDescriptor, const AZ::Vector3& uvw, float tilingX, float tilingY, float defaultValue);
 
 } // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -234,21 +234,13 @@ namespace GradientSignal
 
         ImageGradientRequestBus::Handler::BusConnect(GetEntityId());
         GradientRequestBus::Handler::BusConnect(GetEntityId());
-        AZ::Data::AssetBus::Handler::BusConnect(m_configuration.m_imageAsset.GetId());
 
-        // If the image asset is already ready (e.g. constructed in a unit test),
-        // then go ahead and retrieve the image data now
-        AZStd::unique_lock<decltype(m_imageMutex)> imageLock(m_imageMutex);
-        if (m_configuration.m_imageAsset.IsReady())
-        {
-            GetSubImageData();
-        }
-        // Otherwise for normal use-case, we queue the asset to be loaded now
-        else
-        {
-            m_imageData = AZStd::span<const uint8_t>();
-            m_configuration.m_imageAsset.QueueLoad();
-        }
+        // Invoke the QueueLoad before connecting to the AssetBus, so that
+        // if the asset is already ready, then OnAssetReady will be triggered immediately
+        m_imageData = AZStd::span<const uint8_t>();
+        m_configuration.m_imageAsset.QueueLoad();
+
+        AZ::Data::AssetBus::Handler::BusConnect(m_configuration.m_imageAsset.GetId());
     }
 
     void ImageGradientComponent::Deactivate()

--- a/Gems/GradientSignal/Code/Source/ImageAsset.cpp
+++ b/Gems/GradientSignal/Code/Source/ImageAsset.cpp
@@ -78,11 +78,10 @@ namespace GradientSignal
         return true;
     }
 
-    float GetValueFromImageAsset(const AZ::Data::Asset<AZ::RPI::StreamingImageAsset>& imageAsset, const AZ::Vector3& uvw, float tilingX, float tilingY, float defaultValue)
+    float GetValueFromImageAsset(AZStd::span<const uint8_t> imageData, const AZ::RHI::ImageDescriptor& imageDescriptor, const AZ::Vector3& uvw, float tilingX, float tilingY, float defaultValue)
     {
-        if (imageAsset.IsReady())
+        if (!imageData.empty())
         {
-            auto imageDescriptor = imageAsset->GetImageDescriptor();
             auto width = imageDescriptor.m_size.m_width;
             auto height = imageDescriptor.m_size.m_height;
 
@@ -125,7 +124,7 @@ namespace GradientSignal
                 // Flip the y because images are stored in reverse of our world axes
                 y = (height - 1) - y;
 
-                return AZ::RPI::GetSubImagePixelValue<float>(imageAsset, x, y);
+                return AZ::RPI::GetImageDataPixelValue<float>(imageData, imageDescriptor, x, y);
             }
         }
 


### PR DESCRIPTION
In the original change of the `ImageGradient` to use a `StreamingImageAsset` instead of the custom `GradientSignal::ImageAsset`, the GetValue(s) benchmarks performance degraded. This is because previously the `GradientSignal::ImageAsset` owned the raw byte data itself, as opposed to the `StreamingImageAsset` which has to go through the mip chain to retrieve the actual sub-image data. To optimize the performance, I've updated the `ImageGradient` to cache the raw image data once the asset has been loaded. This uses a new companion API that retrieves pixel values directly from a vector of bytes instead of passing a `StreamingImageAsset`.

GradientSignal ImageGradient benchmarks before change:
```
GradientGetValues/BM_ImageGradient/EbusGetValue:0/size:1024                      58.1 ms         57.8 ms           10
GradientGetValues/BM_ImageGradient/EbusGetValue:0/size:2048                       236 ms          240 ms            3
GradientGetValues/BM_ImageGradient/EbusGetValue:0/size:4096                       933 ms          938 ms            1
GradientGetValues/BM_ImageGradient/EbusGetValues:1/size:1024                     35.7 ms         36.2 ms           19
GradientGetValues/BM_ImageGradient/EbusGetValues:1/size:2048                      144 ms          145 ms            4
GradientGetValues/BM_ImageGradient/EbusGetValues:1/size:4096                      575 ms          578 ms            1
GradientGetValues/BM_ImageGradient/SamplerGetValue:2/size:1024                   77.1 ms         76.4 ms            9
GradientGetValues/BM_ImageGradient/SamplerGetValue:2/size:2048                    315 ms          312 ms            2
GradientGetValues/BM_ImageGradient/SamplerGetValue:2/size:4096                   1253 ms         1250 ms            1
GradientGetValues/BM_ImageGradient/SamplerGetValues:3/size:1024                  37.0 ms         37.0 ms           19
GradientGetValues/BM_ImageGradient/SamplerGetValues:3/size:2048                   148 ms          148 ms            4
GradientGetValues/BM_ImageGradient/SamplerGetValues:3/size:4096                   593 ms          594 ms            1
```

GradientSignal ImageGradient benchmarks after change:
```
GradientGetValues/BM_ImageGradient/EbusGetValue:0/size:1024                      49.3 ms         50.0 ms           10
GradientGetValues/BM_ImageGradient/EbusGetValue:0/size:2048                       198 ms          203 ms            3
GradientGetValues/BM_ImageGradient/EbusGetValue:0/size:4096                       795 ms          797 ms            1
GradientGetValues/BM_ImageGradient/EbusGetValues:1/size:1024                     19.5 ms         19.4 ms           37
GradientGetValues/BM_ImageGradient/EbusGetValues:1/size:2048                     79.8 ms         80.4 ms            7
GradientGetValues/BM_ImageGradient/EbusGetValues:1/size:4096                      321 ms          320 ms            2
GradientGetValues/BM_ImageGradient/SamplerGetValue:2/size:1024                   70.0 ms         71.2 ms            9
GradientGetValues/BM_ImageGradient/SamplerGetValue:2/size:2048                    280 ms          281 ms            2
GradientGetValues/BM_ImageGradient/SamplerGetValue:2/size:4096                   1120 ms         1125 ms            1
GradientGetValues/BM_ImageGradient/SamplerGetValues:3/size:1024                  20.4 ms         20.7 ms           34
GradientGetValues/BM_ImageGradient/SamplerGetValues:3/size:2048                  82.4 ms         82.6 ms            7
GradientGetValues/BM_ImageGradient/SamplerGetValues:3/size:4096                   336 ms          336 ms            2
```
Signed-off-by: Chris Galvan <chgalvan@amazon.com>