### PR TITLE
Fixed intermittent unit test failures.

### DIFF
--- a/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorGradientSurfaceDataComponent.cpp
@@ -108,6 +108,7 @@ namespace GradientSignal
             // Create a fake surface point with the position we're sampling.
             AzFramework::SurfaceData::SurfacePoint point;
             point.m_position = params.m_position;
+            point.m_normal = AZ::Vector3::CreateAxisZ();
             SurfaceData::SurfacePointList pointList = AZStd::span<const AzFramework::SurfaceData::SurfacePoint>(&point, 1);
 
             // Send it into the component, see what emerges

--- a/Gems/GradientSignal/Code/Tests/GradientSignalReferencesTests.cpp
+++ b/Gems/GradientSignal/Code/Tests/GradientSignalReferencesTests.cpp
@@ -78,6 +78,7 @@ namespace UnitTest
                 for (int x = 0; x < dataSize; x++)
                 {
                     float angle = AZ::DegToRad(inputAngles[(y * dataSize) + x]);
+                    point.m_position = AZ::Vector3(aznumeric_cast<float>(x), aznumeric_cast<float>(y), 0.0f);
                     point.m_normal = AZ::Vector3(sinf(angle), 0.0f, cosf(angle));
                     mockSurface->m_surfacePoints[AZStd::make_pair(static_cast<float>(x), static_cast<float>(y))] =
                         AZStd::span<const AzFramework::SurfaceData::SurfacePoint>(&point, 1);
@@ -549,10 +550,10 @@ namespace UnitTest
         mockSurface->m_bounds = mockShapeComponentHandler.m_GetEncompassingAabb;
         AzFramework::SurfaceData::SurfacePoint mockOutputs[] =
         {
-            { AZ::Vector3(0.0f, 0.0f,  0.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f,  2.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f,  5.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f, 10.0f), AZ::Vector3::CreateZero() },
+            { AZ::Vector3(0.0f, 0.0f,  0.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f,  2.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f,  5.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f, 10.0f), AZ::Vector3::CreateAxisZ() },
         };
         
         mockSurface->m_surfacePoints[AZStd::make_pair(0.0f, 0.0f)] =
@@ -597,10 +598,10 @@ namespace UnitTest
         auto mockSurface = surfaceEntity->CreateComponent<MockSurfaceProviderComponent>();
         mockSurface->m_bounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(1.0f));
         AzFramework::SurfaceData::SurfacePoint mockOutputs[] = {
-            { AZ::Vector3(0.0f, 0.0f, 0.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f, 2.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f, 5.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f, 10.0f), AZ::Vector3::CreateZero() },
+            { AZ::Vector3(0.0f, 0.0f, 0.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f, 2.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f, 5.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f, 10.0f), AZ::Vector3::CreateAxisZ() },
         };
 
         mockSurface->m_surfacePoints[AZStd::make_pair(0.0f, 0.0f)] =
@@ -667,10 +668,10 @@ namespace UnitTest
         auto mockSurface = surfaceEntity->CreateComponent<MockSurfaceProviderComponent>();
         mockSurface->m_bounds = AZ::Aabb::CreateFromMinMax(AZ::Vector3(0.0f), AZ::Vector3(1.0f));
         AzFramework::SurfaceData::SurfacePoint mockOutputs[] = {
-            { AZ::Vector3(0.0f, 0.0f, -10.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f,  -5.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f,  15.0f), AZ::Vector3::CreateZero() },
-            { AZ::Vector3(0.0f, 0.0f,  20.0f), AZ::Vector3::CreateZero() },
+            { AZ::Vector3(0.0f, 0.0f, -10.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f,  -5.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f,  15.0f), AZ::Vector3::CreateAxisZ() },
+            { AZ::Vector3(0.0f, 0.0f,  20.0f), AZ::Vector3::CreateAxisZ() },
         };
 
         // Altitude value below min - should result in 0.0f.
@@ -724,6 +725,8 @@ namespace UnitTest
         {
             for (int x = 0; x < dataSize; x++)
             {
+                point.m_position = AZ::Vector3(aznumeric_cast<float>(x), aznumeric_cast<float>(y), 0.0f);
+                point.m_normal = AZ::Vector3::CreateAxisZ();
                 point.m_surfaceTags.clear();
                 point.m_surfaceTags.emplace_back(AZ_CRC_CE("test_mask"), expectedOutput[(y * dataSize) + x]);
                 mockSurface->m_surfacePoints[AZStd::make_pair(static_cast<float>(x), static_cast<float>(y))] =

--- a/Gems/SurfaceData/Code/Source/SurfacePointList.cpp
+++ b/Gems/SurfaceData/Code/Source/SurfacePointList.cpp
@@ -32,7 +32,11 @@ namespace SurfaceData
             inPositionIndex = (inPositionIndex + 1) % m_inputPositions.size();
         }
 
-        AZ_Assert(foundMatch, "Couldn't find input position!");
+        AZ_Assert(
+            foundMatch,
+            "Couldn't find input position: (%0.7f, %0.7f, %0.7f), m_lastInputPositionIndex = %zu, m_inputPositions.size() = %zu",
+            inPosition.GetX(), inPosition.GetY(), inPosition.GetZ(), m_lastInputPositionIndex, m_inputPositions.size());
+
         m_lastInputPositionIndex = inPositionIndex;
         return inPositionIndex;
     }


### PR DESCRIPTION
The problem is that SurfacePoint doesn't have default values when constructed, and a few of the unit tests weren't setting m_position because the values weren't strictly needed for the test. However, the SurfacePointList checks them for validity and asserted when they couldn't be found, which was hit-and-miss due to it being uninitialized memory that was usually but not always 0xCCCCCCCC.
Improved the assert message and set the position values everywhere.

Signed-off-by: Mike Balfour <82224783+mbalfour-amzn@users.noreply.github.com>