### PR TITLE
Fix for ASV shutdown assert on IrradianceImage

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/DiffuseGlobalIllumination/DiffuseGlobalIlluminationFeatureProcessor.cpp
@@ -120,11 +120,12 @@ namespace AZ
                             }
                         }
 
-                        AZ_Assert(irradianceImageAttachment != nullptr, "Unable to find IrradianceImage attachment");
-
-                        RPI::PassAttachmentSizeMultipliers& sizeMultipliers = irradianceImageAttachment->m_sizeMultipliers;
-                        sizeMultipliers.m_widthMultiplier = sizeMultiplier;
-                        sizeMultipliers.m_heightMultiplier = sizeMultiplier;
+                        if (irradianceImageAttachment)
+                        {
+                            RPI::PassAttachmentSizeMultipliers& sizeMultipliers = irradianceImageAttachment->m_sizeMultipliers;
+                            sizeMultipliers.m_widthMultiplier = sizeMultiplier;
+                            sizeMultipliers.m_heightMultiplier = sizeMultiplier;
+                        }
 
                         // handle all downsample passes
                         return RPI::PassFilterExecutionFlow::ContinueVisitingPasses;


### PR DESCRIPTION
Replaced the assert on the IrradianceImage with a conditional, since it may not be present in all pipelines.

Signed-off-by: dmcdiarmid-ly <63674186+dmcdiarmid-ly@users.noreply.github.com>