### PR TITLE
EMotion FX: Fixed reflection issue with render options and made them appear in the Animation Editor Preferences

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
@@ -300,6 +300,11 @@ namespace EMStudio
         return &m_renderOptions;
     }
 
+    PluginOptions* AtomRenderPlugin::GetOptions()
+    {
+        return &m_renderOptions;
+    }
+
     void AtomRenderPlugin::Render([[maybe_unused]]EMotionFX::ActorRenderFlags renderFlags)
     {
         if (!m_animViewportWidget)

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
@@ -60,6 +60,7 @@ namespace EMStudio
         void LoadRenderOptions();
         void SaveRenderOptions();
         RenderOptions* GetRenderOptions();
+        PluginOptions* GetOptions() override;
 
         void Render(EMotionFX::ActorRenderFlags renderFlags) override;
         void SetManipulatorMode(RenderOptions::ManipulatorMode mode);

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/EMStudioManager.cpp
@@ -14,6 +14,7 @@
 #include "MotionEventPresetManager.h"
 #include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/Commands.h>
 #include <EMotionStudio/EMStudioSDK/Source/Allocators.h>
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.h>
 
 // include MCore related
 #include <MCore/Source/LogManager.h>
@@ -176,17 +177,14 @@ namespace EMStudio
         m_pluginManager->LoadPluginsFromDirectory(pluginDir.c_str());
 #endif // EMFX_EMSTUDIOLYEMBEDDED
 
-        // Give a chance to every plugin to reflect data
-        const size_t numPlugins = m_pluginManager->GetNumPlugins();
-        if (numPlugins)
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
+        AZ_Error("EMotionFX", serializeContext, "Can't get serialize context from component application.");
+        if (serializeContext)
         {
-            AZ::SerializeContext* serializeContext = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
-            if (!serializeContext)
-            {
-                AZ_Error("EMotionFX", false, "Can't get serialize context from component application.");
-            }
-            else
+            // Reflect plugin related data.
+            const size_t numPlugins = m_pluginManager->GetNumPlugins();
+            if (numPlugins)
             {
                 for (size_t i = 0; i < numPlugins; ++i)
                 {
@@ -194,6 +192,9 @@ namespace EMStudio
                     plugin->Reflect(serializeContext);
                 }
             }
+
+            // Reflect shared data that might be used by multiple plugins.
+            RenderOptions::Reflect(serializeContext);
         }
         
         // Register the command event processing callback.

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include "RenderOptions.h"
+#include <EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderOptions.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.cpp
@@ -639,11 +639,6 @@ namespace EMStudio
         m_viewWidgets.clear();
     }
 
-    void RenderPlugin::Reflect(AZ::ReflectContext* context)
-    {
-        RenderOptions::Reflect(context);
-    }
-
     bool RenderPlugin::Init()
     {
         // load the cursors

--- a/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.h
+++ b/Gems/EMotionFX/Code/EMotionFX/Tools/EMotionStudio/EMStudioSDK/Source/RenderPlugin/RenderPlugin.h
@@ -85,7 +85,6 @@ namespace EMStudio
         RenderPlugin();
         virtual ~RenderPlugin();
 
-        void Reflect(AZ::ReflectContext* context) override;
         bool Init() override;
         void OnAfterLoadProject() override;
         void OnAfterLoadActors() override;


### PR DESCRIPTION
* It turned out via a flakey AR test that the RenderOptions were reflected multiple times. This happened as the RenderOptions were reflected by the base render plugin and thus the Atom as well as the OpenGL one reflected the render options.
* Also directly fixed another bug along the way, where the render options were not showing up in the Preferences window.

Resolves #7814 

![image](https://user-images.githubusercontent.com/43751992/155128191-9fa81fcb-5ba5-418e-919d-bd778761a10b.png)

Signed-off-by: Benjamin Jillich <jillich@amazon.com>