### PR TITLE
Move benchmark test metrics to their own suite outside of the GPU suite.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/Atom/CMakeLists.txt
@@ -47,4 +47,18 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         COMPONENT
             Atom
     )
+    ly_add_pytest(
+        NAME AutomatedTesting::Atom_TestSuite_Benchmark_GPU
+        TEST_SUITE main
+        TEST_REQUIRES gpu
+        TEST_SERIAL
+        TIMEOUT 700
+        PATH ${CMAKE_CURRENT_LIST_DIR}/TestSuite_Benchmark_GPU.py
+        RUNTIME_DEPENDENCIES
+            AssetProcessor
+            AutomatedTesting.Assets
+            Editor
+        COMPONENT
+            Atom
+    )
 endif()

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Benchmark_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Benchmark_GPU.py
@@ -1,0 +1,59 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+import logging
+import os
+
+import pytest
+
+import editor_python_test_tools.hydra_test_utils as hydra
+from ly_test_tools.benchmark.data_aggregator import BenchmarkDataAggregator
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize('rhi', ['dx12', 'vulkan'])
+@pytest.mark.parametrize("project", ["AutomatedTesting"])
+@pytest.mark.parametrize("launcher_platform", ["windows_editor"])
+@pytest.mark.parametrize("level", ["AtomFeatureIntegrationBenchmark"])
+class TestPerformanceBenchmarkSuite(object):
+    def test_AtomFeatureIntegrationBenchmarkTest_UploadMetrics(
+            self, request, editor, workspace, rhi, project, launcher_platform, level):
+        """
+        Please review the hydra script run by this test for more specific test info.
+        Tests the performance of the Simple level.
+        """
+        expected_lines = [
+            "Benchmark metadata captured.",
+            "Pass timestamps captured.",
+            "CPU frame time captured.",
+            "Captured data successfully.",
+            "Exited game mode"
+        ]
+
+        unexpected_lines = [
+            "Failed to capture data.",
+            "Failed to capture pass timestamps.",
+            "Failed to capture CPU frame time.",
+            "Failed to capture benchmark metadata."
+        ]
+
+        hydra.launch_and_validate_results(
+            request,
+            os.path.join(os.path.dirname(__file__), "tests"),
+            editor,
+            "hydra_GPUTest_AtomFeatureIntegrationBenchmark.py",
+            timeout=600,
+            expected_lines=expected_lines,
+            unexpected_lines=unexpected_lines,
+            halt_on_unexpected=True,
+            cfg_args=[level],
+            null_renderer=False,
+            enable_prefab_system=False,
+        )
+
+        aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')
+        aggregator.upload_metrics(rhi)

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -11,7 +11,6 @@ import pytest
 
 import editor_python_test_tools.hydra_test_utils as hydra
 import ly_test_tools.environment.file_system as file_system
-from ly_test_tools.benchmark.data_aggregator import BenchmarkDataAggregator
 from ly_test_tools.o3de.editor_test import EditorSingleTest, EditorTestSuite
 from Atom.atom_utils.atom_component_helper import compare_screenshot_to_golden_image, golden_images_directory
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -156,50 +156,6 @@ class TestAutomation(EditorTestSuite):
                                                       similarity_threshold=0.96) is True
 
 
-@pytest.mark.parametrize('rhi', ['dx12', 'vulkan'])
-@pytest.mark.parametrize("project", ["AutomatedTesting"])
-@pytest.mark.parametrize("launcher_platform", ["windows_editor"])
-@pytest.mark.parametrize("level", ["AtomFeatureIntegrationBenchmark"])
-class TestPerformanceBenchmarkSuite(object):
-    def test_AtomFeatureIntegrationBenchmark(
-            self, request, editor, workspace, rhi, project, launcher_platform, level):
-        """
-        Please review the hydra script run by this test for more specific test info.
-        Tests the performance of the Simple level.
-        """
-        expected_lines = [
-            "Benchmark metadata captured.",
-            "Pass timestamps captured.",
-            "CPU frame time captured.",
-            "Captured data successfully.",
-            "Exited game mode"
-        ]
-
-        unexpected_lines = [
-            "Failed to capture data.",
-            "Failed to capture pass timestamps.",
-            "Failed to capture CPU frame time.",
-            "Failed to capture benchmark metadata."
-        ]
-
-        hydra.launch_and_validate_results(
-            request,
-            os.path.join(os.path.dirname(__file__), "tests"),
-            editor,
-            "hydra_GPUTest_AtomFeatureIntegrationBenchmark.py",
-            timeout=600,
-            expected_lines=expected_lines,
-            unexpected_lines=unexpected_lines,
-            halt_on_unexpected=True,
-            cfg_args=[level],
-            null_renderer=False,
-            enable_prefab_system=False,
-        )
-
-        aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')
-        aggregator.upload_metrics(rhi)
-
-
 @pytest.mark.parametrize("project", ["AutomatedTesting"])
 @pytest.mark.parametrize("launcher_platform", ['windows_generic'])
 class TestMaterialEditor(object):


### PR DESCRIPTION
- When a timeout occurs in the `TestSuite_Main_GPU.py` file, it can potentially affect the benchmark test metrics. 
- While our underlying metrics problem had to do with clusters on the ES side, this loose end should also be tied off just in case it happens in the future and becomes a cause for metrics not posting.
- Test results below using command `C:\git\o3de>C:\git\o3de\python\runtime\python-3.7.10-rev1-windows\python\python.exe -m pytest -vv -s --build-directory=".\build\bin\profile" AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Benchmark_GPU.py`:
```
# dx12:
--- Expected lines ---
[ FOUND ] Benchmark metadata captured.
[ FOUND ] Pass timestamps captured.
[ FOUND ] CPU frame time captured.
[ FOUND ] Captured data successfully.
[ FOUND ] Exited game mode
Found 5/5 expected lines
94256.62088394165 - INFO - [MainThread] - ly_test_tools.environment.file_system - Restoring backup of C:\git\o3de\system_windows_pc.cfg from C:\Users\jromnoa\AppData\Local\Temp\tmpimbolsi6\system_windows_pc.cfg.bak
94260.67018508911 - WARNING - [MainThread] - ly_test_tools.environment.file_system - Backup file C:\Users\jromnoa\AppData\Local\Temp\tmpimbolsi6\config.ini.bak does not exist, aborting backup restoration.
94277.16875076294 - INFO - [MainThread] - ly_test_tools.o3de.asset_processor - Sent input quit
95285.11381149292 - INFO - [MainThread] - Atom.TestSuite_Benchmark_GPU.filebeat_client - Connecting to Filebeat on 127.0.0.1:9000
PASSED

# vulkan:
--- Expected lines ---
[ FOUND ] Benchmark metadata captured.
[ FOUND ] Pass timestamps captured.
[ FOUND ] CPU frame time captured.
[ FOUND ] Captured data successfully.
[ FOUND ] Exited game mode
Found 5/5 expected lines
188438.63892555237 - INFO - [MainThread] - ly_test_tools.environment.file_system - Restoring backup of C:\git\o3de\system_windows_pc.cfg from C:\Users\jromnoa\AppData\Local\Temp\tmpni0orepq\system_windows_pc.cfg.bak
188441.73073768616 - WARNING - [MainThread] - ly_test_tools.environment.file_system - Backup file C:\Users\jromnoa\AppData\Local\Temp\tmpni0orepq\config.ini.bak does not exist, aborting backup restoration.
188442.24381446838 - INFO - [MainThread] - ly_test_tools.o3de.asset_processor - Sent input quit
189457.53741264343 - INFO - [MainThread] - Atom.TestSuite_Benchmark_GPU.filebeat_client - Connecting to Filebeat on 127.0.0.1:9000
PASSED

=== 2 passed in 190.12s (0:03:10) ===
```
- I will also run a branch GPU job in AR to make sure it passes there as well before merging.