### PR TITLE
Sets AllowDescriptorHeapCompaction to true so the nightly GPU run won't time out

### DIFF
--- a/Gems/Atom/RHI/Registry/Platform/Windows/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Windows/PlatformLimits.setreg
@@ -27,7 +27,7 @@
                             "DESCRIPTOR_HEAP_TYPE_DSV": [2048, 0]
                         },
                         "NumShaderVisibleCbvSrvUavStaticHandles": 2000,
-                        "AllowDescriptorHeapCompaction": false
+                        "AllowDescriptorHeapCompaction": true
                     },
                     "vulkan":
                     {


### PR DESCRIPTION
- This fixes the issue in AR with the nightly GPU run timing out.