### PR TITLE
Combine the 3 LoadInstanceFromPrefab methods to use a single helper method

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -108,6 +108,52 @@ namespace AzToolsFramework
                     }
                     return true;
                 }
+
+                static bool LoadInstanceHelper(
+                    Instance& instance,
+                    const PrefabDom& prefabDom,
+                    LoadFlags flags,
+                    AZ::JsonDeserializerSettings& settings)
+                {
+                    // When entities are rebuilt they are first destroyed. As a result any assets they were exclusively holding on to will
+                    // be released and reloaded once the entities are built up again. By suspending asset release temporarily the asset
+                    // reload is avoided.
+                    AZ::Data::AssetManager::Instance().SuspendAssetRelease();
+
+                    InstanceEntityIdMapper entityIdMapper;
+                    entityIdMapper.SetLoadingInstance(instance);
+                    if ((flags & LoadFlags::AssignRandomEntityId) == LoadFlags::AssignRandomEntityId)
+                    {
+                        entityIdMapper.SetEntityIdGenerationApproach(InstanceEntityIdMapper::EntityIdGenerationApproach::Random);
+                    }
+
+                    auto tracker = AZ::Data::SerializedAssetTracker{};
+                    tracker.SetAssetFixUp(&FixUpInvalidAssets);
+
+                    // The InstanceEntityIdMapper is registered twice because it's used in several places during deserialization where one
+                    // is specific for the InstanceEntityIdMapper and once for the generic JsonEntityIdMapper. Because the Json Serializer's
+                    // meta data has strict typing and doesn't look for inheritance both have to be explicitly added so they're found both
+                    // locations.
+                    settings.m_metadata.Add(static_cast<AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&entityIdMapper));
+                    settings.m_metadata.Add(&entityIdMapper);
+                    settings.m_metadata.Add(tracker);
+
+                    AZ::JsonSerializationResult::ResultCode result = AZ::JsonSerialization::Load(instance, prefabDom, settings);
+
+                    AZ::Data::AssetManager::Instance().ResumeAssetRelease();
+
+                    if (result.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                    {
+                        AZ_Error(
+                            "Prefab", false,
+                            "Failed to de-serialize Prefab Instance from Prefab DOM. "
+                            "Unable to proceed.");
+
+                        return false;
+                    }
+
+                    return true;
+                }
             }
 
             PrefabDomValueReference FindPrefabDomValue(PrefabDomValue& parentValue, const char* valueName)
@@ -197,118 +243,30 @@ namespace AzToolsFramework
 
             bool LoadInstanceFromPrefabDom(Instance& instance, const PrefabDom& prefabDom, LoadFlags flags)
             {
-                // When entities are rebuilt they are first destroyed. As a result any assets they were exclusively holding on to will
-                // be released and reloaded once the entities are built up again. By suspending asset release temporarily the asset reload
-                // is avoided.
-                AZ::Data::AssetManager::Instance().SuspendAssetRelease();
-
-                InstanceEntityIdMapper entityIdMapper;
-                entityIdMapper.SetLoadingInstance(instance);
-                if ((flags & LoadFlags::AssignRandomEntityId) == LoadFlags::AssignRandomEntityId)
-                {
-                    entityIdMapper.SetEntityIdGenerationApproach(InstanceEntityIdMapper::EntityIdGenerationApproach::Random);
-                }
-
-                auto tracker = AZ::Data::SerializedAssetTracker{};
-                tracker.SetAssetFixUp(&FixUpInvalidAssets);
-
                 AZ::JsonDeserializerSettings settings;
-                // The InstanceEntityIdMapper is registered twice because it's used in several places during deserialization where one is
-                // specific for the InstanceEntityIdMapper and once for the generic JsonEntityIdMapper. Because the Json Serializer's meta
-                // data has strict typing and doesn't look for inheritance both have to be explicitly added so they're found both locations.
-                settings.m_metadata.Add(static_cast<AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&entityIdMapper));
-                settings.m_metadata.Add(&entityIdMapper);
-                settings.m_metadata.Add(tracker);
-
-                AZ::JsonSerializationResult::ResultCode result =
-                    AZ::JsonSerialization::Load(instance, prefabDom, settings);
-
-                AZ::Data::AssetManager::Instance().ResumeAssetRelease();
-
-                if (result.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
-                {
-                    AZ_Error("Prefab", false,
-                        "Failed to de-serialize Prefab Instance from Prefab DOM. "
-                        "Unable to proceed.");
-
-                    return false;
-                }
-
-                return true;
+                return Internal::LoadInstanceHelper(instance, prefabDom, flags, settings);
             }
 
             bool LoadInstanceFromPrefabDom(
                 Instance& instance, const PrefabDom& prefabDom, AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>>& referencedAssets, LoadFlags flags)
             {
-                // When entities are rebuilt they are first destroyed. As a result any assets they were exclusively holding on to will
-                // be released and reloaded once the entities are built up again. By suspending asset release temporarily the asset reload
-                // is avoided.
-                AZ::Data::AssetManager::Instance().SuspendAssetRelease();
-
-                InstanceEntityIdMapper entityIdMapper;
-                entityIdMapper.SetLoadingInstance(instance);
-                if ((flags & LoadFlags::AssignRandomEntityId) == LoadFlags::AssignRandomEntityId)
-                {
-                    entityIdMapper.SetEntityIdGenerationApproach(InstanceEntityIdMapper::EntityIdGenerationApproach::Random);
-                }
-
-                auto tracker = AZ::Data::SerializedAssetTracker{};
-                tracker.SetAssetFixUp(&FixUpInvalidAssets);
-
                 AZ::JsonDeserializerSettings settings;
-                // The InstanceEntityIdMapper is registered twice because it's used in several places during deserialization where one is
-                // specific for the InstanceEntityIdMapper and once for the generic JsonEntityIdMapper. Because the Json Serializer's meta
-                // data has strict typing and doesn't look for inheritance both have to be explicitly added so they're found both locations.
-                settings.m_metadata.Add(static_cast<AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&entityIdMapper));
-                settings.m_metadata.Add(&entityIdMapper);
-                settings.m_metadata.Add(tracker);
 
-                AZ::JsonSerializationResult::ResultCode result =
-                    AZ::JsonSerialization::Load(instance, prefabDom, settings);
-
-                AZ::Data::AssetManager::Instance().ResumeAssetRelease();
-
-                if (result.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
+                if (Internal::LoadInstanceHelper(instance, prefabDom, flags, settings))
                 {
-                    AZ_Error("Prefab", false,
-                        "Failed to de-serialize Prefab Instance from Prefab DOM. "
-                        "Unable to proceed.");
-
-                    return false;
+                    AZ::Data::SerializedAssetTracker* assetTracker = settings.m_metadata.Find<AZ::Data::SerializedAssetTracker>();
+                    referencedAssets = AZStd::move(assetTracker->GetTrackedAssets());
                 }
 
-                AZ::Data::SerializedAssetTracker* assetTracker = settings.m_metadata.Find<AZ::Data::SerializedAssetTracker>();
-
-                referencedAssets = AZStd::move(assetTracker->GetTrackedAssets());
                 return true;
             }
 
             bool LoadInstanceFromPrefabDom(
                 Instance& instance, Instance::EntityList& newlyAddedEntities, const PrefabDom& prefabDom, LoadFlags flags)
             {
-                // When entities are rebuilt they are first destroyed. As a result any assets they were exclusively holding on to will
-                // be released and reloaded once the entities are built up again. By suspending asset release temporarily the asset reload
-                // is avoided.
-                AZ::Data::AssetManager::Instance().SuspendAssetRelease();
-
-                InstanceEntityIdMapper entityIdMapper;
-                entityIdMapper.SetLoadingInstance(instance);
-                if ((flags & LoadFlags::AssignRandomEntityId) == LoadFlags::AssignRandomEntityId)
-                {
-                    entityIdMapper.SetEntityIdGenerationApproach(InstanceEntityIdMapper::EntityIdGenerationApproach::Random);
-                }
-
-                auto tracker = AZ::Data::SerializedAssetTracker{};
-                tracker.SetAssetFixUp(&FixUpInvalidAssets);
 
                 AZ::JsonDeserializerSettings settings;
-                // The InstanceEntityIdMapper is registered twice because it's used in several places during deserialization where one is
-                // specific for the InstanceEntityIdMapper and once for the generic JsonEntityIdMapper. Because the Json Serializer's meta
-                // data has strict typing and doesn't look for inheritance both have to be explicitly added so they're found both locations.
-                settings.m_metadata.Add(static_cast<AZ::JsonEntityIdSerializer::JsonEntityIdMapper*>(&entityIdMapper));
-                settings.m_metadata.Add(&entityIdMapper);
                 settings.m_metadata.Create<InstanceEntityScrubber>(newlyAddedEntities);
-                settings.m_metadata.Add(tracker);
 
                 AZStd::string scratchBuffer;
                 auto issueReportingCallback = [&scratchBuffer](
@@ -319,21 +277,7 @@ namespace AzToolsFramework
                 };
                 settings.m_reporting = AZStd::move(issueReportingCallback);
 
-                AZ::JsonSerializationResult::ResultCode result = AZ::JsonSerialization::Load(instance, prefabDom, settings);
-
-                AZ::Data::AssetManager::Instance().ResumeAssetRelease();
-
-                if (result.GetProcessing() == AZ::JsonSerializationResult::Processing::Halted)
-                {
-                    AZ_Error(
-                        "Prefab", false,
-                        "Failed to de-serialize Prefab Instance from Prefab DOM. "
-                        "Unable to proceed.");
-
-                    return false;
-                }
-
-                return true;
+                return Internal::LoadInstanceHelper(instance, prefabDom, flags, settings);
             }
 
             void GetTemplateSourcePaths(const PrefabDomValue& prefabDom, AZStd::unordered_set<AZ::IO::Path>& templateSourcePaths)


### PR DESCRIPTION
There are 3 versions of LoadInstanceFromPrefab method in PrefabDomUtils that share a lot of same code. This PR creates a static helper method with the shared code and makes the 3 methods use it. It both reduces the amount of code and makes it easy to just change the default behavior in 1 function instead of 3 functions.

No new logic changes in this PR. Only moving things around and condensing the amount of code.