### PR TITLE
Provide initial SECURITY.md for O3DE

### DIFF
--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -1,10 +1,9 @@
 # O3DE Security Policy
 
 ## Reporting a Vulnerability
+If you have information about a security issue or vulnerability in O3DE, please send the vulnerability report via e-mail to [security@o3de.org](mailto:security@o3de.org). Please avoid creating GitHub issues, unless the vulnerability is already publicly disclosed for example it has been reported in the [National Vulnerability Database](https://nvd.nist.gov/. 
 
-If you have information about a security issue or vulnerability in O3DE, please send an e-mail to [security@o3de.org](mailto:security@o3de.org).
-
-Please provide as much information as possible, including:
+Please provide as much information as possible in your report, including:
 
 - All relevant fields from the O3DE standard [issue template](https://github.com/o3de/o3de/blob/development/.github/ISSUE_TEMPLATE/bug_template.md).
 

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -1,9 +1,11 @@
 # O3DE Security Policy
 
 ## Reporting a Vulnerability
-If you have information about a security issue or vulnerability in O3DE, please send the vulnerability report via e-mail to [security@o3de.org](mailto:security@o3de.org). Please avoid creating GitHub issues, unless the vulnerability is already publicly disclosed for example it has been reported in the [National Vulnerability Database](https://nvd.nist.gov/. 
+If you have information about a security issue or vulnerability in O3DE, please send the vulnerability report via e-mail to [security@o3de.org](mailto:security@o3de.org). 
 
-Please provide as much information as possible in your report, including:
+> **_NOTE:_**  Please avoid creating GitHub issues, unless the vulnerability is already publicly disclosed, for example it has been reported in the [National Vulnerability Database](https://nvd.nist.gov/). 
+
+The vulnerability report should include as much detail as possible, including:
 
 - All relevant fields from the O3DE standard [issue template](https://github.com/o3de/o3de/blob/development/.github/ISSUE_TEMPLATE/bug_template.md).
 

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -4,16 +4,16 @@
 
 If you have information about a security issue or vulnerability in O3DE, please send an e-mail to [security@o3de.org](mailto:security@o3de.org).
 
-Please provide as much information as possible, ideally include:
+Please provide as much information as possible, including:
 
-- Any relevant fields from the [issue template](https://github.com/o3de/o3de/blob/development/.github/ISSUE_TEMPLATE/bug_template.md) including platform, build and other relevant information.
+- All relevant fields from the O3DE standard [issue template](https://github.com/o3de/o3de/blob/development/.github/ISSUE_TEMPLATE/bug_template.md).
 
-- A detailed description of the vulnerability that we can use to reproduce your findings.
+- A detailed description of the vulnerability we can use to reproduce your findings.
 
-- A definition of who can exploit this vulnerability and what would they gain.
+- A definition of who can exploit this vulnerability and what they would gain.
 
-- Information about known exploits if any.
+- Information about any known exploits.
 
 A member of the [SIG-Security](https://github.com/o3de/sig-security/) Issue Response Team will review your e-mail and contact you to collaborate on resolving the issue.
 
-Please refer to the [Security Documentation](https://www.o3de.org/docs/contributing/security) for O3DE for more details.
+For more details, please refer to the [Security Documentation](https://www.o3de.org/docs/contributing/security) for O3DE.

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -1,0 +1,19 @@
+# O3DE Security Policy
+
+## Reporting a Vulnerability
+
+If you have information about a security issue or vulnerability in O3DE, please send an e-mail to [security@o3de.org](mailto:security@o3de.org).
+
+Please provide as much information as possible, ideally include:
+
+- Any relevant fields from the [issue template](https://github.com/o3de/o3de/blob/development/.github/ISSUE_TEMPLATE/bug_template.md) including platform, build and other relevant information.
+
+- A detailed description of the vulnerability that we can use to reproduce your findings.
+
+- A definition of who can exploit this vulnerability and what would they gain.
+
+- Information about known exploits if any.
+
+A member of the [SIG-Security](https://github.com/o3de/sig-security/) Issue Response Team will review your e-mail and contact you to collaborate on resolving the issue.
+
+Please refer to the [Security Documentation](https://www.o3de.org/docs/contributing/security) for O3DE for more details.


### PR DESCRIPTION
Provide an initial SECURITY.md file for O3DE

Documentation referenced in change is in this PR: https://github.com/o3de/o3de.org/pull/1431. Will not push this change until security page is live on o3de.org

Issue reporting changes to discourage reporting via GHI: https://github.com/o3de/o3de/pull/8040

Having a security.md is a recommended best practice for open source projects. See:
* https://github.com/o3de/o3de/issues/6805 
* https://github.com/ossf/oss-vulnerability-guide/blob/main/guide.md
* https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository - SECURITY.md will get picked up and displayed as the security policy for the project.

Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>