### PR TITLE
Fixed warning treated as error in release in some platforms about not using m_inputBuffer in MultiplayerDebugAuditTrail

### DIFF
--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugAuditTrail.h
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugAuditTrail.h
@@ -69,7 +69,7 @@ namespace Multiplayer
 
         AZStd::string m_filter;
         AzFramework::DebugDisplayRequests* m_debugDisplay = nullptr;
-        char m_inputBuffer[AUDIT_SEARCH_BUFFER_SIZE] = {};
+        [[maybe_unused]] char m_inputBuffer[AUDIT_SEARCH_BUFFER_SIZE] = {};
         bool m_canPumpTrail = false;
     };
 }


### PR DESCRIPTION
````
MultiplayerDebugAuditTrail.h:72:14: error: private field 'm_inputBuffer' is not used [-Werror,-Wunused-private-field]
        char m_inputBuffer[AUDIT_SEARCH_BUFFER_SIZE] = {};
             ^
1 error generated.
````

Signed-off-by: moraaar <moraaar@amazon.com>