### PR TITLE
[development] fixes for targeting macOS Monterey (12.x)

### DIFF
--- a/Code/Editor/LogFile_mac.mm
+++ b/Code/Editor/LogFile_mac.mm
@@ -26,8 +26,13 @@ QString graphicsCardName()
     // Create an iterator
     io_iterator_t iterator;
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_12_0
+    if (IOServiceGetMatchingServices(kIOMainPortDefault,matchDict,
+                                     &iterator) == kIOReturnSuccess)
+#else
     if (IOServiceGetMatchingServices(kIOMasterPortDefault,matchDict,
                                      &iterator) == kIOReturnSuccess)
+#endif
     {
         // Iterator for devices found
         io_registry_entry_t regEntry;

--- a/Gems/Microphone/Code/Source/Platform/Mac/MicrophoneSystemComponent_Mac.mm
+++ b/Gems/Microphone/Code/Source/Platform/Mac/MicrophoneSystemComponent_Mac.mm
@@ -84,7 +84,7 @@ public:
         AudioObjectPropertyAddress theAddress = {
             kAudioHardwarePropertyDefaultInputDevice,
             kAudioObjectPropertyScopeGlobal,
-            kAudioObjectPropertyElementMaster
+            kAudioObjectPropertyElementMain
         };
         
         status = AudioObjectGetPropertyData(kAudioObjectSystemObject,


### PR DESCRIPTION
Targeting macOS 12.x fails to compile due to some named constants being deprecated and replaced

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>