### PR TITLE
Reenable tests on Linux, remove secondary skip

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -7,9 +7,12 @@
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
 
+    set(SMOKETEST_FILTER "SUITE_smoke")
+
     include(${LY_ROOT_FOLDER}/Code/Tools/SerializeContextTools/Platform/${PAL_PLATFORM_NAME}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
     if (PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS)
         list(APPEND additional_dependencies AZ::SerializeContextTools) # test_CLITool_SerializeContextTools depends on it
+        set(SMOKETEST_FILTER "SUITE_smoke and not SerializeContext")
     endif()
 
     ly_add_pytest(
@@ -17,7 +20,7 @@ if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
         TEST_SUITE smoke
         TEST_SERIAL
         PATH ${CMAKE_CURRENT_LIST_DIR}
-        PYTEST_MARKS "SUITE_smoke"
+        PYTEST_MARKS ${SMOKETEST_FILTER}
         RUNTIME_DEPENDENCIES
             AZ::AssetProcessor
             AZ::PythonBindingsExample

--- a/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
+++ b/AutomatedTesting/Gem/PythonTests/smoke/CMakeLists.txt
@@ -7,12 +7,12 @@
 
 if(PAL_TRAIT_BUILD_TESTS_SUPPORTED AND PAL_TRAIT_BUILD_HOST_TOOLS)
 
-    set(SMOKETEST_FILTER "SUITE_smoke")
+    set(SMOKETEST_FILTER "SUITE_smoke and not SerializeContext")
 
     include(${LY_ROOT_FOLDER}/Code/Tools/SerializeContextTools/Platform/${PAL_PLATFORM_NAME}/PAL_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
     if (PAL_TRAIT_BUILD_SERIALIZECONTEXTTOOLS)
         list(APPEND additional_dependencies AZ::SerializeContextTools) # test_CLITool_SerializeContextTools depends on it
-        set(SMOKETEST_FILTER "SUITE_smoke and not SerializeContext")
+        set(SMOKETEST_FILTER "SUITE_smoke")
     endif()
 
     ly_add_pytest(

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_SerializeContextTools_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_SerializeContextTools_Works.py
@@ -16,6 +16,7 @@ import subprocess
 import ly_test_tools
 
 
+@pytest.mark.SerializeContext
 @pytest.mark.SUITE_smoke
 class TestCLIToolSerializeContextToolsWorks(object):
     def test_CLITool_SerializeContextTools_Works(self, build_directory):

--- a/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_SerializeContextTools_Works.py
+++ b/AutomatedTesting/Gem/PythonTests/smoke/test_CLITool_SerializeContextTools_Works.py
@@ -16,7 +16,6 @@ import subprocess
 import ly_test_tools
 
 
-@pytest.mark.skipif(not ly_test_tools.WINDOWS, reason="Only succeeds on windows https://github.com/o3de/o3de/issues/5539")
 @pytest.mark.SUITE_smoke
 class TestCLIToolSerializeContextToolsWorks(object):
     def test_CLITool_SerializeContextTools_Works(self, build_directory):

--- a/Tools/LyTestTools/tests/CMakeLists.txt
+++ b/Tools/LyTestTools/tests/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 # Unit tests.
 ly_add_pytest(
-    NAME LyTestTools_UnitTests
+    NAME LyTestTools_Unit
     TEST_SUITE smoke
     PATH ${CMAKE_CURRENT_LIST_DIR}/unit/
     COMPONENT TestTools
@@ -20,25 +20,22 @@ get_property(LY_PROJECTS_TARGET_NAME GLOBAL PROPERTY LY_PROJECTS_TARGET_NAME)
 if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedTesting IN_LIST LY_PROJECTS_TARGET_NAME)
     # Integration tests.
 
-    set(SUPPORTED_PLATFORMS "Windows" "Mac")
-        if ("${PAL_PLATFORM_NAME}" IN_LIST SUPPORTED_PLATFORMS)
-        ly_add_pytest(
-            NAME LyTestTools_IntegTests_Sanity_smoke_no_gpu
-            PATH ${CMAKE_CURRENT_LIST_DIR}/integ/sanity_tests.py
-            TEST_SERIAL
-            TEST_SUITE smoke
-            RUNTIME_DEPENDENCIES
-                Legacy::Editor
-                AssetProcessor
-                AutomatedTesting.GameLauncher
-                AutomatedTesting.ServerLauncher
-                AutomatedTesting.Assets
-                COMPONENT TestTools
-        )
-    endif()
+    ly_add_pytest(
+        NAME LyTestTools_Integ_Sanity
+        PATH ${CMAKE_CURRENT_LIST_DIR}/integ/sanity_tests.py
+        TEST_SERIAL
+        TEST_SUITE smoke
+        RUNTIME_DEPENDENCIES
+            Legacy::Editor
+            AssetProcessor
+            AutomatedTesting.GameLauncher
+            AutomatedTesting.ServerLauncher
+            AutomatedTesting.Assets
+            COMPONENT TestTools
+    )
 
     ly_add_pytest(
-        NAME LyTestTools_IntegTests_ProcessUtils_smoke_no_gpu
+        NAME LyTestTools_Integ_ProcessUtils
         PATH ${CMAKE_CURRENT_LIST_DIR}/integ/test_process_utils.py
         TEST_SERIAL
         TEST_SUITE smoke
@@ -46,7 +43,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
     )
     
     ly_add_pytest(
-        NAME LyTestTools_IntegTests_ProcessUtilsLinux_smoke_no_gpu
+        NAME LyTestTools_Integ_ProcessUtilsLinux
         PATH ${CMAKE_CURRENT_LIST_DIR}/integ/test_process_utils_linux.py
         TEST_SERIAL
         TEST_SUITE smoke
@@ -55,7 +52,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED AND AutomatedT
 
     # Regression tests.
     ly_add_pytest(
-        NAME LyTestTools_IntegTests_RegressionTests_periodic_no_gpu
+        NAME LyTestTools_Integ_RegressionTests
         PATH ${CMAKE_CURRENT_LIST_DIR}/integ/test_regression.py
         TEST_SERIAL
         TEST_SUITE periodic


### PR DESCRIPTION
Reenables LyTT tests on Linux, modifies SerializeContext to be tested when it is enabled, and simplifies some redundant naming.

Signed-off-by: sweeneys <sweeneys@amazon.com>