### PR TITLE
[Linux] Do not filter XCB_CLIENT_MESSAGE events when in game mode in the Editor

### DIFF
--- a/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
+++ b/Code/Editor/Platform/Linux/Editor/Core/QtEditorApplication_linux.cpp
@@ -12,6 +12,7 @@
 #include <AzFramework/XcbEventHandler.h>
 #include <AzFramework/XcbConnectionManager.h>
 #include <qpa/qplatformnativeinterface.h>
+#include <AzFramework/XcbEventHandler.h>
 #endif
 
 namespace Editor
@@ -55,6 +56,21 @@ namespace Editor
 #ifdef PAL_TRAIT_LINUX_WINDOW_MANAGER_XCB
             AzFramework::XcbEventHandlerBus::Broadcast(
                 &AzFramework::XcbEventHandler::HandleXcbEvent, static_cast<xcb_generic_event_t*>(message));
+
+            const auto event = static_cast<xcb_generic_event_t*>(message);
+            if ((event->response_type & AzFramework::s_XcbResponseTypeMask) == XCB_CLIENT_MESSAGE)
+            {
+                // Do not filter out XCB_CLIENT_MESSAGE events. These include
+                // _NET_WM_PING events, which window managers use to detect if
+                // an application is still responding. When Qt creates the
+                // window, it sets the _NET_WM_PING atom of the WM_PROTOCOLS
+                // property, so window managers will expect the application to
+                // support this protocol. By skipping the filtering of this
+                // event, Qt processes the ping event normally, so that window
+                // managers do not think that the Editor has stopped
+                // responding.
+                return false;
+            }
 #endif
             return true;
         }

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbEventHandler.h
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbEventHandler.h
@@ -15,6 +15,8 @@
 
 namespace AzFramework
 {
+    static constexpr inline uint8_t s_XcbResponseTypeMask = 0x7f; // Mask to extract the specific event type from an xcb event
+
     class XcbEventHandler
     {
     public:

--- a/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
+++ b/Code/Framework/AzFramework/Platform/Common/Xcb/AzFramework/XcbNativeWindow.cpp
@@ -19,7 +19,6 @@ namespace AzFramework
     [[maybe_unused]] const char XcbErrorWindow[] = "XcbNativeWindow";
     static constexpr uint8_t s_XcbFormatDataSize = 32; // Format indicator for xcb for client messages
     static constexpr uint16_t s_DefaultXcbWindowBorderWidth = 4; // The default border with in pixels if a border was specified
-    static constexpr uint8_t s_XcbResponseTypeMask = 0x7f; // Mask to extract the specific event type from an xcb event
 
 #define _NET_WM_STATE_REMOVE 0l
 #define _NET_WM_STATE_ADD 1l


### PR DESCRIPTION
XCB_CLIENT_MESSAGE events include _NET_WM_PING events, which window managers
use to detect if an application is still responding. When Qt creates the
window, it sets the _NET_WM_PING atom of the WM_PROTOCOLS property, so window
managers will expect the application to support this protocol. By skipping the
filtering of this event, Qt processes the ping event normally, so that window
managers do not think that the Editor has stopped responding.

Signed-off-by: Chris Burel <burelc@amazon.com>