### PR TITLE
Disabling problematic NetBindComponent assert with a configuration

### DIFF
--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -22,6 +22,9 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/sort.h>
 
+AZ_CVAR(bool, bg_AssertNetBindOnDeactrivationWithoutMarkForRemoval, false, nullptr, AZ::ConsoleFunctorFlags::Null,
+    "If true, assert when a multiplayer entity is deactivated without first calling MarkForRemoval from NetworkEntityManager.");
+
 namespace Multiplayer
 {
     void NetBindComponent::Reflect(AZ::ReflectContext* context)
@@ -167,10 +170,13 @@ namespace Multiplayer
 
     void NetBindComponent::Deactivate()
     {
-        AZ_Assert(
-            m_needsToBeStopped == false,
-            "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.",
-            GetEntity() ? GetEntity()->GetName().c_str() : "null");
+        if (bg_AssertNetBindOnDeactrivationWithoutMarkForRemoval)
+        {
+            AZ_Assert(
+                m_needsToBeStopped == false,
+                "Entity (%s) appears to have been improperly deleted. Use MarkForRemoval to correctly clean up a networked entity.",
+                GetEntity() ? GetEntity()->GetName().c_str() : "null");
+        }
         m_handleLocalServerRpcMessageEventHandle.Disconnect();
         if (NetworkRoleHasController(m_netEntityRole))
         {

--- a/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Components/NetBindComponent.cpp
@@ -22,7 +22,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/sort.h>
 
-AZ_CVAR(bool, bg_AssertNetBindOnDeactrivationWithoutMarkForRemoval, false, nullptr, AZ::ConsoleFunctorFlags::Null,
+AZ_CVAR(bool, bg_AssertNetBindOnDeactivationWithoutMarkForRemoval, false, nullptr, AZ::ConsoleFunctorFlags::Null,
     "If true, assert when a multiplayer entity is deactivated without first calling MarkForRemoval from NetworkEntityManager.");
 
 namespace Multiplayer
@@ -170,7 +170,7 @@ namespace Multiplayer
 
     void NetBindComponent::Deactivate()
     {
-        if (bg_AssertNetBindOnDeactrivationWithoutMarkForRemoval)
+        if (bg_AssertNetBindOnDeactivationWithoutMarkForRemoval)
         {
             AZ_Assert(
                 m_needsToBeStopped == false,


### PR DESCRIPTION
Added cvar bg_AssertNetBindOnDeactrivationWithoutMarkForRemoval to Multiplayer::NetBindComponent.

This solves the issue of MultiplayerSample-like project launcher hanging in the background due a deadlock when writing AZ_Assert during on application shutdown.

Created #7584  to follow up on.

Signed-off-by: Olex Lozitskiy <5432499+AMZN-Olex@users.noreply.github.com>