### PR TITLE
Add break on assert setting with debugger attached

### DIFF
--- a/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
+++ b/Code/Framework/AzCore/AzCore/Debug/Trace.cpp
@@ -71,7 +71,7 @@ namespace AZ::Debug
     static AZ::EnvironmentVariable<int> g_logVerbosityLevel;
 
     static const char* assertsAutoBreakUID = "assertsAutoBreak";
-    static const char* s_AssertsAutoBreakRegistryPath = "/O3DE/Core/asserts_auto_break";
+    static const char* AssertsAutoBreakRegistryPath = "/O3DE/Core/asserts_auto_break";
     static AZ::EnvironmentVariable<bool> s_AssertsAutoBreak;
 
     static constexpr auto PrintfEventId = EventNameHash("Printf");
@@ -340,7 +340,7 @@ namespace AZ::Debug
                     if (settingsRegistry)
                     {
                         bool assertsAutoBreak;
-                        if (!settingsRegistry->Get(assertsAutoBreak, s_AssertsAutoBreakRegistryPath))
+                        if (!settingsRegistry->Get(assertsAutoBreak, AssertsAutoBreakRegistryPath))
                         {
                             // Currently, asserts will not break in the debugger by default, however THIS IS EXPECTED TO CHANGE
                             // shortly after this settings registry parameter is introduced to discourage asserts firing unchecked


### PR DESCRIPTION
This commit adds a new "bg_assertsAutoBreak" CVAR which defaults
currently to `false`. When enabled, trace asserts will check if a debugger
is attached and emit a debugger interrupt if so.

The idea is that after introduction, developers will be *strongly*
encouraged to enable this flag so that active asserts currently are
fixed. After a period of time, this setting will default to true so that
asserts that trigger are more visible across the community.
