### PR TITLE
Fixed CmpAllLt and CmpAllGt functions in Neon Vec3 class.

### DIFF
--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_neon.inl
@@ -353,26 +353,38 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec3::CmpAllEq(FloatArgType arg1, FloatArgType arg2)
         {
+            // NeonQuad::CmpAllEq compares all 4 elements.
+            // The fourth elements are already equal since it's not used in Vec3.
             return NeonQuad::CmpAllEq(arg1, arg2);
         }
 
         AZ_MATH_INLINE bool Vec3::CmpAllLt(FloatArgType arg1, FloatArgType arg2)
         {
-            return NeonQuad::CmpAllLt(arg1, arg2);
+            // NeonQuad::CmpAllLt compares all 4 elements.
+            // This makes sure unused fourth element of arg1 < arg2.
+            FloatArgType newArg2 = NeonQuad::ReplaceFourth(arg2, 1.0f);
+            return NeonQuad::CmpAllLt(arg1, newArg2);
         }
 
         AZ_MATH_INLINE bool Vec3::CmpAllLtEq(FloatArgType arg1, FloatArgType arg2)
         {
+            // NeonQuad::CmpAllLtEq compares all 4 elements.
+            // The fourth elements are already equal since it's not used in Vec3.
             return NeonQuad::CmpAllLtEq(arg1, arg2);
         }
 
         AZ_MATH_INLINE bool Vec3::CmpAllGt(FloatArgType arg1, FloatArgType arg2)
         {
-            return NeonQuad::CmpAllGt(arg1, arg2);
+            // NeonQuad::CmpAllGt compares all 4 elements.
+            // This makes sure unused fourth element of arg1 > arg2.
+            FloatArgType newArg1 = NeonQuad::ReplaceFourth(arg1, 1.0f);
+            return NeonQuad::CmpAllGt(newArg1, arg2);
         }
 
         AZ_MATH_INLINE bool Vec3::CmpAllGtEq(FloatArgType arg1, FloatArgType arg2)
         {
+            // NeonQuad::CmpAllGtEq compares all 4 elements.
+            // The fourth elements are already equal since it's not used in Vec3.
             return NeonQuad::CmpAllGtEq(arg1, arg2);
         }
 
@@ -408,6 +420,8 @@ namespace AZ
 
         AZ_MATH_INLINE bool Vec3::CmpAllEq(Int32ArgType arg1, Int32ArgType arg2)
         {
+            // NeonQuad::CmpAllEq compares all 4 elements.
+            // The fourth elements are already equal since it's not used in Vec3.
             return NeonQuad::CmpAllEq(arg1, arg2);
         }
 

--- a/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_neon.inl
+++ b/Code/Framework/AzCore/AzCore/Math/Internal/SimdMathVec3_neon.inl
@@ -362,8 +362,9 @@ namespace AZ
         {
             // NeonQuad::CmpAllLt compares all 4 elements.
             // This makes sure unused fourth element of arg1 < arg2.
-            FloatArgType newArg2 = NeonQuad::ReplaceFourth(arg2, 1.0f);
-            return NeonQuad::CmpAllLt(arg1, newArg2);
+            return NeonQuad::CmpAllLt(
+                NeonQuad::ReplaceFourth(arg1, 0.0f),
+                NeonQuad::ReplaceFourth(arg2, 1.0f));
         }
 
         AZ_MATH_INLINE bool Vec3::CmpAllLtEq(FloatArgType arg1, FloatArgType arg2)
@@ -377,8 +378,9 @@ namespace AZ
         {
             // NeonQuad::CmpAllGt compares all 4 elements.
             // This makes sure unused fourth element of arg1 > arg2.
-            FloatArgType newArg1 = NeonQuad::ReplaceFourth(arg1, 1.0f);
-            return NeonQuad::CmpAllGt(newArg1, arg2);
+            return NeonQuad::CmpAllLt(
+                NeonQuad::ReplaceFourth(arg1, 1.0f),
+                NeonQuad::ReplaceFourth(arg2, 0.0f));
         }
 
         AZ_MATH_INLINE bool Vec3::CmpAllGtEq(FloatArgType arg1, FloatArgType arg2)


### PR DESCRIPTION
Fixes #4117

Signed-off-by: moraaar <moraaar@amazon.com>