### PR TITLE
Fix for GHI-7879

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/SurfaceManipulator.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/SurfaceManipulator.cpp
@@ -58,6 +58,12 @@ namespace AzToolsFramework
 
     SurfaceManipulator::SurfaceManipulator(const AZ::Transform& worldFromLocal)
     {
+        // default handler for when no handler is installed via InstallEntityIdsToIgnoreFn
+        m_entityIdsToIgnoreFn = [](const ViewportInteraction::MouseInteraction&)
+        {
+            return UniqueEntityIds{};
+        };
+
         SetSpace(worldFromLocal);
         AttachLeftMouseDownImpl();
 


### PR DESCRIPTION
Sets a default callback to return no entity IDs to ignore when no callback has been installed via `InstallEntityIdsToIgnoreFn`.

Signed-off-by: John <jonawals@amazon.co.uk>