### PR TITLE
Unregister engine on uninstall

### DIFF
--- a/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
+++ b/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
@@ -36,6 +36,7 @@
                 <Directory Id="root.cmake.runtime" Name="runtime"/>
             </Directory>
             <Directory Id="root.python" Name="python"/>
+            <Directory Id="root.scripts" Name="scripts"/>
             <Directory Id="root.tools" Name="Tools">
                 <Directory Id="root.tools.redist" Name="Redistributables">
                     <Directory Id="root.tools.redist.cmake" Name="CMake"/>
@@ -57,6 +58,12 @@
 
         <CustomAction Id="ConfigurePython"
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C set &quot;LY_CMAKE_PATH=[root.cmake.runtime]bin&quot; &amp;&amp; &quot;[root.python]get_python.bat&quot;"
+            Directory="INSTALL_ROOT"
+            Execute="deferred"
+            Impersonate="no"/>
+
+        <CustomAction Id="UnRegisterEngine"
+            ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C @&quot;[root.scripts]o3de.bat&quot; register --remove --this-engine"
             Directory="INSTALL_ROOT"
             Execute="deferred"
             Impersonate="no"/>

--- a/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
+++ b/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
@@ -66,6 +66,7 @@
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C @&quot;[root.scripts]o3de.bat&quot; register --remove --this-engine"
             Directory="INSTALL_ROOT"
             Execute="deferred"
+            Return="ignore"
             Impersonate="no"/>
 
     </Fragment>

--- a/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
+++ b/cmake/Platform/Windows/Packaging/PostInstallSetup.wxs
@@ -65,7 +65,7 @@
         <CustomAction Id="UnRegisterEngine"
             ExeCommand="&quot;[SystemFolder]cmd.exe&quot; /C @&quot;[root.scripts]o3de.bat&quot; register --remove --this-engine"
             Directory="INSTALL_ROOT"
-            Execute="deferred"
+            Execute="immediate"
             Return="ignore"
             Impersonate="no"/>
 

--- a/cmake/Platform/Windows/Packaging/Template.wxs.in
+++ b/cmake/Platform/Windows/Packaging/Template.wxs.in
@@ -58,6 +58,10 @@
             <Custom Action="ConfigurePython" After="MoveCMake">
                 NOT Installed Or REINSTALL
             </Custom>
+            <!-- limit the unregister action to full uninstall -->
+            <Custom Action="UnRegisterEngine" After="InstallInitialize">
+                (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
+            </Custom>
         </InstallExecuteSequence>
 
         <UIRef Id="$(var.CPACK_WIX_UI_REF)" />

--- a/scripts/o3de/o3de/register.py
+++ b/scripts/o3de/o3de/register.py
@@ -225,7 +225,7 @@ def remove_engine_name_to_path(json_data: dict,
 
     returns 0 to indicate no issues has occurred with removal
     """
-    if engine_path.is_dir() and validation.valid_o3de_engine_json(engine_path):
+    if engine_path.is_dir() and validation.valid_o3de_engine_json(pathlib.Path(engine_path).resolve() / 'engine.json'):
         engine_json_data = manifest.get_engine_json_data(engine_path=engine_path)
         if 'engine_name' in engine_json_data and 'engines_path' in json_data:
             engine_name = engine_json_data['engine_name']
@@ -234,6 +234,9 @@ def remove_engine_name_to_path(json_data: dict,
             except KeyError:
                 # Attempting to remove a non-existent engine_name is fine
                 pass
+    else:
+        logger.warning(f'Unable to find engine.json file or file is invalid at path {engine_path.as_posix()}')
+
     return 0
 
 
@@ -354,8 +357,8 @@ def register_engine_path(json_data: dict,
 
     if remove:
         return remove_engine_name_to_path(json_data, engine_path)
-
-    return add_engine_name_to_path(json_data, engine_path, force)
+    else:
+        return add_engine_name_to_path(json_data, engine_path, force)
 
 
 def register_external_subdirectory(json_data: dict,
@@ -797,7 +800,7 @@ def _run_register(args: argparse) -> int:
         remove_invalid_o3de_objects()
         return repo.refresh_repos()
     elif args.this_engine:
-        ret_val = register(engine_path=manifest.get_this_engine_path(), force=args.force)
+        ret_val = register(engine_path=manifest.get_this_engine_path(), force=args.force, remove=args.remove)
         return ret_val
     elif args.all_engines_path:
         return register_all_engines_in_folder(args.all_engines_path, args.remove, args.force)


### PR DESCRIPTION
Add logic to WiX script that calls
```
scripts/o3de.bat register --remove --this-engine
```
on uninstall and fixed two issues with unregistering the engine found along the way
1. engine was not removed from engine_paths because the engine root was passed in and validation expects `engine.json`
2. the `--this-engine` command does not pass the `args.remove` option for removal and I wanted to avoid any potential problems by passing in a path from WiX

*Testing*
- Tested the script command first to verify the register and unregister was working
- Created an installer and verified after installing it added the engine to o3de_manifest.json and after uninstalling the engine was removed from o3de_manifest.json
- Verified the script was run in the installer logs
```
MSI (s) (FC:1C) [10:29:18:310]: Executing op: ActionStart(Name=UnRegisterEngine,,)
MSI (s) (FC:1C) [10:29:18:310]: Executing op: CustomActionSchedule(Action=UnRegisterEngine,ActionType=3106,Source=C:\O3DE\0.0.0.0\,Target="C:\Windows\SysWOW64\cmd.exe" /C @"C:\O3DE\0.0.0.0\scripts\o3de.bat" register --remove --this-engine,)
```

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>