### PR TITLE
Increase the default number of cpu descriptor handles to fix a crash on AMD gpus

### DIFF
--- a/Gems/Atom/RHI/Registry/Platform/Windows/PlatformLimits.setreg
+++ b/Gems/Atom/RHI/Registry/Platform/Windows/PlatformLimits.setreg
@@ -21,7 +21,7 @@
                         "$type": "AZ::DX12::PlatformLimitsDescriptor",
                         "DescriptorHeapLimits":
                         {
-                            "DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV": [100000, 1000000],
+                            "DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV": [500000, 1000000],
                             "DESCRIPTOR_HEAP_TYPE_SAMPLER": [2048, 2048],
                             "DESCRIPTOR_HEAP_TYPE_RTV": [2048, 0],
                             "DESCRIPTOR_HEAP_TYPE_DSV": [2048, 0]


### PR DESCRIPTION
https://github.com/o3de/o3de/issues/7546

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>