### PR TITLE
EMotion FX: Simple motion component blend out time not working (+some more fixes)

### DIFF
--- a/Gems/EMotionFX/Code/EMotionFX/Source/MotionLayerSystem.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/MotionLayerSystem.cpp
@@ -154,13 +154,10 @@ namespace EMotionFX
             {
                 // if numloops not infinite and numloops-1 is the current number of loops
                 // and the current time - blendouttime has been reached
-                if (source->GetBlendOutBeforeEnded())
+                if (source->GetBlendOutBeforeEnded() && !source->GetIsPlayingForever())
                 {
                     // if the motion has to stop
-                    if ((!source->GetIsPlayingForever() &&
-                        (source->GetNumCurrentLoops() >= source->GetMaxLoops()) &&
-                        (source->GetTimeDifToLoopPoint() <= source->GetFadeTime()) &&
-                        !source->GetFreezeAtLastFrame()) ||
+                    if ((source->GetTimeDifToLoopPoint() <= source->GetFadeTime() && !source->GetFreezeAtLastFrame()) ||
                         (source->GetHasEnded() && !source->GetFreezeAtLastFrame()))
                     {
                         // if we have haven't looped yet, so we are still in time to fade out

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.cpp
@@ -30,7 +30,7 @@ namespace EMotionFX
             if (serializeContext)
             {
                 serializeContext->Class<Configuration>()
-                    ->Version(2)
+                    ->Version(3)
                     ->Field("MotionAsset", &Configuration::m_motionAsset)
                     ->Field("Loop", &Configuration::m_loop)
                     ->Field("Retarget", &Configuration::m_retarget)
@@ -41,6 +41,7 @@ namespace EMotionFX
                     ->Field("BlendOut", &Configuration::m_blendOutTime)
                     ->Field("PlayOnActivation", &Configuration::m_playOnActivation)
                     ->Field("InPlace", &Configuration::m_inPlace)
+                    ->Field("FreezeAtLastFrame", &Configuration::m_freezeAtLastFrame)
                     ;
 
                 AZ::EditContext* editContext = serializeContext->GetEditContext();
@@ -50,6 +51,7 @@ namespace EMotionFX
                         ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_motionAsset, "Motion", "EMotion FX motion to be loaded for this actor")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_loop, "Loop motion", "Toggles looping of the animation")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_retarget, "Retarget motion", "Toggles retargeting of the animation")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_reverse, "Reverse motion", "Toggles reversing of the animation")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_mirror, "Mirror motion", "Toggles mirroring of the animation")
@@ -60,14 +62,34 @@ namespace EMotionFX
                             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                             ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_blendOutTime, "Blend Out Time", "Determines the blend out time in seconds")
+                            ->Attribute(AZ::Edit::Attributes::Visibility, &Configuration::GetBlendOutTimeVisibility)
                             ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                             ->Attribute(AZ::Edit::Attributes::Max, 100.0f)
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_playOnActivation, "Play on active", "Playing animation immediately after activation.")
                         ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_inPlace, "In-place",
                             "Plays the animation in-place and removes any positional and rotational changes from root joints.")
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &Configuration::m_freezeAtLastFrame, "Freeze At Last Frame",
+                            "Go back to bind pose after finishing the motion or freeze at the last frame. This only applies for non-looping motions.")
+                            ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                            ->Attribute(AZ::Edit::Attributes::Visibility, &Configuration::GetFreezeAtLastFrameVisibility)
                         ;
                 }
             }
+        }
+
+        AZ::Crc32 SimpleMotionComponent::Configuration::GetBlendOutTimeVisibility() const
+        {
+            if (!m_loop && !m_freezeAtLastFrame)
+            {
+                return AZ::Edit::PropertyVisibility::Show;
+            }
+
+            return AZ::Edit::PropertyVisibility::Hide;
+        }
+
+        AZ::Crc32 SimpleMotionComponent::Configuration::GetFreezeAtLastFrameVisibility() const
+        {
+            return m_loop ? AZ::Edit::PropertyVisibility::Hide : AZ::Edit::PropertyVisibility::Show;
         }
 
         void SimpleMotionComponent::Reflect(AZ::ReflectContext* context)
@@ -460,6 +482,7 @@ namespace EMotionFX
             info.m_blendInTime = cfg.m_blendInTime;
             info.m_blendOutTime = cfg.m_blendOutTime;
             info.m_inPlace = cfg.m_inPlace;
+            info.m_freezeAtLastFrame = cfg.m_freezeAtLastFrame;
             return actorInstance->GetMotionSystem()->PlayMotion(motionAsset->m_emfxMotion.get(), &info);
         }
 

--- a/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
+++ b/Gems/EMotionFX/Code/Source/Integration/Components/SimpleMotionComponent.h
@@ -54,8 +54,12 @@ namespace EMotionFX
                 float                                m_blendOutTime;            ///< Determines the blend out time in seconds.
                 bool                                 m_playOnActivation;        ///< Determines if the motion should be played immediately
                 bool                                 m_inPlace;                 ///< Determines if the motion should be played in-place.
+                bool                                 m_freezeAtLastFrame = true;///< Determines if the motion will go to bind pose after finishing or freeze at the last frame.
 
                 static void Reflect(AZ::ReflectContext* context);
+
+                AZ::Crc32 GetBlendOutTimeVisibility() const;
+                AZ::Crc32 GetFreezeAtLastFrameVisibility() const;
             };
 
             SimpleMotionComponent(const Configuration* config = nullptr);

--- a/Gems/EMotionFX/Code/Tests/MotionLayerSystemTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/MotionLayerSystemTests.cpp
@@ -59,16 +59,16 @@ namespace EMotionFX
         EXPECT_FLOAT_EQ(motionInstance1->GetCurrentTime(), 1.0f);
         EXPECT_FLOAT_EQ(motionInstance2->GetCurrentTime(), 0.0f);
 
-        GetEMotionFX().Update(8.0f);
+        GetEMotionFX().Update(8.0f); // time = 9.0f
         EXPECT_EQ(motionSystem->GetNumMotionInstances(), 2);
         EXPECT_FLOAT_EQ(motionInstance1->GetWeight(), 1.0f);
         EXPECT_FLOAT_EQ(motionInstance2->GetWeight(), 0.0f);
         EXPECT_FLOAT_EQ(motionInstance1->GetCurrentTime(), 9.0f);
         EXPECT_FLOAT_EQ(motionInstance2->GetCurrentTime(), 0.0f);
 
-        GetEMotionFX().Update(0.5f);
+        GetEMotionFX().Update(0.5f); // time = 9.5f
         EXPECT_EQ(motionSystem->GetNumMotionInstances(), 2);
-        EXPECT_FLOAT_EQ(motionInstance1->GetWeight(), 1.0f);
+        EXPECT_FLOAT_EQ(motionInstance1->GetWeight(), 0.5f); // motion 1 started blending out at time 9.0f
         EXPECT_FLOAT_EQ(motionInstance2->GetWeight(), 0.5f);
         EXPECT_FLOAT_EQ(motionInstance1->GetCurrentTime(), 9.5f);
         EXPECT_FLOAT_EQ(motionInstance2->GetCurrentTime(), 0.5f);
@@ -179,7 +179,7 @@ namespace EMotionFX
         GetEMotionFX().Update(9.0f);
         GetEMotionFX().Update(0.5f);
         EXPECT_EQ(motionSystem->GetNumMotionInstances(), 2);
-        EXPECT_FLOAT_EQ(motionInstance1->GetWeight(), 1.0f);
+        EXPECT_FLOAT_EQ(motionInstance1->GetWeight(), 0.5f); // motion 1 started blending out at time 9.0f
         EXPECT_FLOAT_EQ(motionInstance2->GetWeight(), 0.5f);
 
         motionSystem->StopAllMotions();


### PR DESCRIPTION
* Blend out time was not working previously.
* Added the freeze at last frame option to the UI. If disabled, the character goes back to bind pose after the motion ended. If enabled, it stays at the last frame of the animation in case it is not looping.
* Hiding the freeze at last frame option in case the loop option is enabled.
* Showing the blend out option only in case looping and freezing at last frame are disabled. Hiding otherwise.

Resolves #5977

https://user-images.githubusercontent.com/43751992/155109641-f41a1b24-28af-48d7-a539-1e6a8fc7ea30.mp4

Signed-off-by: Benjamin Jillich <jillich@amazon.com>