### PR TITLE
Focus Mode Visual Feedback: Pass Classes

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/CommonSystemComponent.cpp
@@ -44,6 +44,11 @@
 #include <PostProcessing/BlendColorGradingLutsPass.h>
 #include <PostProcessing/BloomParentPass.h>
 #include <PostProcessing/HDRColorGradingPass.h>
+#include <PostProcessing/EditorModeFeedbackParentPass.h>
+#include <PostProcessing/EditorModeDesaturationPass.h>
+#include <PostProcessing/EditorModeTintPass.h>
+#include <PostProcessing/EditorModeBlurPass.h>
+#include <PostProcessing/EditorModeOutlinePass.h>
 #include <PostProcessing/DepthUpsamplePass.h>
 #include <PostProcessing/DepthOfFieldCompositePass.h>
 #include <PostProcessing/DepthOfFieldBokehBlurPass.h>
@@ -227,6 +232,11 @@ namespace AZ
             passSystem->AddPassCreator(Name("LightCullingTilePreparePass"), &LightCullingTilePreparePass::Create);
             passSystem->AddPassCreator(Name("BlendColorGradingLutsPass"), &BlendColorGradingLutsPass::Create);
             passSystem->AddPassCreator(Name("HDRColorGradingPass"), &HDRColorGradingPass::Create);
+            passSystem->AddPassCreator(Name("EditorModeFeedbackParentPass"), &EditorModeFeedbackParentPass::Create);
+            passSystem->AddPassCreator(Name("EditorModeDesaturationPass"), &EditorModeDesaturationPass::Create);
+            passSystem->AddPassCreator(Name("EditorModeTintPass"), &EditorModeTintPass::Create);
+            passSystem->AddPassCreator(Name("EditorModeBlurPass"), &EditorModeBlurPass::Create);
+            passSystem->AddPassCreator(Name("EditorModeOutlinePass"), &EditorModeOutlinePass::Create);
             passSystem->AddPassCreator(Name("LookModificationCompositePass"), &LookModificationCompositePass::Create);
             passSystem->AddPassCreator(Name("LookModificationTransformPass"), &LookModificationPass::Create);
             passSystem->AddPassCreator(Name("LutGenerationPass"), &LutGenerationPass::Create);

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeBlurPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeBlurPass.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <PostProcessing/EditorModeBlurPass.h>
+#include <PostProcess/PostProcessFeatureProcessor.h>
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+
+// Temporary measure for setting the blur pass shader parameters at runtime until GHI 3455 is implemented
+AZ_EDITOR_MODE_PASS_TRANSITION_CVARS(cl_editorModeBlurPass, 0.0f, 0.0f, 20.0f, 1.0f);
+AZ_EDITOR_MODE_PASS_CVAR(float, cl_editorModeBlurPass, KernalWidth, 5.0f);
+
+ namespace AZ
+{
+    namespace Render
+    {
+        RPI::Ptr<EditorModeBlurPass> EditorModeBlurPass::Create(const RPI::PassDescriptor& descriptor)
+        {
+            RPI::Ptr<EditorModeBlurPass> pass = aznew EditorModeBlurPass(descriptor);
+            return AZStd::move(pass);
+        }
+        
+        EditorModeBlurPass::EditorModeBlurPass(const RPI::PassDescriptor& descriptor)
+            : EditorModeFeedbackPassBase(descriptor, { 0.0f, 0.0f, 20.0f }, 1.0f)
+        {
+        }
+        
+        void EditorModeBlurPass::InitializeInternal()
+        {
+            EditorModeFeedbackPassBase::InitializeInternal();
+            m_kernalWidthIndex.Reset();
+        }
+        
+        void EditorModeBlurPass::FrameBeginInternal(FramePrepareParams params)
+        {
+            SetSrgConstants();
+            EditorModeFeedbackPassBase::FrameBeginInternal(params);
+        }
+
+        void EditorModeBlurPass::SetKernalWidth(const float width)
+        {
+            m_kernalWidth = width;
+        }
+
+        void EditorModeBlurPass::SetSrgConstants()
+        {
+            // Temporary measure for setting the pass shader parameters at runtime until GHI 3455 is implemented
+            SetMinDepthTransitionValue(cl_editorModeBlurPass_MinDepthTransitionValue);
+            SetDepthTransitionStart(cl_editorModeBlurPass_DepthTransitionStart);
+            SetDepthTransitionDuration(cl_editorModeBlurPass_DepthTransitionDuration);
+            SetFinalBlendAmount(cl_editorModeBlurPass_FinalBlendAmount);
+            SetKernalWidth(cl_editorModeBlurPass_KernalWidth);
+
+            m_shaderResourceGroup->SetConstant(m_kernalWidthIndex, m_kernalWidth);
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeBlurPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeBlurPass.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <PostProcessing/EditorModeFeedbackPassBase.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Pass for editor mode feedback blur effect.
+        class EditorModeBlurPass
+            : public EditorModeFeedbackPassBase
+        {
+        public:
+            AZ_RTTI(EditorModeBlurPass, "{D907D0ED-61E4-4E46-A682-A849676CF48A}", EditorModeFeedbackPassBase);
+            AZ_CLASS_ALLOCATOR(EditorModeBlurPass, SystemAllocator, 0);
+
+            virtual ~EditorModeBlurPass() = default;
+
+            //! Creates a EditorModeBlurPass
+            static RPI::Ptr<EditorModeBlurPass> Create(const RPI::PassDescriptor& descriptor);
+
+            //! Sets the width of kernal to apply box blur effect.
+            void SetKernalWidth(float width);
+
+        protected:
+            EditorModeBlurPass(const RPI::PassDescriptor& descriptor);
+            
+            //! Pass behavior overrides
+            void InitializeInternal() override;
+            void FrameBeginInternal(FramePrepareParams params) override;
+
+        private:
+            //! Sets the shader constant values for the blur effect.
+            void SetSrgConstants();
+
+            RHI::ShaderInputNameIndex m_kernalWidthIndex = "m_kernalWidth";
+            float m_kernalWidth = 5.0f; //!< Default kernal width for the blur effect.
+        };
+    }   // namespace Render
+}   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeDesaturationPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeDesaturationPass.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <PostProcessing/EditorModeDesaturationPass.h>
+#include <PostProcess/PostProcessFeatureProcessor.h>
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+
+// Temporary measure for setting the desaturation pass shader parameters at runtime until GHI 3455 is implemented
+AZ_EDITOR_MODE_PASS_TRANSITION_CVARS(cl_editorModeDesaturationPass, 0.75f, 0.0f, 20.0f, 1.0f);
+AZ_EDITOR_MODE_PASS_CVAR(float, cl_editorModeDesaturationPass, DesaturationAmount, 1.0f);
+
+ namespace AZ
+{
+    namespace Render
+    {
+        RPI::Ptr<EditorModeDesaturationPass> EditorModeDesaturationPass::Create(const RPI::PassDescriptor& descriptor)
+        {
+            RPI::Ptr<EditorModeDesaturationPass> pass = aznew EditorModeDesaturationPass(descriptor);
+            return AZStd::move(pass);
+        }
+        
+        EditorModeDesaturationPass::EditorModeDesaturationPass(const RPI::PassDescriptor& descriptor)
+            : EditorModeFeedbackPassBase(descriptor, { 0.75f, 0.0f, 20.0f }, 1.0f)
+        {
+        }
+        
+        void EditorModeDesaturationPass::InitializeInternal()
+        {
+            EditorModeFeedbackPassBase::InitializeInternal();
+            m_desaturationAmountIndex.Reset();
+        }
+        
+        void EditorModeDesaturationPass::FrameBeginInternal(FramePrepareParams params)
+        {
+            SetSrgConstants();
+            EditorModeFeedbackPassBase::FrameBeginInternal(params);
+        }
+        
+        void EditorModeDesaturationPass::SetDesaturationAmount(const float amount)
+        {
+            m_desaturationAmount = amount;
+        }
+
+        void EditorModeDesaturationPass::SetSrgConstants()
+        {
+            // Temporary measure for setting the pass shader parameters at runtime until GHI 3455 is implemented
+            SetMinDepthTransitionValue(cl_editorModeDesaturationPass_MinDepthTransitionValue);
+            SetDepthTransitionStart(cl_editorModeDesaturationPass_DepthTransitionStart);
+            SetDepthTransitionDuration(cl_editorModeDesaturationPass_DepthTransitionDuration);
+            SetFinalBlendAmount(cl_editorModeDesaturationPass_FinalBlendAmount);
+            SetDesaturationAmount(cl_editorModeDesaturationPass_DesaturationAmount);
+
+            m_shaderResourceGroup->SetConstant(m_desaturationAmountIndex, m_desaturationAmount);
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeDesaturationPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeDesaturationPass.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <PostProcessing/EditorModeFeedbackPassBase.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Pass for editor mode feedback desaturation effect.
+        class EditorModeDesaturationPass
+            : public EditorModeFeedbackPassBase
+        {
+        public:
+            AZ_RTTI(EditorModeDesaturationPass, "{3587B748-7EA8-497F-B2D1-F60E369EACF4}", EditorModeFeedbackPassBase);
+            AZ_CLASS_ALLOCATOR(EditorModeDesaturationPass, SystemAllocator, 0);
+
+            virtual ~EditorModeDesaturationPass() = default;
+
+            //! Creates a EditorModeDesaturationPass
+            static RPI::Ptr<EditorModeDesaturationPass> Create(const RPI::PassDescriptor& descriptor);
+
+            //! Sets the amount of desaturation to apply.
+            void SetDesaturationAmount(float amount);
+
+        protected:
+            EditorModeDesaturationPass(const RPI::PassDescriptor& descriptor);
+            
+            //! Pass behavior overrides
+            void InitializeInternal() override;
+            void FrameBeginInternal(FramePrepareParams params) override;
+
+        private:
+            //! Sets the shader constant values for the desaturation effect.
+            void SetSrgConstants();
+
+            RHI::ShaderInputNameIndex m_desaturationAmountIndex = "m_desaturationAmount";
+            float m_desaturationAmount = 1.0f; //!< Default desaturation amount for the desaturation effect.
+        };
+    }   // namespace Render
+}   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackParentPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackParentPass.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PostProcess/PostProcessFeatureProcessor.h>
+#include <PostProcessing/EditorModeFeedbackParentPass.h>
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+#include <Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        RPI::Ptr<EditorModeFeedbackParentPass> EditorModeFeedbackParentPass::Create(const RPI::PassDescriptor& descriptor)
+        {
+            RPI::Ptr<EditorModeFeedbackParentPass> pass = aznew EditorModeFeedbackParentPass(descriptor);
+            return AZStd::move(pass);
+        }
+
+        EditorModeFeedbackParentPass::EditorModeFeedbackParentPass(const RPI::PassDescriptor& descriptor)
+            : AZ::RPI::ParentPass(descriptor)
+        {
+        }
+
+        bool EditorModeFeedbackParentPass::IsEnabled() const
+        {
+            if (const auto editorModeFeedback = AZ::Interface<EditorModeFeedbackInterface>::Get())
+            {
+                return ParentPass::IsEnabled() && editorModeFeedback->IsEnabled();
+            }
+
+            return ParentPass::IsEnabled();
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackParentPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackParentPass.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <Atom/RPI.Public/Pass/ParentPass.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Parent pass for the editor mode feedback system.
+        class EditorModeFeedbackParentPass 
+        : public AZ::RPI::ParentPass
+        {
+        public:
+            AZ_RTTI(EditorModeFeedbackParentPass, "{890482AB-192E-45B6-866C-76CB7C799CF3}", AZ::RPI::ParentPass);
+            AZ_CLASS_ALLOCATOR(EditorModeFeedbackParentPass, SystemAllocator, 0);
+
+            virtual ~EditorModeFeedbackParentPass() = default;
+
+            //! Creates a EditorModeFeedbackParentPass
+            static RPI::Ptr<EditorModeFeedbackParentPass> Create(const RPI::PassDescriptor& descriptor);
+
+        protected:
+            EditorModeFeedbackParentPass(const RPI::PassDescriptor& descriptor);
+
+            //! Pass behavior overrides
+            bool IsEnabled() const override;
+
+        private:
+        };
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackPassBase.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackPassBase.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PostProcessing/EditorModeFeedbackPassBase.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        RPI::Ptr<EditorModeFeedbackPassBase> EditorModeFeedbackPassBase::Create(const RPI::PassDescriptor& descriptor)
+        {
+            RPI::Ptr<EditorModeFeedbackPassBase> pass = aznew EditorModeFeedbackPassBase(descriptor);
+            return AZStd::move(pass);
+        }
+
+        EditorModeFeedbackPassBase::EditorModeFeedbackPassBase(
+            const RPI::PassDescriptor& descriptor,
+            const DepthTransition& depthTransition,
+            float finalBlendAmount)
+            : FullscreenTrianglePass(descriptor)
+            , m_depthransition(depthTransition)
+            , m_finalBlendAmount(finalBlendAmount)
+        {
+        }
+
+        void EditorModeFeedbackPassBase::InitializeInternal()
+        {
+            FullscreenTrianglePass::InitializeInternal();
+            m_minDepthTransitionValueIndex.Reset();
+            m_depthTransitionStartIndex.Reset();
+            m_depthTransitionDurationIndex.Reset();
+            m_finalBlendAmountIndex.Reset();
+        }
+
+        void EditorModeFeedbackPassBase::FrameBeginInternal(FramePrepareParams params)
+        {
+            SetSrgConstants();
+            FullscreenTrianglePass::FrameBeginInternal(params);
+        }
+
+        void EditorModeFeedbackPassBase::SetMinDepthTransitionValue(const float minValue)
+        {
+            m_depthransition.m_minDepthTransitionValue = minValue;
+        }
+
+        void EditorModeFeedbackPassBase::SetDepthTransitionStart(const float start)
+        {
+            m_depthransition.m_depthTransitionStart = start;
+        }
+
+        void EditorModeFeedbackPassBase::SetDepthTransitionDuration(const float duration)
+        {
+            m_depthransition.m_depthTransitionDuration = duration;
+        }
+
+        void EditorModeFeedbackPassBase::SetFinalBlendAmount(const float amount)
+        {
+            m_finalBlendAmount = amount;
+        }
+
+        void EditorModeFeedbackPassBase::SetSrgConstants()
+        {
+            m_shaderResourceGroup->SetConstant(m_minDepthTransitionValueIndex, m_depthransition.m_minDepthTransitionValue);
+            m_shaderResourceGroup->SetConstant(m_depthTransitionStartIndex, m_depthransition.m_depthTransitionStart);
+            m_shaderResourceGroup->SetConstant(m_depthTransitionDurationIndex, m_depthransition.m_depthTransitionDuration);
+            m_shaderResourceGroup->SetConstant(m_finalBlendAmountIndex, m_finalBlendAmount);
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackPassBase.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeFeedbackPassBase.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Console/IConsole.h>
+
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Pass/FullscreenTrianglePass.h>
+
+// Temporary measure for configuring editor mode feedback effects at runtime until GHI 3455 is implemented
+#define AZ_EDITOR_MODE_PASS_CVAR(TYPE, NAMESPACE, NAME, INITIAL_VALUE)                              \
+    AZ_CVAR(TYPE, ##NAMESPACE##_##NAME, INITIAL_VALUE, nullptr, AZ::ConsoleFunctorFlags::Null, "");
+
+// Temporary measure for configuring editor mode depth transitions at runtime until GHI 3455 is implemented
+#define AZ_EDITOR_MODE_PASS_TRANSITION_CVARS(NAMESPACE, MIN_VALUE, START, DURATION, FINAL_BLEND)    \
+    AZ_EDITOR_MODE_PASS_CVAR(float, NAMESPACE, MinDepthTransitionValue, MIN_VALUE);                 \
+    AZ_EDITOR_MODE_PASS_CVAR(float, NAMESPACE, DepthTransitionStart, START);                        \
+    AZ_EDITOR_MODE_PASS_CVAR(float, NAMESPACE, DepthTransitionDuration, DURATION);                  \
+    AZ_EDITOR_MODE_PASS_CVAR(float, NAMESPACE, FinalBlendAmount, FINAL_BLEND);
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Base class to provide depth transitioning and final blend control to all visual effect passes of the editor mode
+        //! feedback system.
+        class EditorModeFeedbackPassBase
+            : public AZ::RPI::FullscreenTrianglePass
+        {
+        public:
+            AZ_RTTI(EditorModeFeedbackPassBase, "{F1F345E3-1396-47F7-9CA4-9AC87A2E9829}", AZ::RPI::FullscreenTrianglePass);
+            AZ_CLASS_ALLOCATOR(EditorModeFeedbackPassBase, SystemAllocator, 0);
+
+            //! Creates a EditorModeFeedbackPassBase
+            static RPI::Ptr<EditorModeFeedbackPassBase> Create(const RPI::PassDescriptor& descriptor);
+
+            //! Sets the minimum blend amount that will be calculated through depth transitioning. 
+            void SetMinDepthTransitionValue(float minValue);
+
+            //! Sets the start of depth transtion for non-mask effect blending.
+            void SetDepthTransitionStart(float start);
+
+            //! Sets the duration (depth) of the depth transition band (0.0 = no depth transitioning will be applied).
+            void SetDepthTransitionDuration(float duration);
+
+            //! Sets the final blend amount that is used to scale the calculated blend values.
+            void SetFinalBlendAmount(float amount);
+
+        protected:
+            using AZ::RPI::FullscreenTrianglePass::FullscreenTrianglePass;
+
+            struct DepthTransition
+            {
+                //! No depth transitioning by default
+                float m_minDepthTransitionValue = 0.0f;
+                float m_depthTransitionStart = 0.0f;
+                float m_depthTransitionDuration = 0.0f; 
+            };
+
+            EditorModeFeedbackPassBase(const RPI::PassDescriptor& descriptor, const DepthTransition& depthTransition, float finalBlendAmount);
+
+            //! Pass behavior overrides
+            void InitializeInternal() override;
+            void FrameBeginInternal(FramePrepareParams params) override;
+
+        private:
+            //! Sets the shader constant values for the depth transition and final blend amount for editor mode feedback effects.
+            void SetSrgConstants();
+
+            RHI::ShaderInputNameIndex m_minDepthTransitionValueIndex = "m_minDepthTransitionValue";
+            RHI::ShaderInputNameIndex m_depthTransitionStartIndex = "m_depthTransitionStart";
+            RHI::ShaderInputNameIndex m_depthTransitionDurationIndex = "m_depthTransitionDuration";
+            RHI::ShaderInputNameIndex m_finalBlendAmountIndex = "m_finalBlendAmount";
+
+            DepthTransition m_depthransition;
+            float m_finalBlendAmount = 1.0f;
+        };
+    } // Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeOutlinePass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeOutlinePass.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <PostProcessing/EditorModeOutlinePass.h>
+#include <PostProcess/PostProcessFeatureProcessor.h>
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+#include <Atom/Feature/PostProcess/EditorModeFeedback/EditorModeFeedbackInterface.h>
+
+// Temporary measure for setting the outline pass shader parameters at runtime until GHI 3455 is implemented
+AZ_EDITOR_MODE_PASS_TRANSITION_CVARS(cl_editorModeOutlinePass, 0.0f, 0.0f, 10.0f, 1.0f);
+AZ_EDITOR_MODE_PASS_CVAR(float, cl_editorModeOutlinePass, LineThickness, 3.0f);
+AZ_EDITOR_MODE_PASS_CVAR(AZ::Color, cl_editorModeOutlinePass, LineColor, AZ::Color(0.96f, 0.65f, 0.13f, 1.0f));
+
+ namespace AZ
+{
+    namespace Render
+    {
+        RPI::Ptr<EditorModeOutlinePass> EditorModeOutlinePass::Create(const RPI::PassDescriptor& descriptor)
+        {
+            RPI::Ptr<EditorModeOutlinePass> pass = aznew EditorModeOutlinePass(descriptor);
+            return AZStd::move(pass);
+        }
+        
+        EditorModeOutlinePass::EditorModeOutlinePass(const RPI::PassDescriptor& descriptor)
+            : EditorModeFeedbackPassBase(descriptor, { 0.0f, 0.0f, 10.0f }, 1.0f)
+        {
+        }
+        
+        void EditorModeOutlinePass::InitializeInternal()
+        {
+            EditorModeFeedbackPassBase::InitializeInternal();
+            m_lineThicknessIndex.Reset();
+            m_lineColorIndex.Reset();
+        }
+        
+        void EditorModeOutlinePass::FrameBeginInternal(FramePrepareParams params)
+        {
+            SetSrgConstants();
+            EditorModeFeedbackPassBase::FrameBeginInternal(params);
+        }
+
+        void EditorModeOutlinePass::SetLineThickness(const float thickness)
+        {
+            m_lineThickness = thickness;
+        }
+
+        void EditorModeOutlinePass::SetLineColor(AZ::Color color)
+        {
+            m_lineColor = AZStd::move(color);
+        }
+
+        void EditorModeOutlinePass::SetSrgConstants()
+        {
+            // Temporary measure for setting the pass shader parameters at runtime until GHI 3455 is implemented
+            SetMinDepthTransitionValue(cl_editorModeOutlinePass_MinDepthTransitionValue);
+            SetDepthTransitionStart(cl_editorModeOutlinePass_DepthTransitionStart);
+            SetDepthTransitionDuration(cl_editorModeOutlinePass_DepthTransitionDuration);
+            SetFinalBlendAmount(cl_editorModeOutlinePass_FinalBlendAmount);
+            SetLineThickness(cl_editorModeOutlinePass_LineThickness);
+            SetLineColor(cl_editorModeOutlinePass_LineColor);
+
+            m_shaderResourceGroup->SetConstant(m_lineThicknessIndex, m_lineThickness);
+            m_shaderResourceGroup->SetConstant(m_lineColorIndex, m_lineColor);
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeOutlinePass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeOutlinePass.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <PostProcessing/EditorModeFeedbackPassBase.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Pass for editor mode feedback outline effect.
+        class EditorModeOutlinePass
+            : public EditorModeFeedbackPassBase
+        {
+        public:
+            AZ_RTTI(EditorModeOutlinePass, "{5DEBA4FC-6BB3-417B-B052-7CB87EF15F84}", EditorModeFeedbackPassBase);
+            AZ_CLASS_ALLOCATOR(EditorModeOutlinePass, SystemAllocator, 0);
+
+            virtual ~EditorModeOutlinePass() = default;
+
+            //! Creates a EditorModeOutlinePass
+            static RPI::Ptr<EditorModeOutlinePass> Create(const RPI::PassDescriptor& descriptor);
+
+            //! Sets the outline line thickness.
+            void SetLineThickness(float thickness);
+
+            //! Sets the outline line color.
+            void SetLineColor(AZ::Color color);
+
+        protected:
+            EditorModeOutlinePass(const RPI::PassDescriptor& descriptor);
+            
+            //! Pass behavior overrides
+            void InitializeInternal() override;
+            void FrameBeginInternal(FramePrepareParams params) override;
+
+        private:
+            //! Sets the shader constant values for the outline effect.
+            void SetSrgConstants();
+
+            RHI::ShaderInputNameIndex m_lineThicknessIndex = "m_lineThickness";
+            RHI::ShaderInputNameIndex m_lineColorIndex = "m_lineColor";
+            float m_lineThickness = 3.0f; //!< Default line thickness for the outline effect.
+            AZ::Color m_lineColor = AZ::Color(0.96f, 0.65f, 0.13f, 1.0f); //!< Default line color for the outline effect.
+        };
+    }   // namespace Render
+}   // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeTintPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeTintPass.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+ 
+#include <PostProcessing/EditorModeTintPass.h>
+#include <PostProcess/PostProcessFeatureProcessor.h>
+
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
+
+// Temporary measure for setting the color tint pass shader parameters at runtime until GHI 3455 is implemented
+AZ_EDITOR_MODE_PASS_TRANSITION_CVARS(cl_editorModeTintPass, 0.0f, 0.0f, 0.0f, 1.0f);
+AZ_EDITOR_MODE_PASS_CVAR(float, cl_editorModeTintPass, TintAmount, 0.5f);
+AZ_EDITOR_MODE_PASS_CVAR(AZ::Color, cl_editorModeTintPass, TintColor, AZ::Color(0.0f, 0.0f, 0.0f, 0.0f));
+
+ namespace AZ
+{
+    namespace Render
+    {
+        RPI::Ptr<EditorModeTintPass> EditorModeTintPass::Create(const RPI::PassDescriptor& descriptor)
+        {
+            RPI::Ptr<EditorModeTintPass> pass = aznew EditorModeTintPass(descriptor);
+            return AZStd::move(pass);
+        }
+        
+        EditorModeTintPass::EditorModeTintPass(const RPI::PassDescriptor& descriptor)
+            : EditorModeFeedbackPassBase(descriptor)
+        {
+        }
+        
+        void EditorModeTintPass::InitializeInternal()
+        {
+            EditorModeFeedbackPassBase::InitializeInternal();
+            m_tintAmountIndex.Reset();
+        }
+        
+        void EditorModeTintPass::FrameBeginInternal(FramePrepareParams params)
+        {
+            SetSrgConstants();
+            EditorModeFeedbackPassBase::FrameBeginInternal(params);
+        }
+
+        void EditorModeTintPass::SetTintAmount(const float amount)
+        {
+            m_tintAmount = amount;
+        }
+
+        void EditorModeTintPass::SetTintColor(AZ::Color color)
+        {
+            m_tintColor = color;
+        }
+
+        void EditorModeTintPass::SetSrgConstants()
+        {
+            // Temporary measure for setting the pass shader parameters at runtime until GHI 3455 is implemented
+            SetMinDepthTransitionValue(cl_editorModeTintPass_MinDepthTransitionValue);
+            SetDepthTransitionStart(cl_editorModeTintPass_DepthTransitionStart);
+            SetDepthTransitionDuration(cl_editorModeTintPass_DepthTransitionDuration);
+            SetFinalBlendAmount(cl_editorModeTintPass_FinalBlendAmount);
+            SetTintAmount(cl_editorModeTintPass_TintAmount);
+            SetTintColor(cl_editorModeTintPass_TintColor);
+
+            m_shaderResourceGroup->SetConstant(m_tintAmountIndex, m_tintAmount);
+            m_shaderResourceGroup->SetConstant(m_tintColorIndex, m_tintColor);
+        }
+    } // namespace Render
+} // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeTintPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/PostProcessing/EditorModeTintPass.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <PostProcessing/EditorModeFeedbackPassBase.h>
+
+namespace AZ
+{
+    namespace Render
+    {
+        //! Pass for editor mode feedback color tint effect.
+        class EditorModeTintPass
+            : public EditorModeFeedbackPassBase
+        {
+        public:
+            AZ_RTTI(EditorModeTintPass, "{3E4FEFCB-9416-4CAE-8918-72D31AA482C5}", EditorModeFeedbackPassBase);
+            AZ_CLASS_ALLOCATOR(EditorModeTintPass, SystemAllocator, 0);
+
+            virtual ~EditorModeTintPass() = default;
+
+            //! Creates a EditorModeTintPass
+            static RPI::Ptr<EditorModeTintPass> Create(const RPI::PassDescriptor& descriptor);
+
+            //! Sets the amount of tint to apply.
+            void SetTintAmount(float amount);
+
+            //! Sets the color of tint to apply.
+            void SetTintColor(AZ::Color color);
+
+        protected:
+            EditorModeTintPass(const RPI::PassDescriptor& descriptor);
+            
+            //! Pass behavior overrides
+            void InitializeInternal() override;
+            void FrameBeginInternal(FramePrepareParams params) override;
+
+        private:
+            //! Sets the shader constant values for the color tint effect.
+            void SetSrgConstants();
+
+            RHI::ShaderInputNameIndex m_tintAmountIndex = "m_tintAmount";
+            RHI::ShaderInputNameIndex m_tintColorIndex = "m_tintColor";
+            float m_tintAmount = 0.5f; //!< Default tint amount for the color tint effect.
+            AZ::Color m_tintColor = AZ::Color::CreateZero(); //!< Default tint color for the color tint effect.
+        };
+    }   // namespace Render
+}   // namespace AZ


### PR DESCRIPTION
This PR contains the pass class files for the Editor Mode Visual Feedback system necessary to implement the Focus Mode visual feedback effects (the rest of the work will come in subsequent PRs).

**Note:** This is a reboot of [PR-7678](https://github.com/o3de/o3de/pull/7678)

Signed-off-by: John <jonawals@amazon.co.uk>