### PR TITLE
EMotion FX: Ported skeleton rendering to debug display and fixed depth testing for debug rendering

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -75,13 +75,13 @@ namespace AZ::Render
         // Render simple line skeleton
         if (CheckBitsAny(renderFlags, EMotionFX::ActorRenderFlags::LineSkeleton))
         {
-            RenderLineSkeleton(instance, renderActorSettings.m_lineSkeletonColor);
+            RenderLineSkeleton(debugDisplay, instance, renderActorSettings.m_lineSkeletonColor);
         }
 
         // Render advanced skeleton
         if (CheckBitsAny(renderFlags, EMotionFX::ActorRenderFlags::Skeleton))
         {
-            RenderSkeleton(instance, renderActorSettings.m_skeletonColor);
+            RenderSkeleton(debugDisplay, instance, renderActorSettings.m_skeletonColor);
         }
 
         if (CheckBitsAny(renderFlags, EMotionFX::ActorRenderFlags::NodeNames))
@@ -278,27 +278,22 @@ namespace AZ::Render
         }
     }
 
-    void AtomActorDebugDraw::RenderLineSkeleton(EMotionFX::ActorInstance* instance, const AZ::Color& skeletonColor)
+    void AtomActorDebugDraw::RenderLineSkeleton(AzFramework::DebugDisplayRequests* debugDisplay, EMotionFX::ActorInstance* instance, const AZ::Color& color) const
     {
-        RPI::AuxGeomDrawPtr auxGeom = m_auxGeomFeatureProcessor->GetDrawQueue();
-
         const EMotionFX::TransformData* transformData = instance->GetTransformData();
         const EMotionFX::Skeleton* skeleton = instance->GetActor()->GetSkeleton();
         const EMotionFX::Pose* pose = transformData->GetCurrentPose();
-
         const size_t lodLevel = instance->GetLODLevel();
         const size_t numJoints = skeleton->GetNumNodes();
-
-        m_auxVertices.clear();
-        m_auxVertices.reserve(numJoints * 2);
-        m_auxColors.clear();
-        m_auxColors.reserve(numJoints * 2);
-        AZ::Color renderColor;
 
         const AZStd::unordered_set<size_t>* cachedSelectedJointIndices;
         EMotionFX::JointSelectionRequestBus::BroadcastResult(
             cachedSelectedJointIndices, &EMotionFX::JointSelectionRequests::FindSelectedJointIndices, instance);
 
+        const AZ::u32 oldState = debugDisplay->GetState();
+        debugDisplay->DepthTestOff();
+
+        AZ::Color renderColor;
         for (size_t jointIndex = 0; jointIndex < numJoints; ++jointIndex)
         {
             const EMotionFX::Node* joint = skeleton->GetNode(jointIndex);
@@ -319,41 +314,34 @@ namespace AZ::Render
             }
             else
             {
-                renderColor = skeletonColor;
+                renderColor = color;
             }
 
             const AZ::Vector3 parentPos = pose->GetWorldSpaceTransform(parentIndex).m_position;
-            m_auxVertices.emplace_back(parentPos);
-            m_auxColors.emplace_back(renderColor);
-
             const AZ::Vector3 bonePos = pose->GetWorldSpaceTransform(jointIndex).m_position;
-            m_auxVertices.emplace_back(bonePos);
-            m_auxColors.emplace_back(renderColor);
+
+            debugDisplay->SetColor(renderColor);
+            debugDisplay->DrawLine(parentPos, bonePos);
         }
 
-        RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments lineArgs;
-        lineArgs.m_verts = m_auxVertices.data();
-        lineArgs.m_vertCount = aznumeric_cast<uint32_t>(m_auxVertices.size());
-        lineArgs.m_colors = m_auxColors.data();
-        lineArgs.m_colorCount = lineArgs.m_vertCount;
-        lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
-        auxGeom->DrawLines(lineArgs);
+        debugDisplay->SetState(oldState);
     }
 
-    void AtomActorDebugDraw::RenderSkeleton(EMotionFX::ActorInstance* instance, const AZ::Color& skeletonColor)
+    void AtomActorDebugDraw::RenderSkeleton(AzFramework::DebugDisplayRequests* debugDisplay, EMotionFX::ActorInstance* instance, const AZ::Color& color)
     {
-        RPI::AuxGeomDrawPtr auxGeom = m_auxGeomFeatureProcessor->GetDrawQueue();
-
         const EMotionFX::TransformData* transformData = instance->GetTransformData();
         const EMotionFX::Skeleton* skeleton = instance->GetActor()->GetSkeleton();
         const EMotionFX::Pose* pose = transformData->GetCurrentPose();
         const size_t numEnabled = instance->GetNumEnabledNodes();
 
-        AZ::Color renderColor = skeletonColor;
         const AZStd::unordered_set<size_t>* cachedSelectedJointIndices;
         EMotionFX::JointSelectionRequestBus::BroadcastResult(
             cachedSelectedJointIndices, &EMotionFX::JointSelectionRequests::FindSelectedJointIndices, instance);
 
+        const AZ::u32 oldState = debugDisplay->GetState();
+        debugDisplay->DepthTestOff();
+
+        AZ::Color renderColor;
         for (size_t i = 0; i < numEnabled; ++i)
         {
             EMotionFX::Node* joint = skeleton->GetNode(instance->GetEnabledNode(i));
@@ -382,12 +370,17 @@ namespace AZ::Render
             }
             else
             {
-                renderColor = skeletonColor;
+                renderColor = color;
             }
+            renderColor.SetA(0.75f);
+            debugDisplay->SetColor(renderColor);
+
             // Render the bone cylinder, the cylinder will be directed towards the node's parent and must fit between the spheres
-            auxGeom->DrawCylinder(centerWorldPos, boneDirection, boneScale, cylinderSize, renderColor);
-            auxGeom->DrawSphere(nodeWorldPos, boneScale, renderColor);
+            debugDisplay->DrawSolidCylinder(centerWorldPos, boneDirection, boneScale * 0.75f, cylinderSize);
+            debugDisplay->DrawBall(nodeWorldPos, boneScale);
         }
+
+        debugDisplay->SetState(oldState);
     }
 
     void AtomActorDebugDraw::RenderEMFXDebugDraw(EMotionFX::ActorInstance* instance)
@@ -502,7 +495,7 @@ namespace AZ::Render
                 lineArgs.m_vertCount = aznumeric_cast<uint32_t>(m_auxVertices.size());
                 lineArgs.m_colors = &faceNormalsColor;
                 lineArgs.m_colorCount = 1;
-                lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
+                lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::On;
                 auxGeom->DrawLines(lineArgs);
             }
         }
@@ -536,7 +529,7 @@ namespace AZ::Render
                 lineArgs.m_vertCount = aznumeric_cast<uint32_t>(m_auxVertices.size());
                 lineArgs.m_colors = &vertexNormalsColor;
                 lineArgs.m_colorCount = 1;
-                lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
+                lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::On;
                 auxGeom->DrawLines(lineArgs);
             }
         }
@@ -624,7 +617,7 @@ namespace AZ::Render
         lineArgs.m_vertCount = aznumeric_cast<uint32_t>(m_auxVertices.size());
         lineArgs.m_colors = m_auxColors.data();
         lineArgs.m_colorCount = aznumeric_cast<uint32_t>(m_auxColors.size());
-        lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
+        lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::On;
         auxGeom->DrawLines(lineArgs);
     }
 
@@ -644,7 +637,6 @@ namespace AZ::Render
         }
 
         PrepareForMesh(mesh, worldTM);
-
         const AZ::Vector3* normals = (AZ::Vector3*)mesh->FindVertexData(EMotionFX::Mesh::ATTRIB_NORMALS);
 
         const size_t numSubMeshes = mesh->GetNumSubMeshes();
@@ -684,7 +676,7 @@ namespace AZ::Render
             lineArgs.m_vertCount = aznumeric_cast<uint32_t>(m_auxVertices.size());
             lineArgs.m_colors = &wireframeColor;
             lineArgs.m_colorCount = 1;
-            lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::Off;
+            lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::On;
             auxGeom->DrawLines(lineArgs);
         }
     }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
@@ -55,8 +55,12 @@ namespace AZ::Render
             const AZ::Color& meshAabbColor,
             bool enableStaticAabb,
             const AZ::Color& staticAabbColor);
-        void RenderLineSkeleton(EMotionFX::ActorInstance* instance, const AZ::Color& skeletonColor);
-        void RenderSkeleton(EMotionFX::ActorInstance* instance, const AZ::Color& skeletonColor);
+        void RenderLineSkeleton(AzFramework::DebugDisplayRequests* debugDisplay,
+            EMotionFX::ActorInstance* instance,
+            const AZ::Color& skeletonColor) const;
+        void RenderSkeleton(AzFramework::DebugDisplayRequests* debugDisplay,
+            EMotionFX::ActorInstance* instance,
+            const AZ::Color& color);
         void RenderEMFXDebugDraw(EMotionFX::ActorInstance* instance);
         void RenderNormals(
             EMotionFX::Mesh* mesh,


### PR DESCRIPTION
* Ported line-based and solid skeleton rendering to debug display.
* Disabled depth testing for skeleton rendering so that we can see the skeleton through the solid mesh.
* Remembering the previous render flags and setting them back afterwards.
* Enabled depth testing for emfx debug, vertex & face normals, tangents and wireframe. We don't want to see them through the solid mesh to avoid visual clutter.

![image](https://user-images.githubusercontent.com/43751992/154321376-02ee4b50-f0b0-4373-8da9-68dbcb3bd375.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>