### PR TITLE
Added error handling for unsupported pixel formats on an image gradient

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -246,7 +246,7 @@ namespace AzToolsFramework
         virtual void PopupAssetPicker();
         virtual void PickAssetSelectionFromDialog(AssetSelectionModel& selection, QWidget* parent);
         void OnClearButtonClicked();
-        void UpdateAssetDisplay();
+        virtual void UpdateAssetDisplay();
         void OnLineEditFocus(bool focus);
         virtual void OnEditButtonClicked();
         void OnThumbnailClicked();

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.cpp
@@ -226,6 +226,18 @@ namespace GradientSignal
             return;
         }
 
+        // If we have loaded in an old image asset with an unsupported pixel format,
+        // don't try to access the image data because there will be spam of asserts,
+        // so just log an error message and bail out
+        AZ::RHI::Format format = m_configuration.m_imageAsset->GetImageDescriptor().m_format;
+        bool isFormatSupported = AZ::RPI::IsImageDataPixelAPISupported(format);
+        if (!isFormatSupported)
+        {
+            AZ_Error("GradientSignal", false, "Image asset (%s) has an unsupported pixel format: %s",
+                m_configuration.m_imageAsset.GetHint().c_str(), AZ::RHI::ToString(format));
+            return;
+        }
+
         m_imageData = m_configuration.m_imageAsset->GetSubImageData(0, 0);
     }
 

--- a/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.cpp
@@ -76,6 +76,20 @@ namespace GradientSignal
         }
     }
 
+    void StreamingImagePropertyAssetCtrl::UpdateAssetDisplay()
+    {
+        AzToolsFramework::PropertyAssetCtrl::UpdateAssetDisplay();
+
+        // If there is a valid asset selected but it's not a supported pixel format,
+        // show the error message state for this property
+        if (m_selectedAssetID.IsValid() && !Internal::IsImageDataPixelAPISupportedForAsset(m_selectedAssetID))
+        {
+            UpdateErrorButtonWithMessage(
+                AZStd::string::format("Image asset (%s) has an unsupported pixel format", GetCurrentAssetHint().c_str())
+            );
+        }
+    }
+
     AZ::u32 StreamingImagePropertyHandler::GetHandlerName() const
     {
         return AZ_CRC_CE("GradientSignalStreamingImageAsset");

--- a/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.h
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorStreamingImageAssetCtrl.h
@@ -44,6 +44,7 @@ namespace GradientSignal
 
     public Q_SLOTS:
         void OnAutocomplete(const QModelIndex& index) override;
+        void UpdateAssetDisplay() override;
     };
 
     //! We need a custom asset property handler for the AZ::RPI::StreamingImageAsset on our


### PR DESCRIPTION
The `ImageGradientComponent` has been updated to use the `AZ::RPI::StreamingImageAsset` instead of the `GradientSignal::ImageAsset`, and we already have logic to automatically convert the previous image asset reference from the `.gradimage` to the corresponding `.streamingimageasset` for the source asset (assuming there is one).

Any previous references that already had the "_gsi" suffix on the source asset name, or that had custom .assetinfo directives for having it be converted to an uncompressed format will just work now as a streaming image asset.

However, for any source assets that were going through the default conversion when be compiled to a product `.streamingimageasset`, will likely be in one of the compressed formats (e.g. BC1_UNORM), which we don't currently have support for with the pixel retrieval API. This results in a spam of asserts for unsupported pixel format if you had opened up an old level that had a component with this case.

Now, when an image gradient component has a reference to an asset with an unsupported pixel format, a single error message will be logged and it won't try to actually retrieve values from the image data, eliminating the spam of asserts. Also, we show the property asset error state in the property field.

![ImageGradientUnsupportedFormatErrorHandling](https://user-images.githubusercontent.com/7519264/154533442-dea68e63-83e1-4b62-ab3a-3de7352bef6f.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>