### PR TITLE
ATOM-17367 Update Terrian gem to inject passes to main pipeline inste…

### DIFF
--- a/AutomatedTesting/Passes/MainPipeline.pass
+++ b/AutomatedTesting/Passes/MainPipeline.pass
@@ -51,16 +51,6 @@
                     ]
                 },
                 {
-                    "Name": "TerrainDetailTextureComputePass",
-                    "TemplateName": "TerrainDetailTextureComputePassTemplate",
-                    "Enabled": false
-                },
-                {
-                    "Name": "TerrainMacroTextureComputePass",
-                    "TemplateName": "TerrainMacroTextureComputePassTemplate",
-                    "Enabled": false
-                },
-                {
                     "Name": "DepthPrePass",
                     "TemplateName": "DepthMSAAParentTemplate",
                     "Connections": [

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Public/Scene.h
@@ -209,6 +209,10 @@ namespace AZ
             // Add a created feature processor to this scene
             void AddFeatureProcessor(FeatureProcessorPtr fp);
 
+            // Check each of the added render pipelines and set its recreate flag if it's allowed to be modified by any feature processors
+            // This is usually called when a feature processor was added and removed after scene was activated
+            void CheckRecreateRenderPipeline();
+
             // Send out event to PrepareSceneSrgEvent::Handlers so they can update scene srg as needed
             // This happens in UpdateSrgs()
             void PrepareSceneSrg();

--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Scene.cpp
@@ -178,6 +178,18 @@ namespace AZ
             m_dynamicDrawSystem = nullptr;
         }
 
+        void Scene::CheckRecreateRenderPipeline()
+        {
+            // need to recreate render pipeline passes if the pipeline can be modified by FPs
+            for (auto& renderPipeline : m_pipelines)
+            {
+                if (renderPipeline->m_descriptor.m_allowModification)
+                {
+                    renderPipeline->SetPassNeedsRecreate();
+                }
+            }
+        }
+
         FeatureProcessor* Scene::EnableFeatureProcessor(const FeatureProcessorId& featureProcessorId)
         {
             FeatureProcessor* foundFeatureProcessor = GetFeatureProcessor(featureProcessorId);
@@ -226,15 +238,7 @@ namespace AZ
             if (m_activated)
             {
                 fp->Activate();
-                
-                // need to recreate render pipeline passes if the pipeline can be modified by FP
-                for (auto& renderPipeline : m_pipelines)
-                {
-                    if (renderPipeline->m_descriptor.m_allowModification)
-                    {
-                        renderPipeline->SetPassNeedsRecreate();
-                    }
-                }
+                CheckRecreateRenderPipeline();
             }
 
             m_featureProcessors.emplace_back(AZStd::move(fp));
@@ -258,15 +262,7 @@ namespace AZ
                 if (m_activated)
                 {
                     (*foundFeatureProcessor)->Deactivate();
-                    
-                    // need to recreate render pipeline passes if the pipeline can be modified by FP
-                    for (auto& renderPipeline : m_pipelines)
-                    {
-                        if (renderPipeline->m_descriptor.m_allowModification)
-                        {
-                            renderPipeline->SetPassNeedsRecreate();
-                        }
-                    }
+                    CheckRecreateRenderPipeline();
                 }
 
                 m_featureProcessors.erase(foundFeatureProcessor);

--- a/Gems/Terrain/Assets/Passes/TerrainParentPass.pass
+++ b/Gems/Terrain/Assets/Passes/TerrainParentPass.pass
@@ -1,0 +1,25 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "TerrainParentPassTemplate",
+            "PassClass": "ParentPass",
+            "PassRequests": [			
+                {
+                    "Name": "TerrainDetailTextureComputePass",
+                    "TemplateName": "TerrainDetailTextureComputePassTemplate",
+                    "Enabled": false
+                },
+                {
+                    "Name": "TerrainMacroTextureComputePass",
+                    "TemplateName": "TerrainMacroTextureComputePassTemplate",
+                    "Enabled": false
+                }
+            ]
+        }
+    }
+}
+ 
+

--- a/Gems/Terrain/Assets/Passes/TerrainPassRequest.azasset
+++ b/Gems/Terrain/Assets/Passes/TerrainPassRequest.azasset
@@ -1,0 +1,10 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassRequest",
+    "ClassData": {
+        "Name": "TerrainParentPass",
+        "TemplateName": "TerrainParentPassTemplate",
+        "Enabled": true
+    }
+}

--- a/Gems/Terrain/Assets/Passes/TerrainPassRequest.azasset
+++ b/Gems/Terrain/Assets/Passes/TerrainPassRequest.azasset
@@ -5,6 +5,6 @@
     "ClassData": {
         "Name": "TerrainParentPass",
         "TemplateName": "TerrainParentPassTemplate",
-        "Enabled": true
+        "Enabled": false
     }
 }

--- a/Gems/Terrain/Assets/Passes/TerrainPassTemplates.azasset
+++ b/Gems/Terrain/Assets/Passes/TerrainPassTemplates.azasset
@@ -11,6 +11,10 @@
             {
                 "Name": "TerrainMacroTextureComputePassTemplate",
                 "Path": "Passes/TerrainMacroTextureComputePass.pass"
+            },
+            {
+                "Name": "TerrainParentPassTemplate",
+                "Path": "Passes/TerrainParentPass.pass"
             }
         ]
     }

--- a/Gems/Terrain/Assets/seedList.seed
+++ b/Gems/Terrain/Assets/seedList.seed
@@ -1,0 +1,21 @@
+<ObjectStream version="3">
+	<Class name="AZStd::vector" type="{82FC5264-88D0-57CD-9307-FC52E4DAD550}">
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{D9987129-3063-57BD-8A13-3E0A65BC127E}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/terrainpassrequest.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+		<Class name="SeedInfo" field="element" version="2" type="{FACC3682-2ACA-4AA4-B85A-07AD276D18A0}">
+			<Class name="AssetId" field="assetId" version="1" type="{652ED536-3402-439B-AEBE-4A5DBC554085}">
+				<Class name="AZ::Uuid" field="guid" value="{064CE2C2-E21E-5F81-957D-8389ECC62ED5}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
+				<Class name="unsigned int" field="subId" value="0" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			</Class>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="AZStd::string" field="pathHint" value="passes/terrainpasstemplates.azasset" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+		</Class>
+	</Class>
+</ObjectStream>
+

--- a/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
+++ b/Gems/Terrain/Code/Source/TerrainRenderer/TerrainFeatureProcessor.h
@@ -76,6 +76,9 @@ namespace Terrain
 
         // AZ::RPI::SceneNotificationBus overrides...
         void OnRenderPipelinePassesChanged(AZ::RPI::RenderPipeline* renderPipeline) override;
+        
+        // AZ::RPI::FeatureProcessor overrides...
+        void ApplyRenderPipelineChange(AZ::RPI::RenderPipeline* renderPipeline) override;
 
         void Initialize();
 


### PR DESCRIPTION
…ad of changing mainpipeline.pass file

Changes include:
- Remove terrain passes from MainPipeline.pass in AutomatedTesting project
- Change RPI::Scene to apply render pipeline changes for feature processors which are enabled/disabled dynamically
- Added TerrainPassRequest.pass to create terrain parent pass

Misc change:
- Added seedList.seed file for assets referenced by file name in code.

Tested with AutomatedTesting project in Editor (editor mode and game mode), game launcher.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

![image](https://user-images.githubusercontent.com/55564570/156076278-fae8e5bf-15b0-4d59-906b-ffe7dc73e32a.png)
