### PR TITLE
EMotion FX: Update skeleton transforms when either solid mesh rendering or any of the debug visualizations is enabled

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorDebugDraw.cpp
@@ -758,6 +758,9 @@ namespace AZ::Render
         EMotionFX::JointSelectionRequestBus::BroadcastResult(
             cachedSelectedJointIndices, &EMotionFX::JointSelectionRequests::FindSelectedJointIndices, actorInstance);
 
+        const int oldState = debugDisplay->GetState();
+        debugDisplay->DepthTestOff();
+
         const size_t numEnabled = actorInstance->GetNumEnabledNodes();
         for (size_t i = 0; i < numEnabled; ++i)
         {
@@ -774,6 +777,8 @@ namespace AZ::Render
             }
             RenderLineAxis(debugDisplay, worldTM, size, selected);
         }
+
+        debugDisplay->SetState(oldState);
     }
 
     void AtomActorDebugDraw::RenderLineAxis(

--- a/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderFlag.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Rendering/RenderFlag.h
@@ -75,6 +75,14 @@ namespace EMotionFX
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(ActorRenderFlags);
 
+    static constexpr ActorRenderFlags s_requireUpdateTransforms = 
+        ActorRenderFlags::Solid | ActorRenderFlags::Wireframe | ActorRenderFlags::AABB |
+        ActorRenderFlags::FaceNormals |ActorRenderFlags::VertexNormals | ActorRenderFlags::Tangents |
+        ActorRenderFlags::Skeleton | ActorRenderFlags::LineSkeleton | ActorRenderFlags::NodeOrientation | ActorRenderFlags::NodeNames |
+        ActorRenderFlags::RagdollColliders | ActorRenderFlags::RagdollJointLimits | ActorRenderFlags::HitDetectionColliders |
+        ActorRenderFlags::ClothColliders | ActorRenderFlags::SimulatedObjectColliders | ActorRenderFlags::SimulatedJoints |
+        ActorRenderFlags::EmfxDebug;
+
     class ActorRenderFlagUtil
     {
     public:


### PR DESCRIPTION
* Disabled depth testing for joint orientation debug rendering, so that we can also see them through the solid mesh rendering.
* Update transforms in case solid mesh rendering or any of the debug visualizations are enabled.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>