### PR TITLE
Convert Physics automated tests from Periodic test suite to use prefab system

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -93,14 +93,14 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_RestitutionCombine(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_RestitutionCombine as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     @fm.file_override('physxsystemconfiguration.setreg','Material_FrictionCombine.setreg_override',
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_FrictionCombine(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_FrictionCombine as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_Collider_ColliderPositionOffset(self, request, workspace, editor, launcher_platform):
@@ -198,7 +198,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_RestitutionCombinePriorityOrder(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_RestitutionCombinePriorityOrder as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_ForceRegion_SplineRegionWithModifiedTransform(self, request, workspace, editor, launcher_platform):
@@ -230,7 +230,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_FrictionCombinePriorityOrder(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_FrictionCombinePriorityOrder as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @pytest.mark.xfail(
         reason="Something with the CryRenderer disabling is causing this test to fail now.")
@@ -253,7 +253,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_PerFaceMaterialGetsCorrectMaterial(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_PerFaceMaterialGetsCorrectMaterial as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @pytest.mark.xfail(
         reason="This test will sometimes fail as the ball will continue to roll before the timeout is reached.")
@@ -287,7 +287,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_CharacterController(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_CharacterController as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_Material_EmptyLibraryUsesDefault(self, request, workspace, editor, launcher_platform):
@@ -315,14 +315,14 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Collider_NoneCollisionGroupSameLayerNotCollide(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_NoneCollisionGroupSameLayerNotCollide as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     @fm.file_override('physxsystemconfiguration.setreg','Collider_SameCollisionGroupSameCustomLayerCollide.setreg_override',
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Collider_SameCollisionGroupSameCustomLayerCollide(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_SameCollisionGroupSameCustomLayerCollide as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     @fm.file_override('physxdefaultsceneconfiguration.setreg','ScriptCanvas_PostUpdateEvent.setreg_override',
@@ -336,7 +336,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Material_Restitution(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_Restitution as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     @fm.file_override('physxdefaultsceneconfiguration.setreg', 'ScriptCanvas_PreUpdateEvent.setreg_override',
@@ -378,7 +378,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Collider_AddingNewGroupWorks(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_AddingNewGroupWorks as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_ShapeCollider_InactiveWhenNoShapeComponent(self, request, workspace, editor, launcher_platform):
@@ -466,7 +466,7 @@ class TestAutomation(TestAutomationBase):
                       'AutomatedTesting/Registry', search_subdirs=True)
     def test_Collider_CollisionGroupsWorkflow(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_CollisionGroupsWorkflow as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @revert_physics_config
     def test_Collider_ColliderRotationOffset(self, request, workspace, editor, launcher_platform):
@@ -490,23 +490,23 @@ class TestAutomation(TestAutomationBase):
     
     def test_Joints_Fixed2BodiesConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_Fixed2BodiesConstrained as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_Hinge2BodiesConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_Hinge2BodiesConstrained as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_Ball2BodiesConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_Ball2BodiesConstrained as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_FixedBreakable(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_FixedBreakable as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_HingeBreakable(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_HingeBreakable as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_BallBreakable(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_BallBreakable as test_module
@@ -514,15 +514,15 @@ class TestAutomation(TestAutomationBase):
 
     def test_Joints_HingeNoLimitsConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_HingeNoLimitsConstrained as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_BallNoLimitsConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_BallNoLimitsConstrained as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_GlobalFrameConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_GlobalFrameConstrained as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
     
     @revert_physics_config
     def test_Material_DefaultLibraryUpdatedAcrossLevels(self, request, workspace, editor, launcher_platform):

--- a/AutomatedTesting/Levels/Physics/Collider_AddingNewGroupWorks/Collider_AddingNewGroupWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_AddingNewGroupWorks/Collider_AddingNewGroupWorks.prefab
@@ -1,0 +1,198 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Collider_AddingNewGroupWorks",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[263565336022]": {
+            "Id": "Entity_[263565336022]",
+            "Name": "Sphere",
+            "Components": {
+                "Component_[1077035889980990778]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1077035889980990778
+                },
+                "Component_[11692592828012417110]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11692592828012417110
+                },
+                "Component_[13590770479976021743]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13590770479976021743,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            502.0,
+                            529.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[14942758898379147854]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14942758898379147854
+                },
+                "Component_[15803949093068003505]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15803949093068003505
+                },
+                "Component_[16774751424420453062]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16774751424420453062
+                },
+                "Component_[2076554166090224023]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2076554166090224023
+                },
+                "Component_[3796327233831302715]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3796327233831302715,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13590770479976021743
+                        },
+                        {
+                            "ComponentId": 7172667701871732398,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[6183371783907613009]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6183371783907613009
+                },
+                "Component_[7172667701871732398]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7172667701871732398,
+                    "ColliderConfiguration": {
+                        "CollisionGroupId": {
+                            "GroupId": "{C6156E97-7789-4EFA-AA8B-F987FF1C829F}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[8644543606437575410]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8644543606437575410
+                }
+            }
+        },
+        "Entity_[272326122007]": {
+            "Id": "Entity_[272326122007]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[11336002331418698867]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11336002331418698867
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Collider_CollisionGroupsWorkflow/Collider_CollisionGroupsWorkflow.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_CollisionGroupsWorkflow/Collider_CollisionGroupsWorkflow.prefab
@@ -1,0 +1,828 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Collider_CollisionGroupsWorkflow",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[259466907943]": {
+            "Id": "Entity_[259466907943]",
+            "Name": "Box_1_B",
+            "Components": {
+                "Component_[10356160448665347412]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 10356160448665347412,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.09803920239210129,
+                        1.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.09803920239210129,
+                                1.0,
+                                0.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[10482035445299722089]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10482035445299722089
+                },
+                "Component_[12114140254218839235]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12114140254218839235
+                },
+                "Component_[12796387822906346177]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12796387822906346177
+                },
+                "Component_[13480949097745438122]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 13480949097745438122,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{2C698BDF-B2CC-47FC-8356-6BAB160AFFE9}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[14423264528338185887]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14423264528338185887
+                },
+                "Component_[15053715181575205332]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15053715181575205332
+                },
+                "Component_[17822503912186846842]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17822503912186846842,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4817896429329768343
+                        },
+                        {
+                            "ComponentId": 10356160448665347412,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 13480949097745438122,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 9792903894867167515,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[2810034955465504327]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2810034955465504327
+                },
+                "Component_[3274864013943777794]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3274864013943777794
+                },
+                "Component_[3519576227402671568]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3519576227402671568
+                },
+                "Component_[4817896429329768343]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4817896429329768343,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            68.0,
+                            33.5
+                        ]
+                    }
+                },
+                "Component_[9792903894867167515]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9792903894867167515,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 6.0
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[261736876699]": {
+            "Id": "Entity_[261736876699]",
+            "Name": "Box_2_A",
+            "Components": {
+                "Component_[14938082370709144257]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14938082370709144257,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 6.0
+                        }
+                    }
+                },
+                "Component_[15577190100407053290]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15577190100407053290
+                },
+                "Component_[17531658350158504143]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17531658350158504143
+                },
+                "Component_[18029146420709399357]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18029146420709399357
+                },
+                "Component_[18150197901026880021]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18150197901026880021,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            69.0,
+                            68.0,
+                            33.499996185302734
+                        ]
+                    }
+                },
+                "Component_[2294100868853833784]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2294100868853833784
+                },
+                "Component_[4166489422385287130]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4166489422385287130
+                },
+                "Component_[5590732529768359986]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5590732529768359986
+                },
+                "Component_[6136078924552418110]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6136078924552418110,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18150197901026880021
+                        },
+                        {
+                            "ComponentId": 6314530433035411390,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7888321721748456023,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14938082370709144257,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6314530433035411390]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 6314530433035411390,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        1.0,
+                        1.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                1.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[6609021482930126566]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6609021482930126566
+                },
+                "Component_[7888321721748456023]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7888321721748456023,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 2
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{802547AF-5A11-4FEE-B30F-D12BFA2624C6}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[8010213354206542977]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8010213354206542977
+                }
+            }
+        },
+        "Entity_[263761875239]": {
+            "Id": "Entity_[263761875239]",
+            "Name": "Box_2_B",
+            "Components": {
+                "Component_[14938082370709144257]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14938082370709144257,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 6.0
+                        }
+                    }
+                },
+                "Component_[15577190100407053290]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15577190100407053290
+                },
+                "Component_[17531658350158504143]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17531658350158504143
+                },
+                "Component_[18029146420709399357]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18029146420709399357
+                },
+                "Component_[18150197901026880021]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18150197901026880021,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            71.0,
+                            68.0,
+                            33.499996185302734
+                        ]
+                    }
+                },
+                "Component_[2294100868853833784]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2294100868853833784
+                },
+                "Component_[4166489422385287130]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4166489422385287130
+                },
+                "Component_[5590732529768359986]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5590732529768359986
+                },
+                "Component_[6136078924552418110]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6136078924552418110,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18150197901026880021
+                        },
+                        {
+                            "ComponentId": 6314530433035411390,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7888321721748456023,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14938082370709144257,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6314530433035411390]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 6314530433035411390,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        1.0,
+                        1.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                1.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[6609021482930126566]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6609021482930126566
+                },
+                "Component_[7888321721748456023]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7888321721748456023,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 2
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{802547AF-5A11-4FEE-B30F-D12BFA2624C6}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[8010213354206542977]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8010213354206542977
+                }
+            }
+        },
+        "Entity_[268056842535]": {
+            "Id": "Entity_[268056842535]",
+            "Name": "Terrain_Entity_B",
+            "Components": {
+                "Component_[10264734926658055258]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 10264734926658055258,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                1024.0,
+                                1024.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[11028008287346948467]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11028008287346948467
+                },
+                "Component_[13186228382373041985]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13186228382373041985
+                },
+                "Component_[13699442376833814569]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13699442376833814569
+                },
+                "Component_[15635759330685702346]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15635759330685702346,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2455764014686394094
+                        },
+                        {
+                            "ComponentId": 18266717101791539127,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10264734926658055258,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[16052791866579738900]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16052791866579738900
+                },
+                "Component_[16429863672749850210]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16429863672749850210
+                },
+                "Component_[16455652825442239367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16455652825442239367
+                },
+                "Component_[18266717101791539127]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 18266717101791539127,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 2
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{802547AF-5A11-4FEE-B30F-D12BFA2624C6}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration",
+                            "Configuration": [
+                                1024.0,
+                                1024.0,
+                                1.0
+                            ]
+                        }
+                    ]
+                },
+                "Component_[2455764014686394094]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2455764014686394094,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            31.0
+                        ]
+                    }
+                },
+                "Component_[731075418519800050]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 731075418519800050
+                },
+                "Component_[8899695668795540311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8899695668795540311
+                }
+            }
+        },
+        "Entity_[268071109635]": {
+            "Id": "Entity_[268071109635]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[12380026060924511025]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12380026060924511025
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[276661044227]": {
+            "Id": "Entity_[276661044227]",
+            "Name": "Terrain_Entity_A",
+            "Components": {
+                "Component_[11028008287346948467]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11028008287346948467
+                },
+                "Component_[13186228382373041985]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13186228382373041985
+                },
+                "Component_[13699442376833814569]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13699442376833814569
+                },
+                "Component_[15635759330685702346]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15635759330685702346,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2455764014686394094
+                        },
+                        {
+                            "ComponentId": 3260949453924737135,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17928122885114450139,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[16052791866579738900]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16052791866579738900
+                },
+                "Component_[16429863672749850210]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16429863672749850210
+                },
+                "Component_[16455652825442239367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16455652825442239367
+                },
+                "Component_[17928122885114450139]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 17928122885114450139,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                1024.0,
+                                1024.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[2455764014686394094]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2455764014686394094,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            31.0
+                        ]
+                    }
+                },
+                "Component_[3260949453924737135]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 3260949453924737135,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{2C698BDF-B2CC-47FC-8356-6BAB160AFFE9}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration",
+                            "Configuration": [
+                                1024.0,
+                                1024.0,
+                                1.0
+                            ]
+                        }
+                    ]
+                },
+                "Component_[731075418519800050]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 731075418519800050
+                },
+                "Component_[8899695668795540311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8899695668795540311
+                }
+            }
+        },
+        "Entity_[280956011523]": {
+            "Id": "Entity_[280956011523]",
+            "Name": "Box_1_A",
+            "Components": {
+                "Component_[10356160448665347412]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 10356160448665347412,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.09803920239210129,
+                        1.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.09803920239210129,
+                                1.0,
+                                0.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[10482035445299722089]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10482035445299722089
+                },
+                "Component_[12114140254218839235]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12114140254218839235
+                },
+                "Component_[12796387822906346177]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12796387822906346177
+                },
+                "Component_[13480949097745438122]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 13480949097745438122,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{2C698BDF-B2CC-47FC-8356-6BAB160AFFE9}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[14423264528338185887]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14423264528338185887
+                },
+                "Component_[15053715181575205332]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15053715181575205332
+                },
+                "Component_[17822503912186846842]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17822503912186846842,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4817896429329768343
+                        },
+                        {
+                            "ComponentId": 10356160448665347412,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 13480949097745438122,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 9792903894867167515,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[2810034955465504327]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2810034955465504327
+                },
+                "Component_[3274864013943777794]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3274864013943777794
+                },
+                "Component_[3519576227402671568]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3519576227402671568
+                },
+                "Component_[4817896429329768343]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4817896429329768343,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            68.0,
+                            33.5
+                        ]
+                    }
+                },
+                "Component_[9792903894867167515]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9792903894867167515,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 6.0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Collider_NoneCollisionGroupSameLayerNotCollide/Collider_NoneCollisionGroupSameLayerNotCollide.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_NoneCollisionGroupSameLayerNotCollide/Collider_NoneCollisionGroupSameLayerNotCollide.prefab
@@ -1,0 +1,374 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Collider_NoneCollisionGroupSameLayerNotCollide",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[268759603102]": {
+            "Id": "Entity_[268759603102]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[5816877312108668749]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5816877312108668749
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[277349537694]": {
+            "Id": "Entity_[277349537694]",
+            "Name": "Moving",
+            "Components": {
+                "Component_[14600239388356101800]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14600239388356101800
+                },
+                "Component_[14601040183278831929]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14601040183278831929,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1613019390817348409
+                        },
+                        {
+                            "ComponentId": 3936493991963310515,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17122033235640245445,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 15467128519059179888,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15467128519059179888]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 15467128519059179888,
+                    "GameView": true,
+                    "ShapeColor": [
+                        1.0,
+                        1.0,
+                        0.0
+                    ],
+                    "SphereShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                1.0,
+                                1.0,
+                                0.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[1613019390817348409]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1613019390817348409,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            62.0,
+                            68.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[17122033235640245445]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 17122033235640245445,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            3.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[3600372641817755699]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3600372641817755699
+                },
+                "Component_[3936493991963310515]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3936493991963310515,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{CDB6B8D8-5CD0-40A8-874D-839B00A92EBB}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[5311284232510486283]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5311284232510486283
+                },
+                "Component_[5732416808460670281]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5732416808460670281
+                },
+                "Component_[6412101305540643521]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6412101305540643521
+                },
+                "Component_[890749300010975452]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 890749300010975452
+                },
+                "Component_[9773848631080278394]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9773848631080278394
+                },
+                "Component_[9812021595201603272]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9812021595201603272
+                }
+            }
+        },
+        "Entity_[281644504990]": {
+            "Id": "Entity_[281644504990]",
+            "Name": "Stationary",
+            "Components": {
+                "Component_[14600239388356101800]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14600239388356101800
+                },
+                "Component_[14601040183278831929]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14601040183278831929,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1613019390817348409
+                        },
+                        {
+                            "ComponentId": 3936493991963310515,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17122033235640245445,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 15467128519059179888,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15467128519059179888]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 15467128519059179888,
+                    "GameView": true,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.9019607901573181
+                    ],
+                    "SphereShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                1.0,
+                                0.0,
+                                0.9019607901573181
+                            ]
+                        }
+                    }
+                },
+                "Component_[1613019390817348409]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1613019390817348409,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            63.99999237060547,
+                            68.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[17122033235640245445]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 17122033235640245445,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[3600372641817755699]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3600372641817755699
+                },
+                "Component_[3936493991963310515]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3936493991963310515,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{CDB6B8D8-5CD0-40A8-874D-839B00A92EBB}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[5311284232510486283]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5311284232510486283
+                },
+                "Component_[5732416808460670281]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5732416808460670281
+                },
+                "Component_[6412101305540643521]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6412101305540643521
+                },
+                "Component_[890749300010975452]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 890749300010975452
+                },
+                "Component_[9773848631080278394]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9773848631080278394
+                },
+                "Component_[9812021595201603272]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9812021595201603272
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Collider_SameCollisionGroupSameCustomLayerCollide/Collider_SameCollisionGroupSameCustomLayerCollide.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_SameCollisionGroupSameCustomLayerCollide/Collider_SameCollisionGroupSameCustomLayerCollide.prefab
@@ -1,0 +1,328 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Collider_SameCollisionGroupSameCustomLayerCollide",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[265704169883]": {
+            "Id": "Entity_[265704169883]",
+            "Name": "Moving_Sphere",
+            "Components": {
+                "Component_[10100771772210521946]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10100771772210521946
+                },
+                "Component_[11094539321466845362]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11094539321466845362
+                },
+                "Component_[14971636851132032428]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14971636851132032428
+                },
+                "Component_[17666475791044011040]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 17666475791044011040,
+                    "GameView": true
+                },
+                "Component_[1807102489407624301]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1807102489407624301,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[2138133092078377015]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2138133092078377015
+                },
+                "Component_[3282413301459223431]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3282413301459223431
+                },
+                "Component_[3723381517291357767]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3723381517291357767
+                },
+                "Component_[3912558180088624160]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3912558180088624160
+                },
+                "Component_[6243417971318043028]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6243417971318043028,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            509.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[8438805121118672806]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8438805121118672806,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[9548098618506300725]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9548098618506300725
+                },
+                "Component_[9894939390038688197]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9894939390038688197,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6243417971318043028
+                        },
+                        {
+                            "ComponentId": 1807102489407624301,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8438805121118672806,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 17666475791044011040,
+                            "SortIndex": 3
+                        }
+                    ]
+                }
+            }
+        },
+        "Entity_[272736663385]": {
+            "Id": "Entity_[272736663385]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[11784004445995909177]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11784004445995909177
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[317243777435]": {
+            "Id": "Entity_[317243777435]",
+            "Name": "Stationary_Sphere",
+            "Components": {
+                "Component_[11096631008107390665]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11096631008107390665
+                },
+                "Component_[11596444710974926159]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11596444710974926159
+                },
+                "Component_[16510257363545411112]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16510257363545411112
+                },
+                "Component_[17092854469484066254]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 17092854469484066254,
+                    "GameView": true
+                },
+                "Component_[17567665860913880216]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17567665860913880216
+                },
+                "Component_[17972652067782026005]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17972652067782026005
+                },
+                "Component_[2712027799148208684]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2712027799148208684
+                },
+                "Component_[4148405829114950227]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4148405829114950227,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 10.0
+                    }
+                },
+                "Component_[5364815945345910533]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5364815945345910533,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6855416387675363209
+                        },
+                        {
+                            "ComponentId": 7475975835684456161,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4148405829114950227,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 17092854469484066254,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6855416387675363209]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6855416387675363209,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            514.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[6923655985802285166]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6923655985802285166
+                },
+                "Component_[7475975835684456161]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7475975835684456161,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[91857867292178102]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 91857867292178102
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_Ball2BodiesConstrained/Joints_Ball2BodiesConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_Ball2BodiesConstrained/Joints_Ball2BodiesConstrained.prefab
@@ -1,0 +1,309 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_Ball2BodiesConstrained",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Angular damping": 50.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 999.0,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 0.010010000318288803
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 7467962597485847042,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[7467962597485847042]": {
+                    "$type": "EditorBallJointComponent",
+                    "Id": 7467962597485847042,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.812000036239624
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            89.99400329589844,
+                            180.0
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]"
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_BallBreakable/Joints_BallBreakable.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_BallBreakable/Joints_BallBreakable.prefab
@@ -1,0 +1,310 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_BallBreakable",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Angular damping": 50.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 999.0,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 0.010010000318288803
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 7467962597485847042,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[7467962597485847042]": {
+                    "$type": "EditorBallJointComponent",
+                    "Id": 7467962597485847042,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.812000036239624
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            89.99400329589844,
+                            180.0
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]",
+                        "Breakable": true
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
@@ -1,0 +1,423 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_BallNoLimitsConstrained",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Angular damping": 50.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 999.0,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 0.010010000318288803
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[314332582525]": {
+            "Id": "Entity_[314332582525]",
+            "Name": "dampingRegion",
+            "Components": {
+                "Component_[11704616652043413357]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11704616652043413357
+                },
+                "Component_[12583721063489022967]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12583721063489022967,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.2922248840332
+                        ]
+                    }
+                },
+                "Component_[13338813080904791783]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 13338813080904791783,
+                    "Forces": [
+                        {
+                            "Type": 5,
+                            "ForceLinearDamping": {
+                                "Damping": 5.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[13534401190356364340]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13534401190356364340
+                },
+                "Component_[15628597297223526741]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15628597297223526741
+                },
+                "Component_[18344053313521555612]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18344053313521555612
+                },
+                "Component_[3246808982938353840]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3246808982938353840,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12583721063489022967
+                        },
+                        {
+                            "ComponentId": 13338813080904791783,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7429624549406958440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 9487204736869257485,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[3317660974688951744]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3317660974688951744
+                },
+                "Component_[6861005041189176147]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6861005041189176147
+                },
+                "Component_[7429624549406958440]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 7429624549406958440,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration"
+                        }
+                    ]
+                },
+                "Component_[7543119611900431533]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7543119611900431533
+                },
+                "Component_[8497797771983319252]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8497797771983319252
+                },
+                "Component_[9487204736869257485]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 9487204736869257485
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 7467962597485847042,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{B072A405-BAFA-4B0A-9164-B3A424E642A9}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[7467962597485847042]": {
+                    "$type": "EditorBallJointComponent",
+                    "Id": 7467962597485847042,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.812000036239624
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            89.99400329589844,
+                            180.0
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]"
+                    },
+                    "Swing Limit": {
+                        "Standard Limit Configuration": {
+                            "Is Limited": false,
+                            "Is Soft Limit": true,
+                            "Damping": 2.0,
+                            "Stiffness": 10.0
+                        }
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_Fixed2BodiesConstrained/Joints_Fixed2BodiesConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_Fixed2BodiesConstrained/Joints_Fixed2BodiesConstrained.prefab
@@ -1,0 +1,303 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_Fixed2BodiesConstrained",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 8112340781834095734,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[8112340781834095734]": {
+                    "$type": "EditorFixedJointComponent",
+                    "Id": 8112340781834095734,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.5
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]",
+                        "Display Debug": 0
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_FixedBreakable/Joints_FixedBreakable.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_FixedBreakable/Joints_FixedBreakable.prefab
@@ -1,0 +1,306 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_FixedBreakable",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 8112340781834095734,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[8112340781834095734]": {
+                    "$type": "EditorFixedJointComponent",
+                    "Id": 8112340781834095734,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.5
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]",
+                        "Breakable": true,
+                        "Maximum Force": 0.009999999776482582,
+                        "Maximum Torque": 0.009999999776482582,
+                        "Display Debug": 0
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_GlobalFrameConstrained/Joints_GlobalFrameConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_GlobalFrameConstrained/Joints_GlobalFrameConstrained.prefab
@@ -1,0 +1,447 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_GlobalFrameConstrained",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[2201636842092]": {
+            "Id": "Entity_[2201636842092]",
+            "Name": "follower_fixed",
+            "Components": {
+                "Component_[13023770551629189164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13023770551629189164
+                },
+                "Component_[13351284166364391359]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13351284166364391359,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2645997221019343640
+                        },
+                        {
+                            "ComponentId": 6673572481606270968,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 6293448022581657664,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 7417322249783993390,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 14670106297503136187,
+                            "SortIndex": 4
+                        }
+                    ]
+                },
+                "Component_[13509574154645341879]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13509574154645341879
+                },
+                "Component_[14508130498517636819]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14508130498517636819
+                },
+                "Component_[14670106297503136187]": {
+                    "$type": "EditorFixedJointComponent",
+                    "Id": 14670106297503136187,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.822000026702881
+                        ],
+                        "Parent Entity": "",
+                        "Child Entity": "Entity_[2201636842092]",
+                        "Display Debug": 0
+                    }
+                },
+                "Component_[1549558762740183728]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1549558762740183728
+                },
+                "Component_[17414572235481585057]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17414572235481585057
+                },
+                "Component_[18241619224354846048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18241619224354846048
+                },
+                "Component_[2251080402221450710]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2251080402221450710
+                },
+                "Component_[2645997221019343640]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2645997221019343640,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.9549865722656,
+                            532.2000122070313,
+                            33.98699951171875
+                        ]
+                    }
+                },
+                "Component_[6293448022581657664]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 6293448022581657664,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[6673572481606270968]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6673572481606270968,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[7417322249783993390]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 7417322249783993390,
+                    "GameView": true
+                },
+                "Component_[8471778172276904118]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8471778172276904118
+                }
+            }
+        },
+        "Entity_[2291831155308]": {
+            "Id": "Entity_[2291831155308]",
+            "Name": "follower_hinge",
+            "Components": {
+                "Component_[10842867284021233683]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 10842867284021233683,
+                    "GameView": true
+                },
+                "Component_[11803423706734242758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11803423706734242758
+                },
+                "Component_[12478228765524422170]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12478228765524422170
+                },
+                "Component_[13034425072563314832]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13034425072563314832
+                },
+                "Component_[16753560528979723977]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16753560528979723977,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6810716148372093986
+                        },
+                        {
+                            "ComponentId": 9855539448785808217,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 313974164132491084,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 10842867284021233683,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 6362383642247694142,
+                            "SortIndex": 4
+                        }
+                    ]
+                },
+                "Component_[16813023147250295521]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16813023147250295521
+                },
+                "Component_[18192738096012157956]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18192738096012157956
+                },
+                "Component_[1847840696075169126]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1847840696075169126
+                },
+                "Component_[313974164132491084]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 313974164132491084,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[5051299927880386899]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5051299927880386899
+                },
+                "Component_[6362383642247694142]": {
+                    "$type": "EditorHingeJointComponent",
+                    "Id": 6362383642247694142,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.635999917984009
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            0.11999999731779099,
+                            269.9570007324219
+                        ],
+                        "Parent Entity": "",
+                        "Child Entity": "Entity_[2291831155308]",
+                        "Display Debug": 0
+                    }
+                },
+                "Component_[6810716148372093986]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6810716148372093986,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                },
+                "Component_[9227784122499920440]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9227784122499920440
+                },
+                "Component_[9855539448785808217]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9855539448785808217,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[2394910370412]": {
+            "Id": "Entity_[2394910370412]",
+            "Name": "follower_ball",
+            "Components": {
+                "Component_[10842867284021233683]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 10842867284021233683,
+                    "GameView": true
+                },
+                "Component_[11803423706734242758]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11803423706734242758
+                },
+                "Component_[12478228765524422170]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12478228765524422170
+                },
+                "Component_[13034425072563314832]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13034425072563314832
+                },
+                "Component_[15948185494190946096]": {
+                    "$type": "EditorBallJointComponent",
+                    "Id": 15948185494190946096,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            2.812000036239624
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            89.99400329589844,
+                            180.0
+                        ],
+                        "Parent Entity": "",
+                        "Child Entity": "Entity_[2394910370412]",
+                        "Self Collide": true
+                    }
+                },
+                "Component_[16753560528979723977]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16753560528979723977,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6810716148372093986
+                        },
+                        {
+                            "ComponentId": 9855539448785808217,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 313974164132491084,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 10842867284021233683,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 15948185494190946096,
+                            "SortIndex": 4
+                        }
+                    ]
+                },
+                "Component_[16813023147250295521]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16813023147250295521
+                },
+                "Component_[18192738096012157956]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18192738096012157956
+                },
+                "Component_[1847840696075169126]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1847840696075169126
+                },
+                "Component_[313974164132491084]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 313974164132491084,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[5051299927880386899]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5051299927880386899
+                },
+                "Component_[6810716148372093986]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6810716148372093986,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            519.5679931640625,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                },
+                "Component_[9227784122499920440]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9227784122499920440
+                },
+                "Component_[9855539448785808217]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9855539448785808217,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            2.0,
+                            0.0
+                        ],
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_Hinge2BodiesConstrained/Joints_Hinge2BodiesConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_Hinge2BodiesConstrained/Joints_Hinge2BodiesConstrained.prefab
@@ -1,0 +1,309 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_Hinge2BodiesConstrained",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Angular damping": 50.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 999.0,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 0.010010000318288803
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 7011723427504493749,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            1.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[7011723427504493749]": {
+                    "$type": "EditorHingeJointComponent",
+                    "Id": 7011723427504493749,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            5.5
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            0.0,
+                            89.69599914550781
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]"
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_HingeBreakable/Joints_HingeBreakable.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_HingeBreakable/Joints_HingeBreakable.prefab
@@ -1,0 +1,312 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_HingeBreakable",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Angular damping": 50.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 999.0,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 0.010010000318288803
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5053986797366085195,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 4
+                        },
+                        {
+                            "ComponentId": 7011723427504493749,
+                            "SortIndex": 5
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            1.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[5053986797366085195]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5053986797366085195,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[7011723427504493749]": {
+                    "$type": "EditorHingeJointComponent",
+                    "Id": 7011723427504493749,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            5.5
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            0.0,
+                            89.69599914550781
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]",
+                        "Breakable": true,
+                        "Maximum Force": 0.009999999776482582,
+                        "Maximum Torque": 0.009999999776482582
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Joints_HingeNoLimitsConstrained/Joints_HingeNoLimitsConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_HingeNoLimitsConstrained/Joints_HingeNoLimitsConstrained.prefab
@@ -1,0 +1,302 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Joints_HingeNoLimitsConstrained",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[286081428076]": {
+            "Id": "Entity_[286081428076]",
+            "Name": "lead",
+            "Components": {
+                "Component_[10023033763705225227]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10023033763705225227
+                },
+                "Component_[13011255769289009335]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13011255769289009335
+                },
+                "Component_[14436298445258953954]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14436298445258953954,
+                    "GameView": true
+                },
+                "Component_[1559969656903927382]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1559969656903927382,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7665674456578917002
+                        },
+                        {
+                            "ComponentId": 175613687271623988,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17363654757392362489,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14436298445258953954,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17363654757392362489]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17363654757392362489,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[175613687271623988]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 175613687271623988,
+                    "Configuration": {
+                        "entityId": "",
+                        "Angular damping": 50.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 999.0,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 0.010010000318288803
+                        }
+                    }
+                },
+                "Component_[2634845782760090713]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2634845782760090713
+                },
+                "Component_[2891132756730401943]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2891132756730401943
+                },
+                "Component_[576982830662881539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 576982830662881539
+                },
+                "Component_[7318357674363928677]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7318357674363928677
+                },
+                "Component_[7665674456578917002]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7665674456578917002,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            39.36000061035156
+                        ]
+                    }
+                },
+                "Component_[8971338095608231687]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8971338095608231687
+                },
+                "Component_[9774374628185279496]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9774374628185279496
+                }
+            }
+        },
+        "Entity_[333326068332]": {
+            "Id": "Entity_[333326068332]",
+            "Name": "follower",
+            "Components": {
+                "Component_[13088569405203769999]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13088569405203769999
+                },
+                "Component_[13089741533261337907]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13089741533261337907,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8406471387187750399
+                        },
+                        {
+                            "ComponentId": 2119963470176591658,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1322277184770581793,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 13280771335111037276,
+                            "SortIndex": 3
+                        },
+                        {
+                            "ComponentId": 7011723427504493749,
+                            "SortIndex": 4
+                        }
+                    ]
+                },
+                "Component_[1322277184770581793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1322277184770581793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13280771335111037276]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13280771335111037276,
+                    "GameView": true
+                },
+                "Component_[13337748219983851939]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13337748219983851939
+                },
+                "Component_[16053691607720161901]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16053691607720161901
+                },
+                "Component_[17858634121276502761]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17858634121276502761
+                },
+                "Component_[17977051379650702181]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17977051379650702181
+                },
+                "Component_[2119963470176591658]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 2119963470176591658,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            1.0,
+                            0.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[2304545190715981019]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2304545190715981019
+                },
+                "Component_[281621200381688046]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 281621200381688046
+                },
+                "Component_[3788104328409405778]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3788104328409405778
+                },
+                "Component_[7011723427504493749]": {
+                    "$type": "EditorHingeJointComponent",
+                    "Id": 7011723427504493749,
+                    "Configuration": {
+                        "Local Position": [
+                            0.0,
+                            0.0,
+                            5.5
+                        ],
+                        "Local Rotation": [
+                            180.0,
+                            0.0,
+                            89.69599914550781
+                        ],
+                        "Parent Entity": "Entity_[286081428076]",
+                        "Child Entity": "Entity_[333326068332]"
+                    },
+                    "Angular Limit": {
+                        "Standard Limit Configuration": {
+                            "Is Limited": false,
+                            "Is Soft Limit": true,
+                            "Damping": 2.0,
+                            "Stiffness": 10.0
+                        }
+                    }
+                },
+                "Component_[8406471387187750399]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8406471387187750399,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.9852294921875,
+                            532.199951171875,
+                            33.98699951171875
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_CharacterController/Material_CharacterController.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_CharacterController/Material_CharacterController.prefab
@@ -1,0 +1,1105 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_CharacterController",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[265565686843]": {
+            "Id": "Entity_[265565686843]",
+            "Name": "ball_rubber_trigger",
+            "Components": {
+                "Component_[10331307739444908993]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10331307739444908993
+                },
+                "Component_[11802670604512538628]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11802670604512538628,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            508.0,
+                            517.5,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[13644786812112695620]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13644786812112695620
+                },
+                "Component_[14485404573147334370]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14485404573147334370,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11802670604512538628
+                        },
+                        {
+                            "ComponentId": 2372725671404085774,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8715876380695213524,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15822366981287248494]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15822366981287248494
+                },
+                "Component_[16226109110234870964]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16226109110234870964
+                },
+                "Component_[16230689882780910812]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16230689882780910812
+                },
+                "Component_[17914199320544874011]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17914199320544874011
+                },
+                "Component_[18377528337686856462]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18377528337686856462
+                },
+                "Component_[2372725671404085774]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2372725671404085774,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[8407016953149050130]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8407016953149050130
+                },
+                "Component_[8715876380695213524]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8715876380695213524,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[273914026347]": {
+            "Id": "Entity_[273914026347]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                },
+                "Component_[9846072383584385573]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9846072383584385573
+                }
+            }
+        },
+        "Entity_[303978797419]": {
+            "Id": "Entity_[303978797419]",
+            "Name": "char_rubber",
+            "Components": {
+                "Component_[10006524145407620701]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10006524145407620701,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            508.0,
+                            520.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[1191036568178048800]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1191036568178048800
+                },
+                "Component_[1312913198288358182]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1312913198288358182
+                },
+                "Component_[17767073666136164898]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17767073666136164898
+                },
+                "Component_[2139498823618788773]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2139498823618788773
+                },
+                "Component_[2916022705710962662]": {
+                    "$type": "EditorCapsuleShapeComponent",
+                    "Id": 2916022705710962662,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        1.0
+                    ],
+                    "CapsuleShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                1.0
+                            ],
+                            "Height": 2.200000047683716
+                        }
+                    }
+                },
+                "Component_[5023353798159000894]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5023353798159000894,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10006524145407620701
+                        },
+                        {
+                            "ComponentId": 5825233234536327293,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2916022705710962662,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[5161197217195800603]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5161197217195800603
+                },
+                "Component_[5825233234536327293]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 5825233234536327293,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{81BA7879-C15D-4A32-B1DC-BFC459FA6DDF}"
+                                }
+                            ]
+                        },
+                        "ScaleCoeff": 1.0
+                    },
+                    "ShapeConfig": {
+                        "Capsule": {
+                            "Height": 2.0
+                        }
+                    }
+                },
+                "Component_[6966876403500074211]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6966876403500074211
+                },
+                "Component_[7351004024311869925]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7351004024311869925
+                },
+                "Component_[9658905047320404246]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9658905047320404246
+                }
+            }
+        },
+        "Entity_[308273764715]": {
+            "Id": "Entity_[308273764715]",
+            "Name": "char_rock",
+            "Components": {
+                "Component_[10006524145407620701]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10006524145407620701,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.0,
+                            520.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[1191036568178048800]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1191036568178048800
+                },
+                "Component_[1312913198288358182]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1312913198288358182
+                },
+                "Component_[17767073666136164898]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17767073666136164898
+                },
+                "Component_[2139498823618788773]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2139498823618788773
+                },
+                "Component_[2916022705710962662]": {
+                    "$type": "EditorCapsuleShapeComponent",
+                    "Id": 2916022705710962662,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.3333333134651184,
+                        0.0,
+                        0.0
+                    ],
+                    "CapsuleShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.3333333134651184,
+                                0.0,
+                                0.0
+                            ],
+                            "Height": 2.200000047683716
+                        }
+                    }
+                },
+                "Component_[5023353798159000894]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5023353798159000894,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10006524145407620701
+                        },
+                        {
+                            "ComponentId": 5825233234536327293,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2916022705710962662,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[5161197217195800603]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5161197217195800603
+                },
+                "Component_[5825233234536327293]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 5825233234536327293,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{7F2847AA-8DF5-441F-9121-4B1EC722AB8D}"
+                                }
+                            ]
+                        },
+                        "ScaleCoeff": 1.0
+                    },
+                    "ShapeConfig": {
+                        "Capsule": {
+                            "Height": 2.0
+                        }
+                    }
+                },
+                "Component_[6966876403500074211]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6966876403500074211
+                },
+                "Component_[7351004024311869925]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7351004024311869925
+                },
+                "Component_[9658905047320404246]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9658905047320404246
+                }
+            }
+        },
+        "Entity_[312568732011]": {
+            "Id": "Entity_[312568732011]",
+            "Name": "char_glass",
+            "Components": {
+                "Component_[10006524145407620701]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10006524145407620701,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            514.0,
+                            520.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[1191036568178048800]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1191036568178048800
+                },
+                "Component_[1312913198288358182]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1312913198288358182
+                },
+                "Component_[17767073666136164898]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17767073666136164898
+                },
+                "Component_[2139498823618788773]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2139498823618788773
+                },
+                "Component_[2916022705710962662]": {
+                    "$type": "EditorCapsuleShapeComponent",
+                    "Id": 2916022705710962662,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.3333333134651184,
+                        0.0
+                    ],
+                    "CapsuleShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.3333333134651184,
+                                0.0
+                            ],
+                            "Height": 2.200000047683716
+                        }
+                    }
+                },
+                "Component_[5023353798159000894]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5023353798159000894,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10006524145407620701
+                        },
+                        {
+                            "ComponentId": 5825233234536327293,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2916022705710962662,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[5161197217195800603]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5161197217195800603
+                },
+                "Component_[5825233234536327293]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 5825233234536327293,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{C48AC5E7-DC4B-41D9-8063-06EFA3296E2B}"
+                                }
+                            ]
+                        },
+                        "ScaleCoeff": 1.0
+                    },
+                    "ShapeConfig": {
+                        "Capsule": {
+                            "Height": 2.0
+                        }
+                    }
+                },
+                "Component_[6966876403500074211]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6966876403500074211
+                },
+                "Component_[7351004024311869925]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7351004024311869925
+                },
+                "Component_[9658905047320404246]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9658905047320404246
+                }
+            }
+        },
+        "Entity_[316863699307]": {
+            "Id": "Entity_[316863699307]",
+            "Name": "ball_to_hit_rubber_char_controller",
+            "Components": {
+                "Component_[13079754507717223587]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 13079754507717223587,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[15029401536379575926]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15029401536379575926
+                },
+                "Component_[15485757629925546919]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15485757629925546919
+                },
+                "Component_[18410550505922936342]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 18410550505922936342
+                },
+                "Component_[212116149561142254]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 212116149561142254
+                },
+                "Component_[3469442090661448878]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3469442090661448878
+                },
+                "Component_[4124763457304427835]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4124763457304427835
+                },
+                "Component_[5525245203533945267]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 5525245203533945267,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.498039186000824
+                    ],
+                    "SphereShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.498039186000824
+                            ]
+                        }
+                    }
+                },
+                "Component_[783506180847992878]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 783506180847992878
+                },
+                "Component_[7856841071894788579]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7856841071894788579,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9737631153080585674
+                        },
+                        {
+                            "ComponentId": 13079754507717223587,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5525245203533945267,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8422616281212260312,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8176774462451842724]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8176774462451842724
+                },
+                "Component_[8422616281212260312]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8422616281212260312,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            5.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9737631153080585674]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9737631153080585674,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            508.0,
+                            514.0,
+                            36.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[342875098171]": {
+            "Id": "Entity_[342875098171]",
+            "Name": "ball_rock_trigger",
+            "Components": {
+                "Component_[10331307739444908993]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10331307739444908993
+                },
+                "Component_[11802670604512538628]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11802670604512538628,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.0,
+                            517.5,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[13644786812112695620]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13644786812112695620
+                },
+                "Component_[14485404573147334370]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14485404573147334370,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11802670604512538628
+                        },
+                        {
+                            "ComponentId": 2372725671404085774,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8715876380695213524,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15822366981287248494]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15822366981287248494
+                },
+                "Component_[16226109110234870964]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16226109110234870964
+                },
+                "Component_[16230689882780910812]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16230689882780910812
+                },
+                "Component_[17914199320544874011]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17914199320544874011
+                },
+                "Component_[18377528337686856462]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18377528337686856462
+                },
+                "Component_[2372725671404085774]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2372725671404085774,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[8407016953149050130]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8407016953149050130
+                },
+                "Component_[8715876380695213524]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8715876380695213524,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.3333333134651184,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.3333333134651184,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[347170065467]": {
+            "Id": "Entity_[347170065467]",
+            "Name": "ball_glass_trigger",
+            "Components": {
+                "Component_[10331307739444908993]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10331307739444908993
+                },
+                "Component_[11802670604512538628]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11802670604512538628,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            514.0,
+                            517.5,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[13644786812112695620]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13644786812112695620
+                },
+                "Component_[14485404573147334370]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14485404573147334370,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11802670604512538628
+                        },
+                        {
+                            "ComponentId": 2372725671404085774,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8715876380695213524,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15822366981287248494]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15822366981287248494
+                },
+                "Component_[16226109110234870964]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16226109110234870964
+                },
+                "Component_[16230689882780910812]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16230689882780910812
+                },
+                "Component_[17914199320544874011]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17914199320544874011
+                },
+                "Component_[18377528337686856462]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18377528337686856462
+                },
+                "Component_[2372725671404085774]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2372725671404085774,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[8407016953149050130]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8407016953149050130
+                },
+                "Component_[8715876380695213524]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8715876380695213524,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.3333333134651184,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.3333333134651184,
+                                0.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[621806377323]": {
+            "Id": "Entity_[621806377323]",
+            "Name": "ball_to_hit_rock_char_controller",
+            "Components": {
+                "Component_[13079754507717223587]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 13079754507717223587,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[15029401536379575926]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15029401536379575926
+                },
+                "Component_[15485757629925546919]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15485757629925546919
+                },
+                "Component_[18410550505922936342]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 18410550505922936342
+                },
+                "Component_[212116149561142254]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 212116149561142254
+                },
+                "Component_[3469442090661448878]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3469442090661448878
+                },
+                "Component_[4124763457304427835]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4124763457304427835
+                },
+                "Component_[5525245203533945267]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 5525245203533945267,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.3333333134651184,
+                        0.0,
+                        0.0
+                    ],
+                    "SphereShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.3333333134651184,
+                                0.0,
+                                0.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[783506180847992878]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 783506180847992878
+                },
+                "Component_[7856841071894788579]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7856841071894788579,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9737631153080585674
+                        },
+                        {
+                            "ComponentId": 13079754507717223587,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5525245203533945267,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8422616281212260312,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8176774462451842724]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8176774462451842724
+                },
+                "Component_[8422616281212260312]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8422616281212260312,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            5.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9737631153080585674]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9737631153080585674,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.0,
+                            514.0,
+                            36.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[626101344619]": {
+            "Id": "Entity_[626101344619]",
+            "Name": "ball_to_hit_glass_char_controller",
+            "Components": {
+                "Component_[13079754507717223587]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 13079754507717223587,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[15029401536379575926]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15029401536379575926
+                },
+                "Component_[15485757629925546919]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15485757629925546919
+                },
+                "Component_[18410550505922936342]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 18410550505922936342
+                },
+                "Component_[212116149561142254]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 212116149561142254
+                },
+                "Component_[3469442090661448878]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3469442090661448878
+                },
+                "Component_[4124763457304427835]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4124763457304427835
+                },
+                "Component_[5525245203533945267]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 5525245203533945267,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.3333333134651184,
+                        0.0
+                    ],
+                    "SphereShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.3333333134651184,
+                                0.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[783506180847992878]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 783506180847992878
+                },
+                "Component_[7856841071894788579]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7856841071894788579,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9737631153080585674
+                        },
+                        {
+                            "ComponentId": 13079754507717223587,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5525245203533945267,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8422616281212260312,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8176774462451842724]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8176774462451842724
+                },
+                "Component_[8422616281212260312]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8422616281212260312,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            5.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9737631153080585674]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9737631153080585674,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            514.0,
+                            514.0,
+                            36.0
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_FrictionCombine/Material_FrictionCombine.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_FrictionCombine/Material_FrictionCombine.prefab
@@ -1,0 +1,641 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_FrictionCombine",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[466424751606]": {
+            "Id": "Entity_[466424751606]",
+            "Name": "Ramp",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[470719718902]": {
+            "Id": "Entity_[470719718902]",
+            "Name": "Minimum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            530.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[690315902361]": {
+            "Id": "Entity_[690315902361]",
+            "Name": "Multiply",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            532.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[694610869657]": {
+            "Id": "Entity_[694610869657]",
+            "Name": "Average",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            534.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[698905836953]": {
+            "Id": "Entity_[698905836953]",
+            "Name": "Maximum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            536.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_FrictionCombinePriorityOrder/Material_FrictionCombinePriorityOrder.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_FrictionCombinePriorityOrder/Material_FrictionCombinePriorityOrder.prefab
@@ -1,0 +1,1109 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_FrictionCombinePriorityOrder",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[466424751606]": {
+            "Id": "Entity_[466424751606]",
+            "Name": "RampAverage",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[470719718902]": {
+            "Id": "Entity_[470719718902]",
+            "Name": "Average",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            527.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[479747335392]": {
+            "Id": "Entity_[479747335392]",
+            "Name": "RampMinimum",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        1.0,
+                        0.9333332777023315
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                1.0,
+                                0.9333332777023315
+                            ],
+                            "Dimensions": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            36.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{AAAADE4F-9A35-476B-9424-20D40CBD8E59}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[484042302688]": {
+            "Id": "Entity_[484042302688]",
+            "Name": "RampMultiply",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.14901959896087646,
+                        1.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.14901959896087646,
+                                1.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            37.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{C0067490-4214-4ADC-857A-FA978B6609D8}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[488337269984]": {
+            "Id": "Entity_[488337269984]",
+            "Name": "RampMaximum",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.01568629965186119
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                1.0,
+                                0.0,
+                                0.01568629965186119
+                            ],
+                            "Dimensions": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            38.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EC70218A-5C2F-4E4C-A606-DB0985D80BD9}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[690315902361]": {
+            "Id": "Entity_[690315902361]",
+            "Name": "Minimum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            529.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[694610869657]": {
+            "Id": "Entity_[694610869657]",
+            "Name": "Multiply",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            531.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[698905836953]": {
+            "Id": "Entity_[698905836953]",
+            "Name": "Maximum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            533.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
@@ -1,0 +1,571 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_PerFaceMaterialGetsCorrectMaterial",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[263299149192]": {
+            "Id": "Entity_[263299149192]",
+            "Name": "Perface_Entity",
+            "Components": {
+                "Component_[12895135369190770831]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12895135369190770831,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15478640155202823409
+                        },
+                        {
+                            "ComponentId": 14094829544062915163,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2133472981464928253,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[12933367835807479524]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12933367835807479524
+                },
+                "Component_[14094829544062915163]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14094829544062915163,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{DBC444ED-4809-4EB3-A0B7-3E5608816C57}"
+                                },
+                                {
+                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                },
+                                {
+                                    "MaterialId": "{F529C9BA-5534-4E17-8232-076F4C2A85F1}"
+                                },
+                                {
+                                    "MaterialId": "{F529C9BA-5534-4E17-8232-076F4C2A85F1}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{304E0636-42C3-529D-8D9B-89E1E11A3FDD}",
+                                    "subId": 4070350670
+                                },
+                                "assetHint": "levels/physics/c4044697_material_perfacematerialvalidation/test.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{304E0636-42C3-529D-8D9B-89E1E11A3FDD}",
+                                        "subId": 4070350670
+                                    },
+                                    "loadBehavior": "QueueLoad",
+                                    "assetHint": "levels/physics/c4044697_material_perfacematerialvalidation/test.pxmesh"
+                                },
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "Component_[15478640155202823409]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15478640155202823409,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            495.0,
+                            572.9000244140625,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[18224841233377932914]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18224841233377932914
+                },
+                "Component_[7082917986978722546]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7082917986978722546
+                },
+                "Component_[7271658699149725480]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7271658699149725480
+                },
+                "Component_[7540670373363487170]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7540670373363487170
+                },
+                "Component_[8053204316957148294]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8053204316957148294
+                },
+                "Component_[8366018947807225164]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8366018947807225164
+                },
+                "Component_[9731287096514204919]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9731287096514204919
+                }
+            }
+        },
+        "Entity_[266045546421]": {
+            "Id": "Entity_[266045546421]",
+            "Name": "Sphere_0",
+            "Components": {
+                "Component_[10374258855822788012]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10374258855822788012
+                },
+                "Component_[12634408394535741524]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12634408394535741524,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18340301439114239417
+                        },
+                        {
+                            "ComponentId": 15935184316510963877,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8555372987471605395,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 7932646973871726532,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[1341105588245574408]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1341105588245574408
+                },
+                "Component_[14079522067308699507]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14079522067308699507
+                },
+                "Component_[15509661907948085469]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15509661907948085469
+                },
+                "Component_[15935184316510963877]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 15935184316510963877,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            -10.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[17367340743922879512]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17367340743922879512
+                },
+                "Component_[18340301439114239417]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18340301439114239417,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            495.0,
+                            578.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[5247488740740932766]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5247488740740932766
+                },
+                "Component_[5426837248901054022]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5426837248901054022
+                },
+                "Component_[6859627489735672055]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6859627489735672055
+                },
+                "Component_[7932646973871726532]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 7932646973871726532,
+                    "GameView": true
+                },
+                "Component_[8555372987471605395]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 8555372987471605395,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[412074434485]": {
+            "Id": "Entity_[412074434485]",
+            "Name": "Sphere_1",
+            "Components": {
+                "Component_[10149587071258241793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10149587071258241793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[10435545141396253755]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10435545141396253755
+                },
+                "Component_[10589025713121715221]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10589025713121715221
+                },
+                "Component_[1360399676717184302]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1360399676717184302
+                },
+                "Component_[15421554407663510525]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15421554407663510525
+                },
+                "Component_[3804480771628296473]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3804480771628296473,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7861646633094041878
+                        },
+                        {
+                            "ComponentId": 10149587071258241793,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8863847057479110372,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6222487597540037499,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6222487597540037499]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 6222487597540037499,
+                    "GameView": true
+                },
+                "Component_[7173833067600619389]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7173833067600619389
+                },
+                "Component_[7295001575059808254]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7295001575059808254
+                },
+                "Component_[7519018305041678196]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7519018305041678196
+                },
+                "Component_[7599213652466813166]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7599213652466813166
+                },
+                "Component_[7861646633094041878]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7861646633094041878,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            573.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[8863847057479110372]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8863847057479110372,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            -10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[597927490285]": {
+            "Id": "Entity_[597927490285]",
+            "Name": "Sphere_2",
+            "Components": {
+                "Component_[10149587071258241793]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10149587071258241793,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[10435545141396253755]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10435545141396253755
+                },
+                "Component_[10589025713121715221]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10589025713121715221
+                },
+                "Component_[1360399676717184302]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1360399676717184302
+                },
+                "Component_[15421554407663510525]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15421554407663510525
+                },
+                "Component_[3804480771628296473]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3804480771628296473,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 7861646633094041878
+                        },
+                        {
+                            "ComponentId": 10149587071258241793,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8863847057479110372,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6222487597540037499,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6222487597540037499]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 6222487597540037499,
+                    "GameView": true
+                },
+                "Component_[7173833067600619389]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7173833067600619389
+                },
+                "Component_[7295001575059808254]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7295001575059808254
+                },
+                "Component_[7519018305041678196]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7519018305041678196
+                },
+                "Component_[7599213652466813166]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7599213652466813166
+                },
+                "Component_[7861646633094041878]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7861646633094041878,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0,
+                            573.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[8863847057479110372]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8863847057479110372,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[939513045198]": {
+            "Id": "Entity_[939513045198]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[722204632874297368]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 722204632874297368
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_Restitution/Material_Restitution.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_Restitution/Material_Restitution.prefab
@@ -1,0 +1,614 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_Restitution",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[466424751606]": {
+            "Id": "Entity_[466424751606]",
+            "Name": "Ramp",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false,
+                        "Mass": 100000.0
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[470719718902]": {
+            "Id": "Entity_[470719718902]",
+            "Name": "Zero",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "CCD Enabled": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            530.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[690315902361]": {
+            "Id": "Entity_[690315902361]",
+            "Name": "Low",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "CCD Enabled": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            532.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[694610869657]": {
+            "Id": "Entity_[694610869657]",
+            "Name": "Mid",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "CCD Enabled": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            534.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[698905836953]": {
+            "Id": "Entity_[698905836953]",
+            "Name": "High",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "CCD Enabled": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            536.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_RestitutionCombine/Material_RestitutionCombine.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_RestitutionCombine/Material_RestitutionCombine.prefab
@@ -1,0 +1,641 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_RestitutionCombine",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[466424751606]": {
+            "Id": "Entity_[466424751606]",
+            "Name": "Ramp",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[470719718902]": {
+            "Id": "Entity_[470719718902]",
+            "Name": "Minimum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            530.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[690315902361]": {
+            "Id": "Entity_[690315902361]",
+            "Name": "Multiply",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            532.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[694610869657]": {
+            "Id": "Entity_[694610869657]",
+            "Name": "Average",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            534.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[698905836953]": {
+            "Id": "Entity_[698905836953]",
+            "Name": "Maximum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            536.0,
+                            45.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_RestitutionCombinePriorityOrder/Material_RestitutionCombinePriorityOrder.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_RestitutionCombinePriorityOrder/Material_RestitutionCombinePriorityOrder.prefab
@@ -1,0 +1,1053 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_RestitutionCombinePriorityOrder",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[466424751606]": {
+            "Id": "Entity_[466424751606]",
+            "Name": "RampAverage",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0,
+                            530.0,
+                            39.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[470719718902]": {
+            "Id": "Entity_[470719718902]",
+            "Name": "Average",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            527.0,
+                            53.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[479747335392]": {
+            "Id": "Entity_[479747335392]",
+            "Name": "RampMinimum",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        1.0,
+                        0.9333332777023315
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                1.0,
+                                0.9333332777023315
+                            ],
+                            "Dimensions": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0,
+                            530.0,
+                            38.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{AAAADE4F-9A35-476B-9424-20D40CBD8E59}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[484042302688]": {
+            "Id": "Entity_[484042302688]",
+            "Name": "RampMultiply",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.14901959896087646,
+                        1.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.14901959896087646,
+                                1.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0,
+                            530.0,
+                            37.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{C0067490-4214-4ADC-857A-FA978B6609D8}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[488337269984]": {
+            "Id": "Entity_[488337269984]",
+            "Name": "RampMaximum",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.01568629965186119
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                1.0,
+                                0.0,
+                                0.01568629965186119
+                            ],
+                            "Dimensions": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0,
+                            530.0,
+                            36.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EC70218A-5C2F-4E4C-A606-DB0985D80BD9}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[690315902361]": {
+            "Id": "Entity_[690315902361]",
+            "Name": "Minimum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            529.0,
+                            53.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[694610869657]": {
+            "Id": "Entity_[694610869657]",
+            "Name": "Multiply",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            531.0,
+                            53.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[698905836953]": {
+            "Id": "Entity_[698905836953]",
+            "Name": "Maximum",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Maximum Angular Velocity": 0.0,
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            533.0,
+                            53.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Converted the following tests to use prefab system:
- Collider_AddingNewGroupWorks
- Collider_CollisionGroupsWorkflow
- Collider_NoneCollisionGroupSameLayerNotCollide
- Collider_SameCollisionGroupSameCustomLayerCollide
- Joints_Ball2BodiesConstrained
- Joints_BallBreakable
- Joints_BallNoLimitsConstrained
- Joints_Fixed2BodiesConstrained
- Joints_FixedBreakable
- Joints_GlobalFrameConstrained
- Joints_Hinge2BodiesConstrained
- Joints_HingeBreakable
- Joints_HingeNoLimitsConstrained
- Material_CharacterController
- Material_FrictionCombine
- Material_FrictionCombinePriorityOrder
- Material_PerFaceMaterialGetsCorrectMaterial
- Material_Restitution
- Material_RestitutionCombine
- Material_RestitutionCombinePriorityOrder

These two tests are also in Main_Optimized test suite, so leave them unconverted for now:
- Collider_ColliderPositionOffset
- Collider_ColliderRotationOffset

These two tests are broken before conversion, so leave them unconverted for now:
- Material_DefaultLibraryUpdatedAcrossLevels_after
- Material_DefaultLibraryUpdatedAcrossLevels_before

This test is broken after conversion, so leave it unconverted for now:
- ScriptCanvas_PostUpdateEvent

Tested with the following command:
`python\python.cmd -m pytest AutomatedTesting\Gem\PythonTests\Physics\TestSuite_Periodic.py::TestAutomation --build-directory windows_vs2019\bin\profile`

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>