### PR TITLE
Fix benchmark run crashes.

### DIFF
--- a/Gems/GradientSignal/Code/CMakeLists.txt
+++ b/Gems/GradientSignal/Code/CMakeLists.txt
@@ -141,6 +141,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 Gem::LmbrCentral
                 Gem::LmbrCentral.Mocks
                 Gem::GradientSignal.Mocks
+        RUNTIME_DEPENDENCIES
+            Gem::SurfaceData
     )
     
     ly_add_target(
@@ -161,6 +163,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 Gem::LmbrCentral
                 Gem::LmbrCentral.Mocks
                 Gem::GradientSignal.Mocks
+        RUNTIME_DEPENDENCIES
+            Gem::SurfaceData
     )
     ly_add_googletest(
         NAME Gem::GradientSignal.Tests

--- a/Gems/SurfaceData/Code/CMakeLists.txt
+++ b/Gems/SurfaceData/Code/CMakeLists.txt
@@ -98,6 +98,8 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED)
                 AZ::AzTest
                 Gem::SurfaceData.Static
                 Gem::LmbrCentral
+        RUNTIME_DEPENDENCIES
+            Gem::LmbrCentral
     )
     ly_add_googletest(
         NAME Gem::SurfaceData.Tests


### PR DESCRIPTION
The benchmark builds weren't building the dependent DLLs due to missing dependencies in the cmake files.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>