### PR TITLE
Updated deprecated CMake function usage in PythonToolGem and CppToolGem templates

### DIFF
--- a/Templates/CppToolGem/Template/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/CMakeLists.txt
@@ -6,12 +6,11 @@
 #
 # {END_LICENSE}
 
-set(o3de_gem_path ${CMAKE_CURRENT_LIST_DIR})
-set(o3de_gem_json ${o3de_gem_path}/gem.json)
-o3de_read_json_key(o3de_gem_name ${o3de_gem_json} "gem_name")
-o3de_restricted_path(${o3de_gem_json} o3de_gem_restricted_path)
+set(gem_path ${CMAKE_CURRENT_LIST_DIR})
+set(gem_json ${gem_path}/gem.json)
+o3de_restricted_path(${gem_json} gem_restricted_path gem_parent_relative_path)
 
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${o3de_gem_restricted_path}" ${o3de_gem_path} ${o3de_gem_name})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # project cmake for this platform.

--- a/Templates/CppToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/CppToolGem/Template/Code/CMakeLists.txt
@@ -8,11 +8,11 @@
 
 # Currently we are in the Code folder: ${CMAKE_CURRENT_LIST_DIR}
 # Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
-# Note: ly_get_list_relative_pal_filename will take care of the details for us, as this may be a restricted platform
+# Note: o3de_pal_dir will take care of the details for us, as this may be a restricted platform
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here in our gem : Gems/${Name}/Code/Platform/<platorm_name>  or
 #            <restricted_folder>/<platform_name>/Gems/${Name}/Code
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${o3de_gem_restricted_path} ${o3de_gem_path} ${o3de_gem_name})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_name}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this gem

--- a/Templates/PythonToolGem/Template/Code/CMakeLists.txt
+++ b/Templates/PythonToolGem/Template/Code/CMakeLists.txt
@@ -8,11 +8,11 @@
 
 # Currently we are in the Code folder: ${CMAKE_CURRENT_LIST_DIR}
 # Get the platform specific folder ${pal_dir} for the current folder: ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}
-# Note: ly_get_list_relative_pal_filename will take care of the details for us, as this may be a restricted platform
+# Note: o3de_pal_dir will take care of the details for us, as this may be a restricted platform
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here in our gem : Gems/${Name}/Code/Platform/<platorm_name>  or
 #            <restricted_folder>/<platform_name>/Gems/${Name}/Code
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${o3de_gem_restricted_path} ${o3de_gem_path} ${o3de_gem_name})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_name}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this gem


### PR DESCRIPTION
Fixes #7725 

Replaced the deprecated `ly_get_list_relative_pal_filename` usage with `o3de_pal_dir` in the CMakeLists.txt for `PythonToolGem` and 'CppToolGem` gemplates. Also updated the template to match some other minor updates to the `DefaultGem` template.

Tested by creating new gems from these templates, configured with no CMake warnings, and verified both gems build/run properly.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>