### PR TITLE
EMotion FX: Move character to origin & fix for move groundplane while follow character is disabled

### DIFF
--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.cpp
@@ -186,6 +186,14 @@ namespace EMStudio
         ResetEnvironment();
     }
 
+    void AnimViewportRenderer::MoveActorEntitiesToOrigin()
+    {
+        for (AZ::Entity* entity : m_actorEntities)
+        {
+            AZ::TransformBus::Event(entity->GetId(), &AZ::TransformBus::Events::SetWorldTM, AZ::Transform::CreateIdentity());
+        }
+    }
+
     AZ::Vector3 AnimViewportRenderer::GetCharacterCenter() const
     {
         AZ::Vector3 result = AZ::Vector3::CreateZero();

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.h
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportRenderer.h
@@ -59,8 +59,11 @@ namespace EMStudio
         AZ::EntityId GetEntityId() const;
         AzFramework::EntityContextId GetEntityContextId() const;
 
-        // Moves the groundplane along with the character.
+        //! Moves the groundplane along with the character.
         void UpdateGroundplane();
+
+        //! Apply the identity transform to the actor entities.
+        void MoveActorEntitiesToOrigin();
 
     private:
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportWidget.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Tools/EMStudio/AnimViewportWidget.cpp
@@ -241,7 +241,6 @@ namespace EMStudio
         CalculateCameraProjection();
         RenderCustomPluginData();
         FollowCharacter();
-        m_renderer->UpdateGroundplane();
     }
 
     void AnimViewportWidget::CalculateCameraProjection()
@@ -278,6 +277,8 @@ namespace EMStudio
             AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
                 GetViewportId(), &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::SetCameraPivotAttached,
                 m_renderer->GetCharacterCenter());
+
+            m_renderer->UpdateGroundplane();
         }
     }
 
@@ -366,12 +367,15 @@ namespace EMStudio
                 });
         }
 
-        QAction* resetAction = menu->addAction("Reset Character");
-        connect(resetAction, &QAction::triggered, this, [this]()
-            {
-                m_renderer->Reinit();
-                UpdateCameraViewMode(RenderOptions::CameraViewMode::DEFAULT);
-            });
+        if (m_renderer && m_renderer->GetEntityId() != AZ::EntityId())
+        {
+            QAction* resetAction = menu->addAction("Move Character to Origin");
+            connect(resetAction, &QAction::triggered, this, [this]()
+                {
+                    m_renderer->MoveActorEntitiesToOrigin();
+                    UpdateCameraViewMode(RenderOptions::CameraViewMode::DEFAULT);
+                });
+        }
 
         if (!menu->isEmpty())
         {


### PR DESCRIPTION
* Fixed a bug with moving the ground plane while follow mode is disabled.
* Changed the "Reset Character" option to not re-create the entire entities and render objects, but just move the character to the origin which is what the former "Reset Transform" option did.
* Only showing the option in case a character is actually loaded.

Resolves #7757

Signed-off-by: Benjamin Jillich <jillich@amazon.com>