### PR TITLE
Focus Mode Visual Feedback: Non-Native Assets

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Passes/EditorModeBlur.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EditorModeBlur.pass
@@ -1,0 +1,77 @@
+{
+    // Applies a box blur effect as controlled by the box width
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "EditorModeBlurTemplate",
+            "PassClass": "EditorModeBlurPass",
+            "Slots": [
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_depth",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputEntityMask",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_entityMask",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputColor",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_framebuffer",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "OutputColor",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "InputColor"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "InputColor"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputColor",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "InputColor",
+                    "Output" : "OutputColor"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/EditorModeBlur.shader"
+                },
+                "PipelineViewTag": "MainCamera"
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/EditorModeDesaturation.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EditorModeDesaturation.pass
@@ -1,0 +1,77 @@
+{
+    // Applies a desaturation effect as controlled by the saturation amount
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "EditorModeDesaturationTemplate",
+            "PassClass": "EditorModeDesaturationPass",
+            "Slots": [
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_depth",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputEntityMask",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_entityMask",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputColor",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_framebuffer",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "OutputColor",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "InputColor"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "InputColor"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputColor",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "InputColor",
+                    "Output" : "OutputColor"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/EditorModeDesaturation.shader"
+                },
+                "PipelineViewTag": "MainCamera"
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/EditorModeFeedbackParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EditorModeFeedbackParent.pass
@@ -1,0 +1,171 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "EditorModeFeedbackParentTemplate",
+            "PassClass": "EditorModeFeedbackParentPass",
+            "Slots": [
+                // Depth data for mask geometry and feedback effects
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input"
+                },
+                // Existing swapchain data
+                {
+                    "Name": "InputColor",
+                    "SlotType": "Input"
+                },
+                // Swapchain data after feedback effects have been applied
+                {
+                    "Name": "OutputColor",
+                    "SlotType": "Output"
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputColor",
+                    "AttachmentRef": {
+                        "Pass": "EntityOutlinePass",
+                        "Attachment": "OutputColor"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "InputColor",
+                    "Output" : "OutputColor"
+                }
+            ],
+            "PassRequests": [
+                // Generates the mask for entities of interest
+                {
+                    "Name": "EntityMaskPass",
+                    "TemplateName": "EditorModeMaskTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputDepth"
+                            }
+                        }
+                    ]
+                },
+                // Applied the desaturation effect to entities not of interest
+                {
+                    "Name": "DesaturationPass",
+                    "TemplateName": "EditorModeDesaturationTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputDepth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputEntityMask",
+                            "AttachmentRef": {
+                                "Pass": "EntityMaskPass",
+                                "Attachment": "OutputEntityMask"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputColor",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputColor"
+                            }
+                        }
+                    ]
+                },
+                // Applied the tint effect to entities not of interest
+                {
+                    "Name": "TintPass",
+                    "TemplateName": "EditorModeTintTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputDepth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputEntityMask",
+                            "AttachmentRef": {
+                                "Pass": "EntityMaskPass",
+                                "Attachment": "OutputEntityMask"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputColor",
+                            "AttachmentRef": {
+                                "Pass": "DesaturationPass",
+                                "Attachment": "OutputColor"
+                            }
+                        }
+                    ]
+                },
+                // Applied the box blur effect to entities not of interest
+                {
+                    "Name": "BlurPass",
+                    "TemplateName": "EditorModeBlurTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputDepth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputEntityMask",
+                            "AttachmentRef": {
+                                "Pass": "EntityMaskPass",
+                                "Attachment": "OutputEntityMask"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputColor",
+                            "AttachmentRef": {
+                                "Pass": "TintPass",
+                                "Attachment": "OutputColor"
+                            }
+                        }
+                    ]
+                },
+                // Applied the outlining effect to entities of interest
+                {
+                    "Name": "EntityOutlinePass",
+                    "TemplateName": "EditorModeOutlineTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "InputDepth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputEntityMask",
+                            "AttachmentRef": {
+                                "Pass": "EntityMaskPass",
+                                "Attachment": "OutputEntityMask"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputColor",
+                            "AttachmentRef": {
+                                "Pass": "BlurPass",
+                                "Attachment": "OutputColor"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/EditorModeMask.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EditorModeMask.pass
@@ -1,0 +1,66 @@
+{
+    // Renders entities of interest to a mask as controlled by the entity mask id
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "EditorModeMaskTemplate",
+            "PassClass": "EditorModeMaskPass",
+            "Slots": [
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "DepthStencil"
+                },
+                {
+                    "Name": "OutputEntityMask",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    // Clear the mask to no entities of interest each frame
+                    "LoadStoreAction": {
+                        "ClearValue": {
+                            "Value": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        },
+                        "LoadAction": "Clear"
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputEntityMaskAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "InputDepth"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        // Use R8G8B8A8 format for now, actual format will be determined in LYN-9878 
+                        "Format": "R8G8B8A8_UNORM",
+                        "SharedQueueMask": "Graphics"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputEntityMask",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputEntityMaskAttachment"
+                    }
+                }
+            ],
+            "PassData": {
+                "$type": "RasterPassData",
+                "DrawListTag": "editormodemask",
+                "PipelineViewTag": "MainCamera"
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/EditorModeOutline.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EditorModeOutline.pass
@@ -1,0 +1,77 @@
+{
+    // Applies an outlining effect as controlled by the line thickness
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "EditorModeOutlineTemplate",
+            "PassClass": "EditorModeOutlinePass",
+            "Slots": [
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_depth",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputEntityMask",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_entityMask",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputColor",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_framebuffer",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "OutputColor",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "InputColor"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "InputColor"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputColor",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "InputColor",
+                    "Output" : "OutputColor"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/EditorModeOutline.shader"
+                },
+                "PipelineViewTag": "MainCamera"
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/EditorModeTint.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/EditorModeTint.pass
@@ -1,0 +1,77 @@
+{
+    // Applies a tinting effect as controlled by the tint color and tint amount
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "EditorModeTintTemplate",
+            "PassClass": "EditorModeTintPass",
+            "Slots": [
+                {
+                    "Name": "InputDepth",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_depth",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputEntityMask",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_entityMask",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "InputColor",
+                    "SlotType": "Input",
+                    "ShaderInputName": "m_framebuffer",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "OutputColor",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "LoadAction": "DontCare"
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "This",
+                            "Attachment": "InputColor"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "This",
+                        "Attachment": "InputColor"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "OutputColor",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ],
+            "FallbackConnections": [
+                {
+                    "Input" : "InputColor",
+                    "Output" : "OutputColor"
+                }
+            ],
+            "PassData": {
+                "$type": "FullscreenTrianglePassData",
+                "ShaderAsset": {
+                    "FilePath": "Shaders/PostProcessing/EditorModeTint.shader"
+                },
+                "PipelineViewTag": "MainCamera"
+            }
+        }
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PassTemplates.azasset
@@ -565,6 +565,30 @@
                 "Path": "Passes/HDRColorGrading.pass"
             },
             {
+                "Name": "EditorModeFeedbackParentTemplate",
+                "Path": "Passes/EditorModeFeedbackParent.pass"
+            },
+            {
+                "Name": "EditorModeMaskTemplate",
+                "Path": "Passes/EditorModeMask.pass"
+            },
+            {
+                "Name": "EditorModeDesaturationTemplate",
+                "Path": "Passes/EditorModeDesaturation.pass"
+            },
+            {
+                "Name": "EditorModeTintTemplate",
+                "Path": "Passes/EditorModeTint.pass"
+            },
+            {
+                "Name": "EditorModeBlurTemplate",
+                "Path": "Passes/EditorModeBlur.pass"
+            },
+            {
+                "Name": "EditorModeOutlineTemplate",
+                "Path": "Passes/EditorModeOutline.pass"
+            },
+            {
                 "Name": "LutGenerationTemplate",
                 "Path": "Passes/LutGeneration.pass"
             }

--- a/Gems/Atom/Feature/Common/Assets/Passes/PostProcessParent.pass
+++ b/Gems/Atom/Feature/Common/Assets/Passes/PostProcessParent.pass
@@ -44,7 +44,7 @@
                 {
                     "LocalSlot": "Output",
                     "AttachmentRef": {
-                        "Pass": "ContrastAdaptiveSharpeningPass",
+                        "Pass": "EditorModeFeedbackPassParent",
                         "Attachment": "OutputColor"
                     }
                 },
@@ -199,6 +199,27 @@
                             "AttachmentRef": {
                                 "Pass": "LightAdaptation",
                                 "Attachment": "Output"
+                            }
+                        }
+                    ]
+                },
+                {
+                    "Name": "EditorModeFeedbackPassParent",
+                    "TemplateName": "EditorModeFeedbackParentTemplate",
+                    "Enabled": false,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputDepth",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "Depth"
+                            }
+                        },
+                        {
+                            "LocalSlot": "InputColor",
+                            "AttachmentRef": {
+                                "Pass": "ContrastAdaptiveSharpeningPass",
+                                "Attachment": "OutputColor"
                             }
                         }
                     ]

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <EditorModeCommon.azsli>
+#include <EditorModeDepthTransition.azsli>
+ 
+partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    float m_kernalWidth;
+}
+
+static float2 maskSize;
+
+float2 normalizedUV(float2 uv)
+{
+    return uv/maskSize;
+}
+ 
+float3 Blur(float2 unormalizedUv, const float boxRadius)
+{
+    float3 outColor = float3(0., 0., 0.);
+
+    // Box blur kernal
+    float weights = 0.;
+    for(float u = -boxRadius; u <= boxRadius; u+=1.)
+    {
+        for(float v = -boxRadius; v <= boxRadius; v+=1.)
+        {
+            weights += 1.;
+            outColor += PassSrg::m_framebuffer.Sample(PassSrg::PointSampler, normalizedUV(unormalizedUv + float2(u,v))).rgb;
+        }
+    }
+
+    return outColor / weights;
+}
+
+PSOutput MainPS(VSOutput IN)
+{
+    PSOutput OUT;
+
+    const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+    maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
+    float2 unnormalizedUV = float2(IN.m_texCoord.x * maskSize.x, IN.m_texCoord.y * maskSize.y);
+
+    // Blur effect
+    float3 finalEffect = Blur(unnormalizedUV, PassSrg::m_kernalWidth);
+  
+    // Apply the depth transition to the blend amount
+    const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
+    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+    
+    // Apply the visual effect to non-mask entities, leaving mask entities untouched
+    OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);
+
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
@@ -5,24 +5,20 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
 #include <EditorModeCommon.azsli>
 #include <EditorModeDepthTransition.azsli>
- 
+
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
     float m_kernalWidth;
 }
 
-static float2 maskSize;
-
-float2 normalizedUV(float2 uv)
+float3 Blur(const float2 uv, const float boxRadius)
 {
-    return uv/maskSize;
-}
- 
-float3 Blur(float2 unormalizedUv, const float boxRadius)
-{
+    const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
+    const float2 unormalizedUv = float2(uv.x * maskSize.x, uv.y * maskSize.y);
+    const float2 maskSizeReciprocal = float2(1., 1.0) / maskSize;
     float3 outColor = float3(0., 0., 0.);
 
     // Box blur kernal
@@ -32,7 +28,7 @@ float3 Blur(float2 unormalizedUv, const float boxRadius)
         for(float v = -boxRadius; v <= boxRadius; v+=1.)
         {
             weights += 1.;
-            outColor += PassSrg::m_framebuffer.Sample(PassSrg::PointSampler, normalizedUV(unormalizedUv + float2(u,v))).rgb;
+            outColor += PassSrg::m_framebuffer.Sample(PassSrg::PointSampler, (unormalizedUv + float2(u,v)) * maskSizeReciprocal).rgb;
         }
     }
 
@@ -45,11 +41,9 @@ PSOutput MainPS(VSOutput IN)
 
     const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
     const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
-    maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
-    float2 unnormalizedUV = float2(IN.m_texCoord.x * maskSize.x, IN.m_texCoord.y * maskSize.y);
-
+    
     // Blur effect
-    float3 finalEffect = Blur(unnormalizedUV, PassSrg::m_kernalWidth);
+    float3 finalEffect = Blur(IN.m_texCoord, PassSrg::m_kernalWidth);
   
     // Apply the depth transition to the blend amount
     const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
@@ -19,7 +19,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 //! @note This is not an efficient implementation. Future work will replace this with a multi-pass Gaussian blur.
 float3 Blur(const float2 uv, const float kernalWidth)
 {
-    const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
+    const float2 maskSize = GetImageSize(PassSrg::m_entityMask);
     const float2 unormalizedUv = float2(uv.x * maskSize.x, uv.y * maskSize.y);
     const float2 maskSizeReciprocal = float2(1., 1.0) / maskSize;
     float3 outColor = float3(0., 0., 0.);
@@ -42,7 +42,7 @@ PSOutput MainPS(VSOutput IN)
     PSOutput OUT;
 
     const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
-    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
     
     // Blur effect
     float3 finalEffect = Blur(IN.m_texCoord, PassSrg::m_kernalWidth);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.azsl
@@ -11,21 +11,23 @@
 
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
+    //! Width of kernal to apply box blur effect.
     float m_kernalWidth;
 }
 
-float3 Blur(const float2 uv, const float boxRadius)
+//! Applies a box blur of the specified kernal width
+//! @note This is not an efficient implementation. Future work will replace this with a multi-pass Gaussian blur.
+float3 Blur(const float2 uv, const float kernalWidth)
 {
     const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
     const float2 unormalizedUv = float2(uv.x * maskSize.x, uv.y * maskSize.y);
     const float2 maskSizeReciprocal = float2(1., 1.0) / maskSize;
     float3 outColor = float3(0., 0., 0.);
 
-    // Box blur kernal
     float weights = 0.;
-    for(float u = -boxRadius; u <= boxRadius; u+=1.)
+    for(float u = -kernalWidth; u <= kernalWidth; u+=1.)
     {
-        for(float v = -boxRadius; v <= boxRadius; v+=1.)
+        for(float v = -kernalWidth; v <= kernalWidth; v+=1.)
         {
             weights += 1.;
             outColor += PassSrg::m_framebuffer.Sample(PassSrg::PointSampler, (unormalizedUv + float2(u,v)) * maskSizeReciprocal).rgb;
@@ -47,7 +49,7 @@ PSOutput MainPS(VSOutput IN)
   
     // Apply the depth transition to the blend amount
     const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
-    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+    const float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
     
     // Apply the visual effect to non-mask entities, leaving mask entities untouched
     OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeBlur.shader
@@ -1,0 +1,22 @@
+{
+    "Source" : "EditorModeBlur.azsl",
+ 
+    "DepthStencilState" : {
+        "Depth" : { "Enable" : false }
+    },
+ 
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+   }
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#include <viewsrg.srgi>
+
+#include <Atom/Features/SrgSemantics.azsli> 
+#include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
+#include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
+
+partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    Texture2D<float4> m_framebuffer;
+    Texture2D<float4> m_depth;
+    Texture2D<float4> m_entityMask;
+
+    // The final blend amount level that is used to scale the calculated blend values
+    float m_finalBlendAmount;
+    
+    Sampler LinearSampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Sampler PointSampler
+    {
+        MinFilter = Point;
+        MagFilter = Point;
+        MipFilter = Point;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    float2 GetImageSize(Texture2D<float4> image)
+    {
+        float3 size = float3(0., 0., 0.);
+        image.GetDimensions(size.x, size.y);
+        return size;
+    }
+
+    float CalculateLinearDepth(const float zDepth)
+    {
+        return abs(((ViewSrg::GetFarZTimesNearZ()) / (ViewSrg::GetFarZMinusNearZ() * zDepth - ViewSrg::GetFarZ()))); 
+    }
+
+    float CalculateFinalBlendAmount(float t)
+    {
+        // Apply the final blend amount modifier
+        return lerp(0.0, t, m_finalBlendAmount);
+    }
+
+    float4 CalculateOutputColor(const float3 inColor, const float3 finalEffect, float t)
+    {
+        float4 outColor;
+        outColor.rgb = lerp(inColor, finalEffect, t);
+        outColor.a = 1.0;
+        return outColor;
+    }
+
+    float4 CalculateFinalBlendAmountAndOutputColor(const float3 inColor, const float3 finalEffect, float t)
+    {
+        return CalculateOutputColor(inColor, finalEffect, CalculateFinalBlendAmount(t));
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
@@ -60,14 +60,14 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     }
 
     //! Returns the final blend amount after the final blend amount scale is applied.
-    float CalculateFinalBlendAmount(float t)
+    float CalculateFinalBlendAmount(const float t)
     {
         // Apply the final blend amount modifier
         return lerp(0.0, t, m_finalBlendAmount);
     }
 
     //! Returns the calculated color after blending original framebuffer color with the calculated feedback effect.
-    float4 CalculateOutputColor(const float3 inColor, const float3 finalEffect, float t)
+    float4 CalculateOutputColor(const float3 inColor, const float3 finalEffect, const float t)
     {
         float4 outColor;
         outColor.rgb = lerp(inColor, finalEffect, t);
@@ -76,7 +76,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     }
 
     //! Calculates the final blend anount and returns the blended output color.
-    float4 CalculateFinalBlendAmountAndOutputColor(const float3 inColor, const float3 finalEffect, float t)
+    float4 CalculateFinalBlendAmountAndOutputColor(const float3 inColor, const float3 finalEffect, const float t)
     {
         return CalculateOutputColor(inColor, finalEffect, CalculateFinalBlendAmount(t));
     }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
@@ -11,6 +11,29 @@
 #include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 
+//! Returns the dimensions of the specified 2D image.
+float2 GetImageSize(Texture2D<float4> image)
+{
+    float2 size = float2(0., 0.);
+    image.GetDimensions(size.x, size.y);
+    return size;
+}
+
+//! Returns the linear depth value of the specified non-linear depth value.
+float CalculateLinearDepth(const float zDepth)
+{
+    return abs(((ViewSrg::GetFarZTimesNearZ()) / (ViewSrg::GetFarZMinusNearZ() * zDepth - ViewSrg::GetFarZ()))); 
+}
+
+//! Returns the calculated color after blending original framebuffer color with the calculated feedback effect.
+float4 CalculateOutputColor(const float3 inColor, const float3 finalEffect, const float t)
+{
+    float4 outColor;
+    outColor.rgb = lerp(inColor, finalEffect, t);
+    outColor.a = 1.0;
+    return outColor;
+}
+
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
     //! The color buffer to apply the editor mode feedback effects to.
@@ -45,39 +68,16 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         AddressW = Clamp;
     };
 
-    //! Returns the dimensions of the specified 2D image.
-    float2 GetImageSize(Texture2D<float4> image)
-    {
-        float3 size = float3(0., 0., 0.);
-        image.GetDimensions(size.x, size.y);
-        return size;
-    }
-
-    //! Returns the linear depth value of the specified non-linear depth value.
-    float CalculateLinearDepth(const float zDepth)
-    {
-        return abs(((ViewSrg::GetFarZTimesNearZ()) / (ViewSrg::GetFarZMinusNearZ() * zDepth - ViewSrg::GetFarZ()))); 
-    }
-
     //! Returns the final blend amount after the final blend amount scale is applied.
     float CalculateFinalBlendAmount(const float t)
     {
         // Apply the final blend amount modifier
-        return lerp(0.0, t, m_finalBlendAmount);
-    }
-
-    //! Returns the calculated color after blending original framebuffer color with the calculated feedback effect.
-    float4 CalculateOutputColor(const float3 inColor, const float3 finalEffect, const float t)
-    {
-        float4 outColor;
-        outColor.rgb = lerp(inColor, finalEffect, t);
-        outColor.a = 1.0;
-        return outColor;
+        return lerp(0.0, t, PassSrg::m_finalBlendAmount);
     }
 
     //! Calculates the final blend anount and returns the blended output color.
     float4 CalculateFinalBlendAmountAndOutputColor(const float3 inColor, const float3 finalEffect, const float t)
     {
-        return CalculateOutputColor(inColor, finalEffect, CalculateFinalBlendAmount(t));
+        return CalculateOutputColor(inColor, finalEffect, PassSrg::CalculateFinalBlendAmount(t));
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeCommon.azsli
@@ -13,11 +13,16 @@
 
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
+    //! The color buffer to apply the editor mode feedback effects to.
     Texture2D<float4> m_framebuffer;
+
+    //! The non-linear depth buffer data for fragments in the color buffer.
     Texture2D<float4> m_depth;
+
+    //! The entity mask containing the visible fragments of entities of interest.
     Texture2D<float4> m_entityMask;
 
-    // The final blend amount level that is used to scale the calculated blend values
+    //! The final blend amount that is used to scale the calculated blend values.
     float m_finalBlendAmount;
     
     Sampler LinearSampler
@@ -40,6 +45,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         AddressW = Clamp;
     };
 
+    //! Returns the dimensions of the specified 2D image.
     float2 GetImageSize(Texture2D<float4> image)
     {
         float3 size = float3(0., 0., 0.);
@@ -47,17 +53,20 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         return size;
     }
 
+    //! Returns the linear depth value of the specified non-linear depth value.
     float CalculateLinearDepth(const float zDepth)
     {
         return abs(((ViewSrg::GetFarZTimesNearZ()) / (ViewSrg::GetFarZMinusNearZ() * zDepth - ViewSrg::GetFarZ()))); 
     }
 
+    //! Returns the final blend amount after the final blend amount scale is applied.
     float CalculateFinalBlendAmount(float t)
     {
         // Apply the final blend amount modifier
         return lerp(0.0, t, m_finalBlendAmount);
     }
 
+    //! Returns the calculated color after blending original framebuffer color with the calculated feedback effect.
     float4 CalculateOutputColor(const float3 inColor, const float3 finalEffect, float t)
     {
         float4 outColor;
@@ -66,6 +75,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         return outColor;
     }
 
+    //! Calculates the final blend anount and returns the blended output color.
     float4 CalculateFinalBlendAmountAndOutputColor(const float3 inColor, const float3 finalEffect, float t)
     {
         return CalculateOutputColor(inColor, finalEffect, CalculateFinalBlendAmount(t));

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDepthTransition.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDepthTransition.azsli
@@ -8,16 +8,37 @@
 
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {
+    /* -----------------
+        \      E      /
+         \#####|#####/
+          \####|####/
+           \###|###/
+            \##|##/
+             \-S-/
+              \ /
+               V
+
+        V = View position
+        S = Depth transition start
+        E = Depth transition end
+
+        When E is a non-zero value, the binary mask value will be transformed into a value from [m_minDepthTransitionValue, 1.0]
+        according to the fragment's depth position in the transition band (#) spanning from S to E. This is to allow feedback 
+        feedback effects to be scaled according to the distance of non-mask fragments to the viewer.
+    */
+
     //! The minimum blend about that will be calculated through depth transitioning.
     float m_minDepthTransitionValue;
     
-    //! Start of depth transtion for unmasked effect blending.
+    //! Start of depth transtion for non-mask effect blending.
+    //! @note S in the diagram above.
     float m_depthTransitionStart;
 
     //! The duration (depth) of the depth transition band (0.0 = no depth transitioning will be applied).
+    //! @note E - S in the diagram above.
     float m_depthTransitionDuration;
 
-    //! 0.0 = input color, 1.0 = final effect
+    //! Calculates the blend amount (0.0 = input color, 1.0 = final effect) as scaled by the fragment's linear depth according to the depth transition values.
     float CalculateTransitionBlendAmountFromLinearDepth(const float linearDepth, const float maskValue)
     {
         if(PassSrg::m_depthTransitionDuration > 0.0)
@@ -29,6 +50,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
         return 1.0 - maskValue;
     }
 
+    //! Calculates the blend amount (0.0 = input color, 1.0 = final effect) as scaled by the fragment's non-linear depth according to the depth transition values.
     float CalculateTransitionBlendAmountFromDepth(const float zDepth, const float maskValue)
     {
         const float linearDepth = PassSrg::CalculateLinearDepth(zDepth);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDepthTransition.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDepthTransition.azsli
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    //! The minimum blend about that will be calculated through depth transitioning.
+    float m_minDepthTransitionValue;
+    
+    //! Start of depth transtion for unmasked effect blending.
+    float m_depthTransitionStart;
+
+    //! The duration (depth) of the depth transition band (0.0 = no depth transitioning will be applied).
+    float m_depthTransitionDuration;
+
+    //! 0.0 = input color, 1.0 = final effect
+    float CalculateTransitionBlendAmountFromLinearDepth(const float linearDepth, const float maskValue)
+    {
+        if(PassSrg::m_depthTransitionDuration > 0.0)
+        {
+            const float depthTransition = clamp((linearDepth - m_depthTransitionStart) / (m_depthTransitionDuration), m_minDepthTransitionValue, 1.0);
+            return clamp((1.0 - maskValue) * depthTransition, 0.0, 1.0);
+        }
+
+        return 1.0 - maskValue;
+    }
+
+    float CalculateTransitionBlendAmountFromDepth(const float zDepth, const float maskValue)
+    {
+        const float linearDepth = PassSrg::CalculateLinearDepth(zDepth);
+        return PassSrg_CalculateTransitionBlendAmountFromLinearDepth(linearDepth, maskValue);
+    }
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDepthTransition.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDepthTransition.azsli
@@ -24,10 +24,10 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 
         When E is a non-zero value, the binary mask value will be transformed into a value from [m_minDepthTransitionValue, 1.0]
         according to the fragment's depth position in the transition band (#) spanning from S to E. This is to allow feedback 
-        feedback effects to be scaled according to the distance of non-mask fragments to the viewer.
+        effects to be scaled according to the distance of non-mask fragments to the viewer.
     */
 
-    //! The minimum blend about that will be calculated through depth transitioning.
+    //! The minimum blend amount that will be calculated through depth transitioning.
     float m_minDepthTransitionValue;
     
     //! Start of depth transtion for non-mask effect blending.
@@ -43,7 +43,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     {
         if(PassSrg::m_depthTransitionDuration > 0.0)
         {
-            const float depthTransition = clamp((linearDepth - m_depthTransitionStart) / (m_depthTransitionDuration), m_minDepthTransitionValue, 1.0);
+            const float depthTransition = clamp((linearDepth - PassSrg::m_depthTransitionStart) / (PassSrg::m_depthTransitionDuration), PassSrg::m_minDepthTransitionValue, 1.0);
             return clamp((1.0 - maskValue) * depthTransition, 0.0, 1.0);
         }
 
@@ -53,7 +53,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     //! Calculates the blend amount (0.0 = input color, 1.0 = final effect) as scaled by the fragment's non-linear depth according to the depth transition values.
     float CalculateTransitionBlendAmountFromDepth(const float zDepth, const float maskValue)
     {
-        const float linearDepth = PassSrg::CalculateLinearDepth(zDepth);
-        return PassSrg_CalculateTransitionBlendAmountFromLinearDepth(linearDepth, maskValue);
+        const float linearDepth = CalculateLinearDepth(zDepth);
+        return CalculateTransitionBlendAmountFromLinearDepth(linearDepth, maskValue);
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
@@ -11,7 +11,8 @@
  
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 { 
-    float m_desaturationAmount; //!< Amount of desaturation to apply.
+    //! Amount of desaturation to apply.
+    float m_desaturationAmount;
 }
 
 PSOutput MainPS(VSOutput IN)

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <EditorModeCommon.azsli>
+#include <EditorModeDepthTransition.azsli>
+ 
+partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{ 
+    float m_desaturationAmount; //!< Amount of desaturation to apply.
+}
+
+PSOutput MainPS(VSOutput IN)
+{
+    PSOutput OUT;
+
+    const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+
+    // Desaturation effect
+    const float3 luminanceWeights = float3(0.299,0.587,0.114);
+    const float luminance = dot(inColor, luminanceWeights);
+    const float3 finalEffect = lerp(inColor, luminance, PassSrg::m_desaturationAmount);
+
+    // Apply the depth transition to the blend amount
+    const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
+    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+    
+    // Apply the visual effect to non-mask entities, leaving mask entities untouched
+    OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);
+
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
@@ -23,13 +23,13 @@ PSOutput MainPS(VSOutput IN)
     const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
 
     // Desaturation effect
-    const float3 luminanceWeights = float3(0.299,0.587,0.114);
+    const float3 luminanceWeights = float3(0.299, 0.587, 0.114);
     const float luminance = dot(inColor, luminanceWeights);
     const float3 finalEffect = lerp(inColor, luminance, PassSrg::m_desaturationAmount);
 
     // Apply the depth transition to the blend amount
     const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
-    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+    const float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
     
     // Apply the visual effect to non-mask entities, leaving mask entities untouched
     OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.azsl
@@ -20,7 +20,7 @@ PSOutput MainPS(VSOutput IN)
     PSOutput OUT;
 
     const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
-    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
 
     // Desaturation effect
     const float3 luminanceWeights = float3(0.299, 0.587, 0.114);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeDesaturation.shader
@@ -1,0 +1,22 @@
+{
+    "Source" : "EditorModeDesaturation.azsl",
+ 
+    "DepthStencilState" : {
+        "Depth" : { "Enable" : false }
+    },
+ 
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+   }
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.azsl
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <viewsrg.srgi>
+#include <scenesrg.srgi>
+
+ShaderResourceGroup ObjectSrg : SRG_PerObject
+{
+    //! Id of this draw object for retrieval of transformation matrices.
+    uint m_objectId;
+
+    //! Id to fill the mask with for this draw object.
+    uint m_maskId;
+
+    //! Returns the matrix for transforming points from Object Space to World Space.
+    float4x4 GetWorldMatrix()
+    {
+        return SceneSrg::GetObjectToWorldMatrix(m_objectId);
+    }
+}
+
+struct VSInput
+{
+    // Base fields (required by the template azsli file)...
+    float3 m_position : POSITION;
+};
+
+struct VSOutput
+{
+    // Base fields (required by the template azsli file)...
+    // "centroid" is needed for SV_Depth to compile
+    precise linear centroid float4 m_position : SV_Position;
+};
+
+VSOutput MainVS(VSInput IN)
+{
+    VSOutput OUT;    
+    float3 worldPosition = mul(ObjectSrg::GetWorldMatrix(), float4(IN.m_position, 1.0)).xyz;
+    OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, float4(worldPosition, 1.0));
+
+    // Offset the depth of redrawn entities to avoid z fighting with the underlying entity rendered data
+    // A proper programatic solution will be investigated in LYN-10304
+    OUT.m_position.z += 0.001;
+
+/*
+    For use in LYN-9929
+
+    // NDCs
+    float3 ndc = float3(OUT.m_position.x / OUT.m_position.w, OUT.m_position. y/ OUT.m_position.w, OUT.m_position.z / OUT.m_position.w);
+
+    // Normalized screenspace UVs
+    float2 uv = float2((ndc.x + 1.0) * 0.5, (ndc.y + 1.0) * 0.5);
+
+    // Fragment depth
+    float depth = ndc.z;
+*/
+
+    return OUT;
+}
+
+struct PixelOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+PixelOutput MainPS(VSOutput IN)
+{
+    PixelOutput OUT;
+
+    // Ignore m_maskId for now until LYN-9878 is resolved
+    OUT.m_color = float4(1.,1.,1.,1.);
+
+    return OUT;
+} 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.azsl
@@ -73,7 +73,7 @@ PixelOutput MainPS(VSOutput IN)
     PixelOutput OUT;
 
     // Ignore m_maskId for now until LYN-9878 is resolved
-    OUT.m_color = float4(1.,1.,1.,1.);
+    OUT.m_color = float4(1., 1., 1., 1.);
 
     return OUT;
 } 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.material
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.material
@@ -1,0 +1,6 @@
+{
+    "description": "",
+    "parentMaterial": "",
+    "materialType": "Shaders/PostProcessing/EditorModeMask.materialtype",
+    "materialTypeVersion": 1
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.materialtype
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.materialtype
@@ -1,0 +1,9 @@
+{
+    "description": "A simple default base material for Atom testing.",
+    "version": 1,
+    "shaders": [
+        {
+            "file": "Shaders/PostProcessing/EditorModeMask.shader"
+        }
+    ]
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeMask.shader
@@ -1,0 +1,30 @@
+{
+    "Source" : "EditorModeMask.azsl",
+ 
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }
+    },
+
+    "DrawList" : "editormodemask",
+
+    //"RasterState" :
+    //{
+    //    "depthBias" : "10",
+    //    "depthBiasSlopeScale" : "4"
+    //},
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    }    
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
- 
+
 #include <EditorModeCommon.azsli>
 #include <EditorModeDepthTransition.azsli>
- 
+
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {    
     float m_lineThickness;
@@ -21,7 +21,7 @@ float2 normalizedUV(float2 uv)
 {
     return uv/maskSize;
 }
- 
+
 // Entity outliner effect
 float selectedEntityOutliner(float2 unormalizedUv, float lineThickness)
 {

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -11,7 +11,10 @@
 
 partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 {    
+    //! Outline line thickness.
     float m_lineThickness;
+
+    //! Outline line color.
     float4 m_lineColor;
 }
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -15,7 +15,8 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     float4 m_lineColor;
 }
 
-// Entity outliner effect
+//! Applies an outline effect to the entity mask of the specified line thickness.
+//! @note There are known issues with pimples due to z-fighting of coincident surfaces in the entity mask that will be addressed it LYN-10304.
 float selectedEntityOutliner(float2 uv, float lineThickness)
 {
     const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
@@ -56,7 +57,6 @@ PSOutput MainPS(VSOutput IN)
     float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
 
     // Outline effect
-    // Known issue with pimples due to LYN-10304
     const float lineThickness = lerp(1., PassSrg::m_lineThickness, 1.0 - t);
     const float outline = selectedEntityOutliner(IN.m_texCoord, lineThickness);
 

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <EditorModeCommon.azsli>
+#include <EditorModeDepthTransition.azsli>
+ 
+partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{    
+    float m_lineThickness;
+    float4 m_lineColor;
+}
+
+static float2 maskSize;
+
+float2 normalizedUV(float2 uv)
+{
+    return uv/maskSize;
+}
+ 
+// Entity outliner effect
+float selectedEntityOutliner(float2 unormalizedUv, float lineThickness)
+{
+    float r = 0.;
+
+    // Selected entity mask value
+    float S = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, normalizedUV(unormalizedUv)).a;
+
+    if(S > 0.0)
+    {
+        return 0.0;
+    }
+    
+    // Outliner kernal
+    for(float u = -lineThickness; u <= lineThickness; u+=1.)
+    {
+        for(float v = -lineThickness; v <= lineThickness; v+=1.)
+        {
+            r += PassSrg::m_entityMask.Sample(PassSrg::PointSampler, normalizedUV(unormalizedUv + float2(u,v))).r;
+        }
+    }
+    
+    // Only apply the outliner effect to fragments not part of S
+    return min(1.0, (r / lineThickness));
+}
+
+PSOutput MainPS(VSOutput IN)
+{
+    PSOutput OUT;
+
+    const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+    maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
+    float2 unnormalizedUV = float2(IN.m_texCoord.x * maskSize.x, IN.m_texCoord.y * maskSize.y);
+
+    // Apply the depth transition to the blend amount
+    const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
+    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+
+    // Outline effect
+    // Known issue with pimples due to LYN-10304
+    const float lineThickness = lerp(1., PassSrg::m_lineThickness, 1.0 - t);
+    const float outline = selectedEntityOutliner(unnormalizedUV, lineThickness);
+
+    // Apply the visual effect to non-mask entities, leaving mask entities untouched
+    OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, PassSrg::m_lineColor.rgb, outline);
+
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -15,20 +15,16 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     float4 m_lineColor;
 }
 
-static float2 maskSize;
-
-float2 normalizedUV(float2 uv)
-{
-    return uv/maskSize;
-}
-
 // Entity outliner effect
-float selectedEntityOutliner(float2 unormalizedUv, float lineThickness)
+float selectedEntityOutliner(float2 uv, float lineThickness)
 {
+    const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
+    const float2 unormalizedUv = float2(uv.x * maskSize.x, uv.y * maskSize.y);
+    const float2 maskSizeReciprocal = float2(1., 1.0) / maskSize;
     float r = 0.;
 
     // Selected entity mask value
-    float S = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, normalizedUV(unormalizedUv)).a;
+    float S = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, unormalizedUv * maskSizeReciprocal).a;
 
     if(S > 0.0)
     {
@@ -40,7 +36,7 @@ float selectedEntityOutliner(float2 unormalizedUv, float lineThickness)
     {
         for(float v = -lineThickness; v <= lineThickness; v+=1.)
         {
-            r += PassSrg::m_entityMask.Sample(PassSrg::PointSampler, normalizedUV(unormalizedUv + float2(u,v))).r;
+            r += PassSrg::m_entityMask.Sample(PassSrg::PointSampler, (unormalizedUv + float2(u,v)) * maskSizeReciprocal).r;
         }
     }
     
@@ -54,8 +50,6 @@ PSOutput MainPS(VSOutput IN)
 
     const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
     const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
-    maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
-    float2 unnormalizedUV = float2(IN.m_texCoord.x * maskSize.x, IN.m_texCoord.y * maskSize.y);
 
     // Apply the depth transition to the blend amount
     const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
@@ -64,7 +58,7 @@ PSOutput MainPS(VSOutput IN)
     // Outline effect
     // Known issue with pimples due to LYN-10304
     const float lineThickness = lerp(1., PassSrg::m_lineThickness, 1.0 - t);
-    const float outline = selectedEntityOutliner(unnormalizedUV, lineThickness);
+    const float outline = selectedEntityOutliner(IN.m_texCoord, lineThickness);
 
     // Apply the visual effect to non-mask entities, leaving mask entities untouched
     OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, PassSrg::m_lineColor.rgb, outline);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -17,7 +17,7 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 
 //! Applies an outline effect to the entity mask of the specified line thickness.
 //! @note There are known issues with pimples due to z-fighting of coincident surfaces in the entity mask that will be addressed it LYN-10304.
-float selectedEntityOutliner(float2 uv, float lineThickness)
+float selectedEntityOutliner(const float2 uv, const float lineThickness)
 {
     const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
     const float2 unormalizedUv = float2(uv.x * maskSize.x, uv.y * maskSize.y);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.azsl
@@ -17,32 +17,24 @@ partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 
 //! Applies an outline effect to the entity mask of the specified line thickness.
 //! @note There are known issues with pimples due to z-fighting of coincident surfaces in the entity mask that will be addressed it LYN-10304.
-float selectedEntityOutliner(const float2 uv, const float lineThickness)
+float Outliner(const float2 uv, const float lineThickness)
 {
-    const float2 maskSize = PassSrg::GetImageSize(PassSrg::m_entityMask);
+    const float2 maskSize = GetImageSize(PassSrg::m_entityMask);
     const float2 unormalizedUv = float2(uv.x * maskSize.x, uv.y * maskSize.y);
     const float2 maskSizeReciprocal = float2(1., 1.0) / maskSize;
-    float r = 0.;
-
-    // Selected entity mask value
-    float S = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, unormalizedUv * maskSizeReciprocal).a;
-
-    if(S > 0.0)
-    {
-        return 0.0;
-    }
+    float outline = 0.;
     
     // Outliner kernal
     for(float u = -lineThickness; u <= lineThickness; u+=1.)
     {
         for(float v = -lineThickness; v <= lineThickness; v+=1.)
         {
-            r += PassSrg::m_entityMask.Sample(PassSrg::PointSampler, (unormalizedUv + float2(u,v)) * maskSizeReciprocal).r;
+            outline += PassSrg::m_entityMask.Sample(PassSrg::PointSampler, (unormalizedUv + float2(u,v)) * maskSizeReciprocal).r;
         }
     }
     
     // Only apply the outliner effect to fragments not part of S
-    return min(1.0, (r / lineThickness));
+    return min(1.0, (outline / (lineThickness * lineThickness)));
 }
 
 PSOutput MainPS(VSOutput IN)
@@ -50,7 +42,7 @@ PSOutput MainPS(VSOutput IN)
     PSOutput OUT;
 
     const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
-    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
 
     // Apply the depth transition to the blend amount
     const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
@@ -58,7 +50,7 @@ PSOutput MainPS(VSOutput IN)
 
     // Outline effect
     const float lineThickness = lerp(1., PassSrg::m_lineThickness, 1.0 - t);
-    const float outline = selectedEntityOutliner(IN.m_texCoord, lineThickness);
+    const float outline = mask > 0.0 ? 0.0 : Outliner(IN.m_texCoord, lineThickness);
 
     // Apply the visual effect to non-mask entities, leaving mask entities untouched
     OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, PassSrg::m_lineColor.rgb, outline);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeOutline.shader
@@ -1,0 +1,22 @@
+{
+    "Source" : "EditorModeOutline.azsl",
+ 
+    "DepthStencilState" : {
+        "Depth" : { "Enable" : false }
+    },
+ 
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+   }
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
@@ -30,7 +30,7 @@ PSOutput MainPS(VSOutput IN)
 
     // Apply the depth transition to the blend amount
     const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
-    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+    const float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
     
     // Apply the visual effect to non-mask entities, leaving mask entities untouched
     OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
@@ -23,7 +23,7 @@ PSOutput MainPS(VSOutput IN)
     PSOutput OUT;
 
     const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
-    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
 
     // Tint effect
     const float3 finalEffect = lerp(inColor, PassSrg::m_tintColor.rgb, PassSrg::m_tintAmount);

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
@@ -35,7 +35,5 @@ PSOutput MainPS(VSOutput IN)
     // Apply the visual effect to non-mask entities, leaving mask entities untouched
     OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);
 
-    //OUT.m_color.rgb = float3(t,t,t);
-
     return OUT;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.azsl
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <EditorModeCommon.azsli>
+#include <EditorModeDepthTransition.azsli>
+ 
+partial ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    //! Amount of tint to apply.
+    float m_tintAmount;
+
+    //! Color of tint to apply.
+    float4 m_tintColor;
+}
+
+PSOutput MainPS(VSOutput IN)
+{
+    PSOutput OUT;
+
+    const float3 inColor = PassSrg::m_framebuffer.Sample(PassSrg::LinearSampler, IN.m_texCoord).rgb;
+    const float mask = PassSrg::m_entityMask.Sample(PassSrg::PointSampler, IN.m_texCoord);
+
+    // Tint effect
+    const float3 finalEffect = lerp(inColor, PassSrg::m_tintColor.rgb, PassSrg::m_tintAmount);
+
+    // Apply the depth transition to the blend amount
+    const float zDepth =  PassSrg::m_depth.Sample(PassSrg::PointSampler, IN.m_texCoord).r;
+    float t = PassSrg::CalculateTransitionBlendAmountFromDepth(zDepth, mask);
+    
+    // Apply the visual effect to non-mask entities, leaving mask entities untouched
+    OUT.m_color = PassSrg::CalculateFinalBlendAmountAndOutputColor(inColor, finalEffect, t);
+
+    //OUT.m_color.rgb = float3(t,t,t);
+
+    return OUT;
+}

--- a/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.shader
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/PostProcessing/EditorModeTint.shader
@@ -1,0 +1,22 @@
+{
+    "Source" : "EditorModeTint.azsl",
+ 
+    "DepthStencilState" : {
+        "Depth" : { "Enable" : false }
+    },
+ 
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+   }
+}

--- a/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
+++ b/Gems/Atom/Feature/Common/Assets/atom_feature_common_asset_files.cmake
@@ -105,6 +105,12 @@ set(FILES
     Passes/CascadedShadowmaps.pass
     Passes/CheckerboardResolveColor.pass
     Passes/CheckerboardResolveDepth.pass
+    Passes/EditorModeFeedbackParent.pass
+    Passes/EditorModeMask.pass
+    Passes/EditorModeDesaturation.pass
+    Passes/EditorModeTint.pass
+    Passes/EditorModeBlur.pass
+    Passes/EditorModeOutline.pass
     Passes/ContrastAdaptiveSharpening.pass
     Passes/ConvertToAcescg.pass
     Passes/DebugOverlayParent.pass
@@ -455,6 +461,18 @@ set(FILES
     Shaders/PostProcessing/FullscreenCopy.shader
     Shaders/PostProcessing/HDRColorGrading.azsl
     Shaders/PostProcessing/HDRColorGrading.shader
+    Shaders/PostProcessing/EditorModeCommon.azsli
+    Shaders/PostProcessing/EditorModeDepthTransition.azsli
+    Shaders/PostProcessing/EditorModeMask.azsl
+    Shaders/PostProcessing/EditorModeMask.shader
+    Shaders/PostProcessing/EditorModeDesaturation.azsl
+    Shaders/PostProcessing/EditorModeDesaturation.shader
+    Shaders/PostProcessing/EditorModeTint.azsl
+    Shaders/PostProcessing/EditorModeTint.shader
+    Shaders/PostProcessing/EditorModeBlur.azsl
+    Shaders/PostProcessing/EditorModeBlur.shader
+    Shaders/PostProcessing/EditorModeOutline.azsl
+    Shaders/PostProcessing/EditorModeOutline.shader
     Shaders/PostProcessing/LookModificationTransform.azsl
     Shaders/PostProcessing/LookModificationTransform.shader
     Shaders/PostProcessing/LuminanceHeatmap.azsl


### PR DESCRIPTION
https://user-images.githubusercontent.com/77458631/154082759-06794dfc-537f-489e-896e-a40b06a8150e.mp4

This PR contains the non-native language assets for the Editor Mode Visual Feedback system necessary to implement the Focus Mode visual feedback effects (the rest of the work will come in subsequent PRs). 

![image](https://user-images.githubusercontent.com/77458631/154101315-7b65139b-839e-46f7-a959-e1468852b183.png)
*A prefab containing a red, green and blue shader ball. The prefab is instantiated twice.*

![image](https://user-images.githubusercontent.com/77458631/154101345-ace08240-bbec-4235-943d-dcf62e211b9d.png)
*The visual feedback when the bottom prefab is edited in Focus Mode.*

### Pass System Overview

This system currently provides the following passes chained serially in the order specified below:

#### `EditorModeMaskPass`

Writes out the fragments of entity renderable components to a mask texture the dimensions of the swapchain image where non-zero mask values mean fragments belonging to entities of interest (in this instance, *focused fragments* of entities belonging to the prefab currently being edited in Focus Mode) and zero mask values mean fragments not belonging to entities of interest (in this instance, *unfocused fragments*).

![image](https://user-images.githubusercontent.com/77458631/154102218-3bfc027a-8555-4dfd-a665-376784ab9049.png)
*The focused fragments of the prefab being edited appear as white texels in the mask whereas all other fragments appear as black texels.*

#### `EditorModeDesaturationPass`

Applies a desaturation to the unfocused fragments according to the specified desaturation amount.

![image](https://user-images.githubusercontent.com/77458631/154101497-c532c0e8-db9e-4fa8-abe4-75e345fbebe0.png)
*The desaturation effect as applied to unfocused fragments.*

#### `EditorModeTintPass`

Applies a color tint to the unfocused fragments according to the specified tint color and tint amount.

![image](https://user-images.githubusercontent.com/77458631/154101541-76dc569a-c5dc-4022-aa67-e7fe5a6d5b62.png)
*The color tint effect as applied to unfocused fragments using a black tint.*

#### `EditorModeBlurPass`

Applies a box blur to the unfocused fragments according to the specified filter kernel width.

![image](https://user-images.githubusercontent.com/77458631/154101590-902ba9df-9746-4e13-9239-2602c96822ae.png)
*The blur effect as applied to unfocused fragments using a 5x5 filter kernel.*

#### `EditorModeOutlinePass`

Applies an outline to the focused fragments according to the specified line thickness.

![image](https://user-images.githubusercontent.com/77458631/154101628-1ff33bac-b488-4d84-855e-d90b00b376ac.png)
*The outline effect as applied to focused fragments using a line thickness of 3.*

### Common Pass Configuration

All of the passes bar `EditorModeMaskPass` can optionally be configured to scale the strength of the pass effect according to the distance of the fragment from the viewer and a final strength modifier.

#### Pass Effect Depth Transition

![FocusModeNonNativeAssetsPR](https://user-images.githubusercontent.com/77458631/154081813-879673ea-9b63-414a-95ce-b05e26291bd0.png)

Depth transitioning scales the strength of the pass effect according to the distance of the fragment from the viewer. This scale is determined by a view space transition band that has a start and duration. Fragments lying in front of the transition have their strength set to the specified minimum strength value (`0.0` by default) whereas fragments lying beyond the transition band have their strength set to the specified maximum strength value (`1.0` by default, see *Pass Final Strength Scale* below). Fragments lying within the band are linearly interpolated between the minimum and maximum strength according to their depth position within the band. If the transition band width is zero, no depth scaling will be applied. 

The passes that utilize depth transition are as follows:

* `EditorModeDesaturationPass` to apply more desaturation to unfocused fragments further away from the viewer.
* `EditorModeBlurPass` to apply a minimal blur when unfocused fragments are viewed up close and to apply a heavy blur when viewed afar.
* `EditorModeOutlinePass` to scale the line thickness to approximate a line thickness in world space rather than view space.

![image](https://user-images.githubusercontent.com/77458631/154102792-6b501de0-9848-4ae1-a515-5170172b4737.png)
*When viewed from afar, the desaturation and blur effect of the unfocused scene data are more pronounced.*

#### Pass Final Strength Scale

The highest possible strength of the pass effect can be capped to a fixed value. This is useful to scale the final strength effect as modulated by each pass's specific parameters and any depth transition scaling.