### PR TITLE
set the shortcut to only work when the graph widget is on focus

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendGraphViewWidget.cpp
@@ -273,6 +273,7 @@ namespace EMStudio
 
         for (QAction* action : m_actions)
         {
+            action->setShortcutContext(Qt::WidgetShortcut);
             addAction(action);
         }
 


### PR DESCRIPTION
Signed-off-by: rhhong <rhhong@amazon.com>