### PR TITLE
Checksum of deb package needs to be recomputed after signing

### DIFF
--- a/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
+++ b/cmake/Platform/Linux/PackagingPostBuild_linux.cmake
@@ -22,6 +22,7 @@ if(CPACK_UPLOAD_URL)
 
     # Sign and regenerate checksum
     ly_sign_binaries("${CPACK_TOPLEVEL_DIRECTORY}/*.deb" "")
+    file(${CPACK_PACKAGE_CHECKSUM} ${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb file_checksum)
     file(WRITE ${CPACK_TOPLEVEL_DIRECTORY}/${CPACK_PACKAGE_FILE_NAME}.deb.sha256 "${file_checksum}  ${CPACK_PACKAGE_FILE_NAME}.deb")
 
     # Copy the artifacts intended to be uploaded to a remote server into the folder specified


### PR DESCRIPTION
The nightly linux builds have a deb package with a different sha256 than the accompanying checksum file.
i.e.
```
$ cat O3DE_latest.deb.sha256 
0bbefc977deb11f3dbe5eefdc7e36caaf607758147957fef060e96e6b519f5dd  O3DE_latest.deb%                                    
$ sha256sum O3DE_latest.deb                          
2905441099dc5467b008430e6e14f0c75c96474af965651c1f105a92d496cb5f  O3DE_latest.deb
```

It looks like cmake is writing the sha256 file after signing, but not recomputing the hash.

Signed-off-by: xaque <xaque@duck.com>