### PR TITLE
{lyn10335} closing and disconnecting during AssetProcessorServerUnitTest

### DIFF
--- a/Code/Tools/AssetProcessor/native/unittests/AssetProcessorServerUnitTests.cpp
+++ b/Code/Tools/AssetProcessor/native/unittests/AssetProcessorServerUnitTests.cpp
@@ -45,7 +45,10 @@ AssetProcessorServerUnitTest::AssetProcessorServerUnitTest()
     connect(m_applicationServer.get(), SIGNAL(newIncomingConnection(qintptr)), m_connectionManager, SLOT(NewConnection(qintptr)));
 }
 
-AssetProcessorServerUnitTest::~AssetProcessorServerUnitTest() = default;
+AssetProcessorServerUnitTest::~AssetProcessorServerUnitTest()
+{
+    disconnect();
+}
 
 void AssetProcessorServerUnitTest::AssetProcessorServerTest()
 {

--- a/Code/Tools/AssetProcessor/native/utilities/BatchApplicationServer.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/BatchApplicationServer.cpp
@@ -16,6 +16,7 @@ BatchApplicationServer::BatchApplicationServer(QObject* parent)
 
 BatchApplicationServer::~BatchApplicationServer()
 {
+    close();
 }
 
 bool BatchApplicationServer::startListening(unsigned short port)


### PR DESCRIPTION
Adding disconnect() to AssetProcessorServerUnitTest to match the connect()
Adding close() to BatchApplicationServer to match the listen() 

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>