### PR TITLE
Making scriptcanvas files rebuild due to new Lua version

### DIFF
--- a/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
+++ b/Gems/ScriptCanvas/Code/Builder/ScriptCanvasBuilderWorker.cpp
@@ -167,7 +167,10 @@ namespace ScriptCanvasBuilder
         {
             // compute it the first time
             const AZStd::string runtimeAssetTypeId = azrtti_typeid<ScriptCanvas::RuntimeAsset>().ToString<AZStd::string>();
-            m_fingerprintString = AZStd::string::format("%i%s", GetVersionNumber(), runtimeAssetTypeId.c_str());
+            m_fingerprintString = AZStd::string::format("%s%i%s", 
+                AZ::ScriptDataContext::GetInterpreterVersion(), // this is the version of LUA - if it changes, we need to rebuild
+                GetVersionNumber(), 
+                runtimeAssetTypeId.c_str());
         }
         return m_fingerprintString.c_str();
     }


### PR DESCRIPTION
The version of Lua has updated - script canvas needs to rebuild
all of the scriptcanvas files with the new lua version.

Fixes #7591 

This adds the lua interpreter version into the fingerprint of all scriptcanvas jobs
which will cause them to rebuild next time you start Asset Processor.

Signed-off-by: lawsonamzn <70027408+lawsonamzn@users.noreply.github.com>