### PR TITLE
chore: replace usage of MCore::LinearInterpolate with AZ::Lerp

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/MathUtils.h
+++ b/Code/Framework/AzCore/AzCore/Math/MathUtils.h
@@ -364,6 +364,13 @@ namespace AZ
     }
 
     //! Returns a linear interpolation between 2 values.
+    template<typename T>
+    constexpr T Lerp(const T& a, const T& b, float t)
+    {
+        return static_cast<T>(a + (b - a) * t);
+    }
+
+    //! Returns a linear interpolation between 2 values.
     constexpr float Lerp(float a, float b, float t)
     {
         return a + (b - a) * t;

--- a/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/AnimGraphNode.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Math/MathUtils.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/StringFunc/StringFunc.h>
@@ -1128,9 +1129,9 @@ namespace EMotionFX
         nodeB->SetCurrentPlayTime(animGraphInstance, newTimeB);
         const float timeRatio       = (durationB > MCore::Math::epsilon) ? durationA / durationB : 0.0f;
         const float timeRatio2      = (durationA > MCore::Math::epsilon) ? durationB / durationA : 0.0f;
-        const float factorA         = MCore::LinearInterpolate<float>(1.0f, timeRatio, weight);
-        const float factorB         = MCore::LinearInterpolate<float>(timeRatio2, 1.0f, weight);
-        const float interpolatedSpeed   = MCore::LinearInterpolate<float>(uniqueDataA->GetPlaySpeed(), uniqueDataB->GetPlaySpeed(), weight);
+        const float factorA         = AZ::Lerp(1.0f, timeRatio, weight);
+        const float factorB         = AZ::Lerp(timeRatio2, 1.0f, weight);
+        const float interpolatedSpeed         = AZ::Lerp(uniqueDataA->GetPlaySpeed(), uniqueDataB->GetPlaySpeed(), weight);
 
         if (modifyLeaderSpeed)
         {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeAccumTransformNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeAccumTransformNode.cpp
@@ -188,7 +188,7 @@ namespace EMotionFX
             }
 
             const AZ::Quaternion targetRot = MCore::CreateFromAxisAndAngle(axis, MCore::Math::DegreesToRadians(360.0f * (inputAmount - 0.5f) * invertFactor));
-            AZ::Quaternion deltaRot = MCore::LinearInterpolate<AZ::Quaternion>(AZ::Quaternion::CreateIdentity(), targetRot, uniqueData->m_deltaTime * factor);
+            AZ::Quaternion deltaRot = AZ::Quaternion::CreateIdentity().Lerp(targetRot, uniqueData->m_deltaTime * factor);
             deltaRot.Normalize();
             uniqueData->m_additiveTransform.m_rotation = uniqueData->m_additiveTransform.m_rotation * deltaRot;
             outputTransform.m_rotation = (inputTransform.m_rotation * uniqueData->m_additiveTransform.m_rotation);
@@ -225,7 +225,7 @@ namespace EMotionFX
             }
 
             axis *= (inputAmount - 0.5f) * invertFactor;
-            uniqueData->m_additiveTransform.m_position += MCore::LinearInterpolate<AZ::Vector3>(AZ::Vector3::CreateZero(), axis, uniqueData->m_deltaTime * factor);
+            uniqueData->m_additiveTransform.m_position += AZ::Vector3::CreateZero().Lerp(axis, uniqueData->m_deltaTime * factor);
             outputTransform.m_position = inputTransform.m_position + uniqueData->m_additiveTransform.m_position;
         }
 
@@ -265,7 +265,7 @@ namespace EMotionFX
                 }
 
                 axis *= (inputAmount - 0.5f) * invertFactor;
-                uniqueData->m_additiveTransform.m_scale += MCore::LinearInterpolate<AZ::Vector3>(AZ::Vector3::CreateZero(), axis, uniqueData->m_deltaTime * factor);
+                uniqueData->m_additiveTransform.m_scale += AZ::Vector3::CreateZero().Lerp(axis, uniqueData->m_deltaTime * factor);
                 outputTransform.m_scale = inputTransform.m_scale + uniqueData->m_additiveTransform.m_scale;
             }
         )

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeSmoothingNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeSmoothingNode.cpp
@@ -8,6 +8,7 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Math/MathUtils.h>
 #include "BlendTreeSmoothingNode.h"
 #include "AnimGraphManager.h"
 #include "EMotionFXManager.h"
@@ -109,7 +110,7 @@ namespace EMotionFX
         // perform interpolation
         const float sourceValue = uniqueData->m_currentValue;
         const float interpolationSpeed = m_interpolationSpeed * uniqueData->m_frameDeltaTime * 10.0f;
-        const float interpolationResult = (interpolationSpeed < 0.99999f) ? MCore::LinearInterpolate<float>(sourceValue, destValue, interpolationSpeed) : destValue;
+        const float interpolationResult = (interpolationSpeed < 0.99999f) ? AZ::Lerp(sourceValue, destValue, interpolationSpeed) : destValue;
         // If the interpolation result is close to the dest value within the tolerance, snap to the destination value.
         if (AZ::IsClose((interpolationResult - destValue), 0.0f, m_snapTolerance))
         {

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTransformNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeTransformNode.cpp
@@ -156,7 +156,7 @@ namespace EMotionFX
         {
             OutputIncomingNode(animGraphInstance, GetInputNode(INPUTPORT_ROTATE_AMOUNT));
             const float rotateFactor = MCore::Clamp<float>(GetInputNumberAsFloat(animGraphInstance, INPUTPORT_ROTATE_AMOUNT), 0.0f, 1.0f);
-            const AZ::Vector3 newAngles = MCore::LinearInterpolate<AZ::Vector3>(m_minRotation, m_maxRotation, rotateFactor);
+            const AZ::Vector3 newAngles = m_minRotation.Lerp(m_maxRotation, rotateFactor);
             outputTransform.m_rotation = inputTransform.m_rotation * MCore::AzEulerAnglesToAzQuat(MCore::Math::DegreesToRadians(newAngles.GetX()), 
                 MCore::Math::DegreesToRadians(newAngles.GetY()), 
                 MCore::Math::DegreesToRadians(newAngles.GetZ()));
@@ -167,7 +167,7 @@ namespace EMotionFX
         {
             OutputIncomingNode(animGraphInstance, GetInputNode(INPUTPORT_TRANSLATE_AMOUNT));
             const float factor = MCore::Clamp<float>(GetInputNumberAsFloat(animGraphInstance, INPUTPORT_TRANSLATE_AMOUNT), 0.0f, 1.0f);
-            const AZ::Vector3 newValue = MCore::LinearInterpolate<AZ::Vector3>(m_minTranslation, m_maxTranslation, factor);
+            const AZ::Vector3 newValue = m_minTranslation.Lerp(m_maxTranslation, factor);
             outputTransform.m_position = inputTransform.m_position + newValue;
         }
 
@@ -178,7 +178,7 @@ namespace EMotionFX
             {
                 OutputIncomingNode(animGraphInstance, GetInputNode(INPUTPORT_SCALE_AMOUNT));
                 const float factor = MCore::Clamp<float>(GetInputNumberAsFloat(animGraphInstance, INPUTPORT_SCALE_AMOUNT), 0.0f, 1.0f);
-                const AZ::Vector3 newValue = MCore::LinearInterpolate<AZ::Vector3>(m_minScale, m_maxScale, factor);
+                const AZ::Vector3 newValue = m_minScale.Lerp(m_maxScale, factor);
                 outputTransform.m_scale = inputTransform.m_scale + newValue;
             }
         )

--- a/Gems/EMotionFX/Code/EMotionFX/Source/KeyTrackLinearDynamic.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/KeyTrackLinearDynamic.h
@@ -10,6 +10,7 @@
 
 // include required headers
 #include <AzCore/RTTI/TypeInfo.h>
+#include <AzCore/Math/MathUtils.h>
 #include <AzCore/std/containers/vector.h>
 #include <MCore/Source/StandardHeaders.h>
 #include <MCore/Source/Compare.h>
@@ -18,6 +19,7 @@
 #include "KeyFrame.h"
 #include "CompressedKeyFrames.h"
 #include "KeyFrameFinder.h"
+
 
 
 namespace AZ

--- a/Gems/EMotionFX/Code/EMotionFX/Source/KeyTrackLinearDynamic.inl
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/KeyTrackLinearDynamic.inl
@@ -296,7 +296,7 @@ MCORE_INLINE ReturnType KeyTrackLinearDynamic<ReturnType, StorageType>::Interpol
     const float t = (currentTime - firstKey.GetTime()) / (nextKey.GetTime() - firstKey.GetTime());
 
     // perform the interpolation
-    return MCore::LinearInterpolate<ReturnType>(firstKey.GetValue(), nextKey.GetValue(), t);
+    return AZ::Lerp<ReturnType>(firstKey.GetValue(), nextKey.GetValue(), t);
 }
 
 

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Pose.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Pose.cpp
@@ -515,7 +515,7 @@ namespace EMotionFX
             MCORE_ASSERT(numMorphs == destPose->GetNumMorphWeights());
             for (size_t i = 0; i < numMorphs; ++i)
             {
-                m_morphWeights[i] = MCore::LinearInterpolate<float>(m_morphWeights[i], destPose->m_morphWeights[i], weight);
+                m_morphWeights[i] = AZ::Lerp(m_morphWeights[i], destPose->m_morphWeights[i], weight);
             }
         }
         else
@@ -595,7 +595,7 @@ namespace EMotionFX
             MCORE_ASSERT(numMorphs == destPose->GetNumMorphWeights());
             for (size_t i = 0; i < numMorphs; ++i)
             {
-                m_morphWeights[i] = MCore::LinearInterpolate<float>(m_morphWeights[i], destPose->m_morphWeights[i], weight);
+                m_morphWeights[i] = AZ::Lerp(m_morphWeights[i], destPose->m_morphWeights[i], weight);
             }
         }
         else
@@ -847,7 +847,7 @@ namespace EMotionFX
             MCORE_ASSERT(numMorphs == destPose->GetNumMorphWeights());
             for (size_t i = 0; i < numMorphs; ++i)
             {
-                m_morphWeights[i] = MCore::LinearInterpolate<float>(m_morphWeights[i], destPose->m_morphWeights[i], weight);
+                m_morphWeights[i] = AZ::Lerp(m_morphWeights[i], destPose->m_morphWeights[i], weight);
             }
 
             for (const auto& poseDataItem : m_poseDatas)
@@ -871,7 +871,7 @@ namespace EMotionFX
             MCORE_ASSERT(numMorphs == destPose->GetNumMorphWeights());
             for (size_t i = 0; i < numMorphs; ++i)
             {
-                m_morphWeights[i] = MCore::LinearInterpolate<float>(m_morphWeights[i], destPose->m_morphWeights[i], weight);
+                m_morphWeights[i] = AZ::Lerp(m_morphWeights[i], destPose->m_morphWeights[i], weight);
             }
 
             for (const auto& poseDataItem : m_poseDatas)

--- a/Gems/EMotionFX/Code/EMotionFX/Source/SpringSolver.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/SpringSolver.cpp
@@ -863,7 +863,7 @@ namespace EMotionFX
                     const float jointRadius = joint->GetCollisionRadius() * scaleFactor;
                     if (PerformCollision(particle.m_pos, jointRadius, particle))
                     {
-                        particle.m_oldPos = MCore::LinearInterpolate<AZ::Vector3>(particle.m_oldPos, particle.m_pos, joint->GetFriction());
+                        particle.m_oldPos = particle.m_oldPos.Lerp(particle.m_pos, joint->GetFriction());
                     }
                 }
             }

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Transform.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Transform.cpp
@@ -528,12 +528,12 @@ namespace EMotionFX
     // blend into another transform
     Transform& Transform::Blend(const Transform& dest, float weight)
     {
-        m_position = MCore::LinearInterpolate<AZ::Vector3>(m_position, dest.m_position, weight);
+        m_position = m_position.Lerp(dest.m_position, weight);
         m_rotation = MCore::NLerp(m_rotation, dest.m_rotation, weight);
 
         EMFX_SCALECODE
         (
-            m_scale          = MCore::LinearInterpolate<AZ::Vector3>(m_scale, dest.m_scale, weight);
+            m_scale = m_scale.Lerp(dest.m_scale, weight);
         )
 
         return *this;

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendSpace1DNodeWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendSpace1DNodeWidget.cpp
@@ -148,9 +148,8 @@ namespace EMStudio
         {
             return;
         }
-
-        m_zoomScale = MCore::LinearInterpolate<float>(1.0f, s_maxZoomScale, m_zoomFactor);
-
+        m_zoomScale = AZ::Lerp(1.0f, s_maxZoomScale, m_zoomFactor);
+        
         // Detect if the node is in an active blend tree. Checking if the parent is ready is
         // more stable since a non-connected blend space node wont be ready
         EMotionFX::AnimGraphNode* nodeThatShouldBeReady = m_currentNode->GetParentNode()

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendSpace2DNodeWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendSpace2DNodeWidget.cpp
@@ -12,6 +12,8 @@
 #include <QMouseEvent>
 #include <QFontMetrics>
 
+#include <AzCore/Math/MathUtils.h>
+
 namespace
 {
     inline void DrawTriangle(QPainter& painter, const AZStd::vector<QPointF>& points, uint16_t vert1, uint16_t vert2, uint16_t vert3)
@@ -181,8 +183,8 @@ namespace EMStudio
         {
             return;
         }
-
-        m_zoomScale = MCore::LinearInterpolate<float>(1.0f, s_maxZoomScale, m_zoomFactor);
+        
+        m_zoomScale = AZ::Lerp(1.0f, s_maxZoomScale, m_zoomFactor);
 
         // Detect if the node is in an active blend tree. Checking if the parent is ready is
         // more stable since a non-connected blend space node wont be ready

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendSpaceNodeWidget.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/Plugins/StandardPlugins/Source/AnimGraph/BlendSpaceNodeWidget.cpp
@@ -9,7 +9,7 @@
 #include "BlendSpaceNodeWidget.h"
 #include <MCore/Source/Algorithms.h>
 #include <AzCore/Casting/numeric_cast.h>
-
+#include <AzCore/Math/MathUtils.h>
 
 namespace EMStudio
 {
@@ -45,8 +45,8 @@ void BlendSpaceNodeWidget::RenderCurrentSamplePoint(QPainter& painter, const QPo
 
 void BlendSpaceNodeWidget::RenderSampledMotionPoint(QPainter& painter, const QPointF& point, float weight)
 {
-    const float alpha = MCore::LinearInterpolate<float>(s_motionPointAlphaMin, s_motionPointAlphaMax, weight);
-    const float size = MCore::LinearInterpolate<float>(s_motionPointWidthMin, s_motionPointWidthMax, weight);
+    const float alpha = AZ::Lerp(s_motionPointAlphaMin, s_motionPointAlphaMax, weight);
+    const float size = AZ::Lerp(s_motionPointWidthMin, s_motionPointWidthMax, weight);
     
     QColor color = s_motionPointColor;
     color.setAlphaF(alpha);

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.h
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.h
@@ -11,6 +11,7 @@
 
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Time/ITime.h>
+#include <AzCore/Math/MathUtils.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace Gestures
@@ -63,8 +64,8 @@ namespace Gestures
         AZ::Vector2 GetCurrentPosition0() const { return m_currentPositions[0]; }
         AZ::Vector2 GetCurrentPosition1() const { return m_currentPositions[1]; }
 
-        AZ::Vector2 GetStartMidpoint() const { return Lerp(GetStartPosition0(), GetStartPosition1(), 0.5f); }
-        AZ::Vector2 GetCurrentMidpoint() const { return Lerp(GetCurrentPosition0(), GetCurrentPosition1(), 0.5f); }
+        AZ::Vector2 GetStartMidpoint() const { return AZ::Lerp(GetStartPosition0(), GetStartPosition1(), 0.5f); }
+        AZ::Vector2 GetCurrentMidpoint() const { return AZ::Lerp(GetCurrentPosition0(), GetCurrentPosition1(), 0.5f); }
 
         float GetStartDistance() const { return GetStartPosition1().GetDistance(GetStartPosition0()); }
         float GetCurrentDistance() const { return GetCurrentPosition1().GetDistance(GetCurrentPosition0()); }

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.h
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.h
@@ -11,6 +11,7 @@
 
 #include <AzCore/RTTI/ReflectContext.h>
 #include <AzCore/Time/ITime.h>
+#include <AzCore/Math/MathUtils.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace Gestures
@@ -63,8 +64,8 @@ namespace Gestures
        AZ::Vector2 GetCurrentPosition0() const { return m_currentPositions[0]; }
        AZ::Vector2 GetCurrentPosition1() const { return m_currentPositions[1]; }
 
-       AZ::Vector2 GetStartMidpoint() const { return Lerp(GetStartPosition0(), GetStartPosition1(), 0.5f); }
-       AZ::Vector2 GetCurrentMidpoint() const { return Lerp(GetCurrentPosition0(), GetCurrentPosition1(), 0.5f); }
+       AZ::Vector2 GetStartMidpoint() const { return AZ::Lerp(GetStartPosition0(), GetStartPosition1(), 0.5f); }
+       AZ::Vector2 GetCurrentMidpoint() const { return AZ::Lerp(GetCurrentPosition0(), GetCurrentPosition1(), 0.5f); }
 
        float GetStartDistance() const { return GetStartPosition1().GetDistance(GetStartPosition0()); }
        float GetCurrentDistance() const { return GetCurrentPosition1().GetDistance(GetCurrentPosition0()); }

--- a/Gems/MotionMatching/Code/Source/TrajectoryHistory.cpp
+++ b/Gems/MotionMatching/Code/Source/TrajectoryHistory.cpp
@@ -23,6 +23,11 @@ namespace EMotionFX::MotionMatching
         return {weight * sample.m_position, weight * sample.m_facingDirection};
     }
 
+    TrajectoryHistory::Sample operator-(TrajectoryHistory::Sample lhs, const TrajectoryHistory::Sample& rhs)
+    {
+        return {lhs.m_position - rhs.m_position, lhs.m_facingDirection - rhs.m_facingDirection};
+    }
+
     TrajectoryHistory::Sample operator+(TrajectoryHistory::Sample lhs, const TrajectoryHistory::Sample& rhs)
     {
         return {lhs.m_position + rhs.m_position, lhs.m_facingDirection + rhs.m_facingDirection};


### PR DESCRIPTION
I replaced the usage of MCore::LinearInterpolate with AZ::Lerp. Any clue if there is a plan to move all the math utilities into Math and how would it be organized? 

MathUtils seems too general I guess would it make sense to split things across different headers and just have MathUtils collect those other referenced headers. 