### PR TITLE
Provide config.yml to provide control over GitHub issue templates. Disable blank issues, add security and docs reporting links.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerabilities
-    about: See the O3DE security policy for reporting guidance
+    about: Report a security issue in O3DE. See the O3DE security policy for reporting guidance
     url: https://www.o3de.org/docs/contributing/security
   - name: Documentation Issues
     about: Report issues with the documentation for O3DE
-    url: https://github.com/o3de/o3de.org/issues/new 
+    url: https://github.com/o3de/o3de.org/issues/new/choose 
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerabilities
+    about: See the O3DE security policy for reporting guidance
+    url: https://www.o3de.org/docs/contributing/security
+  - name: Documentation Issues
+    about: Report issues with the documentation for O3DE
+    url: https://github.com/o3de/o3de.org/issues/new 
+


### PR DESCRIPTION
config.yml provides a mechanism to fine tune issue reporting. See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

Change:
* Removes blank issue report (Discussed at TSC by @forhalle)
* Adds link to security vulnerability reporting (https://github.com/o3de/o3de/issues/6804, discussed at TSC)
* Adds handy link for docs issues reporting (@sptramer)

![Screen Shot 2022-03-22 at 8 28 09 AM (2)](https://user-images.githubusercontent.com/61438964/159518531-c11b1b1f-0b5f-4ac5-91ca-1d1c95114ed6.png)


Signed-off-by: Pip Potter <61438964+lmbr-pip@users.noreply.github.com>