### PR TITLE
Framework For Simplifed Python Interface for Project Manager

### DIFF
--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -1,0 +1,301 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+"""
+Contains functions for the project manager to call that gather data from o3de scripts and massage it
+"""
+
+import logging
+import pathlib
+
+from o3de import cmake, disable_gem, download, enable_gem, engine_properties, engine_template, manifest, project_properties, register, repo
+
+logger = logging.getLogger('o3de.project_manager_interface')
+logging.basicConfig(format=utils.LOG_FORMAT)
+
+
+def get_engine_info(engine_name: str = None, engine_path: str or pathlib.Path = None) -> dict or None:
+    """
+        If engine_path is provided then continue
+        Elif only engine_name is provided then call get_registered and use returned path as engine_path
+        Elif neither parameter is provided call get_this_engine_path and use returned path as engine_path
+
+        Call get_engine_json_data using engine_path to populate initial engine data
+
+        Call load_o3de_manifest or get default folders for gems, projects, ect. using get_o3de_..._folder
+        Insert either default folder from manifest or get_o3de_..._folder into engine dict for all folders
+
+        Call get_manifest_engines and check that engine is in the list if it is set registered attr to True
+
+        :param engine_name: Engine name to find engine path for and get json data for
+        :param engine_path: Engine path to gather json data for
+
+        :return dict containing engine info if it was found. Otherwise None is returned
+    """
+    return dict()
+
+
+def set_engine_info(engine_info: dict) -> int:
+    """
+        Call get_engine_info using path from engine_info
+
+        Call edit_engine_props if any relevant properties have changed
+
+        Call register if any relevant properties have changed
+
+        :param engine_info: dict containing values to change in engine
+
+        :return int exit code
+    """
+    return -1
+
+
+def get_project_template_infos() -> list:
+    """
+        Get list of registered project templates using get_templates_for_project_creation
+
+        Gather together list of dicts for each template using get_template_json_data
+
+        :return list of dicts containing template infos.
+    """
+    return list()
+
+
+def register_project(project_path: str or pathlib.Path, remove: bool = False) -> int:
+    """
+        Registers project with engine or removes it
+
+        :param project_path: Project path to register
+        :param remove: bool if False register project, otherwise remove the project from registry
+
+        :return int exit code.
+    """
+    return -1
+
+
+def unregister_invalid_projects() -> int:
+    """
+        Call remove_invalid_o3de_projects
+
+        :return int exit code.
+    """
+    return -1
+
+
+def create_project(project_info: dict, template_path: str or pathlib.Path) -> int:
+    """
+        Creates project from project_info data with template_path using create_project
+
+        If project is created successfully then registers project using register_project
+
+        :param project_info: dict containing project info to create new project
+        :param template_path: Path to template to create project with
+
+        :return int exit code.
+    """
+    return -1
+
+
+def get_project_info(project_path: str or pathlib.Path) -> dict or None:
+    """
+        Call get_project_json_data
+
+        :param project_path: Project path to gather info for
+
+        :return dict with project info. Otherwise None is returned
+    """
+    return dict()
+
+
+def get_all_project_infos() -> list:
+    """
+        Get list of all registered project paths get_all_projects
+
+        Gather together list of dicts for each project using get_project_json_data
+
+        :return list of dicts containing project infos.
+    """
+    return list()
+
+
+def set_project_info(project_info: dict) -> int:
+    """
+        Call edit_project_props using parameters gathered from project_info
+
+        :param engine_info: dict containing values to change in project
+
+        :return int exit code
+    """
+    return -1
+
+
+def get_enabled_gem_names(project_path: str or pathlib.Path) -> list:
+    """
+        Call get_enabled_gem_cmake_file for project_path
+
+        Return get_enabled_gems for cmake file
+
+        :param project_path: Project path to gather enable gems for
+
+        :return list of strs of enable gems for project.
+    """
+    return list()
+
+
+def add_gem_to_project(gem_path: str or pathlib.Path, project_path: str or pathlib.Path) -> int:
+    """
+        Activates gem_path in project_path
+
+        :param gem_path: Gem path to activate
+        :param project_path: Project path to activate
+
+        :return int exit code.
+    """
+    return -1
+
+def remove_gem_from_project(gem_path: str or pathlib.Path, project_path: str or pathlib.Path) -> int:
+    """
+        Deactivates gem_path in project_path
+
+        :param gem_path: Gem path to deactivate
+        :param project_path: Project path to deactivate
+
+        :return int exit code.
+    """
+    return -1
+
+
+def register_gem(gem_path: str or pathlib.Path, project_path: str or pathlib.Path = None, remove: bool = False) -> int:
+    """
+        Un/Registers gem with engine if only gem_path is provided
+        Un/Registers gem to project if path is provided
+
+        :param gem_path: Gem path to register
+        :param project_path: Project path to register project gem with
+        :param remove: bool if False register gem, otherwise remove the gem from registry
+
+        :return int exit code.
+    """
+    return -1
+
+
+def get_gem_info(gem_path: str or pathlib.Path) -> dict or None:
+        """
+        Call get_gem_json_data
+
+        :param gem_path: Gem path to gather info for
+
+        :return dict with project info. Otherwise None is returned
+    """
+    return dict()
+
+
+def get_all_gem_infos(project_path: str or pathlib.Path) -> list:
+    """
+        Get list of all avaliable gem paths for project at project_path using get_all_gems
+
+        Gather together list of dicts for each gem using get_gem_json_data
+
+        :param project_path: Project path to gather avaliable gem infos for
+
+        :return list of dicts containing gem infos.
+    """
+    return list()
+
+
+def register_gem_repo(repo_uri: str, remove: bool = False) -> int:
+    """
+        Un/Registers gem repo using register
+
+        :param repo_uri: Uri of repo to register
+        :param remove: bool if False register repo, otherwise remove the repo from registry
+
+        :return int exit code.
+    """
+    return -1
+
+
+def get_all_repo_infos() -> list:
+    """
+        Get list of all registered repo uris get_manifest_repos
+
+        Gather together list of dicts for each repo using get_repo_json_data
+        Also insert the repo path from get_repo_path as the path attr into each dict
+
+        :return list of dicts containing repo infos.
+    """
+    return list()
+
+
+def get_gem_infos_from_repo(repo_uri: str) -> list:
+    """
+        Call get_gem_json_paths_from_cached_repo for repo_uri
+
+        Gather together list of dicts for each gem using get_gem_json_data
+
+        :param repo_uri: Uri of repo to gather gemo infos from
+
+        :return list of dicts containing gem infos.
+    """
+    return list()
+
+
+def get_gem_infos_from_all_repos() -> list:
+    """
+        Call get_gem_json_paths_from_all_cached_repos
+
+        Gather together list of dicts for each gem using get_gem_json_data
+
+        :return list of dicts containing gem infos.
+    """
+    return list()
+
+
+def refresh_gem_repo(repo_uri: str) -> int:
+    """
+        Call refresh_repo with repo_uri
+
+        :param repo_uri: Uri of repo to refresh
+
+        :return int exit code.
+    """
+    return -1
+
+
+def refresh_all_gem_repos() -> int:
+    """
+        Call refresh_repos
+
+        :return int exit code.
+    """
+    return -1
+    download_gem
+
+
+def download_gem(gem_name: str, force_overwrite: bool = False, progress_callback = None) -> int:
+    """
+        Call download_gem
+
+        :param gem_name: Name of gem to download from a repo
+        :param force_overwrite: bool if False does not overwrite gem if already downloaded, otherwise overwrites gem
+        :param progress_callback: A cpp function callback to update progress
+
+        :return int exit code.
+    """
+    return -1
+
+
+def is_gem_update_avaliable(gem_name: str, last_updated: str) -> bool:
+    """
+        Call is_o3de_gem_update_available
+
+        :param gem_name: Name of gem to check for update on
+        :param last_updated: Timestamp when gem was last updated, must be parsable using datetime.fromisoformat
+
+        :return bool True if update is avaliable, otherwise False.
+    """
+    return -1

--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -69,12 +69,20 @@ def get_project_template_infos() -> list:
 
 #### Project methods ###
 
-def register_project(project_path: str, remove: bool = False):
+def register_project(project_path: str):
     """
-        Registers project with engine or removes it
+        Registers project with engine
 
         :param project_path: Project path to register
-        :param remove: bool if False register project, otherwise remove the project from registry
+    """
+    pass
+
+
+def unregister_project(project_path: str):
+    """
+        Unregisters project with engine
+
+        :param project_path: Project path to unregister
     """
     pass
 
@@ -163,14 +171,24 @@ def remove_gem_from_project(gem_path: str, project_path: str):
 
 #### Gem methods ###
 
-def register_gem(gem_path: str, project_path: str = None, remove: bool = False):
+def register_gem(gem_path: str, project_path: str = None,):
     """
-        Un/Registers gem with engine if only gem_path is provided
-        Un/Registers gem to project if path is provided
+        Registers gem with engine if only gem_path is provided
+        Registers gem to project if path is provided
 
         :param gem_path: Gem path to register
         :param project_path: Project path to register project gem with
-        :param remove: bool if False register gem, otherwise remove the gem from registry
+    """
+    pass
+
+
+def unregister_gem(gem_path: str, project_path: str = None,):
+    """
+        Unregisters gem with engine if only gem_path is provided
+        Unregisters gem to project if path is provided
+
+        :param gem_path: Gem path to unregister
+        :param project_path: Project path to unregister project gem with
     """
     pass
 
@@ -224,12 +242,20 @@ def is_gem_update_avaliable(gem_name: str, last_updated: str) -> bool:
 
 #### Gem Repo methods ###
 
-def register_gem_repo(repo_uri: str, remove: bool = False):
+def register_gem_repo(repo_uri: str):
     """
-        Un/Registers gem repo using register
+        Registers gem repo using register
 
         :param repo_uri: Uri of repo to register
-        :param remove: bool if False register repo, otherwise remove the repo from registry
+    """
+    pass
+
+
+def unregister_gem_repo(repo_uri: str):
+    """
+        Unregisters gem repo using register
+
+        :param repo_uri: Uri of repo to unregister
     """
     pass
 

--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -18,7 +18,9 @@ logger = logging.getLogger('o3de.project_manager_interface')
 logging.basicConfig(format=utils.LOG_FORMAT)
 
 
-def get_engine_info(engine_name: str = None, engine_path: str or pathlib.Path = None) -> dict or None:
+#### Engine methods ###
+
+def get_engine_info(engine_name: str = None, engine_path: str = None) -> dict or None:
     """
         If engine_path is provided then continue
         Elif only engine_name is provided then call get_registered and use returned path as engine_path
@@ -39,7 +41,7 @@ def get_engine_info(engine_name: str = None, engine_path: str or pathlib.Path = 
     return dict()
 
 
-def set_engine_info(engine_info: dict) -> int:
+def set_engine_info(engine_info: dict):
     """
         Call get_engine_info using path from engine_info
 
@@ -48,11 +50,11 @@ def set_engine_info(engine_info: dict) -> int:
         Call register if any relevant properties have changed
 
         :param engine_info: dict containing values to change in engine
-
-        :return int exit code
     """
-    return -1
+    pass
 
+
+#### Template methods ###
 
 def get_project_template_infos() -> list:
     """
@@ -65,28 +67,26 @@ def get_project_template_infos() -> list:
     return list()
 
 
-def register_project(project_path: str or pathlib.Path, remove: bool = False) -> int:
+#### Project methods ###
+
+def register_project(project_path: str, remove: bool = False):
     """
         Registers project with engine or removes it
 
         :param project_path: Project path to register
         :param remove: bool if False register project, otherwise remove the project from registry
-
-        :return int exit code.
     """
-    return -1
+    pass
 
 
-def unregister_invalid_projects() -> int:
+def unregister_invalid_projects():
     """
         Call remove_invalid_o3de_projects
-
-        :return int exit code.
     """
-    return -1
+    pass
 
 
-def create_project(project_info: dict, template_path: str or pathlib.Path) -> int:
+def create_project(project_info: dict, template_path: str):
     """
         Creates project from project_info data with template_path using create_project
 
@@ -94,13 +94,24 @@ def create_project(project_info: dict, template_path: str or pathlib.Path) -> in
 
         :param project_info: dict containing project info to create new project
         :param template_path: Path to template to create project with
-
-        :return int exit code.
     """
-    return -1
+    pass
 
 
-def get_project_info(project_path: str or pathlib.Path) -> dict or None:
+def get_enabled_gem_names(project_path: str) -> list:
+    """
+        Call get_enabled_gem_cmake_file for project_path
+
+        Return get_enabled_gems for cmake file
+
+        :param project_path: Project path to gather enable gems for
+
+        :return list of strs of enable gems for project.
+    """
+    return list()
+
+
+def get_project_info(project_path: str) -> dict or None:
     """
         Call get_project_json_data
 
@@ -122,54 +133,37 @@ def get_all_project_infos() -> list:
     return list()
 
 
-def set_project_info(project_info: dict) -> int:
+def set_project_info(project_info: dict):
     """
         Call edit_project_props using parameters gathered from project_info
 
         :param engine_info: dict containing values to change in project
-
-        :return int exit code
     """
-    return -1
+    pass
 
 
-def get_enabled_gem_names(project_path: str or pathlib.Path) -> list:
-    """
-        Call get_enabled_gem_cmake_file for project_path
-
-        Return get_enabled_gems for cmake file
-
-        :param project_path: Project path to gather enable gems for
-
-        :return list of strs of enable gems for project.
-    """
-    return list()
-
-
-def add_gem_to_project(gem_path: str or pathlib.Path, project_path: str or pathlib.Path) -> int:
+def add_gem_to_project(gem_path: str, project_path: str):
     """
         Activates gem_path in project_path
 
         :param gem_path: Gem path to activate
         :param project_path: Project path to activate
-
-        :return int exit code.
     """
-    return -1
+    pass
 
-def remove_gem_from_project(gem_path: str or pathlib.Path, project_path: str or pathlib.Path) -> int:
+def remove_gem_from_project(gem_path: str, project_path: str):
     """
         Deactivates gem_path in project_path
 
         :param gem_path: Gem path to deactivate
         :param project_path: Project path to deactivate
-
-        :return int exit code.
     """
-    return -1
+    pass
 
 
-def register_gem(gem_path: str or pathlib.Path, project_path: str or pathlib.Path = None, remove: bool = False) -> int:
+#### Gem methods ###
+
+def register_gem(gem_path: str, project_path: str = None, remove: bool = False):
     """
         Un/Registers gem with engine if only gem_path is provided
         Un/Registers gem to project if path is provided
@@ -177,13 +171,11 @@ def register_gem(gem_path: str or pathlib.Path, project_path: str or pathlib.Pat
         :param gem_path: Gem path to register
         :param project_path: Project path to register project gem with
         :param remove: bool if False register gem, otherwise remove the gem from registry
-
-        :return int exit code.
     """
-    return -1
+    pass
 
 
-def get_gem_info(gem_path: str or pathlib.Path) -> dict or None:
+def get_gem_info(gem_path: str) -> dict or None:
         """
         Call get_gem_json_data
 
@@ -194,7 +186,7 @@ def get_gem_info(gem_path: str or pathlib.Path) -> dict or None:
     return dict()
 
 
-def get_all_gem_infos(project_path: str or pathlib.Path) -> list:
+def get_all_gem_infos(project_path: str) -> list:
     """
         Get list of all avaliable gem paths for project at project_path using get_all_gems
 
@@ -207,16 +199,39 @@ def get_all_gem_infos(project_path: str or pathlib.Path) -> list:
     return list()
 
 
-def register_gem_repo(repo_uri: str, remove: bool = False) -> int:
+def download_gem(gem_name: str, force_overwrite: bool = False, progress_callback = None):
+    """
+        Call download_gem
+
+        :param gem_name: Name of gem to download from a repo
+        :param force_overwrite: bool if False does not overwrite gem if already downloaded, otherwise overwrites gem
+        :param progress_callback: A cpp function callback to update progress
+    """
+    pass
+
+
+def is_gem_update_avaliable(gem_name: str, last_updated: str) -> bool:
+    """
+        Call is_o3de_gem_update_available
+
+        :param gem_name: Name of gem to check for update on
+        :param last_updated: Timestamp when gem was last updated, must be parsable using datetime.fromisoformat
+
+        :return bool True if update is avaliable, otherwise False.
+    """
+    return False
+
+
+#### Gem Repo methods ###
+
+def register_gem_repo(repo_uri: str, remove: bool = False):
     """
         Un/Registers gem repo using register
 
         :param repo_uri: Uri of repo to register
         :param remove: bool if False register repo, otherwise remove the repo from registry
-
-        :return int exit code.
     """
-    return -1
+    pass
 
 
 def get_all_repo_infos() -> list:
@@ -255,46 +270,16 @@ def get_gem_infos_from_all_repos() -> list:
     return list()
 
 
-def refresh_gem_repo(repo_uri: str) -> int:
+def refresh_gem_repo(repo_uri: str):
     """
         Call refresh_repo with repo_uri
 
         :param repo_uri: Uri of repo to refresh
-
-        :return int exit code.
     """
-    return -1
+    pass
 
-
-def refresh_all_gem_repos() -> int:
+def refresh_all_gem_repos():
     """
         Call refresh_repos
-
-        :return int exit code.
     """
-    return -1
-
-
-def download_gem(gem_name: str, force_overwrite: bool = False, progress_callback = None) -> int:
-    """
-        Call download_gem
-
-        :param gem_name: Name of gem to download from a repo
-        :param force_overwrite: bool if False does not overwrite gem if already downloaded, otherwise overwrites gem
-        :param progress_callback: A cpp function callback to update progress
-
-        :return int exit code.
-    """
-    return -1
-
-
-def is_gem_update_avaliable(gem_name: str, last_updated: str) -> bool:
-    """
-        Call is_o3de_gem_update_available
-
-        :param gem_name: Name of gem to check for update on
-        :param last_updated: Timestamp when gem was last updated, must be parsable using datetime.fromisoformat
-
-        :return bool True if update is avaliable, otherwise False.
-    """
-    return -1
+    pass

--- a/scripts/o3de/o3de/project_manager_interface.py
+++ b/scripts/o3de/o3de/project_manager_interface.py
@@ -273,7 +273,6 @@ def refresh_all_gem_repos() -> int:
         :return int exit code.
     """
     return -1
-    download_gem
 
 
 def download_gem(gem_name: str, force_overwrite: bool = False, progress_callback = None) -> int:


### PR DESCRIPTION
Does not include any helper functions or other common code that could be shared between methods, only the interface for Project Manager to call.

Is designed to be the minimal interface to expose to Project Manager and to do all data massaging and gathering offloaded work from Project Manager and minimizing calls to python through pybind.

Also centralizes the full Project Manager interface so only one .py files needs to be bound.

Psuedo-code for methods is included in documentation.

Project Manager's main responsibility will be de/serialization between data types ...Info cpp classes and dicts in python.
It will also only need to call this simpler interface, no call to a PythonBindings.cpp function should result in more than one call to a python function through pybind. An subsequent calls to python functions to gather or massage data should only be called directly in python.

Signed-off-by: nggieber <52797929+AMZN-nggieber@users.noreply.github.com>