### PR TITLE
Fix memory allocation that caused benchmark runs to crash.

### DIFF
--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
@@ -90,7 +90,7 @@ namespace UnitTest
         AZStd::unique_ptr<AZ::Entity> BuildTestSurfaceMaskGradient(float shapeHalfBounds);
         AZStd::unique_ptr<AZ::Entity> BuildTestSurfaceSlopeGradient(float shapeHalfBounds);
 
-        AZ::RPI::AssetHandlerPtrList m_assetHandlers;
+        AZStd::fixed_vector<AZStd::unique_ptr<AZ::Data::AssetHandler>, 2> m_assetHandlers;
     };
 
     struct GradientSignalTest


### PR DESCRIPTION
Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>