### PR TITLE
{lyn10536} prefab gem processes UDPs for material assignment

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -36,6 +36,7 @@
 #include <SceneAPI/SceneCore/Containers/Views/SceneGraphDownwardsIterator.h>
 #include <SceneAPI/SceneCore/Containers/Views/SceneGraphUpwardsIterator.h>
 #include <SceneAPI/SceneCore/DataTypes/DataTypeUtilities.h>
+#include <SceneAPI/SceneCore/DataTypes/GraphData/ICustomPropertyData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IMeshData.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/ITransform.h>
 #include <SceneAPI/SceneCore/Events/AssetImportRequest.h>
@@ -96,13 +97,38 @@ namespace AZ::SceneAPI::Behaviors
             return m_preExportEventContextFunction(context);
         }
 
-        using MeshTransformPair = AZStd::pair<Containers::SceneGraph::NodeIndex, Containers::SceneGraph::NodeIndex>;
-        using MeshTransformEntry = AZStd::pair<Containers::SceneGraph::NodeIndex, MeshTransformPair>;
-        using MeshTransformMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, MeshTransformPair>;
+        // this stores the data related with MeshData nodes
+        struct MeshNodeData
+        {
+            Containers::SceneGraph::NodeIndex m_meshIndex = {};
+            Containers::SceneGraph::NodeIndex m_transformIndex = {};
+            Containers::SceneGraph::NodeIndex m_propertyMapIndex = {};
+        };
+
+        using MeshTransformEntry = AZStd::pair<Containers::SceneGraph::NodeIndex, MeshNodeData>;
+        using MeshTransformMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, MeshNodeData>;
         using MeshIndexContainer = AZStd::unordered_set<Containers::SceneGraph::NodeIndex>;
         using ManifestUpdates = AZStd::vector<AZStd::shared_ptr<DataTypes::IManifestObject>>;
         using NodeEntityMap = AZStd::unordered_map<Containers::SceneGraph::NodeIndex, AZ::EntityId>;
         using EntityIdList = AZStd::vector<AZ::EntityId>;
+
+        void AssignCustomPropertyMapIndex(
+            MeshNodeData& meshNodeData,
+            const Containers::SceneGraph& graph,
+            const Containers::SceneGraph::NodeIndex meshIndex)
+        {
+            auto childIndex = graph.GetNodeChild(meshIndex);
+            while (childIndex.IsValid())
+            {
+                const auto nodeContent = graph.GetNodeContent(childIndex);
+                if (nodeContent && azrtti_istypeof<AZ::SceneAPI::DataTypes::ICustomPropertyData>(nodeContent.get()))
+                {
+                    meshNodeData.m_propertyMapIndex = childIndex;
+                    return;
+                }
+                childIndex = graph.GetNodeSibling(childIndex);
+            }
+        }
 
         MeshTransformMap CalculateMeshTransformMap(const Containers::Scene& scene)
         {
@@ -139,8 +165,9 @@ namespace AZ::SceneAPI::Behaviors
                         {
                             // map the node parent to the ITransform
                             meshIndexContainer.erase(parentIndex);
-                            MeshTransformPair pair{ parentIndex, currentIndex };
-                            meshTransformMap.emplace(MeshTransformEntry{ graph.GetNodeParent(parentIndex), AZStd::move(pair) });
+                            MeshNodeData meshNodeData{ parentIndex, currentIndex };
+                            AssignCustomPropertyMapIndex(meshNodeData, graph, parentIndex);
+                            meshTransformMap.emplace(MeshTransformEntry{ graph.GetNodeParent(parentIndex), AZStd::move(meshNodeData) });
                         }
                     }
                     else if (azrtti_istypeof<AZ::SceneAPI::DataTypes::IMeshData>(currentContent.get()))
@@ -155,11 +182,110 @@ namespace AZ::SceneAPI::Behaviors
             // indicate the transform should not be set to a default value
             for( const auto& meshIndex : meshIndexContainer)
             {
-                MeshTransformPair pair{ meshIndex, Containers::SceneGraph::NodeIndex{} };
-                meshTransformMap.emplace(MeshTransformEntry{ graph.GetNodeParent(meshIndex), AZStd::move(pair) });
+                MeshNodeData meshNodeData { meshIndex, Containers::SceneGraph::NodeIndex{} };
+                AssignCustomPropertyMapIndex(meshNodeData, graph, meshIndex);
+                meshTransformMap.emplace(MeshTransformEntry{ graph.GetNodeParent(meshIndex), AZStd::move(meshNodeData) });
             }
 
             return meshTransformMap;
+        }
+
+        bool AddEditorMaterialComponent(const AZ::EntityId& entityId, const DataTypes::ICustomPropertyData& propertyData)
+        {
+            const auto propertyMaterialPathIterator = propertyData.GetPropertyMap().find("o3de.default.material");
+            if (propertyMaterialPathIterator == propertyData.GetPropertyMap().end())
+            {
+                // skip these assignment since the default material override was not provided
+                return true;
+            }
+
+            const AZStd::any& propertyMaterialPath = propertyMaterialPathIterator->second;
+            if (propertyMaterialPath.empty() || propertyMaterialPath.is<AZStd::string>() == false)
+            {
+                AZ_Error("prefab", false, "Must be a string");
+                return false;
+            }
+
+            // find asset path via node data
+            const AZStd::string* materialAssetPath = AZStd::any_cast<AZStd::string>(&propertyMaterialPath);
+            if (materialAssetPath->empty())
+            {
+                AZ_Error("prefab", false, "Material asset path must not be empty.");
+                return false;
+            }
+
+            // create a material component for this entity's mesh to render with
+            AzFramework::BehaviorComponentId editorMaterialComponent;
+            AzToolsFramework::EntityUtilityBus::BroadcastResult(
+                editorMaterialComponent,
+                &AzToolsFramework::EntityUtilityBus::Events::GetOrAddComponentByTypeName,
+                entityId,
+                "EditorMaterialComponent");
+
+            if (editorMaterialComponent.IsValid() == false)
+            {
+                AZ_Warning("prefab", false, "Could not add the EditorMaterialComponent component; project needs Atom enabled.");
+                return {};
+            }
+
+            // the material product asset such as 'myassets/path/to/cool.azmaterial' is assigned via hint
+            auto materialAssetJson = AZStd::string::format(
+                R"JSON(
+                    {"Controller":{"Configuration":{"materials":[{"Value":{"MaterialAsset":{"assetHint":"%s"}}}]}}}
+                    )JSON", materialAssetPath->c_str());
+
+            bool result = false;
+            AzToolsFramework::EntityUtilityBus::BroadcastResult(
+                result,
+                &AzToolsFramework::EntityUtilityBus::Events::UpdateComponentForEntity,
+                entityId,
+                editorMaterialComponent,
+                materialAssetJson);
+
+            AZ_Error("prefab", result, "UpdateComponentForEntity failed for EditorMaterialComponent component");
+            return result;
+        }
+
+        bool AddEditorMeshComponent(
+            const AZ::EntityId& entityId,
+            const AZStd::string& relativeSourcePath,
+            const AZStd::string& meshGroupName)
+        {
+            // Since the mesh component lives in a gem, then create it by name
+            AzFramework::BehaviorComponentId editorMeshComponent;
+            AzToolsFramework::EntityUtilityBus::BroadcastResult(
+                editorMeshComponent,
+                &AzToolsFramework::EntityUtilityBus::Events::GetOrAddComponentByTypeName,
+                entityId,
+                "{DCE68F6E-2E16-4CB4-A834-B6C2F900A7E9} AZ::Render::EditorMeshComponent");
+
+            if (editorMeshComponent.IsValid() == false)
+            {
+                AZ_Warning("prefab", false, "Could not add the EditorMeshComponent component; project needs Atom enabled.");
+                return {};
+            }
+
+            // assign mesh asset id hint using JSON
+            AZStd::string modelAssetPath;
+            modelAssetPath = relativeSourcePath;
+            AZ::StringFunc::Path::ReplaceFullName(modelAssetPath, meshGroupName.c_str());
+            AZ::StringFunc::Replace(modelAssetPath, "\\", "/"); // asset paths use forward slashes
+
+            auto meshAssetJson = AZStd::string::format(
+                R"JSON(
+                        {"Controller": {"Configuration": {"ModelAsset": { "assetHint": "%s.azmodel"}}}}
+                    )JSON", modelAssetPath.c_str());
+
+            bool result = false;
+            AzToolsFramework::EntityUtilityBus::BroadcastResult(
+                result,
+                &AzToolsFramework::EntityUtilityBus::Events::UpdateComponentForEntity,
+                entityId,
+                editorMeshComponent,
+                meshAssetJson);
+
+            AZ_Error("prefab", result, "UpdateComponentForEntity failed for EditorMeshComponent component");
+            return result;
         }
 
         NodeEntityMap CreateMeshGroups(
@@ -174,7 +300,8 @@ namespace AZ::SceneAPI::Behaviors
             for (const auto& entry : meshTransformMap)
             {
                 const auto thisNodeIndex = entry.first;
-                const auto meshNodeIndex = entry.second.first;
+                const auto meshNodeIndex = entry.second.m_meshIndex;
+                const auto propertyDataIndex = entry.second.m_propertyMapIndex;
                 const auto meshNodeName = graph.GetNodeName(meshNodeIndex);
 
                 AZStd::string meshNodePath{ meshNodeName.GetPath() };
@@ -190,7 +317,7 @@ namespace AZ::SceneAPI::Behaviors
                 {
                     if (meshGoupNamePair.first != thisNodeIndex)
                     {
-                        const auto nodeName = graph.GetNodeName(meshGoupNamePair.second.first);
+                        const auto nodeName = graph.GetNodeName(meshGoupNamePair.second.m_meshIndex);
                         meshGroup->GetSceneNodeSelectionList().RemoveSelectedNode(nodeName.GetPath());
                     }
                 }
@@ -225,43 +352,25 @@ namespace AZ::SceneAPI::Behaviors
                     return {};
                 }
 
-                // Since the mesh component lives in a gem, then create it by name
-                AzFramework::BehaviorComponentId editorMeshComponent;
-                AzToolsFramework::EntityUtilityBus::BroadcastResult(
-                    editorMeshComponent,
-                    &AzToolsFramework::EntityUtilityBus::Events::GetOrAddComponentByTypeName,
-                    entityId,
-                    "{DCE68F6E-2E16-4CB4-A834-B6C2F900A7E9} AZ::Render::EditorMeshComponent");
 
-                if (editorMeshComponent.IsValid() == false)
+                if (AddEditorMeshComponent(entityId, relativeSourcePath, meshGroupName) == false)
                 {
-                    AZ_Warning("prefab", false, "Could not add the EditorMeshComponent component; project needs Atom enabled.");
                     return {};
                 }
 
-                // assign mesh asset id hint using JSON
-                AZStd::string modelAssetPath;
-                modelAssetPath = relativeSourcePath;
-                AZ::StringFunc::Path::ReplaceFullName(modelAssetPath, meshGroupName.c_str());
-                AZ::StringFunc::Replace(modelAssetPath, "\\", "/"); // asset paths use forward slashes
-
-                auto meshAssetJson = AZStd::string::format(
-                    R"JSON(
-                        {"Controller": {"Configuration": {"ModelAsset": { "assetHint": "%s.azmodel"}}}}
-                    )JSON", modelAssetPath.c_str());
-
-                bool result = false;
-                AzToolsFramework::EntityUtilityBus::BroadcastResult(
-                    result,
-                    &AzToolsFramework::EntityUtilityBus::Events::UpdateComponentForEntity,
-                    entityId,
-                    editorMeshComponent,
-                    meshAssetJson);
-
-                if (result == false)
+                if (propertyDataIndex.IsValid())
                 {
-                    AZ_Error("prefab", false, "UpdateComponentForEntity failed for EditorMeshComponent component");
-                    return {};
+                    const auto customPropertyData = azrtti_cast<const DataTypes::ICustomPropertyData*>(graph.GetNodeContent(propertyDataIndex));
+                    if (!customPropertyData)
+                    {
+                        AZ_Error("prefab", false, "Missing custom propertiy data content for node.");
+                        return {};
+                    }
+
+                    if (AddEditorMaterialComponent(entityId, *(customPropertyData.get())) == false)
+                    {
+                        return {};
+                    }
                 }
 
                 nodeEntityMap.insert({ thisNodeIndex, entityId });
@@ -323,7 +432,7 @@ namespace AZ::SceneAPI::Behaviors
 
                 auto thisNodeIterator = meshTransformMap.find(thisNodeIndex);
                 AZ_Assert(thisNodeIterator != meshTransformMap.end(), "This node index missing.");
-                auto thisTransformIndex = thisNodeIterator->second.second;
+                auto thisTransformIndex = thisNodeIterator->second.m_transformIndex;
 
                 // get node matrix data to set the entity's local transform
                 const auto nodeTransform = azrtti_cast<const DataTypes::ITransform*>(graph.GetNodeContent(thisTransformIndex));


### PR DESCRIPTION
The Prefab Gem updated to process the custom property map for a mesh node so that it can find the reserved o3de.default.material' property name and assign that asset path to a render material

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>