### PR TITLE
Add support to enable device validation for debug builds.

### DIFF
--- a/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
+++ b/Gems/Atom/RHI/Code/Source/RHI/ValidationLayer.cpp
@@ -10,17 +10,35 @@
 #include <Atom/RHI/RHIUtils.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <AzFramework/API/ApplicationAPI.h>
-
+#include <AzCore/Console/Console.h>
 
 namespace AZ
 {
     namespace RHI
-    {
+    {  
+        AZ_CVAR(
+            bool,
+            r_debugBuildDeviceValidationOverride,
+            true,
+            nullptr,
+            ConsoleFunctorFlags::Null,
+            "Use this cvar to override device validation for debug builds.");
+            
         static const char* ValidationCommandLineOption = "rhi-device-validation";
 
         AZStd::optional<ValidationMode> ReadValidationModeFromCommandArgs()
         {
             ValidationMode mode = ValidationMode::Disabled;
+            bool debugBuildDeviceValidationOverride = true;
+            if (auto* console = Interface<IConsole>::Get())
+            {
+                console->GetCvarValue("r_debugBuildDeviceValidationOverride", debugBuildDeviceValidationOverride);
+            }
+
+            if (AZ::RHI::BuildOptions::IsDebugBuild && debugBuildDeviceValidationOverride)
+            {
+                mode = ValidationMode::Enabled;
+            }
             const AzFramework::CommandLine* commandLine = nullptr;
             AzFramework::ApplicationRequests::Bus::BroadcastResult(commandLine, &AzFramework::ApplicationRequests::GetApplicationCommandLine);
             if (commandLine)


### PR DESCRIPTION
- Also added a cvar to disable this for non-rendering engineers

Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>