### PR TITLE
Adds support for additional VS debugger args

### DIFF
--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -132,7 +132,6 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             endif()
         endif()
 
-        get_target_property(project_game_launcher_additional_args ${project_name} GAMELAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
         set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
             "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${additional_game_vs_debugger_args}")
     endif()

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -124,9 +124,17 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
     # After ensuring that we correctly support DPI scaling, this should be switched to "PerMonitor"
     set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DPI_AWARE "OFF")
     if(LY_DEFAULT_PROJECT_PATH)
+        if (TARGET ${project_name})
+            get_target_property(project_game_launcher_additional_args ${project_name} GAMELAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+            if (project_game_launcher_additional_args)
+                # Avoid pushing param-NOTFOUND into the argument in case this property wasn't found
+                set(additional_game_vs_debugger_args "${project_game_launcher_additional_args}")
+            endif()
+        endif()
+
         get_target_property(project_game_launcher_additional_args ${project_name} GAMELAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
         set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
-            "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${project_game_launcher_additional_args}")
+            "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${additional_game_vs_debugger_args}")
     endif()
 
     # Associate the Clients Gem Variant with each projects GameLauncher
@@ -175,9 +183,16 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             )
 
             if(LY_DEFAULT_PROJECT_PATH)
-                get_target_property(project_server_launcher_additional_args ${project_name} SERVERLAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+                if (TARGET ${project_name})
+                    get_target_property(project_server_launcher_additional_args ${project_name} SERVERLAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+                    if (project_server_launcher_additional_args)
+                        # Avoid pushing param-NOTFOUND into the argument in case this property wasn't found
+                        set(additional_server_vs_debugger_args "${project_server_launcher_additional_args}")
+                    endif()
+                endif()
+                
                 set_property(TARGET ${project_name}.ServerLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
-                    "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${project_server_launcher_additional_args}")
+                    "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${additional_server_vs_debugger_args}")
             endif()
 
             # Associate the Servers Gem Variant with each projects ServerLauncher

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -124,7 +124,7 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
     # After ensuring that we correctly support DPI scaling, this should be switched to "PerMonitor"
     set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DPI_AWARE "OFF")
     if(LY_DEFAULT_PROJECT_PATH)
-        get_property(project_game_launcher_additional_args GLOBAL PROPERTY ${project_name}_GAMELAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+        get_target_property(project_game_launcher_additional_args ${project_name} GAMELAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
         set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
             "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${project_game_launcher_additional_args}")
     endif()
@@ -175,7 +175,7 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             )
 
             if(LY_DEFAULT_PROJECT_PATH)
-                get_property(project_server_launcher_additional_args GLOBAL PROPERTY ${project_name}_SERVERLAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+                get_target_property(project_server_launcher_additional_args ${project_name} SERVERLAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
                 set_property(TARGET ${project_name}.ServerLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
                     "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${project_server_launcher_additional_args}")
             endif()

--- a/Code/LauncherUnified/launcher_generator.cmake
+++ b/Code/LauncherUnified/launcher_generator.cmake
@@ -124,7 +124,9 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
     # After ensuring that we correctly support DPI scaling, this should be switched to "PerMonitor"
     set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DPI_AWARE "OFF")
     if(LY_DEFAULT_PROJECT_PATH)
-        set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\"")
+        get_property(project_game_launcher_additional_args GLOBAL PROPERTY ${project_name}_GAMELAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+        set_property(TARGET ${project_name}.GameLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
+            "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${project_game_launcher_additional_args}")
     endif()
 
     # Associate the Clients Gem Variant with each projects GameLauncher
@@ -173,7 +175,9 @@ foreach(project_name project_path IN ZIP_LISTS LY_PROJECTS_TARGET_NAME LY_PROJEC
             )
 
             if(LY_DEFAULT_PROJECT_PATH)
-                set_property(TARGET ${project_name}.ServerLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\"")
+                get_property(project_server_launcher_additional_args GLOBAL PROPERTY ${project_name}_SERVERLAUNCHER_ADDITIONAL_VS_DEBUGGER_COMMAND_ARGUMENTS)
+                set_property(TARGET ${project_name}.ServerLauncher APPEND PROPERTY VS_DEBUGGER_COMMAND_ARGUMENTS 
+                    "--project-path=\"${LY_DEFAULT_PROJECT_PATH}\" ${project_server_launcher_additional_args}")
             endif()
 
             # Associate the Servers Gem Variant with each projects ServerLauncher


### PR DESCRIPTION
Fixes #7623

See an example of the use here:  https://github.com/o3de/o3de-multiplayersample/pull/113
Tested using the above CR as well. See details in there.

So that one can do the following:

![image](https://user-images.githubusercontent.com/5432499/153898584-7c2e1327-15fc-4494-b098-cb21247b6d00.png)


Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>