### PR TITLE
Disable PSO caching for DX12

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI.Reflect/PipelineLayoutDescriptor.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI.Reflect/PipelineLayoutDescriptor.cpp
@@ -105,6 +105,11 @@ namespace AZ
                     seed = TypeHash64(m_rootConstantsLayout->GetHash(), seed);
                 }
 
+                for (const auto& index : m_bindingSlotToIndex)
+                {
+                    seed = TypeHash64(index, seed);
+                }
+
                 m_hash = GetHashInternal(seed);
             }
 

--- a/Gems/Atom/RHI/Code/Source/RHI/PipelineLibrary.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/PipelineLibrary.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Atom/RHI/PipelineLibrary.h>
+#include <AzFramework/StringFunc/StringFunc.h>
 
 namespace AZ
 {
@@ -39,6 +40,9 @@ namespace AZ
             ResultCode resultCode = InitInternal(device, descriptor);
             if (resultCode == ResultCode::Success)
             {
+                AZStd::string libName;
+                AzFramework::StringFunc::Path::GetFileName(descriptor.m_filePath.c_str(), libName);
+                SetName(Name(libName));
                 DeviceObject::Init(device);
             }
             return resultCode;

--- a/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/DX12_Windows.h
+++ b/Gems/Atom/RHI/DX12/Code/Source/Platform/Windows/RHI/DX12_Windows.h
@@ -34,10 +34,13 @@ AZ_POP_DISABLE_WARNING
     #define PIXEndEvent(...)
 #endif //USE_PIX
 
-// This define controls whether ID3D12PipelineLibrary instances are used to de-duplicate
-// pipeline states. This feature was added in the Windows Anniversary Update, so if you
-// have an older version of windows this will need to be disabled.
-#define AZ_DX12_USE_PIPELINE_LIBRARY
+// Wrapper around PipelineLibrary code
+// We have disabled PSO caching for DX12 as there is a bug where the same PSO hash for a shader (like StandardPBR_ForwardPass_EDS) yields a different PipelineLibrary binary file
+// when written out from different user flows. For example a D3D12_GRAPHICS_PIPELINE_STATE_DESC with the same hash  when written out from ASV full test suite will yield
+// a different binary when compared to the one written out from Editor user flow. The only difference between the two workflows is that the shader options differ but in the
+// end both the flows should yield the same bytecode as they should pick the same shader vairant yet the cached pso differs for some reason.
+// This seems like a driver bug that we suspect is causing flickering issues. Need to follow up with Microsoft with this issue.
+//#define AZ_DX12_USE_PIPELINE_LIBRARY
 
 // Enabling this define will force every scope into its own command list that
 // is explicitly flushed through the GPU before the next scope is processed.

--- a/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineLibrary.cpp
+++ b/Gems/Atom/RHI/DX12/Code/Source/RHI/PipelineLibrary.cpp
@@ -248,15 +248,19 @@ namespace AZ
             AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
 
             AZStd::vector<uint8_t> serializedData(m_library->GetSerializedSize());
-
-            HRESULT hr = m_library->Serialize(serializedData.data(), serializedData.size());
-
-            if (!AssertSuccess(hr))
+            if (serializedData.size())
             {
-                return nullptr;
-            }
+            
+                HRESULT hr = m_library->Serialize(serializedData.data(), serializedData.size());
 
-            return RHI::PipelineLibraryData::Create(AZStd::move(serializedData));
+                if (!AssertSuccess(hr))
+                {
+                    return nullptr;
+                }
+
+                return RHI::PipelineLibraryData::Create(AZStd::move(serializedData));
+            }
+            return nullptr;
 #else
             return nullptr;
 #endif


### PR DESCRIPTION
There is a bug where the same PSO hash for a shader (like StandardPBR_ForwardPass_EDS) yields a different PipelineLibrary binary file when written out from different user flows. For example a D3D12_GRAPHICS_PIPELINE_STATE_DESC with the same hash  when written out from ASV full test suite will yield a different binary when compared to the one written out from Editor user flow. The only difference between the two workflows is that the shader options differ but in the end both the flows should yield the same bytecode as they should pick the same shader variant yet the cached pso blob or the PipelineLibrary with the pso differs. This seems like a driver bug that we suspect is causing flickering issues. Need to follow up with Microsoft with this issue. Re-enable this once the issue is resolved

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>