### PR TITLE
Make RPI pass template pointed object const

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -338,7 +338,7 @@ namespace AZ
                 // Save a reference to the generated BRDF texture so it doesn't get deleted if all the passes refering to it get deleted and it's ref count goes to zero
                 if (!m_brdfTexture)
                 {
-                    const AZStd::shared_ptr<RPI::PassTemplate> brdfTextureTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(Name("BRDFTextureTemplate"));
+                    const AZStd::shared_ptr<const RPI::PassTemplate> brdfTextureTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(Name("BRDFTextureTemplate"));
                     Data::Asset<RPI::AttachmentImageAsset> brdfImageAsset = RPI::AssetUtils::LoadAssetById<RPI::AttachmentImageAsset>(
                         brdfTextureTemplate->m_imageAttachments[0].m_assetRef.m_assetId, RPI::AssetUtils::TraceLevel::Error);
                     if (brdfImageAsset.IsReady())

--- a/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CoreLights/ShadowmapPass.cpp
@@ -41,7 +41,7 @@ namespace AZ
             childRequest.m_connections.emplace_back(passConnection);
 
             // Get the template
-            AZStd::shared_ptr<RPI::PassTemplate> childTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(childRequest.m_templateName);
+            const AZStd::shared_ptr<const RPI::PassTemplate> childTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(childRequest.m_templateName);
             AZ_Assert(childTemplate, "ShadowmapPass::CreateWIthPassRequest - attempting to create a shadowmap pass before the template has been created.");
 
             // Create the pass

--- a/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ReflectionScreenSpace/ReflectionScreenSpaceBlurPass.cpp
@@ -69,8 +69,8 @@ namespace AZ
             }
 
             // load pass templates
-            const AZStd::shared_ptr<RPI::PassTemplate> blurVerticalPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(Name("ReflectionScreenSpaceBlurVerticalPassTemplate"));
-            const AZStd::shared_ptr<RPI::PassTemplate> blurHorizontalPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(Name("ReflectionScreenSpaceBlurHorizontalPassTemplate"));
+            const AZStd::shared_ptr<const RPI::PassTemplate> blurVerticalPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(Name("ReflectionScreenSpaceBlurVerticalPassTemplate"));
+            const AZStd::shared_ptr<const RPI::PassTemplate> blurHorizontalPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(Name("ReflectionScreenSpaceBlurHorizontalPassTemplate"));
 
             // create pass descriptors
             RPI::PassDescriptor verticalBlurChildDesc;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/Pass.h
@@ -405,7 +405,7 @@ namespace AZ
 
             // The PassTemplate used to create this pass
             // Null if this pass was not created by a PassTemplate
-            AZStd::shared_ptr<PassTemplate> m_template = nullptr;
+            AZStd::shared_ptr<const PassTemplate> m_template = nullptr;
 
             // The PassRequest used to create this pass
             // Only valid if m_createdByPassRequest flag is set

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassFactory.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassFactory.h
@@ -59,7 +59,7 @@ namespace AZ
             Ptr<Pass> CreatePassFromClass(Name passClassName, Name passName);
 
             //! Creates a Pass using a PassTemplate
-            Ptr<Pass> CreatePassFromTemplate(const AZStd::shared_ptr<PassTemplate>& passTemplate, Name passName);
+            Ptr<Pass> CreatePassFromTemplate(const AZStd::shared_ptr<const PassTemplate>& passTemplate, Name passName);
 
             //! Creates a Pass using the name of a PassTemplate
             Ptr<Pass> CreatePassFromTemplate(Name templateName, Name passName);
@@ -80,7 +80,7 @@ namespace AZ
             CreatorIndex FindCreatorIndex(Name passClassName);
 
             // Helper function that creates a pass using an index into the list of PassCreators
-            Ptr<Pass> CreatePassFromIndex(CreatorIndex index, Name passName, const AZStd::shared_ptr<PassTemplate>& passTemplate, const PassRequest* passRequest);
+            Ptr<Pass> CreatePassFromIndex(CreatorIndex index, Name passName, const AZStd::shared_ptr<const PassTemplate>& passTemplate, const PassRequest* passRequest);
 
             // --- Members ---
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassLibrary.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassLibrary.h
@@ -74,7 +74,9 @@ namespace AZ
             bool HasPassesForTemplate(const Name& templateName) const;
 
             //! Retrieves a PassTemplate from the library
-            const AZStd::shared_ptr<PassTemplate> GetPassTemplate(const Name& name) const;
+            const AZStd::shared_ptr<const PassTemplate> GetPassTemplate(const Name& name) const;
+
+            //! Returns a list of passes using the template with the name passed as argument
             const AZStd::vector<Pass*>& GetPassesForTemplate(const Name& templateName) const;
 
             //! Removes a PassTemplate by name, only if the following two conditions are met:

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -85,7 +85,7 @@ namespace AZ
             // PassSystemInterface factory related functions...
             void AddPassCreator(Name className, PassCreator createFunction) override;
             Ptr<Pass> CreatePassFromClass(Name passClassName, Name passName) override;
-            Ptr<Pass> CreatePassFromTemplate(const AZStd::shared_ptr<PassTemplate>& passTemplate, Name passName) override;
+            Ptr<Pass> CreatePassFromTemplate(const AZStd::shared_ptr<const PassTemplate>& passTemplate, Name passName) override;
             Ptr<Pass> CreatePassFromTemplate(Name templateName, Name passName) override;
             Ptr<Pass> CreatePassFromRequest(const PassRequest* passRequest) override;
             bool HasCreatorForClass(Name passClassName) override;
@@ -93,7 +93,7 @@ namespace AZ
             // PassSystemInterface library related functions...
             bool HasPassesForTemplateName(const Name& templateName) const override;
             bool AddPassTemplate(const Name& name, const AZStd::shared_ptr<PassTemplate>& passTemplate) override;
-            const AZStd::shared_ptr<PassTemplate> GetPassTemplate(const Name& name) const override;
+            const AZStd::shared_ptr<const PassTemplate> GetPassTemplate(const Name& name) const override;
             void RemovePassTemplate(const Name& name) override;
             void RemovePassFromLibrary(Pass* pass) override;
             void RegisterPass(Pass* pass) override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystem.h
@@ -91,6 +91,7 @@ namespace AZ
             bool HasCreatorForClass(Name passClassName) override;
 
             // PassSystemInterface library related functions...
+            bool HasTemplate(const Name& templateName) const override;
             bool HasPassesForTemplateName(const Name& templateName) const override;
             bool AddPassTemplate(const Name& name, const AZStd::shared_ptr<PassTemplate>& passTemplate) override;
             const AZStd::shared_ptr<const PassTemplate> GetPassTemplate(const Name& name) const override;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
@@ -190,6 +190,9 @@ namespace AZ
 
             // --- Pass Library related functionality ---
 
+            //! Returns true if the pass library contains a pass template with the given template name
+            virtual bool HasTemplate(const Name& templateName) const = 0;
+
             //! Returns true if the pass factory contains passes created with the given template name
             virtual bool HasPassesForTemplateName(const Name& templateName) const = 0;
 

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Pass/PassSystemInterface.h
@@ -177,7 +177,7 @@ namespace AZ
             virtual Ptr<Pass> CreatePassFromClass(Name passClassName, Name passName) = 0;
 
             //! Creates a Pass using a PassTemplate
-            virtual Ptr<Pass> CreatePassFromTemplate(const AZStd::shared_ptr<PassTemplate>& passTemplate, Name passName) = 0;
+            virtual Ptr<Pass> CreatePassFromTemplate(const AZStd::shared_ptr<const PassTemplate>& passTemplate, Name passName) = 0;
 
             //! Creates a Pass using the name of a PassTemplate
             virtual Ptr<Pass> CreatePassFromTemplate(Name templateName, Name passName) = 0;
@@ -197,7 +197,7 @@ namespace AZ
             virtual bool AddPassTemplate(const Name& name, const AZStd::shared_ptr<PassTemplate>& passTemplate) = 0;
 
             //! Retrieves a PassTemplate from the library
-            virtual const AZStd::shared_ptr<PassTemplate> GetPassTemplate(const Name& name) const = 0;
+            virtual const AZStd::shared_ptr<const PassTemplate> GetPassTemplate(const Name& name) const = 0;
 
             //! See remarks in PassLibrary.h for the function with this name.
             virtual void RemovePassTemplate(const Name& name) = 0;

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassDescriptor.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Pass/PassDescriptor.h
@@ -28,7 +28,7 @@ namespace AZ
             PassDescriptor() = default;
             ~PassDescriptor() = default;
 
-            explicit PassDescriptor(Name name, const AZStd::shared_ptr<PassTemplate> passTemplate = nullptr, const PassRequest* passRequest = nullptr)
+            explicit PassDescriptor(Name name, const AZStd::shared_ptr<const PassTemplate> passTemplate = nullptr, const PassRequest* passRequest = nullptr)
                 : m_passName(name)
                 , m_passTemplate(passTemplate)
                 , m_passRequest(passRequest)
@@ -38,7 +38,7 @@ namespace AZ
             Name m_passName;
 
             //! Optional: The PassTemplate used to construct a Pass.
-            AZStd::shared_ptr<PassTemplate> m_passTemplate = nullptr;
+            AZStd::shared_ptr<const PassTemplate> m_passTemplate = nullptr;
 
             //! Optional: The PassRequest used to construct a Pass. If this is valid then m_passTemplate 
             //! cannot be null and m_passTemplate must point to the same template used by the PassRequest.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -60,7 +60,7 @@ namespace AZ
                 // Assert m_template is the same as the one in the pass request
                 if (PassValidation::IsEnabled())
                 {
-                    const AZStd::shared_ptr<PassTemplate> passTemplate = PassSystemInterface::Get()->GetPassTemplate(descriptor.m_passRequest->m_templateName);
+                    const AZStd::shared_ptr<const PassTemplate> passTemplate = PassSystemInterface::Get()->GetPassTemplate(descriptor.m_passRequest->m_templateName);
                     AZ_RPI_PASS_ASSERT(m_template == passTemplate, "Error: template in PassDescriptor doesn't match template from PassRequest!");
                 }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassFactory.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassFactory.cpp
@@ -92,7 +92,7 @@ namespace AZ
 
         // --- Pass Creation Functions ---
 
-        Ptr<Pass> PassFactory::CreatePassFromIndex(CreatorIndex index, Name passName, const AZStd::shared_ptr<PassTemplate>& passTemplate, const PassRequest* passRequest)
+        Ptr<Pass> PassFactory::CreatePassFromIndex(CreatorIndex index, Name passName, const AZStd::shared_ptr<const PassTemplate>& passTemplate, const PassRequest* passRequest)
         {
             if (index.IsNull() || index.GetIndex() >= m_creationFunctions.size())
             {
@@ -112,7 +112,7 @@ namespace AZ
             return CreatePassFromIndex(index, passName, nullptr, nullptr);
         }
 
-        Ptr<Pass> PassFactory::CreatePassFromTemplate(const AZStd::shared_ptr<PassTemplate>& passTemplate, Name passName)
+        Ptr<Pass> PassFactory::CreatePassFromTemplate(const AZStd::shared_ptr<const PassTemplate>& passTemplate, Name passName)
         {
             if (!passTemplate)
             {
@@ -125,7 +125,7 @@ namespace AZ
 
         Ptr<Pass> PassFactory::CreatePassFromTemplate(Name templateName, Name passName)
         {
-            const AZStd::shared_ptr<PassTemplate>& passTemplate = m_passLibrary->GetPassTemplate(templateName);
+            const AZStd::shared_ptr<const PassTemplate>& passTemplate = m_passLibrary->GetPassTemplate(templateName);
             if (passTemplate == nullptr)
             {
                 AZ_Error("PassFactory", false, "FAILED TO CREATE PASS [%s]. Could not find pass template [%s]", passName.GetCStr(), templateName.GetCStr());
@@ -143,7 +143,7 @@ namespace AZ
                 return nullptr;
             }
 
-            const AZStd::shared_ptr<PassTemplate>& passTemplate = m_passLibrary->GetPassTemplate(passRequest->m_templateName);
+            const AZStd::shared_ptr<const PassTemplate>& passTemplate = m_passLibrary->GetPassTemplate(passRequest->m_templateName);
             if (passTemplate == nullptr)
             {
                 AZ_Error("PassFactory", false, "FAILED TO CREATE PASS [%s]. Could not find pass template [%s]", passRequest->m_passName.GetCStr(), passRequest->m_templateName.GetCStr());

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
@@ -62,7 +62,7 @@ namespace AZ
             return nullptr;
         }
 
-        const AZStd::shared_ptr<PassTemplate> PassLibrary::GetPassTemplate(const Name& templateName) const
+        const AZStd::shared_ptr<const PassTemplate> PassLibrary::GetPassTemplate(const Name& templateName) const
         {
             const TemplateEntry* entry = GetEntry(templateName);
             return entry ? entry->m_template : nullptr;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -451,6 +451,11 @@ namespace AZ
 
         // --- Pass Library Functions --- 
 
+        bool PassSystem::HasTemplate(const Name& templateName) const
+        {
+            return m_passLibrary.HasTemplate(templateName);
+        }
+
         bool PassSystem::HasPassesForTemplateName(const Name& templateName) const
         {
             return m_passLibrary.HasPassesForTemplate(templateName);

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassSystem.cpp
@@ -429,7 +429,7 @@ namespace AZ
             return m_passFactory.CreatePassFromClass(passClassName, passName);
         }
 
-        Ptr<Pass> PassSystem::CreatePassFromTemplate(const AZStd::shared_ptr<PassTemplate>& passTemplate, Name passName)
+        Ptr<Pass> PassSystem::CreatePassFromTemplate(const AZStd::shared_ptr<const PassTemplate>& passTemplate, Name passName)
         {
             return m_passFactory.CreatePassFromTemplate(passTemplate, passName);
         }
@@ -461,7 +461,7 @@ namespace AZ
             return m_passLibrary.AddPassTemplate(name, passTemplate);
         }
 
-        const AZStd::shared_ptr<PassTemplate> PassSystem::GetPassTemplate(const Name& name) const
+        const AZStd::shared_ptr<const PassTemplate> PassSystem::GetPassTemplate(const Name& name) const
         {
             return m_passLibrary.GetPassTemplate(name);
         }


### PR DESCRIPTION
**Description**
This PR changes the `GetPassTemplate` function from the pass library and pass system so that they return const pointer to const objects. Previously the returned object wasn't const allowing direct modification to the underlying template in the pass library.  
**This change will introduce a breaking change as all the call to `GetPassTemplate` will need to update their returned object signature to `const AZStd::shared_ptr<const RPI::PassTemplate>`.**

This PR also introduces the `HasTemplate` function in the pass system to expose the function with the same name in the pass library. This is intended as a replacement to the following pattern, that introduced a bump in the shared ptr counter.
```
const AZStd::shared_ptr<const RPI::PassTemplate> rtPassTemplate = RPI::PassSystemInterface::Get()->GetPassTemplate(renderPassTemplateName);
if (rtPassTemplate == nullptr)
{
}
```
That can now be expressed as:
```
if (!RPI::PassSystemInterface::Get()->HasTemplate(renderPassTemplateName))
{
}
```

**Tests**
- Ran the  ASV automated testing _fullsuite with DX12 on windows - No issue reported
- Ran the editor in various scenario