### PR TITLE
Enable prefabs for Atom automated tests.

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
@@ -204,5 +204,5 @@ class TestMaterialEditorBasicTests(object):
             halt_on_unexpected=True,
             null_renderer=True,
             log_file_name="MaterialEditor.log",
-            enable_prefab_system=False,
+            enable_prefab_system=True,
         )

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py
@@ -24,7 +24,6 @@ class TestAutomation(EditorTestSuite):
     # Remove -autotest_mode from global_extra_cmdline_args since we need rendering for these tests.
     global_extra_cmdline_args = ["-autotest_mode"]  # Default is ["-BatchMode", "-autotest_mode"]
     use_null_renderer = False  # Default is True
-    enable_prefab_system = False
 
     @staticmethod
     def screenshot_setup(screenshot_directory, screenshot_names):
@@ -42,7 +41,6 @@ class TestAutomation(EditorTestSuite):
             golden_image_path = os.path.join(golden_images_directory(), golden_image)
             golden_images.append(golden_image_path)
         return test_screenshots, golden_images
-
 
     @pytest.mark.test_case_id("C34525095")
     class AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_DX12(EditorSingleTest):
@@ -187,5 +185,5 @@ class TestMaterialEditor(object):
             null_renderer=False,
             cfg_args=[cfg_args],
             log_file_name="MaterialEditor.log",
-            enable_prefab_system=False,
+            enable_prefab_system=True,
         )


### PR DESCRIPTION
- Change was simpler than expected, didn't really require anything other than switching the flag and running all of the tests afterwards.
- I re-tested the tests after enabling the prefabs and got expected passing results (2 expected failing Vulkan tests from https://github.com/o3de/o3de/blob/development/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main_GPU.py - `AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_Vulkan` and `AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages_Vulkan`. These are being fixed internally.)
- Test Run 1: `TestSuite_Main.py`:
```
==== 30 passed, 2 warnings in 150.26s (0:02:30) ====
```
- Test Run 2: `TestSuite_Main_GPU.py:`
```
Use the following commands to re-run each test that failed locally
(NOTE: The 'PYTHON' or 'PYTHONPATH' environment variables need values for accurate commands):
C:\git\o3de\python\python.cmd -m pytest --build-directory .\build\bin\profile  C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py::TestAutomation::AtomGPU_LightComponent_AreaLightScreenshotsMatchGoldenImages_Vulkan[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
C:\git\o3de\python\python.cmd -m pytest --build-directory .\build\bin\profile  C:\git\o3de\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main_GPU.py::TestAutomation::AtomGPU_LightComponent_SpotLightScreenshotsMatchGoldenImages_Vulkan[windows-crash_log_watchdog0-windows_editor-AutomatedTesting]
==== 2 failed, 4 passed, 3 warnings in 697.72s (0:11:37) ====
```