### PR TITLE
Nightly GPU Area light - fixing a casing issue on a dictionary key

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_AreaLightScreenshotTest.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_AreaLightScreenshotTest.py
@@ -139,11 +139,11 @@ def AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages():
 
         # 7. Set the Attenuation Radius Mode property of the Light component to 1 (automatic).
         light_component.set_component_property_value(
-            AtomComponentProperties.light('Attenuation Radius Mode'), ATTENUATION_RADIUS_MODE['automatic'])
+            AtomComponentProperties.light('Attenuation radius Mode'), ATTENUATION_RADIUS_MODE['automatic'])
         Report.result(
             Tests.light_component_attenuation_radius_property_set,
             light_component.get_component_property_value(
-                AtomComponentProperties.light('Attenuation Radius Mode')) == ATTENUATION_RADIUS_MODE['automatic'])
+                AtomComponentProperties.light('Attenuation radius Mode')) == ATTENUATION_RADIUS_MODE['automatic'])
 
         # 8. Enter game mode and take a screenshot then exit game mode.
         enter_exit_game_mode_take_screenshot("AreaLight_2.ppm", Tests.enter_game_mode, Tests.exit_game_mode)


### PR DESCRIPTION
the key for an atom_constants.py component property path was changed in a different PR. That caused a failure in nightly GPU tests

`EXCEPTION raised:
  Traceback (most recent call last):
    File "d:\workspace\o3de\automatedtesting\gem\pythontests\editorpythontesttools\editor_python_test_tools\utils.py", line 308, in start_test
      test_function()
    File "D:/workspace/o3de/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomGPU_AreaLightScreenshotTest.py", line 142, in AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages
      AtomComponentProperties.light('Attenuation Radius Mode'), ATTENUATION_RADIUS_MODE['automatic'])
    File "D:\workspace\o3de\AutomatedTesting\Gem\Editor\Scripts/../../PythonTests\Atom\atom_utils\atom_constants.py", line 374, in light
      return properties[property]
  KeyError: 'Attenuation Radius Mode'
Test result:  FAILURE
JSON_START({"name": "hydra_AtomGPU_AreaLightScreenshotTest", "success": false, "exception": "Traceback (most recent call last):\n    File `

DX12 versions of this test pass in local testing. vulkan versions fail for a different reason.

the vulkan versions of tests are the two failing ones listed:
D:\workspace\o3de\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py::TestAutomation::AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_Vulkan[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
D:\workspace\o3de\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  D:\workspace\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py::TestAutomation::AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages_Vulkan[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
===================== 2 failed, 4 passed, 3 warnings in 473.71s (0:07:53)

Signed-off-by: Scott Murray <scottmur@amazon.com>