### PR TITLE
POC - AZ::NameLiteral and AZ_NAME_LITERAL

### DIFF
--- a/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
+++ b/Code/Editor/TrackView/AtomOutputFrameCapture.cpp
@@ -45,7 +45,7 @@ namespace TrackView
         m_passHierarchy.push_back("CopyToSwapChain");
 
         // retrieve View from the camera that's animating
-        AZ::Name viewName = AZ::Name("MainCamera");
+        AZ::Name viewName = AZ_NAME_LITERAL("MainCamera");
         m_view = AZ::RPI::View::CreateView(viewName, AZ::RPI::View::UsageCamera);
         m_renderPipeline->SetDefaultView(m_view);
         m_targetView = scene.GetDefaultRenderPipeline()->GetDefaultView();

--- a/Code/Framework/AzCore/AzCore/Name/Internal/NameData.cpp
+++ b/Code/Framework/AzCore/AzCore/Name/Internal/NameData.cpp
@@ -16,6 +16,17 @@ namespace AZ::Internal
         , m_hash{hash}
     {}
 
+    NameData::~NameData()
+    {
+        while (m_literalLinkedList != nullptr)
+        {
+            NameLiteral* next = m_literalLinkedList->m_nextLiteral;
+            m_literalLinkedList->m_data = nullptr;
+            m_literalLinkedList->m_nextLiteral = nullptr;
+            m_literalLinkedList = next;
+        }
+    }
+
     AZStd::string_view NameData::GetName() const
     {
         return m_name;

--- a/Code/Framework/AzCore/AzCore/Name/Internal/NameData.h
+++ b/Code/Framework/AzCore/AzCore/Name/Internal/NameData.h
@@ -17,12 +17,14 @@
 namespace AZ
 {
     class NameDictionary;
+    class NameLiteral;
 
     namespace Internal
     {
         class NameData final
         {
             friend NameDictionary;
+            friend NameLiteral;
         public:
             AZ_CLASS_ALLOCATOR(NameData, AZ::SystemAllocator, 0);
 
@@ -33,6 +35,8 @@ namespace AZ
 
             //! Returns the hash part of the name data.
             Hash GetHash() const;
+
+            ~NameData();
 
         private:
             NameData(AZStd::string&& name, Hash hash);
@@ -45,6 +49,7 @@ namespace AZ
 
             AZStd::atomic_int m_useCount = {0};
             AZStd::string m_name;
+            NameLiteral* m_literalLinkedList = nullptr;
             Hash m_hash;
 
             // TODO: We should be able to change this to a normal bool after introducing name dictionary garbage collection

--- a/Code/Framework/AzCore/AzCore/Name/Name.h
+++ b/Code/Framework/AzCore/AzCore/Name/Name.h
@@ -34,6 +34,7 @@ namespace AZ
     class Name
     {
         friend NameDictionary;
+        friend class NameLiteral;
         friend UnitTest::NameTest;
     public:
         using Hash = Internal::NameData::Hash;
@@ -121,6 +122,32 @@ namespace AZ
         //! Pointer to NameData in the NameDictionary. This holds both the hash and string pair.
         AZStd::intrusive_ptr<Internal::NameData> m_data;
     };
+
+    class NameLiteral final
+    {
+        friend class Internal::NameData;
+
+    public:
+        NameLiteral(const char* value);
+        ~NameLiteral();
+        Name GetName() const;
+
+        bool operator==(const Name& rhs) const;
+
+        inline operator Name() const { return GetName(); }
+
+    private:
+        AZStd::string_view m_view;
+        mutable Internal::NameData* m_data = nullptr;
+
+        mutable NameLiteral* m_nextLiteral = nullptr;
+    };
+
+    #define AZ_NAME_LITERAL(str) \
+        ([]() noexcept -> AZ::NameLiteral { \
+            static AZ::NameLiteral strLiteral(str); \
+            return strLiteral; \
+        }())
 
 } // namespace AZ
 

--- a/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
+++ b/Code/Framework/AzCore/AzCore/Name/NameDictionary.h
@@ -77,6 +77,8 @@ namespace AZ
         //! @return A Name instance. If the hash was not found, the Name will be empty.
         Name FindName(Name::Hash hash) const;
 
+        Internal::NameData* MakeNameLiteral(AZStd::string_view name);
+
         NameDictionary();
     private:
         ~NameDictionary();
@@ -97,6 +99,7 @@ namespace AZ
         Name::Hash CalcHash(AZStd::string_view name);
 
         AZStd::unordered_map<Name::Hash, Internal::NameData*> m_dictionary;
+        AZStd::unordered_map<const char*, Internal::NameData*> m_literals;
         mutable AZStd::shared_mutex m_sharedMutex;
     };
 }

--- a/Code/Framework/AzCore/Tests/Name/NameTests.cpp
+++ b/Code/Framework/AzCore/Tests/Name/NameTests.cpp
@@ -635,6 +635,26 @@ namespace UnitTest
         RunConcurrencyTest<ThreadRepeatedlyCreatesAndReleasesOneName<100>>(100, 2);
     }
 
+    TEST_F(NameTest, NameLiteral)
+    {
+        static AZ::NameLiteral s_nameLiteral = AZ::NameLiteral("name_literal");
+        AZ::NameLiteral secondLiteral("name_literal");
+        EXPECT_EQ(AZ::Name("name_literal"), s_nameLiteral);
+        EXPECT_EQ(AZ::Name("name_literal"), secondLiteral);
+        EXPECT_EQ(AZ::Name("name_literal"), AZ_NAME_LITERAL("name_literal"));
+        {
+            AZ::NameLiteral temporaryLiteral("name_literal");
+            EXPECT_EQ(AZ::Name("name_literal"), temporaryLiteral);
+        }
+        EXPECT_EQ(AZ::Name("name_literal"), s_nameLiteral);
+        EXPECT_EQ(AZ::Name("name_literal"), secondLiteral);
+        AZ::NameDictionary::Destroy();
+        AZ::NameDictionary::Create();
+        EXPECT_EQ(AZ::Name("name_literal"), s_nameLiteral);
+        EXPECT_EQ(AZ::Name("name_literal"), secondLiteral);
+        EXPECT_EQ(secondLiteral, AZ_NAME_LITERAL("name_literal"));
+    }
+
     TEST_F(NameTest, DISABLED_NameVsStringPerf_Creation)
     {
         constexpr int CreateCount = 1000;

--- a/Code/Framework/AzFramework/AzFramework/Visibility/OctreeSystemComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Visibility/OctreeSystemComponent.cpp
@@ -524,7 +524,7 @@ namespace AzFramework
         AZ::Interface<IVisibilitySystem>::Register(this);
         IVisibilitySystemRequestBus::Handler::BusConnect();
 
-        m_defaultScene = aznew OctreeScene(AZ::Name("DefaultVisibilityScene"));
+        m_defaultScene = aznew OctreeScene(AZ_NAME_LITERAL("DefaultVisibilityScene"));
     }
 
     OctreeSystemComponent::~OctreeSystemComponent()

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpSocket.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpSocket.cpp
@@ -162,7 +162,7 @@ namespace AzNetworking
 
             DeferredData deferred = DeferredData(address, data, size, encrypt, dtlsEndpoint);
             AZ::Interface<AZ::IEventScheduler>::Get()->AddCallback([&, deferredData = deferred]
-                    { SendInternalDeferred(deferredData); }, AZ::Name("Deferred packet"), deferTimeMs);
+                    { SendInternalDeferred(deferredData); }, AZ_NAME_LITERAL("Deferred packet"), deferTimeMs);
         }
 #endif
 

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/LightCullingPass.cpp
@@ -257,7 +257,7 @@ namespace AZ
 
         void LightCullingPass::BuildInternal()
         {
-            m_tileDataIndex = FindInputBinding(AZ::Name("TileLightData"));
+            m_tileDataIndex = FindInputBinding(AZ_NAME_LITERAL("TileLightData"));
             CreateLightList();
             AttachLightList();
         }


### PR DESCRIPTION
Work in progress change to provide a `NameLiteral` class that can provide `AZ::Name` data in a static context, prior to the instantiation of the Name dictionary, and supports the name dictionary being destroyed/recreated. Ref counting is disabled for literal names, but presently we still allocate an `AZStd::string` for the name table entry (can be reduced to a `string_view` for literals with no ref counter with a vtable, precalc hash, etc)

This also provides an `AZ_NAME_LITERAL` macro for creating a static `AZ::Name` in function scope using a lambda, similar to Qt's approach to string literals.

Signed-off-by: Nicholas Van Sickle <nvsickle@amazon.com>