### PR TITLE
Disable "Open a blank issue" option for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Disables the "Open a blank issue" option when choosing a template for a new issue.

**This should only be merged upon acceptance by the Technical Steering Committee. See o3de/tsc#16**

![image](https://user-images.githubusercontent.com/71404632/154603342-ddac9f80-fd42-45cc-ae70-fd37206aecf7.png)