### PR TITLE
[iOS] Bump version of libpng for iOS. The new version has arm neon optimizations enabled.

### DIFF
--- a/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
+++ b/cmake/3rdParty/Platform/iOS/BuiltInPackages_ios.cmake
@@ -24,7 +24,7 @@ ly_associate_package(PACKAGE_NAME PhysX-4.1.2.29882248-rev5-ios  TARGETS PhysX  
 ly_associate_package(PACKAGE_NAME mikkelsen-1.0.0.4-ios          TARGETS mikkelsen       PACKAGE_HASH 976aaa3ccd8582346132a10af253822ccc5d5bcc9ea5ba44d27848f65ee88a8a)
 ly_associate_package(PACKAGE_NAME googletest-1.8.1-rev4-ios      TARGETS googletest      PACKAGE_HASH 2f121ad9784c0ab73dfaa58e1fee05440a82a07cc556bec162eeb407688111a7)
 ly_associate_package(PACKAGE_NAME googlebenchmark-1.5.0-rev2-ios TARGETS GoogleBenchmark PACKAGE_HASH c2ffaed2b658892b1bcf81dee4b44cd1cb09fc78d55584ef5cb8ab87f2d8d1ae)
-ly_associate_package(PACKAGE_NAME libpng-1.6.37-ios              TARGETS libpng          PACKAGE_HASH 18a8217721083c4dc46514105be43ca764fa9c994a74aa0b57766ea6f8187e7b)
+ly_associate_package(PACKAGE_NAME libpng-1.6.37-rev2-ios         TARGETS libpng          PACKAGE_HASH 2cc9296d89e151b00b3ef6d4d0ed372764ef521f38f15182efee80d51ce6bfbd)
 ly_associate_package(PACKAGE_NAME libsamplerate-0.2.1-rev2-ios   TARGETS libsamplerate   PACKAGE_HASH 7656b961697f490d4f9c35d2e61559f6fc38c32102e542a33c212cd618fc2119)
 ly_associate_package(PACKAGE_NAME OpenSSL-1.1.1b-rev1-ios        TARGETS OpenSSL         PACKAGE_HASH cd0dfce3086a7172777c63dadbaf0ac3695b676119ecb6d0614b5fb1da03462f)
 ly_associate_package(PACKAGE_NAME zlib-1.2.11-rev5-ios           TARGETS ZLIB            PACKAGE_HASH c7f10b4d0fe63192054d926f53b08e852cdf472bc2b18e2f7be5aecac1869f7f)


### PR DESCRIPTION
Signed-off-by: amzn-sj <srikkant@amazon.com>