### PR TITLE
ATOM-17253 Using AtomTressFX gem as an example to inject hair passes to main pipeline at run-time

### DIFF
--- a/AutomatedTesting/Passes/MainPipeline.pass
+++ b/AutomatedTesting/Passes/MainPipeline.pass
@@ -215,99 +215,6 @@
                         }
                     ]
                 },
-
-                {
-                    // NOTE: HairParentPass does not write into Depth MSAA from Opaque Pass. If new passes downstream
-                    // of HairParentPass will need to use Depth MSAA, HairParentPass will need to be updated to use Depth MSAA
-                    // instead of regular Depth as DepthStencil. Specifically, HairResolvePPLL.pass and the associated 
-                    // .azsl file will need to be updated.
-                    "Name": "HairParentPass",
-                    // Note: The following two lines represent the choice of rendering pipeline for the hair.
-                    // You can either choose to use PPLL or ShortCut and accordingly change the flag 
-                    // 'm_usePPLLRenderTechnique' in the class 'HairFeatureProcessor.cpp'
-                    // "TemplateName": "HairParentPassTemplate",
-                    "TemplateName": "HairParentShortCutPassTemplate",
-                    "Enabled": true,
-                    "Connections": [
-                        // Critical to keep DepthLinear as input - used to set the size of the Head PPLL image buffer.
-                        // If DepthLinear is not available - connect to another viewport (non MSAA) image.
-                        {
-                            "LocalSlot": "DepthLinearInput",
-                            "AttachmentRef": {
-                                "Pass": "DepthPrePass",
-                                "Attachment": "DepthLinear"
-                            }
-                        },
-                        {
-                            "LocalSlot": "Depth",
-                            "AttachmentRef": {
-                                "Pass": "DepthPrePass",
-                                "Attachment": "Depth"
-                            }
-                        },
-                        {
-                            "LocalSlot": "RenderTargetInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "OpaquePass",
-                                "Attachment": "Output"
-                            }
-                        },
-                        {
-                            "LocalSlot": "RenderTargetInputOnly",
-                            "AttachmentRef": {
-                                "Pass": "OpaquePass",
-                                "Attachment": "Output"
-                            }
-                        },
-
-                        // Shadows resources
-                        {
-                            "LocalSlot": "DirectionalShadowmap",
-                            "AttachmentRef": {
-                                "Pass": "ShadowPass",
-                                "Attachment": "DirectionalShadowmap"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DirectionalESM",
-                            "AttachmentRef": {
-                                "Pass": "ShadowPass",
-                                "Attachment": "DirectionalESM"
-                            }
-                        },
-                        {
-                            "LocalSlot": "ProjectedShadowmap",
-                            "AttachmentRef": {
-                                "Pass": "ShadowPass",
-                                "Attachment": "ProjectedShadowmap"
-                            }
-                        },
-                        {
-                            "LocalSlot": "ProjectedESM",
-                            "AttachmentRef": {
-                                "Pass": "ShadowPass",
-                                "Attachment": "ProjectedESM"
-                            }
-                        },
-
-                        // Lighting Resources
-                        {
-                            "LocalSlot": "TileLightData",
-                            "AttachmentRef": {
-                                "Pass": "LightCullingPass",
-                                "Attachment": "TileLightData"
-                            }
-                        },
-                        {
-                            "LocalSlot": "LightListRemapped",
-                            "AttachmentRef": {
-                                "Pass": "LightCullingPass",
-                                "Attachment": "LightListRemapped"
-                            }
-                        }
-                    ]
-                },
-
                 {
                     "Name": "TransparentPass",
                     "TemplateName": "TransparentParentTemplate",
@@ -357,22 +264,22 @@
                         {
                             "LocalSlot": "InputLinearDepth",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "DepthLinear"
                             }
                         },
                         {
                             "LocalSlot": "DepthStencil",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "Depth"
                             }
                         },
                         {
                             "LocalSlot": "InputOutput",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
-                                "Attachment": "RenderTargetInputOutput"
+                                "Pass": "OpaquePass",
+                                "Attachment": "Output"
                             }
                         }
                     ]
@@ -385,22 +292,22 @@
                         {
                             "LocalSlot": "InputLinearDepth",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "DepthLinear"
                             }
                         },
                         {
                             "LocalSlot": "InputDepthStencil",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "Depth"
                             }
                         },
                         {
                             "LocalSlot": "RenderTargetInputOutput",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
-                                "Attachment": "RenderTargetInputOutput"
+                                "Pass": "TransparentPass",
+                                "Attachment": "InputOutput"
                             }
                         }
                     ],
@@ -440,7 +347,7 @@
                         {
                             "LocalSlot": "Depth",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "Depth"
                             }
                         },
@@ -475,7 +382,7 @@
                         {
                             "LocalSlot": "DepthInputOutput",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "Depth"
                             }
                         }
@@ -534,7 +441,7 @@
                         {
                             "LocalSlot": "DepthInputOutput",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "Depth"
                             }
                         }
@@ -547,14 +454,14 @@
                         {
                             "LocalSlot": "InputOutput",
                             "AttachmentRef": {
-                                "Pass": "LyShinePass",
-                                "Attachment": "ColorInputOutput"
+                                "Pass": "DebugOverlayPass",
+                                "Attachment": "InputOutput"
                             }
                         },
                         {
                             "LocalSlot": "DepthInputOutput",
                             "AttachmentRef": {
-                                "Pass": "HairParentPass",
+                                "Pass": "DepthPrePass",
                                 "Attachment": "Depth"
                             }
                         }

--- a/Code/Editor/CryEdit.cpp
+++ b/Code/Editor/CryEdit.cpp
@@ -1340,6 +1340,8 @@ void CCryEditApp::CompileCriticalAssets() const
     }
     assetsInQueueNotifcation.BusDisconnect();
 
+    AZ_TracePrintf("Editor", "CriticalAssetsCompiled\n");
+
     // Signal the "CriticalAssetsCompiled" lifecycle event
     // Also reload the "assetcatalog.xml" if it exists
     if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
@@ -1411,11 +1413,13 @@ bool CCryEditApp::ConnectToAssetProcessor() const
 
     if (connectedToAssetProcessor)
     {
+        AZ_TracePrintf("Editor", "Connected to Asset Processor\n");
         CCryEditApp::OutputStartupMessage(QString("Connected to Asset Processor"));
         CompileCriticalAssets();
         return true;
     }
 
+    AZ_TracePrintf("Editor", "Failed to connect to Asset Processor\n");
     CCryEditApp::OutputStartupMessage(QString("Failed to connect to Asset Processor"));
     return false;
 }

--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -327,6 +327,7 @@ namespace AZ
                 {
                     RPI::RenderPipelinePtr renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(renderPipelineDescriptor, *viewportContext->GetWindowContext().get());
                     pipelineAsset.Release();
+                    scene->ApplyRenderPipelineChange(renderPipeline.get());
                     scene->AddRenderPipeline(renderPipeline);
                 }
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -89,7 +89,7 @@ namespace AZ
             //! Perform any necessary deactivation.
             virtual void Deactivate() {}
 
-            //! Apply changes to render pipeline from feature processors
+            //! Apply changes and add additional render passes to the render pipeline from the feature processors
             virtual void ApplyRenderPipelineChange(RenderPipeline* ) {}
 
             //! Allows the feature processor to expose supporting views based on

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/FeatureProcessor.h
@@ -30,6 +30,8 @@ namespace AZ
 
     namespace RPI
     {
+        class RenderPipeline;
+
         //! @class FeatureProcessor
         //! @brief Interface that FeatureProcessors should derive from
         //! @detail FeatureProcceors will record simulation state from the simulation job graph into a buffer that is isolated from the asynchronous rendering graph.
@@ -86,6 +88,9 @@ namespace AZ
 
             //! Perform any necessary deactivation.
             virtual void Deactivate() {}
+
+            //! Apply changes to render pipeline from feature processors
+            virtual void ApplyRenderPipelineChange(RenderPipeline* ) {}
 
             //! Allows the feature processor to expose supporting views based on
             //! the main views passed in. Main views (persistent views) are views that must be 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/ParentPass.h
@@ -66,6 +66,7 @@ namespace AZ
             //! Inserts a pass at specified position
             //! If the position is invalid, the child pass won't be added, and the function returns false
             bool InsertChild(const Ptr<Pass>& child, ChildPassIndex position);
+            bool InsertChild(const Ptr<Pass>& child, uint32_t index);
 
             //! Searches for a child pass with the given name. Returns the child's index if found, null index otherwise
             ChildPassIndex FindChildPassIndex(const Name& passName) const;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -169,6 +169,9 @@ namespace AZ
             //! This function is called every time scene's render pipelines change.
             //! User may call this function explicitly if render pipelines were changed
             void RebuildPipelineStatesLookup();
+                        
+            //! apply render pipeline changes from each feature processors
+            void ApplyRenderPipelineChange(RenderPipeline* pipeline);
 
         protected:
             // SceneFinder overrides...
@@ -191,6 +194,7 @@ namespace AZ
             // Update and compile scene and view srgs
             // This is called after PassSystem's FramePrepare so passes can still modify view srgs in its FramePrepareIntenal function before they are submitted to command list
             void UpdateSrgs();
+
 
         private:
             Scene();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/ParentPass.cpp
@@ -77,19 +77,29 @@ namespace AZ
 
         bool ParentPass::InsertChild(const Ptr<Pass>& child, ChildPassIndex position)
         {
+            if (!position.IsValid())
+            {
+                AZ_Assert(false, "Can't insert a child pass with invalid position");
+                return false;
+            }
+            return InsertChild(child, position.GetIndex());
+        }
+        
+        bool ParentPass::InsertChild(const Ptr<Pass>& child, uint32_t index)
+        {
             if (child->m_parent != nullptr)
             {
                 AZ_Assert(false, "Can't add Pass that already has a parent. Remove the Pass from it's parent before adding it to another Pass.");
                 return false;
             }
 
-            if (!position.IsValid() || position.GetIndex() > m_children.size())
+            if (index > m_children.size())
             {
                 AZ_Assert(false, "Can't insert a child pass with invalid position");
                 return false;
             }
 
-            auto insertPos = m_children.cbegin() + position.GetIndex();
+            auto insertPos = m_children.cbegin() + index;
             m_children.insert(insertPos, child);
 
             child->m_parent = this;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/RPISystem.cpp
@@ -370,6 +370,7 @@ namespace AZ
             m_commonShaderAssetForSrgs = AssetUtils::LoadCriticalAsset<ShaderAsset>( m_descriptor.m_commonSrgsShaderAssetPath.c_str());
             if (!m_commonShaderAssetForSrgs.IsReady())
             {
+                AZ_Error("RPI system", false, "Failed to load RPI system asset %s", m_descriptor.m_commonSrgsShaderAssetPath.c_str());
                 return;
             }
             m_sceneSrgLayout = m_commonShaderAssetForSrgs->FindShaderResourceGroupLayout(SrgBindingSlot::Scene);
@@ -395,6 +396,7 @@ namespace AZ
             m_passSystem.InitPassTemplates();
 
             m_systemAssetsInitialized = true;
+            AZ_TracePrintf("RPI system", "System assets initialized\n");
         }
 
         bool RPISystem::IsInitialized() const

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -285,6 +285,14 @@ namespace AZ
             return foundFP == AZStd::end(m_featureProcessors) ? nullptr : (*foundFP).get();
         }
 
+        void Scene::ApplyRenderPipelineChange(RenderPipeline* pipeline)
+        {
+            for (auto& fp : m_featureProcessors)
+            {
+                fp->ApplyRenderPipelineChange(pipeline);
+            }
+        }
+
         void Scene::AddRenderPipeline(RenderPipelinePtr pipeline)
         {
             if (pipeline->m_scene != nullptr)

--- a/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportWidget.cpp
+++ b/Gems/Atom/Tools/MaterialEditor/Code/Source/Viewport/MaterialViewportWidget.cpp
@@ -93,6 +93,7 @@ namespace MaterialEditor
             m_defaultPipelineAssetPath.c_str(), AZ::RPI::AssetUtils::TraceLevel::Error);
         m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineAsset, *GetViewportContext()->GetWindowContext().get());
         pipelineAsset.Release();
+        m_scene->ApplyRenderPipelineChange(m_renderPipeline.get());
         m_scene->AddRenderPipeline(m_renderPipeline);
 
         // As part of our initialization we need to create the BRDF texture generation pipeline

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -70,6 +70,7 @@ namespace EMStudio
             defaultPipelineAssetPath.c_str(), AZ::RPI::AssetUtils::TraceLevel::Error);
         m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineAsset, *m_windowContext.get());
         pipelineAsset.Release();
+        m_scene->ApplyRenderPipelineChange(m_renderPipeline.get());
         m_scene->AddRenderPipeline(m_renderPipeline);
         m_renderPipeline->SetDefaultView(viewportContext->GetDefaultView());
 

--- a/Gems/AtomTressFX/Assets/Passes/AtomTressFX_PassRequest.azasset
+++ b/Gems/AtomTressFX/Assets/Passes/AtomTressFX_PassRequest.azasset
@@ -1,0 +1,96 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassRequest",
+    "ClassData": {
+        // NOTE: HairParentPass does not write into Depth MSAA from Opaque Pass. If new passes downstream
+        // of HairParentPass will need to use Depth MSAA, HairParentPass will need to be updated to use Depth MSAA
+        // instead of regular Depth as DepthStencil. Specifically, HairResolvePPLL.pass and the associated 
+        // .azsl file will need to be updated.
+        "Name": "HairParentPass",
+        // Note: The following two lines represent the choice of rendering pipeline for the hair.
+        // You can either choose to use PPLL or ShortCut by changing TemplateName to HairParentPassTemplate (for PPLL)
+        // or HairParentShortCutPassTemplate (for Shortcut)
+        // "TemplateName": "HairParentPassTemplate",
+        "TemplateName": "HairParentShortCutPassTemplate",
+        "Enabled": true,
+        "Connections": [
+            // Critical to keep DepthLinear as input - used to set the size of the Head PPLL image buffer.
+            // If DepthLinear is not available - connect to another viewport (non MSAA) image.
+            {
+                "LocalSlot": "DepthLinear",
+                "AttachmentRef": {
+                    "Pass": "DepthPrePass",
+                    "Attachment": "DepthLinear"
+                }
+            },
+            {
+                "LocalSlot": "Depth",
+                "AttachmentRef": {
+                    "Pass": "DepthPrePass",
+                    "Attachment": "Depth"
+                }
+            },
+            {
+                "LocalSlot": "RenderTargetInputOutput",
+                "AttachmentRef": {
+                    "Pass": "OpaquePass",
+                    "Attachment": "Output"
+                }
+            },
+            {
+                "LocalSlot": "RenderTargetInputOnly",
+                "AttachmentRef": {
+                    "Pass": "OpaquePass",
+                    "Attachment": "Output"
+                }
+            },
+
+            // Shadows resources
+            {
+                "LocalSlot": "DirectionalShadowmap",
+                "AttachmentRef": {
+                    "Pass": "ShadowPass",
+                    "Attachment": "DirectionalShadowmap"
+                }
+            },
+            {
+                "LocalSlot": "DirectionalESM",
+                "AttachmentRef": {
+                    "Pass": "ShadowPass",
+                    "Attachment": "DirectionalESM"
+                }
+            },
+            {
+                "LocalSlot": "ProjectedShadowmap",
+                "AttachmentRef": {
+                    "Pass": "ShadowPass",
+                    "Attachment": "ProjectedShadowmap"
+                }
+            },
+            {
+                "LocalSlot": "ProjectedESM",
+                "AttachmentRef": {
+                    "Pass": "ShadowPass",
+                    "Attachment": "ProjectedESM"
+                }
+            },
+
+            // Lighting Resources
+            {
+                "LocalSlot": "TileLightData",
+                "AttachmentRef": {
+                    "Pass": "LightCullingPass",
+                    "Attachment": "TileLightData"
+                }
+            },
+            {
+                "LocalSlot": "LightListRemapped",
+                "AttachmentRef": {
+                    "Pass": "LightCullingPass",
+                    "Attachment": "LightListRemapped"
+                }
+            }
+        ]
+    }
+}

--- a/Gems/AtomTressFX/Assets/Passes/AtomTressFX_PassTemplates.azasset
+++ b/Gems/AtomTressFX/Assets/Passes/AtomTressFX_PassTemplates.azasset
@@ -62,6 +62,10 @@
             {
                 "Name": "HairShortCutResolveColorPassTemplate",
                 "Path": "Passes/HairShortCutResolveColor.pass"
+            },
+            {
+                "Name": "HairDepthToLinearTemplate",
+                "Path": "Passes/HairDepthToLinear.pass"
             }
         ]
     }

--- a/Gems/AtomTressFX/Assets/Passes/HairDepthToLinear.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairDepthToLinear.pass
@@ -1,0 +1,38 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "HairDepthToLinearTemplate",
+            "PassClass": "FullScreenTriangle",
+            "Slots": [
+                {
+                    "Name": "Input",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader",
+                    "ImageViewDesc": {
+                        "AspectFlags": [
+                            "Depth"
+                        ]
+                    }
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/DepthToLinearDepth.shader"
+                },
+                "PipelineViewTag": "MainCamera"
+            }
+        }
+    }
+}

--- a/Gems/AtomTressFX/Assets/Passes/HairParentPass.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairParentPass.pass
@@ -25,17 +25,11 @@
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "DepthStencil"
                 },
-                // Keep DepthLinear as input - used to set the size of the Head PPLL image buffer.
-                // If DepthLinear is not availbale - connect to another viewport (non MSAA) image.
-                {
-                    "Name": "DepthLinearInput",
-                    "SlotType": "Input"
-                },
+                // used to set the size of the Head PPLL image buffer.
                 {
                     "Name": "DepthLinear",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 },
-
                 // Lights & Shadows resources
                 {
                     "Name": "DirectionalShadowmap",
@@ -60,21 +54,6 @@
                 {
                     "Name": "LightListRemapped",
                     "SlotType": "Input"
-                }
-            ],
-            "Connections": [
-                {
-                    "LocalSlot": "DepthLinear",
-                    "AttachmentRef": {
-                        "Pass": "DepthToDepthLinearPass",
-                        "Attachment": "Output"
-                    }
-                }
-            ],
-            "FallbackConnections": [
-                {
-                    "Input": "DepthLinearInput",
-                    "Output": "DepthLinear"
                 }
             ],
             "PassRequests": [
@@ -172,7 +151,7 @@
                             "LocalSlot": "DepthLinear",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "DepthLinearInput"
+                                "Attachment": "DepthLinear"
                             }
                         },
                         {
@@ -260,7 +239,7 @@
                             "LocalSlot": "DepthLinear",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "DepthLinearInput"
+                                "Attachment": "DepthLinear"
                             }
                         },
 
@@ -334,7 +313,7 @@
                     // buffer pixels that were touched by HairPPLLResolvePass hence preventing depth update unless
                     // it is hair.
                     "Name": "DepthToDepthLinearPass",
-                    "TemplateName": "DepthToLinearTemplate",
+                    "TemplateName": "HairDepthToLinearTemplate",
                     "Enabled": true,
                     "Connections": [
                         {
@@ -342,6 +321,13 @@
                             "AttachmentRef": {
                                 "Pass": "HairPPLLResolvePass",
                                 "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "DepthLinear"
                             }
                         }
                     ]

--- a/Gems/AtomTressFX/Assets/Passes/HairParentShortCutPass.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairParentShortCutPass.pass
@@ -26,15 +26,10 @@
                     "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "DepthStencil"
                 },
-                // Keep DepthLinear as input - used to set the size of the Head PPLL image buffer.
-                // If DepthLinear is not availbale - connect to another viewport (non MSAA) image.
-                {
-                    "Name": "DepthLinearInput",
-                    "SlotType": "Input"
-                },
+                // Used to set the size of the Head PPLL image buffer.
                 {
                     "Name": "DepthLinear",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 },
 
                 // Lights & Shadows resources
@@ -61,21 +56,6 @@
                 {
                     "Name": "LightListRemapped",
                     "SlotType": "Input"
-                }
-            ],
-            "Connections": [
-                {
-                    "LocalSlot": "DepthLinear",
-                    "AttachmentRef": {
-                        "Pass": "DepthToDepthLinearPass",
-                        "Attachment": "Output"
-                    }
-                }
-            ],
-            "FallbackConnections": [
-                {
-                    "Input": "DepthLinearInput",
-                    "Output": "DepthLinear"
                 }
             ],
             "PassRequests": [
@@ -277,7 +257,7 @@
                             "LocalSlot": "DepthLinear",
                             "AttachmentRef": {
                                 "Pass": "Parent",
-                                "Attachment": "DepthLinearInput"
+                                "Attachment": "DepthLinear"
                             }
                         },
                         {
@@ -387,7 +367,7 @@
                     // buffer pixels that were touched by HairPPLLResolvePass hence preventing depth update unless
                     // it is hair.
                     "Name": "DepthToDepthLinearPass",
-                    "TemplateName": "DepthToLinearTemplate",
+                    "TemplateName": "HairDepthToLinearTemplate",
                     "Enabled": true,
                     "Connections": [
                         {
@@ -395,6 +375,13 @@
                             "AttachmentRef": {
                                 "Pass": "HairShortCutResolveDepthPass",
                                 "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "DepthLinear"
                             }
                         }
                     ]

--- a/Gems/AtomTressFX/Assets/Passes/HairResolvePPLL.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairResolvePPLL.pass
@@ -139,6 +139,7 @@
             ],
             "PassData": {
                 "$type": "FullscreenTrianglePassData",
+                "PipelineViewTag": "MainCamera",
                 "ShaderAsset": {
                     // Looking for it in the Shaders directory relative to the Assets directory
                     "FilePath": "Shaders/HairRenderingResolvePPLL.shader"

--- a/Gems/AtomTressFX/Assets/seedList.seed
+++ b/Gems/AtomTressFX/Assets/seedList.seed
@@ -5,7 +5,7 @@
 				<Class name="AZ::Uuid" field="guid" value="{A10B5BBC-8C5B-5CFA-BD2C-0FD712737F82}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="1000" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="defaultwhite.png.streamingimage" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
@@ -13,7 +13,7 @@
 				<Class name="AZ::Uuid" field="guid" value="{0847ECF0-FBC6-557E-BCFC-58784C2ED459}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="passes/atomtressfx_passtemplates.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
@@ -21,80 +21,16 @@
 				<Class name="AZ::Uuid" field="guid" value="{259539B9-DEB6-52F7-9BEC-CFEC0773566C}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="shaders/hairrenderingfillppll.azshader" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
 			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{E8301497-7A8B-559E-9CE1-2884592AE667}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="AZ::Uuid" field="guid" value="{902FE8CB-B6FC-599C-8986-9E44BF67E15E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairparentpass.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{7E9E13B4-BEFB-581A-AEBB-0BA3B71F7B5A}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairglobalshapeconstraintscompute.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{A97D5FFA-F0CB-5A65-B080-9B9387FD1EA4}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/haircalculatestrandleveldatacompute.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{3F874810-7999-5573-80E7-6134631D431F}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairvelocityshockpropagationcompute.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{E4F74482-CB83-5BC2-A50E-60A5882C9193}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairlocalshapeconstraintscompute.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{0DD4BCEB-3FEE-5575-A20C-4B0D343EE78D}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairlengthconstraintswindandcollisioncompute.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{67B559EE-1445-5A2C-8E01-78CF06460D7E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairupdatefollowhaircompute.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{2B332B34-23CE-588E-9BCA-73BFEE29AEEE}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairfillppll.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
-		</Class>
-		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
-			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
-				<Class name="AZ::Uuid" field="guid" value="{184ED1B4-118F-5506-8E61-91A4D5DFFEA5}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
-				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			</Class>
-			<Class name="unsigned int" field="platformFlags" value="3" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
-			<Class name="AZStd::string" field="pathHint" value="passes/hairresolveppll.pass" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/atomtressfx_passrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 	</Class>
 </ObjectStream>

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -268,6 +268,12 @@ namespace AZ
                     return;
                 }
 
+                // Skip adding draw or dispath items if there it no hair render objects
+                if (m_hairRenderObjects.size() == 0)
+                {
+                    return;
+                }
+
                 // [To Do] - no culling scheme applied yet.
                 // Possibly setup the hair culling work group to be re-used for each view.
                 // See SkinnedMeshFeatureProcessor::Render for more details
@@ -321,7 +327,7 @@ namespace AZ
                 if (HasHairParentPass(renderPipeline))
                 {
                     CreatePerPassResources();
-                    return false;
+                    return true;
                 }
                 const char* passRequestAssetFilePath = "Passes/AtomTressFX_PassRequest.azasset";
                 m_hairPassRequestAsset = AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::RPI::AnyAsset>(
@@ -333,7 +339,7 @@ namespace AZ
                 }
                 if (!passRequest)
                 {
-                    AZ_Warning("AtomTressFx", false, "Failed to load PassRequest from %s", passRequestAssetFilePath);
+                    AZ_Error("AtomTressFx", false, "Failed to create hair parent pass. Can't load PassRequest from %s", passRequestAssetFilePath);
                     return false;
                 }
 
@@ -356,6 +362,8 @@ namespace AZ
 
                 if (!opaquePass)
                 {
+                    AZ_Error("AtomTressFx", false, "Failed to create hair parent pass. Can't find pass created with OpaqueParentTemplate in render pipeline [%s]",
+                        renderPipeline->GetId().GetCStr());
                     return false;
                 }
                 // insert the pass 
@@ -368,6 +376,11 @@ namespace AZ
                 if (success)
                 {
                     CreatePerPassResources();
+                }
+                else
+                {
+                    AZ_Error("AtomTressFx", false, "Failed to create hair parent pass. Insert the pass to render pipeline [%s] failed",
+                        renderPipeline->GetId().GetCStr());
                 }
                 return success;
             }

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -69,12 +69,6 @@ namespace AZ
                 HairShortCutResolveColorPassName = Name{ "HairShortCutResolveColorPass" };
 
                 ++s_instanceCount;
-
-                if (!CreatePerPassResources())
-                {   // this might not be an error - if the pass system is still empty / minimal
-                    //  and these passes are not part of the minimal pipeline, they will not be created.
-                    AZ_Error("Hair Gem", false, "Failed to create the hair shared buffer resource");
-                }
             }
 
             HairFeatureProcessor::~HairFeatureProcessor()
@@ -106,9 +100,15 @@ namespace AZ
 
             void HairFeatureProcessor::Deactivate()
             {
+                m_hairPassRequestAsset.Reset();
                 DisableSceneNotification();
                 TickBus::Handler::BusDisconnect();
                 HairGlobalSettingsRequestBus::Handler::BusDisconnect();
+            }
+
+            void HairFeatureProcessor::ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline)
+            {
+                CreateHairParentPass(renderPipeline);
             }
 
             void HairFeatureProcessor::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
@@ -314,6 +314,62 @@ namespace AZ
                 RPI::PassFilter passFilter = RPI::PassFilter::CreateWithPassName(HairParentPassName, renderPipeline);
                 RPI::Pass* pass = RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
                 return pass ? true : false;
+            }
+
+            bool HairFeatureProcessor::CreateHairParentPass(RPI::RenderPipeline* renderPipeline)
+            {
+                if (HasHairParentPass(renderPipeline))
+                {
+                    CreatePerPassResources();
+                    return false;
+                }
+                const char* passRequestAssetFilePath = "Passes/AtomTressFX_PassRequest.azasset";
+                m_hairPassRequestAsset = AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::RPI::AnyAsset>(
+                    passRequestAssetFilePath, AZ::RPI::AssetUtils::TraceLevel::Warning);
+                const AZ::RPI::PassRequest* passRequest = nullptr;
+                if (m_hairPassRequestAsset->IsReady())
+                {
+                    passRequest = m_hairPassRequestAsset->GetDataAs<AZ::RPI::PassRequest>();
+                }
+                if (!passRequest)
+                {
+                    AZ_Warning("AtomTressFx", false, "Failed to load PassRequest from %s", passRequestAssetFilePath);
+                    return false;
+                }
+
+                m_usePPLLRenderTechnique = passRequest->m_templateName == AZ::Name("HairParentPassTemplate");
+
+                 // Create the pass
+                RPI::Ptr<RPI::Pass> hairParentPass  = RPI::PassSystemInterface::Get()->CreatePassFromRequest(passRequest);
+
+                // add the pass to render pipeline
+                RPI::Ptr<RPI::ParentPass> rootPass = renderPipeline->GetRootPass();
+
+                // Find opaque pass
+                auto passFilter = RPI::PassFilter::CreateWithTemplateName(Name("OpaqueParentTemplate"), renderPipeline);
+                RPI::Ptr<RPI::Pass> opaquePass = nullptr;
+                RPI::PassSystemInterface::Get()->ForEachPass(passFilter, [&opaquePass](RPI::Pass* pass) -> RPI::PassFilterExecutionFlow
+                    {
+                        opaquePass = pass;
+                        return RPI::PassFilterExecutionFlow::StopVisitingPasses;
+                    });
+
+                if (!opaquePass)
+                {
+                    return false;
+                }
+                // insert the pass 
+                auto parentPass = opaquePass->GetParent();
+                auto passIndex = parentPass->FindChildPassIndex(Name("OpaquePass"));
+                    
+                bool success = parentPass->InsertChild(hairParentPass, passIndex.GetIndex()+1);
+
+                // only create pass resources 
+                if (success)
+                {
+                    CreatePerPassResources();
+                }
+                return success;
             }
 
             void HairFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline)

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -113,6 +113,7 @@ namespace AZ
                 // FeatureProcessor overrides ...
                 void Activate() override;
                 void Deactivate() override;
+                void ApplyRenderPipelineChange(RPI::RenderPipeline* renderPipeline) override;
                 void Simulate(const FeatureProcessor::SimulatePacket& packet) override;
                 void Render(const FeatureProcessor::RenderPacket& packet) override;
 
@@ -167,6 +168,8 @@ namespace AZ
 
                 bool HasHairParentPass(RPI::RenderPipeline* renderPipeline);
 
+                bool CreateHairParentPass(RPI::RenderPipeline* renderPipeline);
+
                 //! The following will serve to register the FP in the Thumbnail system
                 AZStd::vector<AZStd::string> m_hairFeatureProcessorRegistryName;
 
@@ -192,6 +195,9 @@ namespace AZ
                 // ShortCut Render Passes - special case for the geometry render passes
                 Data::Instance<HairShortCutGeometryDepthAlphaPass> m_hairShortCutGeometryDepthAlphaPass = nullptr;
                 Data::Instance<HairShortCutGeometryShadingPass> m_hairShortCutGeometryShadingPass = nullptr;
+
+                // Cache the pass request data for creating a hair parent pass
+                AZ::Data::Asset<AZ::RPI::AnyAsset> m_hairPassRequestAsset;
 
                 //--------------------------------------------------------------
                 //                      Per Pass Resources 

--- a/Gems/LyShine/Code/Source/UiRenderer.cpp
+++ b/Gems/LyShine/Code/Source/UiRenderer.cpp
@@ -107,6 +107,7 @@ AZ::RPI::ScenePtr UiRenderer::CreateScene(AZStd::shared_ptr<AZ::RPI::ViewportCon
     AZStd::shared_ptr<AZ::RPI::WindowContext> windowContext = viewportContext->GetWindowContext();
     auto renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineAsset, *windowContext.get());
     pipelineAsset.Release();
+    atomScene->ApplyRenderPipelineChange(renderPipeline.get());
     atomScene->AddRenderPipeline(renderPipeline);
 
     atomScene->Activate();


### PR DESCRIPTION
Changes include:
- New RPI API Scene::ApplyRenderPipelineChange was added. Each FP can override that function to change RenderPipeline.
- Removed hair parent pass from mainPipeline.pass in AutomatedTesting project.
- Overrided FeatureProcessor::ApplyRenderPipelineChange() function in Hair feature processor to create hair passes.
- Added AtomTressFX_PassRequest.azasset which contains pass request of creating hair parent pass
- Remove redundant depth linear attachment created in hair passes and write to the inputOutput depthlinear

Tests done: 
Editor with hair components (both PPLL and Shortcut) and deferred fog, UI editor, material editor, game mode.