### PR TITLE
{lyn10540} Fixing some cases where the return value for GraphObjectProxy Invoke

### DIFF
--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -296,9 +296,13 @@ namespace AZ
 
                     if (returnBehaviorValue.m_traits & BehaviorParameter::TR_POINTER)
                     {
-                        // we need value to pointer be pointer to a pointer
-                        void* valuePointer = returnBehaviorValue.m_tempData.allocate(2 * sizeof(void*), 16);
-                        returnBehaviorValue.m_value = &valuePointer;
+                        // Used to allocate storage to store a copy of a pointer and the allocated memory address in one block.
+                        constexpr size_t PointerAllocationStorage = 2 * sizeof(void*);
+                        void* valueAddress = returnBehaviorValue.m_tempData.allocate(PointerAllocationStorage, 16, 0);
+                        void* valueAddressPtr = reinterpret_cast<AZ::u8*>(valueAddress) + sizeof(void*);
+                        ::memset(valueAddress, 0, sizeof(void*));
+                        *reinterpret_cast<void**>(valueAddressPtr) = valueAddress;
+                        returnBehaviorValue.m_value = valueAddressPtr;
                     }
                     else if (returnBehaviorValue.m_traits & BehaviorParameter::TR_REFERENCE)
                     {

--- a/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
+++ b/Code/Tools/SceneAPI/SceneCore/Containers/GraphObjectProxy.cpp
@@ -292,8 +292,28 @@ namespace AZ
                 if (behaviorMethod->HasResult())
                 {
                     returnBehaviorValue.Set(*behaviorMethod->GetResult());
-                    returnBehaviorValue.m_value =
-                        returnBehaviorValue.m_tempData.allocate(returnBehaviorValue.m_azRtti->GetTypeSize(), 16);
+                    const size_t typeSize = returnBehaviorValue.m_azRtti->GetTypeSize();
+
+                    if (returnBehaviorValue.m_traits & BehaviorParameter::TR_POINTER)
+                    {
+                        // we need value to pointer be pointer to a pointer
+                        void* valuePointer = returnBehaviorValue.m_tempData.allocate(2 * sizeof(void*), 16);
+                        returnBehaviorValue.m_value = &valuePointer;
+                    }
+                    else if (returnBehaviorValue.m_traits & BehaviorParameter::TR_REFERENCE)
+                    {
+                        // the reference value will just be assigned
+                        returnBehaviorValue.m_value = nullptr;
+                    }
+                    else if (typeSize < returnBehaviorValue.m_tempData.max_size())
+                    {
+                        returnBehaviorValue.m_value = returnBehaviorValue.m_tempData.allocate(typeSize, 16);
+                    }
+                    else
+                    {
+                        AZ_Warning("SceneAPI", false, "Can't invoke method since the return value is too big; %d bytes", typeSize);
+                        return AZStd::any(false);
+                    }
                 }
 
                 if (!entry->second->Call(behaviorParamList, paramCount, &returnBehaviorValue))


### PR DESCRIPTION
Fixing some cases where the return value for GraphObjectProxy Invoke where a pointer, reference, or big value could be returned. Updated the tests to reflect the changes.

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>