### PR TITLE
Fix race condition crash with the gradient preview.

### DIFF
--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <LmbrCentral/Dependency/DependencyNotificationBus.h>
+#include <GradientSignal/Ebuses/GradientPreviewRequestBus.h>
 
 namespace GradientSignal
 {
@@ -61,6 +62,12 @@ namespace GradientSignal
 
     void EditorGradientSurfaceDataComponent::Deactivate()
     {
+        // Make sure any previews for this entity aren't currently trying to refresh. Otherwise, the preview job could call
+        // back into our FilterFunc lambda below after the entity has already been destroyed.
+        AZ::EntityId canceledEntity;
+        GradientSignal::GradientPreviewRequestBus::EventResult(
+            canceledEntity, GetEntityId(), &GradientSignal::GradientPreviewRequestBus::Events::CancelRefresh);
+
         // If the preview shouldn't be active, use an invalid entityId
         m_gradientEntityId = AZ::EntityId();
         AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();


### PR DESCRIPTION
When duplicating an entity with a Gradient SurfaceData Component, it's possible to get a hang/crash due to a race condition between entity deactivation and the gradient preview job refresh. This change ensures that the preview job is canceled on deactivation.

Closes #7525 .

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>