### PR TITLE
Atom Tools: asset selection combo box thumbnail support

### DIFF
--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h
@@ -10,6 +10,7 @@
 
 #if !defined(Q_MOC_RUN)
 #include <AzFramework/Asset/AssetCatalogBus.h>
+#include <AzToolsFramework/Thumbnails/Thumbnail.h>
 #include <QComboBox>
 #endif
 
@@ -28,6 +29,9 @@ namespace AtomToolsFramework
         void SetFilterCallback(const AZStd::function<bool(const AZ::Data::AssetInfo&)>& filterCallback);
         void SelectAsset(const AZ::Data::AssetId& assetId);
 
+        void SetThumbnailsEnabled(bool enabled);
+        void SetThumbnailDelayMs(AZ::u32 delay);
+
     Q_SIGNALS:
         void AssetSelected(const AZ::Data::AssetId& assetId);
 
@@ -38,6 +42,15 @@ namespace AtomToolsFramework
         void OnCatalogAssetAdded(const AZ::Data::AssetId& assetId) override;
         void OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo) override;
 
+        void AddAsset(const AZ::Data::AssetInfo& assetInfo);
+        void RegisterThumbnail(const AZ::Data::AssetId& assetId);
+        void UpdateThumbnail(const AZ::Data::AssetId& assetId);
+        void QueueUpdateThumbnail(const AZ::Data::AssetId& assetId);
+
         AZStd::function<bool(const AZ::Data::AssetInfo&)> m_filterCallback;
+
+        bool m_thumbnailsEnabled = false;
+        AZ::u32 m_thumbnailDelayMs = 2000;
+        AZStd::unordered_map<AZ::Data::AssetId, AzToolsFramework::Thumbnailer::SharedThumbnailKey> m_thumbnailKeys;
     };
 } // namespace AtomToolsFramework

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/AssetSelection/AssetSelectionComboBox.cpp
@@ -9,9 +9,12 @@
 #include <Atom/RPI.Edit/Common/AssetUtils.h>
 #include <AtomToolsFramework/AssetSelection/AssetSelectionComboBox.h>
 #include <AtomToolsFramework/Util/Util.h>
+#include <AzToolsFramework/AssetBrowser/Thumbnails/ProductThumbnail.h>
+#include <AzToolsFramework/Thumbnails/ThumbnailerBus.h>
 
 #include <QAbstractItemView>
 #include <QFileInfo>
+#include <QTimer>
 
 namespace AtomToolsFramework
 {
@@ -44,25 +47,18 @@ namespace AtomToolsFramework
     void AssetSelectionComboBox::Reset()
     {
         clear();
+        m_thumbnailKeys.clear();
 
-        if (m_filterCallback)
+        AZ::Data::AssetCatalogRequests::AssetEnumerationCB enumerateCB =
+            [&]([[maybe_unused]] const AZ::Data::AssetId assetId, const AZ::Data::AssetInfo& assetInfo)
         {
-            AZ::Data::AssetCatalogRequests::AssetEnumerationCB enumerateCB =
-                [&]([[maybe_unused]] const AZ::Data::AssetId id, const AZ::Data::AssetInfo& assetInfo)
-            {
-                if (m_filterCallback(assetInfo))
-                {
-                    addItem(
-                        GetDisplayNameFromPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId).c_str()),
-                        QVariant(QString(assetInfo.m_assetId.ToString<AZStd::string>().c_str())));
-                }
-            };
+            AddAsset(assetInfo);
+        };
 
-            AZ::Data::AssetCatalogRequestBus::Broadcast(
-                &AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, enumerateCB, nullptr);
+        AZ::Data::AssetCatalogRequestBus::Broadcast(
+            &AZ::Data::AssetCatalogRequestBus::Events::EnumerateAssets, nullptr, enumerateCB, nullptr);
 
-            model()->sort(0, Qt::AscendingOrder);
-        }
+        model()->sort(0, Qt::AscendingOrder);
 
         setCurrentIndex(0);
     }
@@ -78,33 +74,107 @@ namespace AtomToolsFramework
         setCurrentIndex(findData(QVariant(QString(assetId.ToString<AZStd::string>().c_str()))));
     }
 
+    void AssetSelectionComboBox::SetThumbnailsEnabled(bool enabled)
+    {
+        if (m_thumbnailsEnabled != enabled)
+        {
+            m_thumbnailKeys.clear();
+            m_thumbnailsEnabled = enabled;
+            for (int index = 0; index < count(); ++index)
+            {
+                setItemIcon(index, QIcon());
+                RegisterThumbnail(AZ::Data::AssetId::CreateString(itemData(index).toString().toUtf8().constData()));
+            }
+        }
+    }
+
+    void AssetSelectionComboBox::SetThumbnailDelayMs(AZ::u32 delay)
+    {
+        m_thumbnailDelayMs = delay;
+    }
+
     void AssetSelectionComboBox::OnCatalogAssetAdded(const AZ::Data::AssetId& assetId)
     {
         AZ::Data::AssetCatalogRequestBus::Broadcast(
             [this, assetId](AZ::Data::AssetCatalogRequests* assetCatalogRequests)
             {
-                AZ::Data::AssetInfo assetInfo = assetCatalogRequests->GetAssetInfoById(assetId);
-                if (m_filterCallback && m_filterCallback(assetInfo))
-                {
-                    addItem(
-                        GetDisplayNameFromPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId).c_str()),
-                        QVariant(QString(assetInfo.m_assetId.ToString<AZStd::string>().c_str())));
-                }
+                AddAsset(assetCatalogRequests->GetAssetInfoById(assetId));
                 model()->sort(0, Qt::AscendingOrder);
             });
     }
 
-    void AssetSelectionComboBox::OnCatalogAssetRemoved(
-        [[maybe_unused]] const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo)
+    void AssetSelectionComboBox::OnCatalogAssetRemoved(const AZ::Data::AssetId& assetId, const AZ::Data::AssetInfo& assetInfo)
     {
         if (m_filterCallback && m_filterCallback(assetInfo))
         {
-            int index = findData(QVariant(QString(assetInfo.m_assetId.ToString<AZStd::string>().c_str())));
-            if (index >= 0 && index < count())
+            int index = findData(QVariant(QString(assetId.ToString<AZStd::string>().c_str())));
+            if (index >= 0)
             {
                 removeItem(index);
             }
         }
+    }
+
+    void AssetSelectionComboBox::AddAsset(const AZ::Data::AssetInfo& assetInfo)
+    {
+        if (m_filterCallback && m_filterCallback(assetInfo))
+        {
+            addItem(
+                GetDisplayNameFromPath(AZ::RPI::AssetUtils::GetSourcePathByAssetId(assetInfo.m_assetId).c_str()),
+                QVariant(QString(assetInfo.m_assetId.ToString<AZStd::string>().c_str())));
+
+            RegisterThumbnail(assetInfo.m_assetId);
+        }
+    }
+
+    void AssetSelectionComboBox::RegisterThumbnail(const AZ::Data::AssetId& assetId)
+    {
+        if (m_thumbnailsEnabled)
+        {
+            AzToolsFramework::Thumbnailer::SharedThumbnailKey thumbnailKey =
+                MAKE_TKEY(AzToolsFramework::AssetBrowser::ProductThumbnailKey, assetId);
+            m_thumbnailKeys[assetId] = thumbnailKey;
+
+            connect(
+                thumbnailKey.data(), &AzToolsFramework::Thumbnailer::ThumbnailKey::ThumbnailUpdatedSignal, this,
+                [this, assetId]() { QueueUpdateThumbnail(assetId); });
+
+            QueueUpdateThumbnail(assetId);
+        }
+    }
+
+    void AssetSelectionComboBox::UpdateThumbnail(const AZ::Data::AssetId& assetId)
+    {
+        if (m_thumbnailsEnabled)
+        {
+            auto thumbnailKeyItr = m_thumbnailKeys.find(assetId);
+            if (thumbnailKeyItr != m_thumbnailKeys.end())
+            {
+                int index = findData(QVariant(QString(assetId.ToString<AZStd::string>().c_str())));
+                if (index >= 0)
+                {
+                    AzToolsFramework::Thumbnailer::SharedThumbnail thumbnail;
+                    AzToolsFramework::Thumbnailer::ThumbnailerRequestBus::BroadcastResult(
+                        thumbnail, &AzToolsFramework::Thumbnailer::ThumbnailerRequests::GetThumbnail, thumbnailKeyItr->second);
+                    if (thumbnail)
+                    {
+                        // Adding pixmaps for all of the states so they don't disappear when highlighting 
+                        const QPixmap pixmap = thumbnail->GetPixmap().scaled(iconSize(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+                        QIcon icon;
+                        icon.addPixmap(pixmap, QIcon::Normal);
+                        icon.addPixmap(pixmap, QIcon::Disabled);
+                        icon.addPixmap(pixmap, QIcon::Active);
+                        icon.addPixmap(pixmap, QIcon::Selected);
+                        setItemIcon(index, icon);
+                    }
+                }
+            }
+        }
+    }
+
+    void AssetSelectionComboBox::QueueUpdateThumbnail(const AZ::Data::AssetId& assetId)
+    {
+        QTimer::singleShot(m_thumbnailDelayMs, this, [this, assetId]() { UpdateThumbnail(assetId); });
     }
 } // namespace AtomToolsFramework
 


### PR DESCRIPTION
Uses the thumbnail system to add preview images to combo box entries
Disabled by default

Signed-off-by: Guthrie Adams <guthadam@amazon.com>
![image](https://user-images.githubusercontent.com/82461473/155843236-5d60b746-02bd-4c94-98f8-32a67d1ea5f5.png)
