### PR TITLE
Fixed the module name declarations in the CrashReporting,

### DIFF
--- a/Gems/AtomTressFX/CMakeLists.txt
+++ b/Gems/AtomTressFX/CMakeLists.txt
@@ -31,8 +31,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Code
                 External
                 External/Code/src
-            PUBLIC
-                Code/Include
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzCore
@@ -56,8 +54,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Code
                 External
                 External/Code/src
-            PUBLIC
-                Code/Include
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzCore
@@ -79,8 +75,6 @@ else()
                 Code
                 External
                 External/Code/src
-            PUBLIC
-                Code/Include
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzCore
@@ -103,8 +97,6 @@ else()
                 Code
                 External
                 External/Code/src
-            PUBLIC
-                Code/Include
         BUILD_DEPENDENCIES
             PRIVATE
                 AZ::AzCore
@@ -130,8 +122,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Code
                 External
                 External/Code/src
-            PUBLIC
-                Code/Include
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AssetBuilderSDK
@@ -148,8 +138,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Code
                 External
                 External/Code/src
-            PUBLIC
-                Code/Include
         BUILD_DEPENDENCIES
             PRIVATE
                 Gem::AtomTressFX.Builders.Static

--- a/Gems/CrashReporting/Code/Source/GameCrashHandler.cpp
+++ b/Gems/CrashReporting/Code/Source/GameCrashHandler.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/Module/Module.h>
 
 namespace CrashHandler
 {
@@ -90,3 +91,5 @@ namespace CrashHandler
         return returnPath;
     }
 }
+
+AZ_DECLARE_MODULE_CLASS(Gem_CrashReporting, AZ::Module)

--- a/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionModule.cpp
+++ b/Gems/MultiplayerCompression/Code/Source/MultiplayerCompressionModule.cpp
@@ -41,7 +41,4 @@ namespace MultiplayerCompression
     };
 }
 
-// DO NOT MODIFY THIS LINE UNLESS YOU RENAME THE GEM
-// The first parameter should be GemName_GemIdLower
-// The second should be the fully qualified name of the class above
-AZ_DECLARE_MODULE_CLASS(MultiplayerCompression_1d353c8ca3c74ed193fd6c6783ae41cc, MultiplayerCompression::MultiplayerCompressionModule)
+AZ_DECLARE_MODULE_CLASS(Gem_MultiplayerCompression, MultiplayerCompression::MultiplayerCompressionModule)

--- a/Gems/ScriptCanvasDeveloper/Code/Game/Source/ScriptCanvasDeveloperGem.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Game/Source/ScriptCanvasDeveloperGem.cpp
@@ -42,4 +42,4 @@ namespace ScriptCanvasDeveloper
     }
 }
 
-AZ_DECLARE_MODULE_CLASS(Gem_ScriptCanvasDeveloperGem, ScriptCanvasDeveloper::ScriptCanvasDeveloperModule)
+AZ_DECLARE_MODULE_CLASS(Gem_ScriptCanvasDeveloper, ScriptCanvasDeveloper::ScriptCanvasDeveloperModule)


### PR DESCRIPTION
MultiplayerCompression and ScriptCanvasDeveloper gems

Removed the missing include directories from AtomTressFX CMakeLists.txt
This was causing the AtomTressFX arget when used as an IMPORTED target in
the SDK layout

fixes #7851

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>