### PR TITLE
{lyn9869} adding a 'debug' flag in the PreExportEventContext

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportEventContext.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportEventContext.cpp
@@ -18,19 +18,31 @@ namespace AZ
             // PreExportEventContext
             /////////////
 
-            PreExportEventContext::PreExportEventContext(ExportProductList& productList, const AZStd::string& outputDirectory, const Containers::Scene& scene, const char* platformIdentifier)
+            PreExportEventContext::PreExportEventContext(
+                    ExportProductList& productList,
+                    const AZStd::string& outputDirectory,
+                    const Containers::Scene& scene,
+                    const char* platformIdentifier,
+                    bool debug)
                 : m_outputDirectory(outputDirectory)
                 , m_productList(productList)
                 , m_scene(scene)
                 , m_platformIdentifier(platformIdentifier)
+                , m_debug(debug)
             {
             }
 
-            PreExportEventContext::PreExportEventContext(ExportProductList& productList, AZStd::string&& outputDirectory, const Containers::Scene& scene, const char* platformIdentifier)
+            PreExportEventContext::PreExportEventContext(
+                    ExportProductList& productList,
+                    AZStd::string&& outputDirectory,
+                    const Containers::Scene& scene,
+                    const char* platformIdentifier,
+                    bool debug)
                 : m_outputDirectory(AZStd::move(outputDirectory))
                 , m_productList(productList)
                 , m_scene(scene)
                 , m_platformIdentifier(platformIdentifier)
+                , m_debug(debug)
             {
             }
 
@@ -57,6 +69,11 @@ namespace AZ
             const char* PreExportEventContext::GetPlatformIdentifier() const
             {
                 return m_platformIdentifier;
+            }
+
+            bool PreExportEventContext::GetDebug() const
+            {
+                return m_debug;
             }
 
             /////////////

--- a/Code/Tools/SceneAPI/SceneCore/Events/ExportEventContext.h
+++ b/Code/Tools/SceneAPI/SceneCore/Events/ExportEventContext.h
@@ -38,14 +38,15 @@ namespace AZ
             public:
                 AZ_RTTI(PreExportEventContext, "{6B303E35-8BF0-43DD-9AD7-7D7F24F18F37}", ICallContext);
                 ~PreExportEventContext() override = default;
-                SCENE_CORE_API PreExportEventContext(ExportProductList& productList, const AZStd::string& outputDirectory, const Containers::Scene& scene, const char* platformIdentifier);
-                SCENE_CORE_API PreExportEventContext(ExportProductList& productList, AZStd::string&& outputDirectory, const Containers::Scene& scene, const char* platformIdentifier);
+                SCENE_CORE_API PreExportEventContext(ExportProductList& productList, const AZStd::string& outputDirectory, const Containers::Scene& scene, const char* platformIdentifier, bool debug = false);
+                SCENE_CORE_API PreExportEventContext(ExportProductList& productList, AZStd::string&& outputDirectory, const Containers::Scene& scene, const char* platformIdentifier, bool debug = false);
 
                 SCENE_CORE_API const AZStd::string& GetOutputDirectory() const;
                 SCENE_CORE_API ExportProductList& GetProductList();
                 SCENE_CORE_API const ExportProductList& GetProductList() const;
                 SCENE_CORE_API const Containers::Scene& GetScene() const;
                 SCENE_CORE_API const char* GetPlatformIdentifier() const;
+                SCENE_CORE_API bool GetDebug() const;
 
             private:
                 AZStd::string m_outputDirectory;
@@ -58,6 +59,8 @@ namespace AZ
                 * this const char* points at memory owned by the caller but it will always survive for the duration of the call.
                 */
                 const char* m_platformIdentifier = nullptr;
+
+                bool m_debug = false;
             };
 
             // Signals the scene that the contained scene needs to be exported to the specified directory.

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -591,7 +591,7 @@ namespace AZ::SceneAPI::Behaviors
         {
             rapidjson::PrettyWriter<rapidjson::StringBuffer, rapidjson::UTF8<>> writer(sb);
             writerResult = doc.Accept(writer);
-            productPath.append(".debug");
+            productPath.append(".json");
             assetType = {};
         }
         else

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.h
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.h
@@ -50,6 +50,13 @@ namespace AZ::SceneAPI::Behaviors
             const SceneData::PrefabGroup* prefabGroup,
             const rapidjson::Document& doc) const;
 
+        bool WriteOutProductAssetFile(
+            const AZStd::string& filePath,
+            Events::PreExportEventContext& context,
+            const SceneData::PrefabGroup* prefabGroup,
+            const rapidjson::Document& doc,
+            bool debug) const;
+
         struct ExportEventHandler;
         AZStd::shared_ptr<ExportEventHandler> m_exportEventHandler;
     };

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -389,18 +389,19 @@ namespace SceneBuilder
         AZ_TracePrintf(Utilities::LogWindow, "Creating export entities.\n");
         EntityConstructor::EntityPointer exporter = EntityConstructor::BuildEntity("Scene Exporters", ExportingComponent::TYPEINFO_Uuid());
 
+        auto itr = request.m_jobDescription.m_jobParameters.find(AZ_CRC_CE("DebugFlag"));
+        const bool isDebug = (itr != request.m_jobDescription.m_jobParameters.end() && itr->second == "true");
+
         ExportProductList productList;
         ProcessingResultCombiner result;
         AZ_TracePrintf(Utilities::LogWindow, "Preparing for export.\n");
-        result += Process<PreExportEventContext>(productList, outputFolder, *scene, platformIdentifier);
+        result += Process<PreExportEventContext>(productList, outputFolder, *scene, platformIdentifier, isDebug);
         AZ_TracePrintf(Utilities::LogWindow, "Exporting...\n");
         result += Process<ExportEventContext>(productList, outputFolder, *scene, platformIdentifier);
         AZ_TracePrintf(Utilities::LogWindow, "Finalizing export process.\n");
         result += Process<PostExportEventContext>(productList, outputFolder, platformIdentifier);
 
-        auto itr = request.m_jobDescription.m_jobParameters.find(AZ_CRC_CE("DebugFlag"));
-
-        if (itr != request.m_jobDescription.m_jobParameters.end() && itr->second == "true")
+        if (isDebug)
         {
             AZStd::string productName;
             AzFramework::StringFunc::Path::GetFullFileName(scene->GetSourceFilename().c_str(), productName);


### PR DESCRIPTION
adding a 'debug' flag in the PreExportEventContext so that the scene builders can write out a human readable version of the product assets the Prefab gem has been updated to use the flag when writing out a procedural prefab product asset using a pretty JSON printer

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>