### PR TITLE
Make Vulkan StreamingImagePool validate a successful allocation before touching the memory

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/StreamingImagePool.cpp
@@ -76,11 +76,18 @@ namespace AZ
                 return RHI::ResultCode::OutOfMemory;
             }
 
+            auto memoryView = m_memoryAllocator.Allocate(memoryRequirements.size, memoryRequirements.alignment);
+            if (!memoryView.IsValid())
+            {
+                memoryUsage.m_reservedInBytes -= memoryRequirements.size;
+                return RHI::ResultCode::OutOfMemory;
+            }
+
             RHI::ResultCode result = image.Init(device, imageDescriptor);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 
             result = image.BindMemoryView(
-                m_memoryAllocator.Allocate(image.m_memoryRequirements.size, image.m_memoryRequirements.alignment), 
+                memoryView, 
                 m_memoryAllocator.GetDescriptor().m_heapMemoryLevel);
             RETURN_RESULT_IF_UNSUCCESSFUL(result);
 


### PR DESCRIPTION
Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>