### PR TITLE
Fixes Vulkan RHI timeout in the benchmark nightly GPU test

### DIFF
--- a/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.h
+++ b/Gems/Atom/RHI/Vulkan/Code/Source/RHI/Buffer.h
@@ -38,7 +38,7 @@ namespace AZ
             friend class Device;
 
         public:
-            AZ_CLASS_ALLOCATOR(Buffer, AZ::ThreadPoolAllocator, 0);
+            AZ_CLASS_ALLOCATOR(Buffer, AZ::SystemAllocator, 0);
             AZ_RTTI(Buffer, "D3416E5D-D058-4EB1-95D9-06C9B3B1C52A", Base);
 
             ~Buffer();


### PR DESCRIPTION
- Change was suggested by @moudgils and it fixes the timeout issue. The test also passes after applying the change.
- Test run - edited the script to use only `Vulkan` RHI using command `C:\git\o3de\python\runtime\python-3.7.10-rev1-windows\python\python.exe -m pytest -vv -s --build-directory=".\build\bin\profile" Standalone\PythonTests\Automated\benchmark_runner_periodic_suite.py -k test_PerformanceBenchmarkPeriodicSuite`:
```
==== 1 passed in 1446.23s (0:24:06) ====
```
- The test is quite long but does pass now.