### PR TITLE
Fix NoneType errors in EditorTest

### DIFF
--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -4,11 +4,12 @@ For complete copyright and license terms please see the LICENSE at the root of t
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 
-This file provides editor testing functionality to easily write automated editor tests for O3DE.
-For using these utilities, you can subclass your test suite from EditorTestSuite, this allows an easy way of
-specifying python test scripts that the editor will run without needing to write any boilerplace code.
-It supports out of the box parallelization(running multiple editor instances at once), batching(running multiple tests
-in the same editor instance) and crash detection.
+Simplified O3DE Editor test-writing utilities.
+
+Test writers should subclass a test suite from EditorTestSuite for easy specifcation of python test scripts for
+the editor to run. Tests can be parallelized (run in multiple editor instances at once) and/or batched (multiple tests
+run in the same editor instance), with collated results and crash detection.
+
 Usage example:
    class MyTestSuite(EditorTestSuite):
 
@@ -20,46 +21,38 @@ Usage example:
 
        class MyTestInParallel_2(EditorParallelTest):
            from . import yet_another_script_to_be_run_by_editor as test_module
-
-
-EditorTestSuite does introspection of the defined classes inside of it and automatically prepares the tests,
-parallelizing/batching as required
 """
 from __future__ import annotations
+
 import pytest
+import _pytest.python
 from _pytest.skipping import pytest_runtest_setup as skipping_pytest_runtest_setup
 
-import inspect
-from typing import List
-from abc import ABC
-from inspect import getmembers, isclass
-import os, sys
-import threading
-import inspect
-import math
-import json
-import logging
-import types
+import abc
 import functools
+import inspect
+import json
+import math
+import os
 import re
+import threading
+import types
 
-from os import path
-
-import ly_test_tools.environment.file_system as file_system
-import ly_test_tools.environment.waiter as waiter
 import ly_test_tools.environment.process_utils as process_utils
-import ly_test_tools.o3de.editor_test
 import ly_test_tools.o3de.editor_test_utils as editor_utils
-import ly_test_tools._internal.pytest_plugin
+import ly_test_tools._internal.pytest_plugin.test_tools_fixtures
 
 from ly_test_tools.o3de.asset_processor import AssetProcessor
 from ly_test_tools.launchers.exceptions import WaitTimeoutError
 
-# This file contains no tests, but with this we make sure it won't be picked up by the runner since the file ends with _test
+# This file contains ready-to-use test functions which are not actual tests, avoid pytest collection
 __test__ = False
 
-# Abstract base class for an editor test.
-class EditorTestBase(ABC):
+
+class EditorTestBase(abc.ABC):
+    """
+    Abstract Editor Test
+    """
     # Maximum time for run, in seconds
     timeout = 180
     # Test file that this test will run
@@ -70,46 +63,74 @@ class EditorTestBase(ABC):
     # Wait until a debugger is attached at the startup of the test, this is another way of debugging.
     wait_for_debugger = False
 
-# Test that will be run alone in one editor
-class EditorSingleTest(EditorTestBase):
-    #- Configurable params -#
-    # Extra cmdline arguments to supply to the editor for the test
-    extra_cmdline_args = []
-    # Whether to use null renderer, this will override use_null_renderer for the Suite if not None
-    use_null_renderer = None
 
-    # Custom setup function, will run before the test
+class EditorSingleTest(EditorTestBase):
+    """
+    Test that will be run alone in one editor, with no parallel editors
+    """
+    def __init__(self):
+        # Extra cmdline arguments to supply to the editor for the test
+        self.extra_cmdline_args = []
+        # Whether to use null renderer, this will override use_null_renderer for the Suite if not None
+        self.use_null_renderer = None
+
     @staticmethod
     def setup(instance, request, workspace, editor, editor_test_results, launcher_platform):
+        """
+        User-overrideable setup function, which will run before the test
+        """
         pass
 
-    # Custom run wrapping. The code before yield will run before the test, and after the yield after the test
     @staticmethod
     def wrap_run(instance, request, workspace, editor, editor_test_results, launcher_platform):
+        """
+        User-overrideable wrapper function, which will run before and after test.
+        Any code before the 'yield' statement will run before the test. With code after yield run after the test.
+        """
         yield
 
-    # Custom teardown function, will run after the test    
     @staticmethod
     def teardown(instance, request, workspace, editor, editor_test_results, launcher_platform):
+        """
+        User-overrideable teardown function, which will run after the test
+        """
         pass
 
-# Test that will be both be run in parallel and batched with eachother in a single editor.
-# Does not support per test setup/teardown for avoiding any possible race conditions
+
 class EditorSharedTest(EditorTestBase):
+    """
+    Test that will be run in parallel with tests in different editor instances, as well as serially batched with other
+    tests in each editor instance. Minimizes total test run duration.
+
+    Does not support per test setup/teardown to avoid creating race conditions
+    """
     # Specifies if the test can be batched in the same editor
     is_batchable = True
     # Specifies if the test can be run in multiple editors in parallel
     is_parallelizable = True
 
-# Test that will be only run in parallel editors.
+
 class EditorParallelTest(EditorSharedTest):
+    """
+    Test that will be run in parallel with tests in different editor instances, though not serially batched with other
+    tests in each editor instance. Reduces total test run duration, while limiting side-effects between tests.
+
+    Does not support per test setup/teardown to avoid creating race conditions
+    """
     is_batchable = False
     is_parallelizable = True
 
-# Test that will be batched along with the other batched tests in the same editor.
+
 class EditorBatchedTest(EditorSharedTest):
+    """
+    Test that will be batched along with the other batched tests in the same editor instance, though not executed in
+    parallel with other editor instances. Reduces repeated overhead from starting the Editor.
+
+    Does not support per test setup/teardown to avoid creating race conditions
+    """
     is_batchable = True
     is_parallelizable = False
+
 
 class Result:
     class Base:
@@ -117,10 +138,11 @@ class Result:
             # type () -> str
             """
             Checks if the output attribute exists and returns it.
-            :return: Either the output string or a no output message
+            :return: Output string from running a test, or a no output message
             """
-            if hasattr(self, "output") and self.output is not None:
-                return self.output
+            output = getattr(self, "output", None)
+            if output:
+                return output
             else:
                 return "-- No output --"
             
@@ -130,26 +152,24 @@ class Result:
             Checks if the editor_log attribute exists and returns it.
             :return: Either the editor_log string or a no output message
             """
-            if hasattr(self, "editor_log") and self.editor_log is not None:
-                return self.editor_log
+            log = getattr(self, "editor_log", None)
+            if log:
+                return log
             else:
                 return "-- No editor log found --"
 
     class Pass(Base):
-        @classmethod
-        def create(cls, test_spec: EditorTestBase, output: str, editor_log: str) -> Pass:
+
+        def __init__(self, test_spec: type(EditorTestBase), output: str, editor_log: str):
             """
-            Creates a Pass object with a given test spec, output string, and editor log string.
+            Represents a test success
             :test_spec: The type of EditorTestBase
             :output: The test output
             :editor_log: The editor log's output
-            :return: the Pass object
             """
-            r = cls()
-            r.test_spec = test_spec
-            r.output = output
-            r.editor_log = editor_log
-            return r
+            self.test_spec = test_spec
+            self.output = output
+            self.editor_log = editor_log
 
         def __str__(self):
             output = (
@@ -161,21 +181,18 @@ class Result:
             )
             return output
 
-    class Fail(Base):       
-        @classmethod
-        def create(cls, test_spec: EditorTestBase, output: str, editor_log: str) -> Fail:
+    class Fail(Base):
+
+        def __init__(self, test_spec: type(EditorTestBase), output: str, editor_log: str):
             """
-            Creates a Fail object with a given test spec, output string, and editor log string.
+            Represents a normal test failure
             :test_spec: The type of EditorTestBase
             :output: The test output
             :editor_log: The editor log's output
-            :return: the Fail object
             """
-            r = cls()
-            r.test_spec = test_spec
-            r.output = output
-            r.editor_log = editor_log
-            return r
+            self.test_spec = test_spec
+            self.output = output
+            self.editor_log = editor_log
             
         def __str__(self):
             output = (
@@ -192,25 +209,22 @@ class Result:
             return output
 
     class Crash(Base):
-        @classmethod
-        def create(cls, test_spec: EditorTestBase, output: str, ret_code: int, stacktrace: str, editor_log: str) -> Crash:
+
+        def __init__(self, test_spec: type(EditorTestBase), output: str, ret_code: int, stacktrace: str,
+                     editor_log: str):
             """
-            Creates a Crash object with a given test spec, output string, and editor log string. This also includes the
-            return code and stacktrace.
+            Represents a test which failed with an unexpected crash
             :test_spec: The type of EditorTestBase
             :output: The test output
             :ret_code: The test's return code
             :stacktrace: The test's stacktrace if available
             :editor_log: The editor log's output
-            :return: The Crash object
             """
-            r = cls()
-            r.output = output
-            r.test_spec = test_spec
-            r.ret_code = ret_code
-            r.stacktrace = stacktrace
-            r.editor_log = editor_log
-            return r
+            self.output = output
+            self.test_spec = test_spec
+            self.ret_code = ret_code
+            self.stacktrace = stacktrace
+            self.editor_log = editor_log
             
         def __str__(self):
             stacktrace_str = "-- No stacktrace data found --" if not self.stacktrace else self.stacktrace
@@ -232,27 +246,24 @@ class Result:
             return output
 
     class Timeout(Base):
-        @classmethod
-        def create(cls, test_spec: EditorTestBase, output: str, time_secs: float, editor_log: str) -> Timeout:
+
+        def __init__(self, test_spec: type(EditorTestBase), output: str, time_secs: float, editor_log: str):
             """
-            Creates a Timeout object with a given test spec, output string, and editor log string. The timeout time
-            should be provided in seconds
+            Represents a test which failed due to freezing, hanging, or executing slowly
             :test_spec: The type of EditorTestBase
             :output: The test output
             :time_secs: The timeout duration in seconds
             :editor_log: The editor log's output
             :return: The Timeout object
             """
-            r = cls()
-            r.output = output
-            r.test_spec = test_spec
-            r.time_secs = time_secs
-            r.editor_log = editor_log
-            return r
+            self.output = output
+            self.test_spec = test_spec
+            self.time_secs = time_secs
+            self.editor_log = editor_log
             
         def __str__(self):
             output = (
-                f"Test TIMED OUT after {self.time_secs} seconds\n"
+                f"Test ABORTED after not completing within {self.time_secs} seconds\n"
                 f"------------\n"
                 f"|  Output  |\n"
                 f"------------\n"
@@ -265,26 +276,24 @@ class Result:
             return output
 
     class Unknown(Base):
-        @classmethod
-        def create(cls, test_spec: EditorTestBase, output: str, extra_info: str, editor_log: str) -> Unknown:
+
+        def __init__(self, test_spec: type(EditorTestBase), output: str = None, extra_info: str = None,
+                     editor_log: str = None):
             """
-            Creates an Unknown test results object if something goes wrong.
+            Represents a failure that the test framework cannot classify
             :test_spec: The type of EditorTestBase
             :output: The test output
             :extra_info: Any extra information as a string
             :editor_log: The editor log's output
-            :return: The Unknown object
             """
-            r = cls()
-            r.output = output
-            r.test_spec = test_spec
-            r.editor_log = editor_log
-            r.extra_info = extra_info
-            return r
+            self.output = output
+            self.test_spec = test_spec
+            self.editor_log = editor_log
+            self.extra_info = extra_info
 
         def __str__(self):
             output = (
-                f"Unknown test result, possible cause: {self.extra_info}\n"
+                f"Indeterminate test result interpreted as failure, possible cause: {self.extra_info}\n"
                 f"------------\n"
                 f"|  Output  |\n"
                 f"------------\n"
@@ -296,10 +305,9 @@ class Result:
             )
             return output
 
+
 @pytest.mark.parametrize("crash_log_watchdog", [("raise_on_crash", False)])
-class EditorTestSuite():
-    #- Configurable params -#
-    
+class EditorTestSuite:
     # Extra cmdline arguments to supply for every editor instance for this test suite
     global_extra_cmdline_args = ["-BatchMode", "-autotest_mode"]
     # Tests usually run with no renderer, however some tests require a renderer 
@@ -309,35 +317,34 @@ class EditorTestSuite():
     # Flag to determine whether to use new prefab system or use deprecated slice system for this test suite
     enable_prefab_system = True
 
-    # Function to calculate number of editors to run in parallel, this can be overriden by the user
+    # Function to calculate number of editors to run in parallel, this can be overridden by the user
     @staticmethod
     def get_number_parallel_editors():
         return 8
 
-    ## Internal ##
-    _TIMEOUT_CRASH_LOG = 20 # Maximum time (seconds) for waiting for a crash file, in seconds
-    _TEST_FAIL_RETCODE = 0xF # Return code for test failure
+    _TIMEOUT_CRASH_LOG = 20  # Maximum time (seconds) for waiting for a crash file, in seconds
+    _TEST_FAIL_RETCODE = 0xF  # Return code for test failure
+
+    class TestData:
+        def __init__(self):
+            self.results = {}  # Dict of str(test_spec.__name__) -> Result
+            self.asset_processor = None
 
     @pytest.fixture(scope="class")
-    def editor_test_data(self, request: Request) -> TestData:
+    def editor_test_data(self, request: _pytest.fixtures.FixtureRequest) -> EditorTestSuite.TestData:
         """
         Yields a per-testsuite structure to store the data of each test result and an AssetProcessor object that will be
         re-used on the whole suite
-        :request: The Pytest request
+        :request: The Pytest request object
         :yield: The TestData object
         """
         yield from self._editor_test_data(request)
 
-    def _editor_test_data(self, request: Request) -> TestData:
+    def _editor_test_data(self, request: _pytest.fixtures.FixtureRequest) -> EditorTestSuite.TestData:
         """
-        A wrapper function for unit testing to call directly
+        A wrapper function for unit testing of this file to call directly. Do not use in production.
         """
-        class TestData():
-            def __init__(self):
-                self.results = {} # Dict of str(test_spec.__name__) -> Result
-                self.asset_processor = None
-
-        test_data = TestData()
+        test_data = EditorTestSuite.TestData()
         yield test_data
         if test_data.asset_processor:
             test_data.asset_processor.stop(1)
@@ -347,7 +354,7 @@ class EditorTestSuite():
         else:
             editor_utils.kill_all_ly_processes(include_asset_processor=False)
 
-    class Runner():
+    class Runner:
         def __init__(self, name, func, tests):
             self.name = name
             self.func = func
@@ -355,21 +362,23 @@ class EditorTestSuite():
             self.run_pytestfunc = None
             self.result_pytestfuncs = []
 
-    # Custom collector class. This collector is where the magic happens, it programatically adds the test functions
-    # to the class based on the test specifications used in the TestSuite class.
     class EditorTestClass(pytest.Class):
+        """
+        Custom pytest collector which programmatically adds test functions based on data in the TestSuite class
+        """
 
         def collect(self):
+            """
+            This collector does the following:
+            1) Iterates through all the EditorSingleTest subclasses defined inside the suite.
+               Adds a test function to the suite to run each separately, and report results
+            2) Iterates through all the EditorSharedTest subclasses defined inside the suite,
+               grouping tests based on the specs in by 3 categories: batched, parallel and batched+parallel.
+               Each category gets a single test runner function registered to run all the tests of the category
+               A result function will be added for every individual test, which will pass/fail based on the results
+               from the previously executed runner function
+            """
             cls = self.obj
-            # This collector does the following:
-            # 1) Iterates through all the EditorSingleTest subclasses defined inside the suite.
-            #    With these, it adds a test function to the suite per each, that will run the test using the specs
-            # 2) Iterates through all the EditorSharedTest subclasses defined inside the suite.
-            #    The subclasses then are grouped based on the specs in by 3 categories: 
-            #    batched, parallel and batched+parallel. 
-            #    Each category will have a test runner function associated that will run all the tests of the category,
-            #    then a result function will be added for every test, which will pass/fail based on what happened in the previos
-            #    runner function
 
             # Decorator function to add extra lookup information for the test functions
             def set_marks(marks):
@@ -405,8 +414,9 @@ class EditorTestSuite():
             # Add the single tests, these will run normally
             for test_spec in single_tests:
                 name = test_spec.__name__
+
                 def make_test_func(name, test_spec):
-                    @set_marks({"run_type" : "run_single"})
+                    @set_marks({"run_type": "run_single"})
                     def single_run(self, request, workspace, editor, editor_test_data, launcher_platform):
                         # only single tests are allowed to have setup/teardown, however we can have shared tests that
                         # were explicitly set as single, for example via cmdline argument override
@@ -437,8 +447,9 @@ class EditorTestSuite():
 
             def create_runner(name, function, tests):
                 runner = EditorTestSuite.Runner(name, function, tests)
+
                 def make_func():
-                    @set_marks({"runner" : runner, "run_type" : "run_shared"})
+                    @set_marks({"runner": runner, "run_type": "run_shared"})
                     def shared_run(self, request, workspace, editor, editor_test_data, launcher_platform):
                         getattr(self, function.__name__)(request, workspace, editor, editor_test_data, runner.tests)
                     return shared_run
@@ -447,7 +458,7 @@ class EditorTestSuite():
                 # Add the shared tests results, these just succeed/fail based what happened on the Runner.
                 for test_spec in tests:
                     def make_func(test_spec):
-                        @set_marks({"runner" : runner, "test_spec" : test_spec, "run_type" : "result"})
+                        @set_marks({"runner": runner, "test_spec": test_spec, "run_type": "result"})
                         def result(self, request, workspace, editor, editor_test_data, launcher_platform):
                             # The runner must have filled the editor_test_data.results dict fixture for this test.
                             # Hitting this assert could mean if there was an error executing the runner
@@ -472,13 +483,16 @@ class EditorTestSuite():
             # Override the istestfunction for the object, with this we make sure that the
             # runners are always collected, even if they don't follow the "test_" naming
             original_istestfunction = instance.istestfunction
+
             def istestfunction(self, obj, name):
                 ret = original_istestfunction(obj, name)
                 if not ret:
                     ret = hasattr(obj, "marks")
                 return ret
+
             instance.istestfunction = types.MethodType(istestfunction, instance)
             collection = instance.collect()
+
             def get_func_run_type(f):
                 return getattr(f, "marks", {}).setdefault("run_type", None)
 
@@ -492,7 +506,7 @@ class EditorTestSuite():
             # be deselected by any filtering mechanism. The result functions for these we are actually
             # interested on them to be filtered to tell what is the final subset of tests to run
             collection = [
-                item for item in collection if item not in (collected_run_pytestfuncs)
+                item for item in collection if item not in collected_run_pytestfuncs
             ]
                             
             # Match each generated pytestfunctions with every runner and store them 
@@ -507,13 +521,13 @@ class EditorTestSuite():
             self.obj._runners = runners
             return collection
 
-
     @staticmethod
     def pytest_custom_makeitem(collector, name, obj):
         return EditorTestSuite.EditorTestClass(name, collector)
 
     @classmethod
-    def pytest_custom_modify_items(cls, session: Session, items: list[EditorTestBase], config: Config) -> None:
+    def pytest_custom_modify_items(cls, session: _pytest.main.Session, items: list[EditorTestBase],
+                                   config: _pytest.config.Config) -> None:
         """
         Adds the runners' functions and filters the tests that will run. The runners will be added if they have any
         selected tests
@@ -563,7 +577,7 @@ class EditorTestSuite():
         return shared_tests
 
     @classmethod
-    def get_session_shared_tests(cls, session: Session) -> list[EditorTestBase]:
+    def get_session_shared_tests(cls, session: _pytest.main.Session) -> list[EditorTestBase]:
         """
         Filters and returns all of the shared tests in a given session.
         :session: The test session
@@ -573,7 +587,7 @@ class EditorTestSuite():
         return cls.filter_session_shared_tests(session, shared_tests)
 
     @staticmethod
-    def filter_session_shared_tests(session_items: list[EditorTestBase], shared_tests: list[EditorSharedTest]) -> list[EditorTestBase]:
+    def filter_session_shared_tests(session_items: list[_pytest.python.Function(EditorTestBase)], shared_tests: list[EditorSharedTest]) -> list[EditorTestBase]:
         """
         Retrieve the test sub-set that was collected this can be less than the original set if were overriden via -k
         argument or similars
@@ -585,10 +599,10 @@ class EditorTestSuite():
             try:
                 skipping_pytest_runtest_setup(item)
                 return True
-            except:
+            except Exception:  # intentionally broad
                 return False
         
-        session_items_by_name = { item.originalname:item for item in session_items }
+        session_items_by_name = {item.originalname: item for item in session_items}
         selected_shared_tests = [test for test in shared_tests if test.__name__ in session_items_by_name.keys() and
                                  will_run(session_items_by_name[test.__name__])]
         return selected_shared_tests
@@ -611,8 +625,8 @@ class EditorTestSuite():
             )
         ]
 
-    ### Utils ###
-    def _prepare_asset_processor(self, workspace: AbstractWorkspace, editor_test_data: TestData) -> None:
+    def _prepare_asset_processor(self, workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                                 editor_test_data: TestData) -> None:
         """
         Prepares the asset processor for the test depending on whether or not the process is open and if the current
         test owns it.
@@ -637,7 +651,9 @@ class EditorTestSuite():
             editor_test_data.asset_processor = None
             raise ex
 
-    def _setup_editor_test(self, editor: Editor, workspace: AbstractWorkspace, editor_test_data: TestData) -> None:
+    def _setup_editor_test(self, editor: ly_test_tools.launchers.platforms.base.Launcher,
+                           workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                           editor_test_data: TestData) -> None:
         """
         Sets up an editor test by preparing the Asset Processor, killing all other O3DE processes, and configuring
         :editor: The launcher Editor object
@@ -667,8 +683,8 @@ class EditorTestSuite():
             try:
                 elem = json.loads(m.groups()[0])
                 found_jsons[elem["name"]] = elem
-            except Exception:
-                continue # Avoid to fail if the output data is corrupt
+            except Exception:  # Intentionally broad to avoid failing if the output data is corrupt
+                continue
         
         # Try to find the element in the log, this is used for cutting the log contents later
         log_matches = pattern.finditer(editor_log_content)
@@ -677,16 +693,16 @@ class EditorTestSuite():
                 elem = json.loads(m.groups()[0])
                 if elem["name"] in found_jsons:
                     found_jsons[elem["name"]]["log_match"] = m
-            except Exception:
-                continue # Avoid to fail if the log data is corrupt
+            except Exception:  # Intentionally broad, to avoid failing if the log data is corrupt
+                continue
 
         log_start = 0
         for test_spec in test_spec_list:
             name = editor_utils.get_module_filename(test_spec.test_module)
             if name not in found_jsons.keys():
-                results[test_spec.__name__] = Result.Unknown.create(test_spec, output,
-                                                                    "Couldn't find any test run information on stdout",
-                                                                    editor_log_content)
+                results[test_spec.__name__] = Result.Unknown(test_spec, output,
+                                                             "Found no test run information on stdout",
+                                                             editor_log_content)
             else:
                 result = None
                 json_result = found_jsons[name]
@@ -698,13 +714,13 @@ class EditorTestSuite():
                     end = m.end() if test_spec != test_spec_list[-1] else -1
                 else:
                     end = -1
-                cur_log = editor_log_content[log_start : end]
+                cur_log = editor_log_content[log_start: end]
                 log_start = end
 
                 if json_result["success"]:
-                    result = Result.Pass.create(test_spec, json_output, cur_log)
+                    result = Result.Pass(test_spec, json_output, cur_log)
                 else:
-                    result = Result.Fail.create(test_spec, json_output, cur_log)
+                    result = Result.Fail(test_spec, json_output, cur_log)
                 results[test_spec.__name__] = result
 
         return results
@@ -724,9 +740,11 @@ class EditorTestSuite():
             error_str = f"Test {name}:\n{str(result)}"
             pytest.fail(error_str)
 
-    ### Running tests ###
-    def _exec_editor_test(self, request: Request, workspace: AbstractWorkspace, editor: Editor, run_id: int,
-                          log_name: str, test_spec: EditorTestBase, cmdline_args: list[str] = []) -> dict[str, Result]:
+    def _exec_editor_test(self, request: _pytest.fixtures.FixtureRequest,
+                          workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                          editor: ly_test_tools.launchers.platforms.base.Launcher,
+                          run_id: int, log_name: str, test_spec: EditorTestBase,
+                          cmdline_args: list[str] = None) -> dict[str, Result]:
         """
         Starts the editor with the given test and retuns an result dict with a single element specifying the result
         :request: The pytest request
@@ -738,6 +756,8 @@ class EditorTestSuite():
         :cmdline_args: Any additional command line args
         :return: a dictionary of Result objects
         """
+        if cmdline_args is None:
+            cmdline_args = []
         test_cmdline_args = self.global_extra_cmdline_args + cmdline_args
         test_spec_uses_null_renderer = getattr(test_spec, "use_null_renderer", None)
         if test_spec_uses_null_renderer or (test_spec_uses_null_renderer is None and self.use_null_renderer):
@@ -749,7 +769,7 @@ class EditorTestSuite():
         if self.enable_prefab_system:
             test_cmdline_args += [
                 "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-                f"--regset-file={path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
+                f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
         else:
             test_cmdline_args += ["--regset=/Amazon/Preferences/EnablePrefabSystem=false"]
 
@@ -764,7 +784,7 @@ class EditorTestSuite():
             "-logfile", f"@log@/{log_name}",
             "-project-log-path", editor_utils.retrieve_log_path(run_id, workspace)] + test_cmdline_args
         editor.args.extend(cmdline)
-        editor.start(backupFiles = False, launch_ap = False, configure_settings=False)
+        editor.start(backupFiles=False, launch_ap=False, configure_settings=False)
 
         try:
             editor.wait(test_spec.timeout)
@@ -775,31 +795,35 @@ class EditorTestSuite():
             workspace.artifact_manager.save_artifact(os.path.join(editor_utils.retrieve_log_path(run_id, workspace), log_name),
                                                      f'({run_id}){log_name}')
             if return_code == 0:
-                test_result = Result.Pass.create(test_spec, output, editor_log_content)
+                test_result = Result.Pass(test_spec, output, editor_log_content)
             else:
                 has_crashed = return_code != EditorTestSuite._TEST_FAIL_RETCODE
                 if has_crashed:
-                    test_result = Result.Crash.create(test_spec, output, return_code, editor_utils.retrieve_crash_output
-                    (run_id, workspace, self._TIMEOUT_CRASH_LOG), None)
+                    crash_output = editor_utils.retrieve_crash_output(run_id, workspace, self._TIMEOUT_CRASH_LOG)
+                    test_result = Result.Crash(test_spec, output, return_code, crash_output, None)
                     # Save the crash log
                     crash_file_name = os.path.basename(workspace.paths.crash_log())
-                    workspace.artifact_manager.save_artifact(os.path.join(editor_utils.retrieve_log_path(run_id, workspace), crash_file_name))
+                    workspace.artifact_manager.save_artifact(
+                        os.path.join(editor_utils.retrieve_log_path(run_id, workspace), crash_file_name))
                     editor_utils.cycle_crash_report(run_id, workspace)
                 else:
-                    test_result = Result.Fail.create(test_spec, output, editor_log_content)
+                    test_result = Result.Fail(test_spec, output, editor_log_content)
         except WaitTimeoutError:
             output = editor.get_output()
             editor.stop()
             editor_log_content = editor_utils.retrieve_editor_log_content(run_id, log_name, workspace)
-            test_result = Result.Timeout.create(test_spec, output, test_spec.timeout, editor_log_content)
+            test_result = Result.Timeout(test_spec, output, test_spec.timeout, editor_log_content)
     
         editor_log_content = editor_utils.retrieve_editor_log_content(run_id, log_name, workspace)
         results = self._get_results_using_output([test_spec], output, editor_log_content)
         results[test_spec.__name__] = test_result
         return results
 
-    def _exec_editor_multitest(self, request: Request, workspace: AbstractWorkspace, editor: Editor, run_id: int, log_name: str,
-                               test_spec_list: list[EditorTestBase], cmdline_args: list[str] = []) -> dict[str, Result]:
+    def _exec_editor_multitest(self, request: _pytest.fixtures.FixtureRequest,
+                               workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                               editor: ly_test_tools.launchers.platforms.base.Launcher, run_id: int, log_name: str,
+                               test_spec_list: list[EditorTestBase],
+                               cmdline_args: list[str] = None) -> dict[str, Result]:
         """
         Starts an editor executable with a list of tests and returns a dict of the result of every test ran within that
         editor instance. In case of failure this function also parses the editor output to find out what specific tests
@@ -813,6 +837,8 @@ class EditorTestSuite():
         :cmdline_args: Any additional command line args
         :return: A dict of Result objects
         """
+        if cmdline_args is None:
+            cmdline_args = []
         test_cmdline_args = self.global_extra_cmdline_args + cmdline_args
         if self.use_null_renderer:
             test_cmdline_args += ["-rhi=null"]
@@ -823,7 +849,7 @@ class EditorTestSuite():
         if self.enable_prefab_system:
             test_cmdline_args += [
                 "--regset=/Amazon/Preferences/EnablePrefabSystem=true",
-                f"--regset-file={path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
+                f"--regset-file={os.path.join(workspace.paths.engine_root(), 'Registry', 'prefab.test.setreg')}"]
         else:
             test_cmdline_args += ["--regset=/Amazon/Preferences/EnablePrefabSystem=false"]
 
@@ -853,7 +879,7 @@ class EditorTestSuite():
             if return_code == 0:
                 # No need to scrape the output, as all the tests have passed
                 for test_spec in test_spec_list:
-                    results[test_spec.__name__] = Result.Pass.create(test_spec, output, editor_log_content)
+                    results[test_spec.__name__] = Result.Pass(test_spec, output, editor_log_content)
             else:
                 # Scrape the output to attempt to find out which tests failed.
                 # This function should always populate the result list, if it didn't find it, it will have "Unknown" type of result
@@ -875,8 +901,8 @@ class EditorTestSuite():
                                 workspace.artifact_manager.save_artifact(
                                     os.path.join(editor_utils.retrieve_log_path(run_id, workspace), crash_file_name))
                                 editor_utils.cycle_crash_report(run_id, workspace)
-                                results[test_spec_name] = Result.Crash.create(result.test_spec, output, return_code,
-                                                                              crash_error, result.editor_log)
+                                results[test_spec_name] = Result.Crash(result.test_spec, output, return_code,
+                                                                       crash_error, result.editor_log)
                                 crashed_result = result
                             else:
                                 # If there are remaning "Unknown" results, these couldn't execute because of the crash,
@@ -888,8 +914,8 @@ class EditorTestSuite():
                     if not crashed_result:
                         crash_error = editor_utils.retrieve_crash_output(run_id, workspace, self._TIMEOUT_CRASH_LOG)
                         editor_utils.cycle_crash_report(run_id, workspace)
-                        results[test_spec_name] = Result.Crash.create(crashed_result.test_spec, output, return_code,
-                                                                      crash_error, crashed_result.editor_log)
+                        results[test_spec_name] = Result.Crash(crashed_result.test_spec, output, return_code,
+                                                               crash_error, crashed_result.editor_log)
         except WaitTimeoutError:            
             editor.stop()
             output = editor.get_output()
@@ -903,9 +929,9 @@ class EditorTestSuite():
             for test_spec_name, result in results.items():
                 if isinstance(result, Result.Unknown):
                     if not timed_out_result:
-                        results[test_spec_name] = Result.Timeout.create(result.test_spec, result.output,
-                                                                        self.timeout_editor_shared_test,
-                                                                        result.editor_log)
+                        results[test_spec_name] = Result.Timeout(result.test_spec, result.output,
+                                                                 self.timeout_editor_shared_test,
+                                                                 result.editor_log)
                         timed_out_result = result
                     else:
                         # If there are remaning "Unknown" results, these couldn't execute because of the timeout,
@@ -915,12 +941,14 @@ class EditorTestSuite():
                                                              f"before this test could be executed"
             # if all the tests ran, the one that has caused the timeout is the last test, as it didn't close the editor
             if not timed_out_result:
-                results[test_spec_name] = Result.Timeout.create(timed_out_result.test_spec,
-                                                                results[test_spec_name].output,
-                                                                self.timeout_editor_shared_test, result.editor_log)
+                results[test_spec_name] = Result.Timeout(timed_out_result.test_spec,
+                                                         results[test_spec_name].output,
+                                                         self.timeout_editor_shared_test, result.editor_log)
         return results
     
-    def _run_single_test(self, request: Request, workspace: AbstractWorkspace, editor: Editor,
+    def _run_single_test(self, request: _pytest.fixtures.FixtureRequest,
+                         workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                         editor: ly_test_tools.launchers.platforms.base.Launcher,
                          editor_test_data: TestData, test_spec: EditorSingleTest) -> None:
         """
         Runs a single test (one editor, one test) with the given specs
@@ -936,16 +964,20 @@ class EditorTestSuite():
         if hasattr(test_spec, "extra_cmdline_args"):
             extra_cmdline_args = test_spec.extra_cmdline_args
 
-        results = self._exec_editor_test(request, workspace, editor, 1, "editor_test.log", test_spec, extra_cmdline_args)
-        editor_test_data.results.update(results)
-        test_name, test_result = next(iter(results.items()))
+        result = self._exec_editor_test(request, workspace, editor, 1, "editor_test.log", test_spec, extra_cmdline_args)
+        if result is None:
+            result = Result.Unknown(test_spec=EditorSingleTest)
+        editor_test_data.results.update(result)
+        test_name, test_result = next(iter(result.items()))
         self._report_result(test_name, test_result)
         # If test did not pass, save assets with errors and warnings
         if not isinstance(test_result, Result.Pass):
             editor_utils.save_failed_asset_joblogs(workspace)
 
-    def _run_batched_tests(self, request: Request, workspace: AbstractWorkspace, editor: Editor, editor_test_data: TestData,
-                           test_spec_list: list[EditorSharedTest], extra_cmdline_args: list[str] = []) -> None:
+    def _run_batched_tests(self, request: _pytest.fixtures.FixtureRequest,
+                           workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                           editor: ly_test_tools.launchers.platforms.base.Launcher, editor_test_data: TestData,
+                           test_spec_list: list[EditorSharedTest], extra_cmdline_args: list[str] = None) -> None:
         """
         Runs a batch of tests in one single editor with the given spec list (one editor, multiple tests)
         :request: The Pytest Request
@@ -956,22 +988,28 @@ class EditorTestSuite():
         :extra_cmdline_args: Any extra command line args in a list
         :return: None
         """
+        if extra_cmdline_args is None:
+            extra_cmdline_args = []
+
         if not test_spec_list:
             return
 
         self._setup_editor_test(editor, workspace, editor_test_data)
         results = self._exec_editor_multitest(request, workspace, editor, 1, "editor_test.log", test_spec_list,
                                               extra_cmdline_args)
-        assert results is not None
         editor_test_data.results.update(results)
         # If at least one test did not pass, save assets with errors and warnings
         for result in results:
+            if result is None:
+                result = Result.Unknown(test_spec=EditorBatchedTest)
             if not isinstance(result, Result.Pass):
                 editor_utils.save_failed_asset_joblogs(workspace)
                 return
 
-    def _run_parallel_tests(self, request: Request, workspace: AbstractWorkspace, editor: Editor, editor_test_data: TestData,
-                            test_spec_list: list[EditorSharedTest], extra_cmdline_args: list[str] = []) -> None:
+    def _run_parallel_tests(self, request: _pytest.fixtures.FixtureRequest,
+                            workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                            editor: ly_test_tools.launchers.platforms.base.Launcher, editor_test_data: TestData,
+                            test_spec_list: list[EditorSharedTest], extra_cmdline_args: list[str] = None) -> None:
         """
         Runs multiple editors with one test on each editor (multiple editor, one test each)
         :request: The Pytest Request
@@ -982,6 +1020,9 @@ class EditorTestSuite():
         :extra_cmdline_args: Any extra command line args in a list
         :return: None
         """
+        if extra_cmdline_args is None:
+            extra_cmdline_args = []
+
         if not test_spec_list:
             return
 
@@ -1016,7 +1057,10 @@ class EditorTestSuite():
                 t.join()
 
             save_asset_logs = False
+
             for result in results_per_thread:
+                if result is None:
+                    result = Result.Unknown(test_spec=EditorParallelTest)
                 editor_test_data.results.update(result)
                 if not isinstance(result, Result.Pass):
                     save_asset_logs = True
@@ -1024,8 +1068,10 @@ class EditorTestSuite():
             if save_asset_logs:
                 editor_utils.save_failed_asset_joblogs(workspace)
 
-    def _run_parallel_batched_tests(self, request: Request, workspace: AbstractWorkspace, editor: Editor, editor_test_data: TestData,
-                                    test_spec_list: list[EditorSharedTest], extra_cmdline_args: list[str] = []) -> None:
+    def _run_parallel_batched_tests(self, request: _pytest.fixtures.FixtureRequest,
+                                    workspace: ly_test_tools._internal.managers.workspace.AbstractWorkspaceManager,
+                                    editor: ly_test_tools.launchers.platforms.base.Launcher, editor_test_data: TestData,
+                                    test_spec_list: list[EditorSharedTest], extra_cmdline_args: list[str] = None) -> None:
         """
         Runs multiple editors with a batch of tests for each editor (multiple editor, multiple tests each)
         :request: The Pytest Request
@@ -1036,6 +1082,9 @@ class EditorTestSuite():
         :extra_cmdline_args: Any extra command line args in a list
         :return: None
         """
+        if extra_cmdline_args is None:
+            extra_cmdline_args = []
+
         if not test_spec_list:
             return
 
@@ -1047,6 +1096,7 @@ class EditorTestSuite():
         results_per_thread = [None] * total_threads
         for i in range(total_threads):
             tests_for_thread = test_spec_list[i*tests_per_editor:(i+1)*tests_per_editor]
+
             def make_func(test_spec_list_for_editor, index, my_editor):
                 def run(request, workspace, extra_cmdline_args):
                     results = None
@@ -1072,6 +1122,8 @@ class EditorTestSuite():
 
         save_asset_logs = False
         for result in results_per_thread:
+            if result is None:
+                result = Result.Unknown(test_spec=EditorSharedTest)
             editor_test_data.results.update(result)
             if not isinstance(result, Result.Pass):
                 save_asset_logs = True
@@ -1079,7 +1131,7 @@ class EditorTestSuite():
         if save_asset_logs:
             editor_utils.save_failed_asset_joblogs(workspace)
 
-    def _get_number_parallel_editors(self, request: Request) -> int:
+    def _get_number_parallel_editors(self, request: _pytest.fixtures.FixtureRequest) -> int:
         """
         Retrieves the number of parallel preference cmdline overrides
         :request: The Pytest Request

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -700,9 +700,10 @@ class EditorTestSuite:
         for test_spec in test_spec_list:
             name = editor_utils.get_module_filename(test_spec.test_module)
             if name not in found_jsons.keys():
-                results[test_spec.__name__] = Result.Unknown(test_spec, output,
-                                                             "Found no test run information on stdout",
-                                                             editor_log_content)
+                results[test_spec.__name__] = Result.Unknown(
+                    test_spec, output,
+                    f"Found no test run information on stdout for {name} in the editor log",
+                    editor_log_content)
             else:
                 result = None
                 json_result = found_jsons[name]
@@ -966,7 +967,8 @@ class EditorTestSuite:
 
         result = self._exec_editor_test(request, workspace, editor, 1, "editor_test.log", test_spec, extra_cmdline_args)
         if result is None:
-            result = Result.Unknown(test_spec=EditorSingleTest)
+            result = Result.Unknown(test_spec=test_spec,
+                                    extra_info="Unexpectedly found no test run information on stdout in the editor log")
         editor_test_data.results.update(result)
         test_name, test_result = next(iter(result.items()))
         self._report_result(test_name, test_result)
@@ -1001,7 +1003,8 @@ class EditorTestSuite:
         # If at least one test did not pass, save assets with errors and warnings
         for result in results:
             if result is None:
-                result = Result.Unknown(test_spec=EditorBatchedTest)
+                result = Result.Unknown(test_spec=EditorBatchedTest,
+                                        extra_info=f"Unexpectedly found no test run information on stdout in the editor log")
             if not isinstance(result, Result.Pass):
                 editor_utils.save_failed_asset_joblogs(workspace)
                 return
@@ -1060,7 +1063,8 @@ class EditorTestSuite:
 
             for result in results_per_thread:
                 if result is None:
-                    result = Result.Unknown(test_spec=EditorParallelTest)
+                    result = Result.Unknown(test_spec=EditorParallelTest,
+                                            extra_info=f"Unexpectedly found no test run information on stdout in the editor log")
                 editor_test_data.results.update(result)
                 if not isinstance(result, Result.Pass):
                     save_asset_logs = True
@@ -1123,7 +1127,8 @@ class EditorTestSuite:
         save_asset_logs = False
         for result in results_per_thread:
             if result is None:
-                result = Result.Unknown(test_spec=EditorSharedTest)
+                result = Result.Unknown(test_spec=EditorSharedTest,
+                                        extra_info=f"Unexpectedly found no test run information on stdout in the editor log")
             editor_test_data.results.update(result)
             if not isinstance(result, Result.Pass):
                 save_asset_logs = True

--- a/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
+++ b/Tools/LyTestTools/ly_test_tools/o3de/editor_test.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import pytest
 import _pytest.python
+import _pytest.outcomes
 from _pytest.skipping import pytest_runtest_setup as skipping_pytest_runtest_setup
 
 import abc
@@ -37,6 +38,7 @@ import os
 import re
 import threading
 import types
+import warnings
 
 import ly_test_tools.environment.process_utils as process_utils
 import ly_test_tools.o3de.editor_test_utils as editor_utils
@@ -599,7 +601,9 @@ class EditorTestSuite:
             try:
                 skipping_pytest_runtest_setup(item)
                 return True
-            except Exception:  # intentionally broad
+            except (Warning, Exception, _pytest.outcomes.OutcomeException) as ex:
+                # intentionally broad to avoid events other than system interrupts
+                warnings.warn(f"Test deselected from execution queue due to {ex}")
                 return False
         
         session_items_by_name = {item.originalname: item for item in session_items}

--- a/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
@@ -544,12 +544,6 @@ class TestUtils(unittest.TestCase):
                           ')JSON_END'
 
         results = mock_test_suite._get_results_using_output(mock_test_list, mock_output, mock_editor_log)
-#        mock_create_pass.assert_called_with(
-#            mock_test_pass, 'mock_std_out', 'JSON_START({"name": "mock_module_name_pass"})JSON_END')
-#        mock_create_fail.assert_called_with(
-#            mock_test_fail, 'mock_std_out', 'JSON_START({"name": "mock_module_name_fail"})JSON_END')
-#        mock_create_unknown.assert_called_with(
-#            mock_test_unknown, mock_output, "Couldn't find any test run information on stdout", mock_editor_log)
         assert len(results) == 3
         assert 'mock_test_name_pass' in results.keys()
         assert 'mock_test_name_fail' in results.keys()

--- a/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
+++ b/Tools/LyTestTools/tests/unit/test_o3de_editor_test.py
@@ -11,8 +11,10 @@ import unittest.mock as mock
 
 import ly_test_tools
 import ly_test_tools.o3de.editor_test as editor_test
+import ly_test_tools.launchers.exceptions
 
 pytestmark = pytest.mark.SUITE_smoke
+
 
 class TestEditorTestBase(unittest.TestCase):
 
@@ -30,6 +32,7 @@ class TestEditorTestBase(unittest.TestCase):
         mock_editorsharedtest = editor_test.EditorBatchedTest()
         assert mock_editorsharedtest.is_batchable == True
         assert mock_editorsharedtest.is_parallelizable == False
+
 
 class TestResultBase(unittest.TestCase):
 
@@ -52,6 +55,7 @@ class TestResultBase(unittest.TestCase):
         self.mock_result.editor_log = None
         assert self.mock_result.get_editor_log_str() == '-- No editor log found --'
 
+
 class TestResultPass(unittest.TestCase):
 
     def test_Create_ValidArgs_CorrectAttributes(self):
@@ -59,18 +63,19 @@ class TestResultPass(unittest.TestCase):
         mock_output = mock.MagicMock()
         mock_editor_log = mock.MagicMock()
 
-        mock_pass = editor_test.Result.Pass.create(mock_test_spec, mock_output, mock_editor_log)
-        assert mock_pass.test_spec == mock_test_spec
-        assert mock_pass.output == mock_output
-        assert mock_pass.editor_log == mock_editor_log
+        under_test = editor_test.Result.Pass(mock_test_spec, mock_output, mock_editor_log)
+        assert under_test.test_spec == mock_test_spec
+        assert under_test.output == mock_output
+        assert under_test.editor_log == mock_editor_log
 
     def test_Str_ValidString_ReturnsOutput(self):
         mock_test_spec = mock.MagicMock()
         mock_output = 'mock_output'
         mock_editor_log = mock.MagicMock()
 
-        mock_pass = editor_test.Result.Pass.create(mock_test_spec, mock_output, mock_editor_log)
-        assert mock_output in str(mock_pass)
+        under_test = editor_test.Result.Pass(mock_test_spec, mock_output, mock_editor_log)
+        assert mock_output in str(under_test)
+
 
 class TestResultFail(unittest.TestCase):
 
@@ -79,19 +84,20 @@ class TestResultFail(unittest.TestCase):
         mock_output = mock.MagicMock()
         mock_editor_log = mock.MagicMock()
 
-        mock_pass = editor_test.Result.Fail.create(mock_test_spec, mock_output, mock_editor_log)
-        assert mock_pass.test_spec == mock_test_spec
-        assert mock_pass.output == mock_output
-        assert mock_pass.editor_log == mock_editor_log
+        under_test = editor_test.Result.Fail(mock_test_spec, mock_output, mock_editor_log)
+        assert under_test.test_spec == mock_test_spec
+        assert under_test.output == mock_output
+        assert under_test.editor_log == mock_editor_log
 
     def test_Str_ValidString_ReturnsOutput(self):
         mock_test_spec = mock.MagicMock()
         mock_output = 'mock_output'
         mock_editor_log = 'mock_editor_log'
 
-        mock_pass = editor_test.Result.Fail.create(mock_test_spec, mock_output, mock_editor_log)
-        assert mock_output in str(mock_pass)
-        assert mock_editor_log in str(mock_pass)
+        under_test = editor_test.Result.Fail(mock_test_spec, mock_output, mock_editor_log)
+        assert mock_output in str(under_test)
+        assert mock_editor_log in str(under_test)
+
 
 class TestResultCrash(unittest.TestCase):
 
@@ -102,13 +108,13 @@ class TestResultCrash(unittest.TestCase):
         mock_ret_code = mock.MagicMock()
         mock_stacktrace = mock.MagicMock()
 
-        mock_pass = editor_test.Result.Crash.create(mock_test_spec, mock_output, mock_ret_code, mock_stacktrace,
+        under_test = editor_test.Result.Crash(mock_test_spec, mock_output, mock_ret_code, mock_stacktrace,
                                                     mock_editor_log)
-        assert mock_pass.test_spec == mock_test_spec
-        assert mock_pass.output == mock_output
-        assert mock_pass.editor_log == mock_editor_log
-        assert mock_pass.ret_code == mock_ret_code
-        assert mock_pass.stacktrace == mock_stacktrace
+        assert under_test.test_spec == mock_test_spec
+        assert under_test.output == mock_output
+        assert under_test.editor_log == mock_editor_log
+        assert under_test.ret_code == mock_ret_code
+        assert under_test.stacktrace == mock_stacktrace
 
     def test_Str_ValidString_ReturnsOutput(self):
         mock_test_spec = mock.MagicMock()
@@ -117,11 +123,11 @@ class TestResultCrash(unittest.TestCase):
         mock_return_code = 0
         mock_stacktrace = 'mock stacktrace'
 
-        mock_pass = editor_test.Result.Crash.create(mock_test_spec, mock_output, mock_return_code, mock_stacktrace,
+        under_test = editor_test.Result.Crash(mock_test_spec, mock_output, mock_return_code, mock_stacktrace,
                                                     mock_editor_log)
-        assert mock_stacktrace in str(mock_pass)
-        assert mock_output in str(mock_pass)
-        assert mock_editor_log in str(mock_pass)
+        assert mock_stacktrace in str(under_test)
+        assert mock_output in str(under_test)
+        assert mock_editor_log in str(under_test)
 
     def test_Str_MissingStackTrace_ReturnsCorrectly(self):
         mock_test_spec = mock.MagicMock()
@@ -129,10 +135,11 @@ class TestResultCrash(unittest.TestCase):
         mock_editor_log = 'mock_editor_log'
         mock_return_code = 0
         mock_stacktrace = None
-        mock_pass = editor_test.Result.Crash.create(mock_test_spec, mock_output, mock_return_code, mock_stacktrace,
-                                                    mock_editor_log)
-        assert mock_output in str(mock_pass)
-        assert mock_editor_log in str(mock_pass)
+        under_test = editor_test.Result.Crash(mock_test_spec, mock_output, mock_return_code, mock_stacktrace,
+                                              mock_editor_log)
+        assert mock_output in str(under_test)
+        assert mock_editor_log in str(under_test)
+
 
 class TestResultTimeout(unittest.TestCase):
 
@@ -142,11 +149,11 @@ class TestResultTimeout(unittest.TestCase):
         mock_editor_log = mock.MagicMock()
         mock_timeout = mock.MagicMock()
 
-        mock_pass = editor_test.Result.Timeout.create(mock_test_spec, mock_output, mock_timeout, mock_editor_log)
-        assert mock_pass.test_spec == mock_test_spec
-        assert mock_pass.output == mock_output
-        assert mock_pass.editor_log == mock_editor_log
-        assert mock_pass.time_secs == mock_timeout
+        under_test = editor_test.Result.Timeout(mock_test_spec, mock_output, mock_timeout, mock_editor_log)
+        assert under_test.test_spec == mock_test_spec
+        assert under_test.output == mock_output
+        assert under_test.editor_log == mock_editor_log
+        assert under_test.time_secs == mock_timeout
 
     def test_Str_ValidString_ReturnsOutput(self):
         mock_test_spec = mock.MagicMock()
@@ -154,9 +161,10 @@ class TestResultTimeout(unittest.TestCase):
         mock_editor_log = 'mock_editor_log'
         mock_timeout = 0
 
-        mock_pass = editor_test.Result.Timeout.create(mock_test_spec, mock_output, mock_timeout, mock_editor_log)
-        assert mock_output in str(mock_pass)
-        assert mock_editor_log in str(mock_pass)
+        under_test = editor_test.Result.Timeout(mock_test_spec, mock_output, mock_timeout, mock_editor_log)
+        assert mock_output in str(under_test)
+        assert mock_editor_log in str(under_test)
+
 
 class TestResultUnknown(unittest.TestCase):
 
@@ -166,11 +174,11 @@ class TestResultUnknown(unittest.TestCase):
         mock_editor_log = mock.MagicMock()
         mock_extra_info = mock.MagicMock()
 
-        mock_pass = editor_test.Result.Unknown.create(mock_test_spec, mock_output, mock_extra_info, mock_editor_log)
-        assert mock_pass.test_spec == mock_test_spec
-        assert mock_pass.output == mock_output
-        assert mock_pass.editor_log == mock_editor_log
-        assert mock_pass.extra_info == mock_extra_info
+        under_test = editor_test.Result.Unknown(mock_test_spec, mock_output, mock_extra_info, mock_editor_log)
+        assert under_test.test_spec == mock_test_spec
+        assert under_test.output == mock_output
+        assert under_test.editor_log == mock_editor_log
+        assert under_test.extra_info == mock_extra_info
 
     def test_Str_ValidString_ReturnsOutput(self):
         mock_test_spec = mock.MagicMock()
@@ -178,9 +186,10 @@ class TestResultUnknown(unittest.TestCase):
         mock_editor_log = 'mock_editor_log'
         mock_extra_info = 'mock extra info'
 
-        mock_pass = editor_test.Result.Unknown.create(mock_test_spec, mock_output, mock_extra_info, mock_editor_log)
-        assert mock_output in str(mock_pass)
-        assert mock_editor_log in str(mock_pass)
+        under_test = editor_test.Result.Unknown(mock_test_spec, mock_output, mock_extra_info, mock_editor_log)
+        assert mock_output in str(under_test)
+        assert mock_editor_log in str(under_test)
+
 
 class TestEditorTestSuite(unittest.TestCase):
 
@@ -387,6 +396,7 @@ class TestEditorTestSuite(unittest.TestCase):
             mock_shared_tests, is_batchable=False, is_parallelizable=False)
         assert filtered_tests == [mock_test_2]
 
+
 class TestUtils(unittest.TestCase):
 
     @mock.patch('ly_test_tools.o3de.editor_test_utils.kill_all_ly_processes')
@@ -458,9 +468,8 @@ class TestUtils(unittest.TestCase):
         assert mock_prepare_ap.called
         mock_kill_processes.assert_called_once_with(include_asset_processor=False)
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Pass.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_module_filename')
-    def test_GetResultsUsingOutput_ValidJsonSuccess_CreatesPassResult(self, mock_get_module, mock_create):
+    def test_GetResultsUsingOutput_ValidJsonSuccess_CreatesPassResult(self, mock_get_module):
         mock_get_module.return_value = 'mock_module_name'
         mock_test_suite = editor_test.EditorTestSuite()
         mock_test = mock.MagicMock()
@@ -469,17 +478,14 @@ class TestUtils(unittest.TestCase):
         mock_output = 'JSON_START(' \
                       '{"name": "mock_module_name", "output": "mock_std_out", "success": "mock_success_data"}' \
                       ')JSON_END'
-        mock_pass = mock.MagicMock()
-        mock_create.return_value = mock_pass
 
         results = mock_test_suite._get_results_using_output(mock_test_list, mock_output, '')
-        assert mock_create.called
         assert len(results) == 1
-        assert results[mock_test.__name__] == mock_pass
+        assert 'mock_test_name' in results.keys()
+        assert isinstance(results['mock_test_name'], editor_test.Result.Pass)
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Fail.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_module_filename')
-    def test_GetResultsUsingOutput_ValidJsonFail_CreatesFailResult(self, mock_get_module, mock_create):
+    def test_GetResultsUsingOutput_ValidJsonFail_CreatesFailResult(self, mock_get_module):
         mock_get_module.return_value = 'mock_module_name'
         mock_test_suite = editor_test.EditorTestSuite()
         mock_test = mock.MagicMock()
@@ -488,17 +494,14 @@ class TestUtils(unittest.TestCase):
         mock_output = 'JSON_START(' \
                       '{"name": "mock_module_name", "output": "mock_std_out", "failed": "mock_fail_data", "success": ""}' \
                       ')JSON_END'
-        mock_fail = mock.MagicMock()
-        mock_create.return_value = mock_fail
 
         results = mock_test_suite._get_results_using_output(mock_test_list, mock_output, '')
-        assert mock_create.called
         assert len(results) == 1
-        assert results[mock_test.__name__] == mock_fail
+        assert 'mock_test_name' in results.keys()
+        assert isinstance(results['mock_test_name'], editor_test.Result.Fail)
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Unknown.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_module_filename')
-    def test_GetResultsUsingOutput_ModuleNotInLog_CreatesUnknownResult(self, mock_get_module, mock_create):
+    def test_GetResultsUsingOutput_ModuleNotInLog_CreatesUnknownResult(self, mock_get_module):
         mock_get_module.return_value = 'different_module_name'
         mock_test_suite = editor_test.EditorTestSuite()
         mock_test = mock.MagicMock()
@@ -507,20 +510,14 @@ class TestUtils(unittest.TestCase):
         mock_output = 'JSON_START(' \
                       '{"name": "mock_module_name", "output": "mock_std_out", "failed": "mock_fail_data"}' \
                       ')JSON_END'
-        mock_unknown = mock.MagicMock()
-        mock_create.return_value = mock_unknown
 
         results = mock_test_suite._get_results_using_output(mock_test_list, mock_output, '')
-        assert mock_create.called
         assert len(results) == 1
-        assert results[mock_test.__name__] == mock_unknown
+        assert 'mock_test_name' in results.keys()
+        assert isinstance(results['mock_test_name'], editor_test.Result.Unknown)
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Pass.create')
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Fail.create')
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Unknown.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_module_filename')
-    def test_GetResultsUsingOutput_MultipleTests_CreatesCorrectResults(self, mock_get_module, mock_create_unknown,
-                                                                       mock_create_fail, mock_create_pass):
+    def test_GetResultsUsingOutput_MultipleTests_CreatesCorrectResults(self, mock_get_module):
         mock_get_module.side_effect = ['mock_module_name_pass', 'mock_module_name_fail', 'different_module_name']
         mock_test_suite = editor_test.EditorTestSuite()
         mock_test_pass = mock.MagicMock()
@@ -545,45 +542,42 @@ class TestUtils(unittest.TestCase):
                           'JSON_START(' \
                           '{"name": "mock_module_name_fail"}' \
                           ')JSON_END'
-        mock_unknown = mock.MagicMock()
-        mock_pass = mock.MagicMock()
-        mock_fail = mock.MagicMock()
-        mock_create_unknown.return_value = mock_unknown
-        mock_create_pass.return_value = mock_pass
-        mock_create_fail.return_value = mock_fail
 
         results = mock_test_suite._get_results_using_output(mock_test_list, mock_output, mock_editor_log)
-        mock_create_pass.assert_called_with(
-            mock_test_pass, 'mock_std_out', 'JSON_START({"name": "mock_module_name_pass"})JSON_END')
-        mock_create_fail.assert_called_with(
-            mock_test_fail, 'mock_std_out', 'JSON_START({"name": "mock_module_name_fail"})JSON_END')
-        mock_create_unknown.assert_called_with(
-            mock_test_unknown, mock_output, "Couldn't find any test run information on stdout", mock_editor_log)
+#        mock_create_pass.assert_called_with(
+#            mock_test_pass, 'mock_std_out', 'JSON_START({"name": "mock_module_name_pass"})JSON_END')
+#        mock_create_fail.assert_called_with(
+#            mock_test_fail, 'mock_std_out', 'JSON_START({"name": "mock_module_name_fail"})JSON_END')
+#        mock_create_unknown.assert_called_with(
+#            mock_test_unknown, mock_output, "Couldn't find any test run information on stdout", mock_editor_log)
         assert len(results) == 3
-        assert results[mock_test_pass.__name__] == mock_pass
-        assert results[mock_test_fail.__name__] == mock_fail
-        assert results[mock_test_unknown.__name__] == mock_unknown
+        assert 'mock_test_name_pass' in results.keys()
+        assert 'mock_test_name_fail' in results.keys()
+        assert 'mock_test_name_unknown' in results.keys()
+        assert isinstance(results['mock_test_name_pass'], editor_test.Result.Pass)
+        assert isinstance(results['mock_test_name_fail'], editor_test.Result.Fail)
+        assert isinstance(results['mock_test_name_unknown'], editor_test.Result.Unknown)
 
     @mock.patch('builtins.print')
     def test_ReportResult_TestPassed_ReportsCorrectly(self, mock_print):
         mock_test_name = 'mock name'
-        mock_pass = ly_test_tools.o3de.editor_test.Result.Pass()
+        mock_pass = ly_test_tools.o3de.editor_test.Result.Pass("", "", "")
         ly_test_tools.o3de.editor_test.EditorTestSuite._report_result(mock_test_name, mock_pass)
         mock_print.assert_called_with(f'Test {mock_test_name}:\nTest Passed\n------------\n|  Output  |\n------------\n'
                                       f'-- No output --\n')
 
     @mock.patch('pytest.fail')
     def test_ReportResult_TestFailed_FailsCorrectly(self, mock_pytest_fail):
-        mock_fail = ly_test_tools.o3de.editor_test.Result.Fail()
+        mock_fail = ly_test_tools.o3de.editor_test.Result.Fail("", "", "")
 
         ly_test_tools.o3de.editor_test.EditorTestSuite._report_result('mock_test_name', mock_fail)
         mock_pytest_fail.assert_called_with('Test mock_test_name:\nTest FAILED\n------------\n|  Output  |'
                                             '\n------------\n-- No output --\n--------------\n| Editor log |'
                                             '\n--------------\n-- No editor log found --\n')
 
+
 class TestRunningTests(unittest.TestCase):
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Pass.create')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
@@ -592,7 +586,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('os.path.join', mock.MagicMock())
     def test_ExecEditorTest_TestSucceeds_ReturnsPass(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                      mock_retrieve_log, mock_retrieve_editor_log,
-                                                     mock_get_output_results, mock_create):
+                                                     mock_get_output_results):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -601,17 +595,14 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec.__name__ = 'mock_test_name'
         mock_editor.get_returncode.return_value = 0
         mock_get_output_results.return_value = {}
-        mock_pass = mock.MagicMock()
-        mock_create.return_value = mock_pass
 
         results = mock_test_suite._exec_editor_test(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                     'mock_log_name', mock_test_spec, [])
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Pass)
         assert mock_cycle_crash.called
         assert mock_editor.start.called
-        assert mock_create.called
-        assert results == {mock_test_spec.__name__: mock_pass}
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Fail.create')
+
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
@@ -620,7 +611,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('os.path.join', mock.MagicMock())
     def test_ExecEditorTest_TestFails_ReturnsFail(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                      mock_retrieve_log, mock_retrieve_editor_log,
-                                                     mock_get_output_results, mock_create):
+                                                     mock_get_output_results):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -629,17 +620,14 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec.__name__ = 'mock_test_name'
         mock_editor.get_returncode.return_value = 15
         mock_get_output_results.return_value = {}
-        mock_fail = mock.MagicMock()
-        mock_create.return_value = mock_fail
 
         results = mock_test_suite._exec_editor_test(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                     'mock_log_name', mock_test_spec, [])
+
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Fail)
         assert mock_cycle_crash.called
         assert mock_editor.start.called
-        assert mock_create.called
-        assert results == {mock_test_spec.__name__: mock_fail}
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Crash.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
@@ -650,7 +638,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('os.path.basename', mock.MagicMock())
     def test_ExecEditorTest_TestCrashes_ReturnsCrash(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                      mock_retrieve_log, mock_retrieve_editor_log,
-                                                     mock_get_output_results, mock_retrieve_crash, mock_create):
+                                                     mock_get_output_results, mock_retrieve_crash):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -659,18 +647,14 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec.__name__ = 'mock_test_name'
         mock_editor.get_returncode.return_value = 1
         mock_get_output_results.return_value = {}
-        mock_crash = mock.MagicMock()
-        mock_create.return_value = mock_crash
 
         results = mock_test_suite._exec_editor_test(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                     'mock_log_name', mock_test_spec, [])
         assert mock_cycle_crash.call_count == 2
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Crash)
         assert mock_editor.start.called
         assert mock_retrieve_crash.called
-        assert mock_create.called
-        assert results == {mock_test_spec.__name__: mock_crash}
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Timeout.create')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
@@ -678,7 +662,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
     def test_ExecEditorTest_TestTimeout_ReturnsTimeout(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                      mock_retrieve_log, mock_retrieve_editor_log,
-                                                     mock_get_output_results, mock_create):
+                                                     mock_get_output_results):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -687,25 +671,20 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec.__name__ = 'mock_test_name'
         mock_editor.wait.side_effect = ly_test_tools.launchers.exceptions.WaitTimeoutError()
         mock_get_output_results.return_value = {}
-        mock_timeout = mock.MagicMock()
-        mock_create.return_value = mock_timeout
 
         results = mock_test_suite._exec_editor_test(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                     'mock_log_name', mock_test_spec, [])
+
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Timeout)
         assert mock_cycle_crash.called
         assert mock_editor.start.called
         assert mock_editor.stop.called
-        assert mock_create.called
-        assert results == {mock_test_spec.__name__: mock_timeout}
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Pass.create')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
     @mock.patch('os.path.join', mock.MagicMock())
-    def test_ExecEditorMultitest_AllTestsPass_ReturnsPasses(self, mock_cycle_crash, mock_get_testcase_filepath,
-                                                            mock_retrieve_log, mock_retrieve_editor_log, mock_create):
+    @mock.patch('os.path.splitext', mock.MagicMock())
+    def test_ExecEditorMultitest_AllTestsPass_ReturnsPasses(self, mock_cycle_crash, mock_get_filepath):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_artifact_manager = mock.MagicMock()
@@ -719,25 +698,23 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec_2 = mock.MagicMock()
         mock_test_spec_2.__name__ = 'mock_test_name_2'
         mock_test_spec_list = [mock_test_spec, mock_test_spec_2]
-        mock_get_testcase_filepath.side_effect = ['mock_path', 'mock_path_2']
-        mock_pass = mock.MagicMock()
-        mock_pass_2 = mock.MagicMock()
-        mock_create.side_effect = [mock_pass, mock_pass_2]
+        mock_get_filepath.return_value = ""
 
         results = mock_test_suite._exec_editor_multitest(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                          'mock_log_name', mock_test_spec_list, [])
-        assert results == {mock_test_spec.__name__: mock_pass, mock_test_spec_2.__name__: mock_pass_2}
+        assert len(results) == 2
+        assert isinstance(results['mock_test_name'], editor_test.Result.Pass)
+        assert isinstance(results['mock_test_name_2'], editor_test.Result.Pass)
         assert mock_cycle_crash.called
-        assert mock_create.call_count == 2
+        assert mock_get_filepath.called
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
-    @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.get_testcase_module_filepath')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
     @mock.patch('os.path.join', mock.MagicMock())
+    @mock.patch('os.path.splitext', mock.MagicMock())
     def test_ExecEditorMultitest_OneFailure_CallsCorrectFunc(self, mock_cycle_crash, mock_get_testcase_filepath,
-                                                           mock_retrieve_log, mock_retrieve_editor_log, mock_get_results):
+                                                             mock_get_results):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -751,10 +728,11 @@ class TestRunningTests(unittest.TestCase):
 
         results = mock_test_suite._exec_editor_multitest(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                          'mock_log_name', mock_test_spec_list, [])
+
+        assert len(results) == 2
         assert mock_cycle_crash.called
         assert mock_get_results.called
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Crash.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
@@ -765,7 +743,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('os.path.basename', mock.MagicMock())
     def test_ExecEditorMultitest_OneCrash_ReportsOnUnknownResult(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                                  mock_retrieve_log, mock_retrieve_editor_log,
-                                                                 mock_get_results, mock_retrieve_crash, mock_create):
+                                                                 mock_get_results, mock_retrieve_crash):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -776,22 +754,19 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec_2 = mock.MagicMock()
         mock_test_spec_2.__name__ = 'mock_test_name_2'
         mock_test_spec_list = [mock_test_spec, mock_test_spec_2]
-        mock_unknown_result = ly_test_tools.o3de.editor_test.Result.Unknown()
+        mock_unknown_result = ly_test_tools.o3de.editor_test.Result.Unknown(test_spec=None)
         mock_unknown_result.test_spec = mock.MagicMock()
         mock_unknown_result.editor_log = mock.MagicMock()
         mock_get_testcase_filepath.side_effect = ['mock_path', 'mock_path_2']
         mock_get_results.return_value = {mock_test_spec.__name__: mock_unknown_result,
                                          mock_test_spec_2.__name__: mock.MagicMock()}
-        mock_crash = mock.MagicMock()
-        mock_create.return_value = mock_crash
 
         results = mock_test_suite._exec_editor_multitest(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                          'mock_log_name', mock_test_spec_list, [])
         assert mock_cycle_crash.call_count == 2
         assert mock_get_results.called
-        assert results[mock_test_spec.__name__] == mock_crash
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Crash)
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Crash.create')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_crash_output')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
@@ -802,7 +777,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('os.path.basename', mock.MagicMock())
     def test_ExecEditorMultitest_ManyUnknown_ReportsUnknownResults(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                                    mock_retrieve_log, mock_retrieve_editor_log,
-                                                                   mock_get_results, mock_retrieve_crash, mock_create):
+                                                                   mock_get_results, mock_retrieve_crash):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -813,7 +788,7 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec_2 = mock.MagicMock()
         mock_test_spec_2.__name__ = 'mock_test_name_2'
         mock_test_spec_list = [mock_test_spec, mock_test_spec_2]
-        mock_unknown_result = ly_test_tools.o3de.editor_test.Result.Unknown()
+        mock_unknown_result = ly_test_tools.o3de.editor_test.Result.Unknown(test_spec=None)
         mock_unknown_result.__name__ = 'mock_test_name'
         mock_unknown_result.test_spec = mock.MagicMock()
         mock_unknown_result.test_spec.__name__ = 'mock_test_spec_name'
@@ -821,17 +796,15 @@ class TestRunningTests(unittest.TestCase):
         mock_get_testcase_filepath.side_effect = ['mock_path', 'mock_path_2']
         mock_get_results.return_value = {mock_test_spec.__name__: mock_unknown_result,
                                          mock_test_spec_2.__name__: mock_unknown_result}
-        mock_crash = mock.MagicMock()
-        mock_create.return_value = mock_crash
 
         results = mock_test_suite._exec_editor_multitest(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                          'mock_log_name', mock_test_spec_list, [])
         assert mock_cycle_crash.call_count == 2
         assert mock_get_results.called
-        assert results[mock_test_spec.__name__] == mock_crash
-        assert results[mock_test_spec_2.__name__].extra_info
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Crash)
+        assert isinstance(results[mock_test_spec_2.__name__], editor_test.Result.Unknown)
+        assert results[mock_test_spec_2.__name__].extra_info, "Extra info missing from Unknown failure"
 
-    @mock.patch('ly_test_tools.o3de.editor_test.Result.Timeout.create')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._get_results_using_output')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_editor_log_content')
     @mock.patch('ly_test_tools.o3de.editor_test_utils.retrieve_log_path')
@@ -839,7 +812,7 @@ class TestRunningTests(unittest.TestCase):
     @mock.patch('ly_test_tools.o3de.editor_test_utils.cycle_crash_report')
     def test_ExecEditorMultitest_EditorTimeout_ReportsCorrectly(self, mock_cycle_crash, mock_get_testcase_filepath,
                                                                 mock_retrieve_log, mock_retrieve_editor_log,
-                                                                mock_get_results, mock_create):
+                                                                mock_get_results):
         mock_test_suite = ly_test_tools.o3de.editor_test.EditorTestSuite()
         mock_workspace = mock.MagicMock()
         mock_workspace.paths.engine_root.return_value = ""
@@ -850,7 +823,7 @@ class TestRunningTests(unittest.TestCase):
         mock_test_spec_2 = mock.MagicMock()
         mock_test_spec_2.__name__ = 'mock_test_name_2'
         mock_test_spec_list = [mock_test_spec, mock_test_spec_2]
-        mock_unknown_result = ly_test_tools.o3de.editor_test.Result.Unknown()
+        mock_unknown_result = ly_test_tools.o3de.editor_test.Result.Unknown(test_spec=None)
         mock_unknown_result.test_spec = mock.MagicMock()
         mock_unknown_result.test_spec.__name__ = 'mock_test_spec_name'
         mock_unknown_result.output = mock.MagicMock()
@@ -858,15 +831,14 @@ class TestRunningTests(unittest.TestCase):
         mock_get_testcase_filepath.side_effect = ['mock_path', 'mock_path_2']
         mock_get_results.return_value = {mock_test_spec.__name__: mock_unknown_result,
                                          mock_test_spec_2.__name__: mock_unknown_result}
-        mock_timeout = mock.MagicMock()
-        mock_create.return_value = mock_timeout
 
         results = mock_test_suite._exec_editor_multitest(mock.MagicMock(), mock_workspace, mock_editor, 0,
                                                          'mock_log_name', mock_test_spec_list, [])
         assert mock_cycle_crash.called
         assert mock_get_results.called
-        assert results[mock_test_spec_2.__name__].extra_info
-        assert results[mock_test_spec.__name__] == mock_timeout
+        assert isinstance(results[mock_test_spec.__name__], editor_test.Result.Timeout)
+        assert isinstance(results[mock_test_spec_2.__name__], editor_test.Result.Unknown)
+        assert results[mock_test_spec_2.__name__].extra_info, "Extra info missing from Unknown failure"
 
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._report_result')
     @mock.patch('ly_test_tools.o3de.editor_test.EditorTestSuite._exec_editor_test')
@@ -1030,6 +1002,7 @@ class TestRunningTests(unittest.TestCase):
 
         num_of_editors = mock_test_suite._get_number_parallel_editors(mock_request)
         assert num_of_editors == mock_test_suite.get_number_parallel_editors()
+
 
 @mock.patch('_pytest.python.Class.collect')
 class TestEditorTestClass(unittest.TestCase):


### PR DESCRIPTION
Reduces EditorTest NoneType errors, remove dead code, update docstrings, fix pep8 warnings.

Addresses a failure seen in https://github.com/o3de/o3de/issues/7657 which unexpectedly removed test reporting from an AR failure.

Signed-off-by: sweeneys <sweeneys@amazon.com>