### PR TITLE
EMotion FX: Minimized distance between wireframe and solid mesh rendering

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -135,7 +135,7 @@ namespace AZ::Render
                 }
                 if (renderWireframe)
                 {
-                    RenderWireframe(mesh, globalTM, renderActorSettings.m_wireframeScale, scaleMultiplier, renderActorSettings.m_wireframeColor);
+                    RenderWireframe(mesh, globalTM, renderActorSettings.m_wireframeScale * scaleMultiplier, renderActorSettings.m_wireframeColor);
                 }
             }
         }
@@ -621,8 +621,8 @@ namespace AZ::Render
         auxGeom->DrawLines(lineArgs);
     }
 
-    void AtomActorDebugDraw::RenderWireframe(
-        EMotionFX::Mesh* mesh, const AZ::Transform& worldTM, float wireframeScale, float scaleMultiplier, const AZ::Color& wireframeColor)
+    void AtomActorDebugDraw::RenderWireframe(EMotionFX::Mesh* mesh, const AZ::Transform& worldTM,
+        float scale, const AZ::Color& color)
     {
         // Check if the mesh is valid and skip the node in case it's not
         if (!mesh)
@@ -657,9 +657,9 @@ namespace AZ::Render
                 const uint32 indexB = indices[triangleStartIndex + 1] + startVertex;
                 const uint32 indexC = indices[triangleStartIndex + 2] + startVertex;
 
-                const AZ::Vector3 posA = m_worldSpacePositions[indexA] + normals[indexA] * wireframeScale * scaleMultiplier;
-                const AZ::Vector3 posB = m_worldSpacePositions[indexB] + normals[indexB] * wireframeScale * scaleMultiplier;
-                const AZ::Vector3 posC = m_worldSpacePositions[indexC] + normals[indexC] * wireframeScale * scaleMultiplier;
+                const AZ::Vector3 posA = m_worldSpacePositions[indexA] + normals[indexA] * scale;
+                const AZ::Vector3 posB = m_worldSpacePositions[indexB] + normals[indexB] * scale;
+                const AZ::Vector3 posC = m_worldSpacePositions[indexC] + normals[indexC] * scale;
 
                 m_auxVertices.emplace_back(posA);
                 m_auxVertices.emplace_back(posB);
@@ -674,7 +674,7 @@ namespace AZ::Render
             RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments lineArgs;
             lineArgs.m_verts = m_auxVertices.data();
             lineArgs.m_vertCount = aznumeric_cast<uint32_t>(m_auxVertices.size());
-            lineArgs.m_colors = &wireframeColor;
+            lineArgs.m_colors = &color;
             lineArgs.m_colorCount = 1;
             lineArgs.m_depthTest = RPI::AuxGeomDraw::DepthTest::On;
             auxGeom->DrawLines(lineArgs);

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.h
@@ -75,8 +75,8 @@ namespace AZ::Render
         void RenderTangents(
             EMotionFX::Mesh* mesh, const AZ::Transform& worldTM, float tangentsScale, float scaleMultiplier,
             const AZ::Color& tangentsColor, const AZ::Color& mirroredBitangentsColor, const AZ::Color& bitangentsColor);
-        void RenderWireframe(EMotionFX::Mesh* mesh, const AZ::Transform& worldTM, float wireframeScale, float scaleMultiplier,
-            const AZ::Color& wireframeColor);
+        void RenderWireframe(EMotionFX::Mesh* mesh, const AZ::Transform& worldTM,
+            float scale, const AZ::Color& color);
         void RenderJointNames(EMotionFX::ActorInstance* actorInstance, RPI::ViewportContextPtr viewportContext, const AZ::Color& jointNameColor);
         void RenderNodeOrientations(EMotionFX::ActorInstance* actorInstance, AzFramework::DebugDisplayRequests* debugDisplay, float scale = 1.0f);
         void RenderLineAxis(

--- a/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderActorSettings.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderActorSettings.h
@@ -25,7 +25,12 @@ namespace AZ::Render
         float m_vertexNormalsScale = 1.0f;
         float m_faceNormalsScale = 1.0f;
         float m_tangentsScale = 1.0f;
-        float m_wireframeScale = 1.0f;
+
+        //! Use the vertex normals to scale the wireframe a bit to avoid Z-fighting when rendering.
+        //! Scale the normal by the m_wireframeScale to push the wireframe a bit above the solide mesh rendering.
+        //! Additionally the character bounds will be taken into account, so this is a relative-to the character size value.
+        float m_wireframeScale = 0.1f;
+
         float m_nodeOrientationScale = 1.0f;
 
         bool m_enabledNodeBasedAabb = true;


### PR DESCRIPTION
while preventing Z-fighting

| Before | After |
| ----------- | ----------- |
|  ![image](https://user-images.githubusercontent.com/43751992/154443525-13cdf475-2687-4ee4-9a97-349de7c1a0e4.png) |   ![image](https://user-images.githubusercontent.com/43751992/154443565-0eb86170-3adb-4042-ac78-52de11821171.png)     |

Signed-off-by: Benjamin Jillich <jillich@amazon.com>