### PR TITLE
Fix side effect bug for NodeFunctionGeneric, 0-1 arity and 0-1 result…

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -80,10 +80,14 @@ namespace ScriptCanvas
         using ResultType = FunctionTraits::result_type;\
         static const size_t s_numArgs = FunctionTraits::arity;\
         static const size_t s_numNames = SCRIPT_CANVAS_FUNCTION_VAR_ARGS(__VA_ARGS__);\
-        /*static const size_t s_numResults = ScriptCanvas::Internal::extended_tuple_size<ResultType>::value;*/\
+        static const size_t s_numResults = ScriptCanvas::Internal::extended_tuple_size<ResultType>::value;\
         \
         static AZStd::string GetArgName(size_t i)\
         {\
+            if (s_numArgs < 2)\
+            {\
+                return GetName(i);\
+            }\
             AZStd::string_view argName = GetName(i);\
             if (!argName.empty())\
             {\
@@ -104,6 +108,10 @@ namespace ScriptCanvas
             }\
             else\
             {\
+                if (s_numResults < 2)\
+                {\
+                    return "Result";\
+                }\
                 return AZStd::string::format("Result [%zu]", i);\
             }\
         }\

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -84,7 +84,7 @@ namespace ScriptCanvas
         \
         static AZStd::string GetArgName(size_t i)\
         {\
-            if (s_numArgs < 2)\
+            if constexpr (s_numArgs < 2)\
             {\
                 return GetName(i);\
             }\
@@ -108,7 +108,7 @@ namespace ScriptCanvas
             }\
             else\
             {\
-                if (s_numResults < 2)\
+                if constexpr (s_numResults < 2)\
                 {\
                     return "Result";\
                 }\


### PR DESCRIPTION
…s nodes are restored to pre-bug-fix behavior

A previous bug for for node function generics introduced a bug for nodes that had either 0-1 results, or 0-1 inputs, by adding superfluous slots if the programmer had NOT named those slots manually. This bug would only appear by opening the graph in the editor, and then saving and running it. This change leaves the original bug fixed, while not breaking old graphs using these nodes.

Signed-off-by: carlitosan <82187351+carlitosan@users.noreply.github.com>