### PR TITLE
Copyable Spawnable Ticket

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Entity/GameEntityContextComponent.cpp
@@ -294,14 +294,10 @@ namespace AzFramework
                     {
                         SpawnableEntitiesDefinition* spawnableEntitiesInterface = SpawnableEntitiesInterface::Get();
                         AZ_Assert(spawnableEntitiesInterface != nullptr, "SpawnableEntitiesInterface is not found.");
-                        spawnableEntitiesInterface->RetrieveEntitySpawnTicket(
-                            currentEntity->GetSpawnTicketId(),
-                            [spawnableEntitiesInterface, currentEntity](EntitySpawnTicket* entitySpawnTicket)
+                        spawnableEntitiesInterface->RetrieveTicket(currentEntity->GetSpawnTicketId(),
+                            [spawnableEntitiesInterface, currentEntity](EntitySpawnTicket&& entitySpawnTicket)
                             {
-                                if (entitySpawnTicket != nullptr)
-                                {
-                                    spawnableEntitiesInterface->DespawnEntity(currentEntity->GetId(), *entitySpawnTicket);
-                                }
+                                spawnableEntitiesInterface->DespawnEntity(currentEntity->GetId(), entitySpawnTicket);
                             });
                         return;
                     }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.cpp
@@ -279,75 +279,98 @@ namespace AzFramework
     // EntitySpawnTicket
     //
 
+    EntitySpawnTicket::EntitySpawnTicket(const EntitySpawnTicket& rhs)
+        : m_payload(rhs.m_payload)
+        , m_interface(rhs.m_interface)
+    {
+        rhs.m_interface->IncrementTicketReference(rhs.m_payload);
+    }
+
     EntitySpawnTicket::EntitySpawnTicket(EntitySpawnTicket&& rhs)
         : m_payload(rhs.m_payload)
-        , m_id(rhs.m_id)
+        , m_interface(rhs.m_interface)
     {
-        auto manager = SpawnableEntitiesInterface::Get();
-        AZ_Assert(manager, "SpawnableEntitiesInterface has no implementation.");
         rhs.m_payload = nullptr;
-        rhs.m_id = 0;
-        AZStd::scoped_lock lock(manager->m_entitySpawnTicketMapMutex);
-        manager->m_entitySpawnTicketMap.insert_or_assign(rhs.m_id, this);
+        rhs.m_interface = nullptr;
     }
 
     EntitySpawnTicket::EntitySpawnTicket(AZ::Data::Asset<Spawnable> spawnable)
     {
         auto manager = SpawnableEntitiesInterface::Get();
         AZ_Assert(manager, "Attempting to create an entity spawn ticket while the SpawnableEntitiesInterface has no implementation.");
-        AZStd::pair<EntitySpawnTicket::Id, void*> result = manager->CreateTicket(AZStd::move(spawnable));
-        m_id = result.first;
-        m_payload = result.second;
-        AZStd::scoped_lock lock(manager->m_entitySpawnTicketMapMutex);
-        manager->m_entitySpawnTicketMap.insert_or_assign(m_id, this);
+        m_payload = manager->CreateTicket(AZStd::move(spawnable));
+        m_interface = manager;
     }
 
     EntitySpawnTicket::~EntitySpawnTicket()
     {
-        if (m_payload)
+        if (IsValid())
         {
-            auto manager = SpawnableEntitiesInterface::Get();
-            AZ_Assert(manager, "Attempting to destroy an entity spawn ticket while the SpawnableEntitiesInterface has no implementation.");
-            manager->DestroyTicket(m_payload);
+            m_interface->DecrementTicketReference(m_payload);
             m_payload = nullptr;
-            AZStd::scoped_lock lock(manager->m_entitySpawnTicketMapMutex);
-            manager->m_entitySpawnTicketMap.erase(m_id);
-            m_id = 0;
+            m_interface = nullptr;
         }
+    }
+
+    EntitySpawnTicket& EntitySpawnTicket::operator=(const EntitySpawnTicket& rhs)
+    {
+        if (this != &rhs)
+        {
+            if (IsValid())
+            {
+                m_interface->DecrementTicketReference(m_payload);
+            }
+
+            m_interface = rhs.m_interface;
+            m_payload = rhs.m_payload;
+
+            if (rhs.IsValid())
+            {
+                rhs.m_interface->IncrementTicketReference(rhs.m_payload);
+            }
+
+        }
+        return *this;
     }
 
     EntitySpawnTicket& EntitySpawnTicket::operator=(EntitySpawnTicket&& rhs)
     {
         if (this != &rhs)
         {
-            auto manager = SpawnableEntitiesInterface::Get();
-            AZ_Assert(manager, "Attempting to destroy an entity spawn ticket while the SpawnableEntitiesInterface has no implementation.");
-            if (m_payload)
+            if (IsValid())
             {
-                manager->DestroyTicket(m_payload);
+                m_interface->DecrementTicketReference(m_payload);
             }
 
-            Id previousId = m_id;
-            m_id = rhs.m_id;
-            rhs.m_id = 0;
+            m_interface = rhs.m_interface;
+            rhs.m_interface = nullptr;
 
             m_payload = rhs.m_payload;
             rhs.m_payload = nullptr;
-
-            AZStd::scoped_lock lock(manager->m_entitySpawnTicketMapMutex);
-            manager->m_entitySpawnTicketMap.erase(previousId);
-            manager->m_entitySpawnTicketMap.insert_or_assign(m_id, this);
         }
         return *this;
     }
 
     auto EntitySpawnTicket::GetId() const -> Id
     {
-        return m_id;
+        return IsValid() ? m_interface->GetTicketId(m_payload) : 0;
+    }
+
+    const AZ::Data::Asset<Spawnable>* EntitySpawnTicket::GetSpawnable() const
+    {
+        return IsValid() ? &(m_interface->GetSpawnableOnTicket(m_payload)) : nullptr;
     }
 
     bool EntitySpawnTicket::IsValid() const
     {
         return m_payload != nullptr;
+    }
+
+    EntitySpawnTicket SpawnableEntitiesDefinition::InternalToExternalTicket(void* internalTicket, SpawnableEntitiesDefinition* owner)
+    {
+        EntitySpawnTicket result;
+        result.m_interface = owner;
+        result.m_payload = internalTicket;
+        return result;
     }
 } // namespace AzFramework

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -6,6 +6,9 @@
  *
  */
 
+// Note that the tests for the Spawnables are in the AzToolsFramework.Tests in order to get access to easy ways to construct
+// spawnables in memory.
+
 #pragma once
 
 #include <AzCore/Asset/AssetCommon.h>

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesInterface.h
@@ -170,26 +170,30 @@ namespace AzFramework
         using Id = uint32_t;
 
         EntitySpawnTicket() = default;
-        EntitySpawnTicket(const EntitySpawnTicket&) = delete;
+        EntitySpawnTicket(const EntitySpawnTicket& rhs);
         EntitySpawnTicket(EntitySpawnTicket&& rhs);
         explicit EntitySpawnTicket(AZ::Data::Asset<Spawnable> spawnable);
         ~EntitySpawnTicket();
 
-        EntitySpawnTicket& operator=(const EntitySpawnTicket&) = delete;
+        EntitySpawnTicket& operator=(const EntitySpawnTicket& rhs);
         EntitySpawnTicket& operator=(EntitySpawnTicket&& rhs);
 
+        //! Returns an id that uniquely identifies this ticket or 0 if not spawnable has been assigned.
         Id GetId() const;
+        //! Returns the assets associated with the ticket or a nullptr if no spawnable has been assigned yet.
+        const AZ::Data::Asset<Spawnable>* GetSpawnable() const;
+        //! Returns whether or not the ticket is in a usable state.
         bool IsValid() const;
 
     private:
         void* m_payload{ nullptr };
-        Id m_id { 0 }; //!< An id that uniquely identifies a ticket.
+        class SpawnableEntitiesDefinition* m_interface{ nullptr };
     };
 
     using EntitySpawnCallback = AZStd::function<void(EntitySpawnTicket::Id, SpawnableConstEntityContainerView)>;
     using EntityPreInsertionCallback = AZStd::function<void(EntitySpawnTicket::Id, SpawnableEntityContainerView)>;
     using EntityDespawnCallback = AZStd::function<void(EntitySpawnTicket::Id)>;
-    using RetrieveEntitySpawnTicketCallback = AZStd::function<void(EntitySpawnTicket*)>;
+    using RetrieveEntitySpawnTicketCallback = AZStd::function<void(EntitySpawnTicket&&)>;
     using ReloadSpawnableCallback = AZStd::function<void(EntitySpawnTicket::Id, SpawnableConstEntityContainerView)>;
     using UpdateEntityAliasTypesCallback = AZStd::function<void(EntitySpawnTicket::Id)>;
     using ListEntitiesCallback = AZStd::function<void(EntitySpawnTicket::Id, SpawnableConstEntityContainerView)>;
@@ -246,6 +250,12 @@ namespace AzFramework
         //! Callback that's called when despawning entity has completed. This can be triggered from a different thread than the one that
         //! made the function call to despawn.
         EntityDespawnCallback m_completionCallback;
+        //! The priority at which this call will be executed.
+        SpawnablePriority m_priority{ SpawnablePriority_Default };
+    };
+
+    struct RetrieveTicketOptionalArgs final
+    {
         //! The priority at which this call will be executed.
         SpawnablePriority m_priority{ SpawnablePriority_Default };
     };
@@ -342,7 +352,8 @@ namespace AzFramework
         //! Gets the EntitySpawnTicket associated with the entitySpawnTicketId.
         //! @param entitySpawnTicketId the id of EntitySpawnTicket to get.
         //! @param callback The callback to execute upon retrieving the ticket.
-        virtual void RetrieveEntitySpawnTicket(EntitySpawnTicket::Id entitySpawnTicketId, RetrieveEntitySpawnTicketCallback callback) = 0;
+        virtual void RetrieveTicket(
+            EntitySpawnTicket::Id ticketId, RetrieveEntitySpawnTicketCallback callback, RetrieveTicketOptionalArgs optionalArgs = {}) = 0;
         //! Removes all entities in the provided list from the environment and reconstructs the entities from the provided spawnable.
         //! @param ticket Holds the information on the entities to reload.
         //! @param priority The priority at which this call will be executed.
@@ -400,9 +411,14 @@ namespace AzFramework
             EntitySpawnTicket& ticket, BarrierCallback completionCallback, LoadBarrierOptionalArgs optionalArgs = {}) = 0;
 
     protected:
-        [[nodiscard]] virtual AZStd::pair<EntitySpawnTicket::Id, void*> CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable) = 0;
-        virtual void DestroyTicket(void* ticket) = 0;
+        [[nodiscard]] virtual void* CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable) = 0;
+        virtual void IncrementTicketReference(void* ticket) = 0;
+        virtual void DecrementTicketReference(void* ticket) = 0;
+        [[nodiscard]] virtual EntitySpawnTicket::Id GetTicketId(void* ticket) = 0;
+        [[nodiscard]] virtual const AZ::Data::Asset<Spawnable>& GetSpawnableOnTicket(void* ticket) = 0;
 
+        static EntitySpawnTicket InternalToExternalTicket(void* internalTicket, SpawnableEntitiesDefinition* owner);
+        
         template<typename T>
         [[nodiscard]] static T& GetTicketPayload(EntitySpawnTicket& ticket)
         {
@@ -426,9 +442,6 @@ namespace AzFramework
         {
             return reinterpret_cast<const T*>(ticket->m_payload);
         }
-
-        AZStd::unordered_map<EntitySpawnTicket::Id, EntitySpawnTicket*> m_entitySpawnTicketMap;
-        AZStd::recursive_mutex m_entitySpawnTicketMapMutex;
     };
 
     using SpawnableEntitiesInterface = AZ::Interface<SpawnableEntitiesDefinition>;

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.cpp
@@ -46,6 +46,11 @@ namespace AzFramework
         }
     }
 
+    SpawnableEntitiesManager::~SpawnableEntitiesManager()
+    {
+        AZ_Assert(m_totalTickets == 0, "Shutting down the Spawnable Entities Manager while there are still active Spawnable Tickets.");
+    }
+
     void SpawnableEntitiesManager::SpawnAllEntities(EntitySpawnTicket& ticket, SpawnAllEntitiesOptionalArgs optionalArgs)
     {
         AZ_Assert(ticket.IsValid(), "Ticket provided to SpawnAllEntities hasn't been initialized.");
@@ -96,22 +101,24 @@ namespace AzFramework
         QueueRequest(ticket, optionalArgs.m_priority, AZStd::move(queueEntry));
     }
 
-    void SpawnableEntitiesManager::RetrieveEntitySpawnTicket(EntitySpawnTicket::Id entitySpawnTicketId, RetrieveEntitySpawnTicketCallback callback)
+    void SpawnableEntitiesManager::RetrieveTicket(
+        EntitySpawnTicket::Id ticketId, RetrieveEntitySpawnTicketCallback callback, RetrieveTicketOptionalArgs optionalArgs)
     {
-        if (entitySpawnTicketId == 0)
+        if (ticketId == 0)
         {
             AZ_Assert(false, "Ticket id provided to RetrieveEntitySpawnTicket is invalid.");
             return;
         }
 
-        AZStd::scoped_lock lock(m_entitySpawnTicketMapMutex);
-        auto entitySpawnTicketIterator = m_entitySpawnTicketMap.find(entitySpawnTicketId);
-        if (entitySpawnTicketIterator == m_entitySpawnTicketMap.end())
+        RetrieveTicketCommand queueEntry;
+        queueEntry.m_ticketId = ticketId;
+        queueEntry.m_callback = AZStd::move(callback);
+
+        Queue& queue = optionalArgs.m_priority <= m_highPriorityThreshold ? m_highPriorityQueue : m_regularPriorityQueue;
         {
-            AZ_Assert(false, "The EntitySpawnTicket corresponding to id '%lu' cannot be found", entitySpawnTicketId);
-            return;
+            AZStd::scoped_lock queueLock(queue.m_pendingRequestMutex);
+            queue.m_pendingRequest.push(AZStd::move(queueEntry));
         }
-        callback(entitySpawnTicketIterator->second);
     }
 
     void SpawnableEntitiesManager::ReloadSpawnable(
@@ -279,25 +286,58 @@ namespace AzFramework
         return queue.m_delayed.empty() ? CommandQueueStatus::NoCommandsLeft : CommandQueueStatus::HasCommandsLeft;
     }
 
-    AZStd::pair<EntitySpawnTicket::Id, void*> SpawnableEntitiesManager::CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable)
+    void* SpawnableEntitiesManager::CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable)
     {
         static AZStd::atomic_uint32_t idCounter { 1 };
 
         auto result = aznew Ticket();
         result->m_spawnable = AZStd::move(spawnable);
+        result->m_ticketId = idCounter++;
+
+        m_totalTickets++;
+        m_ticketsPendingRegistration++;
+        AZ_Assert(
+            m_ticketsPendingRegistration <= m_totalTickets, "There are less total tickets than there are tickets pending registration.");
+
+        RegisterTicketCommand queueEntry;
+        queueEntry.m_ticket = result;
+        {
+            AZStd::scoped_lock queueLock(m_highPriorityQueue.m_pendingRequestMutex);
+            queueEntry.m_requestId = result->m_nextRequestId++;
+            m_highPriorityQueue.m_pendingRequest.push(AZStd::move(queueEntry));
+        }
         
-        return AZStd::make_pair<EntitySpawnTicket::Id, void*>(idCounter++, result);
+        return result;
     }
 
-    void SpawnableEntitiesManager::DestroyTicket(void* ticket)
+    void SpawnableEntitiesManager::IncrementTicketReference(void* ticket)
     {
-        DestroyTicketCommand queueEntry;
-        queueEntry.m_ticket = reinterpret_cast<Ticket*>(ticket);
+        reinterpret_cast<Ticket*>(ticket)->m_referenceCount++;
+    }
+
+    void SpawnableEntitiesManager::DecrementTicketReference(void* ticket)
+    {
+        auto ticketInstance = reinterpret_cast<Ticket*>(ticket);
+        if (ticketInstance->m_referenceCount-- == 1)
         {
-            AZStd::scoped_lock queueLock(m_regularPriorityQueue.m_pendingRequestMutex);
-            queueEntry.m_requestId = reinterpret_cast<Ticket*>(ticket)->m_nextRequestId++;
-            m_regularPriorityQueue.m_pendingRequest.push(AZStd::move(queueEntry));
+            DestroyTicketCommand queueEntry;
+            queueEntry.m_ticket = ticketInstance;
+            {
+                AZStd::scoped_lock queueLock(m_regularPriorityQueue.m_pendingRequestMutex);
+                queueEntry.m_requestId = ticketInstance->m_nextRequestId++;
+                m_regularPriorityQueue.m_pendingRequest.push(AZStd::move(queueEntry));
+            }
         }
+    }
+
+    EntitySpawnTicket::Id SpawnableEntitiesManager::GetTicketId(void* ticket)
+    {
+        return reinterpret_cast<Ticket*>(ticket)->m_ticketId;
+    }
+
+    const AZ::Data::Asset<Spawnable>& SpawnableEntitiesManager::GetSpawnableOnTicket(void* ticket)
+    {
+        return reinterpret_cast<Ticket*>(ticket)->m_spawnable;
     }
 
     AZ::Entity* SpawnableEntitiesManager::CloneSingleEntity(const AZ::Entity& entityPrototype,
@@ -928,6 +968,47 @@ namespace AzFramework
         }
     }
 
+    auto SpawnableEntitiesManager::ProcessRequest(RetrieveTicketCommand& request) -> CommandResult
+    {
+        auto entitySpawnTicketIterator = m_entitySpawnTicketMap.find(request.m_ticketId);
+        if (entitySpawnTicketIterator == m_entitySpawnTicketMap.end())
+        {
+            if (m_ticketsPendingRegistration > 0)
+            {
+                // There are still tickets pending registration, which may hold the reference, so 
+                return CommandResult::Requeue;
+            }
+            else
+            {
+                AZ_Assert(false, "The EntitySpawnTicket corresponding to id '%lu' cannot be found", request.m_ticketId);
+                return CommandResult::Executed;
+            }
+        }
+
+        // About to make a copy so increase the reference count.
+        entitySpawnTicketIterator->second->m_referenceCount++;
+        request.m_callback(InternalToExternalTicket(entitySpawnTicketIterator->second, this));
+        return CommandResult::Executed;
+    }
+
+    auto SpawnableEntitiesManager::ProcessRequest(RegisterTicketCommand& request) -> CommandResult
+    {
+        if (request.m_requestId == request.m_ticket->m_currentRequestId)
+        {
+            m_entitySpawnTicketMap.insert_or_assign(request.m_ticket->m_ticketId, request.m_ticket);
+            request.m_ticket->m_currentRequestId++;
+            AZ_Assert(
+                m_ticketsPendingRegistration > 0,
+                "Attempting to decrement the number of tickets pending registration while there are no registrations pending.");
+            m_ticketsPendingRegistration--;
+            return CommandResult::Executed;
+        }
+        else
+        {
+            return CommandResult::Requeue;
+        }
+    }
+
     auto SpawnableEntitiesManager::ProcessRequest(DestroyTicketCommand& request) -> CommandResult
     {
         if (request.m_requestId == request.m_ticket->m_currentRequestId)
@@ -942,7 +1023,12 @@ namespace AzFramework
                         &GameEntityContextRequestBus::Events::DestroyGameEntity, entity->GetId());
                 }
             }
+
+            m_entitySpawnTicketMap.erase(request.m_ticket->m_ticketId);
+
             delete request.m_ticket;
+            AZ_Assert(m_totalTickets > 0, "Attempting to decrement the total number of tickets while it's zero.");
+            m_totalTickets--;
 
             return CommandResult::Executed;
         }

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableEntitiesManager.h
@@ -14,6 +14,7 @@
 #include <AzCore/std/containers/deque.h>
 #include <AzCore/std/containers/variant.h>
 #include <AzCore/std/containers/vector.h>
+#include <AzCore/std/parallel/atomic.h>
 #include <AzCore/std/parallel/mutex.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
@@ -47,7 +48,7 @@ namespace AzFramework
         };
 
         SpawnableEntitiesManager();
-        ~SpawnableEntitiesManager() override = default;
+        ~SpawnableEntitiesManager() override;
 
         //
         // The following functions are thread safe
@@ -58,7 +59,10 @@ namespace AzFramework
             EntitySpawnTicket& ticket, AZStd::vector<uint32_t> entityIndices, SpawnEntitiesOptionalArgs optionalArgs = {}) override;
         void DespawnAllEntities(EntitySpawnTicket& ticket, DespawnAllEntitiesOptionalArgs optionalArgs = {}) override;
         void DespawnEntity(AZ::EntityId entityId, EntitySpawnTicket& ticket, DespawnEntityOptionalArgs optionalArgs = {}) override;
-        void RetrieveEntitySpawnTicket(EntitySpawnTicket::Id entitySpawnTicketId, RetrieveEntitySpawnTicketCallback callback) override;
+        void RetrieveTicket(
+            EntitySpawnTicket::Id ticketId,
+            RetrieveEntitySpawnTicketCallback callback,
+            RetrieveTicketOptionalArgs optionalArgs = {}) override;
         void ReloadSpawnable(
             EntitySpawnTicket& ticket, AZ::Data::Asset<Spawnable> spawnable, ReloadSpawnableOptionalArgs optionalArgs = {}) override;
 
@@ -96,6 +100,7 @@ namespace AzFramework
             AZ_CLASS_ALLOCATOR(Ticket, AZ::ThreadPoolAllocator, 0);
             static constexpr uint32_t Processing = AZStd::numeric_limits<uint32_t>::max();
 
+            AZStd::atomic_int64_t m_referenceCount{ 1 };
             //! Map of prototype entity ids to their associated instance ids.
             //! Tickets can be used to spawn the same prototype entities multiple times, in any order, across multiple calls.
             //! Since prototype entities can reference other entities, this map is used to fix up those references across calls
@@ -115,8 +120,9 @@ namespace AzFramework
             AZStd::vector<AZ::Entity*> m_spawnedEntities;
             AZStd::vector<uint32_t> m_spawnedEntityIndices;
             AZ::Data::Asset<Spawnable> m_spawnable;
-            uint32_t m_nextRequestId{ 0 }; //!< Next id for this ticket.
+            uint32_t m_nextRequestId{ 0 }; //!< Next id to be handed out to command that's using this ticket..
             uint32_t m_currentRequestId { 0 }; //!< The id for the command that should be executed.
+            uint32_t m_ticketId{ 0 }; //!< The unique id that identifies this ticket.
             bool m_loadAll{ true };
         };
 
@@ -208,6 +214,16 @@ namespace AzFramework
             uint32_t m_requestId;
             bool m_checkAliasSpawnables;
         };
+        struct RetrieveTicketCommand final
+        {
+            EntitySpawnTicket::Id m_ticketId;
+            RetrieveEntitySpawnTicketCallback m_callback;
+        };
+        struct RegisterTicketCommand final
+        {
+            Ticket* m_ticket;
+            uint32_t m_requestId;
+        };
         struct DestroyTicketCommand final
         {
             Ticket* m_ticket;
@@ -226,6 +242,8 @@ namespace AzFramework
             ClaimEntitiesCommand,
             BarrierCommand,
             LoadBarrierCommand,
+            RetrieveTicketCommand,
+            RegisterTicketCommand,
             DestroyTicketCommand>;
 
         struct Queue
@@ -237,9 +255,13 @@ namespace AzFramework
 
         template<typename T>
         void QueueRequest(EntitySpawnTicket& ticket, SpawnablePriority priority, T&& request);
-        AZStd::pair<EntitySpawnTicket::Id, void*> CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable) override;
-        void DestroyTicket(void* ticket) override;
 
+        void* CreateTicket(AZ::Data::Asset<Spawnable>&& spawnable) override;
+        void IncrementTicketReference(void* ticket) override;
+        void DecrementTicketReference(void* ticket) override;
+        EntitySpawnTicket::Id GetTicketId(void* ticket) override;
+        const AZ::Data::Asset<Spawnable>& GetSpawnableOnTicket(void* ticket) override;
+        
         CommandQueueStatus ProcessQueue(Queue& queue);
 
         AZ::Entity* CloneSingleEntity(
@@ -267,6 +289,8 @@ namespace AzFramework
         CommandResult ProcessRequest(ClaimEntitiesCommand& request);
         CommandResult ProcessRequest(BarrierCommand& request);
         CommandResult ProcessRequest(LoadBarrierCommand& request);
+        CommandResult ProcessRequest(RetrieveTicketCommand& request);
+        CommandResult ProcessRequest(RegisterTicketCommand& request);
         CommandResult ProcessRequest(DestroyTicketCommand& request);
 
         //! Generate a base set of original-to-new entity ID mappings to use during spawning.
@@ -287,6 +311,10 @@ namespace AzFramework
         //! SpawnablePriority_Default which gives users a bit of room to fine tune the priorities as this value can be configured
         //! through the Settings Registry under the key "/O3DE/AzFramework/Spawnables/HighPriorityThreshold".
         SpawnablePriority m_highPriorityThreshold { 64 };
+
+        AZStd::unordered_map<EntitySpawnTicket::Id, Ticket*> m_entitySpawnTicketMap;
+        AZStd::atomic_int m_totalTickets{ 0 };
+        AZStd::atomic_int m_ticketsPendingRegistration{ 0 };
     };
 
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(AzFramework::SpawnableEntitiesManager::CommandQueuePriority);

--- a/Code/Framework/AzFramework/Tests/Mocks/MockSpawnableEntitiesInterface.h
+++ b/Code/Framework/AzFramework/Tests/Mocks/MockSpawnableEntitiesInterface.h
@@ -42,8 +42,9 @@ namespace AzFramework
 
         MOCK_METHOD3(DespawnEntity, void(AZ::EntityId entityId, EntitySpawnTicket& ticket, DespawnEntityOptionalArgs optionalArgs));
 
-        MOCK_METHOD2(
-            RetrieveEntitySpawnTicket, void(EntitySpawnTicket::Id entitySpawnTicketId, RetrieveEntitySpawnTicketCallback callback));
+        MOCK_METHOD3(
+            RetrieveTicket,
+            void(EntitySpawnTicket::Id ticketId, RetrieveEntitySpawnTicketCallback callback, RetrieveTicketOptionalArgs optionalArgs));
 
         MOCK_METHOD3(
             ReloadSpawnable,
@@ -70,8 +71,12 @@ namespace AzFramework
         MOCK_METHOD3(Barrier, void(EntitySpawnTicket& ticket, BarrierCallback completionCallback, BarrierOptionalArgs optionalArgs));
         MOCK_METHOD3(LoadBarrier, void(EntitySpawnTicket& ticket, BarrierCallback completionCallback, LoadBarrierOptionalArgs optionalArgs));
 
-        MOCK_METHOD1(CreateTicket, AZStd::pair<EntitySpawnTicket::Id, void*>(AZ::Data::Asset<Spawnable>&& spawnable));
+        MOCK_METHOD1(CreateTicket, void*(AZ::Data::Asset<Spawnable>&& spawnable));
+        MOCK_METHOD1(IncrementTicketReference, void(void* ticket));
+        MOCK_METHOD1(DecrementTicketReference, void(void* ticket));
         MOCK_METHOD1(DestroyTicket, void(void* ticket));
+        MOCK_METHOD1(GetTicketId, EntitySpawnTicket::Id(void* ticket));
+        MOCK_METHOD1(GetSpawnableOnTicket, const AZ::Data::Asset<Spawnable>&(void* ticket));
 
         /** Installs some default result values for the above functions.
          *   Note that you can always override these in scope of your test by adding additional ON_CALL / EXPECT_CALL
@@ -82,10 +87,8 @@ namespace AzFramework
             using namespace ::testing;
 
             // The ID and pointer are completely arbitrary, they just need to both be non-zero to look like a valid ticket.
-            constexpr EntitySpawnTicket::Id ticketId(1);
             static int ticketPayload = 0;
-            ON_CALL(target, CreateTicket(_)).WillByDefault(
-                Return(AZStd::make_pair<AzFramework::EntitySpawnTicket::Id, void*>(ticketId, &ticketPayload)));
+            ON_CALL(target, CreateTicket(_)).WillByDefault(Return(&ticketPayload));
         }
 
     };

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableTestFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableTestFixture.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/std/containers/vector.h>
+#include <AzFramework/Components/TransformComponent.h>
+#include <AzToolsFramework/Prefab/PrefabDomTypes.h>
+#include <AzToolsFramework/Prefab/Spawnable/SpawnableUtils.h>
+#include <Prefab/Spawnable/SpawnableTestFixture.h>
+
+namespace UnitTest
+{
+    AZStd::unique_ptr<AZ::Entity> SpawnableTestFixture::CreateEntity(const char* entityName, AZ::EntityId parentId)
+    {
+        auto result = AZStd::make_unique<AZ::Entity>(entityName);
+        auto transformComponent = result->CreateComponent<AzFramework::TransformComponent>();
+        transformComponent->SetParent(parentId);
+        
+        return result;
+    }
+
+    AZ::Data::Asset<AzFramework::Spawnable> SpawnableTestFixture::CreateSpawnableAsset(uint64_t entityCount)
+    {
+        // The life cycle of a spawnable is managed through the asset.
+        AzFramework::Spawnable* spawnable = new AzFramework::Spawnable(
+            AZ::Data::AssetId::CreateString("{612F2AB1-30DF-44BB-AFBE-17A85199F09E}:0"), AZ::Data::AssetData::AssetStatus::Ready);
+
+        AzFramework::Spawnable::EntityList& entities = spawnable->GetEntities();
+        entities.reserve(entityCount);
+        for (uint64_t i = 0; i < entityCount; i++)
+        {
+            entities.emplace_back(CreateEntity("Entity"));
+        }
+
+        return AZ::Data::Asset<AzFramework::Spawnable>(spawnable, AZ::Data::AssetLoadBehavior::Default);
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableTestFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableTestFixture.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
+
+namespace AZ
+{
+    class Entity;
+}
+
+namespace UnitTest
+{
+    class SpawnableTestFixture : public ToolsApplicationFixture
+    {
+    public:
+        constexpr static const char* PathString = "path/to/template";
+
+    protected:
+        AZStd::unique_ptr<AZ::Entity> CreateEntity(const char* entityName, AZ::EntityId parentId = AZ::EntityId());
+        AZ::Data::Asset<AzFramework::Spawnable> CreateSpawnableAsset(uint64_t entityCount);
+    };
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableTicketTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Spawnable/SpawnableTicketTests.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <Prefab/Spawnable/SpawnableTestFixture.h>
+
+namespace UnitTest
+{
+    class SpawnableTicketTests : public SpawnableTestFixture
+    {
+    };
+
+    TEST_F(SpawnableTicketTests, CreateAndDestroyEmptyTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket;
+    }
+
+    TEST_F(SpawnableTicketTests, CreateAndDestroyAssignedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+    }
+
+    TEST_F(SpawnableTicketTests, IsValidTicketWithEmtpyTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket;
+        EXPECT_FALSE(ticket.IsValid());
+    }
+
+    TEST_F(SpawnableTicketTests, IsValidTicketWithAssignedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        EXPECT_TRUE(ticket.IsValid());
+    }
+
+    TEST_F(SpawnableTicketTests, RetrieveTicketId)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        EXPECT_NE(0, ticket.GetId());
+    }
+
+    TEST_F(SpawnableTicketTests, RetrieveSpawnable)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = ticket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_NE(nullptr, spawnable->GetData());
+    }
+
+    TEST_F(SpawnableTicketTests, MoveConstructedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        AzFramework::EntitySpawnTicket movedToTicket(AZStd::move(ticket));
+
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = movedToTicket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_EQ(32, spawnable->Get()->GetEntities().size());
+    }
+
+    TEST_F(SpawnableTicketTests, MoveAssignedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        AzFramework::EntitySpawnTicket movedToTicket;
+        movedToTicket = AZStd::move(ticket);
+
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = movedToTicket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_EQ(32, spawnable->Get()->GetEntities().size());
+    }
+
+    TEST_F(SpawnableTicketTests, MoveAssignedTicketToAlreadyAssignedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        AzFramework::EntitySpawnTicket movedToTicket(CreateSpawnableAsset(16));
+        movedToTicket = AZStd::move(ticket);
+
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = movedToTicket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_EQ(32, spawnable->Get()->GetEntities().size());
+    }
+
+    TEST_F(SpawnableTicketTests, CopyConstructedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        AzFramework::EntitySpawnTicket copiedToTicket(ticket);
+
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = copiedToTicket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_EQ(32, spawnable->Get()->GetEntities().size());
+    }
+
+    TEST_F(SpawnableTicketTests, CopyAssignedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        AzFramework::EntitySpawnTicket copiedToTicket;
+        copiedToTicket = ticket;
+
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = copiedToTicket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_EQ(32, spawnable->Get()->GetEntities().size());
+    }
+
+    TEST_F(SpawnableTicketTests, CopyAssignedTicketToAlreadyAssignedTicket)
+    {
+        AzFramework::EntitySpawnTicket ticket(CreateSpawnableAsset(32));
+        AzFramework::EntitySpawnTicket copiedToTicket(CreateSpawnableAsset(16));
+        copiedToTicket = ticket;
+
+        const AZ::Data::Asset<AzFramework::Spawnable>* spawnable = copiedToTicket.GetSpawnable();
+        ASSERT_NE(nullptr, spawnable);
+        EXPECT_EQ(32, spawnable->Get()->GetEntities().size());
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -98,6 +98,9 @@ set(FILES
     Prefab/PrefabUpdateTemplateTests.cpp
     Prefab/PrefabUpdateWithPatchesTests.cpp
     Prefab/Spawnable/SpawnableMetaDataTests.cpp
+    Prefab/Spawnable/SpawnableTestFixture.h
+    Prefab/Spawnable/SpawnableTestFixture.cpp
+    Prefab/Spawnable/SpawnableTicketTests.cpp
     Prefab/SpawnableCreateTests.cpp
     Prefab/SpawnableRemoveEditorInfoTestFixture.cpp
     Prefab/SpawnableRemoveEditorInfoTestFixture.h


### PR DESCRIPTION
Spawnable Tickets can now be copied. Behind the scenes a ref counted object is used to track the status of the tickets so they get cleaned up when there are no more copies of a ticket in use. To support this the call to retrieve a ticket instance from a ticket id had to be updated to return a copy, which had the additional side-effect that the mutex around the ticket-id-to-ticket map is no longer needed. This change also allows the spawnable asset associated with the ticket to be retrieved.

Unit tests for the Spawnable Ticket were added. This update also introduces a test fixture for spawnables to be further extended in the future to support more tests of the Spawnable system. The fixture is stored in AzToolsFramework so that future tests have access to the utilities in AzToolsFramework to create complex spawnables.