### PR TITLE
Added an additional search location for launching the AP.

### DIFF
--- a/Code/Framework/AzFramework/Platform/Linux/AzFramework/Asset/AssetSystemComponentHelper_Linux.cpp
+++ b/Code/Framework/AzFramework/Platform/Linux/AzFramework/Asset/AssetSystemComponentHelper_Linux.cpp
@@ -88,7 +88,16 @@ namespace AzFramework::AssetSystem::Platform
 
             if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
             {
-                return false;
+                // Now try with the "Default" permutation
+                constexpr const char* BuildPermutation = "Default";
+
+                assetProcessorPath =
+                    AZ::IO::FixedMaxPath{ engineRoot } / "bin" / AZ_TRAIT_OS_PLATFORM_NAME /
+                    AZ_BUILD_CONFIGURATION_TYPE / BuildPermutation / "AssetProcessor";
+                if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
+                {
+                    return false;
+                }
             }
         }
 
@@ -134,7 +143,7 @@ namespace AzFramework::AssetSystem::Platform
                 return true;
             }
             // wait for first child to exit to ensure the second child was started
-            int status = 0; 
+            int status = 0;
             pid_t ret = waitpid(firstChildPid, &status, 0);
             return (ret == firstChildPid) && (status == 0);
         }

--- a/Code/Framework/AzFramework/Platform/Mac/AzFramework/Asset/AssetSystemComponentHelper_Mac.cpp
+++ b/Code/Framework/AzFramework/Platform/Mac/AzFramework/Asset/AssetSystemComponentHelper_Mac.cpp
@@ -43,6 +43,15 @@ namespace AzFramework::AssetSystem::Platform
 
             if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
             {
+                // Now try with the "Default" permutation
+                constexpr const char* BuildPermutation = "Default";
+
+                assetProcessorPath = AZ::IO::FixedMaxPath{ engineRoot } / installedBinariesPath / BuildPermutation
+                    / "AssetProcessor.app/Contents/MacOS/AssetProcessor";
+            }
+
+            if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
+            {
                 return false;
             }
         }

--- a/Code/Framework/AzFramework/Platform/Windows/AzFramework/Asset/AssetSystemComponentHelper_Windows.cpp
+++ b/Code/Framework/AzFramework/Platform/Windows/AzFramework/Asset/AssetSystemComponentHelper_Windows.cpp
@@ -76,7 +76,18 @@ namespace AzFramework::AssetSystem::Platform
 
             if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
             {
-                return false;
+                // Now try with the "Default" permutation
+                // The Monolithic permutation will not have tools such as the AssetProcessor
+                // so need to check there
+                constexpr const char* BuildPermutation = "Default";
+
+                assetProcessorPath =
+                    AZ::IO::FixedMaxPath{ engineRoot } / "bin" / AZ_TRAIT_OS_PLATFORM_NAME /
+                    AZ_BUILD_CONFIGURATION_TYPE / BuildPermutation / "AssetProcessor.exe";
+                if (!AZ::IO::SystemFile::Exists(assetProcessorPath.c_str()))
+                {
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
The `<SDKRoot>/bin/<platform>/<config>/Default` directory will be
searched for the AssetProcessor.

In an install layout the AssetProcessor is copied over to the Default
permutation folder.

In the Monolithic permutation, tools are not build so there is no need to check
for the AP in that permutation.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>