### PR TITLE
Introduce Atom/GraphicsDevMode settings registry key

### DIFF
--- a/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
+++ b/Gems/Atom/Asset/Shader/Code/Source/Editor/AzslShaderBuilderSystemComponent.cpp
@@ -82,7 +82,7 @@ namespace AZ
             // Register Shader Asset Builder
             AssetBuilderSDK::AssetBuilderDesc shaderAssetBuilderDescriptor;
             shaderAssetBuilderDescriptor.m_name = "Shader Asset Builder";
-            shaderAssetBuilderDescriptor.m_version = 110; // Add "Definitions" field to shader asset to support convenient addition of preprocessor definitions
+            shaderAssetBuilderDescriptor.m_version = 111; // Enable shader PDB generation globally if Atom/GraphicsDevMode settings registry key is set
             shaderAssetBuilderDescriptor.m_patterns.push_back(AssetBuilderSDK::AssetBuilderPattern( AZStd::string::format("*.%s", RPI::ShaderSourceData::Extension), AssetBuilderSDK::AssetBuilderPattern::PatternType::Wildcard));
             shaderAssetBuilderDescriptor.m_busId = azrtti_typeid<ShaderAssetBuilder>();
             shaderAssetBuilderDescriptor.m_createJobFunction = AZStd::bind(&ShaderAssetBuilder::CreateJobs, &m_shaderAssetBuilder, AZStd::placeholders::_1, AZStd::placeholders::_2);

--- a/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
+++ b/Gems/Atom/RHI/Code/Include/Atom/RHI/RHIUtils.h
@@ -42,6 +42,9 @@ namespace AZ
 
         //! Returns if the current bakcend is a null renderer
         bool IsNullRenderer();
+
+        //! Returns true if the Atom/GraphicsDevMode settings registry key is set
+        bool IsGraphicsDevModeEnabled();
     }
 }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/RHIUtils.cpp
@@ -9,8 +9,11 @@
 #include <Atom/RHI/RHIUtils.h>
 #include <Atom/RHI/RHISystemInterface.h>
 #include <Atom/RHI/Factory.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/API/ApplicationAPI.h>
 #include <AzFramework/CommandLine/CommandLine.h>
+
+static constexpr char GraphicsDevModeSetting[] = "/Atom/GraphicsDevMode";
 
 namespace AZ
 {
@@ -133,6 +136,17 @@ namespace AZ
                 return commandLine->HasSwitch(commandLineOption);
             }
             return false;
+        }
+
+        bool IsGraphicsDevModeEnabled()
+        {
+            AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
+            bool graphicsDevMode = false;
+            if (settingsRegistry)
+            {
+                settingsRegistry->Get(graphicsDevMode, GraphicsDevModeSetting);
+            }
+            return graphicsDevMode;
         }
     }
 }

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -12,10 +12,10 @@
 #include <Atom/RHI.Edit/Utils.h>
 #include <Atom/RHI.Reflect/DX12/PipelineLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/DX12/ShaderStageFunction.h>
+#include <Atom/RHI/RHIUtils.h>
 
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
-
 #include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
@@ -253,9 +253,11 @@ namespace AZ
                 return false;
             }
 
+            const bool graphicsDevMode = RHI::IsGraphicsDevModeEnabled();
+
             // Compilation parameters
             AZStd::string params = shaderCompilerArguments.MakeAdditionalDxcCommandLineString();
-            if (BuildHasDebugInfo(shaderCompilerArguments))
+            if (graphicsDevMode || BuildHasDebugInfo(shaderCompilerArguments))
             {
                 params += " -Zi";  // Generate debug information
                 params += " -Zss"; // Compute Shader Hash considering source information
@@ -284,7 +286,7 @@ namespace AZ
             // If we use the auto-name (hash), there is no way we can retrieve that name apart from listing the directory.
             // Instead, let's just generate that hash ourselves.
             AZStd::string symbolDatabaseFileCliArgument{" "};  // when not debug: still insert a space between 5.dxil and 7.hlsl-in
-            if (BuildHasDebugInfo(shaderCompilerArguments))
+            if (graphicsDevMode || BuildHasDebugInfo(shaderCompilerArguments))
             {
                 // prepare .pdb filename:
                 AZStd::string md5hex = RHI::ByteToHexString(md5);
@@ -353,7 +355,7 @@ namespace AZ
                 byProducts.m_dynamicBranchCount = ByProducts::UnknownDynamicBranchCount;
             }
 
-            if (BuildHasDebugInfo(shaderCompilerArguments))
+            if (graphicsDevMode || BuildHasDebugInfo(shaderCompilerArguments))
             {
                 byProducts.m_intermediatePaths.emplace(AZStd::move(objectCodeOutputFile));
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI.Builders/ShaderPlatformInterface.cpp
@@ -11,6 +11,7 @@
 
 #include <Atom/RHI.Reflect/Vulkan/Base.h>
 #include <Atom/RHI.Reflect/Vulkan/ShaderStageFunction.h>
+#include <Atom/RHI/RHIUtils.h>
 
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
@@ -281,7 +282,9 @@ namespace AZ
             args.m_destinationFolder = tempFolder.c_str();
 
             const auto dxcInputFile = RHI::PrependFile(args);  // Prepend header
-            if (BuildHasDebugInfo(shaderCompilerArguments))
+            const bool graphicsDevMode = RHI::IsGraphicsDevModeEnabled();
+
+            if (graphicsDevMode || BuildHasDebugInfo(shaderCompilerArguments))
             {
                 // dump intermediate "true final HLSL" file (shadername.vulkan.shadersource.prepend)
                 byProducts.m_intermediatePaths.insert(dxcInputFile);
@@ -334,7 +337,7 @@ namespace AZ
                 byProducts.m_dynamicBranchCount = ByProducts::UnknownDynamicBranchCount;
             }
 
-            if (BuildHasDebugInfo(shaderCompilerArguments))
+            if (graphicsDevMode || BuildHasDebugInfo(shaderCompilerArguments))
             {
                 byProducts.m_intermediatePaths.emplace(AZStd::move(objectCodeOutputFile));
             }


### PR DESCRIPTION
When `"Atom": {"GraphicsDevMode": true}` is found in a `.setreg` file,
PDBs for all shaders will be emitted to their corresponding output
locations. This allows global PDB generation without needing to
explicitly modify each `.shader` file to include the `GenerateDebugInfo`
compilation option.

Signed-off-by: Jeremy Ong <jcong@amazon.com>