### PR TITLE
Fix GPU crash when loading a level from Editor

### DIFF
--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.cpp
@@ -68,7 +68,8 @@ namespace AZ
                         
                 Platform::AttachViewController(m_nativeWindow, m_viewController, m_metalView);
                 
-                m_metalView.metalLayer.drawableSize = CGSizeMake(descriptor.m_dimensions.m_imageWidth, descriptor.m_dimensions.m_imageHeight);
+                m_drawableSize = CGSizeMake(descriptor.m_dimensions.m_imageWidth, descriptor.m_dimensions.m_imageHeight);
+                m_metalView.metalLayer.drawableSize = m_drawableSize;
             }
             else
             {
@@ -168,7 +169,8 @@ namespace AZ
         {
             if(m_metalView)
             {
-                Platform::ResizeInternal(m_metalView, CGSizeMake(dimensions.m_imageWidth, dimensions.m_imageHeight));
+                //Cache the new dimensions. We update the layer right before requesting the drawable.
+                m_drawableSize = CGSizeMake(dimensions.m_imageWidth, dimensions.m_imageHeight);
             }
             else
             {
@@ -203,6 +205,12 @@ namespace AZ
             }
             else
             {
+                //Resize the layer if the dimensions dont align.
+                if(m_drawableSize.width != m_metalView.metalLayer.drawableSize.width ||
+                   m_drawableSize.height != m_metalView.metalLayer.drawableSize.height)
+                {
+                    Platform::ResizeInternal(m_metalView, m_drawableSize);
+                }
                 m_drawables[currentImageIndex] = [m_metalView.metalLayer nextDrawable];
                 AZ_Assert(m_drawables[currentImageIndex], "Drawable can not be null");
                 

--- a/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.h
+++ b/Gems/Atom/RHI/Metal/Code/Source/RHI/SwapChain.h
@@ -54,6 +54,7 @@ namespace AZ
             NativeWindowType* m_nativeWindow = nullptr;
             AZStd::vector<id<CAMetalDrawable>> m_drawables;
             uint32_t m_refreshRate = 0;
+            CGSize m_drawableSize;
         };
     }
 }


### PR DESCRIPTION
The main issue was that Qt was changing the drawable size after the resize event to a different dimension. Hence there was a mismatch between the swap chain texture and the viewport/scissor size. The fix is to cache the dimension and update the metalLayer right before the drawable is requested.

Signed-off-by: moudgils <moudgils@amazon.com>