### PR TITLE
Fix Clang built executables so they can be launched from the file explorer

### DIFF
--- a/cmake/Platform/Linux/Configurations_linux.cmake
+++ b/cmake/Platform/Linux/Configurations_linux.cmake
@@ -24,8 +24,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             -Wl,-z,relro,-z,now
             -Wl,-z,noexecstack
         LINK_EXE
-            -pie
-            -fpie
             -Wl,-z,relro,-z,now
             -Wl,-z,noexecstack
     )

--- a/cmake/Platform/Linux/Configurations_linux.cmake
+++ b/cmake/Platform/Linux/Configurations_linux.cmake
@@ -24,6 +24,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             -Wl,-z,relro,-z,now
             -Wl,-z,noexecstack
         LINK_EXE
+            -fpie
             -Wl,-z,relro,-z,now
             -Wl,-z,noexecstack
     )


### PR DESCRIPTION
For some reason, adding the '-pie' to the exe link flags causes executables to not launch by double clicking it.  (This flag was introduced as part of https://github.com/o3de/o3de/pull/7358 

Signed-off-by: Steve Pham <82231385+spham-amzn@users.noreply.github.com>