### PR TITLE
[Linux] Respond to the `_NET_WM_PING` client message event

### DIFF
--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -144,7 +144,6 @@ namespace AzFramework
 
     void XcbNativeWindow::InitializeAtoms()
     {
-        AZStd::vector<xcb_atom_t> Atoms;
 
         _NET_ACTIVE_WINDOW = GetAtom("_NET_ACTIVE_WINDOW");
         _NET_WM_BYPASS_COMPOSITOR = GetAtom("_NET_WM_BYPASS_COMPOSITOR");
@@ -157,11 +156,12 @@ namespace AzFramework
 
         // This atom is used to close a window. Emitted when user clicks the close button.
         WM_DELETE_WINDOW = GetAtom("WM_DELETE_WINDOW");
+        _NET_WM_PING = GetAtom("_NET_WM_PING");
 
-        Atoms.push_back(WM_DELETE_WINDOW);
+        const AZStd::array atoms {WM_DELETE_WINDOW, _NET_WM_PING};
 
         xcb_change_property(
-            m_xcbConnection, XCB_PROP_MODE_REPLACE, m_xcbWindow, WM_PROTOCOLS, XCB_ATOM_ATOM, 32, Atoms.size(), Atoms.data());
+            m_xcbConnection, XCB_PROP_MODE_REPLACE, m_xcbWindow, WM_PROTOCOLS, XCB_ATOM_ATOM, 32, atoms.size(), atoms.data());
 
         xcb_flush(m_xcbConnection);
 
@@ -382,11 +382,24 @@ namespace AzFramework
             {
                 xcb_client_message_event_t* cme = reinterpret_cast<xcb_client_message_event_t*>(event);
 
-                if ((cme->type == WM_PROTOCOLS) && (cme->format == s_XcbFormatDataSize) && (cme->data.data32[0] == WM_DELETE_WINDOW))
+                if ((cme->type == WM_PROTOCOLS) && (cme->format == s_XcbFormatDataSize))
                 {
-                    Deactivate();
+                    const xcb_atom_t protocolAtom = cme->data.data32[0];
+                    if (protocolAtom == WM_DELETE_WINDOW)
+                    {
+                        Deactivate();
 
-                    ApplicationRequests::Bus::Broadcast(&ApplicationRequests::ExitMainLoop);
+                        ApplicationRequests::Bus::Broadcast(&ApplicationRequests::ExitMainLoop);
+                    }
+                    else if (protocolAtom == _NET_WM_PING && cme->window != m_xcbRootScreen->root)
+                    {
+                        xcb_client_message_event_t reply = *cme;
+                        reply.response_type = XCB_CLIENT_MESSAGE;
+                        reply.window = m_xcbRootScreen->root;
+
+                        xcb_send_event(m_xcbConnection, 0, m_xcbRootScreen->root, XCB_EVENT_MASK_STRUCTURE_NOTIFY | XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT, reinterpret_cast<const char*>(&reply));
+                        xcb_flush(m_xcbConnection);
+                    }
                 }
                 break;
             }

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.h
@@ -86,5 +86,7 @@ namespace AzFramework
         xcb_atom_t _NET_FRAME_EXTENTS;
         // This atom is used to allow WM to kill app if not responsive anymore
         xcb_atom_t _NET_WM_PID;
+        // This atom is used to inform the window manager that the window is responding
+        xcb_atom_t _NET_WM_PING;
     };
 } // namespace AzFramework


### PR DESCRIPTION
Some window managers (like mutter) will query an application at some
interval to see if it is processing its event loop. They do this by sending
the window a `_NET_WM_PING` message. The application is expected to process
that message and send it back to the server.

During normal execution, responding to the `_NET_WM_PING` message is
handled by Qt. However, when the user enters game mode in the editor,
processing of Qt's event loop stops, and everything is processed by the
XcbNativeWindow instead. This adds the proper response to that event, so
that mutter does not consider the Editor process as hung while the user is
in game mode.

Signed-off-by: Chris Burel <burelc@amazon.com>