### PR TITLE
Fixing LyShine dependency in gem.json

### DIFF
--- a/Gems/Atom/Tools/MaterialEditor/gem.json
+++ b/Gems/Atom/Tools/MaterialEditor/gem.json
@@ -20,7 +20,6 @@
         "Atom_Feature_Common",
         "ImageProcessingAtom",
         "Atom_Component_DebugCamera",
-        "CommonFeaturesAtom",
-        "LyShine"
+        "CommonFeaturesAtom"
     ]
 }

--- a/Gems/MessagePopup/gem.json
+++ b/Gems/MessagePopup/gem.json
@@ -17,5 +17,7 @@
     "icon_path": "preview.png",
     "requirements": "",
     "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/ui/message-popup/",
-    "dependencies": []
+    "dependencies": [
+        "LyShine"
+    ]
 }


### PR DESCRIPTION
Fixes #7727, MaterialEditor does not depend on LyShine.  Also adds missing dependency to MessagePopup Gem which has a build dependency on `Gem::LyShine.Clients.API`

Signed-off-by: Alex Peterson <26804013+AMZN-alexpete@users.noreply.github.com>