### PR TITLE
EMotion FX: Moving ground plane along with the character bug fix

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -224,20 +224,17 @@ namespace EMStudio
         return m_entityContext->GetContextId();
     }
 
-    void AnimViewportRenderer::CheckBounds()
+    void AnimViewportRenderer::UpdateGroundplane()
     {
         AZ::Vector3 groundPos;
         AZ::TransformBus::EventResult(groundPos, m_groundEntity->GetId(), &AZ::TransformBus::Events::GetWorldTranslation);
 
         const AZ::Vector3 characterPos = GetCharacterCenter();
-        if (AZStd::abs(characterPos.GetX() - groundPos.GetX()) > BoundMaxDistance ||
-            AZStd::abs(characterPos.GetY() - groundPos.GetY()) > BoundMaxDistance)
-        {
-            const float tileOffsetX = AZStd::fmod(characterPos.GetX(), TileSize);
-            const float tileOffsetY = AZStd::fmod(characterPos.GetX(), TileSize);
-            const AZ::Vector3 newGroundPos(characterPos.GetX() - tileOffsetX, characterPos.GetY() - tileOffsetY, groundPos.GetZ());
-            AZ::TransformBus::Event(m_groundEntity->GetId(), &AZ::TransformBus::Events::SetWorldTranslation, newGroundPos);
-        }
+        const float tileOffsetX = AZStd::fmod(characterPos.GetX(), TileSize);
+        const float tileOffsetY = AZStd::fmod(characterPos.GetY(), TileSize);
+        const AZ::Vector3 newGroundPos(characterPos.GetX() - tileOffsetX, characterPos.GetY() - tileOffsetY, groundPos.GetZ());
+
+        AZ::TransformBus::Event(m_groundEntity->GetId(), &AZ::TransformBus::Events::SetWorldTranslation, newGroundPos);
     }
 
     void AnimViewportRenderer::ResetEnvironment()

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.h
@@ -59,8 +59,8 @@ namespace EMStudio
         AZ::EntityId GetEntityId() const;
         AzFramework::EntityContextId GetEntityContextId() const;
 
-        // Call this function on update to prevent the character going out of bounds of the ground.
-        void CheckBounds();
+        // Moves the groundplane along with the character.
+        void UpdateGroundplane();
 
     private:
 
@@ -94,7 +94,6 @@ namespace EMStudio
         const RenderOptions* m_renderOptions;
 
         const float DefaultFrustumDimension = 128.0f;
-        const float BoundMaxDistance = 150.0f;
         const float TileSize = 1.0f;
         AZStd::vector<AZ::Render::DirectionalLightFeatureProcessorInterface::LightHandle> m_lightHandles;
     };

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportWidget.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportWidget.cpp
@@ -241,7 +241,7 @@ namespace EMStudio
         CalculateCameraProjection();
         RenderCustomPluginData();
         FollowCharacter();
-        m_renderer->CheckBounds();
+        m_renderer->UpdateGroundplane();
     }
 
     void AnimViewportWidget::CalculateCameraProjection()


### PR DESCRIPTION
Fixed a bug with moving the ground plane along with the character, the Y coordinate was not taken into account.

Also removed the bounds check which prevents moving the groundplane before reaching 150 tiles for two reasons:
1. Code safety: If something changes in the ground plane texture, we won't notice as the repositioning is done so rarely that we won't notice a possible pop. If this is done every frame and tile, we will be able to identify issues with it right when they get introduced. Code safety is a higher virtue here than saving a repositioning ebus call.
2. By moving 150 tiles, we are 1/3 of the plane closer to the cliff already, so when repositioning, we will see a pop in the horizon.

Signed-off-by: Benjamin Jillich <jillich@amazon.com>