### PR TITLE
Various Benchmark Fixes for AzCore

### DIFF
--- a/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/TestTypes.h
@@ -159,6 +159,36 @@ namespace UnitTest
             TeardownAllocator();
         }
     };
+
+    /**
+    * RAII wrapper around a BenchmarkEnvironmentBase to encapsulate
+    * the creation and destuction of the SystemAllocator
+    * SetUpBenchmark and TearDownBenchmark can still be used for custom
+    * benchmark environment setup
+    */
+    class ScopedAllocatorBenchmarkEnvironment
+        : public AZ::Test::BenchmarkEnvironmentBase
+    {
+    public:
+        ScopedAllocatorBenchmarkEnvironment()
+        {
+            // Only create the allocator if it doesn't exist
+            if (!AZ::AllocatorInstance<AZ::SystemAllocator>::IsReady())
+            {
+                AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
+                m_ownsAllocator = true;
+            }
+        }
+        ~ScopedAllocatorBenchmarkEnvironment() override
+        {
+            if (m_ownsAllocator)
+            {
+                AZ::AllocatorInstance<AZ::SystemAllocator>::Destroy();
+            }
+        }
+    private:
+        bool m_ownsAllocator{};
+    };
 #endif
 
     class DLLTestVirtualClass

--- a/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h
+++ b/Code/Framework/AzCore/AzCore/std/containers/intrusive_set.h
@@ -42,20 +42,13 @@ namespace AZStd
         template<class U, class Hook, class Compare>
         friend class intrusive_multiset;
 
-#ifdef AZ_DEBUG_BUILD
-        intrusive_multiset_node()
-        {
-            m_children[0] = nullptr;
-            m_children[1] = nullptr;
-            m_neighbours[0] = nullptr;
-            m_neighbours[1] = nullptr;
-            m_parentColorSide = nullptr;
-        }
+        intrusive_multiset_node() = default;
         ~intrusive_multiset_node()
         {
+#if defined(AZ_DEBUG_BUILD)
             AZSTD_CONTAINER_ASSERT(m_children[0] == nullptr && m_children[1] == nullptr && m_parentColorSide == nullptr, "AZStd::intrusive_multiset_node - intrusive list node is being destroyed while still in a container!");
-        }
 #endif
+        }
         // We use the lower 2 bits of the parent pointer to store
         enum Bits
         {
@@ -95,9 +88,9 @@ namespace AZStd
         AZ_FORCE_INLINE T*      next() const { return m_neighbours[AZSTD_RBTREE_RIGHT];  }
 
     protected:
-        T* m_children[2];
-        T* m_neighbours[2];
-        T* m_parentColorSide;
+        T* m_children[2]{};
+        T* m_neighbours[2]{};
+        T* m_parentColorSide{};
     } AZ_MAY_ALIAS; // we access the object in such way that we potentially can break strict aliasing rules
 
     /**
@@ -659,12 +652,10 @@ namespace AZStd
 
             --m_numElements;
 
-#ifdef AZ_DEBUG_BUILD
             nodeHook->m_children[0] = nodeHook->m_children[1] = nullptr;
             nodeHook->m_parentColorSide = nullptr;
-#ifdef DEBUG_INTRUSIVE_MULTISET
+#if defined(AZ_DEBUG_BUILD) && defined(DEBUG_INTRUSIVE_MULTISET)
             validate();
-#endif
 #endif
         }
 
@@ -955,8 +946,11 @@ namespace AZStd
             hookNode->setParentSide(side);
         }
 
+        //! pre-condition
+        //! @param node must be non-nullptr
         inline static node_ptr_type MinOrMax(const_node_ptr_type node, SideType side)
         {
+            AZSTD_CONTAINER_ASSERT(node != nullptr, "MinOrMax can only be called with a non-nullptr node")
             const_node_ptr_type cur = node;
             const_node_ptr_type minMax = cur;
             while (!iterator_impl::isNil(cur))

--- a/Code/Framework/AzCore/Tests/Main.cpp
+++ b/Code/Framework/AzCore/Tests/Main.cpp
@@ -7,29 +7,13 @@
  */
 
 #include <AzCore/UnitTest/UnitTest.h>
+#include <AzCore/UnitTest/TestTypes.h>
 #include <AzTest/AzTest.h>
-#include <AzCore/Memory/SystemAllocator.h>
 
 
 #if defined(HAVE_BENCHMARK)
 
-namespace AzCore
-{
-    class AzCoreBenchmarkEnvironment
-        : public AZ::Test::BenchmarkEnvironmentBase
-    {
-        void SetUpBenchmark() override
-        {
-            AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
-        }
-        void TearDownBenchmark() override
-        {
-            AZ::AllocatorInstance<AZ::SystemAllocator>::Destroy();
-        }
-    };
-}
-
-AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV, AzCore::AzCoreBenchmarkEnvironment)
+AZ_UNIT_TEST_HOOK(DEFAULT_UNIT_TEST_ENV, UnitTest::ScopedAllocatorBenchmarkEnvironment)
 
 #else
 

--- a/Code/Framework/AzCore/Tests/Memory/AllocatorBenchmarks.cpp
+++ b/Code/Framework/AzCore/Tests/Memory/AllocatorBenchmarks.cpp
@@ -291,7 +291,7 @@ namespace Benchmark
             for (auto _ : state)
             {
                 state.PauseTiming();
-                
+
                 AZStd::vector<void*>& perThreadAllocations = base::GetPerThreadAllocations(state.thread_index);
                 const size_t numberOfAllocations = perThreadAllocations.size();
                 size_t totalAllocationSize = 0;
@@ -300,7 +300,7 @@ namespace Benchmark
                     const AllocationSizeArray& allocationArray = s_allocationSizes[TAllocationSize];
                     const size_t allocationSize = allocationArray[allocationIndex % allocationArray.size()];
                     totalAllocationSize += allocationSize;
-                    
+
                     state.ResumeTiming();
                     perThreadAllocations[allocationIndex] = TestAllocatorType::Allocate(allocationSize, 0);
                     state.PauseTiming();
@@ -319,6 +319,8 @@ namespace Benchmark
                 TestAllocatorType::GarbageCollect();
 
                 state.SetItemsProcessed(numberOfAllocations);
+
+                state.ResumeTiming();
             }
         }
     };
@@ -364,6 +366,8 @@ namespace Benchmark
                 state.SetItemsProcessed(numberOfAllocations);
 
                 TestAllocatorType::GarbageCollect();
+
+                state.ResumeTiming();
             }
         }
     };
@@ -519,6 +523,8 @@ namespace Benchmark
                 state.SetItemsProcessed(itemsProcessed);
 
                 TestAllocatorType::GarbageCollect();
+
+                state.ResumeTiming();
             }
         }
     };

--- a/Code/Framework/AzTest/AzTest/AzTest.h
+++ b/Code/Framework/AzTest/AzTest/AzTest.h
@@ -164,6 +164,16 @@ namespace AZ
                 m_envs.push_back(std::move(env));
             }
 
+            // Remove a registered benchmark from the registry
+            void RemoveBenchmarkEnvironment(BenchmarkEnvironmentBase* env)
+            {
+                auto RemoveBenchmarkFunc = [env](const std::unique_ptr<BenchmarkEnvironmentBase>& envElement)
+                {
+                    return envElement.get() == env;
+                };
+                m_envs.erase(std::remove_if(m_envs.begin(), m_envs.end(), std::move(RemoveBenchmarkFunc)));
+            }
+
             std::vector<std::unique_ptr<BenchmarkEnvironmentBase>>& GetBenchmarkEnvironments()
             {
                 return m_envs;
@@ -194,21 +204,26 @@ namespace AZ
             return *benchmarkEnv;
         }
 
-        template<typename... Ts>
-        std::array<BenchmarkEnvironmentBase*, sizeof...(Ts)> RegisterBenchmarkEnvironments()
+        /*
+         * An RAII wrapper about registering a BenchmarkEnvironment with the BenchmarkRegistry
+         * It will unregister the BenchmarkEnvironment with the BenchmarkRegistry on destruction
+         */
+        struct ScopedRegisterBenchmarkEnvironment
         {
-            constexpr size_t EnvironmentCount{ sizeof...(Ts) };
-            if constexpr (EnvironmentCount)
+            template<typename T>
+            ScopedRegisterBenchmarkEnvironment(T& benchmarkEnv)
+                : m_benchmarkEnv(benchmarkEnv)
+            {}
+            ~ScopedRegisterBenchmarkEnvironment()
             {
-                std::array<BenchmarkEnvironmentBase*, EnvironmentCount> benchmarkEnvs{ { &RegisterBenchmarkEnvironment<Ts>()... } };
-                return benchmarkEnvs;
+                if (auto benchmarkRegistry = AZ::Environment::FindVariable<BenchmarkEnvironmentRegistry>(s_benchmarkEnvironmentName);
+                    benchmarkRegistry != nullptr)
+                {
+                    benchmarkRegistry->RemoveBenchmarkEnvironment(&m_benchmarkEnv);
+                }
             }
-            else
-            {
-                std::array<BenchmarkEnvironmentBase*, EnvironmentCount> benchmarkEnvs{};
-                return benchmarkEnvs;
-            }
-        }
+            BenchmarkEnvironmentBase& m_benchmarkEnv;
+        };
 #endif
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         //! listener class to capture and print test output for embedded platforms
@@ -276,7 +291,7 @@ namespace AZ
 #define AZ_BENCHMARK_HOOK_ENV(TEST_ENV) \
 AZTEST_EXPORT int AzRunBenchmarks(int argc, char** argv) \
 { \
-    AZ::Test::RegisterBenchmarkEnvironments<TEST_ENV>(); \
+    AZ::Test::ScopedRegisterBenchmarkEnvironment scopedBenchmarkEnv(AZ::Test::RegisterBenchmarkEnvironment<TEST_ENV>()); \
     auto benchmarkEnvRegistry = AZ::Environment::FindVariable<AZ::Test::BenchmarkEnvironmentRegistry>(AZ::Test::s_benchmarkEnvironmentName); \
     std::vector<std::unique_ptr<AZ::Test::BenchmarkEnvironmentBase>>* benchmarkEnvs = benchmarkEnvRegistry ? &(benchmarkEnvRegistry->GetBenchmarkEnvironments()) : nullptr; \
     if (benchmarkEnvs != nullptr) \
@@ -307,7 +322,6 @@ AZTEST_EXPORT int AzRunBenchmarks(int argc, char** argv) \
 #define AZ_BENCHMARK_HOOK() \
 AZTEST_EXPORT int AzRunBenchmarks(int argc, char** argv) \
 { \
-    AZ::Test::RegisterBenchmarkEnvironments<>(); \
     auto benchmarkEnvRegistry = AZ::Environment::FindVariable<AZ::Test::BenchmarkEnvironmentRegistry>(AZ::Test::s_benchmarkEnvironmentName); \
     std::vector<std::unique_ptr<AZ::Test::BenchmarkEnvironmentBase>>* benchmarkEnvs = benchmarkEnvRegistry ? &(benchmarkEnvRegistry->GetBenchmarkEnvironments()) : nullptr; \
     if (benchmarkEnvs != nullptr) \


### PR DESCRIPTION
Fixed crash in Allocators Benchmark multithreaded test due to the HPHA schema not having proper multithread protection around the `mFreeTree` member in `tree_get_unused_memory` function.
The `mFreeTree intrusive set is able to modified on multiple threads.

Replaced the custom intrusive_list implementation n HPHA schema with AZStd::intrusive_list

Added a `ScopedAllocatorBenchmarkEnvironment` class to provide an RAI mechanism for initializing the SystemAllocator in Benchmark Test

Rermoved the `AzCoreBenchmarkEnvironment` in lieu of the `ScopedAllocatorBenchmarkEnvironment` class

Fixed assert when running Allocator Benchmarks in debug due to mismatch PauseTiming/ResumeTiming in Allocator Benchmark Fixtures

Added `ScopedRegisterBenchmarkEnvironment` RAII class to provide lifetime guarantees on BenchmarkEnvironments registered via the `AZ_UNIT_TEST_HOOK`

Initialized the intrusive_multiset_node members to nullptr in all build configurations instead of only debug as the cost negligible and it is useful for debugging.

fixes LYN-10210

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>