### PR TITLE
Fixed render viewport not working when both Animation Editor and UI Editor are opened in the editor.

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -86,15 +86,6 @@ namespace EMStudio
         m_scene->AddRenderPipeline(m_renderPipeline);
         m_renderPipeline->SetDefaultView(viewportContext->GetDefaultView());
 
-        // Create a render pipeline from the specified asset for the window context and add the pipeline to the scene
-        AZStd::string defaultPipelineAssetPath = "passes/MainRenderPipeline.azasset";
-        AZ::Data::Asset<AZ::RPI::AnyAsset> pipelineAsset = AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::RPI::AnyAsset>(
-            defaultPipelineAssetPath.c_str(), AZ::RPI::AssetUtils::TraceLevel::Error);
-        m_renderPipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineAsset, *m_windowContext.get());
-        pipelineAsset.Release();
-        m_scene->AddRenderPipeline(m_renderPipeline);
-        m_renderPipeline->SetDefaultView(viewportContext->GetDefaultView());
-
         // Currently the scene has to be activated after render pipeline was added so some feature processors (i.e. imgui) can be
         // initialized properly with pipeline's pass information.
         m_scene->Activate();


### PR DESCRIPTION
Both Animation Editor and UI Editor render viewports use the same render pipeline ("passes/MainRenderPipeline.azasset"), but each one needs its own unique name, otherwise it fails when both are opened at the same time, giving the following kind of errors:

````
[Error] (FrameScheduler) - Scope Root.MainPipeline.MainPipeline.MorphTargetPass already exists. You must specify a unique name.
````

Added viewport id suffix to render pipeline name to fix the issue.

Signed-off-by: moraaar <moraaar@amazon.com>