### PR TITLE
7698: Fix broken documentation link for Terrain Gem

### DIFF
--- a/Gems/Terrain/gem.json
+++ b/Gems/Terrain/gem.json
@@ -15,7 +15,7 @@
         "Design",
         "Terrain"
     ],
-    "documentation_url": "https://o3de.org/docs/user-guide/gems/reference/terrain/",
+    "documentation_url": "https://www.o3de.org/docs/user-guide/gems/reference/environment/terrain/",
     "dependencies": [
         "Atom_RPI",
         "Atom",


### PR DESCRIPTION
Testing:
* Updated gem.json
* Reran project manager
* Confirmed link now goes to Terrain gem documentation on o3de.org


Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>