### PR TITLE
Fixed Script Event registration going to the incorrect Behavior Context

### DIFF
--- a/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
+++ b/Code/Framework/AzCore/AzCore/RTTI/BehaviorContext.h
@@ -1337,6 +1337,7 @@ namespace AZ
         // EBusInterface settings
         static const EBusAddressPolicy AddressPolicy = EBusAddressPolicy::ById;
         typedef BehaviorContext* BusIdType;
+        using MutexType = AZStd::recursive_mutex;
         //////////////////////////////////////////////////////////////////////////
 
         /// Called when a new global method is reflected in behavior context or removed from it

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Material/LuaMaterialFunctor.cpp
@@ -39,7 +39,7 @@ namespace AZ
             // [GFX TODO][ATOM-13648] Add local system allocator to material system
             // ScriptContext creates a new allocator if null (default) is passed in.
             // Temporarily using system allocator for preventing hitting the max allocator number.
-            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>(ScriptContextIds::DefaultScriptContextId, &AZ::AllocatorInstance<AZ::SystemAllocator>::Get());
+            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>(AZ_CRC_CE("MaterialFunctor"), &AZ::AllocatorInstance<AZ::SystemAllocator>::Get());
             m_sriptBehaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
 
             ReflectScriptContext(m_sriptBehaviorContext.get());

--- a/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventRegistration.cpp
+++ b/Gems/ScriptEvents/Code/Include/ScriptEvents/ScriptEventRegistration.cpp
@@ -115,7 +115,7 @@ namespace ScriptEvents
                 m_maxVersion = definition.GetVersion();
             }
 
-            AZ::BehaviorContextBus::Broadcast(&AZ::BehaviorContextBus::Events::OnAddEBus, m_busName.c_str(), bus);
+            AZ::BehaviorContextBus::Event(behaviorContext, &AZ::BehaviorContextBus::Events::OnAddEBus, m_busName.c_str(), bus);
             m_scriptEventBindings[m_assetId] = AZStd::make_unique<ScriptEventBinding>(behaviorContext, m_busName.c_str(), definition.GetAddressType());
 
             ScriptEventNotificationBus::Event(m_assetId, &ScriptEventNotifications::OnRegistered, definition);


### PR DESCRIPTION
- Changed the LuaMaterialFunctor ScriptContext ID to be specific instead of the default
- Set the MutexType in BehaviorContextEventBus to recursive_mutex

Closes #6550
Closes #7620
Closes #6817


Signed-off-by: lsemp3d <58790905+lsemp3d@users.noreply.github.com>