### PR TITLE
EMotion FX: Removing reflecting the render options from the Atom plugin

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.cpp
@@ -49,11 +49,6 @@ namespace EMStudio
         AzToolsFramework::ViewportInteraction::ViewportMouseRequestBus::Handler::BusDisconnect();
     }
 
-    void AtomRenderPlugin::Reflect(AZ::ReflectContext* context)
-    {
-        RenderOptions::Reflect(context);
-    }
-
     const char* AtomRenderPlugin::GetName() const
     {
         return "Atom Render Window";

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AtomRenderPlugin.h
@@ -42,8 +42,6 @@ namespace EMStudio
         AtomRenderPlugin();
         ~AtomRenderPlugin();
 
-        void Reflect(AZ::ReflectContext* context) override;
-
         // Plugin information
         const char* GetName() const override;
         uint32 GetClassID() const override;


### PR DESCRIPTION
Removing another duplicated reflect call for the render options

Signed-off-by: Benjamin Jillich <jillich@amazon.com>