### PR TITLE
Add 3p vulkan validation layer support. 

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
+++ b/Gems/Atom/RHI/Vulkan/Code/CMakeLists.txt
@@ -108,6 +108,7 @@ ly_add_target(
     BUILD_DEPENDENCIES
         PUBLIC
             AZ::AzCore
+            AZ::AzTest
             AZ::AzFramework
             Gem::Atom_RHI.Reflect
             Gem::Atom_RHI_Vulkan.Reflect
@@ -130,6 +131,7 @@ ly_add_target(
         PRIVATE
             Gem::Atom_RHI_Vulkan.Private.Static
             Gem::Atom_RHI.Public
+            ${VULKAN_VALIDATION_LAYER}
 )
 
 ly_add_target(

--- a/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/PAL_windows.cmake
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/Platform/Windows/PAL_windows.cmake
@@ -7,3 +7,4 @@
 #
 
 set(PAL_TRAIT_ATOM_RHI_VULKAN_SUPPORTED TRUE)
+set(VULKAN_VALIDATION_LAYER 3rdParty::vulkan-validationlayers)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -9,6 +9,7 @@
 #include <RHI/Instance.h>
 #include <Atom/RHI.Loader/FunctionLoader.h>
 #include <AzCore/Debug/Trace.h>
+#include <AzTest/Utils.h>
 
 namespace AZ
 {
@@ -45,8 +46,22 @@ namespace AZ
 
         bool Instance::Init(const Descriptor& descriptor)
         {
-            m_descriptor = descriptor;   
+            m_descriptor = descriptor;
+            if (GetValidationMode() != RHI::ValidationMode::Disabled)
+            {
+                //This env var (VK_LAYER_PATH) is used by the drivers to look for VkLayer_khronos_validation.dll
+                AZStd::string exeFolder = AZ::Test::GetCurrentExecutablePath().c_str();
+                AZ::Test::SetEnv("VK_LAYER_PATH", exeFolder.c_str(), 1);
 
+                RawStringList validationLayers = Debug::GetValidationLayers();
+                m_descriptor.m_optionalLayers.insert(m_descriptor.m_requiredLayers.end(), validationLayers.begin(), validationLayers.end());
+                m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+                m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+            }
+#if defined(AZ_VULKAN_USE_DEBUG_LABELS)
+            m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+#endif
+            
             m_functionLoader = FunctionLoader::Create();
             if (!m_functionLoader->Init())
             {
@@ -88,17 +103,6 @@ namespace AZ
             instanceCreateInfo.pApplicationInfo = &appInfo;
 
             StringList instanceLayerNames = GetInstanceLayerNames();
-            if (GetValidationMode() != RHI::ValidationMode::Disabled)
-            {
-                RawStringList validationLayers = Debug::GetValidationLayers();
-                m_descriptor.m_optionalLayers.insert(m_descriptor.m_requiredLayers.end(), validationLayers.begin(), validationLayers.end());
-                m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-                m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-            }
-#if defined(AZ_VULKAN_USE_DEBUG_LABELS)
-            m_descriptor.m_optionalExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-#endif
-
             RawStringList optionalLayers = FilterList(m_descriptor.m_optionalLayers, instanceLayerNames);
             m_descriptor.m_requiredLayers.insert(m_descriptor.m_requiredLayers.end(), optionalLayers.begin(), optionalLayers.end());
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Instance.cpp
@@ -50,8 +50,7 @@ namespace AZ
             if (GetValidationMode() != RHI::ValidationMode::Disabled)
             {
                 //This env var (VK_LAYER_PATH) is used by the drivers to look for VkLayer_khronos_validation.dll
-                AZStd::string exeFolder = AZ::Test::GetCurrentExecutablePath().c_str();
-                AZ::Test::SetEnv("VK_LAYER_PATH", exeFolder.c_str(), 1);
+                AZ::Test::SetEnv("VK_LAYER_PATH", AZ::Test::GetCurrentExecutablePath().c_str(), 1);
 
                 RawStringList validationLayers = Debug::GetValidationLayers();
                 m_descriptor.m_optionalLayers.insert(m_descriptor.m_requiredLayers.end(), validationLayers.begin(), validationLayers.end());

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -50,4 +50,4 @@ ly_associate_package(PACKAGE_NAME lz4-1.9.3-vcpkg-rev4-windows                  
 ly_associate_package(PACKAGE_NAME azslc-1.7.35-rev1-windows                             TARGETS azslc                       PACKAGE_HASH 606aea611f2f20afcd8467ddabeecd3661e946eac3c843756c7df2871c1fb8a0)
 ly_associate_package(PACKAGE_NAME SQLite-3.37.2-rev1-windows        	                TARGETS SQLite                      PACKAGE_HASH c1658c8ed5cf0e45d4a5da940c6a6d770b76e0f4f57313b70d0fd306885f015e)
 ly_associate_package(PACKAGE_NAME AwsIotDeviceSdkCpp-1.15.2-rev1-windows                TARGETS AwsIotDeviceSdkCpp          PACKAGE_HASH b03475a9f0f7a7e7c90619fba35f1a74fb2b8f4cd33fa07af99f2ae9e0c079dd)
-ly_associate_package(PACKAGE_NAME vulkan-validationlayers-1.2.198-rev1-windows          TARGETS vulkan-validationlayers     PACKAGE_HASH 56b36ced446f523508cce9910429df4789fdb7fdbdb424166264fb02a0da5aa0)
+ly_associate_package(PACKAGE_NAME vulkan-validationlayers-1.2.198-rev1-windows          TARGETS vulkan-validationlayers     PACKAGE_HASH 4c617b83611f9f990b7e6ff21f2e2d22bda154591bff7e0e39610e319a3e5a53)

--- a/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
+++ b/cmake/3rdParty/Platform/Windows/BuiltInPackages_windows.cmake
@@ -50,3 +50,4 @@ ly_associate_package(PACKAGE_NAME lz4-1.9.3-vcpkg-rev4-windows                  
 ly_associate_package(PACKAGE_NAME azslc-1.7.35-rev1-windows                             TARGETS azslc                       PACKAGE_HASH 606aea611f2f20afcd8467ddabeecd3661e946eac3c843756c7df2871c1fb8a0)
 ly_associate_package(PACKAGE_NAME SQLite-3.37.2-rev1-windows        	                TARGETS SQLite                      PACKAGE_HASH c1658c8ed5cf0e45d4a5da940c6a6d770b76e0f4f57313b70d0fd306885f015e)
 ly_associate_package(PACKAGE_NAME AwsIotDeviceSdkCpp-1.15.2-rev1-windows                TARGETS AwsIotDeviceSdkCpp          PACKAGE_HASH b03475a9f0f7a7e7c90619fba35f1a74fb2b8f4cd33fa07af99f2ae9e0c079dd)
+ly_associate_package(PACKAGE_NAME vulkan-validationlayers-1.2.198-rev1-windows          TARGETS vulkan-validationlayers     PACKAGE_HASH 56b36ced446f523508cce9910429df4789fdb7fdbdb424166264fb02a0da5aa0)


### PR DESCRIPTION
Enabling device validation will automatically load the VkLayer_khronos_validation.dll ensuring that validation checks will work correctly

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>