### PR TITLE
gtest_repeat crashes

### DIFF
--- a/Code/Framework/AzTest/AzTest/GemTestEnvironment.cpp
+++ b/Code/Framework/AzTest/AzTest/GemTestEnvironment.cpp
@@ -52,7 +52,6 @@ namespace AZ
 
         GemTestEnvironment::GemTestEnvironment()
         {
-            m_parameters = new Parameters;
         }
 
         void GemTestEnvironment::AddDynamicModulePaths(const AZStd::vector<AZStd::string>& dynamicModulePaths)
@@ -83,6 +82,8 @@ namespace AZ
             UnitTest::TraceBusHook::SetupEnvironment();
 
             AZ::AllocatorInstance<AZ::SystemAllocator>::Create();
+
+            m_parameters = new Parameters;
 
             AddGemsAndComponents();
             PreCreateApplication();

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.cpp
@@ -75,6 +75,22 @@ namespace UnitTest
         });
     }
 
+    void GradientSignalTestEnvironment::PostCreateApplication()
+    {
+        // Ebus usage will allocate a global context on first usage. If that first usage occurs in a DLL, then the context will be
+        // invalid on subsequent unit test runs if using gtest_repeat. However, if we force the ebus to create their global context in
+        // the main test DLL (this one), the context will remain active throughout repeated runs. By creating them in
+        // PostCreateApplication(), they will be created before the DLLs get loaded and any system components from those DLLs run, so we
+        // can guarantee this will be the first usage.
+
+        // These ebuses need their contexts created here before any of the dependent DLLs get loaded:
+        AZ::AssetTypeInfoBus::GetOrCreateContext();
+        SurfaceData::SurfaceDataSystemRequestBus::GetOrCreateContext();
+        SurfaceData::SurfaceDataProviderRequestBus::GetOrCreateContext();
+        SurfaceData::SurfaceDataModifierRequestBus::GetOrCreateContext();
+        LmbrCentral::ShapeComponentRequestsBus::GetOrCreateContext();
+    }
+
     void GradientSignalBaseFixture::SetupCoreSystems()
     {
         // Using the AZ::RPI::MakeAssetHandler will both create the asset handlers,

--- a/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalTestFixtures.h
@@ -21,6 +21,7 @@ namespace UnitTest
     {
     public:
         void AddGemsAndComponents() override;
+        void PostCreateApplication() override;
     };
 
 #ifdef HAVE_BENCHMARK


### PR DESCRIPTION
The Gradient Signal Gem was failing to run its unit tests with gtest_repeat. This contains two fixes:
1. GemTestEnvironment was allocating m_parameters in the constructor, but deallocating in TeardownEnvironment, causing it to be invalid on a second run. This is moved to SetupEnvironment for balanced usage.
2. EBus usage that first occurs in a DLL creates a global context that gets destroyed when the DLL is unloaded, and never gets recreated again. The workaround is to force those EBuses to create their context in the main test DLL instead of a dependent one.