### PR TITLE
Add automated tests for complex workflows around creating a prefab

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main.py
@@ -66,6 +66,18 @@ class TestAutomation(TestAutomationBase):
         from Prefab.tests.create_prefab import CreatePrefab_UnderAnotherPrefab as test_module
         self._run_prefab_test(request, workspace, editor, test_module, autotest_mode=False)
 
+    def test_CreatePrefab_UnderChildEntityOfAnotherPrefab(self, request, workspace, editor, launcher_platform):
+        from Prefab.tests.create_prefab import CreatePrefab_UnderChildEntityOfAnotherPrefab as test_module
+        self._run_prefab_test(request, workspace, editor, test_module, autotest_mode=False)
+
+    def test_CreatePrefab_WithNestedEntities(self, request, workspace, editor, launcher_platform):
+        from Prefab.tests.create_prefab import CreatePrefab_WithNestedEntities as test_module
+        self._run_prefab_test(request, workspace, editor, test_module, autotest_mode=False)
+
+    def test_CreatePrefab_WithNestedEntitiesAndNestedPrefabs(self, request, workspace, editor, launcher_platform):
+        from Prefab.tests.create_prefab import CreatePrefab_WithNestedEntitiesAndNestedPrefabs as test_module
+        self._run_prefab_test(request, workspace, editor, test_module, autotest_mode=False)
+
     def test_DeleteEntity_UnderAnotherPrefab(self, request, workspace, editor, launcher_platform):
         from Prefab.tests.delete_entity import DeleteEntity_UnderAnotherPrefab as test_module
         self._run_prefab_test(request, workspace, editor, test_module, autotest_mode=False)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main_Optimized.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/TestSuite_Main_Optimized.py
@@ -24,6 +24,15 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_CreatePrefab_UnderAnotherPrefab(EditorSharedTest):
         from .tests.create_prefab import CreatePrefab_UnderAnotherPrefab as test_module
 
+    class test_CreatePrefab_UnderChildEntityOfAnotherPrefab(EditorSharedTest):
+        from .tests.create_prefab import CreatePrefab_UnderChildEntityOfAnotherPrefab as test_module
+
+    class test_CreatePrefab_WithNestedEntities(EditorSharedTest):
+        from .tests.create_prefab import CreatePrefab_WithNestedEntities as test_module
+    
+    class test_CreatePrefab_WithNestedEntitiesAndNestedPrefabs(EditorSharedTest):
+        from .tests.create_prefab import CreatePrefab_WithNestedEntitiesAndNestedPrefabs as test_module
+
     class test_DeleteEntity_UnderAnotherPrefab(EditorSharedTest):
         from .tests.delete_entity import DeleteEntity_UnderAnotherPrefab as test_module
 

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
@@ -25,7 +25,7 @@ def get_linear_nested_items_name(nested_items_name_prefix, current_level):
 def create_linear_nested_entities(nested_entities_name_prefix, level_count, pos):
     """
     This is a helper function which helps create nested entities 
-    where each nested entity has only one child entity most. For example:
+    where each nested entity has only one child entity at most. For example:
 
     Entity_0
     |- Entity_1 
@@ -91,7 +91,7 @@ def validate_linear_nested_entities(nested_entities_root, expected_level_count, 
 def create_linear_nested_prefabs(entities, nested_prefabs_file_name_prefix, nested_prefabs_instance_name_prefix, level_count):
     """
     This is a helper function which helps create nested prefabs 
-    where each nested prefab has only one child prefab most. For example:
+    where each nested prefab has only one child prefab at most. For example:
 
     Prefab_0
     |- Prefab_1 

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/PrefabTestUtils.py
@@ -19,31 +19,101 @@ import azlmbr.components as components
 import azlmbr.entity as entity
 import azlmbr.legacy.general as general
 
-def get_linear_nested_items_name(nested_items_name_prefix, current_layer):
-    return f"{nested_items_name_prefix}{current_layer}"
+def get_linear_nested_items_name(nested_items_name_prefix, current_level):
+    return f"{nested_items_name_prefix}{current_level}"
 
-def create_linear_nested_entities(nested_entities_name_prefix, layer_count, pos):
-    assert layer_count > 0, "Can't create nested entities with less than one layer"
+def create_linear_nested_entities(nested_entities_name_prefix, level_count, pos):
+    """
+    This is a helper function which helps create nested entities 
+    where each nested entity has only one child entity most. For example:
+
+    Entity_0
+    |- Entity_1 
+    |  |- Entity_2
+    ...
+
+    :param nested_entities_name_prefix: Name prefix which will be used to generate names of newly created nested entities.
+    :param level_count: Number of levels which the newly constructed nested entities will have.
+    :param pos: The position where the nested entities will be.
+    :return: Root of the newly created nested entities.
+    """
+    assert level_count > 0, "Can't create nested entities with less than one level"
 
     current_entity = EditorEntity.create_editor_entity_at(
         pos, name=get_linear_nested_items_name(nested_entities_name_prefix, 0))
     root_entity = current_entity
-    for current_layer in range(1, layer_count):
+    for current_level in range(1, level_count):
         current_entity = EditorEntity.create_editor_entity(
-            parent_id=current_entity.id, name=get_linear_nested_items_name(nested_entities_name_prefix, current_layer))
+            parent_id=current_entity.id, name=get_linear_nested_items_name(nested_entities_name_prefix, current_level))
 
     return root_entity
 
-def create_linear_nested_prefabs(entities, nested_prefabs_file_name_prefix, nested_prefabs_instance_name_prefix, layer_count):
-    assert layer_count > 0, "Can't create nested prefabs with less than one layer"
+def validate_linear_nested_entities(nested_entities_root, expected_level_count, expected_pos):
+    """
+    This is a helper function which helps validate linear nested entities
+    created by helper function create_linear_nested_entities.
+
+    :param nested_entities_root: Root of nested entities created by create_linear_nested_entities.
+    :param expected_level_count: Number of levels which target nested entities should have.
+    :param expected_pos: The position where target nested entities should be.
+    """
+    assert expected_level_count > 0, "Can't validate nested entities with less than one layer"
+    assert nested_entities_root.get_parent_id().IsValid(), \
+        "Root of nested entities should have a valid parent entity"
+    
+    current_entity = nested_entities_root
+    level_count = 1
+    while True:
+        assert current_entity.id.IsValid(), f"Entity '{current_entity.get_name()}' is not valid"
+
+        current_entity_pos = current_entity.get_world_translation()
+        assert current_entity_pos.IsClose(expected_pos), \
+            f"Entity '{current_entity.get_name()}' position '{current_entity_pos.ToString()}' " \
+            f"is not located at expected position '{expected_pos.ToString()}'"
+
+        child_entities = current_entity.get_children()
+        if len(child_entities) == 0:
+            break
+
+        assert len(child_entities) == 1, \
+            f"These entities are not linearly nested. Entity '{current_entity.get_name}' has {len(child_entities)} child entities"
+
+        level_count += 1
+        child_entity = child_entities[0]
+        assert child_entity.get_parent_id() == current_entity.id, \
+            f"Entity '{child_entity.get_name()}' should be under entity '{current_entity.get_name()}'"
+
+        current_entity = child_entity
+        
+    assert level_count == expected_level_count, \
+        f"Number of levels of nested entities should be {expected_level_count}, not {level_count}"
+
+def create_linear_nested_prefabs(entities, nested_prefabs_file_name_prefix, nested_prefabs_instance_name_prefix, level_count):
+    """
+    This is a helper function which helps create nested prefabs 
+    where each nested prefab has only one child prefab most. For example:
+
+    Prefab_0
+    |- Prefab_1 
+    |  |- Prefab_2
+    |  |  |- TestEntity
+    ...
+
+    :param entities: Entities which the nested prefabs will be built from.
+    :param nested_prefabs_file_name_prefix: Name prefix which will be used to generate file names of newly created nested prefabs.
+    :param level_count: Number of levels the newly constructed nested prefabs will have.
+    :param nested_prefabs_instance_name_prefix: Name prefix which will be used to generate names of newly created nested prefab instances.
+    :return: A list of created nested prefabs and a list of created nested prefab instances. Ordered from top to bottom.
+    """
+    assert level_count > 0, "Can't create nested prefabs with less than one level"
 
     created_prefabs = []
     created_prefab_instances = []
 
-    for current_layer in range(0, layer_count):
+    for current_level in range(0, level_count):
         current_prefab, current_prefab_instance = Prefab.create_prefab(
-            entities, get_linear_nested_items_name(nested_prefabs_file_name_prefix, current_layer), 
-            prefab_instance_name=get_linear_nested_items_name(nested_prefabs_instance_name_prefix, current_layer))
+            entities, get_linear_nested_items_name(nested_prefabs_file_name_prefix, current_level), 
+            prefab_instance_name=get_linear_nested_items_name(nested_prefabs_instance_name_prefix, current_level))
         created_prefabs.append(current_prefab)
         created_prefab_instances.append(current_prefab_instance)
         entities = current_prefab_instance.get_direct_child_entities()
@@ -51,6 +121,12 @@ def create_linear_nested_prefabs(entities, nested_prefabs_file_name_prefix, nest
     return created_prefabs, created_prefab_instances
 
 def validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances):
+    """
+    This is a helper function which helps validate linear nested prefabs 
+    created by helper function create_linear_nested_prefabs.
+
+    :param nested_prefab_instances: A list of nested prefab instances created by create_linear_nested_prefabs. Ordered from top to bottom.
+    """
     if len(nested_prefab_instances) == 0:
         return
 
@@ -59,8 +135,8 @@ def validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances):
         "Root of nested prefabs should have a valid parent entity"
 
     parent_prefab_instance = nested_prefab_instances_root
-    for current_layer in range(0, len(nested_prefab_instances) - 1):
-        current_prefab_instance = nested_prefab_instances[current_layer]
+    for current_level in range(0, len(nested_prefab_instances) - 1):
+        current_prefab_instance = nested_prefab_instances[current_level]
         current_prefab_instance_container_entity = current_prefab_instance.container_entity
         assert current_prefab_instance_container_entity.id.IsValid(), \
             f"Prefab '{current_prefab_instance_container_entity.get_name()}' is not valid"
@@ -71,7 +147,7 @@ def validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances):
             f"Entity '{current_entity.get_name}' has {len(direct_child_entities)} direct child entities"
 
         direct_child_entity = direct_child_entities[0]
-        inner_prefab_instance = nested_prefab_instances[current_layer + 1]
+        inner_prefab_instance = nested_prefab_instances[current_level + 1]
         inner_prefab_instance_container_entity = inner_prefab_instance.container_entity
         assert direct_child_entity.id == inner_prefab_instance_container_entity.id, \
             f"Direct child entity of prefab '{current_prefab_instance_container_entity.get_name()}' " \
@@ -90,38 +166,6 @@ def validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances):
     for entity in direct_child_entities:
         assert entity.get_parent_id() == most_inner_prefab_instance_container_entity.id, \
             f"Entity '{entity.get_name()}' should be under prefab '{most_inner_prefab_instance_container_entity.get_name()}'" 
-
-def validate_linear_nested_entities(nested_entities_root, expected_layer_count, expected_pos):
-    assert expected_layer_count > 0, "Can't validate nested entities with less than one layer"
-    assert nested_entities_root.get_parent_id().IsValid(), \
-        "Root of nested entities should have a valid parent entity"
-    
-    current_entity = nested_entities_root
-    layer_count = 1
-    while True:
-        assert current_entity.id.IsValid(), f"Entity '{current_entity.get_name()}' is not valid"
-
-        current_entity_pos = current_entity.get_world_translation()
-        assert current_entity_pos.IsClose(expected_pos), \
-            f"Entity '{current_entity.get_name()}' position '{current_entity_pos.ToString()}' " \
-            f"is not located at expected position '{expected_pos.ToString()}'"
-
-        child_entities = current_entity.get_children()
-        if len(child_entities) == 0:
-            break
-
-        assert len(child_entities) == 1, \
-            f"These entities are not linearly nested. Entity '{current_entity.get_name}' has {len(child_entities)} child entities"
-
-        layer_count += 1
-        child_entity = child_entities[0]
-        assert child_entity.get_parent_id() == current_entity.id, \
-            f"Entity '{child_entity.get_name()}' should be under entity '{current_entity.get_name()}'"
-
-        current_entity = child_entity
-        
-    assert layer_count == expected_layer_count, \
-        f"Number of layers of nested entities should be {expected_layer_count}, not {layer_count}"
 
 def check_entity_children_count(entity_id, expected_children_count):
     entity_children_count_matched_result = (

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderAnotherPrefab.py
@@ -11,7 +11,7 @@ def CreatePrefab_UnderAnotherPrefab():
     - Creates an entity with a physx collider
     - Creates a prefab "Outer_prefab" and an instance based of that entity 
     - Creates a prefab "Inner_prefab" inside "Outer_prefab" based the entity contained inside of it
-    Checks that the entity is correctly handlded by the prefab system checking the name and that it contains the physx collider
+    Checks that the entity is correctly handled by the prefab system checking the name and that it contains the physx collider
     """
     
     from pathlib import Path
@@ -31,7 +31,7 @@ def CreatePrefab_UnderAnotherPrefab():
     entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), name="TestEntity")
     assert entity.id.IsValid(), "Couldn't create entity"
     entity.add_component("PhysX Collider")
-    assert entity.has_component("PhysX Collider"), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+    assert entity.has_component("PhysX Collider"), "Failed to add a PhysX Collider"
 
     # Create a prefab based on that entity
     outer_prefab, outer_instance = Prefab.create_prefab([entity], OUTER_PREFAB_FILE_NAME)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderAnotherPrefab.py
@@ -13,23 +13,28 @@ def CreatePrefab_UnderAnotherPrefab():
     - Creates a prefab "Inner_prefab" inside "Outer_prefab" based the entity contained inside of it
     Checks that the entity is correctly handlded by the prefab system checking the name and that it contains the physx collider
     """
+    
+    from pathlib import Path
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.prefab_utils import Prefab
 
     import Prefab.tests.PrefabTestUtils as prefab_test_utils
 
+    OUTER_PREFAB_FILE_NAME = Path(__file__).stem + 'Outer_prefab'
+    INNER_PREFAB_FILE_NAME = Path(__file__).stem + 'Inner_prefab'
+
     prefab_test_utils.open_base_tests_level()
 
     # Creates a new Entity at the root level
     # Asserts if creation didn't succeed
-    entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), name = "TestEntity")
+    entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), name="TestEntity")
     assert entity.id.IsValid(), "Couldn't create entity"
     entity.add_component("PhysX Collider")
     assert entity.has_component("PhysX Collider"), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
 
     # Create a prefab based on that entity
-    outer_prefab, outer_instance = Prefab.create_prefab([entity], "Outer_prefab")
+    outer_prefab, outer_instance = Prefab.create_prefab([entity], OUTER_PREFAB_FILE_NAME)
     # The test should be now inside the outer prefab instance.
     entity = outer_instance.get_direct_child_entities()[0]
     # We track if that is the same entity by checking the name and if it still contains the component that we created before
@@ -37,7 +42,7 @@ def CreatePrefab_UnderAnotherPrefab():
     assert entity.has_component("PhysX Collider"), "Entity name inside outer_prefab doesn't have the collider component it should"
 
     # Now, create another prefab, based on the entity that is inside outer_prefab
-    inner_prefab, inner_instance = Prefab.create_prefab([entity], "Inner_prefab")
+    inner_prefab, inner_instance = Prefab.create_prefab([entity], INNER_PREFAB_FILE_NAME)
     # The test entity should now be inside the inner prefab instance
     entity = inner_instance.get_direct_child_entities()[0]
     # We track if that is the same entity by checking the name and if it still contains the component that we created before

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderChildEntityOfAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderChildEntityOfAnotherPrefab.py
@@ -1,0 +1,82 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def CreatePrefab_UnderChildEntityOfAnotherPrefab():
+    """
+    Test description:
+    - Creates parent/child entities with the entities having a physx collider
+    - Creates a prefab "Outer_prefab" and an instance based of the entities
+    - Creates a prefab "Inner_prefab" inside "Outer_prefab" based the child entity contained inside of it
+
+    Checks that the parent/child entity is correctly handlded by the prefab system checking the name and that it contains the physx collider
+    """
+
+    from pathlib import Path
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    OUTER_PREFAB_NAME = 'Outer_prefab'
+    INNER_PREFAB_NAME = 'Inner_prefab'
+    OUTER_PREFAB_FILE_NAME = Path(__file__).stem + OUTER_PREFAB_NAME
+    INNER_PREFAB_FILE_NAME = Path(__file__).stem + INNER_PREFAB_NAME
+    PARENT_ENTITY_NAME = "ParentEntity"
+    CHILD_ENTITY_NAME = "ChildEntity"
+    PHYSX_COLLIDER_NAME = "PhysX Collider"
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Creates new parent/child Entities at the root level
+    # Asserts if creation didn't succeed
+    parent_entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), name=PARENT_ENTITY_NAME)
+    assert parent_entity.id.IsValid(), "Couldn't create parententity"
+    parent_entity.add_component(PHYSX_COLLIDER_NAME)
+    assert parent_entity.has_component(PHYSX_COLLIDER_NAME), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+    child_entity = EditorEntity.create_editor_entity(parent_id=parent_entity.id, name=CHILD_ENTITY_NAME)
+    assert child_entity.id.IsValid(), "Couldn't create child entity"
+    child_entity.add_component(PHYSX_COLLIDER_NAME)
+    assert child_entity.has_component(PHYSX_COLLIDER_NAME), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+
+    # Create a prefab based on that entity
+    _, outer_instance = Prefab.create_prefab([parent_entity], OUTER_PREFAB_FILE_NAME)
+    # The entities should be now inside the outer prefab instance.
+    parent_entity_on_outer_instance = outer_instance.get_direct_child_entities()[0]
+    child_entity_on_outer_instance = parent_entity_on_outer_instance.get_children()[0]
+
+    # We track if the parent entity the same one by checking the name and if it still contains the component that we created before
+    assert parent_entity_on_outer_instance.get_name() == PARENT_ENTITY_NAME, \
+        f"Entity name inside '{OUTER_PREFAB_NAME}' doesn't match the original name, original:'{PARENT_ENTITY_NAME}' " \
+        f"current:'{parent_entity_on_outer_instance.get_name()}'"
+    assert parent_entity_on_outer_instance.has_component(PHYSX_COLLIDER_NAME), \
+        "Entity inside outer_prefab doesn't have the collider component it should"
+
+    # Now, create another prefab, based on the child entity that is inside outer_prefab
+    _, inner_instance = Prefab.create_prefab([child_entity_on_outer_instance], INNER_PREFAB_FILE_NAME)
+    # The child entity should now be inside the inner prefab instance
+    child_entity_on_inner_instance = inner_instance.get_direct_child_entities()[0]
+    # We track if the child entity is the same entity by checking the name and if it still contains the component that we created before
+    assert child_entity_on_inner_instance.get_name() == CHILD_ENTITY_NAME, \
+        f"Entity name inside '{INNER_PREFAB_NAME}' doesn't match the original name, original:'{CHILD_ENTITY_NAME}' " \
+        f"current:'{child_entity_on_inner_instance.get_name()}'"
+    assert child_entity_on_inner_instance.has_component("PhysX Collider"), \
+        "Entity inside inner_prefab doesn't have the collider component it should"
+
+    # Verify hierarchy of entities:
+    # Outer_prefab
+    # |- ParentEntity
+    # |  |- Inner_prefab 
+    # |  |  |- ChildEntity
+    assert child_entity_on_inner_instance.get_parent_id() == inner_instance.container_entity.id
+    assert inner_instance.container_entity.get_parent_id() == parent_entity_on_outer_instance.id
+    assert parent_entity_on_outer_instance.get_parent_id() == outer_instance.container_entity.id
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(CreatePrefab_UnderChildEntityOfAnotherPrefab)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderChildEntityOfAnotherPrefab.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_UnderChildEntityOfAnotherPrefab.py
@@ -12,7 +12,7 @@ def CreatePrefab_UnderChildEntityOfAnotherPrefab():
     - Creates a prefab "Outer_prefab" and an instance based of the entities
     - Creates a prefab "Inner_prefab" inside "Outer_prefab" based the child entity contained inside of it
 
-    Checks that the parent/child entity is correctly handlded by the prefab system checking the name and that it contains the physx collider
+    Checks that the parent/child entity is correctly handled by the prefab system checking the name and that it contains the physx collider
     """
 
     from pathlib import Path
@@ -26,22 +26,22 @@ def CreatePrefab_UnderChildEntityOfAnotherPrefab():
     INNER_PREFAB_NAME = 'Inner_prefab'
     OUTER_PREFAB_FILE_NAME = Path(__file__).stem + OUTER_PREFAB_NAME
     INNER_PREFAB_FILE_NAME = Path(__file__).stem + INNER_PREFAB_NAME
-    PARENT_ENTITY_NAME = "ParentEntity"
-    CHILD_ENTITY_NAME = "ChildEntity"
-    PHYSX_COLLIDER_NAME = "PhysX Collider"
+    PARENT_ENTITY_NAME = 'ParentEntity'
+    CHILD_ENTITY_NAME = 'ChildEntity'
+    PHYSX_COLLIDER_NAME = 'PhysX Collider'
 
     prefab_test_utils.open_base_tests_level()
 
     # Creates new parent/child Entities at the root level
     # Asserts if creation didn't succeed
     parent_entity = EditorEntity.create_editor_entity_at((100.0, 100.0, 100.0), name=PARENT_ENTITY_NAME)
-    assert parent_entity.id.IsValid(), "Couldn't create parententity"
+    assert parent_entity.id.IsValid(), "Couldn't create parent entity"
     parent_entity.add_component(PHYSX_COLLIDER_NAME)
-    assert parent_entity.has_component(PHYSX_COLLIDER_NAME), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+    assert parent_entity.has_component(PHYSX_COLLIDER_NAME), f"Failed to add a {PHYSX_COLLIDER_NAME}"
     child_entity = EditorEntity.create_editor_entity(parent_id=parent_entity.id, name=CHILD_ENTITY_NAME)
     assert child_entity.id.IsValid(), "Couldn't create child entity"
     child_entity.add_component(PHYSX_COLLIDER_NAME)
-    assert child_entity.has_component(PHYSX_COLLIDER_NAME), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+    assert child_entity.has_component(PHYSX_COLLIDER_NAME), f"Failed to add a {PHYSX_COLLIDER_NAME}"
 
     # Create a prefab based on that entity
     _, outer_instance = Prefab.create_prefab([parent_entity], OUTER_PREFAB_FILE_NAME)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntities.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntities.py
@@ -11,7 +11,7 @@ def CreatePrefab_WithNestedEntities():
     - Creates linear nested entities. 
     - Creates a prefab from the nested entities.
 
-    Test passed if the newly instanced prefab of the 3 entities have correct hierarchy and positions.
+    Test passed if the 3 entities inside the newly instanced prefab have correct hierarchy and positions.
     """
 
     from pathlib import Path
@@ -25,23 +25,23 @@ def CreatePrefab_WithNestedEntities():
     NESTED_ENTITIES_NAME_PREFIX = 'Entity_'
     OLD_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
     NEW_POSITION = azlmbr.math.Vector3(200.0, 200.0, 200.0)
-    NUM_NESTED_ENTITIES_LAYERS = 3
+    NUM_NESTED_ENTITIES_LEVELS = 3
 
     prefab_test_utils.open_base_tests_level()
 
     # Creates new nested entities at the root level
     # Asserts if creation didn't succeed
-    nested_entities_root = prefab_test_utils.create_linear_nested_entities(NESTED_ENTITIES_NAME_PREFIX, NUM_NESTED_ENTITIES_LAYERS, OLD_POSITION)
-    prefab_test_utils.validate_linear_nested_entities(nested_entities_root, NUM_NESTED_ENTITIES_LAYERS, OLD_POSITION)
+    nested_entities_root = prefab_test_utils.create_linear_nested_entities(NESTED_ENTITIES_NAME_PREFIX, NUM_NESTED_ENTITIES_LEVELS, OLD_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root, NUM_NESTED_ENTITIES_LEVELS, OLD_POSITION)
 
     # Asserts if prefab creation doesn't succeed
     _, nested_entities_prefab_instance = Prefab.create_prefab([nested_entities_root], NESTED_ENTITIES_PREFAB_FILE_NAME)
     nested_entities_root_on_instance = nested_entities_prefab_instance.get_direct_child_entities()[0]
-    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LAYERS, OLD_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LEVELS, OLD_POSITION)
 
     # Moves the position of root of the nested entities, it should also update all the entites' positions
     nested_entities_root_on_instance.set_world_translation(NEW_POSITION)
-    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LAYERS, NEW_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LEVELS, NEW_POSITION)
 
 
 if __name__ == "__main__":

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntities.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntities.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def CreatePrefab_WithNestedEntities():
+    """
+    Test description:
+    - Creates linear nested entities. 
+    - Creates a prefab from the nested entities.
+
+    Test passed if the newly instanced prefab of the 3 entities have correct hierarchy and positions.
+    """
+
+    from pathlib import Path
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    NESTED_ENTITIES_PREFAB_FILE_NAME = Path(__file__).stem + 'nested_entities_prefab'
+    NESTED_ENTITIES_NAME_PREFIX = 'Entity_'
+    OLD_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
+    NEW_POSITION = azlmbr.math.Vector3(200.0, 200.0, 200.0)
+    NUM_NESTED_ENTITIES_LAYERS = 3
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Creates new nested entities at the root level
+    # Asserts if creation didn't succeed
+    nested_entities_root = prefab_test_utils.create_linear_nested_entities(NESTED_ENTITIES_NAME_PREFIX, NUM_NESTED_ENTITIES_LAYERS, OLD_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root, NUM_NESTED_ENTITIES_LAYERS, OLD_POSITION)
+
+    # Asserts if prefab creation doesn't succeed
+    _, nested_entities_prefab_instance = Prefab.create_prefab([nested_entities_root], NESTED_ENTITIES_PREFAB_FILE_NAME)
+    nested_entities_root_on_instance = nested_entities_prefab_instance.get_direct_child_entities()[0]
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LAYERS, OLD_POSITION)
+
+    # Moves the position of root of the nested entities, it should also update all the entites' positions
+    nested_entities_root_on_instance.set_world_translation(NEW_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LAYERS, NEW_POSITION)
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(CreatePrefab_WithNestedEntities)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntitiesAndNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntitiesAndNestedPrefabs.py
@@ -1,0 +1,100 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
+    """
+    Test description:
+    - Creates linear nested entities. 
+    - Creates a prefab from the nested entities.
+
+    Test passed if the newly instanced prefab of the 3 entities have correct hierarchy and positions.
+    """
+
+    from pathlib import Path
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import Prefab
+
+    import Prefab.tests.PrefabTestUtils as prefab_test_utils
+
+    NESTED_ENTITIES_PREFAB_FILE_NAME = Path(__file__).stem + '_' + 'nested_entities_prefab'
+    NESTED_ENTITIES_NAME_PREFIX = 'Entity_'
+    NESTED_PREFABS_FILE_NAME_PREFIX = Path(__file__).stem + '_' + 'nested_prefabs_'
+    NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
+    FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS = Path(__file__).stem + '_' + 'new_prefab'
+    NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
+    PHYSX_COLLIDER_NAME = "PhysX Collider"
+    CREATION_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
+    NUM_NESTED_ENTITIES_LAYERS = 3
+    NUM_NESTED_PREFABS_LAYERS = 3
+
+    prefab_test_utils.open_base_tests_level()
+
+    # Creates new nested entities at the root level
+    # Asserts if creation didn't succeed
+    nested_entities_root = prefab_test_utils.create_linear_nested_entities(
+        NESTED_ENTITIES_NAME_PREFIX, NUM_NESTED_ENTITIES_LAYERS, CREATION_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root, NUM_NESTED_ENTITIES_LAYERS, CREATION_POSITION)
+    nested_entities_root_name = nested_entities_root.get_name()
+
+    # Creates a new nested prefabs at the root level
+    # Asserts if creation didn't succeed
+    entity = EditorEntity.create_editor_entity_at(CREATION_POSITION, name=NESTED_PREFABS_TEST_ENTITY_NAME)
+    assert entity.id.IsValid(), "Couldn't create TestEntity"
+    entity.add_component(PHYSX_COLLIDER_NAME)
+    assert entity.has_component(PHYSX_COLLIDER_NAME), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+    _, nested_prefab_instances = prefab_test_utils.create_linear_nested_prefabs(
+        [entity], NESTED_PREFABS_FILE_NAME_PREFIX, NESTED_PREFABS_NAME_PREFIX, NUM_NESTED_PREFABS_LAYERS)
+    prefab_test_utils.validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances)
+
+    # Asserts if prefab creation doesn't succeed
+    _, new_prefab = Prefab.create_prefab(
+        [nested_entities_root, nested_prefab_instances[0].container_entity], FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS)
+    new_prefab_container_entity = new_prefab.container_entity
+
+    nested_entities_root_on_instance = new_prefab.get_direct_child_entities()[0]
+    nested_prefabs_root_container_entity_on_instance = new_prefab.get_direct_child_entities()[1]
+    if new_prefab.get_direct_child_entities()[0].get_name() != nested_entities_root_name:
+        nested_entities_root_on_instance, nested_prefabs_root_container_entity_on_instance = \
+            nested_prefabs_root_container_entity_on_instance, nested_entities_root_on_instance
+
+    assert nested_entities_root_on_instance.get_name() == nested_entities_root_name \
+        and nested_entities_root_on_instance.get_parent_id() == new_prefab_container_entity.id, \
+        f"The name of the first child entity of the new prefab '{new_prefab_container_entity.get_name()}' " \
+        f"should be '{nested_entities_root_name}', " \
+        f"not '{nested_entities_root_on_instance.get_name()}'"
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LAYERS, CREATION_POSITION)
+
+    parent_prefab_container_entity_on_instance = new_prefab_container_entity
+    child_entity_on_inner_instance = nested_prefabs_root_container_entity_on_instance
+    for current_layer in range(0, NUM_NESTED_PREFABS_LAYERS):
+        assert child_entity_on_inner_instance.get_name() == prefab_test_utils.get_linear_nested_items_name(NESTED_PREFABS_NAME_PREFIX, current_layer), \
+            f"The name of a prefab inside the nested prefabs should be " \
+            f"'{prefab_test_utils.get_linear_nested_items_name(NESTED_PREFABS_NAME_PREFIX, current_layer)}', " \
+            f"not '{child_entity_on_inner_instance.get_name()}'"
+        assert child_entity_on_inner_instance.get_parent_id() == parent_prefab_container_entity_on_instance.id, \
+            f"Prefab '{child_entity_on_inner_instance.get_name()}' should be the direct inner prefab of " \
+            f"prefab with id '{parent_prefab_container_entity_on_instance.id.ToString()}', " \
+            f"not '{child_entity_on_inner_instance.get_parent_id()}'"
+        parent_prefab_container_entity_on_instance = child_entity_on_inner_instance
+        child_entity_on_inner_instance = child_entity_on_inner_instance.get_children()[0]
+    
+    assert child_entity_on_inner_instance.id.IsValid(), \
+        f"Entity '{child_entity_on_inner_instance.get_name()}' is not valid"
+    assert child_entity_on_inner_instance.get_name() == NESTED_PREFABS_TEST_ENTITY_NAME, \
+        f"The name of the entity inside the nested prefabs should be '{NESTED_PREFABS_TEST_ENTITY_NAME}', " \
+        f"not '{child_entity_on_inner_instance.get_name()}'"
+    assert child_entity_on_inner_instance.has_component(PHYSX_COLLIDER_NAME), \
+        "Entity inside inner_prefab doesn't have the collider component it should"
+    assert child_entity_on_inner_instance.get_parent_id() == parent_prefab_container_entity_on_instance.id, \
+        f"Entity '{child_entity_on_inner_instance.get_name()}' should be under " \
+        f"prefab with id '{parent_prefab_container_entity_on_instance.id.ToString()}', " \
+        f"not '{child_entity_on_inner_instance.get_parent_id()}'"
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+    Report.start_test(CreatePrefab_WithNestedEntitiesAndNestedPrefabs)

--- a/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntitiesAndNestedPrefabs.py
+++ b/AutomatedTesting/Gem/PythonTests/Prefab/tests/create_prefab/CreatePrefab_WithNestedEntitiesAndNestedPrefabs.py
@@ -9,9 +9,11 @@ def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
     """
     Test description:
     - Creates linear nested entities. 
-    - Creates a prefab from the nested entities.
+    - Creates linear nested prefabs based of an entity with a physx collider.
+    - Creates a prefab from the nested entities and the nested prefabs.
 
-    Test passed if the newly instanced prefab of the 3 entities have correct hierarchy and positions.
+    Test passed if the the nested entities/prefabs under the newly instanced prefab 
+    have correct hierarchy and positions.
     """
 
     from pathlib import Path
@@ -27,18 +29,18 @@ def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
     NESTED_PREFABS_NAME_PREFIX = 'NestedPrefabs_Prefab_'
     FILE_NAME_OF_PREFAB_WITH_NESTED_ENTITIES_AND_NESTED_PREFABS = Path(__file__).stem + '_' + 'new_prefab'
     NESTED_PREFABS_TEST_ENTITY_NAME = 'TestEntity'
-    PHYSX_COLLIDER_NAME = "PhysX Collider"
+    PHYSX_COLLIDER_NAME = 'PhysX Collider'
     CREATION_POSITION = azlmbr.math.Vector3(100.0, 100.0, 100.0)
-    NUM_NESTED_ENTITIES_LAYERS = 3
-    NUM_NESTED_PREFABS_LAYERS = 3
+    NUM_NESTED_ENTITIES_LEVELS = 3
+    NUM_NESTED_PREFABS_LEVELS = 3
 
     prefab_test_utils.open_base_tests_level()
 
     # Creates new nested entities at the root level
     # Asserts if creation didn't succeed
     nested_entities_root = prefab_test_utils.create_linear_nested_entities(
-        NESTED_ENTITIES_NAME_PREFIX, NUM_NESTED_ENTITIES_LAYERS, CREATION_POSITION)
-    prefab_test_utils.validate_linear_nested_entities(nested_entities_root, NUM_NESTED_ENTITIES_LAYERS, CREATION_POSITION)
+        NESTED_ENTITIES_NAME_PREFIX, NUM_NESTED_ENTITIES_LEVELS, CREATION_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root, NUM_NESTED_ENTITIES_LEVELS, CREATION_POSITION)
     nested_entities_root_name = nested_entities_root.get_name()
 
     # Creates a new nested prefabs at the root level
@@ -46,9 +48,9 @@ def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
     entity = EditorEntity.create_editor_entity_at(CREATION_POSITION, name=NESTED_PREFABS_TEST_ENTITY_NAME)
     assert entity.id.IsValid(), "Couldn't create TestEntity"
     entity.add_component(PHYSX_COLLIDER_NAME)
-    assert entity.has_component(PHYSX_COLLIDER_NAME), "Attempted to add a PhysX Collider but no physx collider collider was found afterwards"
+    assert entity.has_component(PHYSX_COLLIDER_NAME), f"Failed to add a {PHYSX_COLLIDER_NAME}"
     _, nested_prefab_instances = prefab_test_utils.create_linear_nested_prefabs(
-        [entity], NESTED_PREFABS_FILE_NAME_PREFIX, NESTED_PREFABS_NAME_PREFIX, NUM_NESTED_PREFABS_LAYERS)
+        [entity], NESTED_PREFABS_FILE_NAME_PREFIX, NESTED_PREFABS_NAME_PREFIX, NUM_NESTED_PREFABS_LEVELS)
     prefab_test_utils.validate_linear_nested_prefab_instances_hierarchy(nested_prefab_instances)
 
     # Asserts if prefab creation doesn't succeed
@@ -67,14 +69,14 @@ def CreatePrefab_WithNestedEntitiesAndNestedPrefabs():
         f"The name of the first child entity of the new prefab '{new_prefab_container_entity.get_name()}' " \
         f"should be '{nested_entities_root_name}', " \
         f"not '{nested_entities_root_on_instance.get_name()}'"
-    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LAYERS, CREATION_POSITION)
+    prefab_test_utils.validate_linear_nested_entities(nested_entities_root_on_instance, NUM_NESTED_ENTITIES_LEVELS, CREATION_POSITION)
 
     parent_prefab_container_entity_on_instance = new_prefab_container_entity
     child_entity_on_inner_instance = nested_prefabs_root_container_entity_on_instance
-    for current_layer in range(0, NUM_NESTED_PREFABS_LAYERS):
-        assert child_entity_on_inner_instance.get_name() == prefab_test_utils.get_linear_nested_items_name(NESTED_PREFABS_NAME_PREFIX, current_layer), \
+    for current_level in range(0, NUM_NESTED_PREFABS_LEVELS):
+        assert child_entity_on_inner_instance.get_name() == prefab_test_utils.get_linear_nested_items_name(NESTED_PREFABS_NAME_PREFIX, current_level), \
             f"The name of a prefab inside the nested prefabs should be " \
-            f"'{prefab_test_utils.get_linear_nested_items_name(NESTED_PREFABS_NAME_PREFIX, current_layer)}', " \
+            f"'{prefab_test_utils.get_linear_nested_items_name(NESTED_PREFABS_NAME_PREFIX, current_level)}', " \
             f"not '{child_entity_on_inner_instance.get_name()}'"
         assert child_entity_on_inner_instance.get_parent_id() == parent_prefab_container_entity_on_instance.id, \
             f"Prefab '{child_entity_on_inner_instance.get_name()}' should be the direct inner prefab of " \


### PR DESCRIPTION
Add the following new automated tests for complex workflows around creating a prefab:
- CreatePrefab_UnderChildEntityOfAnotherPrefab
- CreatePrefab_WithNestedEntities
- CreatePrefab_WithNestedEntitiesAndNestedPrefabs

Tested with the following commands:
`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Prefab\TestSuite_Main.py --build-directory windows_vs2019\bin\profile`
`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Prefab\TestSuite_Main_Optimized.py::TestAutomationNoAutoTestMode --build-directory windows_vs2019\bin\profile`

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>