### PR TITLE
Linux Clang unoptimized build fix.

### DIFF
--- a/cmake/Platform/Common/Clang/Configurations_clang.cmake
+++ b/cmake/Platform/Common/Clang/Configurations_clang.cmake
@@ -9,7 +9,9 @@
 include(cmake/Platform/Common/Configurations_common.cmake)
 
 ly_append_configurations_options(
-    DEFINES
+    DEFINES_PROFILE
+        _FORTIFY_SOURCE=2
+    DEFINES_RELEASE
         _FORTIFY_SOURCE=2
     COMPILATION
         -fno-exceptions
@@ -23,7 +25,7 @@ ly_append_configurations_options(
         ###################
         # Disabled warnings (please do not disable any others without first consulting sig-build)
         ###################
-        -Wno-inconsistent-missing-override # unfortunately there is no warning in MSVC to detect missing overrides, 
+        -Wno-inconsistent-missing-override # unfortunately there is no warning in MSVC to detect missing overrides,
             # MSVC's static analyzer can, but that is a different run that most developers are not aware of. A pass
             # was done to fix all hits. Leaving this disabled until there is a matching warning in MSVC.
 
@@ -33,7 +35,7 @@ ly_append_configurations_options(
         -Wno-reorder
         -Wno-switch
         -Wno-undefined-var-template
-        
+
         ###################
         # Enabled warnings (that are disabled by default)
         ###################

--- a/cmake/Platform/Common/GCC/Configurations_gcc.cmake
+++ b/cmake/Platform/Common/GCC/Configurations_gcc.cmake
@@ -20,7 +20,9 @@ endif()
 
 
 ly_append_configurations_options(
-    DEFINES
+    DEFINES_PROFILE
+        _FORTIFY_SOURCE=2
+    DEFINES_RELEASE
         _FORTIFY_SOURCE=2
 
     COMPILATION_C
@@ -48,7 +50,7 @@ ly_append_configurations_options(
         ${LY_GCC_GCOV_FLAGS}
         ${LY_GCC_GPROF_FLAGS}
 
-        # Disabled warnings 
+        # Disabled warnings
         -Wno-array-bounds
         -Wno-attributes
         -Wno-class-memaccess


### PR DESCRIPTION
The _FORTIFY_SOURCE option must be used with the -O optimization flag.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>