### PR TITLE
Convert physics automated tests in InDevelopment to use prefab system instead

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_InDevelopment.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_InDevelopment.py
@@ -26,154 +26,133 @@ class TestAutomation(TestAutomationBase):
                     r"AutomatedTesting\Levels\Physics\Material_LibraryCrudOperationsReflectOnRagdollBones")
     def test_Material_LibraryCrudOperationsReflectOnRagdollBones(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_LibraryCrudOperationsReflectOnRagdollBones as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Material_RagdollBones(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_RagdollBones as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @fm.file_revert("c15308221_material_componentsinsyncwithlibrary.physmaterial",
                     r"AutomatedTesting\Levels\Physics\Material_ComponentsInSyncWithLibrary")
     def test_Material_ComponentsInSyncWithLibrary(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_ComponentsInSyncWithLibrary as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     # BUG: LY-107723")
     def test_ScriptCanvas_SetKinematicTargetTransform(self, request, workspace, editor, launcher_platform):
         from .tests.script_canvas import ScriptCanvas_SetKinematicTargetTransform as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     # Failing, PhysXTerrain
     @fm.file_revert("c4925579_material_addmodifydeleteonterrain.physmaterial",
                     r"AutomatedTesting\Levels\Physics\Material_LibraryCrudOperationsReflectOnTerrain")
     def test_Material_LibraryCrudOperationsReflectOnTerrain(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_LibraryCrudOperationsReflectOnTerrain as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     # Failing, PhysXTerrain
     def test_Terrain_TerrainTexturePainterWorks(self, request, workspace, editor, launcher_platform):
         from .tests.terrain import Terrain_TerrainTexturePainterWorks as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     # Failing, PhysXTerrain
     def test_Material_CanBeAssignedToTerrain(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_CanBeAssignedToTerrain as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     # Failing, PhysXTerrain
     def test_Material_DefaultLibraryConsistentOnAllFeatures(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_DefaultLibraryConsistentOnAllFeatures as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     # Failing, PhysXTerrain
     @fm.file_revert("all_ones_1.physmaterial", r"AutomatedTesting\Levels\Physics\Material_DefaultMaterialLibraryChangesWork")
     @fm.file_override("default.physxconfiguration", "Material_DefaultMaterialLibraryChangesWork.physxconfiguration", "AutomatedTesting")
     def test_Material_DefaultMaterialLibraryChangesWork(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_DefaultMaterialLibraryChangesWork as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Collider_SameCollisionGroupSameLayerCollide(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_SameCollisionGroupSameLayerCollide as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Ragdoll_OldRagdollSerializationNoErrors(self, request, workspace, editor, launcher_platform):
         from .tests.ragdoll import Ragdoll_OldRagdollSerializationNoErrors as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @fm.file_override("default.physxconfiguration", "ScriptCanvas_OverlapNode.physxconfiguration")
     def test_ScriptCanvas_OverlapNode(self, request, workspace, editor, launcher_platform):
         from .tests.script_canvas import ScriptCanvas_OverlapNode as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Material_StaticFriction(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_StaticFriction as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
         
     @fm.file_revert("c4888315_material_addmodifydeleteoncollider.physmaterial",
                     r"AutomatedTesting\Levels\Physics\Material_LibraryCrudOperationsReflectOnCollider")
     def test_Material_LibraryCrudOperationsReflectOnCollider(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_LibraryCrudOperationsReflectOnCollider as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @fm.file_revert("c15563573_material_addmodifydeleteoncharactercontroller.physmaterial",
                     r"AutomatedTesting\Levels\Physics\Material_LibraryCrudOperationsReflectOnCharacterController")
     def test_Material_LibraryCrudOperationsReflectOnCharacterController(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_LibraryCrudOperationsReflectOnCharacterController as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
-
-    @fm.file_revert("c4888315_material_addmodifydeleteoncollider.physmaterial",
-                    r"AutomatedTesting\Levels\Physics\Material_LibraryCrudOperationsReflectOnCollider")
-    def test_Material_LibraryCrudOperationsReflectOnCollider(self, request, workspace, editor, launcher_platform):
-        from .tests.material import Material_LibraryCrudOperationsReflectOnCollider as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
-    
-
-    @fm.file_revert("c15563573_material_addmodifydeleteoncharactercontroller.physmaterial",
-                    r"AutomatedTesting\Levels\Physics\Material_LibraryCrudOperationsReflectOnCharacterController")
-    def test_Material_LibraryCrudOperationsReflectOnCharacterController(self, request, workspace, editor, launcher_platform):
-        from .tests.material import Material_LibraryCrudOperationsReflectOnCharacterController as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @fm.file_revert("c4044455_material_librarychangesinstantly.physmaterial",
                     r"AutomatedTesting\Levels\Physics\C4044455_Material_LibraryChangesInstantly")
     def test_Material_LibraryChangesReflectInstantly(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_LibraryChangesReflectInstantly as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     @fm.file_revert("Material_LibraryUpdatedAcrossLevels.physmaterial",
                     r"AutomatedTesting\Levels\Physics\Material_LibraryUpdatedAcrossLevels")
     def test_Material_LibraryUpdatedAcrossLevels(self, request, workspace, editor, launcher_platform):
         from .tests.material import Material_LibraryUpdatedAcrossLevels as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
     
     def test_RigidBody_LinearDampingAffectsMotion(self, request, workspace, editor, launcher_platform):
         from .tests.rigid_body import RigidBody_LinearDampingAffectsMotion as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Terrain_CollisionAgainstRigidBody(self, request, workspace, editor, launcher_platform):
         from .tests.terrain import Terrain_CollisionAgainstRigidBody as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
-
-    def test_ShapeCollider_CylinderShapeCollides(self, request, workspace, editor, launcher_platform):
-        from .tests.collider import ShapeCollider_CylinderShapeCollides as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Physics_WorldBodyBusWorksOnEditorComponents(self, request, workspace, editor, launcher_platform):
         from .tests import Physics_WorldBodyBusWorksOnEditorComponents as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Collider_PxMeshErrorIfNoMesh(self, request, workspace, editor, launcher_platform):
         from .tests.collider import Collider_PxMeshErrorIfNoMesh as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_ForceRegion_ImpulsesBoxShapedRigidBody(self, request, workspace, editor, launcher_platform):
         from .tests.force_region import ForceRegion_ImpulsesBoxShapedRigidBody as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Terrain_AddPhysTerrainComponent(self, request, workspace, editor, launcher_platform):
         from .tests.terrain import Terrain_AddPhysTerrainComponent as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Terrain_CanAddMultipleTerrainComponents(self, request, workspace, editor, launcher_platform):
         from .tests.terrain import Terrain_CanAddMultipleTerrainComponents as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Terrain_MultipleTerrainComponentsWarning(self, request, workspace, editor, launcher_platform):
         from .tests.terrain import Terrain_MultipleTerrainComponentsWarning as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
-
-    def test_Terrain_MultipleTerrainComponentsWarning(self, request, workspace, editor, launcher_platform):
-        from .tests.terrain import Terrain_MultipleTerrainComponentsWarning as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_ForceRegion_HighValuesDirectionAxesWorkWithNoError(self, request, workspace, editor, launcher_platform):
         from .tests.force_region import ForceRegion_HighValuesDirectionAxesWorkWithNoError as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Terrain_MultipleResolutionsValid(self, request, workspace, editor, launcher_platform):
         from .tests.terrain import Terrain_MultipleResolutionsValid as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_ForceRegion_SmallMagnitudeDeviationOnLargeForces(self, request, workspace, editor, launcher_platform):
         from .tests.force_region import ForceRegion_SmallMagnitudeDeviationOnLargeForces as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -482,12 +482,7 @@ class TestAutomation(TestAutomationBase):
     def test_ShapeCollider_CanBeAddedWitNoWarnings(self, request, workspace, editor, launcher_platform):
         from .tests.shape_collider import ShapeCollider_CanBeAddedWitNoWarnings as test_module
         self._run_test(request, workspace, editor, test_module)
-        
-    @revert_physics_config
-    def test_Physics_UndoRedoWorksOnEntityWithPhysComponents(self, request, workspace, editor, launcher_platform):
-        from .tests import Physics_UndoRedoWorksOnEntityWithPhysComponents as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
-    
+
     def test_Joints_Fixed2BodiesConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_Fixed2BodiesConstrained as test_module
         self._run_test(request, workspace, editor, test_module)

--- a/AutomatedTesting/Levels/Physics/Collider_PxMeshErrorIfNoMesh/Collider_PxMeshErrorIfNoMesh.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_PxMeshErrorIfNoMesh/Collider_PxMeshErrorIfNoMesh.prefab
@@ -1,0 +1,192 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Collider_PxMeshErrorIfNoMesh",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[270830584265]": {
+            "Id": "Entity_[270830584265]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[10509673222115697954]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10509673222115697954
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[279420518857]": {
+            "Id": "Entity_[279420518857]",
+            "Name": "test_entity",
+            "Components": {
+                "Component_[11074988777883974258]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11074988777883974258,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            70.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[14197962870538087335]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14197962870538087335,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                "Component_[16543103047436943265]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16543103047436943265
+                },
+                "Component_[17315977504121488846]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17315977504121488846
+                },
+                "Component_[3453880057571726529]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3453880057571726529
+                },
+                "Component_[3872983895105774546]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3872983895105774546
+                },
+                "Component_[4534782371004434129]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4534782371004434129
+                },
+                "Component_[657568858670829150]": {
+                    "$type": "SelectionComponent",
+                    "Id": 657568858670829150
+                },
+                "Component_[6962773877616982646]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6962773877616982646
+                },
+                "Component_[7497731834731657132]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7497731834731657132,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11074988777883974258
+                        },
+                        {
+                            "ComponentId": 14197962870538087335,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7984512026446357803]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7984512026446357803
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Collider_SameCollisionGroupSameLayerCollide/Collider_SameCollisionGroupSameLayerCollide.prefab
+++ b/AutomatedTesting/Levels/Physics/Collider_SameCollisionGroupSameLayerCollide/Collider_SameCollisionGroupSameLayerCollide.prefab
@@ -1,0 +1,345 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Collider_SameCollisionGroupSameLayerCollide",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[678057008134]": {
+            "Id": "Entity_[678057008134]",
+            "Name": "Sphere_Moving",
+            "Components": {
+                "Component_[158491845118288574]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 158491845118288574,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{45EBDE87-10BA-405B-9118-1FE9C750E5A3}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[15882836540317052831]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15882836540317052831
+                },
+                "Component_[15988538924200810686]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15988538924200810686
+                },
+                "Component_[17332118306686659923]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17332118306686659923
+                },
+                "Component_[18013098363541384892]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18013098363541384892
+                },
+                "Component_[3299242856338866058]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3299242856338866058
+                },
+                "Component_[3368757662560547573]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3368757662560547573,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9646670826592538370
+                        },
+                        {
+                            "ComponentId": 158491845118288574,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7177752238184232813,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3538399061071907667,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[3538399061071907667]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3538399061071907667,
+                    "GameView": true
+                },
+                "Component_[3584595476595239676]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3584595476595239676
+                },
+                "Component_[4539775501292735153]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4539775501292735153
+                },
+                "Component_[5885911623396957736]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5885911623396957736
+                },
+                "Component_[7177752238184232813]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 7177752238184232813,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9646670826592538370]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9646670826592538370,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.0,
+                            532.0,
+                            41.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[682351975430]": {
+            "Id": "Entity_[682351975430]",
+            "Name": "Sphere_Stationary",
+            "Components": {
+                "Component_[14428979635353087750]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14428979635353087750
+                },
+                "Component_[14459069801260260996]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14459069801260260996
+                },
+                "Component_[14953689964266032999]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14953689964266032999,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[16353277599917996564]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16353277599917996564
+                },
+                "Component_[16528484535459302978]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16528484535459302978
+                },
+                "Component_[17689177494335411023]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17689177494335411023
+                },
+                "Component_[18116908665747450198]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 18116908665747450198
+                },
+                "Component_[3544855145233062627]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3544855145233062627,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3826825320808092990
+                        },
+                        {
+                            "ComponentId": 4006198856955600111,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 14953689964266032999,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8911963076780837600,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[3569626399556956817]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3569626399556956817
+                },
+                "Component_[3826825320808092990]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3826825320808092990,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            511.0,
+                            532.0,
+                            38.5
+                        ]
+                    }
+                },
+                "Component_[4006198856955600111]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4006198856955600111,
+                    "ColliderConfiguration": {
+                        "CollisionLayer": {
+                            "Index": 1
+                        },
+                        "CollisionGroupId": {
+                            "GroupId": "{45EBDE87-10BA-405B-9118-1FE9C750E5A3}"
+                        },
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[7159608037522336146]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7159608037522336146
+                },
+                "Component_[8911963076780837600]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 8911963076780837600,
+                    "GameView": true
+                }
+            }
+        },
+        "Entity_[686646942726]": {
+            "Id": "Entity_[686646942726]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[10250027574050772454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10250027574050772454
+                },
+                "Component_[10351011824952478005]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10351011824952478005
+                },
+                "Component_[10686207692106954083]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10686207692106954083
+                },
+                "Component_[12188797190671051283]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 12188797190671051283
+                },
+                "Component_[17653871823876638056]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17653871823876638056
+                },
+                "Component_[18021843710938917042]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 18021843710938917042
+                },
+                "Component_[380201997414535198]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 380201997414535198,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9240165245826350197
+                        },
+                        {
+                            "ComponentId": 4148460034741565439,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4464302464021066083]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4464302464021066083
+                },
+                "Component_[6724551657600078431]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6724551657600078431
+                },
+                "Component_[9240165245826350197]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9240165245826350197,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            532.0,
+                            36.5
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ForceRegion_HighValuesDirectionAxesWorkWithNoError/ForceRegion_HighValuesDirectionAxesWorkWithNoError.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_HighValuesDirectionAxesWorkWithNoError/ForceRegion_HighValuesDirectionAxesWorkWithNoError.prefab
@@ -1,0 +1,1179 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "ForceRegion_HighValuesDirectionAxesWorkWithNoError",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[264175050024]": {
+            "Id": "Entity_[264175050024]",
+            "Name": "Sphere_Local_Space",
+            "Components": {
+                "Component_[10151915657249448888]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10151915657249448888,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10362238253378591862
+                        },
+                        {
+                            "ComponentId": 14337613086038282335,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9099663809895823238,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4857393051047969648,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10362238253378591862]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362238253378591862,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            551.0,
+                            530.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[1217101245303897300]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1217101245303897300
+                },
+                "Component_[12291252161569845485]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12291252161569845485
+                },
+                "Component_[13343962314071886811]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13343962314071886811
+                },
+                "Component_[14337613086038282335]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14337613086038282335,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 1.0
+                        }
+                    }
+                },
+                "Component_[17150739529318426854]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17150739529318426854
+                },
+                "Component_[3165280802238151869]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3165280802238151869
+                },
+                "Component_[3271228901464231695]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3271228901464231695
+                },
+                "Component_[3310634801113131146]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3310634801113131146
+                },
+                "Component_[4506117462678364464]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4506117462678364464
+                },
+                "Component_[4857393051047969648]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4857393051047969648,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[268470017320]": {
+            "Id": "Entity_[268470017320]",
+            "Name": "ForceVol_Local_Space",
+            "Components": {
+                "Component_[10916379708253472570]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10916379708253472570
+                },
+                "Component_[11453957172394612175]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11453957172394612175,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15529417857362096874
+                        },
+                        {
+                            "ComponentId": 3791323987864351241,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7533425702745957756,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[1184472558140852547]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1184472558140852547
+                },
+                "Component_[15529417857362096874]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15529417857362096874,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            551.0,
+                            530.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[17444672391153729398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17444672391153729398
+                },
+                "Component_[3791323987864351241]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3791323987864351241,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                8.0,
+                                8.0,
+                                4.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[4680012562900031353]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4680012562900031353
+                },
+                "Component_[5180749011316010468]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5180749011316010468
+                },
+                "Component_[7533425702745957756]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 7533425702745957756,
+                    "DebugForces": true,
+                    "Forces": [
+                        {
+                            "Type": 1,
+                            "ForceWorldSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLocalSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLinearDamping": {
+                                "Damping": 99.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[7673319437897703826]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7673319437897703826
+                },
+                "Component_[8974245314304170844]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8974245314304170844
+                },
+                "Component_[9297559262237278199]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9297559262237278199
+                }
+            }
+        },
+        "Entity_[272764984616]": {
+            "Id": "Entity_[272764984616]",
+            "Name": "Sphere_Point",
+            "Components": {
+                "Component_[10151915657249448888]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10151915657249448888,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10362238253378591862
+                        },
+                        {
+                            "ComponentId": 14337613086038282335,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9099663809895823238,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4857393051047969648,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10362238253378591862]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362238253378591862,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            455.0,
+                            530.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[1217101245303897300]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1217101245303897300
+                },
+                "Component_[12291252161569845485]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12291252161569845485
+                },
+                "Component_[13343962314071886811]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13343962314071886811
+                },
+                "Component_[14337613086038282335]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14337613086038282335,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 1.0
+                        }
+                    }
+                },
+                "Component_[17150739529318426854]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17150739529318426854
+                },
+                "Component_[3165280802238151869]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3165280802238151869
+                },
+                "Component_[3271228901464231695]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3271228901464231695
+                },
+                "Component_[3310634801113131146]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3310634801113131146
+                },
+                "Component_[4506117462678364464]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4506117462678364464
+                },
+                "Component_[4857393051047969648]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4857393051047969648,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[277059951912]": {
+            "Id": "Entity_[277059951912]",
+            "Name": "ForceVol_Point",
+            "Components": {
+                "Component_[10916379708253472570]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10916379708253472570
+                },
+                "Component_[11453957172394612175]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11453957172394612175,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15529417857362096874
+                        },
+                        {
+                            "ComponentId": 3791323987864351241,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7533425702745957756,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[1184472558140852547]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1184472558140852547
+                },
+                "Component_[15529417857362096874]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15529417857362096874,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            455.0,
+                            530.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[17444672391153729398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17444672391153729398
+                },
+                "Component_[3791323987864351241]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3791323987864351241,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                8.0,
+                                8.0,
+                                4.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[4680012562900031353]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4680012562900031353
+                },
+                "Component_[5180749011316010468]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5180749011316010468
+                },
+                "Component_[7533425702745957756]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 7533425702745957756,
+                    "DebugForces": true,
+                    "Forces": [
+                        {
+                            "Type": 2,
+                            "ForceWorldSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLocalSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForcePoint": {
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLinearDamping": {
+                                "Damping": 99.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[7673319437897703826]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7673319437897703826
+                },
+                "Component_[8974245314304170844]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8974245314304170844
+                },
+                "Component_[9297559262237278199]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9297559262237278199
+                }
+            }
+        },
+        "Entity_[281354919208]": {
+            "Id": "Entity_[281354919208]",
+            "Name": "Sphere_Simple_Drag",
+            "Components": {
+                "Component_[10151915657249448888]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10151915657249448888,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10362238253378591862
+                        },
+                        {
+                            "ComponentId": 14337613086038282335,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9099663809895823238,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4857393051047969648,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10362238253378591862]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362238253378591862,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            477.0,
+                            611.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[1217101245303897300]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1217101245303897300
+                },
+                "Component_[12291252161569845485]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12291252161569845485
+                },
+                "Component_[13343962314071886811]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13343962314071886811
+                },
+                "Component_[14337613086038282335]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14337613086038282335,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 1.0
+                        }
+                    }
+                },
+                "Component_[17150739529318426854]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17150739529318426854
+                },
+                "Component_[3165280802238151869]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3165280802238151869
+                },
+                "Component_[3271228901464231695]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3271228901464231695
+                },
+                "Component_[3310634801113131146]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3310634801113131146
+                },
+                "Component_[4506117462678364464]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4506117462678364464
+                },
+                "Component_[4857393051047969648]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4857393051047969648,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[283375942204]": {
+            "Id": "Entity_[283375942204]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[10879485153719707478]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10879485153719707478
+                },
+                "Component_[11121425344864359822]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11121425344864359822
+                },
+                "Component_[15255763170409911822]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15255763170409911822
+                },
+                "Component_[16487716786068262334]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16487716786068262334
+                },
+                "Component_[3657230180793708178]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3657230180793708178
+                },
+                "Component_[4865013418085112633]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4865013418085112633
+                },
+                "Component_[6635022822919266404]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6635022822919266404,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[7782238073293319650]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7782238073293319650
+                },
+                "Component_[8344288205153633917]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8344288205153633917
+                },
+                "Component_[8874306356207296754]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8874306356207296754,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6635022822919266404
+                        },
+                        {
+                            "ComponentId": 6419369211537273444,
+                            "SortIndex": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "Entity_[285649886504]": {
+            "Id": "Entity_[285649886504]",
+            "Name": "ForceVol_Simple_Drag",
+            "Components": {
+                "Component_[10916379708253472570]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10916379708253472570
+                },
+                "Component_[11453957172394612175]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11453957172394612175,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15529417857362096874
+                        },
+                        {
+                            "ComponentId": 3791323987864351241,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 14233226606852213112,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[1184472558140852547]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1184472558140852547
+                },
+                "Component_[14233226606852213112]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 14233226606852213112,
+                    "DebugForces": true,
+                    "Forces": [
+                        {
+                            "Type": 4,
+                            "ForceSimpleDrag": {
+                                "Volume Density": 400.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[15529417857362096874]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15529417857362096874,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            477.0,
+                            611.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[17444672391153729398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17444672391153729398
+                },
+                "Component_[3791323987864351241]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3791323987864351241,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                8.0,
+                                8.0,
+                                4.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[4680012562900031353]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4680012562900031353
+                },
+                "Component_[5180749011316010468]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5180749011316010468
+                },
+                "Component_[7673319437897703826]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7673319437897703826
+                },
+                "Component_[8974245314304170844]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8974245314304170844
+                },
+                "Component_[9297559262237278199]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9297559262237278199
+                }
+            }
+        },
+        "Entity_[287670909500]": {
+            "Id": "Entity_[287670909500]",
+            "Name": "ForceVol_World_Space",
+            "Components": {
+                "Component_[10916379708253472570]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10916379708253472570
+                },
+                "Component_[11453957172394612175]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11453957172394612175,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15529417857362096874
+                        },
+                        {
+                            "ComponentId": 3791323987864351241,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7533425702745957756,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[1184472558140852547]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1184472558140852547
+                },
+                "Component_[15529417857362096874]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15529417857362096874,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            518.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[17444672391153729398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17444672391153729398
+                },
+                "Component_[3791323987864351241]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3791323987864351241,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                8.0,
+                                8.0,
+                                4.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[4680012562900031353]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4680012562900031353
+                },
+                "Component_[5180749011316010468]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5180749011316010468
+                },
+                "Component_[7533425702745957756]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 7533425702745957756,
+                    "DebugForces": true,
+                    "Forces": [
+                        {
+                            "ForceWorldSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLocalSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLinearDamping": {
+                                "Damping": 99.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[7673319437897703826]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7673319437897703826
+                },
+                "Component_[8974245314304170844]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8974245314304170844
+                },
+                "Component_[9297559262237278199]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9297559262237278199
+                }
+            }
+        },
+        "Entity_[289944853800]": {
+            "Id": "Entity_[289944853800]",
+            "Name": "Sphere_Linear_Damping",
+            "Components": {
+                "Component_[10151915657249448888]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10151915657249448888,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10362238253378591862
+                        },
+                        {
+                            "ComponentId": 14337613086038282335,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9099663809895823238,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4857393051047969648,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10362238253378591862]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362238253378591862,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            542.0,
+                            600.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[1217101245303897300]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1217101245303897300
+                },
+                "Component_[12291252161569845485]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12291252161569845485
+                },
+                "Component_[13343962314071886811]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13343962314071886811
+                },
+                "Component_[14337613086038282335]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14337613086038282335,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 1.0
+                        }
+                    }
+                },
+                "Component_[17150739529318426854]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17150739529318426854
+                },
+                "Component_[3165280802238151869]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3165280802238151869
+                },
+                "Component_[3271228901464231695]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3271228901464231695
+                },
+                "Component_[3310634801113131146]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3310634801113131146
+                },
+                "Component_[4506117462678364464]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4506117462678364464
+                },
+                "Component_[4857393051047969648]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4857393051047969648,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[291965876796]": {
+            "Id": "Entity_[291965876796]",
+            "Name": "Sphere_World_Space",
+            "Components": {
+                "Component_[10151915657249448888]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10151915657249448888,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10362238253378591862
+                        },
+                        {
+                            "ComponentId": 14337613086038282335,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9099663809895823238,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4857393051047969648,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10362238253378591862]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10362238253378591862,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            518.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[1217101245303897300]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1217101245303897300
+                },
+                "Component_[12291252161569845485]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12291252161569845485
+                },
+                "Component_[13343962314071886811]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13343962314071886811
+                },
+                "Component_[14337613086038282335]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14337613086038282335,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 1.0
+                        }
+                    }
+                },
+                "Component_[17150739529318426854]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17150739529318426854
+                },
+                "Component_[3165280802238151869]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3165280802238151869
+                },
+                "Component_[3271228901464231695]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3271228901464231695
+                },
+                "Component_[3310634801113131146]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3310634801113131146
+                },
+                "Component_[4506117462678364464]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4506117462678364464
+                },
+                "Component_[4857393051047969648]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4857393051047969648,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[294239821096]": {
+            "Id": "Entity_[294239821096]",
+            "Name": "ForceVol_Linear_Damping",
+            "Components": {
+                "Component_[10916379708253472570]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10916379708253472570
+                },
+                "Component_[11453957172394612175]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11453957172394612175,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15529417857362096874
+                        },
+                        {
+                            "ComponentId": 3791323987864351241,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7533425702745957756,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[1184472558140852547]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1184472558140852547
+                },
+                "Component_[15529417857362096874]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15529417857362096874,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            542.0,
+                            600.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[17444672391153729398]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17444672391153729398
+                },
+                "Component_[3791323987864351241]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3791323987864351241,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                8.0,
+                                8.0,
+                                4.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[4680012562900031353]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4680012562900031353
+                },
+                "Component_[5180749011316010468]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5180749011316010468
+                },
+                "Component_[7533425702745957756]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 7533425702745957756,
+                    "DebugForces": true,
+                    "Forces": [
+                        {
+                            "Type": 5,
+                            "ForceWorldSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLocalSpace": {
+                                "Direction": [
+                                    0.0,
+                                    0.0,
+                                    999999.0
+                                ],
+                                "Magnitude": 999999.0
+                            },
+                            "ForceLinearDamping": {
+                                "Damping": 99.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[7673319437897703826]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7673319437897703826
+                },
+                "Component_[8974245314304170844]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8974245314304170844
+                },
+                "Component_[9297559262237278199]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9297559262237278199
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesBoxShapedRigidBody/ForceRegion_ImpulsesBoxShapedRigidBody.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_ImpulsesBoxShapedRigidBody/ForceRegion_ImpulsesBoxShapedRigidBody.prefab
@@ -1,0 +1,325 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "ForceRegion_ImpulsesBoxShapedRigidBody",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[270002999212]": {
+            "Id": "Entity_[270002999212]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[16471175805292296441]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16471175805292296441
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            4096.0,
+                            4096.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[355506484304]": {
+            "Id": "Entity_[355506484304]",
+            "Name": "Force Region",
+            "Components": {
+                "Component_[11280909321423981689]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11280909321423981689
+                },
+                "Component_[16854315530707009745]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16854315530707009745
+                },
+                "Component_[17353673997408976547]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17353673997408976547
+                },
+                "Component_[17359555270396547210]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17359555270396547210,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                3.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[2141533656337780700]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2141533656337780700
+                },
+                "Component_[371669865141874831]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 371669865141874831
+                },
+                "Component_[4108135523594206804]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4108135523594206804,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            84.19999694824219,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[5728595771543274047]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5728595771543274047
+                },
+                "Component_[5888163144028789147]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5888163144028789147
+                },
+                "Component_[6424236228697592522]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 6424236228697592522,
+                    "Forces": [
+                        {
+                            "Type": 2,
+                            "ForcePoint": {
+                                "Magnitude": 1000.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[6787109320607361672]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6787109320607361672
+                },
+                "Component_[8129116085258127112]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8129116085258127112,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4108135523594206804
+                        },
+                        {
+                            "ComponentId": 6424236228697592522,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17359555270396547210,
+                            "SortIndex": 2
+                        }
+                    ]
+                }
+            }
+        },
+        "Entity_[359801451600]": {
+            "Id": "Entity_[359801451600]",
+            "Name": "Cube",
+            "Components": {
+                "Component_[10150988222811879262]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10150988222811879262,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17097133730143355750
+                        },
+                        {
+                            "ComponentId": 14249981200955481965,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1168061487500377532,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 2017365638220260352,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[1168061487500377532]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1168061487500377532,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            1.0
+                        ],
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                2.0,
+                                2.0,
+                                2.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[13386170058723120734]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13386170058723120734
+                },
+                "Component_[14249981200955481965]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14249981200955481965,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[16753379648037728845]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16753379648037728845
+                },
+                "Component_[1702798579844760976]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1702798579844760976
+                },
+                "Component_[17034025940531214159]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17034025940531214159
+                },
+                "Component_[17097133730143355750]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17097133730143355750,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            84.19999694824219,
+                            50.0
+                        ]
+                    }
+                },
+                "Component_[2106091205299323420]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2106091205299323420
+                },
+                "Component_[2563939741415868411]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2563939741415868411
+                },
+                "Component_[4019243667332044207]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4019243667332044207
+                },
+                "Component_[9551210940681210081]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9551210940681210081
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ForceRegion_SmallMagnitudeDeviationOnLargeForces/ForceRegion_SmallMagnitudeDeviationOnLargeForces.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_SmallMagnitudeDeviationOnLargeForces/ForceRegion_SmallMagnitudeDeviationOnLargeForces.prefab
@@ -1,0 +1,280 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "ForceRegion_SmallMagnitudeDeviationOnLargeForces",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[282582611817]": {
+            "Id": "Entity_[282582611817]",
+            "Name": "ForceRegion",
+            "Components": {
+                "Component_[10545024360029383624]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10545024360029383624
+                },
+                "Component_[11547710738062207988]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11547710738062207988
+                },
+                "Component_[11768479446596949960]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11768479446596949960,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2874534696976320351
+                        },
+                        {
+                            "ComponentId": 9051868454744069975,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16858457281256471736,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 17134683886712702706,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15731411676638928554]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15731411676638928554
+                },
+                "Component_[16858457281256471736]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16858457281256471736,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                2.0,
+                                2.0,
+                                2.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[17134683886712702706]": {
+                    "$type": "EditorForceRegionComponent",
+                    "Id": 17134683886712702706,
+                    "Forces": [
+                        {
+                            "ForceWorldSpace": {
+                                "Magnitude": 1000000.0
+                            }
+                        }
+                    ]
+                },
+                "Component_[2382195023719464458]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2382195023719464458
+                },
+                "Component_[2874534696976320351]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2874534696976320351,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            400.0,
+                            550.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[5763927342520629215]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5763927342520629215
+                },
+                "Component_[7531376322926995655]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7531376322926995655
+                },
+                "Component_[8264507417233530976]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8264507417233530976
+                },
+                "Component_[8358337765875207462]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8358337765875207462
+                },
+                "Component_[9051868454744069975]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 9051868454744069975,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                2.0,
+                                2.0,
+                                2.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[286877579113]": {
+            "Id": "Entity_[286877579113]",
+            "Name": "Sphere",
+            "Components": {
+                "Component_[10453303204725323574]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10453303204725323574
+                },
+                "Component_[1115113803276103220]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1115113803276103220
+                },
+                "Component_[11924195204198903977]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11924195204198903977
+                },
+                "Component_[1276345366428075735]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1276345366428075735
+                },
+                "Component_[1562869265404548559]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1562869265404548559
+                },
+                "Component_[16172305626787000438]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16172305626787000438,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[17210494727673176703]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 17210494727673176703,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -2.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[17480415042829772500]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17480415042829772500
+                },
+                "Component_[18438709353321038847]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18438709353321038847,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            400.0,
+                            550.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[6755940455000978742]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6755940455000978742,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18438709353321038847
+                        },
+                        {
+                            "ComponentId": 8005910842284590493,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17210494727673176703,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 16172305626787000438,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[7206966251904438867]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7206966251904438867
+                },
+                "Component_[8005910842284590493]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 8005910842284590493,
+                    "GameView": true
+                },
+                "Component_[9566923257747018842]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9566923257747018842
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_CanBeAssignedToTerrain/Material_CanBeAssignedToTerrain.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_CanBeAssignedToTerrain/Material_CanBeAssignedToTerrain.prefab
@@ -1,0 +1,463 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_CanBeAssignedToTerrain",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[265260511818]": {
+            "Id": "Entity_[265260511818]",
+            "Name": "Ball_Default",
+            "Components": {
+                "Component_[11260599825150522846]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11260599825150522846
+                },
+                "Component_[14543093085573529000]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14543093085573529000
+                },
+                "Component_[14636813764343589281]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14636813764343589281
+                },
+                "Component_[1566052376666973619]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1566052376666973619,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 194410571818650054
+                        },
+                        {
+                            "ComponentId": 997098632118048412,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3819115674736394998,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3852987457272860369,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16741737051114372319]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16741737051114372319
+                },
+                "Component_[1737463233081170940]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1737463233081170940
+                },
+                "Component_[194410571818650054]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 194410571818650054,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            70.0,
+                            42.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[3819115674736394998]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3819115674736394998,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[3852987457272860369]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 3852987457272860369,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[4307738578681477187]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4307738578681477187
+                },
+                "Component_[7933906863398152040]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7933906863398152040
+                },
+                "Component_[8098663489176132586]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8098663489176132586
+                }
+            }
+        },
+        "Entity_[271568184331]": {
+            "Id": "Entity_[271568184331]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[11483818492292822053]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11483818492292822053
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[280158118923]": {
+            "Id": "Entity_[280158118923]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[10046708004808200366]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10046708004808200366
+                },
+                "Component_[17123702470777844290]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17123702470777844290,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6528200531317933023
+                        },
+                        {
+                            "ComponentId": 4163047169642183407,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[2728812209609776310]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2728812209609776310
+                },
+                "Component_[273895809569022836]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 273895809569022836
+                },
+                "Component_[3063363901974354715]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3063363901974354715
+                },
+                "Component_[4207632796115449881]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4207632796115449881
+                },
+                "Component_[5774735815889614505]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5774735815889614505
+                },
+                "Component_[6528200531317933023]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6528200531317933023,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            45.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[8263130417850461690]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8263130417850461690
+                },
+                "Component_[9898829109579909717]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9898829109579909717
+                }
+            }
+        },
+        "Entity_[284453086219]": {
+            "Id": "Entity_[284453086219]",
+            "Name": "Ball_Rubber",
+            "Components": {
+                "Component_[11260599825150522846]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11260599825150522846
+                },
+                "Component_[14543093085573529000]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14543093085573529000
+                },
+                "Component_[14636813764343589281]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14636813764343589281
+                },
+                "Component_[1566052376666973619]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1566052376666973619,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 194410571818650054
+                        },
+                        {
+                            "ComponentId": 997098632118048412,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3819115674736394998,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3852987457272860369,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16741737051114372319]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16741737051114372319
+                },
+                "Component_[1737463233081170940]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1737463233081170940
+                },
+                "Component_[194410571818650054]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 194410571818650054,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            60.000003814697266,
+                            42.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[3819115674736394998]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3819115674736394998,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[3852987457272860369]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 3852987457272860369,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[4307738578681477187]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4307738578681477187
+                },
+                "Component_[7933906863398152040]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7933906863398152040
+                },
+                "Component_[8098663489176132586]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8098663489176132586
+                }
+            }
+        },
+        "Entity_[542956087794]": {
+            "Id": "Entity_[542956087794]",
+            "Name": "Ball_Concrete",
+            "Components": {
+                "Component_[11260599825150522846]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11260599825150522846
+                },
+                "Component_[14543093085573529000]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14543093085573529000
+                },
+                "Component_[14636813764343589281]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14636813764343589281
+                },
+                "Component_[1566052376666973619]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1566052376666973619,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 194410571818650054
+                        },
+                        {
+                            "ComponentId": 997098632118048412,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3819115674736394998,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3852987457272860369,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16741737051114372319]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16741737051114372319
+                },
+                "Component_[1737463233081170940]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1737463233081170940
+                },
+                "Component_[194410571818650054]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 194410571818650054,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            80.0,
+                            42.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[3819115674736394998]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3819115674736394998,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[3852987457272860369]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 3852987457272860369,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[4307738578681477187]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4307738578681477187
+                },
+                "Component_[7933906863398152040]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7933906863398152040
+                },
+                "Component_[8098663489176132586]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8098663489176132586
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_ComponentsInSyncWithLibrary/Material_ComponentsInSyncWithLibrary.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_ComponentsInSyncWithLibrary/Material_ComponentsInSyncWithLibrary.prefab
@@ -1,0 +1,657 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_ComponentsInSyncWithLibrary",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[260776734078]": {
+            "Id": "Entity_[260776734078]",
+            "Name": "controller_box",
+            "Components": {
+                "Component_[10933116477407589503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10933116477407589503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            500.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[12319515305242899177]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12319515305242899177
+                },
+                "Component_[14007768344670229883]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14007768344670229883,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10933116477407589503
+                        },
+                        {
+                            "ComponentId": 16374954456473261689,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4434530361734934283,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 15932040375149139516,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15429412525665412876]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15429412525665412876
+                },
+                "Component_[15932040375149139516]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 15932040375149139516,
+                    "GameView": true
+                },
+                "Component_[16374954456473261689]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 16374954456473261689,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[4434530361734934283]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 4434530361734934283,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration"
+                        }
+                    ]
+                },
+                "Component_[6047578667723454428]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6047578667723454428
+                },
+                "Component_[6157199618550876647]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6157199618550876647
+                },
+                "Component_[6352321906375244992]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6352321906375244992
+                },
+                "Component_[7112374037901853821]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7112374037901853821
+                },
+                "Component_[8445463631325337286]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8445463631325337286
+                },
+                "Component_[9535219735492863488]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9535219735492863488
+                }
+            }
+        },
+        "Entity_[276610354993]": {
+            "Id": "Entity_[276610354993]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[12314253239514361945]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12314253239514361945
+                },
+                "Component_[12990604225390789300]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12990604225390789300
+                },
+                "Component_[15336241938188309393]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15336241938188309393,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8280059665222875635
+                        },
+                        {
+                            "ComponentId": 14461330450401599926,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[16912713578984042941]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16912713578984042941
+                },
+                "Component_[18374758657635401221]": {
+                    "$type": "SelectionComponent",
+                    "Id": 18374758657635401221
+                },
+                "Component_[1953027903130323243]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1953027903130323243
+                },
+                "Component_[4927071606767414468]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4927071606767414468
+                },
+                "Component_[6949081301917907780]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 6949081301917907780
+                },
+                "Component_[8280059665222875635]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8280059665222875635,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            514.6111450195313,
+                            517.0299682617188,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[9629037490790468733]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9629037490790468733
+                }
+            }
+        },
+        "Entity_[280905322289]": {
+            "Id": "Entity_[280905322289]",
+            "Name": "terrain_box",
+            "Components": {
+                "Component_[10933116477407589503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10933116477407589503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0,
+                            500.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[12319515305242899177]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12319515305242899177
+                },
+                "Component_[14007768344670229883]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14007768344670229883,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10933116477407589503
+                        },
+                        {
+                            "ComponentId": 16374954456473261689,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4434530361734934283,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 15932040375149139516,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15429412525665412876]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15429412525665412876
+                },
+                "Component_[15932040375149139516]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 15932040375149139516,
+                    "GameView": true
+                },
+                "Component_[16374954456473261689]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 16374954456473261689,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[4434530361734934283]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 4434530361734934283,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration"
+                        }
+                    ]
+                },
+                "Component_[6047578667723454428]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6047578667723454428
+                },
+                "Component_[6157199618550876647]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6157199618550876647
+                },
+                "Component_[6352321906375244992]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6352321906375244992
+                },
+                "Component_[7112374037901853821]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7112374037901853821
+                },
+                "Component_[8445463631325337286]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8445463631325337286
+                },
+                "Component_[9535219735492863488]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9535219735492863488
+                }
+            }
+        },
+        "Entity_[312985852304]": {
+            "Id": "Entity_[312985852304]",
+            "Name": "ragdoll",
+            "Components": {
+                "Component_[12622895186928536742]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12622895186928536742,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent",
+                        "PositionIterations": 100,
+                        "VelocityIterations": 100,
+                        "ProjectionLinearTol": 90.0,
+                        "ProjectionAngularTol": 90.0
+                    }
+                },
+                "Component_[16629806302166538605]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16629806302166538605,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            470.0,
+                            500.0,
+                            40.0
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            0.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            1.0,
+                            0.9999998807907104,
+                            0.9999998807907104
+                        ]
+                    }
+                },
+                "Component_[17247506969745334411]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17247506969745334411
+                },
+                "Component_[18259695023364429623]": {
+                    "$type": "SelectionComponent",
+                    "Id": 18259695023364429623
+                },
+                "Component_[2106362673565806802]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2106362673565806802
+                },
+                "Component_[2582671693884540432]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 2582671693884540432,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{0ACDF673-A69E-5A86-ABEE-63DC8413BCAE}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/ragdoll_modified/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c15308221_material_componentsinsyncwithlibrary/ragdoll_modified/modified.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c15308221_material_componentsinsyncwithlibrary/ragdoll_modified/modified.mtl"
+                    },
+                    "AttachmentTarget": "",
+                    "RenderSkeleton": true
+                },
+                "Component_[3397839887265359124]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3397839887265359124
+                },
+                "Component_[5949177739034552475]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5949177739034552475
+                },
+                "Component_[7249154114131397513]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7249154114131397513
+                },
+                "Component_[7518688196708395643]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7518688196708395643
+                },
+                "Component_[7676267777646927878]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7676267777646927878,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 16629806302166538605
+                        },
+                        {
+                            "ComponentId": 2582671693884540432,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12622895186928536742,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8101717768174926581,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8101717768174926581]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 8101717768174926581,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{566386FA-46B8-594E-B434-9D9A823487DF}"
+                        },
+                        "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/ragdoll_modified/animgraphphysx.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{358D8774-CE61-5216-B0BB-51292C2AC2E2}"
+                        },
+                        "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/ragdoll_modified/rinlocomotion.motionset"
+                    },
+                    "ActiveMotionSetName": "MotionSet1"
+                },
+                "Component_[8993213661162788548]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8993213661162788548
+                }
+            }
+        },
+        "Entity_[317280819600]": {
+            "Id": "Entity_[317280819600]",
+            "Name": "character_controller",
+            "Components": {
+                "Component_[11940548489598098992]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11940548489598098992
+                },
+                "Component_[12215849266116967830]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12215849266116967830
+                },
+                "Component_[14215769083649417730]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14215769083649417730
+                },
+                "Component_[15386046162697600514]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15386046162697600514,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18418239390115391469
+                        },
+                        {
+                            "ComponentId": 2223745084206416722,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 7012119881965377247,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15742080812473071437]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15742080812473071437
+                },
+                "Component_[18206096422844537164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18206096422844537164
+                },
+                "Component_[18418239390115391469]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18418239390115391469,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            500.0,
+                            31.0
+                        ]
+                    }
+                },
+                "Component_[2116202150291171718]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2116202150291171718
+                },
+                "Component_[2223745084206416722]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 2223745084206416722,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                }
+                            ]
+                        },
+                        "ContactOffset": 1.0,
+                        "ScaleCoeff": 1.0
+                    },
+                    "ShapeConfig": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                5.0,
+                                5.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[2967405891117234762]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2967405891117234762
+                },
+                "Component_[7012119881965377247]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 7012119881965377247,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                5.0,
+                                5.0,
+                                4.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[8768801565671791723]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8768801565671791723
+                }
+            }
+        },
+        "Entity_[802612124048]": {
+            "Id": "Entity_[802612124048]",
+            "Name": "collider",
+            "Components": {
+                "Component_[10933116477407589503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10933116477407589503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            480.0,
+                            500.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[12319515305242899177]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12319515305242899177
+                },
+                "Component_[14007768344670229883]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14007768344670229883,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10933116477407589503
+                        },
+                        {
+                            "ComponentId": 16374954456473261689,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4434530361734934283,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 15932040375149139516,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15429412525665412876]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15429412525665412876
+                },
+                "Component_[15932040375149139516]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 15932040375149139516,
+                    "GameView": true
+                },
+                "Component_[16374954456473261689]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 16374954456473261689,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[4434530361734934283]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 4434530361734934283,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration"
+                        }
+                    ]
+                },
+                "Component_[6047578667723454428]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6047578667723454428
+                },
+                "Component_[6157199618550876647]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6157199618550876647
+                },
+                "Component_[6352321906375244992]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6352321906375244992
+                },
+                "Component_[7112374037901853821]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7112374037901853821
+                },
+                "Component_[8445463631325337286]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8445463631325337286
+                },
+                "Component_[9535219735492863488]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9535219735492863488
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/Material_DefaultLibraryConsistentOnAllFeatures.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/Material_DefaultLibraryConsistentOnAllFeatures.prefab
@@ -1,0 +1,3751 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_DefaultLibraryConsistentOnAllFeatures",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1056869436257]": {
+            "Id": "Entity_[1056869436257]",
+            "Name": "Terrain_Trigger_Rubber_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.000003814697266,
+                            50.0,
+                            36.5
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[1061164403553]": {
+            "Id": "Entity_[1061164403553]",
+            "Name": "Terrain_Trigger_Rubber_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.000003814697266,
+                            50.0,
+                            36.25
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[1968096657969]": {
+            "Id": "Entity_[1968096657969]",
+            "Name": "Ragdoll_Concrete",
+            "Components": {
+                "Component_[10039400268976952148]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10039400268976952148
+                },
+                "Component_[12004717137284752362]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 12004717137284752362,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{656B7DD7-5B36-5AE9-A786-426E43EF3402}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/concrete/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/concrete/rin_concrete.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/concrete/rin_concrete.mtl"
+                    },
+                    "AttachmentTarget": ""
+                },
+                "Component_[12440370822854437265]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 12440370822854437265
+                },
+                "Component_[12478064043384491499]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12478064043384491499,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1342518183210792438
+                        },
+                        {
+                            "ComponentId": 12004717137284752362,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 6834674425612629705,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 2645118264714559996,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[12955943650864821141]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12955943650864821141
+                },
+                "Component_[1342518183210792438]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1342518183210792438,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.49999237060547,
+                            33.98466491699219,
+                            32.22990417480469
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            0.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            1.0,
+                            0.9999998807907104,
+                            0.9999998807907104
+                        ]
+                    }
+                },
+                "Component_[15970275978245520354]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15970275978245520354
+                },
+                "Component_[202435863520473857]": {
+                    "$type": "SelectionComponent",
+                    "Id": 202435863520473857
+                },
+                "Component_[2546823006136226180]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2546823006136226180
+                },
+                "Component_[2602268934708924092]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2602268934708924092
+                },
+                "Component_[2645118264714559996]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 2645118264714559996,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[3455650601495660597]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3455650601495660597
+                },
+                "Component_[6834674425612629705]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 6834674425612629705,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{6D6B7967-87B5-52AE-8426-D7A61B6A075F}"
+                        },
+                        "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/concrete/concrete_animgraph.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{93B57A30-6EF1-53C4-9F92-D8451A9B9234}"
+                        },
+                        "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/concrete/concrete_motionset.motionset"
+                    },
+                    "ActiveMotionSetName": "concrete_motionset"
+                }
+            }
+        },
+        "Entity_[262341950589]": {
+            "Id": "Entity_[262341950589]",
+            "Name": "Platform_Concrete",
+            "Components": {
+                "Component_[10275136119458161255]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10275136119458161255
+                },
+                "Component_[1134350850708629993]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1134350850708629993
+                },
+                "Component_[14358908923983911426]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14358908923983911426,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14593484270742240842]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14593484270742240842
+                },
+                "Component_[17237228324925120355]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17237228324925120355
+                },
+                "Component_[2521242760918763980]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2521242760918763980,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.125
+                            ]
+                        }
+                    }
+                },
+                "Component_[4791314600057497309]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4791314600057497309
+                },
+                "Component_[7946554280901980058]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7946554280901980058
+                },
+                "Component_[8509455762384969468]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8509455762384969468,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.01568629965186119,
+                        1.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.01568629965186119,
+                                1.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.125
+                            ]
+                        }
+                    }
+                },
+                "Component_[8864356873621999403]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8864356873621999403,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            65.99999237060547,
+                            43.5,
+                            32.25
+                        ]
+                    }
+                },
+                "Component_[9029552694603958207]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9029552694603958207,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8864356873621999403
+                        },
+                        {
+                            "ComponentId": 14358908923983911426,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2521242760918763980,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8509455762384969468,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[9585173934037095588]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9585173934037095588
+                },
+                "Component_[9888463018895687707]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9888463018895687707
+                }
+            }
+        },
+        "Entity_[262502211968]": {
+            "Id": "Entity_[262502211968]",
+            "Name": "Platform_Rubber",
+            "Components": {
+                "Component_[10275136119458161255]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10275136119458161255
+                },
+                "Component_[1134350850708629993]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1134350850708629993
+                },
+                "Component_[14358908923983911426]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14358908923983911426,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[14593484270742240842]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14593484270742240842
+                },
+                "Component_[17237228324925120355]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17237228324925120355
+                },
+                "Component_[2521242760918763980]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2521242760918763980,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.125
+                            ]
+                        }
+                    }
+                },
+                "Component_[4791314600057497309]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4791314600057497309
+                },
+                "Component_[7946554280901980058]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7946554280901980058
+                },
+                "Component_[8509455762384969468]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8509455762384969468,
+                    "GameView": true,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.01568629965186119
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                1.0,
+                                0.0,
+                                0.01568629965186119
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.125
+                            ]
+                        }
+                    }
+                },
+                "Component_[8864356873621999403]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8864356873621999403,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.5,
+                            43.5,
+                            32.25
+                        ]
+                    }
+                },
+                "Component_[9029552694603958207]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9029552694603958207,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8864356873621999403
+                        },
+                        {
+                            "ComponentId": 14358908923983911426,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2521242760918763980,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8509455762384969468,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[9585173934037095588]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9585173934037095588
+                },
+                "Component_[9888463018895687707]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9888463018895687707
+                }
+            }
+        },
+        "Entity_[266284568365]": {
+            "Id": "Entity_[266284568365]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[11582296547117097418]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11582296547117097418
+                },
+                "Component_[13890214561657812702]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13890214561657812702
+                },
+                "Component_[15450818340261509148]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15450818340261509148
+                },
+                "Component_[15966660706974585263]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15966660706974585263
+                },
+                "Component_[2251383250964041996]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2251383250964041996
+                },
+                "Component_[3557869430458031692]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3557869430458031692
+                },
+                "Component_[4920652687285202617]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4920652687285202617
+                },
+                "Component_[6770894707828051399]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6770894707828051399
+                },
+                "Component_[7816062748148182468]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7816062748148182468,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 806865472820060037
+                        },
+                        {
+                            "ComponentId": 10542701001760672561,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[806865472820060037]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 806865472820060037,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            63.0,
+                            66.5,
+                            32.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[266636917885]": {
+            "Id": "Entity_[266636917885]",
+            "Name": "Platform_Rubber_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11133178406925561766]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 11133178406925561766,
+                    "GameView": true,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.125
+                        }
+                    }
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11133178406925561766,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.00000762939453,
+                            43.5,
+                            34.75
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{7D4BE734-81B5-4271-B41B-340F4D77F3D0}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[270931885181]": {
+            "Id": "Entity_[270931885181]",
+            "Name": "Platform_Trigger_Concrete_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            43.5,
+                            33.25
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[272256256673]": {
+            "Id": "Entity_[272256256673]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17051326141381084486]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17051326141381084486
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[275226852477]": {
+            "Id": "Entity_[275226852477]",
+            "Name": "Platform_Concrete_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 16356620596071523647,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16356620596071523647]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 16356620596071523647,
+                    "GameView": true,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.125
+                        }
+                    }
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            43.5,
+                            34.75
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{92DC3AA3-AD2D-4DBC-9036-BC5E880A921B}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[279521819773]": {
+            "Id": "Entity_[279521819773]",
+            "Name": "Platform_Trigger_Rubber_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.000003814697266,
+                            43.5,
+                            36.5
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[283816787069]": {
+            "Id": "Entity_[283816787069]",
+            "Name": "Platform_Trigger_Concrete_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            43.5,
+                            33.5
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[288111754365]": {
+            "Id": "Entity_[288111754365]",
+            "Name": "Platform_Trigger_Rubber_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.000003814697266,
+                            43.5,
+                            36.75
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[3341833501821]": {
+            "Id": "Entity_[3341833501821]",
+            "Name": "Controller_Concrete_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 13179142364262044124,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[13179142364262044124]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 13179142364262044124,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.24999237060547,
+                            38.25,
+                            34.75
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[3359940209213]": {
+            "Id": "Entity_[3359940209213]",
+            "Name": "Terrain_Rubber_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11133178406925561766]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 11133178406925561766,
+                    "GameView": true,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.125
+                        }
+                    }
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11133178406925561766,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.00000762939453,
+                            50.0,
+                            34.5
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[572232286769]": {
+            "Id": "Entity_[572232286769]",
+            "Name": "Ragdoll_Rubber",
+            "Components": {
+                "Component_[10039400268976952148]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10039400268976952148
+                },
+                "Component_[12004717137284752362]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 12004717137284752362,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{4FDB3B29-0A4E-5555-950D-13C50B9929AF}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/rubber/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/rubber/rin_rubber.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/rubber/rin_rubber.mtl"
+                    },
+                    "AttachmentTarget": ""
+                },
+                "Component_[12440370822854437265]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 12440370822854437265
+                },
+                "Component_[12478064043384491499]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12478064043384491499,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1342518183210792438
+                        },
+                        {
+                            "ComponentId": 12004717137284752362,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 6834674425612629705,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 2645118264714559996,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[12955943650864821141]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12955943650864821141
+                },
+                "Component_[1342518183210792438]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1342518183210792438,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.5,
+                            33.98466491699219,
+                            32.22990417480469
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            0.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            1.0,
+                            0.9999998807907104,
+                            0.9999998807907104
+                        ]
+                    }
+                },
+                "Component_[15970275978245520354]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15970275978245520354
+                },
+                "Component_[202435863520473857]": {
+                    "$type": "SelectionComponent",
+                    "Id": 202435863520473857
+                },
+                "Component_[2546823006136226180]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2546823006136226180
+                },
+                "Component_[2602268934708924092]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2602268934708924092
+                },
+                "Component_[2645118264714559996]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 2645118264714559996,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[3455650601495660597]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3455650601495660597
+                },
+                "Component_[6834674425612629705]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 6834674425612629705,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{E7AAEE58-72A8-5913-BFA3-9DE0AB51BF21}"
+                        },
+                        "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/rubber/rubber_animgraph.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{E1EAB5BE-A498-5938-83D6-A7365A736B5A}"
+                        },
+                        "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/ragdoll/rubber/rubber_motionset.motionset"
+                    },
+                    "ActiveMotionSetName": "rubber_motionset"
+                }
+            }
+        },
+        "Entity_[593012968289]": {
+            "Id": "Entity_[593012968289]",
+            "Name": "Terrain_Trigger_Concrete_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            49.0,
+                            33.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[597532945520]": {
+            "Id": "Entity_[597532945520]",
+            "Name": "Terrain_Concrete_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 16356620596071523647,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16356620596071523647]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 16356620596071523647,
+                    "GameView": true,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.125
+                        }
+                    }
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            49.0,
+                            34.5
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[743378287741]": {
+            "Id": "Entity_[743378287741]",
+            "Name": "Controller_Rubber",
+            "Components": {
+                "Component_[1093548322450453329]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 1093548322450453329,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{7D4BE734-81B5-4271-B41B-340F4D77F3D0}"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[10961108575362702323]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10961108575362702323
+                },
+                "Component_[11690509593126538189]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11690509593126538189
+                },
+                "Component_[13783802219168995402]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13783802219168995402
+                },
+                "Component_[14861141019965582501]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14861141019965582501,
+                    "Child Entity Order": [
+                        "Entity_[747673255037]"
+                    ]
+                },
+                "Component_[17563245726535966919]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17563245726535966919
+                },
+                "Component_[1923115844782213906]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1923115844782213906,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6829193817742906833
+                        },
+                        {
+                            "ComponentId": 1093548322450453329,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5140743593405126500]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5140743593405126500
+                },
+                "Component_[5505701545442838469]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5505701545442838469
+                },
+                "Component_[6829193817742906833]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6829193817742906833,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.500003814697266,
+                            38.25,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[9457875004127466112]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9457875004127466112
+                }
+            }
+        },
+        "Entity_[747673255037]": {
+            "Id": "Entity_[747673255037]",
+            "Name": "Controller_Rubber_Capsule",
+            "Components": {
+                "Component_[10043205585359756329]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10043205585359756329
+                },
+                "Component_[10477999087069277663]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10477999087069277663
+                },
+                "Component_[14975018461333704669]": {
+                    "$type": "EditorCapsuleShapeComponent",
+                    "Id": 14975018461333704669,
+                    "GameView": true,
+                    "ShapeColor": [
+                        1.0,
+                        0.0,
+                        0.01568629965186119
+                    ],
+                    "CapsuleShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                1.0,
+                                0.0,
+                                0.01568629965186119
+                            ],
+                            "Height": 0.800000011920929,
+                            "Radius": 0.1875
+                        }
+                    }
+                },
+                "Component_[15645170693335739256]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15645170693335739256
+                },
+                "Component_[1580182453287462118]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1580182453287462118
+                },
+                "Component_[3146614964891511007]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3146614964891511007
+                },
+                "Component_[4187386723339130447]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4187386723339130447
+                },
+                "Component_[6572263505108290646]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6572263505108290646,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9704093509355629561
+                        },
+                        {
+                            "ComponentId": 14975018461333704669,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[6762053194556083421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6762053194556083421
+                },
+                "Component_[805711657842385583]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 805711657842385583
+                },
+                "Component_[9704093509355629561]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9704093509355629561,
+                    "Parent Entity": "Entity_[743378287741]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.000003800000058618025,
+                            0.0,
+                            0.6000000238418579
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[751968222333]": {
+            "Id": "Entity_[751968222333]",
+            "Name": "Controller_Concrete",
+            "Components": {
+                "Component_[1093548322450453329]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 1093548322450453329,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{92DC3AA3-AD2D-4DBC-9036-BC5E880A921B}"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "Component_[10961108575362702323]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10961108575362702323
+                },
+                "Component_[11690509593126538189]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11690509593126538189
+                },
+                "Component_[13783802219168995402]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13783802219168995402
+                },
+                "Component_[14861141019965582501]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14861141019965582501,
+                    "Child Entity Order": [
+                        "Entity_[756263189629]"
+                    ]
+                },
+                "Component_[17563245726535966919]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17563245726535966919
+                },
+                "Component_[1923115844782213906]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1923115844782213906,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6829193817742906833
+                        },
+                        {
+                            "ComponentId": 1093548322450453329,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5140743593405126500]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5140743593405126500
+                },
+                "Component_[5505701545442838469]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5505701545442838469
+                },
+                "Component_[6829193817742906833]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6829193817742906833,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.25,
+                            38.25,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[9457875004127466112]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9457875004127466112
+                }
+            }
+        },
+        "Entity_[756263189629]": {
+            "Id": "Entity_[756263189629]",
+            "Name": "Controller_Concrete_Capsule",
+            "Components": {
+                "Component_[10043205585359756329]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10043205585359756329
+                },
+                "Component_[10477999087069277663]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10477999087069277663
+                },
+                "Component_[14975018461333704669]": {
+                    "$type": "EditorCapsuleShapeComponent",
+                    "Id": 14975018461333704669,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.09803920239210129,
+                        1.0
+                    ],
+                    "CapsuleShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.09803920239210129,
+                                1.0
+                            ],
+                            "Height": 0.800000011920929,
+                            "Radius": 0.1875
+                        }
+                    }
+                },
+                "Component_[15645170693335739256]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15645170693335739256
+                },
+                "Component_[1580182453287462118]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1580182453287462118
+                },
+                "Component_[3146614964891511007]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3146614964891511007
+                },
+                "Component_[4187386723339130447]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4187386723339130447
+                },
+                "Component_[6572263505108290646]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6572263505108290646,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9704093509355629561
+                        },
+                        {
+                            "ComponentId": 14975018461333704669,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[6762053194556083421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6762053194556083421
+                },
+                "Component_[805711657842385583]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 805711657842385583
+                },
+                "Component_[9704093509355629561]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9704093509355629561,
+                    "Parent Entity": "Entity_[751968222333]",
+                    "Transform Data": {
+                        "Translate": [
+                            0.00000760000011723605,
+                            0.0,
+                            0.5999984741210938
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[760558156925]": {
+            "Id": "Entity_[760558156925]",
+            "Name": "Controller_Trigger_Rubber_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.500003814697266,
+                            38.25,
+                            36.875
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[764853124221]": {
+            "Id": "Entity_[764853124221]",
+            "Name": "Controller_Trigger_Rubber_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.500003814697266,
+                            38.25,
+                            37.125
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[769148091517]": {
+            "Id": "Entity_[769148091517]",
+            "Name": "Controller_Trigger_Concrete_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.25,
+                            38.25,
+                            34.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[773443058813]": {
+            "Id": "Entity_[773443058813]",
+            "Name": "Controller_Trigger_Concrete_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.25,
+                            38.25,
+                            34.25
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[777738026109]": {
+            "Id": "Entity_[777738026109]",
+            "Name": "Controller_Rubber_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 13179142364262044124,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[13179142364262044124]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 13179142364262044124,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.5,
+                            38.25,
+                            34.75
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[820646234977]": {
+            "Id": "Entity_[820646234977]",
+            "Name": "Terrain_Trigger_Concrete_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            49.0,
+                            33.25
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[901216228795]": {
+            "Id": "Entity_[901216228795]",
+            "Name": "Ragdoll_Trigger_Rubber_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.375003814697266,
+                            33.0,
+                            37.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[905511196091]": {
+            "Id": "Entity_[905511196091]",
+            "Name": "Ragdoll_Trigger_Concrete_High",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.375,
+                            33.0,
+                            34.25
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[909806163387]": {
+            "Id": "Entity_[909806163387]",
+            "Name": "Ragdoll_Trigger_Rubber_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.375003814697266,
+                            33.0,
+                            36.75
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[914101130683]": {
+            "Id": "Entity_[914101130683]",
+            "Name": "Ragdoll_Concrete_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 16356620596071523647,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16356620596071523647]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 16356620596071523647,
+                    "GameView": true,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.125
+                        }
+                    }
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.375,
+                            33.0,
+                            34.75
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        },
+        "Entity_[918396097979]": {
+            "Id": "Entity_[918396097979]",
+            "Name": "Ragdoll_Trigger_Concrete_Low",
+            "Components": {
+                "Component_[10840566128898283059]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10840566128898283059
+                },
+                "Component_[10983094587467278454]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10983094587467278454
+                },
+                "Component_[11383036399300899746]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11383036399300899746,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6266147445640237600
+                        },
+                        {
+                            "ComponentId": 1781937210102373025,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 3428108517473506,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[13530932529430511545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13530932529430511545
+                },
+                "Component_[156509540013497987]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 156509540013497987
+                },
+                "Component_[1721990367369414539]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1721990367369414539
+                },
+                "Component_[1781937210102373025]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1781937210102373025,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[2005399217246976371]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2005399217246976371
+                },
+                "Component_[3428108517473506]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 3428108517473506,
+                    "GameView": true,
+                    "ShapeColor": [
+                        0.0,
+                        0.0,
+                        0.0
+                    ],
+                    "BoxShape": {
+                        "Configuration": {
+                            "DrawColor": [
+                                0.0,
+                                0.0,
+                                0.0
+                            ],
+                            "Dimensions": [
+                                3.0,
+                                3.0,
+                                0.009999999776482582
+                            ]
+                        }
+                    }
+                },
+                "Component_[5040620082781400644]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5040620082781400644
+                },
+                "Component_[5110395982372092581]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5110395982372092581
+                },
+                "Component_[6266147445640237600]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6266147445640237600,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.375,
+                            33.0,
+                            34.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[922691065275]": {
+            "Id": "Entity_[922691065275]",
+            "Name": "Ragdoll_Rubber_Result",
+            "Components": {
+                "Component_[10387790400092616169]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10387790400092616169
+                },
+                "Component_[11133178406925561766]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 11133178406925561766,
+                    "GameView": true,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.125
+                        }
+                    }
+                },
+                "Component_[11968214853385516517]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11968214853385516517,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5014083328249971503
+                        },
+                        {
+                            "ComponentId": 9893204879060929949,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8845538424051770440,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11133178406925561766,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17823417752576404336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17823417752576404336
+                },
+                "Component_[2401496945657124059]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2401496945657124059
+                },
+                "Component_[4104197490219530434]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4104197490219530434
+                },
+                "Component_[4223677810573014319]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4223677810573014319
+                },
+                "Component_[5014083328249971503]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5014083328249971503,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            61.37500762939453,
+                            33.0,
+                            34.75
+                        ]
+                    }
+                },
+                "Component_[6548352878184664029]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6548352878184664029
+                },
+                "Component_[8180764373409636939]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8180764373409636939
+                },
+                "Component_[8845538424051770440]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8845538424051770440,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9893204879060929949]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9893204879060929949,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 0.125
+                        },
+                        "Box": {
+                            "Configuration": [
+                                0.25,
+                                0.25,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[9925166748883748513]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9925166748883748513
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_DefaultMaterialLibraryChangesWork/Material_DefaultMaterialLibraryChangesWork.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultMaterialLibraryChangesWork/Material_DefaultMaterialLibraryChangesWork.prefab
@@ -1,0 +1,459 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_DefaultMaterialLibraryChangesWork",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[262227687841]": {
+            "Id": "Entity_[262227687841]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[14338738333215565352]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14338738333215565352
+                },
+                "Component_[15885805202678481775]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15885805202678481775
+                },
+                "Component_[16070370098584104890]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16070370098584104890
+                },
+                "Component_[1617621207078008239]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1617621207078008239
+                },
+                "Component_[17657269192108207502]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17657269192108207502,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            532.2000122070313,
+                            33.981990814208984
+                        ]
+                    }
+                },
+                "Component_[18160618617940682957]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18160618617940682957
+                },
+                "Component_[4088315653425856875]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4088315653425856875
+                },
+                "Component_[6638994313051957826]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6638994313051957826,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17657269192108207502
+                        },
+                        {
+                            "ComponentId": 15199377543135402457,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[6750853591797412277]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6750853591797412277
+                },
+                "Component_[7562794595084708929]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7562794595084708929
+                }
+            }
+        },
+        "Entity_[272448747216]": {
+            "Id": "Entity_[272448747216]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[6280030280979048622]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6280030280979048622
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[466071907108]": {
+            "Id": "Entity_[466071907108]",
+            "Name": "phase1",
+            "Components": {
+                "Component_[11196152194792490753]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11196152194792490753
+                },
+                "Component_[11402573677726518273]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11402573677726518273
+                },
+                "Component_[11517188390615113139]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11517188390615113139
+                },
+                "Component_[12367734151396640273]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12367734151396640273
+                },
+                "Component_[14470164252983122863]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14470164252983122863,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1791692616836511153
+                        },
+                        {
+                            "ComponentId": 5404795836532944986,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[16660300799311798923]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16660300799311798923
+                },
+                "Component_[16692712966223522090]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16692712966223522090,
+                    "VisibilityFlag": false
+                },
+                "Component_[17021277671392049783]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17021277671392049783
+                },
+                "Component_[1791692616836511153]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1791692616836511153,
+                    "Parent Entity": "ContainerEntity",
+                    "IsStatic": true
+                },
+                "Component_[5404795836532944986]": {
+                    "$type": "EditorLayerComponent",
+                    "Id": 5404795836532944986,
+                    "m_layerFileName": "phase1"
+                },
+                "Component_[674215168682933257]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 674215168682933257,
+                    "Child Entity Order": [
+                        "",
+                        "",
+                        "",
+                        ""
+                    ]
+                }
+            }
+        },
+        "Entity_[470366874404]": {
+            "Id": "Entity_[470366874404]",
+            "Name": "phase2",
+            "Components": {
+                "Component_[14096912367064766817]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14096912367064766817
+                },
+                "Component_[14340198292637979599]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14340198292637979599,
+                    "Parent Entity": "ContainerEntity",
+                    "IsStatic": true
+                },
+                "Component_[14651428074192300130]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14651428074192300130
+                },
+                "Component_[16900427906234471517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16900427906234471517
+                },
+                "Component_[17226010388967689692]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17226010388967689692,
+                    "VisibilityFlag": false
+                },
+                "Component_[3290804759059411077]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3290804759059411077,
+                    "Child Entity Order": [
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        ""
+                    ]
+                },
+                "Component_[3655928794276605152]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3655928794276605152
+                },
+                "Component_[8007658104744215645]": {
+                    "$type": "EditorLayerComponent",
+                    "Id": 8007658104744215645,
+                    "m_layerFileName": "phase2"
+                },
+                "Component_[9314627772410259256]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9314627772410259256,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14340198292637979599
+                        },
+                        {
+                            "ComponentId": 8007658104744215645,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[9341025896132800760]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9341025896132800760
+                },
+                "Component_[9434332989607122606]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9434332989607122606
+                }
+            }
+        },
+        "Entity_[474661841700]": {
+            "Id": "Entity_[474661841700]",
+            "Name": "phase3",
+            "Components": {
+                "Component_[10754799706207633458]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10754799706207633458,
+                    "Child Entity Order": [
+                        "",
+                        "",
+                        "",
+                        ""
+                    ]
+                },
+                "Component_[10932672898084753622]": {
+                    "$type": "EditorLayerComponent",
+                    "Id": 10932672898084753622,
+                    "m_layerFileName": "phase3"
+                },
+                "Component_[14080656117155793680]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14080656117155793680
+                },
+                "Component_[18032353188965743879]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18032353188965743879,
+                    "Parent Entity": "ContainerEntity",
+                    "IsStatic": true
+                },
+                "Component_[2266507945729034055]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2266507945729034055
+                },
+                "Component_[2770504922948751602]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2770504922948751602
+                },
+                "Component_[3616585599181401852]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3616585599181401852
+                },
+                "Component_[4693930217038360239]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4693930217038360239
+                },
+                "Component_[6409441444724007595]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6409441444724007595
+                },
+                "Component_[7533545861052433759]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7533545861052433759,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18032353188965743879
+                        },
+                        {
+                            "ComponentId": 10932672898084753622,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[8234223187577316563]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8234223187577316563,
+                    "VisibilityFlag": false
+                }
+            }
+        },
+        "Entity_[478956808996]": {
+            "Id": "Entity_[478956808996]",
+            "Name": "phase4",
+            "Components": {
+                "Component_[10238926677417445112]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10238926677417445112
+                },
+                "Component_[13259575983608052466]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13259575983608052466,
+                    "Child Entity Order": [
+                        "",
+                        "",
+                        "",
+                        ""
+                    ]
+                },
+                "Component_[1357315533430049540]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 1357315533430049540
+                },
+                "Component_[13940283670653073472]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13940283670653073472
+                },
+                "Component_[15525113235296143532]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15525113235296143532,
+                    "Parent Entity": "ContainerEntity",
+                    "IsStatic": true
+                },
+                "Component_[15766845792760422540]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15766845792760422540
+                },
+                "Component_[18187339123277703601]": {
+                    "$type": "SelectionComponent",
+                    "Id": 18187339123277703601
+                },
+                "Component_[2957143837331761705]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2957143837331761705,
+                    "VisibilityFlag": false
+                },
+                "Component_[3605870977960149534]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3605870977960149534,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15525113235296143532
+                        },
+                        {
+                            "ComponentId": 8424296461858183757,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[6009213789878282346]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6009213789878282346
+                },
+                "Component_[8424296461858183757]": {
+                    "$type": "EditorLayerComponent",
+                    "Id": 8424296461858183757,
+                    "m_layerFileName": "phase4"
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryChangesReflectInstantly/Material_LibraryChangesReflectInstantly.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryChangesReflectInstantly/Material_LibraryChangesReflectInstantly.prefab
@@ -1,0 +1,1046 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_LibraryChangesReflectInstantly",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1011301294950]": {
+            "Id": "Entity_[1011301294950]",
+            "Name": "trigger",
+            "Components": {
+                "Component_[10177271249943941360]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10177271249943941360
+                },
+                "Component_[15134750255872632480]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 15134750255872632480,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                20.0,
+                                5.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[1632168420894708243]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1632168420894708243,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9795705876663826409
+                        },
+                        {
+                            "ComponentId": 2771976567503322305,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15134750255872632480,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3555675341180739959,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16436517280388201614]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16436517280388201614
+                },
+                "Component_[17044248283146127093]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17044248283146127093
+                },
+                "Component_[17656225355810724488]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17656225355810724488
+                },
+                "Component_[17970766687213692304]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17970766687213692304
+                },
+                "Component_[2025493072630587732]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2025493072630587732
+                },
+                "Component_[2610843270063344297]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2610843270063344297
+                },
+                "Component_[2771976567503322305]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2771976567503322305,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "Rotation": [
+                            0.00872649997472763,
+                            0.0,
+                            0.0,
+                            0.9999622702598572
+                        ],
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                19.989999771118164,
+                                5.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[628927360910821792]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 628927360910821792
+                },
+                "Component_[9795705876663826409]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9795705876663826409,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            497.0,
+                            529.0,
+                            37.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[272566920038]": {
+            "Id": "Entity_[272566920038]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[8964779992189042072]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8964779992189042072
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[281156854630]": {
+            "Id": "Entity_[281156854630]",
+            "Name": "sphere_0",
+            "Components": {
+                "Component_[10422448568969909101]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10422448568969909101
+                },
+                "Component_[10608077766366924597]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 10608077766366924597,
+                    "GameView": true
+                },
+                "Component_[10878409986827663706]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10878409986827663706,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14916338350890535230
+                        },
+                        {
+                            "ComponentId": 5742240157833915092,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11247125349883914931,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 10608077766366924597,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[11247125349883914931]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11247125349883914931,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[11764000867252871753]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11764000867252871753
+                },
+                "Component_[12840306624920458233]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12840306624920458233
+                },
+                "Component_[13136686057178084477]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13136686057178084477
+                },
+                "Component_[14916338350890535230]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14916338350890535230,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            529.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[15206702839284673033]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15206702839284673033
+                },
+                "Component_[4099965652380679772]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4099965652380679772
+                },
+                "Component_[4336955054176839701]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4336955054176839701
+                },
+                "Component_[5742240157833915092]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5742240157833915092,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{990FB3E0-0F65-46E0-9D91-FD948263D204}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[9493475781182370841]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9493475781182370841
+                }
+            }
+        },
+        "Entity_[285451821926]": {
+            "Id": "Entity_[285451821926]",
+            "Name": "sphere_1",
+            "Components": {
+                "Component_[12143596828987144855]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12143596828987144855
+                },
+                "Component_[12216594936013376980]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12216594936013376980,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            529.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[12287644288883736884]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12287644288883736884
+                },
+                "Component_[13363420471903321484]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13363420471903321484
+                },
+                "Component_[1348552420471387682]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1348552420471387682
+                },
+                "Component_[13685829686549383844]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13685829686549383844
+                },
+                "Component_[14193232010361497904]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14193232010361497904
+                },
+                "Component_[15140792967452273555]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15140792967452273555
+                },
+                "Component_[4017241308446098853]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4017241308446098853
+                },
+                "Component_[5079066243697779191]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5079066243697779191,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12216594936013376980
+                        },
+                        {
+                            "ComponentId": 9243168508986239530,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 6639881595565478748,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 9646129936594822050,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6639881595565478748]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 6639881595565478748,
+                    "GameView": true
+                },
+                "Component_[9243168508986239530]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9243168508986239530,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{4CE235BC-9483-4C13-8A3A-D9DF0DEB34BE}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[9646129936594822050]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9646129936594822050,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[289746789222]": {
+            "Id": "Entity_[289746789222]",
+            "Name": "sphere_2",
+            "Components": {
+                "Component_[10880848152918698630]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10880848152918698630
+                },
+                "Component_[10993747078839261711]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10993747078839261711
+                },
+                "Component_[11962089952362907403]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11962089952362907403
+                },
+                "Component_[14011849940054946291]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14011849940054946291
+                },
+                "Component_[14484679928173003221]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14484679928173003221
+                },
+                "Component_[14558792999386175226]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14558792999386175226
+                },
+                "Component_[17031894266271126099]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17031894266271126099
+                },
+                "Component_[1979590444290717748]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1979590444290717748,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6799363483582765524
+                        },
+                        {
+                            "ComponentId": 8037889069626634204,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8150225541959947967,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 2429084782432605763,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[2429084782432605763]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 2429084782432605763,
+                    "GameView": true
+                },
+                "Component_[6799363483582765524]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6799363483582765524,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            496.0,
+                            529.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[8037889069626634204]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 8037889069626634204,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{DE5438E9-52CE-4294-B2EE-250BB4D45A30}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[8056824717940315824]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8056824717940315824
+                },
+                "Component_[8150225541959947967]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8150225541959947967,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                }
+            }
+        },
+        "Entity_[294041756518]": {
+            "Id": "Entity_[294041756518]",
+            "Name": "cube_0",
+            "Components": {
+                "Component_[10912606567686727099]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10912606567686727099
+                },
+                "Component_[11684126416620709027]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11684126416620709027
+                },
+                "Component_[1446496530619556822]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1446496530619556822
+                },
+                "Component_[15822388646937623025]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15822388646937623025
+                },
+                "Component_[17754229616475343453]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17754229616475343453
+                },
+                "Component_[1800813603458203995]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1800813603458203995
+                },
+                "Component_[18069998247943285889]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 18069998247943285889,
+                    "GameView": true
+                },
+                "Component_[409216256029017752]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 409216256029017752
+                },
+                "Component_[5932223075168112202]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5932223075168112202,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            -0.009999999776482582,
+                            0.0,
+                            0.0
+                        ],
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34AD1046-240B-448C-A694-AE80F595C431}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[5986385136640000431]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5986385136640000431,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            536.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[6199518646890605975]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6199518646890605975,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5986385136640000431
+                        },
+                        {
+                            "ComponentId": 5932223075168112202,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 969119709860529359,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 18069998247943285889,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6408021591593091139]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6408021591593091139
+                },
+                "Component_[969119709860529359]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 969119709860529359,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[298336723814]": {
+            "Id": "Entity_[298336723814]",
+            "Name": "cube_1",
+            "Components": {
+                "Component_[10932875001923737893]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 10932875001923737893,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ]
+                    }
+                },
+                "Component_[12317113598061669381]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12317113598061669381,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[13558624633219310097]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13558624633219310097
+                },
+                "Component_[17851857614423757842]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17851857614423757842
+                },
+                "Component_[2298534458147006343]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2298534458147006343
+                },
+                "Component_[4250589817528997607]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4250589817528997607
+                },
+                "Component_[4386109395436141393]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4386109395436141393
+                },
+                "Component_[5517533395396945754]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5517533395396945754
+                },
+                "Component_[7300632340196303477]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7300632340196303477
+                },
+                "Component_[7958296118436118664]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7958296118436118664,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12317113598061669381
+                        },
+                        {
+                            "ComponentId": 8062409581128028241,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10932875001923737893,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 9044899334212236841,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8062409581128028241]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 8062409581128028241,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{6DB5BFA8-8D3F-4A62-BB00-80CD20DE4FC3}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[9044899334212236841]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 9044899334212236841,
+                    "GameView": true
+                },
+                "Component_[9926491691330614170]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9926491691330614170
+                }
+            }
+        },
+        "Entity_[302631691110]": {
+            "Id": "Entity_[302631691110]",
+            "Name": "cube_2",
+            "Components": {
+                "Component_[11080670972133255641]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11080670972133255641,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            496.0,
+                            536.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[11754890050424692549]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11754890050424692549,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11080670972133255641
+                        },
+                        {
+                            "ComponentId": 17055748108217384148,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16771618408365282049,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 17998392348447200702,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[12339977811876199089]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12339977811876199089
+                },
+                "Component_[13341540524348368618]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13341540524348368618
+                },
+                "Component_[14133485969952499547]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14133485969952499547
+                },
+                "Component_[16597981452459555417]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16597981452459555417
+                },
+                "Component_[16771618408365282049]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 16771618408365282049,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ]
+                    }
+                },
+                "Component_[17055748108217384148]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17055748108217384148,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{C4EE226F-2344-48EB-855C-5E7DC1FF30DE}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[17998392348447200702]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 17998392348447200702,
+                    "GameView": true
+                },
+                "Component_[1964072586603507375]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1964072586603507375
+                },
+                "Component_[3796980743963885327]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3796980743963885327
+                },
+                "Component_[5708434177314435286]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5708434177314435286
+                },
+                "Component_[7913078894745745037]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7913078894745745037
+                }
+            }
+        },
+        "Entity_[306926658406]": {
+            "Id": "Entity_[306926658406]",
+            "Name": "block",
+            "Components": {
+                "Component_[12382634988339210856]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12382634988339210856,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            540.0,
+                            34.0
+                        ]
+                    }
+                },
+                "Component_[1642001252034831296]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1642001252034831296
+                },
+                "Component_[16765360923859371834]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16765360923859371834
+                },
+                "Component_[16775762924926972264]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16775762924926972264,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12382634988339210856
+                        },
+                        {
+                            "ComponentId": 9873641921497409447,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 513154408972280568,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[1704922845822997969]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1704922845822997969
+                },
+                "Component_[2760308094792316787]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2760308094792316787
+                },
+                "Component_[3465195283579058488]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3465195283579058488
+                },
+                "Component_[4584462549661987060]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4584462549661987060
+                },
+                "Component_[513154408972280568]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 513154408972280568,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                10.0,
+                                10.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[5493593570289811910]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5493593570289811910
+                },
+                "Component_[8410997340656467467]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8410997340656467467
+                },
+                "Component_[9873641921497409447]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 9873641921497409447,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{C05FBCC0-F28E-49CD-92BC-F317B50BD459}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                1.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[311221625702]": {
+            "Id": "Entity_[311221625702]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[10474504837576669078]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10474504837576669078
+                },
+                "Component_[10953518714776809892]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10953518714776809892,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18125739413490339036
+                        },
+                        {
+                            "ComponentId": 11283802783959541951,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[13149306339480844843]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13149306339480844843
+                },
+                "Component_[15406556389305311118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15406556389305311118
+                },
+                "Component_[18125739413490339036]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18125739413490339036,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            502.0,
+                            529.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[2179235284330045411]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2179235284330045411
+                },
+                "Component_[2385453534192885322]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2385453534192885322
+                },
+                "Component_[6711532756284776563]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6711532756284776563
+                },
+                "Component_[7027064350878945104]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7027064350878945104
+                },
+                "Component_[789490538071906007]": {
+                    "$type": "SelectionComponent",
+                    "Id": 789490538071906007
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCharacterController/Material_LibraryCrudOperationsReflectOnCharacterController.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCharacterController/Material_LibraryCrudOperationsReflectOnCharacterController.prefab
@@ -1,0 +1,489 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_LibraryCrudOperationsReflectOnCharacterController",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1983591773128]": {
+            "Id": "Entity_[1983591773128]",
+            "Name": "on_default",
+            "Components": {
+                "Component_[11888873654361267781]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11888873654361267781
+                },
+                "Component_[12024462660202178611]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12024462660202178611,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13279700498368782451
+                        },
+                        {
+                            "ComponentId": 13603650242832603040,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 18441975369007490586,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4856611058839746987,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[12181695625842589206]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12181695625842589206
+                },
+                "Component_[13279700498368782451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13279700498368782451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            511.0,
+                            33.599998474121094
+                        ]
+                    }
+                },
+                "Component_[13603650242832603040]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 13603650242832603040,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[17609841900327077079]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17609841900327077079
+                },
+                "Component_[18441975369007490586]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 18441975369007490586,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[2292661485016154941]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2292661485016154941
+                },
+                "Component_[4856611058839746987]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4856611058839746987,
+                    "GameView": true
+                },
+                "Component_[549740363981341302]": {
+                    "$type": "SelectionComponent",
+                    "Id": 549740363981341302
+                },
+                "Component_[6014435101200744383]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6014435101200744383
+                },
+                "Component_[8319080743100417461]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8319080743100417461
+                },
+                "Component_[9957506408144797072]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9957506408144797072
+                }
+            }
+        },
+        "Entity_[1987886740424]": {
+            "Id": "Entity_[1987886740424]",
+            "Name": "default_controller",
+            "Components": {
+                "Component_[10799389367375591019]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10799389367375591019
+                },
+                "Component_[1210935227296872738]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1210935227296872738
+                },
+                "Component_[14399102793718028065]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 14399102793718028065,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        },
+                        "ScaleCoeff": 1.0
+                    },
+                    "ShapeConfig": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                80.0,
+                                10.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[15929741973030026333]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15929741973030026333,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2434577524100120776
+                        },
+                        {
+                            "ComponentId": 14399102793718028065,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8674951244981813776,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[2434577524100120776]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2434577524100120776,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            511.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[3393534074150524693]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3393534074150524693
+                },
+                "Component_[3918046621186384040]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3918046621186384040
+                },
+                "Component_[4602912363774870175]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4602912363774870175
+                },
+                "Component_[5167895015907855900]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5167895015907855900
+                },
+                "Component_[7525218412037342240]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7525218412037342240
+                },
+                "Component_[7838257857225411031]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7838257857225411031
+                },
+                "Component_[8674951244981813776]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8674951244981813776,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                80.0,
+                                10.0,
+                                2.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[282784723912]": {
+            "Id": "Entity_[282784723912]",
+            "Name": "modified_controller",
+            "Components": {
+                "Component_[10799389367375591019]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 10799389367375591019
+                },
+                "Component_[1210935227296872738]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1210935227296872738
+                },
+                "Component_[14399102793718028065]": {
+                    "$type": "EditorCharacterControllerComponent",
+                    "Id": 14399102793718028065,
+                    "Configuration": {
+                        "entityId": "",
+                        "Material": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{C9E8CE58-FC4F-4498-B502-21B87CE7321E}"
+                                }
+                            ]
+                        },
+                        "ScaleCoeff": 1.0
+                    },
+                    "ShapeConfig": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                80.0,
+                                10.0,
+                                1.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[15929741973030026333]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15929741973030026333,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2434577524100120776
+                        },
+                        {
+                            "ComponentId": 14399102793718028065,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 8674951244981813776,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[2434577524100120776]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2434577524100120776,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            500.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[3393534074150524693]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3393534074150524693
+                },
+                "Component_[3918046621186384040]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3918046621186384040
+                },
+                "Component_[4602912363774870175]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4602912363774870175
+                },
+                "Component_[5167895015907855900]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5167895015907855900
+                },
+                "Component_[7525218412037342240]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7525218412037342240
+                },
+                "Component_[7838257857225411031]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7838257857225411031
+                },
+                "Component_[8674951244981813776]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 8674951244981813776,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                80.0,
+                                10.0,
+                                2.0
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "Entity_[514712957896]": {
+            "Id": "Entity_[514712957896]",
+            "Name": "on_modified",
+            "Components": {
+                "Component_[11888873654361267781]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11888873654361267781
+                },
+                "Component_[12024462660202178611]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12024462660202178611,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13279700498368782451
+                        },
+                        {
+                            "ComponentId": 13603650242832603040,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 18441975369007490586,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4856611058839746987,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[12181695625842589206]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12181695625842589206
+                },
+                "Component_[13279700498368782451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13279700498368782451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            500.0,
+                            33.599998474121094
+                        ]
+                    }
+                },
+                "Component_[13603650242832603040]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 13603650242832603040,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            10.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[17609841900327077079]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17609841900327077079
+                },
+                "Component_[18441975369007490586]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 18441975369007490586,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[2292661485016154941]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2292661485016154941
+                },
+                "Component_[4856611058839746987]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4856611058839746987,
+                    "GameView": true
+                },
+                "Component_[549740363981341302]": {
+                    "$type": "SelectionComponent",
+                    "Id": 549740363981341302
+                },
+                "Component_[6014435101200744383]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6014435101200744383
+                },
+                "Component_[8319080743100417461]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8319080743100417461
+                },
+                "Component_[9957506408144797072]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9957506408144797072
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCollider/Material_LibraryCrudOperationsReflectOnCollider.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCollider/Material_LibraryCrudOperationsReflectOnCollider.prefab
@@ -1,0 +1,334 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_LibraryCrudOperationsReflectOnCollider",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[290936593070]": {
+            "Id": "Entity_[290936593070]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[11602866005706340349]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11602866005706340349
+                },
+                "Component_[15504423793278733500]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15504423793278733500
+                },
+                "Component_[15896625995555534644]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15896625995555534644
+                },
+                "Component_[16701918939627521982]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16701918939627521982
+                },
+                "Component_[18327433647066794656]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 18327433647066794656
+                },
+                "Component_[2268078677769677613]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2268078677769677613
+                },
+                "Component_[4860050218879749598]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4860050218879749598,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            537.3837890625,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[7949034982877954412]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7949034982877954412
+                },
+                "Component_[9360788528696510004]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9360788528696510004,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4860050218879749598
+                        },
+                        {
+                            "ComponentId": 18361146065405412452,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[9620815581399963111]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9620815581399963111
+                }
+            }
+        },
+        "Entity_[295231560366]": {
+            "Id": "Entity_[295231560366]",
+            "Name": "default",
+            "Components": {
+                "Component_[10406158083191885257]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10406158083191885257,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            500.0,
+                            32.5
+                        ]
+                    }
+                },
+                "Component_[1082551358992947306]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1082551358992947306
+                },
+                "Component_[11883683304226633452]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11883683304226633452,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[12282645318067988562]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12282645318067988562
+                },
+                "Component_[12476099436355708554]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12476099436355708554
+                },
+                "Component_[15933302684017549809]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15933302684017549809
+                },
+                "Component_[17296979228069175463]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17296979228069175463
+                },
+                "Component_[17326474236439773306]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17326474236439773306
+                },
+                "Component_[17798352767352601900]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17798352767352601900,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10406158083191885257
+                        },
+                        {
+                            "ComponentId": 18082739249556167219,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4885704332670198105,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11883683304226633452,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[18082739249556167219]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 18082739249556167219,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[18186401669145888786]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18186401669145888786
+                },
+                "Component_[4885704332670198105]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4885704332670198105,
+                    "GameView": true
+                },
+                "Component_[7844629875309638330]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7844629875309638330
+                }
+            }
+        },
+        "Entity_[497095023278]": {
+            "Id": "Entity_[497095023278]",
+            "Name": "modified",
+            "Components": {
+                "Component_[10406158083191885257]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10406158083191885257,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            503.0,
+                            32.5
+                        ]
+                    }
+                },
+                "Component_[1082551358992947306]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1082551358992947306
+                },
+                "Component_[11883683304226633452]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11883683304226633452,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[12282645318067988562]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 12282645318067988562
+                },
+                "Component_[12476099436355708554]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12476099436355708554
+                },
+                "Component_[15933302684017549809]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15933302684017549809
+                },
+                "Component_[17296979228069175463]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17296979228069175463
+                },
+                "Component_[17326474236439773306]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17326474236439773306
+                },
+                "Component_[17798352767352601900]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17798352767352601900,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10406158083191885257
+                        },
+                        {
+                            "ComponentId": 18082739249556167219,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4885704332670198105,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11883683304226633452,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[18082739249556167219]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 18082739249556167219,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{BC7E0096-0D0E-452E-8D3C-E239B4DC6D42}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[18186401669145888786]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 18186401669145888786
+                },
+                "Component_[4885704332670198105]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4885704332670198105,
+                    "GameView": true
+                },
+                "Component_[7844629875309638330]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7844629875309638330
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnRagdollBones/Material_LibraryCrudOperationsReflectOnRagdollBones.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnRagdollBones/Material_LibraryCrudOperationsReflectOnRagdollBones.prefab
@@ -1,0 +1,368 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_LibraryCrudOperationsReflectOnRagdollBones",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[264055852606]": {
+            "Id": "Entity_[264055852606]",
+            "Name": "default",
+            "Components": {
+                "Component_[11451652018825216748]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11451652018825216748
+                },
+                "Component_[12334266845701483067]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12334266845701483067,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[125629283710930287]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 125629283710930287
+                },
+                "Component_[13472203310961076026]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13472203310961076026,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            63.0,
+                            64.0,
+                            36.01451873779297
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            0.00000960000033956021,
+                            0.000009999999747378752
+                        ],
+                        "Scale": [
+                            1.0,
+                            0.9999998807907104,
+                            0.9999998807907104
+                        ]
+                    }
+                },
+                "Component_[15477458438279713223]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15477458438279713223
+                },
+                "Component_[16820598479284110143]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16820598479284110143,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13472203310961076026
+                        },
+                        {
+                            "ComponentId": 17605851486708743694,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9608781458903523320,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 12334266845701483067,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17326817116380613649]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17326817116380613649
+                },
+                "Component_[17605851486708743694]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 17605851486708743694,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{C79B7B64-5EAF-5C2A-8A9E-AEBA3BCEBCF4}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_default/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_default/default.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_default/default.mtl"
+                    },
+                    "AttachmentTarget": ""
+                },
+                "Component_[673926832579344982]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 673926832579344982
+                },
+                "Component_[7389125836440846093]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7389125836440846093
+                },
+                "Component_[886011054758218213]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 886011054758218213
+                },
+                "Component_[9237669932190470399]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9237669932190470399
+                },
+                "Component_[9608781458903523320]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 9608781458903523320,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{665B4907-CDD5-53FB-9FB0-2C77EF9CA147}"
+                        },
+                        "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_default/animgraphphysx.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{961B552C-4C8C-5361-9798-0142AFB27185}"
+                        },
+                        "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_default/rinlocomotion.motionset"
+                    },
+                    "ActiveMotionSetName": "MotionSet1"
+                }
+            }
+        },
+        "Entity_[268350819902]": {
+            "Id": "Entity_[268350819902]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[10780143927672919477]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10780143927672919477
+                },
+                "Component_[11432115963825126951]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11432115963825126951
+                },
+                "Component_[1365374619742748417]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1365374619742748417
+                },
+                "Component_[13764320959482640799]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13764320959482640799
+                },
+                "Component_[14661909163484522903]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14661909163484522903
+                },
+                "Component_[15750293542299007902]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15750293542299007902,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17850420510072144368
+                        },
+                        {
+                            "ComponentId": 8993693402819244535,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17850420510072144368]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17850420510072144368,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[18132510613169190178]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18132510613169190178
+                },
+                "Component_[8531319443213679278]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8531319443213679278
+                },
+                "Component_[8743651980659628746]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8743651980659628746
+                }
+            }
+        },
+        "Entity_[678163502462]": {
+            "Id": "Entity_[678163502462]",
+            "Name": "modified",
+            "Components": {
+                "Component_[11451652018825216748]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11451652018825216748
+                },
+                "Component_[12334266845701483067]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12334266845701483067,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[125629283710930287]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 125629283710930287
+                },
+                "Component_[13472203310961076026]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13472203310961076026,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            65.0,
+                            64.0,
+                            36.01451873779297
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            0.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            1.0,
+                            0.9999998807907104,
+                            0.9999998807907104
+                        ]
+                    }
+                },
+                "Component_[15477458438279713223]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15477458438279713223
+                },
+                "Component_[16820598479284110143]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16820598479284110143,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13472203310961076026
+                        },
+                        {
+                            "ComponentId": 17605851486708743694,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9608781458903523320,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 12334266845701483067,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17326817116380613649]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17326817116380613649
+                },
+                "Component_[17605851486708743694]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 17605851486708743694,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{91685CA2-1E0F-5EB7-85DA-FBD94AFF16B6}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_modified/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_modified/modified.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_modified/modified.mtl"
+                    },
+                    "AttachmentTarget": ""
+                },
+                "Component_[673926832579344982]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 673926832579344982
+                },
+                "Component_[7389125836440846093]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7389125836440846093
+                },
+                "Component_[886011054758218213]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 886011054758218213
+                },
+                "Component_[9237669932190470399]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9237669932190470399
+                },
+                "Component_[9608781458903523320]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 9608781458903523320,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{0F327FD4-F0F2-556B-96BB-7CC83C9E3063}"
+                        },
+                        "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_modified/animgraphphysx.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{0EDF7BC1-ABE9-5DEB-9786-94B374868E81}"
+                        },
+                        "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdoll_modified/rinlocomotion.motionset"
+                    },
+                    "ActiveMotionSetName": "MotionSet1"
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnTerrain/Material_LibraryCrudOperationsReflectOnTerrain.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnTerrain/Material_LibraryCrudOperationsReflectOnTerrain.prefab
@@ -1,0 +1,340 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_LibraryCrudOperationsReflectOnTerrain",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1068457357332]": {
+            "Id": "Entity_[1068457357332]",
+            "Name": "on_modified",
+            "Components": {
+                "Component_[12063240711932650080]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12063240711932650080,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            58.0,
+                            32.5
+                        ]
+                    }
+                },
+                "Component_[13442813569909489956]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13442813569909489956
+                },
+                "Component_[15666061343131544818]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15666061343131544818
+                },
+                "Component_[16384515596170070435]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16384515596170070435
+                },
+                "Component_[16397672764670496797]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16397672764670496797
+                },
+                "Component_[2337899965711777946]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2337899965711777946
+                },
+                "Component_[2408415195615352299]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2408415195615352299,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3890482968722605487]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3890482968722605487
+                },
+                "Component_[4055393434497673146]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4055393434497673146,
+                    "GameView": true
+                },
+                "Component_[6482830287068289176]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6482830287068289176,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[7597144335784772444]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7597144335784772444,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12063240711932650080
+                        },
+                        {
+                            "ComponentId": 4055393434497673146,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2408415195615352299,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6482830287068289176,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[7769497401063477266]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7769497401063477266
+                },
+                "Component_[935644539930837164]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 935644539930837164
+                }
+            }
+        },
+        "Entity_[269593440276]": {
+            "Id": "Entity_[269593440276]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 6648226279942713114,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[6250324283699746138]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6250324283699746138
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[321133047828]": {
+            "Id": "Entity_[321133047828]",
+            "Name": "on_default",
+            "Components": {
+                "Component_[12063240711932650080]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12063240711932650080,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            32.5
+                        ]
+                    }
+                },
+                "Component_[13442813569909489956]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13442813569909489956
+                },
+                "Component_[15666061343131544818]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15666061343131544818
+                },
+                "Component_[16384515596170070435]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16384515596170070435
+                },
+                "Component_[16397672764670496797]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16397672764670496797
+                },
+                "Component_[2337899965711777946]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2337899965711777946
+                },
+                "Component_[2408415195615352299]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 2408415195615352299,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3890482968722605487]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3890482968722605487
+                },
+                "Component_[4055393434497673146]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4055393434497673146,
+                    "GameView": true
+                },
+                "Component_[6482830287068289176]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6482830287068289176,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 0.0,
+                        "Compute Mass": false,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[7597144335784772444]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7597144335784772444,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12063240711932650080
+                        },
+                        {
+                            "ComponentId": 4055393434497673146,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 2408415195615352299,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6482830287068289176,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[7769497401063477266]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7769497401063477266
+                },
+                "Component_[935644539930837164]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 935644539930837164
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/0/0.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/0/0.prefab
@@ -1,0 +1,514 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "0",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[264789916205]": {
+            "Id": "Entity_[264789916205]",
+            "Name": "delete_sphere",
+            "Components": {
+                "Component_[13283763866324553532]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13283763866324553532
+                },
+                "Component_[13768910835395039194]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13768910835395039194,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6892324455403945249
+                        },
+                        {
+                            "ComponentId": 4355996461495376905,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15801860688188820006,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14945683669767088243,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[14945683669767088243]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14945683669767088243,
+                    "GameView": true
+                },
+                "Component_[15368407803325784956]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15368407803325784956
+                },
+                "Component_[15801860688188820006]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 15801860688188820006,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[15836496613906916845]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15836496613906916845
+                },
+                "Component_[16597972522349022176]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16597972522349022176
+                },
+                "Component_[17890758700265187382]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17890758700265187382
+                },
+                "Component_[2194137972938231887]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2194137972938231887
+                },
+                "Component_[4355996461495376905]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4355996461495376905,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4731025796475530857]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4731025796475530857
+                },
+                "Component_[6892324455403945249]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6892324455403945249,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            535.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[8043870790188508109]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8043870790188508109
+                }
+            }
+        },
+        "Entity_[272586630199]": {
+            "Id": "Entity_[272586630199]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3552038377029839116]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3552038377029839116
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[281176564791]": {
+            "Id": "Entity_[281176564791]",
+            "Name": "modify_sphere",
+            "Components": {
+                "Component_[13283763866324553532]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13283763866324553532
+                },
+                "Component_[13768910835395039194]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13768910835395039194,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6892324455403945249
+                        },
+                        {
+                            "ComponentId": 4355996461495376905,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15801860688188820006,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14945683669767088243,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[14945683669767088243]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14945683669767088243,
+                    "GameView": true
+                },
+                "Component_[15368407803325784956]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15368407803325784956
+                },
+                "Component_[15801860688188820006]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 15801860688188820006,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[15836496613906916845]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15836496613906916845
+                },
+                "Component_[16597972522349022176]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16597972522349022176
+                },
+                "Component_[17890758700265187382]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17890758700265187382
+                },
+                "Component_[2194137972938231887]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2194137972938231887
+                },
+                "Component_[4355996461495376905]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4355996461495376905,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4731025796475530857]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4731025796475530857
+                },
+                "Component_[6892324455403945249]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6892324455403945249,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[8043870790188508109]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8043870790188508109
+                }
+            }
+        },
+        "Entity_[323759304911]": {
+            "Id": "Entity_[323759304911]",
+            "Name": "trigger",
+            "Components": {
+                "Component_[1050289664219159184]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1050289664219159184,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9887670603324237690
+                        },
+                        {
+                            "ComponentId": 8196625280592793317,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 13525843115778417206,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[10871399259191966069]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10871399259191966069
+                },
+                "Component_[12515684864447251759]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12515684864447251759
+                },
+                "Component_[13525843115778417206]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 13525843115778417206,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                5.0,
+                                10.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[14594864599053887741]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14594864599053887741
+                },
+                "Component_[17528928375330580470]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17528928375330580470
+                },
+                "Component_[1878013952443381068]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1878013952443381068
+                },
+                "Component_[3078346116579265539]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3078346116579265539
+                },
+                "Component_[4904090692018630100]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4904090692018630100
+                },
+                "Component_[7960354929538954982]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7960354929538954982
+                },
+                "Component_[8196625280592793317]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 8196625280592793317,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                5.0,
+                                10.0,
+                                0.27000001072883606
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Configuration": {
+                                "AssetScale": [
+                                    5.0,
+                                    10.0,
+                                    0.25
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[9887670603324237690]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9887670603324237690,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            532.5,
+                            37.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[401435649079]": {
+            "Id": "Entity_[401435649079]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[10600125948162734477]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10600125948162734477
+                },
+                "Component_[11608508148608783557]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11608508148608783557
+                },
+                "Component_[13364083755949444301]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13364083755949444301
+                },
+                "Component_[14205173885379775139]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14205173885379775139
+                },
+                "Component_[14473011574473392330]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14473011574473392330
+                },
+                "Component_[14655437163550715333]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14655437163550715333,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14745384092448301210
+                        },
+                        {
+                            "ComponentId": 10382880065917225938,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[14745384092448301210]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14745384092448301210,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            530.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[17091889001278130304]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17091889001278130304
+                },
+                "Component_[2029679326492259668]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2029679326492259668
+                },
+                "Component_[6843859049760163738]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6843859049760163738
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/1/1.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryUpdatedAcrossLevels/1/1.prefab
@@ -1,0 +1,505 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "1",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[258566956692]": {
+            "Id": "Entity_[258566956692]",
+            "Name": "trigger",
+            "Components": {
+                "Component_[10838929952987945603]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10838929952987945603,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                5.0,
+                                10.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[1123857429414571971]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1123857429414571971,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                5.0,
+                                10.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[12789356655754661713]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12789356655754661713,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            532.5,
+                            37.0
+                        ]
+                    }
+                },
+                "Component_[14008409169411839836]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14008409169411839836
+                },
+                "Component_[14271127770049628743]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14271127770049628743,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12789356655754661713
+                        },
+                        {
+                            "ComponentId": 10838929952987945603,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1123857429414571971,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[17871090743916940997]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17871090743916940997
+                },
+                "Component_[18263618414370492472]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18263618414370492472
+                },
+                "Component_[4769459002306564121]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4769459002306564121
+                },
+                "Component_[6842026349006198912]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6842026349006198912
+                },
+                "Component_[7032746559459810857]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7032746559459810857
+                },
+                "Component_[8337730768526893029]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8337730768526893029
+                },
+                "Component_[9124821875600387219]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9124821875600387219
+                }
+            }
+        },
+        "Entity_[272586630199]": {
+            "Id": "Entity_[272586630199]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3552038377029839116]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3552038377029839116
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[281176564791]": {
+            "Id": "Entity_[281176564791]",
+            "Name": "delete_sphere",
+            "Components": {
+                "Component_[13283763866324553532]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13283763866324553532
+                },
+                "Component_[13768910835395039194]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13768910835395039194,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6892324455403945249
+                        },
+                        {
+                            "ComponentId": 4355996461495376905,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15801860688188820006,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14945683669767088243,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[14945683669767088243]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14945683669767088243,
+                    "GameView": true
+                },
+                "Component_[15368407803325784956]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15368407803325784956
+                },
+                "Component_[15801860688188820006]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 15801860688188820006,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[15836496613906916845]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15836496613906916845
+                },
+                "Component_[16597972522349022176]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16597972522349022176
+                },
+                "Component_[17890758700265187382]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17890758700265187382
+                },
+                "Component_[2194137972938231887]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2194137972938231887
+                },
+                "Component_[4355996461495376905]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4355996461495376905,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4731025796475530857]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4731025796475530857
+                },
+                "Component_[6892324455403945249]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6892324455403945249,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[8043870790188508109]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8043870790188508109
+                }
+            }
+        },
+        "Entity_[401435649079]": {
+            "Id": "Entity_[401435649079]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[10600125948162734477]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10600125948162734477
+                },
+                "Component_[11608508148608783557]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11608508148608783557
+                },
+                "Component_[13364083755949444301]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13364083755949444301
+                },
+                "Component_[14205173885379775139]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14205173885379775139
+                },
+                "Component_[14473011574473392330]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14473011574473392330
+                },
+                "Component_[14655437163550715333]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14655437163550715333,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14745384092448301210
+                        },
+                        {
+                            "ComponentId": 10382880065917225938,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[14745384092448301210]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14745384092448301210,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            530.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[17091889001278130304]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17091889001278130304
+                },
+                "Component_[2029679326492259668]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2029679326492259668
+                },
+                "Component_[6843859049760163738]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6843859049760163738
+                }
+            }
+        },
+        "Entity_[737236318765]": {
+            "Id": "Entity_[737236318765]",
+            "Name": "modify_sphere",
+            "Components": {
+                "Component_[13283763866324553532]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13283763866324553532
+                },
+                "Component_[13768910835395039194]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13768910835395039194,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6892324455403945249
+                        },
+                        {
+                            "ComponentId": 4355996461495376905,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15801860688188820006,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 14945683669767088243,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[14945683669767088243]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14945683669767088243,
+                    "GameView": true
+                },
+                "Component_[15368407803325784956]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15368407803325784956
+                },
+                "Component_[15801860688188820006]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 15801860688188820006,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[15836496613906916845]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15836496613906916845
+                },
+                "Component_[16597972522349022176]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16597972522349022176
+                },
+                "Component_[17890758700265187382]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17890758700265187382
+                },
+                "Component_[2194137972938231887]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2194137972938231887
+                },
+                "Component_[4355996461495376905]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4355996461495376905,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4731025796475530857]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4731025796475530857
+                },
+                "Component_[6892324455403945249]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6892324455403945249,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            535.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[8043870790188508109]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8043870790188508109
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_RagdollBones/Material_RagdollBones.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_RagdollBones/Material_RagdollBones.prefab
@@ -1,0 +1,426 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_RagdollBones",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[264055852606]": {
+            "Id": "Entity_[264055852606]",
+            "Name": "Concrete Ragdoll",
+            "Components": {
+                "Component_[11451652018825216748]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11451652018825216748
+                },
+                "Component_[12334266845701483067]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12334266845701483067,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[125629283710930287]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 125629283710930287
+                },
+                "Component_[13472203310961076026]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13472203310961076026,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            62.0,
+                            64.0,
+                            34.72864532470703
+                        ],
+                        "Rotate": [
+                            90.0,
+                            0.00000960000033956021,
+                            7.125417232513428
+                        ]
+                    }
+                },
+                "Component_[15477458438279713223]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15477458438279713223
+                },
+                "Component_[16820598479284110143]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16820598479284110143,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13472203310961076026
+                        },
+                        {
+                            "ComponentId": 17605851486708743694,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9608781458903523320,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 12334266845701483067,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17326817116380613649]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17326817116380613649
+                },
+                "Component_[17605851486708743694]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 17605851486708743694,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{A4603DC6-8465-552D-A83E-B4EC7ED735CA}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_concrete/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_concrete/concrete.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_concrete/concrete.mtl"
+                    },
+                    "AttachmentTarget": ""
+                },
+                "Component_[673926832579344982]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 673926832579344982
+                },
+                "Component_[7389125836440846093]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7389125836440846093
+                },
+                "Component_[886011054758218213]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 886011054758218213
+                },
+                "Component_[9237669932190470399]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9237669932190470399
+                },
+                "Component_[9608781458903523320]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 9608781458903523320,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{24AB103C-C5DB-51A0-BEE1-CA0AFACD4267}"
+                        },
+                        "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_concrete/animgraphphysx.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{BD4BBD7C-5126-5172-A660-CA8292B83475}"
+                        },
+                        "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_concrete/rinlocomotion.motionset"
+                    },
+                    "ActiveMotionSetName": "MotionSet1"
+                }
+            }
+        },
+        "Entity_[268350819902]": {
+            "Id": "Entity_[268350819902]",
+            "Name": "PhysX Terrain",
+            "Components": {
+                "Component_[10780143927672919477]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10780143927672919477
+                },
+                "Component_[11432115963825126951]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11432115963825126951
+                },
+                "Component_[1365374619742748417]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1365374619742748417
+                },
+                "Component_[13764320959482640799]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13764320959482640799
+                },
+                "Component_[14661909163484522903]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14661909163484522903
+                },
+                "Component_[15750293542299007902]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 15750293542299007902,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17850420510072144368
+                        },
+                        {
+                            "ComponentId": 8993693402819244535,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17850420510072144368]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17850420510072144368,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[18132510613169190178]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18132510613169190178
+                },
+                "Component_[8531319443213679278]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8531319443213679278
+                },
+                "Component_[8743651980659628746]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8743651980659628746
+                }
+            }
+        },
+        "Entity_[273611165354]": {
+            "Id": "Entity_[273611165354]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13412501984183209535]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13412501984183209535
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[678163502462]": {
+            "Id": "Entity_[678163502462]",
+            "Name": "Rubber Ragdoll",
+            "Components": {
+                "Component_[11451652018825216748]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11451652018825216748
+                },
+                "Component_[12334266845701483067]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12334266845701483067,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[125629283710930287]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 125629283710930287
+                },
+                "Component_[13472203310961076026]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 13472203310961076026,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            66.0,
+                            64.0,
+                            34.72864532470703
+                        ],
+                        "Rotate": [
+                            90.00000762939453,
+                            0.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            1.0,
+                            0.9999998807907104,
+                            0.9999998807907104
+                        ]
+                    }
+                },
+                "Component_[15477458438279713223]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15477458438279713223
+                },
+                "Component_[16820598479284110143]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16820598479284110143,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 13472203310961076026
+                        },
+                        {
+                            "ComponentId": 17605851486708743694,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9608781458903523320,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 12334266845701483067,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[17326817116380613649]": {
+                    "$type": "SelectionComponent",
+                    "Id": 17326817116380613649
+                },
+                "Component_[17605851486708743694]": {
+                    "$type": "EditorActorComponent",
+                    "Id": 17605851486708743694,
+                    "ActorAsset": {
+                        "assetId": {
+                            "guid": "{1E09256A-6474-56BD-9A35-2689CED10FB3}",
+                            "subId": 3760641326
+                        },
+                        "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_rubber/rin_skeleton_newgeo.actor"
+                    },
+                    "MaterialPerLOD": [
+                        {
+                            "AssetPath": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_rubber/rubber.mtl"
+                        }
+                    ],
+                    "MaterialPerActor": {
+                        "AssetPath": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_rubber/rubber.mtl"
+                    },
+                    "AttachmentTarget": ""
+                },
+                "Component_[673926832579344982]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 673926832579344982
+                },
+                "Component_[7389125836440846093]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7389125836440846093
+                },
+                "Component_[886011054758218213]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 886011054758218213
+                },
+                "Component_[9237669932190470399]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9237669932190470399
+                },
+                "Component_[9608781458903523320]": {
+                    "$type": "EditorAnimGraphComponent",
+                    "Id": 9608781458903523320,
+                    "AnimGraphAsset": {
+                        "assetId": {
+                            "guid": "{E03F4FC0-7674-5ED4-86E2-FCCFDCD4C100}"
+                        },
+                        "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_rubber/animgraphphysx.animgraph"
+                    },
+                    "MotionSetAsset": {
+                        "assetId": {
+                            "guid": "{0FAF569D-035C-50D7-93C0-888567ABDAFE}"
+                        },
+                        "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/ragdoll_rubber/rinlocomotion.motionset"
+                    },
+                    "ActiveMotionSetName": "MotionSet1"
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_StaticFriction/Material_StaticFriction.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_StaticFriction/Material_StaticFriction.prefab
@@ -1,0 +1,645 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Material_StaticFriction",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[466424751606]": {
+            "Id": "Entity_[466424751606]",
+            "Name": "Ramp",
+            "Components": {
+                "Component_[10327124523666310780]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10327124523666310780
+                },
+                "Component_[11959116158231937437]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 11959116158231937437,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        }
+                    }
+                },
+                "Component_[12451510204722203961]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12451510204722203961,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13396737954818371455]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13396737954818371455
+                },
+                "Component_[14094079953882345085]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14094079953882345085
+                },
+                "Component_[15151923958895865240]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15151923958895865240
+                },
+                "Component_[2374380279612689881]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2374380279612689881,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.5
+                        ]
+                    }
+                },
+                "Component_[2585829855117783008]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2585829855117783008
+                },
+                "Component_[354263134058746381]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 354263134058746381,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2374380279612689881
+                        },
+                        {
+                            "ComponentId": 4637782058154060578,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12451510204722203961,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11959116158231937437,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4114026138788506526]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4114026138788506526
+                },
+                "Component_[4637782058154060578]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4637782058154060578,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                50.0,
+                                50.0,
+                                0.5
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "Scale": [
+                                    20.0,
+                                    5.0,
+                                    0.20000000298023224
+                                ],
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                },
+                                "AssetScale": [
+                                    1.0010000467300415,
+                                    1.000999927520752,
+                                    1.0
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Component_[6437575279376969517]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6437575279376969517
+                },
+                "Component_[6480033008069026308]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6480033008069026308
+                }
+            }
+        },
+        "Entity_[470719718902]": {
+            "Id": "Entity_[470719718902]",
+            "Name": "Zero",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Sleep threshold": 0.00009999999747378752,
+                        "Compute Mass": false,
+                        "Mass": 10.0,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            530.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[690315902361]": {
+            "Id": "Entity_[690315902361]",
+            "Name": "Low",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Sleep threshold": 0.00009999999747378752,
+                        "Compute Mass": false,
+                        "Mass": 10.0,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            532.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[694610869657]": {
+            "Id": "Entity_[694610869657]",
+            "Name": "Mid",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Sleep threshold": 0.00009999999747378752,
+                        "Compute Mass": false,
+                        "Mass": 10.0,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            534.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        },
+        "Entity_[698905836953]": {
+            "Id": "Entity_[698905836953]",
+            "Name": "High",
+            "Components": {
+                "Component_[1023574085031020591]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 1023574085031020591,
+                    "GameView": true
+                },
+                "Component_[10363299452777111055]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10363299452777111055,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3145706138697924441
+                        },
+                        {
+                            "ComponentId": 11469830523341831478,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16270212748521211284,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1023574085031020591,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[10516303889368809827]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10516303889368809827
+                },
+                "Component_[11252974442733513437]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11252974442733513437
+                },
+                "Component_[11469830523341831478]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11469830523341831478,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 0.0,
+                        "Angular damping": 0.0,
+                        "Sleep threshold": 0.00009999999747378752,
+                        "Compute Mass": false,
+                        "Mass": 10.0,
+                        "Compute COM": false,
+                        "Centre of mass offset": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "Debug Draw Center of Mass": true
+                    }
+                },
+                "Component_[14489129428014319742]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14489129428014319742
+                },
+                "Component_[16041525411193662409]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16041525411193662409
+                },
+                "Component_[16150027655784373243]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16150027655784373243
+                },
+                "Component_[16270212748521211284]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16270212748521211284,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[3145706138697924441]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3145706138697924441,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            490.0000305175781,
+                            536.0,
+                            40.25
+                        ]
+                    }
+                },
+                "Component_[4617797181782904654]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4617797181782904654
+                },
+                "Component_[6856403602110832659]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6856403602110832659
+                },
+                "Component_[8608623946578987367]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8608623946578987367
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Physics_WorldBodyBusWorksOnEditorComponents/Physics_WorldBodyBusWorksOnEditorComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/Physics_WorldBodyBusWorksOnEditorComponents/Physics_WorldBodyBusWorksOnEditorComponents.prefab
@@ -1,0 +1,944 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Physics_WorldBodyBusWorksOnEditorComponents",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[367907818018]": {
+            "Id": "Entity_[367907818018]",
+            "Name": "Box",
+            "Components": {
+                "Component_[16300212154464470531]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16300212154464470531,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5039778416348640269]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 5039778416348640269,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.32421875,
+                            530.1578979492188,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 5039778416348640269,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16300212154464470531,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[372202785314]": {
+            "Id": "Entity_[372202785314]",
+            "Name": "StaticBox",
+            "Components": {
+                "Component_[10271136976310200923]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10271136976310200923,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.579833984375,
+                            530.1578979492188,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 10271136976310200923,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[376497752610]": {
+            "Id": "Entity_[376497752610]",
+            "Name": "StaticSphere",
+            "Components": {
+                "Component_[10271136976310200923]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10271136976310200923,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.579833984375,
+                            526.8870849609375,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 10271136976310200923,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[380792719906]": {
+            "Id": "Entity_[380792719906]",
+            "Name": "Sphere",
+            "Components": {
+                "Component_[16300212154464470531]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16300212154464470531,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5039778416348640269]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 5039778416348640269,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.32421875,
+                            526.8870849609375,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 5039778416348640269,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16300212154464470531,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[385087687202]": {
+            "Id": "Entity_[385087687202]",
+            "Name": "StaticCapsule",
+            "Components": {
+                "Component_[10271136976310200923]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10271136976310200923,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 2
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.579833984375,
+                            533.9490356445313,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 10271136976310200923,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[389382654498]": {
+            "Id": "Entity_[389382654498]",
+            "Name": "Capsule",
+            "Components": {
+                "Component_[16300212154464470531]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16300212154464470531,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 2
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5039778416348640269]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 5039778416348640269,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.32421875,
+                            533.9490356445313,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 5039778416348640269,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16300212154464470531,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[393677621794]": {
+            "Id": "Entity_[393677621794]",
+            "Name": "StaticMesh",
+            "Components": {
+                "Component_[10271136976310200923]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 10271136976310200923,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
+                                    "subId": 1454228742
+                                },
+                                "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
+                                        "subId": 1454228742
+                                    },
+                                    "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.579833984375,
+                            538.2955932617188,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 10271136976310200923,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[397972589090]": {
+            "Id": "Entity_[397972589090]",
+            "Name": "Mesh",
+            "Components": {
+                "Component_[16300212154464470531]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16300212154464470531,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
+                                    "subId": 1454228742
+                                },
+                                "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{6B6C2A7C-DC44-54F6-8A30-DA370189C11B}",
+                                        "subId": 1454228742
+                                    },
+                                    "assetHint": "levels/physics/c29032500_editorcomponents_worldbodybusworks/physxsedan/_dev_sedan_r0-b.pxmesh"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5039778416348640269]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 5039778416348640269,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.32421875,
+                            538.2955932617188,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 5039778416348640269,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 16300212154464470531,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        },
+        "Entity_[535411542562]": {
+            "Id": "Entity_[535411542562]",
+            "Name": "ShapeBox",
+            "Components": {
+                "Component_[13537223427520009753]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 13537223427520009753
+                },
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[5039778416348640269]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 5039778416348640269,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.32421875,
+                            523.5823364257813,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 5039778416348640269,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9011838012457954872,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 13537223427520009753,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                },
+                "Component_[9011838012457954872]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 9011838012457954872,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration"
+                        }
+                    ]
+                }
+            }
+        },
+        "Entity_[539706509858]": {
+            "Id": "Entity_[539706509858]",
+            "Name": "StaticShapeBox",
+            "Components": {
+                "Component_[17486590914851669702]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17486590914851669702
+                },
+                "Component_[17487900436023939565]": {
+                    "$type": "EditorShapeColliderComponent",
+                    "Id": 17487900436023939565,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfigs": [
+                        {
+                            "$type": "BoxShapeConfiguration"
+                        }
+                    ]
+                },
+                "Component_[2355668156940730228]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2355668156940730228
+                },
+                "Component_[2801111889414931848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2801111889414931848
+                },
+                "Component_[4403703683034890123]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 4403703683034890123
+                },
+                "Component_[4635575268560658898]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 4635575268560658898
+                },
+                "Component_[5115055889801448541]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5115055889801448541,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.579833984375,
+                            523.5823364257813,
+                            33.314109802246094
+                        ]
+                    }
+                },
+                "Component_[5743451229161796048]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5743451229161796048
+                },
+                "Component_[6813315874512071748]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6813315874512071748
+                },
+                "Component_[7662566943517188147]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7662566943517188147,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5115055889801448541
+                        },
+                        {
+                            "ComponentId": 17487900436023939565,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4635575268560658898,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[7727668093466019223]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7727668093466019223
+                },
+                "Component_[7787160929786176144]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7787160929786176144
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Ragdoll_OldRagdollSerializationNoErrors/Ragdoll_OldRagdollSerializationNoErrors.prefab
+++ b/AutomatedTesting/Levels/Physics/Ragdoll_OldRagdollSerializationNoErrors/Ragdoll_OldRagdollSerializationNoErrors.prefab
@@ -1,0 +1,188 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Ragdoll_OldRagdollSerializationNoErrors",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[250898471366]": {
+            "Id": "Entity_[250898471366]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[4621689348269009090]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4621689348269009090
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0999755859375,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[259488405958]": {
+            "Id": "Entity_[259488405958]",
+            "Name": "Ragdoll",
+            "Components": {
+                "Component_[11143644425727218274]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11143644425727218274
+                },
+                "Component_[12006693116600544416]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12006693116600544416
+                },
+                "Component_[12278528218722397131]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 12278528218722397131,
+                    "m_template": {
+                        "$type": "PhysX::RagdollComponent"
+                    }
+                },
+                "Component_[14337669518987722325]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14337669518987722325
+                },
+                "Component_[15914750685177685465]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15914750685177685465
+                },
+                "Component_[16417428937981244570]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16417428937981244570,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3352725021105555874
+                        },
+                        {
+                            "ComponentId": 12278528218722397131,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[3352725021105555874]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3352725021105555874,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[4779565506241811757]": {
+                    "$type": "SelectionComponent",
+                    "Id": 4779565506241811757
+                },
+                "Component_[6151707582483331535]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 6151707582483331535
+                },
+                "Component_[682344866867843985]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 682344866867843985
+                },
+                "Component_[8940447728239893033]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8940447728239893033
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/RigidBody_LinearDampingAffectsMotion/RigidBody_LinearDampingAffectsMotion.prefab
+++ b/AutomatedTesting/Levels/Physics/RigidBody_LinearDampingAffectsMotion/RigidBody_LinearDampingAffectsMotion.prefab
@@ -1,0 +1,660 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "RigidBody_LinearDampingAffectsMotion",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[261241062587]": {
+            "Id": "Entity_[261241062587]",
+            "Name": "Trigger1",
+            "Components": {
+                "Component_[10904551616375160623]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10904551616375160623
+                },
+                "Component_[11009491042829657860]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11009491042829657860
+                },
+                "Component_[11805321832125191208]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11805321832125191208,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17708193097712213074
+                        },
+                        {
+                            "ComponentId": 11870564076933940051,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15267130334138395966,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15251041960189410484]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15251041960189410484
+                },
+                "Component_[15267130334138395966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 15267130334138395966,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Scale": [
+                                3.0,
+                                3.0,
+                                3.0
+                            ],
+                            "Configuration": [
+                                0.460999995470047,
+                                0.460999995470047,
+                                0.00009999999747378752
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Configuration": {
+                                "Scale": [
+                                    3.0,
+                                    3.0,
+                                    3.0
+                                ],
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "Component_[17106484645172612912]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17106484645172612912
+                },
+                "Component_[17708193097712213074]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17708193097712213074,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            92.9990005493164,
+                            100.5999984741211,
+                            40.099998474121094
+                        ],
+                        "Rotate": [
+                            0.0,
+                            270.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            3.0,
+                            3.0,
+                            3.0
+                        ],
+                        "UniformScale": 3.0
+                    }
+                },
+                "Component_[4252376017882677834]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4252376017882677834
+                },
+                "Component_[4550006388201929911]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4550006388201929911
+                },
+                "Component_[7566595799749134094]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7566595799749134094
+                },
+                "Component_[8818011697750170772]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8818011697750170772
+                }
+            }
+        },
+        "Entity_[267317880208]": {
+            "Id": "Entity_[267317880208]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3014003324858039654]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3014003324858039654
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[275907814800]": {
+            "Id": "Entity_[275907814800]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[13959461383545993831]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13959461383545993831
+                },
+                "Component_[14284355951818281828]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14284355951818281828
+                },
+                "Component_[14491932256728454678]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14491932256728454678,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5769143411507559894
+                        },
+                        {
+                            "ComponentId": 3542857759455016342,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 17402815682744232463,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[14532080444774604174]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14532080444774604174
+                },
+                "Component_[15460193905310649551]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15460193905310649551
+                },
+                "Component_[2810289078252205415]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2810289078252205415
+                },
+                "Component_[3411841210940475918]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3411841210940475918
+                },
+                "Component_[3701699266693432591]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3701699266693432591
+                },
+                "Component_[4812474930202994623]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4812474930202994623
+                },
+                "Component_[5769143411507559894]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5769143411507559894,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            100.0,
+                            100.0,
+                            32.0
+                        ],
+                        "Scale": [
+                            10.0,
+                            10.0,
+                            0.05000000074505806
+                        ],
+                        "UniformScale": 10.0
+                    },
+                    "IsStatic": true
+                }
+            }
+        },
+        "Entity_[314185627059]": {
+            "Id": "Entity_[314185627059]",
+            "Name": "Trigger2",
+            "Components": {
+                "Component_[10904551616375160623]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10904551616375160623
+                },
+                "Component_[11009491042829657860]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11009491042829657860
+                },
+                "Component_[11805321832125191208]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11805321832125191208,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17708193097712213074
+                        },
+                        {
+                            "ComponentId": 11870564076933940051,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15267130334138395966,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15251041960189410484]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15251041960189410484
+                },
+                "Component_[15267130334138395966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 15267130334138395966,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Scale": [
+                                3.0,
+                                3.0,
+                                3.0
+                            ],
+                            "Configuration": [
+                                0.5,
+                                0.5,
+                                0.00009999999747378752
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Configuration": {
+                                "Scale": [
+                                    3.0,
+                                    3.0,
+                                    3.0
+                                ],
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "Component_[17106484645172612912]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17106484645172612912
+                },
+                "Component_[17708193097712213074]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17708193097712213074,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            93.19999694824219,
+                            100.19999694824219,
+                            40.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            270.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            3.0,
+                            3.0,
+                            3.0
+                        ],
+                        "UniformScale": 3.0
+                    }
+                },
+                "Component_[4252376017882677834]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4252376017882677834
+                },
+                "Component_[4550006388201929911]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4550006388201929911
+                },
+                "Component_[7566595799749134094]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7566595799749134094
+                },
+                "Component_[8818011697750170772]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8818011697750170772
+                }
+            }
+        },
+        "Entity_[318480594355]": {
+            "Id": "Entity_[318480594355]",
+            "Name": "Trigger3",
+            "Components": {
+                "Component_[10904551616375160623]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10904551616375160623
+                },
+                "Component_[11009491042829657860]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11009491042829657860
+                },
+                "Component_[11805321832125191208]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11805321832125191208,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 17708193097712213074
+                        },
+                        {
+                            "ComponentId": 11870564076933940051,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 15267130334138395966,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[15251041960189410484]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15251041960189410484
+                },
+                "Component_[15267130334138395966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 15267130334138395966,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Scale": [
+                                3.0,
+                                3.0,
+                                3.0
+                            ],
+                            "Configuration": [
+                                0.5,
+                                0.5,
+                                0.00009999999747378752
+                            ]
+                        },
+                        "PhysicsAsset": {
+                            "Configuration": {
+                                "Scale": [
+                                    3.0,
+                                    3.0,
+                                    3.0
+                                ],
+                                "UseMaterialsFromAsset": false
+                            }
+                        }
+                    }
+                },
+                "Component_[17106484645172612912]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17106484645172612912
+                },
+                "Component_[17708193097712213074]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17708193097712213074,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            93.5,
+                            100.19999694824219,
+                            40.0
+                        ],
+                        "Rotate": [
+                            0.0,
+                            270.0,
+                            0.0
+                        ],
+                        "Scale": [
+                            3.0,
+                            3.0,
+                            3.0
+                        ],
+                        "UniformScale": 3.0
+                    }
+                },
+                "Component_[4252376017882677834]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4252376017882677834
+                },
+                "Component_[4550006388201929911]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4550006388201929911
+                },
+                "Component_[7566595799749134094]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7566595799749134094
+                },
+                "Component_[8818011697750170772]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8818011697750170772
+                }
+            }
+        },
+        "Entity_[421936702864]": {
+            "Id": "Entity_[421936702864]",
+            "Name": "Sphere",
+            "Components": {
+                "Component_[10571481803213158066]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10571481803213158066
+                },
+                "Component_[10609293005894939915]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10609293005894939915
+                },
+                "Component_[13208852873506236611]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13208852873506236611
+                },
+                "Component_[13222097061619369926]": {
+                    "$type": "SelectionComponent",
+                    "Id": 13222097061619369926
+                },
+                "Component_[14812140231390143898]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14812140231390143898
+                },
+                "Component_[1504629059616604220]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 1504629059616604220,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            5.0,
+                            0.0,
+                            0.0
+                        ],
+                        "Linear damping": 5.0,
+                        "Start Asleep": true,
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Mass": 5.0
+                    }
+                },
+                "Component_[16066027089711095181]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16066027089711095181,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{CFE4F3C6-0553-5489-A3D9-5372D800C577}",
+                                    "subId": 1
+                                },
+                                "assetHint": "editor/objects/sphere.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{CFE4F3C6-0553-5489-A3D9-5372D800C577}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "editor/objects/sphere.pxmesh"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[3854758958560909320]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3854758958560909320
+                },
+                "Component_[4560374219963511913]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4560374219963511913,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            92.42377471923828,
+                            100.33763122558594,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[5166440709260761329]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5166440709260761329,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4560374219963511913
+                        },
+                        {
+                            "ComponentId": 16066027089711095181,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1504629059616604220,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 2147921642803419861,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6252902138496947806]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6252902138496947806
+                },
+                "Component_[9806649135338314312]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9806649135338314312
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_OverlapNode/ScriptCanvas_OverlapNode.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_OverlapNode/ScriptCanvas_OverlapNode.prefab
@@ -1,0 +1,7206 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "ScriptCanvas_OverlapNode",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[18014764943288]": {
+            "Id": "Entity_[18014764943288]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2541727186101753017]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2541727186101753017
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[18023354877880]": {
+            "Id": "Entity_[18023354877880]",
+            "Name": "Sphere_0_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18027649845176]": {
+            "Id": "Entity_[18027649845176]",
+            "Name": "Sphere_0_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18031944812472]": {
+            "Id": "Entity_[18031944812472]",
+            "Name": "Sphere_0_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18036239779768]": {
+            "Id": "Entity_[18036239779768]",
+            "Name": "Sphere_0_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18040534747064]": {
+            "Id": "Entity_[18040534747064]",
+            "Name": "Sphere_0_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18044829714360]": {
+            "Id": "Entity_[18044829714360]",
+            "Name": "Sphere_0_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18049124681656]": {
+            "Id": "Entity_[18049124681656]",
+            "Name": "Sphere_1_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18053419648952]": {
+            "Id": "Entity_[18053419648952]",
+            "Name": "Sphere_1_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18057714616248]": {
+            "Id": "Entity_[18057714616248]",
+            "Name": "Sphere_1_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18062009583544]": {
+            "Id": "Entity_[18062009583544]",
+            "Name": "Sphere_1_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18066304550840]": {
+            "Id": "Entity_[18066304550840]",
+            "Name": "Sphere_1_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18070599518136]": {
+            "Id": "Entity_[18070599518136]",
+            "Name": "Sphere_1_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18074894485432]": {
+            "Id": "Entity_[18074894485432]",
+            "Name": "Sphere_2_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18079189452728]": {
+            "Id": "Entity_[18079189452728]",
+            "Name": "Sphere_2_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18083484420024]": {
+            "Id": "Entity_[18083484420024]",
+            "Name": "Sphere_2_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18087779387320]": {
+            "Id": "Entity_[18087779387320]",
+            "Name": "Sphere_2_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18092074354616]": {
+            "Id": "Entity_[18092074354616]",
+            "Name": "Sphere_2_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18096369321912]": {
+            "Id": "Entity_[18096369321912]",
+            "Name": "Sphere_2_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18100664289208]": {
+            "Id": "Entity_[18100664289208]",
+            "Name": "Sphere_3_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18104959256504]": {
+            "Id": "Entity_[18104959256504]",
+            "Name": "Sphere_3_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18109254223800]": {
+            "Id": "Entity_[18109254223800]",
+            "Name": "Sphere_3_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18113549191096]": {
+            "Id": "Entity_[18113549191096]",
+            "Name": "Sphere_3_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18117844158392]": {
+            "Id": "Entity_[18117844158392]",
+            "Name": "Sphere_3_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18122139125688]": {
+            "Id": "Entity_[18122139125688]",
+            "Name": "Sphere_3_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18126434092984]": {
+            "Id": "Entity_[18126434092984]",
+            "Name": "Sphere_4_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18130729060280]": {
+            "Id": "Entity_[18130729060280]",
+            "Name": "Sphere_4_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18135024027576]": {
+            "Id": "Entity_[18135024027576]",
+            "Name": "Sphere_4_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18139318994872]": {
+            "Id": "Entity_[18139318994872]",
+            "Name": "Sphere_4_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18143613962168]": {
+            "Id": "Entity_[18143613962168]",
+            "Name": "Sphere_4_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18147908929464]": {
+            "Id": "Entity_[18147908929464]",
+            "Name": "Sphere_4_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18152203896760]": {
+            "Id": "Entity_[18152203896760]",
+            "Name": "Sphere_5_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18156498864056]": {
+            "Id": "Entity_[18156498864056]",
+            "Name": "Sphere_5_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18160793831352]": {
+            "Id": "Entity_[18160793831352]",
+            "Name": "Sphere_5_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18165088798648]": {
+            "Id": "Entity_[18165088798648]",
+            "Name": "Sphere_5_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18169383765944]": {
+            "Id": "Entity_[18169383765944]",
+            "Name": "Sphere_5_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18173678733240]": {
+            "Id": "Entity_[18173678733240]",
+            "Name": "Sphere_5_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[18177973700536]": {
+            "Id": "Entity_[18177973700536]",
+            "Name": "Script_Canvas_Entity",
+            "Components": {
+                "Component_[11430789579056235624]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11430789579056235624
+                },
+                "Component_[134913747924094238]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 134913747924094238
+                },
+                "Component_[14035746630634393552]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14035746630634393552
+                },
+                "Component_[1566166581686414602]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1566166581686414602
+                },
+                "Component_[3238640815758608408]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3238640815758608408
+                },
+                "Component_[4760587474748632688]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4760587474748632688,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6057662559679579230
+                        },
+                        {
+                            "ComponentId": 9210710681276017259,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5416705945446256765]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5416705945446256765
+                },
+                "Component_[6007813224544176559]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 6007813224544176559
+                },
+                "Component_[6057662559679579230]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6057662559679579230,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.5,
+                            41.5
+                        ],
+                        "Rotate": [
+                            0.0,
+                            90.0,
+                            0.0
+                        ]
+                    }
+                },
+                "Component_[9210710681276017259]": {
+                    "$type": "EditorScriptCanvasComponent",
+                    "Id": 9210710681276017259,
+                    "m_name": "C12712454_ScriptCanvas_OverlapNodeVerification",
+                    "runtimeDataIsValid": true,
+                    "runtimeDataOverrides": {
+                        "source": {
+                            "id": "{C185A978-C1A5-5DCA-A747-54C939F77525}"
+                        }
+                    },
+                    "sourceHandle": {
+                        "id": "{C185A978-C1A5-5DCA-A747-54C939F77525}",
+                        "path": "scriptcanvas/c12712454_scriptcanvas_overlapnodeverification.scriptcanvas"
+                    }
+                },
+                "Component_[9591082614332177969]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9591082614332177969
+                }
+            }
+        },
+        "Entity_[312383844551]": {
+            "Id": "Entity_[312383844551]",
+            "Name": "Comm_From_Test_0",
+            "Components": {
+                "Component_[10706189483610288279]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10706189483610288279
+                },
+                "Component_[11014187326460258872]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11014187326460258872,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[13946194230066068622]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13946194230066068622,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1779081884649906030
+                        },
+                        {
+                            "ComponentId": 3722600517675068088,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 14656501100774816027,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 11014187326460258872,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[14656501100774816027]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 14656501100774816027,
+                    "GameView": true
+                },
+                "Component_[16690452742105884655]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16690452742105884655
+                },
+                "Component_[1779081884649906030]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1779081884649906030,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            515.0,
+                            525.0,
+                            50.0
+                        ]
+                    }
+                },
+                "Component_[17822787176040684459]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17822787176040684459
+                },
+                "Component_[2283612551706886971]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2283612551706886971
+                },
+                "Component_[2979807890426079534]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2979807890426079534
+                },
+                "Component_[3722600517675068088]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 3722600517675068088,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[6618845706525046536]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6618845706525046536
+                },
+                "Component_[8943672312656575179]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8943672312656575179
+                },
+                "Component_[9386084671311411633]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9386084671311411633
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[316678811847]": {
+            "Id": "Entity_[316678811847]",
+            "Name": "Comm_From_Test_1",
+            "Components": {
+                "Component_[10706189483610288279]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10706189483610288279
+                },
+                "Component_[11710089777842139075]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 11710089777842139075,
+                    "GameView": true
+                },
+                "Component_[13946194230066068622]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13946194230066068622,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1779081884649906030
+                        },
+                        {
+                            "ComponentId": 7370699876002520651,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11710089777842139075,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6854205315940143283,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16690452742105884655]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16690452742105884655
+                },
+                "Component_[1779081884649906030]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1779081884649906030,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.0,
+                            525.0,
+                            50.0
+                        ]
+                    }
+                },
+                "Component_[17822787176040684459]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17822787176040684459
+                },
+                "Component_[2283612551706886971]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2283612551706886971
+                },
+                "Component_[2979807890426079534]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2979807890426079534
+                },
+                "Component_[6618845706525046536]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6618845706525046536
+                },
+                "Component_[6854205315940143283]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6854205315940143283,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[7370699876002520651]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7370699876002520651,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[8943672312656575179]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8943672312656575179
+                },
+                "Component_[9386084671311411633]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9386084671311411633
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[320973779143]": {
+            "Id": "Entity_[320973779143]",
+            "Name": "Comm_From_Test_2",
+            "Components": {
+                "Component_[10605585003758887597]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 10605585003758887597,
+                    "GameView": true
+                },
+                "Component_[10706189483610288279]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10706189483610288279
+                },
+                "Component_[13946194230066068622]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13946194230066068622,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 1779081884649906030
+                        },
+                        {
+                            "ComponentId": 16489941890651842140,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10605585003758887597,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8527531733752008349,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[16489941890651842140]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 16489941890651842140,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[16690452742105884655]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16690452742105884655
+                },
+                "Component_[1779081884649906030]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 1779081884649906030,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            525.0,
+                            50.0
+                        ]
+                    }
+                },
+                "Component_[17822787176040684459]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17822787176040684459
+                },
+                "Component_[2283612551706886971]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2283612551706886971
+                },
+                "Component_[2979807890426079534]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2979807890426079534
+                },
+                "Component_[6618845706525046536]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6618845706525046536
+                },
+                "Component_[8527531733752008349]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8527531733752008349,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[8943672312656575179]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8943672312656575179
+                },
+                "Component_[9386084671311411633]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9386084671311411633
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[325268746439]": {
+            "Id": "Entity_[325268746439]",
+            "Name": "Comm_To_Test_0",
+            "Components": {
+                "Component_[10208275779338651033]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 10208275779338651033,
+                    "GameView": true
+                },
+                "Component_[10579061094402413909]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10579061094402413909
+                },
+                "Component_[12500224404758374945]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12500224404758374945
+                },
+                "Component_[12633946814443726046]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12633946814443726046
+                },
+                "Component_[13921253887642475085]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13921253887642475085
+                },
+                "Component_[13926465872760147078]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13926465872760147078
+                },
+                "Component_[17467027168476294187]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17467027168476294187
+                },
+                "Component_[3575042858546838271]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3575042858546838271,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5878178024961657998
+                        },
+                        {
+                            "ComponentId": 8184321601112499821,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10208275779338651033,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 9572012560283355653,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4947673063063877207]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4947673063063877207
+                },
+                "Component_[5878178024961657998]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5878178024961657998,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            515.0,
+                            525.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[7233516000061925521]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7233516000061925521
+                },
+                "Component_[8184321601112499821]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 8184321601112499821,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[9572012560283355653]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 9572012560283355653,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[329563713735]": {
+            "Id": "Entity_[329563713735]",
+            "Name": "Comm_To_Test_1",
+            "Components": {
+                "Component_[10579061094402413909]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10579061094402413909
+                },
+                "Component_[12185288554794743054]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 12185288554794743054,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[12500224404758374945]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12500224404758374945
+                },
+                "Component_[12633946814443726046]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12633946814443726046
+                },
+                "Component_[13921253887642475085]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13921253887642475085
+                },
+                "Component_[13926465872760147078]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13926465872760147078
+                },
+                "Component_[16376990579871092055]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 16376990579871092055,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[17467027168476294187]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17467027168476294187
+                },
+                "Component_[3575042858546838271]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3575042858546838271,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5878178024961657998
+                        },
+                        {
+                            "ComponentId": 12185288554794743054,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 9159038938233766639,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 16376990579871092055,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4947673063063877207]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4947673063063877207
+                },
+                "Component_[5878178024961657998]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5878178024961657998,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            510.0,
+                            525.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[7233516000061925521]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7233516000061925521
+                },
+                "Component_[9159038938233766639]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 9159038938233766639,
+                    "GameView": true
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[333858681031]": {
+            "Id": "Entity_[333858681031]",
+            "Name": "Comm_To_Test_2",
+            "Components": {
+                "Component_[10372907362920789655]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 10372907362920789655,
+                    "GameView": true
+                },
+                "Component_[10579061094402413909]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10579061094402413909
+                },
+                "Component_[12500224404758374945]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12500224404758374945
+                },
+                "Component_[12633946814443726046]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12633946814443726046
+                },
+                "Component_[13921253887642475085]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13921253887642475085
+                },
+                "Component_[13926465872760147078]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13926465872760147078
+                },
+                "Component_[17111080331680529331]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 17111080331680529331,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[17467027168476294187]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17467027168476294187
+                },
+                "Component_[3575042858546838271]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3575042858546838271,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5878178024961657998
+                        },
+                        {
+                            "ComponentId": 17111080331680529331,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10372907362920789655,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6068499565313040825,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[4947673063063877207]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4947673063063877207
+                },
+                "Component_[5878178024961657998]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5878178024961657998,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            525.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[6068499565313040825]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6068499565313040825,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[7233516000061925521]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7233516000061925521
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[47980751767480]": {
+            "Id": "Entity_[47980751767480]",
+            "Name": "Sphere_5_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[47985046734776]": {
+            "Id": "Entity_[47985046734776]",
+            "Name": "Sphere_4_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[47989341702072]": {
+            "Id": "Entity_[47989341702072]",
+            "Name": "Sphere_3_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[47993636669368]": {
+            "Id": "Entity_[47993636669368]",
+            "Name": "Sphere_2_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[47997931636664]": {
+            "Id": "Entity_[47997931636664]",
+            "Name": "Sphere_1_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48002226603960]": {
+            "Id": "Entity_[48002226603960]",
+            "Name": "Sphere_0_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48006521571256]": {
+            "Id": "Entity_[48006521571256]",
+            "Name": "Sphere_0_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            45.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48010816538552]": {
+            "Id": "Entity_[48010816538552]",
+            "Name": "Sphere_1_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            44.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48015111505848]": {
+            "Id": "Entity_[48015111505848]",
+            "Name": "Sphere_2_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            43.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48019406473144]": {
+            "Id": "Entity_[48019406473144]",
+            "Name": "Sphere_3_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            42.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48023701440440]": {
+            "Id": "Entity_[48023701440440]",
+            "Name": "Sphere_4_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            41.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48027996407736]": {
+            "Id": "Entity_[48027996407736]",
+            "Name": "Sphere_5_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            40.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48032291375032]": {
+            "Id": "Entity_[48032291375032]",
+            "Name": "Sphere_6_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48036586342328]": {
+            "Id": "Entity_[48036586342328]",
+            "Name": "Sphere_6_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48040881309624]": {
+            "Id": "Entity_[48040881309624]",
+            "Name": "Sphere_6_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48049471244216]": {
+            "Id": "Entity_[48049471244216]",
+            "Name": "Sphere_6_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48053766211512]": {
+            "Id": "Entity_[48053766211512]",
+            "Name": "Sphere_6_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48058061178808]": {
+            "Id": "Entity_[48058061178808]",
+            "Name": "Sphere_6_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48062356146104]": {
+            "Id": "Entity_[48062356146104]",
+            "Name": "Sphere_6_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48066651113400]": {
+            "Id": "Entity_[48066651113400]",
+            "Name": "Sphere_7_6",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            536.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48070946080696]": {
+            "Id": "Entity_[48070946080696]",
+            "Name": "Sphere_7_1",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            531.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48075241047992]": {
+            "Id": "Entity_[48075241047992]",
+            "Name": "Sphere_7_2",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            532.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48079536015288]": {
+            "Id": "Entity_[48079536015288]",
+            "Name": "Sphere_7_3",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48083830982584]": {
+            "Id": "Entity_[48083830982584]",
+            "Name": "Sphere_7_4",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            534.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48088125949880]": {
+            "Id": "Entity_[48088125949880]",
+            "Name": "Sphere_7_7",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            537.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48092420917176]": {
+            "Id": "Entity_[48092420917176]",
+            "Name": "Sphere_7_5",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            535.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[48096715884472]": {
+            "Id": "Entity_[48096715884472]",
+            "Name": "Sphere_7_0",
+            "Components": {
+                "Component_[13313432560389810240]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13313432560389810240
+                },
+                "Component_[14722226676036793268]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14722226676036793268
+                },
+                "Component_[14839689545179860303]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14839689545179860303,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15774494985204003587
+                        },
+                        {
+                            "ComponentId": 3217262739779752094,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4475218309195342966,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 4772788856388964850,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[15774494985204003587]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15774494985204003587,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            530.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[2228830644014898173]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 2228830644014898173
+                },
+                "Component_[2646026623911650739]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2646026623911650739
+                },
+                "Component_[3217262739779752094]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 3217262739779752094,
+                    "GameView": true
+                },
+                "Component_[4381126695607119421]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4381126695607119421
+                },
+                "Component_[4475218309195342966]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4475218309195342966,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4772788856388964850]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4772788856388964850,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5317339793856781803]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5317339793856781803
+                },
+                "Component_[5533230850385199684]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5533230850385199684
+                },
+                "Component_[5883799261965018512]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5883799261965018512
+                }
+            }
+        },
+        "Entity_[60611778069840]": {
+            "Id": "Entity_[60611778069840]",
+            "Name": "Sphere_6_3",
+            "Components": {
+                "Component_[11569808425385225425]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 11569808425385225425,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[1217407537134152568]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1217407537134152568
+                },
+                "Component_[13458455345651764431]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 13458455345651764431,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[2520577437219861355]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 2520577437219861355,
+                    "GameView": true
+                },
+                "Component_[3354788156937565539]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3354788156937565539
+                },
+                "Component_[4481853060225881677]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4481853060225881677
+                },
+                "Component_[5350022851123971519]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5350022851123971519,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5497556216387764086
+                        },
+                        {
+                            "ComponentId": 2520577437219861355,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 11569808425385225425,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 13458455345651764431,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[5497556216387764086]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5497556216387764086,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            500.0,
+                            533.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[6287275924364378103]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6287275924364378103
+                },
+                "Component_[6816736643920737525]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6816736643920737525
+                },
+                "Component_[6985626510638261579]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6985626510638261579
+                },
+                "Component_[9007817910517805801]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 9007817910517805801
+                },
+                "Component_[9522113078303874141]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9522113078303874141
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_SetKinematicTargetTransform/ScriptCanvas_SetKinematicTargetTransform.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_SetKinematicTargetTransform/ScriptCanvas_SetKinematicTargetTransform.prefab
@@ -1,0 +1,507 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "ScriptCanvas_SetKinematicTargetTransform",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[265115683694]": {
+            "Id": "Entity_[265115683694]",
+            "Name": "Sphere",
+            "Components": {
+                "Component_[10387191141982171769]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10387191141982171769
+                },
+                "Component_[10477092639574726027]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10477092639574726027,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            79.0,
+                            39.0,
+                            34.0
+                        ],
+                        "Rotate": [
+                            1.0,
+                            2.0,
+                            3.0
+                        ]
+                    }
+                },
+                "Component_[1186974414245374750]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 1186974414245374750,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10477092639574726027
+                        },
+                        {
+                            "ComponentId": 5270810333240787810,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12624949585141460502,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8426262808843690649,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[12624949585141460502]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 12624949585141460502,
+                    "Configuration": {
+                        "entityId": "",
+                        "Gravity Enabled": false,
+                        "Kinematic": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[15801602737250076678]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15801602737250076678
+                },
+                "Component_[1622263645846990448]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1622263645846990448
+                },
+                "Component_[16255990662927292757]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16255990662927292757
+                },
+                "Component_[16453836939617735307]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16453836939617735307
+                },
+                "Component_[2737626405596747847]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2737626405596747847
+                },
+                "Component_[5270810333240787810]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5270810333240787810,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0,
+                        "Sphere": {
+                            "Radius": 1.0
+                        }
+                    },
+                    "DebugDrawSettings": {
+                        "LocallyEnabled": false
+                    }
+                },
+                "Component_[5573333427262808861]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5573333427262808861
+                },
+                "Component_[8653504952843199016]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8653504952843199016
+                }
+            }
+        },
+        "Entity_[265252875814]": {
+            "Id": "Entity_[265252875814]",
+            "Name": "Kinematic_Target",
+            "Components": {
+                "Component_[12542107743173162930]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12542107743173162930
+                },
+                "Component_[13472832505672026212]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13472832505672026212,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15166056977417818764
+                        },
+                        {
+                            "ComponentId": 14374952805814930586,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[15166056977417818764]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15166056977417818764,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            48.0,
+                            56.0,
+                            36.0
+                        ],
+                        "Rotate": [
+                            11.0,
+                            12.0,
+                            13.0
+                        ],
+                        "Scale": [
+                            1.100000023841858,
+                            1.2000000476837158,
+                            1.2999999523162842
+                        ],
+                        "UniformScale": 1.2999999523162842
+                    }
+                },
+                "Component_[17253217319408933361]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17253217319408933361
+                },
+                "Component_[1822933737844686186]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1822933737844686186
+                },
+                "Component_[3198179139221545296]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3198179139221545296
+                },
+                "Component_[3607112428387153474]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3607112428387153474
+                },
+                "Component_[4210006066135134855]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4210006066135134855
+                },
+                "Component_[876509647122876164]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 876509647122876164
+                },
+                "Component_[9985981318692320224]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9985981318692320224
+                }
+            }
+        },
+        "Entity_[269547843110]": {
+            "Id": "Entity_[269547843110]",
+            "Name": "Transform_Target",
+            "Components": {
+                "Component_[12542107743173162930]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12542107743173162930
+                },
+                "Component_[13472832505672026212]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13472832505672026212,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 15166056977417818764
+                        },
+                        {
+                            "ComponentId": 14374952805814930586,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[15166056977417818764]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15166056977417818764,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            72.0,
+                            80.0,
+                            38.0
+                        ],
+                        "Rotate": [
+                            21.0,
+                            22.0,
+                            23.0
+                        ],
+                        "Scale": [
+                            2.0999999046325684,
+                            2.200000047683716,
+                            2.299999952316284
+                        ],
+                        "UniformScale": 2.299999952316284
+                    }
+                },
+                "Component_[17253217319408933361]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17253217319408933361
+                },
+                "Component_[1822933737844686186]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1822933737844686186
+                },
+                "Component_[3198179139221545296]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3198179139221545296
+                },
+                "Component_[3607112428387153474]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3607112428387153474
+                },
+                "Component_[4210006066135134855]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4210006066135134855
+                },
+                "Component_[876509647122876164]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 876509647122876164
+                },
+                "Component_[9985981318692320224]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9985981318692320224
+                }
+            }
+        },
+        "Entity_[274076707858]": {
+            "Id": "Entity_[274076707858]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3533850000287417281]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3533850000287417281
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[34120993082394]": {
+            "Id": "Entity_[34120993082394]",
+            "Name": "Signal",
+            "Components": {
+                "Component_[1035484039927433959]": {
+                    "$type": "EditorScriptCanvasComponent",
+                    "Id": 1035484039927433959,
+                    "m_name": "Signal",
+                    "runtimeDataIsValid": true,
+                    "runtimeDataOverrides": {
+                        "source": {
+                            "id": "{072105AB-EF62-57F9-88A6-E268362F643C}"
+                        },
+                        "overrides": [
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[265252875814]",
+                                    "label": "Kinematic Target"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{867284B3-23C0-4F56-AAFC-550FCFCBB375}"
+                                },
+                                "VariableName": "Kinematic Target"
+                            },
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[265115683694]",
+                                    "label": "Sphere"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{2E61C792-8857-4DE1-99A9-709611296EE1}"
+                                },
+                                "VariableName": "Sphere"
+                            },
+                            {
+                                "Datum": {
+                                    "scriptCanvasType": {
+                                        "m_type": 1
+                                    },
+                                    "isNullPointer": false,
+                                    "$type": "EntityId",
+                                    "value": "Entity_[269547843110]",
+                                    "label": "Transform Target"
+                                },
+                                "InputControlVisibility": {
+                                    "Value": 850104567
+                                },
+                                "VariableId": {
+                                    "m_id": "{BBCA92FC-FA7B-41A1-88D3-6D17C47BF9A0}"
+                                },
+                                "VariableName": "Transform Target"
+                            }
+                        ]
+                    },
+                    "sourceHandle": {
+                        "id": "{072105AB-EF62-57F9-88A6-E268362F643C}",
+                        "path": "levels/physics/c14976308_scriptcanvas_setkinematictargettransform/signal.scriptcanvas"
+                    }
+                },
+                "Component_[10783807159758542065]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10783807159758542065
+                },
+                "Component_[14528693785875583072]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14528693785875583072,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 5430669014707200037
+                        },
+                        {
+                            "ComponentId": 1035484039927433959,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[15348685740586871657]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15348685740586871657
+                },
+                "Component_[1694739841493310630]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1694739841493310630
+                },
+                "Component_[17525312528415040033]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17525312528415040033
+                },
+                "Component_[5049955255581441231]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5049955255581441231
+                },
+                "Component_[5430669014707200037]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5430669014707200037,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            27.0,
+                            123.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[7212475253995600840]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7212475253995600840
+                },
+                "Component_[8703715503355271783]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8703715503355271783
+                },
+                "Component_[9118512032223569859]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9118512032223569859
+                }
+            },
+            "IsRuntimeActive": false
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_AddPhysTerrainComponent/Terrain_AddPhysTerrainComponent.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_AddPhysTerrainComponent/Terrain_AddPhysTerrainComponent.prefab
@@ -1,0 +1,183 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Terrain_AddPhysTerrainComponent",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[280360158972]": {
+            "Id": "Entity_[280360158972]",
+            "Name": "Terrain1",
+            "Components": {
+                "Component_[10451788377959525813]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10451788377959525813
+                },
+                "Component_[13496127053290008999]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13496127053290008999
+                },
+                "Component_[14422908325375821799]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14422908325375821799
+                },
+                "Component_[15570865703508119991]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15570865703508119991
+                },
+                "Component_[4342878576216983477]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4342878576216983477,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4829115504356614054
+                        },
+                        {
+                            "ComponentId": 2799645160125025820,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[4829115504356614054]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4829115504356614054,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[5275155191373267231]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5275155191373267231
+                },
+                "Component_[6236201515090652396]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 6236201515090652396
+                },
+                "Component_[672853054005968576]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 672853054005968576
+                },
+                "Component_[6848844490945783705]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6848844490945783705
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[284655126268]": {
+            "Id": "Entity_[284655126268]",
+            "Name": "Terrain2",
+            "Components": {
+                "Component_[16831867061678131249]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16831867061678131249
+                },
+                "Component_[17977580200180220187]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17977580200180220187
+                },
+                "Component_[181448255165678627]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 181448255165678627
+                },
+                "Component_[2147217210855427800]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2147217210855427800
+                },
+                "Component_[5379065467962647976]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5379065467962647976,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8777164391318973312
+                        },
+                        {
+                            "ComponentId": 15010007152427174520,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5627758928043388471]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5627758928043388471
+                },
+                "Component_[7030263505983674272]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7030263505983674272
+                },
+                "Component_[8002320350267307536]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8002320350267307536
+                },
+                "Component_[8777164391318973312]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8777164391318973312,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[9463709839643144893]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9463709839643144893
+                }
+            },
+            "IsRuntimeActive": false
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_CanAddMultipleTerrainComponents/Terrain_CanAddMultipleTerrainComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_CanAddMultipleTerrainComponents/Terrain_CanAddMultipleTerrainComponents.prefab
@@ -1,0 +1,311 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Terrain_CanAddMultipleTerrainComponents",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[279749851039]": {
+            "Id": "Entity_[279749851039]",
+            "Name": "Terrain1",
+            "Components": {
+                "Component_[10142742887582097130]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10142742887582097130
+                },
+                "Component_[11679255880298009540]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11679255880298009540
+                },
+                "Component_[12905841853929797516]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12905841853929797516
+                },
+                "Component_[14542007487146320902]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14542007487146320902
+                },
+                "Component_[15059650343038797336]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15059650343038797336
+                },
+                "Component_[17030340816093357986]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17030340816093357986
+                },
+                "Component_[17999808164339249449]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17999808164339249449,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3971881544932750993
+                        },
+                        {
+                            "ComponentId": 6546620459032992342,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[3971881544932750993]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3971881544932750993,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[4413664384227969155]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4413664384227969155
+                },
+                "Component_[5618262751971784264]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5618262751971784264
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[284044818335]": {
+            "Id": "Entity_[284044818335]",
+            "Name": "Terrain2",
+            "Components": {
+                "Component_[10666138737049886980]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10666138737049886980,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6651167915359712319
+                        },
+                        {
+                            "ComponentId": 18359975858803265960,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[13012293432095350336]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13012293432095350336
+                },
+                "Component_[13339834493292485091]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13339834493292485091
+                },
+                "Component_[18020356037396894458]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18020356037396894458
+                },
+                "Component_[2039726624894621683]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2039726624894621683
+                },
+                "Component_[2501670298237449093]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2501670298237449093
+                },
+                "Component_[5035546556125622848]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5035546556125622848
+                },
+                "Component_[6651167915359712319]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6651167915359712319,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[8413631038999446385]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8413631038999446385
+                },
+                "Component_[8703699898889762802]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 8703699898889762802
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[288339785631]": {
+            "Id": "Entity_[288339785631]",
+            "Name": "Terrain3",
+            "Components": {
+                "Component_[1062532306779893342]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1062532306779893342
+                },
+                "Component_[13548376592624776951]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13548376592624776951,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 914229744892703826
+                        },
+                        {
+                            "ComponentId": 879976683277303386,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[15686911375966719107]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15686911375966719107
+                },
+                "Component_[16766710761074554162]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16766710761074554162
+                },
+                "Component_[2704533708730891016]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2704533708730891016
+                },
+                "Component_[3936595714244739357]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3936595714244739357
+                },
+                "Component_[5244301368021788847]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5244301368021788847
+                },
+                "Component_[5418346252947106562]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5418346252947106562
+                },
+                "Component_[914229744892703826]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 914229744892703826,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[9163684543057900344]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9163684543057900344
+                }
+            },
+            "IsRuntimeActive": false
+        },
+        "Entity_[292634752927]": {
+            "Id": "Entity_[292634752927]",
+            "Name": "Terrain4",
+            "Components": {
+                "Component_[113724138404263507]": {
+                    "$type": "SelectionComponent",
+                    "Id": 113724138404263507
+                },
+                "Component_[13256738956318411671]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13256738956318411671
+                },
+                "Component_[13397192069560951045]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13397192069560951045
+                },
+                "Component_[1415659344183917654]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1415659344183917654
+                },
+                "Component_[15710145818853112021]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15710145818853112021
+                },
+                "Component_[2501790182975793370]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2501790182975793370,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            504.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[4897215946789386609]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4897215946789386609,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2501790182975793370
+                        },
+                        {
+                            "ComponentId": 11393670873126924680,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7322454045598328587]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 7322454045598328587
+                },
+                "Component_[8322892938995860793]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8322892938995860793
+                },
+                "Component_[9226828631733139556]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9226828631733139556
+                }
+            },
+            "IsRuntimeActive": false
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_CollisionAgainstRigidBody/Terrain_CollisionAgainstRigidBody.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_CollisionAgainstRigidBody/Terrain_CollisionAgainstRigidBody.prefab
@@ -1,0 +1,279 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Terrain_CollisionAgainstRigidBody",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[270206757548]": {
+            "Id": "Entity_[270206757548]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[11287304175179628889]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11287304175179628889
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[278796692140]": {
+            "Id": "Entity_[278796692140]",
+            "Name": "PhysX_Sphere",
+            "Components": {
+                "Component_[12562878296232564887]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12562878296232564887
+                },
+                "Component_[12928869001516931380]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12928869001516931380
+                },
+                "Component_[14908351847598463700]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14908351847598463700
+                },
+                "Component_[15162993894621821891]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15162993894621821891
+                },
+                "Component_[17768134285301225203]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 17768134285301225203,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[1786139103798713999]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1786139103798713999
+                },
+                "Component_[18438921188908086427]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18438921188908086427
+                },
+                "Component_[2164709206238219559]": {
+                    "$type": "SelectionComponent",
+                    "Id": 2164709206238219559
+                },
+                "Component_[4254573492361478143]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4254573492361478143,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            532.0,
+                            35.0
+                        ]
+                    }
+                },
+                "Component_[4905437890688559755]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4905437890688559755,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            0.5
+                        ],
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[5321343238977456550]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5321343238977456550
+                },
+                "Component_[9516009656839530849]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9516009656839530849,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4254573492361478143
+                        },
+                        {
+                            "ComponentId": 4674827956492126875,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4905437890688559755,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 17768134285301225203,
+                            "SortIndex": 3
+                        }
+                    ]
+                }
+            }
+        },
+        "Entity_[386170874540]": {
+            "Id": "Entity_[386170874540]",
+            "Name": "PhysX_Terrain",
+            "Components": {
+                "Component_[10317342041353831286]": {
+                    "$type": "SelectionComponent",
+                    "Id": 10317342041353831286
+                },
+                "Component_[11585184024706601961]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11585184024706601961
+                },
+                "Component_[14006577748526833088]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14006577748526833088
+                },
+                "Component_[16281914842474259705]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16281914842474259705
+                },
+                "Component_[17893369289827132898]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17893369289827132898
+                },
+                "Component_[2898992326720722500]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2898992326720722500
+                },
+                "Component_[3682388432836415897]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3682388432836415897,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            535.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[6198179446563630797]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6198179446563630797
+                },
+                "Component_[6419439984199667980]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6419439984199667980
+                },
+                "Component_[7969080839567329624]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7969080839567329624,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 3682388432836415897
+                        },
+                        {
+                            "ComponentId": 8651736200977041641,
+                            "SortIndex": 1
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/1024x1024_32m/C6032082_Terrain_MultipleResolutionsValid_1024x1024_32m.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/1024x1024_32m/C6032082_Terrain_MultipleResolutionsValid_1024x1024_32m.prefab
@@ -1,0 +1,304 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "C6032082_Terrain_MultipleResolutionsValid_1024x1024_32m",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[334854602755]": {
+            "Id": "Entity_[334854602755]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[13958328618171047314]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13958328618171047314
+                },
+                "Component_[16355626870584936933]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16355626870584936933
+                },
+                "Component_[17713265972451370705]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17713265972451370705,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2809313185049668583
+                        },
+                        {
+                            "ComponentId": 10785357532914894975,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[2809313185049668583]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2809313185049668583,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[3769729613350868554]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3769729613350868554
+                },
+                "Component_[467906868262249046]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 467906868262249046
+                },
+                "Component_[6610749147366252498]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 6610749147366252498
+                },
+                "Component_[6617283692747515536]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 6617283692747515536
+                },
+                "Component_[7541697601542341651]": {
+                    "$type": "SelectionComponent",
+                    "Id": 7541697601542341651
+                },
+                "Component_[9909292515971905467]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9909292515971905467
+                }
+            }
+        },
+        "Entity_[831544151880]": {
+            "Id": "Entity_[831544151880]",
+            "Name": "Ball On Terrain",
+            "Components": {
+                "Component_[12007183601434835306]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12007183601434835306
+                },
+                "Component_[12038581290659014388]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12038581290659014388
+                },
+                "Component_[12398230145724964177]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 12398230145724964177,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[15794741442488717900]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15794741442488717900
+                },
+                "Component_[17541837446522180650]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17541837446522180650
+                },
+                "Component_[3598582754056686265]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3598582754056686265
+                },
+                "Component_[6640136202825687834]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6640136202825687834
+                },
+                "Component_[6856957689910738229]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6856957689910738229,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[7553211856186004871]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7553211856186004871,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8474346317861803796
+                        },
+                        {
+                            "ComponentId": 2385717002765711690,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12398230145724964177,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6856957689910738229,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8474346317861803796]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8474346317861803796,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[9210592447754999144]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9210592447754999144
+                },
+                "Component_[9909774659085643993]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9909774659085643993
+                }
+            }
+        },
+        "Entity_[835839119176]": {
+            "Id": "Entity_[835839119176]",
+            "Name": "Ball Outside Terrain",
+            "Components": {
+                "Component_[12007183601434835306]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12007183601434835306
+                },
+                "Component_[12038581290659014388]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12038581290659014388
+                },
+                "Component_[12398230145724964177]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 12398230145724964177,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[15794741442488717900]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15794741442488717900
+                },
+                "Component_[17541837446522180650]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17541837446522180650
+                },
+                "Component_[3598582754056686265]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3598582754056686265
+                },
+                "Component_[6640136202825687834]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6640136202825687834
+                },
+                "Component_[6856957689910738229]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 6856957689910738229,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[7553211856186004871]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7553211856186004871,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 8474346317861803796
+                        },
+                        {
+                            "ComponentId": 2385717002765711690,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 12398230145724964177,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6856957689910738229,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8474346317861803796]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 8474346317861803796,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.0,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[9210592447754999144]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9210592447754999144
+                },
+                "Component_[9909774659085643993]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9909774659085643993
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/128x128_1m/C6032082_Terrain_MultipleResolutionsValid_128x128_1m.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/128x128_1m/C6032082_Terrain_MultipleResolutionsValid_128x128_1m.prefab
@@ -1,0 +1,304 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "C6032082_Terrain_MultipleResolutionsValid_128x128_1m",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[264608468808]": {
+            "Id": "Entity_[264608468808]",
+            "Name": "Ball Outside Terrain",
+            "Components": {
+                "Component_[1006536283160765594]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 1006536283160765594,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[10726823780463083723]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10726823780463083723,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            -4.999999046325684,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[14747177354481515102]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14747177354481515102,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[16274140846694341666]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16274140846694341666
+                },
+                "Component_[16856190225229259515]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16856190225229259515
+                },
+                "Component_[2262560441116896496]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2262560441116896496
+                },
+                "Component_[3751487227529444277]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3751487227529444277
+                },
+                "Component_[5233292243359655185]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5233292243359655185
+                },
+                "Component_[70975351006773031]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 70975351006773031
+                },
+                "Component_[7203778688277363932]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7203778688277363932
+                },
+                "Component_[7770392152831340083]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7770392152831340083,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10726823780463083723
+                        },
+                        {
+                            "ComponentId": 1006536283160765594,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 14747177354481515102,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3958311356309766093,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8187418012770674418]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8187418012770674418
+                }
+            }
+        },
+        "Entity_[268903436104]": {
+            "Id": "Entity_[268903436104]",
+            "Name": "Ball On Terrain",
+            "Components": {
+                "Component_[1006536283160765594]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 1006536283160765594,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[10726823780463083723]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10726823780463083723,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            5.999998092651367,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[14747177354481515102]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 14747177354481515102,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[16274140846694341666]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16274140846694341666
+                },
+                "Component_[16856190225229259515]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16856190225229259515
+                },
+                "Component_[2262560441116896496]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2262560441116896496
+                },
+                "Component_[3751487227529444277]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3751487227529444277
+                },
+                "Component_[5233292243359655185]": {
+                    "$type": "SelectionComponent",
+                    "Id": 5233292243359655185
+                },
+                "Component_[70975351006773031]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 70975351006773031
+                },
+                "Component_[7203778688277363932]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7203778688277363932
+                },
+                "Component_[7770392152831340083]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7770392152831340083,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10726823780463083723
+                        },
+                        {
+                            "ComponentId": 1006536283160765594,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 14747177354481515102,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 3958311356309766093,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[8187418012770674418]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8187418012770674418
+                }
+            }
+        },
+        "Entity_[282320393952]": {
+            "Id": "Entity_[282320393952]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[11413499689805143900]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 11413499689805143900,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11590808202023407308
+                        },
+                        {
+                            "ComponentId": 12088493744679669148,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[11590808202023407308]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11590808202023407308,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[14015398763056040891]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14015398763056040891
+                },
+                "Component_[14945943068708436100]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14945943068708436100
+                },
+                "Component_[16539125371976929245]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16539125371976929245
+                },
+                "Component_[1919649005808170755]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 1919649005808170755
+                },
+                "Component_[52589976260870465]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 52589976260870465
+                },
+                "Component_[8108949127482046685]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 8108949127482046685
+                },
+                "Component_[8469435646487801155]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8469435646487801155
+                },
+                "Component_[9517230252535639563]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9517230252535639563
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/4096x4096_16m/C6032082_Terrain_MultipleResolutionsValid_4096x4096_16m.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/4096x4096_16m/C6032082_Terrain_MultipleResolutionsValid_4096x4096_16m.prefab
@@ -1,0 +1,304 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "C6032082_Terrain_MultipleResolutionsValid_4096x4096_16m",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[386394210307]": {
+            "Id": "Entity_[386394210307]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[10133109462026866237]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 10133109462026866237
+                },
+                "Component_[10272941122136767449]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 10272941122136767449
+                },
+                "Component_[14852632376146017604]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14852632376146017604
+                },
+                "Component_[15257770494299942582]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 15257770494299942582
+                },
+                "Component_[15409427525998206678]": {
+                    "$type": "SelectionComponent",
+                    "Id": 15409427525998206678
+                },
+                "Component_[16845913644928018834]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16845913644928018834
+                },
+                "Component_[2317736036048422462]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2317736036048422462,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[3605249992731434337]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3605249992731434337,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2317736036048422462
+                        },
+                        {
+                            "ComponentId": 10500913320325619468,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[7377883813327996707]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7377883813327996707
+                },
+                "Component_[9469716285517668555]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9469716285517668555
+                }
+            }
+        },
+        "Entity_[402907936022]": {
+            "Id": "Entity_[402907936022]",
+            "Name": "Ball On Terrain",
+            "Components": {
+                "Component_[12978891841797996845]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12978891841797996845,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[13387120353369061020]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13387120353369061020
+                },
+                "Component_[15163129439832742559]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15163129439832742559
+                },
+                "Component_[1650750679049244090]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1650750679049244090,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[17909761619015782934]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17909761619015782934
+                },
+                "Component_[18211758578981459580]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 18211758578981459580,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12978891841797996845
+                        },
+                        {
+                            "ComponentId": 15687269203091549718,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1650750679049244090,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8160676361232213436,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[2873982541598976552]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2873982541598976552
+                },
+                "Component_[326944765741982598]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 326944765741982598
+                },
+                "Component_[595031646108762367]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 595031646108762367
+                },
+                "Component_[8160676361232213436]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8160676361232213436,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9225062701316704761]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9225062701316704761
+                },
+                "Component_[9375509841770977642]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9375509841770977642
+                }
+            }
+        },
+        "Entity_[407202903318]": {
+            "Id": "Entity_[407202903318]",
+            "Name": "Ball Outside Terrain",
+            "Components": {
+                "Component_[12978891841797996845]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12978891841797996845,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.0,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[13387120353369061020]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13387120353369061020
+                },
+                "Component_[15163129439832742559]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15163129439832742559
+                },
+                "Component_[1650750679049244090]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1650750679049244090,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[17909761619015782934]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17909761619015782934
+                },
+                "Component_[18211758578981459580]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 18211758578981459580,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 12978891841797996845
+                        },
+                        {
+                            "ComponentId": 15687269203091549718,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1650750679049244090,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8160676361232213436,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[2873982541598976552]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2873982541598976552
+                },
+                "Component_[326944765741982598]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 326944765741982598
+                },
+                "Component_[595031646108762367]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 595031646108762367
+                },
+                "Component_[8160676361232213436]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 8160676361232213436,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[9225062701316704761]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9225062701316704761
+                },
+                "Component_[9375509841770977642]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9375509841770977642
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/512x512_2m/C6032082_Terrain_MultipleResolutionsValid_512x512_2m.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_MultipleResolutionsValid/512x512_2m/C6032082_Terrain_MultipleResolutionsValid_512x512_2m.prefab
@@ -1,0 +1,304 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "C6032082_Terrain_MultipleResolutionsValid_512x512_2m",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[269763949846]": {
+            "Id": "Entity_[269763949846]",
+            "Name": "Ball On Terrain",
+            "Components": {
+                "Component_[13525867626087491752]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13525867626087491752
+                },
+                "Component_[14125456544917329753]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14125456544917329753
+                },
+                "Component_[14378752879557712497]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14378752879557712497,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[14958873239215654931]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14958873239215654931
+                },
+                "Component_[1623538098294970536]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1623538098294970536,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[16490998470086638234]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16490998470086638234
+                },
+                "Component_[16727530986700088201]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16727530986700088201
+                },
+                "Component_[3477364365443234553]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3477364365443234553
+                },
+                "Component_[4064907565600753895]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4064907565600753895,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5162624575174375766]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5162624575174375766,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14378752879557712497
+                        },
+                        {
+                            "ComponentId": 4064907565600753895,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1115916852187630416,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1623538098294970536,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[5701311929175750718]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5701311929175750718
+                },
+                "Component_[5818428778719552175]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5818428778719552175
+                }
+            }
+        },
+        "Entity_[274058917142]": {
+            "Id": "Entity_[274058917142]",
+            "Name": "Ball Outside Terrain",
+            "Components": {
+                "Component_[13525867626087491752]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13525867626087491752
+                },
+                "Component_[14125456544917329753]": {
+                    "$type": "SelectionComponent",
+                    "Id": 14125456544917329753
+                },
+                "Component_[14378752879557712497]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14378752879557712497,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            -5.0,
+                            16.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[14958873239215654931]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14958873239215654931
+                },
+                "Component_[1623538098294970536]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 1623538098294970536,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[16490998470086638234]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 16490998470086638234
+                },
+                "Component_[16727530986700088201]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16727530986700088201
+                },
+                "Component_[3477364365443234553]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3477364365443234553
+                },
+                "Component_[4064907565600753895]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4064907565600753895,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[5162624575174375766]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5162624575174375766,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 14378752879557712497
+                        },
+                        {
+                            "ComponentId": 4064907565600753895,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 1115916852187630416,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1623538098294970536,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[5701311929175750718]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5701311929175750718
+                },
+                "Component_[5818428778719552175]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5818428778719552175
+                }
+            }
+        },
+        "Entity_[283314995203]": {
+            "Id": "Entity_[283314995203]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[11739157069149725462]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11739157069149725462
+                },
+                "Component_[12090280726018536554]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12090280726018536554
+                },
+                "Component_[14557195266444931075]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14557195266444931075,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2716017339831847202
+                        },
+                        {
+                            "ComponentId": 11697262852243701306,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[16188036410469378443]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16188036410469378443
+                },
+                "Component_[18176727626288830782]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18176727626288830782
+                },
+                "Component_[2716017339831847202]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2716017339831847202,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            6.0,
+                            16.0,
+                            33.0
+                        ]
+                    }
+                },
+                "Component_[3422754761252968011]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3422754761252968011
+                },
+                "Component_[3954115704751364629]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3954115704751364629
+                },
+                "Component_[7182529338138258068]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7182529338138258068
+                },
+                "Component_[8097744341785684357]": {
+                    "$type": "SelectionComponent",
+                    "Id": 8097744341785684357
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_MultipleTerrainComponentsWarning/Terrain_MultipleTerrainComponentsWarning.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_MultipleTerrainComponentsWarning/Terrain_MultipleTerrainComponentsWarning.prefab
@@ -1,0 +1,244 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Terrain_MultipleTerrainComponentsWarning",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[281634098889]": {
+            "Id": "Entity_[281634098889]",
+            "Name": "Terrain1",
+            "Components": {
+                "Component_[12514265927498408862]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12514265927498408862
+                },
+                "Component_[1327407643282894459]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1327407643282894459
+                },
+                "Component_[16337816687010317474]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16337816687010317474
+                },
+                "Component_[16407936087195189768]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16407936087195189768
+                },
+                "Component_[17689642393948749878]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17689642393948749878,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18211730421050142474
+                        },
+                        {
+                            "ComponentId": 3829652485474996274,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[18211730421050142474]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18211730421050142474,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[18264029946952979471]": {
+                    "$type": "SelectionComponent",
+                    "Id": 18264029946952979471
+                },
+                "Component_[18375968119881868380]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18375968119881868380
+                },
+                "Component_[2659714745194424061]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2659714745194424061
+                },
+                "Component_[7198416420466128656]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7198416420466128656
+                }
+            }
+        },
+        "Entity_[285929066185]": {
+            "Id": "Entity_[285929066185]",
+            "Name": "Terrain2",
+            "Components": {
+                "Component_[12514265927498408862]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12514265927498408862
+                },
+                "Component_[1327407643282894459]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1327407643282894459
+                },
+                "Component_[16337816687010317474]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16337816687010317474
+                },
+                "Component_[16407936087195189768]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16407936087195189768
+                },
+                "Component_[17689642393948749878]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17689642393948749878,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18211730421050142474
+                        },
+                        {
+                            "ComponentId": 3829652485474996274,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[18211730421050142474]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18211730421050142474,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[18264029946952979471]": {
+                    "$type": "SelectionComponent",
+                    "Id": 18264029946952979471
+                },
+                "Component_[18375968119881868380]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18375968119881868380
+                },
+                "Component_[2659714745194424061]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2659714745194424061
+                },
+                "Component_[7198416420466128656]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7198416420466128656
+                }
+            }
+        },
+        "Entity_[290224033481]": {
+            "Id": "Entity_[290224033481]",
+            "Name": "Terrain3",
+            "Components": {
+                "Component_[12514265927498408862]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 12514265927498408862
+                },
+                "Component_[1327407643282894459]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1327407643282894459
+                },
+                "Component_[16337816687010317474]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16337816687010317474
+                },
+                "Component_[16407936087195189768]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16407936087195189768
+                },
+                "Component_[17689642393948749878]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17689642393948749878,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18211730421050142474
+                        },
+                        {
+                            "ComponentId": 3829652485474996274,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[18211730421050142474]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18211730421050142474,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            505.0,
+                            530.0,
+                            39.0
+                        ]
+                    }
+                },
+                "Component_[18264029946952979471]": {
+                    "$type": "SelectionComponent",
+                    "Id": 18264029946952979471
+                },
+                "Component_[18375968119881868380]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18375968119881868380
+                },
+                "Component_[2659714745194424061]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2659714745194424061
+                },
+                "Component_[7198416420466128656]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7198416420466128656
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Terrain_TerrainTexturePainterWorks/Terrain_TerrainTexturePainterWorks.prefab
+++ b/AutomatedTesting/Levels/Physics/Terrain_TerrainTexturePainterWorks/Terrain_TerrainTexturePainterWorks.prefab
@@ -1,0 +1,404 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Terrain_TerrainTexturePainterWorks",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[823224218562]": {
+            "Id": "Entity_[823224218562]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[14318876785767304039]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14318876785767304039
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            64.0,
+                            64.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[831814153154]": {
+            "Id": "Entity_[831814153154]",
+            "Name": "Terrain",
+            "Components": {
+                "Component_[10310042084087366895]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10310042084087366895
+                },
+                "Component_[12582827930982658478]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12582827930982658478
+                },
+                "Component_[16307323181516068861]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16307323181516068861
+                },
+                "Component_[2168463858943235928]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2168463858943235928
+                },
+                "Component_[6337947463720387893]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6337947463720387893,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            60.0,
+                            65.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[6377562975054454677]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6377562975054454677,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6337947463720387893
+                        },
+                        {
+                            "ComponentId": 1103209842192145197,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[6828754158041039130]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6828754158041039130
+                },
+                "Component_[6955998902872432970]": {
+                    "$type": "SelectionComponent",
+                    "Id": 6955998902872432970
+                },
+                "Component_[8927996614704873075]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8927996614704873075
+                },
+                "Component_[9666066542844509532]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9666066542844509532
+                }
+            }
+        },
+        "Entity_[836109120450]": {
+            "Id": "Entity_[836109120450]",
+            "Name": "Box_No_Bounce",
+            "Components": {
+                "Component_[10794143454261519863]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 10794143454261519863,
+                    "Configuration": {
+                        "entityId": "",
+                        "Start Asleep": true,
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[11008613182812530236]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11008613182812530236
+                },
+                "Component_[12891687142257945688]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12891687142257945688
+                },
+                "Component_[14687169436266111654]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14687169436266111654
+                },
+                "Component_[18134027654334582002]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18134027654334582002
+                },
+                "Component_[5667754420390135547]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5667754420390135547
+                },
+                "Component_[5957633558999524796]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5957633558999524796
+                },
+                "Component_[6604549024937617657]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6604549024937617657,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 892644441405346302
+                        },
+                        {
+                            "ComponentId": 8007657465173253133,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10794143454261519863,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6932085897351938491,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6932085897351938491]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 6932085897351938491,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[7421290059112616871]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7421290059112616871
+                },
+                "Component_[892644441405346302]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 892644441405346302,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            35.0,
+                            65.0,
+                            36.0
+                        ]
+                    }
+                },
+                "Component_[9509889254994715183]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9509889254994715183
+                }
+            }
+        },
+        "Entity_[943483302850]": {
+            "Id": "Entity_[943483302850]",
+            "Name": "Box_Yes_Bounce",
+            "Components": {
+                "Component_[10794143454261519863]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 10794143454261519863,
+                    "Configuration": {
+                        "entityId": "",
+                        "Compute Mass": false
+                    }
+                },
+                "Component_[11008613182812530236]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 11008613182812530236
+                },
+                "Component_[12891687142257945688]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12891687142257945688
+                },
+                "Component_[14687169436266111654]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14687169436266111654
+                },
+                "Component_[18134027654334582002]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 18134027654334582002
+                },
+                "Component_[5667754420390135547]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5667754420390135547
+                },
+                "Component_[5957633558999524796]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5957633558999524796
+                },
+                "Component_[6604549024937617657]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6604549024937617657,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 892644441405346302
+                        },
+                        {
+                            "ComponentId": 8007657465173253133,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 10794143454261519863,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 6932085897351938491,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[6932085897351938491]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 6932085897351938491,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "PhysicsAsset": {
+                            "Asset": {
+                                "assetId": {
+                                    "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                    "subId": 1
+                                },
+                                "assetHint": "objects/default/primitive_cube.pxmesh"
+                            },
+                            "Configuration": {
+                                "PhysicsAsset": {
+                                    "assetId": {
+                                        "guid": "{878C6CF2-D4A8-5A2B-8EE0-3FD30AD967CD}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "objects/default/primitive_cube.pxmesh"
+                                }
+                            }
+                        }
+                    }
+                },
+                "Component_[7421290059112616871]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7421290059112616871
+                },
+                "Component_[892644441405346302]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 892644441405346302,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            83.0,
+                            65.0,
+                            38.0
+                        ]
+                    }
+                },
+                "Component_[9509889254994715183]": {
+                    "$type": "SelectionComponent",
+                    "Id": 9509889254994715183
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Converted the following physics automated tests in **InDevelopment** test suite to use prefab system:
- Tests already failed before conversion:
  - Material_RagdollBones
  - ScriptCanvas_SetKinematicTargetTransform
  - Terrain_TerrainTexturePainterWorks
  - Material_CanBeAssignedToTerrain
  - Material_DefaultLibraryConsistentOnAllFeatures
  - Ragdoll_OldRagdollSerializationNoErrors
  - Material_StaticFriction
  - RigidBody_LinearDampingAffectsMotion
  - Terrain_CollisionAgainstRigidBody
  - Physics_WorldBodyBusWorksOnEditorComponents
  - Terrain_AddPhysTerrainComponent
  - Terrain_CanAddMultipleTerrainComponents
  - Terrain_MultipleTerrainComponentsWarning
  - Terrain_MultipleResolutionsValid
  - Material_LibraryCrudOperationsReflectOnRagdollBones
  - Material_ComponentsInSyncWithLibrary
  - Material_LibraryCrudOperationsReflectOnTerrain
  - Material_DefaultMaterialLibraryChangesWork
  - Material_LibraryCrudOperationsReflectOnCollider
  - Material_LibraryCrudOperationsReflectOnCharacterController
  - Material_LibraryChangesReflectInstantly
  - Material_LibraryUpdatedAcrossLevels
  - ScriptCanvas_OverlapNode

- Test failed before conversion but passed after conversion:
  - ForceRegion_HighValuesDirectionAxesWorkWithNoError

- Tests passed before and after conversion(Should be moved to **Periodic/Main/Main_Optimized**?):
  - Collider_SameCollisionGroupSameLayerCollide
  - Collider_PxMeshErrorIfNoMesh
  - ForceRegion_ImpulsesBoxShapedRigidBody
  - ForceRegion_SmallMagnitudeDeviationOnLargeForces

Also, remove Physics_UndoRedoWorksOnEntityWithPhysComponents from **Periodic** test suite and ShapeCollider_CylinderShapeCollides from **InDevelopment** since they are already in **Main/Main_Optimized** test suites.

Lastly, remove some duplicated code in **InDevelopment**.

See details: 
#6041 
#6042 
#6043

Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>