### PR TITLE
Focus Mode | Fix issue with cached focused TemplateId occasionally being set to Invalid by the EOS

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.cpp
@@ -225,7 +225,6 @@ namespace AzToolsFramework::Prefab
         const InstanceOptionalReference previousFocusedInstance = GetInstanceReference(previousContainerRootAliasPath);
 
         m_rootAliasFocusPath = focusedInstance->get().GetAbsoluteInstanceAliasPath();
-        m_focusedTemplateId = focusedInstance->get().GetTemplateId();
         m_rootAliasFocusPathLength = aznumeric_cast<int>(AZStd::distance(m_rootAliasFocusPath.begin(), m_rootAliasFocusPath.end()));
 
         // Focus on the descendants of the container entity in the Editor, if the interface is initialized.
@@ -266,7 +265,16 @@ namespace AzToolsFramework::Prefab
     
     TemplateId PrefabFocusHandler::GetFocusedPrefabTemplateId([[maybe_unused]] AzFramework::EntityContextId entityContextId) const
     {
-        return m_focusedTemplateId;
+        InstanceOptionalReference instance = GetInstanceReference(m_rootAliasFocusPath);
+
+        if (instance.has_value())
+        {
+            return instance->get().GetTemplateId();
+        }
+        else
+        {
+            return Prefab::InvalidTemplateId;
+        }
     }
 
     InstanceOptionalReference PrefabFocusHandler::GetFocusedPrefabInstance(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabFocusHandler.h
@@ -83,8 +83,6 @@ namespace AzToolsFramework::Prefab
 
         //! The alias path for the instance the editor is currently focusing on, starting from the root instance.
         RootAliasPath m_rootAliasFocusPath = RootAliasPath();
-        //! The templateId of the focused instance.
-        TemplateId m_focusedTemplateId = Prefab::InvalidTemplateId;
         //! A path containing the filenames of the instances in the focus hierarchy, separated with a /.
         AZ::IO::Path m_filenameFocusPath;
         //! The length of the current focus path. Stored to simplify internal checks.


### PR DESCRIPTION
The changes to the Prefab Save workflows introduced in #7649 surfaced an issue with the EOS: when loading a level, OnContextReset triggers an update to the PrefabFocusHandler but at that time the rootInstance is still set to an invalid TemplateId. In that state, pressing Ctrl+S or clicking on Save in the File menu results in no action even if there are changes that need to be saved, because the cached TemplateId in the FocusHandler would be set to Invalid even though the root instance is valid.

Given the amount of hits the cached root template id would get anyways, I preferred removing the variable and just retrieving the updated value on demand. That fixes the issue.

Signed-off-by: Danilo Aimini <82231674+AMZN-daimini@users.noreply.github.com>