### PR TITLE
ATOM-17276 [ASV] [Vulkan] Two PassTree.bv.lua screenshots failed with…

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Conversion.cpp
@@ -808,10 +808,6 @@ namespace AZ
             {
                 usageFlags |= VK_IMAGE_USAGE_STORAGE_BIT;
             }
-            if (RHI::CheckBitsAny(formatFeatureFlags, static_cast<VkFormatFeatureFlags>(VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)))
-            {
-                usageFlags |= VK_IMAGE_USAGE_STORAGE_BIT;
-            }
             if (RHI::CheckBitsAny(formatFeatureFlags, static_cast<VkFormatFeatureFlags>(VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)))
             {
                 usageFlags |= (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -189,9 +189,25 @@ namespace AZ
         RHI::ResultCode Image::BuildNativeImage()
         {
             AZ_Assert(m_vkImage == VK_NULL_HANDLE, "Vulkan's native image has already been initialized.");
+
             auto& device = static_cast<Device&>(GetDevice());
+            const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
             const RHI::ImageDescriptor& descriptor = GetDescriptor();
-            const VkImageFormatProperties formatProps = GetImageFormatProperties();
+            
+            VkImageCreateInfo createInfo{};
+            createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+            createInfo.pNext = nullptr;
+            createInfo.format = ConvertFormat(descriptor.m_format);
+            createInfo.flags = GetImageCreateFlags();
+            createInfo.imageType = ConvertToImageType(descriptor.m_dimension);
+            createInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+            createInfo.usage = GetImageUsageFlags();
+
+            VkImageFormatProperties formatProps{};
+            AssertSuccess(vkGetPhysicalDeviceImageFormatProperties(
+                physicalDevice.GetNativePhysicalDevice(), createInfo.format,
+                createInfo.imageType, createInfo.tiling, createInfo.usage,
+                createInfo.flags, &formatProps));
 
             AZ_Assert(descriptor.m_sharedQueueMask != RHI::HardwareQueueClassMask::None, "Invalid shared queue mask");
             AZStd::vector<uint32_t> queueFamilies(device.GetCommandQueueContext().GetQueueFamilyIndices(descriptor.m_sharedQueueMask));
@@ -204,13 +220,7 @@ namespace AZ
                 RHI::CountBitsSet(static_cast<uint32_t>(descriptor.m_sharedQueueMask)) == 2;    // And ONLY copy + another queue. This means that the
                                                                                                 // copy queue can transition the resource to the correct queue
                                                                                                 // after finishing copying.
-
-            VkImageCreateInfo createInfo{};
-            createInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-            createInfo.pNext = nullptr;
-            createInfo.flags = GetImageCreateFlags();
-            createInfo.imageType = ConvertToImageType(descriptor.m_dimension);
-            createInfo.format = ConvertFormat(descriptor.m_format);
+            
             VkExtent3D extent = ConvertToExtent3D(descriptor.m_size);
             extent.width = AZStd::min<uint32_t>(extent.width, formatProps.maxExtent.width);
             extent.height = AZStd::min<uint32_t>(extent.height, formatProps.maxExtent.height);
@@ -220,61 +230,16 @@ namespace AZ
             createInfo.arrayLayers = AZStd::min<uint32_t>(descriptor.m_arraySize, formatProps.maxArrayLayers);
             VkSampleCountFlagBits sampleCountFlagBits = static_cast<VkSampleCountFlagBits>(RHI::FilterBits(static_cast<VkSampleCountFlags>(ConvertSampleCount(descriptor.m_multisampleState.m_samples)), formatProps.sampleCounts));
             createInfo.samples = (static_cast<uint32_t>(sampleCountFlagBits) > 0) ? sampleCountFlagBits : VK_SAMPLE_COUNT_1_BIT;
-            createInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-            createInfo.usage = GetImageUsageFlags();
             createInfo.sharingMode = exclusiveOwnership ? VK_SHARING_MODE_EXCLUSIVE : VK_SHARING_MODE_CONCURRENT;
             createInfo.queueFamilyIndexCount = static_cast<uint32_t>(queueFamilies.size());
             createInfo.pQueueFamilyIndices = queueFamilies.empty() ? nullptr : queueFamilies.data();
             createInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-#ifdef AZ_RHI_ENABLE_VALIDATION
-            switch (createInfo.imageType)
-            {
-            case VK_IMAGE_TYPE_1D:
-                AZ_Assert(createInfo.extent.width <= device.GetLimits().m_maxImageDimension1D, "Image width exceeds device capability.");
-                break;
-            case VK_IMAGE_TYPE_2D:
-                if (RHI::CheckBitsAny(createInfo.flags, static_cast<VkImageCreateFlags>(VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)))
-                {
-                    AZ_Assert(createInfo.extent.width <= device.GetLimits().m_maxImageDimensionCube, "Image width exceeds device capability.");
-                    AZ_Assert(createInfo.extent.height <= device.GetLimits().m_maxImageDimensionCube, "Image height exceeds device capability.");
-                }
-                else
-                {
-                    AZ_Assert(createInfo.extent.width <= device.GetLimits().m_maxImageDimension2D, "Image width exceeds device capability.");
-                    AZ_Assert(createInfo.extent.height <= device.GetLimits().m_maxImageDimension2D, "Image height exceeds device capability.");
-                }
-                break;
-            case VK_IMAGE_TYPE_3D:
-                AZ_Assert(createInfo.extent.width <= device.GetLimits().m_maxImageDimension3D, "Image width exceeds device capability.");
-                AZ_Assert(createInfo.extent.height <= device.GetLimits().m_maxImageDimension3D, "Image height exceeds device capability.");
-                AZ_Assert(createInfo.extent.depth <= device.GetLimits().m_maxImageDimension3D, "Image depth exceeds device capability.");
-                break;
-            default:
-                AZ_Assert(false, "Image Type is illegal.");
-            }
-#endif
 
             const VkResult result = vkCreateImage(device.GetNativeDevice(), &createInfo, nullptr, &m_vkImage);
             AssertSuccess(result);
 
             m_isOwnerOfNativeImage = true;
             return ConvertResult(result);
-        }
-
-        VkImageFormatProperties Image::GetImageFormatProperties() const
-        {
-            auto& device = static_cast<Device&>(GetDevice());
-            const auto& physicalDevice = static_cast<const PhysicalDevice&>(device.GetPhysicalDevice());
-            const RHI::ImageDescriptor& descriptor = GetDescriptor();
-
-            VkImageFormatProperties imageFormatProperties{};
-            AssertSuccess(vkGetPhysicalDeviceImageFormatProperties(
-                physicalDevice.GetNativePhysicalDevice(), ConvertFormat(descriptor.m_format),
-                ConvertToImageType(descriptor.m_dimension), VK_IMAGE_TILING_OPTIMAL, GetImageUsageFlags(),
-                GetImageCreateFlags(), &imageFormatProperties));
-
-            return imageFormatProperties;
         }
 
         VkImageCreateFlags Image::GetImageCreateFlags() const
@@ -331,11 +296,6 @@ namespace AZ
             {
                 usageFlags |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
             }
-            // MSAA images may be resolved using a command list function, so we need to add the transfer src bit.
-            if (RHI::CheckBitsAny(bindFlags, RHI::ImageBindFlags::CopyRead) || GetDescriptor().m_multisampleState.m_samples > 1)
-            {
-                usageFlags |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-            }
             if (RHI::CheckBitsAny(bindFlags, RHI::ImageBindFlags::CopyWrite))
             {
                 usageFlags |= VK_IMAGE_USAGE_TRANSFER_DST_BIT;
@@ -346,10 +306,21 @@ namespace AZ
                 usageFlags |= VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
             }
 
+            // add transfer src usage for all images since we may want them to be copyied for preview or readback
+            usageFlags |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
             auto& device = static_cast<Device&>(GetDevice());
             const VkImageUsageFlags usageMask = device.GetImageUsageFromFormat(GetDescriptor().m_format);
 
-            return usageFlags & usageMask;
+            auto finalFlags = usageFlags & usageMask;
+
+            // Output a warning about desired usages are not support
+            if (finalFlags != usageFlags)
+            {
+                AZ_Warning("Vulkan", false, "missing usage (unsupported): %d", usageFlags & ~finalFlags);
+            }
+
+            return finalFlags;
         }
         
         void Image::SetNameInternal(const AZStd::string_view& name)

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -317,7 +317,7 @@ namespace AZ
             // Output a warning about desired usages are not support
             if (finalFlags != usageFlags)
             {
-                AZ_Warning("Vulkan", false, "Missing usage big flags (unsupported): %x", usageFlags & ~finalFlags);
+                AZ_Warning("Vulkan", false, "Missing usage bit flags (unsupported): %x", usageFlags & ~finalFlags);
             }
 
             return finalFlags;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.cpp
@@ -317,7 +317,7 @@ namespace AZ
             // Output a warning about desired usages are not support
             if (finalFlags != usageFlags)
             {
-                AZ_Warning("Vulkan", false, "missing usage (unsupported): %d", usageFlags & ~finalFlags);
+                AZ_Warning("Vulkan", false, "Missing usage big flags (unsupported): %x", usageFlags & ~finalFlags);
             }
 
             return finalFlags;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Image.h
@@ -95,7 +95,6 @@ namespace AZ
             RHI::ResultCode BindMemoryView(const MemoryView& memoryView, const RHI::HeapMemoryLevel heapMemoryLevel);
 
             RHI::ResultCode BuildNativeImage();
-            VkImageFormatProperties GetImageFormatProperties() const;
 
             VkImageCreateFlags GetImageCreateFlags() const;
             VkImageUsageFlags GetImageUsageFlags() const;

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImagePool.cpp
@@ -49,6 +49,9 @@ namespace AZ
             uint32_t memoryTypeBits = 0;
             {
                 // Use an image descriptor of size 1x1 to get the memory requirements.
+                // Note: The descriptorBase.m_bindFlags may contain both ImageBindFlags::Color and ImageBindFlags::DepthStencil.
+                //       Vulkan can't create an image with both color and depthstencil usage for RHI::Format::R8G8B8A8_UNORM.
+                //       Use compatiable ImageBindFlags instead
                 RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyWrite;
                 RHI::ImageDescriptor imageDescriptor = RHI::ImageDescriptor::Create2D(bindFlags, 1, 1, RHI::Format::R8G8B8A8_UNORM);
                 VkMemoryRequirements memRequirements = device.GetImageMemoryRequirements(imageDescriptor);
@@ -85,6 +88,11 @@ namespace AZ
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
             MemoryView memoryView = m_memoryAllocator.Allocate(image->m_memoryRequirements.size, image->m_memoryRequirements.alignment);
+
+            if (!memoryView.IsValid())
+            {
+                return RHI::ResultCode::OutOfMemory;
+            }
             result = image->BindMemoryView(
                 memoryView,
                 m_memoryAllocator.GetDescriptor().m_heapMemoryLevel);

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/ImagePool.cpp
@@ -49,7 +49,8 @@ namespace AZ
             uint32_t memoryTypeBits = 0;
             {
                 // Use an image descriptor of size 1x1 to get the memory requirements.
-                RHI::ImageDescriptor imageDescriptor = RHI::ImageDescriptor::Create2D(descriptorBase.m_bindFlags, 1, 1, RHI::Format::R8G8B8A8_UNORM);
+                RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyWrite;
+                RHI::ImageDescriptor imageDescriptor = RHI::ImageDescriptor::Create2D(bindFlags, 1, 1, RHI::Format::R8G8B8A8_UNORM);
                 VkMemoryRequirements memRequirements = device.GetImageMemoryRequirements(imageDescriptor);
                 memoryTypeBits = memRequirements.memoryTypeBits;
             }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/SwapChain.cpp
@@ -525,7 +525,7 @@ namespace AZ
 
             RHI::ResultCode result = BuildNativeSwapChain(m_dimensions);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            AZ_TracePrintf("Swapchain", "Swapchain created. Width: %u, Height: %u.", m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
+            AZ_TracePrintf("Vulkan", "Swapchain created. Width: %u, Height: %u.\n", m_dimensions.m_imageWidth, m_dimensions.m_imageHeight);
 
             // Do not recycle the semaphore because they may not ever get signaled and since
             // we can't recycle Vulkan semaphores we just delete them.
@@ -551,13 +551,13 @@ namespace AZ
                 device.GetNativeDevice(), m_nativeSwapChain, &m_dimensions.m_imageCount, m_swapchainNativeImages.data());
             AssertSuccess(vkResult);
             RETURN_RESULT_IF_UNSUCCESSFUL(ConvertResult(vkResult));
-            AZ_TracePrintf("Swapchain", "Obtained presentable images.");
+            AZ_TracePrintf("Swapchain", "Obtained presentable images.\n");
 
             // Acquire the first image
             uint32_t imageIndex = 0;
             result = AcquireNewImage(&imageIndex);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
-            AZ_TracePrintf("Swapchain", "Acquired the first image.");
+            AZ_TracePrintf("Swapchain", "Acquired the first image.\n");
 
             return RHI::ResultCode::Success;
         }

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TransientAttachmentPool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/TransientAttachmentPool.cpp
@@ -144,7 +144,7 @@ namespace AZ
             if (descriptor.m_renderTargetBudgetInBytes || allowNoBudget)
             {
                 // Use an image descriptor of size 1x1 to get the memory requirements.
-                RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::DepthStencil | RHI::ImageBindFlags::ShaderRead;
+                RHI::ImageBindFlags bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderRead;
                 RHI::ImageDescriptor imageDescriptor = RHI::ImageDescriptor::Create2D(bindFlags, 1, 1, RHI::Format::R8G8B8A8_UNORM);
                 VkMemoryRequirements memRequirements = device.GetImageMemoryRequirements(imageDescriptor);
 

--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Vulkan.h
@@ -90,7 +90,10 @@ namespace AZ
         /// Checks whether the result is successful; if not, it break program execution.
         inline void AssertSuccess([[maybe_unused]] VkResult result)
         {
-            AZ_Assert(result == VK_SUCCESS, "ASSERT: Vulkan API method failed: %s", GetResultString(result));
+            if (result != VK_SUCCESS)
+            {
+                AZ_Assert(false, "ASSERT: Vulkan API method failed: %s", GetResultString(result));
+            }
         }
 
         /// Checks whether the result is successful; if not, reports the error and returns false. Otherwise, returns true.

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Buffer/BufferSystem.cpp
@@ -121,7 +121,8 @@ namespace AZ
                 bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Read;
                 break;
             case CommonBufferPoolType::ReadWrite:
-                bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderWrite | RHI::BufferBindFlags::ShaderRead;
+                // Add CopyRead flag too since it's often we need to readback gpu attachment buffers.
+                bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderWrite | RHI::BufferBindFlags::ShaderRead | RHI::BufferBindFlags::CopyRead;
                 bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
                 bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
                 break;

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Image/AttachmentImage.cpp
@@ -174,7 +174,7 @@ namespace AZ
         
         void AttachmentImage::Shutdown()
         {
-            if (m_imageAsset->HasUniqueName())
+            if (m_imageAsset && m_imageAsset->HasUniqueName())
             {
                 ImageSystemInterface::Get()->UnregisterAttachmentImage(this);
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -371,7 +371,14 @@ namespace AZ
         {
             // add attachments to the scope
             // input attachment
-            frameGraph.UseAttachment(RHI::ImageScopeAttachmentDescriptor{ m_imageAttachmentId }, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentUsage::Shader);
+            RHI::FrameGraphAttachmentInterface attachmentDatabase = frameGraph.GetAttachmentDatabase();
+            RHI::ImageDescriptor imageDesc = attachmentDatabase.GetImageDescriptor(m_imageAttachmentId);
+            auto scopeAttachmentDesc = RHI::ImageScopeAttachmentDescriptor{ m_imageAttachmentId };
+            // aspect flag needs to be set for SRV (espectially for image contains both depth and stencil)
+            // Note: only support preview depth here if the image contains both depth and stencil
+            scopeAttachmentDesc.m_imageViewDescriptor.m_aspectFlags = RHI::CheckBitsAll(RHI::GetImageAspectFlags(imageDesc.m_format), RHI::ImageAspectFlags::Depth)?
+                RHI::ImageAspectFlags::Depth:RHI::ImageAspectFlags::Color;
+            frameGraph.UseAttachment(scopeAttachmentDesc, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentUsage::Shader);
 
             // output attachment
             frameGraph.UseColorAttachment(RHI::ImageScopeAttachmentDescriptor{ m_outputColorAttachment->GetAttachmentId() });

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Specific/ImageAttachmentPreviewPass.cpp
@@ -373,11 +373,20 @@ namespace AZ
             // input attachment
             RHI::FrameGraphAttachmentInterface attachmentDatabase = frameGraph.GetAttachmentDatabase();
             RHI::ImageDescriptor imageDesc = attachmentDatabase.GetImageDescriptor(m_imageAttachmentId);
-            auto scopeAttachmentDesc = RHI::ImageScopeAttachmentDescriptor{ m_imageAttachmentId };
-            // aspect flag needs to be set for SRV (espectially for image contains both depth and stencil)
-            // Note: only support preview depth here if the image contains both depth and stencil
-            scopeAttachmentDesc.m_imageViewDescriptor.m_aspectFlags = RHI::CheckBitsAll(RHI::GetImageAspectFlags(imageDesc.m_format), RHI::ImageAspectFlags::Depth)?
-                RHI::ImageAspectFlags::Depth:RHI::ImageAspectFlags::Color;
+            // only preview mip 0 and array 0
+            RHI::ImageViewDescriptor imageViewDesc = RHI::ImageViewDescriptor::Create(
+                RHI::Format::Unknown, // no overwrite
+                0,  //mipSliceMin
+                0,  //mipSliceMax
+                0,  //arraySliceMin
+                0   //arraySliceMax
+            );
+
+            // If the format contains depth, set m_aspectFlags to depth, otherwise set it to color
+            imageViewDesc.m_aspectFlags = RHI::CheckBitsAny(RHI::GetImageAspectFlags(imageDesc.m_format), RHI::ImageAspectFlags::Depth) ? 
+                RHI::ImageAspectFlags::Depth : RHI::ImageAspectFlags::Color;
+
+            auto scopeAttachmentDesc = RHI::ImageScopeAttachmentDescriptor{ m_imageAttachmentId, imageViewDesc};
             frameGraph.UseAttachment(scopeAttachmentDesc, RHI::ScopeAttachmentAccess::Read, RHI::ScopeAttachmentUsage::Shader);
 
             // output attachment


### PR DESCRIPTION
… wrong depth data 
- AttachmenImagePreview need to add aspect flag when preview image with multiple aspects. 
Also fixed some vulkan debug layer validation issues. 
- Add transfer src bit to all the images so they can be captured. 
- Add transfer src bit to all writable buffers. 
- Refactor BuildNativeImage to reduce some duplicated function calls. 

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>