### PR TITLE
[iOS] Fix issues in python scripts that are used to build and run tests on iOS

### DIFF
--- a/cmake/Tools/Platform/iOS/build_ios_test.py
+++ b/cmake/Tools/Platform/iOS/build_ios_test.py
@@ -21,7 +21,7 @@ if ROOT_DEV_PATH not in sys.path:
 
 from cmake.Tools import common
 
-def build_ios_test(build_dir, configuration):
+def build_ios_test(build_dir, configuration, device_name):
     build_path = pathlib.Path(build_dir) if os.path.isabs(build_dir) else pathlib.Path(ROOT_DEV_PATH) / build_dir
     if not build_path.is_dir():
         raise common.LmbrCmdError(f"Invalid build directory '{str(build_path)}'")
@@ -32,7 +32,8 @@ def build_ios_test(build_dir, configuration):
                               '-scheme', SCHEME_NAME,
                               '-configuration', configuration,
                               '-allowProvisioningUpdates',
-                              '-allowProvisioningDeviceRegistration']
+                              '-allowProvisioningDeviceRegistration',
+                              '-destination', f'platform=iOS,name={device_name}']
                               
     xcode_out = xcode_build.popen(command_line_arguments, cwd=build_path, shell=False)
     while xcode_out.poll() is None:
@@ -45,6 +46,10 @@ def main(args):
     parser.add_argument('-b', '--build-dir',
                         help='The relative build directory to deploy from.',
                         required=True)
+
+    parser.add_argument('--device-name',
+                        help='The name of the iOS device on which to launch.',
+                        required=True)
                         
     parser.add_argument('-c', '--configuration',
                         help='The build configuration from the build directory for the source deployment files',
@@ -53,6 +58,7 @@ def main(args):
     parsed_args = parser.parse_args(args)
 
     build_ios_test(build_dir=parsed_args.build_dir,
+                   device_name=parsed_args.device_name,
                    configuration=parsed_args.configuration)
     return 0
 

--- a/cmake/Tools/Platform/iOS/launch_ios_test.py
+++ b/cmake/Tools/Platform/iOS/launch_ios_test.py
@@ -75,7 +75,7 @@ def launch_ios_test(build_dir, target_dev_name, test_target, timeout_secs, test_
         
         command_line_arguments = [target, 'AzRunUnitTests']
         if test_filter:
-            command_line_arguments.extend(['gtest_filter', test_filter])
+            command_line_arguments.extend([f'--gtest_filter={test_filter}'])
         test_run_contents[TEST_TARGET_NAME]['CommandLineArguments'] = command_line_arguments
         
         with open(test_run_file, 'wb') as fp:


### PR DESCRIPTION
Fix gtest_filter parameter being passed to AzTestRunner. On M1 Macs, the Mac gets chosen as the default test device for building. Make that parameter explicit for build so that an iOS device is chosen.

Signed-off-by: amzn-sj <srikkant@amazon.com>