### PR TITLE
Fix the StringToNumber Script Canvas node

### DIFF
--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Nodes/Math_StringToNumber.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Nodes/Math_StringToNumber.names
@@ -31,7 +31,7 @@
                 {
                     "base": "DataInput_StringValue_0",
                     "details": {
-                        "name": "StringValue"
+                        "name": "String Value"
                     }
                 }
             ]

--- a/Gems/ScriptCanvas/Assets/TranslationAssets/Nodes/Math_StringToNumber.names
+++ b/Gems/ScriptCanvas/Assets/TranslationAssets/Nodes/Math_StringToNumber.names
@@ -27,6 +27,12 @@
                     "details": {
                         "name": "Result"
                     }
+                },
+                {
+                    "base": "DataInput_StringValue_0",
+                    "details": {
+                        "name": "StringValue"
+                    }
                 }
             ]
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathGenerics.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathGenerics.h
@@ -28,7 +28,7 @@ namespace ScriptCanvas
             return AZStd::stof(stringValue);
         }
 
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE(StringToNumber, k_categoryName, "{FD2D9758-5EA2-45A3-B293-A748D951C4A3}", "Converts the given string to it's numeric representation if possible.", "StringValue");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE(StringToNumber, k_categoryName, "{FD2D9758-5EA2-45A3-B293-A748D951C4A3}", "Converts the given string to it's numeric representation if possible.", "String Value");
 
         AZ_INLINE AZStd::tuple<ScriptCanvas::Data::Vector3Type, ScriptCanvas::Data::StringType, ScriptCanvas::Data::BooleanType>
             ThreeGeneric(const ScriptCanvas::Data::Vector3Type& v, const ScriptCanvas::Data::StringType& s, const ScriptCanvas::Data::BooleanType& b)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathGenerics.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathGenerics.h
@@ -28,7 +28,7 @@ namespace ScriptCanvas
             return AZStd::stof(stringValue);
         }
 
-        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE(StringToNumber, k_categoryName, "{FD2D9758-5EA2-45A3-B293-A748D951C4A3}", "Converts the given string to it's numeric representation if possible.", "", "");
+        SCRIPT_CANVAS_GENERIC_FUNCTION_NODE(StringToNumber, k_categoryName, "{FD2D9758-5EA2-45A3-B293-A748D951C4A3}", "Converts the given string to it's numeric representation if possible.", "StringValue");
 
         AZ_INLINE AZStd::tuple<ScriptCanvas::Data::Vector3Type, ScriptCanvas::Data::StringType, ScriptCanvas::Data::BooleanType>
             ThreeGeneric(const ScriptCanvas::Data::Vector3Type& v, const ScriptCanvas::Data::StringType& s, const ScriptCanvas::Data::BooleanType& b)


### PR DESCRIPTION
Signed-off-by: Junbo Liang <68558268+junbo75@users.noreply.github.com>

Found an issue with the StringToNumber Script Canvas node where it doesn't accept any input. Got the following error when added this node to a graph:
`[Error] (ScriptCanvas) - NodeFunctionGenericMultiReturn failed to add a required data slot`

Verified that the node worked as expected with this PR.
Before:
![Before](https://user-images.githubusercontent.com/68558268/156230300-546e850d-6a03-4d45-8508-48b871c0b7ba.PNG)
After:
![image](https://user-images.githubusercontent.com/68558268/156230336-64359337-738b-47d1-8258-92c8a92b276c.png)

