### PR TITLE
Focus Mode Visual Feedback: System Component

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -130,6 +130,7 @@ namespace AZ
             MeshFeatureProcessor() = default;
             virtual ~MeshFeatureProcessor() = default;
 
+
             // FeatureProcessor overrides ...
             //! Creates pools, buffers, and buffer views
             void Activate() override;
@@ -142,6 +143,7 @@ namespace AZ
             void OnBeginPrepareRender() override;
             void OnEndPrepareRender() override;
 
+            TransformServiceFeatureProcessorInterface::ObjectId GetObjectId(const MeshHandle& meshHandle) const override;
             MeshHandle AcquireMesh(
                 const MeshHandleDescriptor& descriptor,
                 const MaterialAssignmentMap& materials = {}) override;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessor.h
@@ -130,7 +130,6 @@ namespace AZ
             MeshFeatureProcessor() = default;
             virtual ~MeshFeatureProcessor() = default;
 
-
             // FeatureProcessor overrides ...
             //! Creates pools, buffers, and buffer views
             void Activate() override;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/Mesh/MeshFeatureProcessorInterface.h
@@ -15,6 +15,7 @@
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <Atom/Utils/StableDynamicArray.h>
+#include <Atom/Feature/TransformService/TransformServiceFeatureProcessorInterface.h>
 
 namespace AZ
 {
@@ -42,6 +43,9 @@ namespace AZ
 
             using MeshHandle = StableDynamicArrayHandle<ModelDataInstance>;
             using ModelChangedEvent = Event<const Data::Instance<RPI::Model>>;
+
+            //! Returns the object id for a mesh handle.
+            virtual TransformServiceFeatureProcessorInterface::ObjectId GetObjectId(const MeshHandle& meshHandle) const = 0;
 
             //! Acquires a model with an optional collection of material assignments.
             //! @param requiresCloneCallback The callback indicates whether cloning is required for a given model asset.

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Interface/Interface.h>
+#include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! The interface for the visual feedback component of the central editor mode tracker for all viewports.
+        class EditorModeFeedbackInterface
+        {
+        public:
+            AZ_RTTI(EditorModeFeedbackInterface, "{3B36BE06-52B1-439C-AA8E-027AF80298AA}");
+
+            virtual ~EditorModeFeedbackInterface() = default;
+
+            //! Returns true if the editor mode feedback effect is enabled, otherwise false.
+            virtual bool IsEnabled() const = 0;
+
+            //! Registers a drawable component to be associated with the provided entity id.
+            //! @param entityComponentId The id of the entity and drawable component to be registered.
+            //! @param meshHandle The handle of this drawable component's mesh.
+            virtual void RegisterDrawableComponent(
+                EntityComponentIdPair entityComponentId, const MeshFeatureProcessorInterface::MeshHandle& meshHandle) = 0;
+        };
+    } // namespace Render
+} // namespace AZ
+

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h
@@ -26,10 +26,10 @@ namespace AZ
             //! Returns true if the editor mode feedback effect is enabled, otherwise false.
             virtual bool IsEnabled() const = 0;
 
-            //! Registers a drawable component to be associated with the provided entity id.
+            //! Registers a new (or updates an existing) drawable component to be associated with the provided entity id.
             //! @param entityComponentId The id of the entity and drawable component to be registered.
             //! @param meshHandle The handle of this drawable component's mesh.
-            virtual void RegisterDrawableComponent(
+            virtual void RegisterOrUpdateDrawableComponent(
                 EntityComponentIdPair entityComponentId, const MeshFeatureProcessorInterface::MeshHandle& meshHandle) = 0;
         };
     } // namespace Render

--- a/Gems/Atom/Feature/Common/Code/Mocks/MockMeshFeatureProcessor.h
+++ b/Gems/Atom/Feature/Common/Code/Mocks/MockMeshFeatureProcessor.h
@@ -15,6 +15,7 @@ namespace UnitTest
     class MockMeshFeatureProcessor : public AZ::Render::MeshFeatureProcessorInterface
     {
     public:
+        MOCK_CONST_METHOD1(GetObjectId, AZ::Render::TransformServiceFeatureProcessorInterface::ObjectId(const MeshHandle&));
         MOCK_METHOD1(ReleaseMesh, bool(MeshHandle&));
         MOCK_METHOD1(CloneMesh, MeshHandle(const MeshHandle&));
         MOCK_CONST_METHOD1(GetModel, AZStd::intrusive_ptr<AZ::RPI::Model>(const MeshHandle&));

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -75,7 +75,12 @@ namespace AZ
 
         TransformServiceFeatureProcessorInterface::ObjectId MeshFeatureProcessor::GetObjectId(const MeshHandle& meshHandle) const
         {
-            return meshHandle->m_objectId;
+            if (meshHandle.IsValid())
+            {
+                return meshHandle->m_objectId;
+            }
+
+            return TransformServiceFeatureProcessorInterface::ObjectId::Null;
         }
 
         void MeshFeatureProcessor::Simulate(const FeatureProcessor::SimulatePacket& packet)

--- a/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/Mesh/MeshFeatureProcessor.cpp
@@ -73,6 +73,11 @@ namespace AZ
             m_forceRebuildDrawPackets = false;
         }
 
+        TransformServiceFeatureProcessorInterface::ObjectId MeshFeatureProcessor::GetObjectId(const MeshHandle& meshHandle) const
+        {
+            return meshHandle->m_objectId;
+        }
+
         void MeshFeatureProcessor::Simulate(const FeatureProcessor::SimulatePacket& packet)
         {
             AZ_PROFILE_SCOPE(RPI, "MeshFeatureProcessor: Simulate");

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -250,16 +250,18 @@ namespace AZ
                 m_stats.m_meshStatsForLod.emplace_back(AZStd::move(stats));
             }
 
+            // Register this component with the editor mode feedback system
+            if (auto* editorModeFeedbackInterface = AZ::Interface<EditorModeFeedbackInterface>::Get())
+            {
+                editorModeFeedbackInterface->RegisterOrUpdateDrawableComponent(
+                    EntityComponentIdPair{ GetEntityId(), GetId() }, m_controller.m_meshHandle);
+            }
+
             // Refresh the tree when the model loads to update UI based on the model.
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
                 AzToolsFramework::Refresh_EntireTree);
 
-            // Register this component with the editor mode feedback system
-            if (auto* editorModeFeedbackInterface = AZ::Interface<EditorModeFeedbackInterface>::Get())
-            {
-                editorModeFeedbackInterface->RegisterDrawableComponent({ GetEntityId(), GetId() }, m_controller.m_meshHandle);
-            }
         }
 
         AZ::u32 EditorMeshComponent::OnConfigurationChanged()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Mesh/EditorMeshComponent.cpp
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/Entity/EditorEntityInfoBus.h>
 #include <AzToolsFramework/API/EntityCompositionRequestBus.h>
 
+#include <Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h>
 #include <AtomLyIntegration/CommonFeatures/Material/MaterialComponentConstants.h>
 
 namespace AZ
@@ -253,6 +254,12 @@ namespace AZ
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay,
                 AzToolsFramework::Refresh_EntireTree);
+
+            // Register this component with the editor mode feedback system
+            if (auto* editorModeFeedbackInterface = AZ::Interface<EditorModeFeedbackInterface>::Get())
+            {
+                editorModeFeedbackInterface->RegisterDrawableComponent({ GetEntityId(), GetId() }, m_controller.m_meshHandle);
+            }
         }
 
         AZ::u32 EditorMeshComponent::OnConfigurationChanged()

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Module.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/Module.cpp
@@ -43,6 +43,7 @@
 #ifdef ATOMLYINTEGRATION_FEATURE_COMMON_EDITOR
 #include <EditorCommonFeaturesSystemComponent.h>
 #include <PostProcess/EditorPostFxSystemComponent.h>
+#include <PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h>
 #include <CoreLights/EditorAreaLightComponent.h>
 #include <CoreLights/EditorDirectionalLightComponent.h>
 #include <Decals/EditorDecalComponent.h>
@@ -124,6 +125,7 @@ namespace AZ
                         EditorAreaLightComponent::CreateDescriptor(),
                         EditorCommonFeaturesSystemComponent::CreateDescriptor(),
                         EditorPostFxSystemComponent::CreateDescriptor(),
+                        EditorEditorModeFeedbackSystemComponent::CreateDescriptor(),
                         EditorDecalComponent::CreateDescriptor(),
                         EditorDirectionalLightComponent::CreateDescriptor(),
                         EditorBloomComponent::CreateDescriptor(),
@@ -166,6 +168,7 @@ namespace AZ
                     azrtti_typeid<EditorMeshSystemComponent>(),
                     azrtti_typeid<EditorCommonFeaturesSystemComponent>(),
                     azrtti_typeid<EditorPostFxSystemComponent>(),
+                    azrtti_typeid<EditorEditorModeFeedbackSystemComponent>()
 #endif
                 };
             }

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h>
+#include <AzCore/Component/ComponentBus.h>
+#include <AzCore/Component/TransformBus.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzToolsFramework/Viewport/ViewportMessages.h>
+#include <AzToolsFramework/FocusMode/FocusModeInterface.h>
+#include <AzToolsFramework/Entity/EditorEntityHelpers.h>
+#include <Atom/RPI.Public/MeshDrawPacket.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Model/ModelLodUtils.h>
+#include <Atom/RPI.Public/MeshDrawPacket.h>
+#include <Atom/RPI.Public/Model/Model.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/ViewportContext.h>
+#include <Atom/RPI.Public/ViewportContextBus.h>
+#include <Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h>
+#include <Atom/Utils/Utils.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        static AZStd::vector<RPI::MeshDrawPacket> BuildMeshDrawPackets(
+            const RPI::View* view,
+            const AZ::Transform& worldTM,
+            const Data::Asset<RPI::ModelAsset>& modelAsset,
+            const Data::Instance<RPI::Material>& material,
+            const Data::Instance<RPI::ShaderResourceGroup>& meshObjectSrg)
+        {
+            AZStd::vector<RPI::MeshDrawPacket> meshDrawPackets;
+            RPI::Model& model = *RPI::Model::FindOrCreate(modelAsset);
+            auto modelLodIndex = RPI::ModelLodUtils::SelectLod(view, worldTM, model);
+            const Data::Asset<RPI::ModelLodAsset>& modelLodAsset = modelAsset->GetLodAssets()[0];
+            RPI::ModelLod& modelLod = *RPI::ModelLod::FindOrCreate(modelLodAsset, modelAsset).get();
+        
+            for (auto i = 0; i < modelLod.GetMeshes().size(); i++)
+            {
+                RPI::MeshDrawPacket drawPacket(modelLod, i, material, meshObjectSrg);
+                meshDrawPackets.push_back(AZStd::move(drawPacket));
+            }
+        
+            return meshDrawPackets;
+        }
+
+        static Data::Instance<RPI::ShaderResourceGroup> CreateMaskShaderResourceGroup(
+            const MeshFeatureProcessorInterface* featureProcessor,
+            const MeshFeatureProcessorInterface::MeshHandle& meshHandle,
+            Data::Instance<RPI::Material> maskMaterial)
+        {
+            auto& shaderAsset = maskMaterial->GetAsset()->GetMaterialTypeAsset()->GetShaderAssetForObjectSrg();
+            auto& objectSrgLayout = maskMaterial->GetAsset()->GetObjectSrgLayout();
+            auto maskMeshObjectSrg = RPI::ShaderResourceGroup::Create(shaderAsset, objectSrgLayout->GetName());
+            auto objectId = featureProcessor->GetObjectId(meshHandle).GetIndex();
+            RHI::ShaderInputNameIndex objectIdIndex = "m_objectId";
+            maskMeshObjectSrg->SetConstant(objectIdIndex, objectId);
+            RHI::ShaderInputNameIndex maskIdIndex = "m_maskId";
+            maskMeshObjectSrg->SetConstant(maskIdIndex, 1);
+            maskMeshObjectSrg->Compile();
+
+            return maskMeshObjectSrg;
+        }
+
+        static const RPI::ViewPtr GetViewFromScene(const RPI::Scene* scene)
+        {
+            auto viewportContextRequests = RPI::ViewportContextRequests::Get();
+            auto viewportContext = viewportContextRequests->GetViewportContextByScene(scene);
+            const RPI::ViewPtr viewPtr = viewportContext->GetDefaultView();
+            return viewPtr;
+        }
+
+        static Data::Instance<RPI::Material> CreateMaskMaterial()
+        {
+            AZStd::string path = "shaders/postprocessing/editormodemask.azmaterial";
+            auto materialAsset = GetAssetFromPath<RPI::MaterialAsset>(path, Data::AssetLoadBehavior::PreLoad, true);
+            auto maskMaterial = RPI::Material::FindOrCreate(materialAsset);
+            return maskMaterial;
+        }
+
+        static AZ::Transform GetWorldTransformForEntity(EntityId entityId)
+        {
+            AZ::Transform worldTM;
+            AZ::TransformBus::EventResult(worldTM, entityId, &AZ::TransformBus::Events::GetWorldTM);
+            return worldTM;
+        }
+
+        EditorEditorModeFeedbackSystemComponent::MeshDrawPackets::~MeshDrawPackets() = default;
+
+        void EditorEditorModeFeedbackSystemComponent::Reflect(AZ::ReflectContext* context)
+        {
+            if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
+            {
+                serialize->Class<EditorEditorModeFeedbackSystemComponent, AzToolsFramework::Components::EditorComponentBase>()
+                    ->Version(0)
+                    ;
+
+                if (AZ::EditContext* ec = serialize->GetEditContext())
+                {
+                    ec->Class<EditorEditorModeFeedbackSystemComponent>(
+                          "Editor Mode Feedback System", "Manages discovery of Editr Mode Feedback effects")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("System", 0xc94d118b))
+                        ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                        ;
+                }
+            }
+        }
+
+        EditorEditorModeFeedbackSystemComponent::~EditorEditorModeFeedbackSystemComponent() = default;
+
+        void EditorEditorModeFeedbackSystemComponent::Init()
+        {
+            AzToolsFramework::Components::EditorComponentBase::Init();
+        }
+
+        void EditorEditorModeFeedbackSystemComponent::Activate()
+        {
+            AzToolsFramework::Components::EditorComponentBase::Activate();
+            AzToolsFramework::ViewportEditorModeNotificationsBus::Handler::BusConnect(AzToolsFramework::GetEntityContextId());
+            AZ::Interface<EditorModeFeedbackInterface>::Register(this);
+            AZ::TickBus::Handler::BusConnect();
+        }
+
+        void EditorEditorModeFeedbackSystemComponent::Deactivate()
+        {
+            AZ::TickBus::Handler::BusDisconnect();
+            AZ::Interface<EditorModeFeedbackInterface>::Unregister(this);
+            AzToolsFramework::ViewportEditorModeNotificationsBus::Handler::BusDisconnect();
+            AzToolsFramework::Components::EditorComponentBase::Deactivate();
+        }
+
+        bool EditorEditorModeFeedbackSystemComponent::IsEnabled() const
+        {
+            return m_enabled;
+        }
+
+        void EditorEditorModeFeedbackSystemComponent::RegisterDrawableComponent(
+            EntityComponentIdPair entityComponentId, const MeshFeatureProcessorInterface::MeshHandle& meshHandle)
+        {
+            auto& [componentMeshHandle, componentMeshDrawPackets] =
+                m_entityComponentMeshDrawPackets[entityComponentId.GetEntityId()][entityComponentId.GetComponentId()];
+            componentMeshHandle = &meshHandle;
+
+            // The same component can call RegisterDrawableEntity multiple times in order to update its model asset so always
+            // clear any existing draw packets for the component upon registration
+            componentMeshDrawPackets.clear();
+        }
+
+        void EditorEditorModeFeedbackSystemComponent::OnEditorModeActivated(
+            [[maybe_unused]] const AzToolsFramework::ViewportEditorModesInterface& editorModeState,
+            AzToolsFramework::ViewportEditorMode mode)
+        {
+            if (mode == AzToolsFramework::ViewportEditorMode::Focus)
+            {
+                for (auto& it : m_entityComponentMeshDrawPackets)
+                {
+                    for (auto& it2 : it.second)
+                    {
+                        auto& [componentMeshHandle, componentMeshDrawPackets] = it2.second;
+                        componentMeshDrawPackets.clear();
+                    }
+                }
+
+                m_enabled = true;
+            }
+        }
+
+        void EditorEditorModeFeedbackSystemComponent::OnEditorModeDeactivated(
+            [[maybe_unused]] const AzToolsFramework::ViewportEditorModesInterface& editorModeState,
+            AzToolsFramework::ViewportEditorMode mode)
+        {
+            if (mode == AzToolsFramework::ViewportEditorMode::Focus)
+            {
+                m_enabled = false;
+            }
+        }
+
+        void EditorEditorModeFeedbackSystemComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+        {
+            if (!m_enabled)
+            {
+                return;
+            }
+
+            const auto focusModeInterface = AZ::Interface<AzToolsFramework::FocusModeInterface>::Get();
+            if (!focusModeInterface)
+            {
+                return;
+            }
+
+            // TODO: see if there is a more reliable method of creating the required resources once the depender systems are initialized
+            if (!m_maskMaterial)
+            {
+                m_maskMaterial = CreateMaskMaterial();
+            }
+
+            // Build the draw packets (where required) for each registered component and add them to the draw list
+            const auto focusedEntityIds = focusModeInterface->GetFocusedEntities(AzToolsFramework::GetEntityContextId());
+            for (const auto& focusedEntityId : focusedEntityIds)
+            {
+                const auto it = m_entityComponentMeshDrawPackets.find(focusedEntityId);
+                if (it == m_entityComponentMeshDrawPackets.end())
+                {
+                    // No drawable data for this entity
+                    continue;
+                }
+
+                auto& [entityId, componentModelAssetDrawPackets] = *it;
+
+                for (auto& it2 : componentModelAssetDrawPackets)
+                {
+                    auto& [componentId, meshDrawPackets] = it2;
+
+                    const auto scene = RPI::Scene::GetSceneForEntityId(entityId);
+                    if (meshDrawPackets.m_drawPackets.empty())
+                    {
+                        if (const auto featureProcessor =
+                                RPI::Scene::GetFeatureProcessorForEntity<MeshFeatureProcessorInterface>(focusedEntityId))
+                        {
+                            const auto maskMeshObjectSrg = CreateMaskShaderResourceGroup(featureProcessor, *meshDrawPackets.m_meshHandle, m_maskMaterial);
+                            const auto view = GetViewFromScene(scene);
+                            const auto worldTM = GetWorldTransformForEntity(focusedEntityId);
+                            meshDrawPackets.m_drawPackets = BuildMeshDrawPackets(
+                                view.get(),
+                                worldTM,
+                                featureProcessor->GetModelAsset(*meshDrawPackets.m_meshHandle), m_maskMaterial,
+                                maskMeshObjectSrg);
+                        }
+                        else
+                        {
+                            // This really shouldn't fail, but just in case...
+                            AZ_Error(
+                                "EditorEditorModeFeedbackSystemComponent",
+                                false,
+                                AZStd::string::format("Could't get feature processor for entity '%s'", focusedEntityId.ToString().c_str()).c_str());
+                        }
+                    }
+
+                    AZ::RPI::DynamicDrawInterface* dynamicDraw = AZ::RPI::GetDynamicDraw();
+                    for (auto& drawPacket : meshDrawPackets.m_drawPackets)
+                    {
+                        drawPacket.Update(*scene);
+                        dynamicDraw->AddDrawPacket(scene, drawPacket.GetRHIDrawPacket());
+                    }
+                }
+            }
+        }
+
+        int EditorEditorModeFeedbackSystemComponent::GetTickOrder()
+        {
+            return AZ::TICK_PRE_RENDER;
+        }
+    }
+}

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.cpp
@@ -126,11 +126,6 @@ namespace AZ
 
         EditorEditorModeFeedbackSystemComponent::~EditorEditorModeFeedbackSystemComponent() = default;
 
-        void EditorEditorModeFeedbackSystemComponent::Init()
-        {
-            AzToolsFramework::Components::EditorComponentBase::Init();
-        }
-
         void EditorEditorModeFeedbackSystemComponent::Activate()
         {
             AzToolsFramework::Components::EditorComponentBase::Activate();

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.cpp
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.cpp
@@ -264,5 +264,5 @@ namespace AZ
         {
             return AZ::TICK_PRE_RENDER;
         }
-    }
-}
+    } // namespace Render
+} // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
@@ -16,6 +16,7 @@
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h>
 #include <Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h>
+#include <Atom/RPI.Reflect/Model/ModelLodIndex.h>
 #include <AtomCore/Instance/Instance.h>
 
 namespace AZ
@@ -48,7 +49,8 @@ namespace AZ
 
             // EditorModeFeedbackInterface overrides ...
             bool IsEnabled() const override;
-            void RegisterDrawableComponent(EntityComponentIdPair entityComponentId, const MeshFeatureProcessorInterface::MeshHandle& meshHandle) override;
+            void RegisterOrUpdateDrawableComponent(
+                EntityComponentIdPair entityComponentId, const MeshFeatureProcessorInterface::MeshHandle& meshHandle) override;
 
         private:
             // ViewportEditorModeNotificationsBus overrides ...
@@ -70,6 +72,7 @@ namespace AZ
                 ~MeshHandleDrawPackets();
 
                 const MeshFeatureProcessorInterface::MeshHandle* m_meshHandle;
+                RPI::ModelLodIndex m_modelLodIndex = RPI::ModelLodIndex::Null; 
                 AZStd::vector<RPI::MeshDrawPacket> m_meshDrawPackets;
             };
             

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/functional.h>
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <AzToolsFramework/API/ViewportEditorModeTrackerNotificationBus.h>
+#include <Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h>
+#include <AtomCore/Instance/Instance.h>
+
+namespace AZ
+{
+    namespace RPI
+    {
+        class MeshDrawPacket;
+        class Material;
+    }
+
+    namespace Render
+    {
+        //! Component for the editor mode feedback system.
+        class EditorEditorModeFeedbackSystemComponent
+            : public AzToolsFramework::Components::EditorComponentBase
+            , public EditorModeFeedbackInterface
+            , public AZ::TickBus::Handler
+            , private AzToolsFramework::ViewportEditorModeNotificationsBus::Handler
+        {
+        public:
+            AZ_EDITOR_COMPONENT(EditorEditorModeFeedbackSystemComponent, "{A88EE29D-4C72-4995-B3BD-41EEDE480487}");
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            ~EditorEditorModeFeedbackSystemComponent();
+
+            // EditorComponentBase overrides ...
+            void Init() override;
+            void Activate() override;
+            void Deactivate() override;
+
+            // EditorModeFeedbackInterface overrides ...
+            bool IsEnabled() const override;
+            void RegisterDrawableComponent(EntityComponentIdPair entityComponentId, const MeshFeatureProcessorInterface::MeshHandle& meshHandle) override;
+
+        private:
+            // ViewportEditorModeNotificationsBus overrides ...
+            void OnEditorModeActivated(
+                const AzToolsFramework::ViewportEditorModesInterface& editorModeState, AzToolsFramework::ViewportEditorMode mode) override;
+            void OnEditorModeDeactivated(
+                const AzToolsFramework::ViewportEditorModesInterface& editorModeState, AzToolsFramework::ViewportEditorMode mode) override;
+
+            // TickBus overrides ...
+            void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+            int GetTickOrder() override;
+
+            //! Flag to specify whether or not the editor feedback effects are active.
+            bool m_enabled = false;
+
+            //! Data to construct draw packets for meshes.
+            struct MeshDrawPackets
+            {
+                ~MeshDrawPackets();
+
+                const MeshFeatureProcessorInterface::MeshHandle* m_meshHandle;
+                AZStd::vector<RPI::MeshDrawPacket> m_drawPackets;
+            };
+            
+            //! Map for entities and their drawable components.
+            AZStd::unordered_map<EntityId, AZStd::unordered_map<ComponentId, MeshDrawPackets>> m_entityComponentMeshDrawPackets;
+
+            //! Material for sending draw packets to the entity mask pass.
+            Data::Instance<RPI::Material> m_maskMaterial = nullptr;
+        };
+    }
+}

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
@@ -43,7 +43,6 @@ namespace AZ
             ~EditorEditorModeFeedbackSystemComponent();
 
             // EditorComponentBase overrides ...
-            void Init() override;
             void Activate() override;
             void Deactivate() override;
 

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
@@ -79,5 +79,5 @@ namespace AZ
             //! Material for sending draw packets to the entity mask pass.
             Data::Instance<RPI::Material> m_maskMaterial = nullptr;
         };
-    }
-}
+    } // namespace Render
+} // namespace AZ

--- a/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
+++ b/Gems/AtomLyIntegration/CommonFeatures/Code/Source/PostProcess/EditorModeFeedback/EditorEditorModeFeedbackSystemComponent.h
@@ -66,16 +66,16 @@ namespace AZ
             bool m_enabled = false;
 
             //! Data to construct draw packets for meshes.
-            struct MeshDrawPackets
+            struct MeshHandleDrawPackets
             {
-                ~MeshDrawPackets();
+                ~MeshHandleDrawPackets();
 
                 const MeshFeatureProcessorInterface::MeshHandle* m_meshHandle;
-                AZStd::vector<RPI::MeshDrawPacket> m_drawPackets;
+                AZStd::vector<RPI::MeshDrawPacket> m_meshDrawPackets;
             };
             
             //! Map for entities and their drawable components.
-            AZStd::unordered_map<EntityId, AZStd::unordered_map<ComponentId, MeshDrawPackets>> m_entityComponentMeshDrawPackets;
+            AZStd::unordered_map<EntityId, AZStd::unordered_map<ComponentId, MeshHandleDrawPackets>> m_entityComponentMeshHandleDrawPackets;
 
             //! Material for sending draw packets to the entity mask pass.
             Data::Instance<RPI::Material> m_maskMaterial = nullptr;


### PR DESCRIPTION
## Overview

This PR contains the pass class files for the Editor Mode Visual Feedback system necessary to implement the Focus Mode visual feedback effects (the rest of the work will come in subsequent PRs). 

For context, the passes themselves and overall design of the visual feedback system are described in [this PR](https://github.com/o3de/o3de/pull/7638) whereas the pass classes themselves are described in [this PR](https://github.com/o3de/o3de/pull/7966).

## Mask Rendering

Other than enabling/disabling the effect in sync with the entering/exiting of Focus Mode, the primary role of this component is to facilitate the rendering of entities of interest to the `EditorModeMaskPass` (see [this PR](https://github.com/o3de/o3de/pull/7638) for the necessary background information). It achieves this by allowing entities with drawable components (e.g. mesh components, actor components, etc.) to register themselves with the component such that when a prefab enters Focus Mode, the entities in focus that compose that prefab are redrawn with a simple shader that writes the apppropriate mask value for that entity to the entity mask texture.

### Known Limitations

* Only mesh components are currently supported.
* Mesh LoD is not fully supported.

Signed-off-by: John <jonawals@amazon.co.uk>