### PR TITLE
Mac Runtime Fix: Up the hard coded size for the HpAllocator buffer to 18KiB

### DIFF
--- a/Code/Framework/AzCore/AzCore/Memory/HphaSchema.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/HphaSchema.cpp
@@ -2440,7 +2440,7 @@ namespace AZ
             m_capacity = desc.m_capacity;
         }
 
-        AZ_Assert(sizeof(HpAllocator) <= sizeof(m_hpAllocatorBuffer), "Increase the m_hpAllocatorBuffer, we need %d bytes but we have %d bytes!", sizeof(HpAllocator), sizeof(m_hpAllocatorBuffer));
+        static_assert(sizeof(HpAllocator) <= sizeof(m_hpAllocatorBuffer), "Increase the m_hpAllocatorBuffer, it needs to be atleast the sizeof(HpAllocator)");
         m_allocator = new (&m_hpAllocatorBuffer) HpAllocator(m_desc);
     }
 

--- a/Code/Framework/AzCore/AzCore/Memory/HphaSchema.cpp
+++ b/Code/Framework/AzCore/AzCore/Memory/HphaSchema.cpp
@@ -2440,7 +2440,7 @@ namespace AZ
             m_capacity = desc.m_capacity;
         }
 
-        static_assert(sizeof(HpAllocator) <= sizeof(m_hpAllocatorBuffer), "Increase the m_hpAllocatorBuffer, it needs to be atleast the sizeof(HpAllocator)");
+        static_assert(sizeof(HpAllocator) <= sizeof(m_hpAllocatorBuffer), "Increase the m_hpAllocatorBuffer, it needs to be at least the sizeof(HpAllocator)");
         m_allocator = new (&m_hpAllocatorBuffer) HpAllocator(m_desc);
     }
 

--- a/Code/Framework/AzCore/AzCore/Memory/HphaSchema.h
+++ b/Code/Framework/AzCore/AzCore/Memory/HphaSchema.h
@@ -73,17 +73,21 @@ namespace AZ
         void            GarbageCollect() override;
 
     private:
-        // [LY-84974][sconel@][2018-08-10] SliceStrike integration up to CL 671758
         // this must be at least the max size of HpAllocator (defined in the cpp) + any platform compiler padding
-        static const int hpAllocatorStructureSize = 16584;
-        // [LY][sconel@] end
+        // A static assert inside of HphaSchema.cpp validates that this is the case
+        // as of commit https://github.com/o3de/o3de/commit/92cd457c256e1ec91eeabe04b56d1d4c61f8b1af
+        // When MULTITHREADED and USE_MUTEX_PER_BUCKET is defined
+        // the largest sizeof for HpAllocator is 16640 on MacOS
+        // On Windows the sizeof HpAllocator is 8384
+        // Up this value to 18 KiB to be safe
+        static constexpr size_t hpAllocatorStructureSize = 18 * 1024;
         
         Descriptor          m_desc;
         int                 m_pad;      // pad the Descriptor to avoid C4355
         size_type           m_capacity;                 ///< Capacity in bytes.
         HpAllocator*        m_allocator;
         // [LY-84974][sconel@][2018-08-10] SliceStrike integration up to CL 671758
-        AZStd::aligned_storage<hpAllocatorStructureSize, 16>::type m_hpAllocatorBuffer;    ///< Memory buffer for HpAllocator
+        AZStd::aligned_storage_t<hpAllocatorStructureSize, 16> m_hpAllocatorBuffer;    ///< Memory buffer for HpAllocator
         // [LY][sconel@] end
         bool                m_ownMemoryBlock;
     };

--- a/Code/Framework/AzCore/AzCore/Memory/HphaSchema.h
+++ b/Code/Framework/AzCore/AzCore/Memory/HphaSchema.h
@@ -86,9 +86,7 @@ namespace AZ
         int                 m_pad;      // pad the Descriptor to avoid C4355
         size_type           m_capacity;                 ///< Capacity in bytes.
         HpAllocator*        m_allocator;
-        // [LY-84974][sconel@][2018-08-10] SliceStrike integration up to CL 671758
         AZStd::aligned_storage_t<hpAllocatorStructureSize, 16> m_hpAllocatorBuffer;    ///< Memory buffer for HpAllocator
-        // [LY][sconel@] end
         bool                m_ownMemoryBlock;
     };
 } // namespace AZ


### PR DESCRIPTION
Added a static assert in the HphaSchema.cpp file to validate that the
HpAllocator aligned storage buffer is at least the size of the
HpAllocator class.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>