### PR TITLE
Remove unnecessary enable_prefab_system flag in some tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py
@@ -21,8 +21,6 @@ TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
 
-    enable_prefab_system = True
-
     @pytest.mark.test_case_id("C36529679")
     class AtomLevelLoadTest_Editor(EditorSharedTest):
         from Atom.tests import hydra_Atom_LevelLoadTest as test_module

--- a/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Sandbox.py
@@ -20,8 +20,6 @@ TEST_DIRECTORY = os.path.join(os.path.dirname(__file__), "tests")
 @pytest.mark.parametrize("launcher_platform", ['windows_editor'])
 class TestAutomation(EditorTestSuite):
 
-    enable_prefab_system = True
-
     # this test is intermittently timing out without ever having executed. sandboxing while we investigate cause.
     @pytest.mark.test_case_id("C36525660")
     class AtomEditorComponents_DisplayMapperAdded(EditorSharedTest):

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonBindings/ComponentUpdateListProperty_test.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonBindings/ComponentUpdateListProperty_test.py
@@ -52,5 +52,4 @@ class TestComponentAssetListAutomation(object):
             "ComponentUpdateListProperty_test_case.py",
             expected_lines=expected_lines,
             cfg_args=[level],
-            enable_prefab_system=False,
         )

--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -505,7 +505,7 @@ class TestAutomation(TestAutomationBase):
 
     def test_Joints_BallBreakable(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_BallBreakable as test_module
-        self._run_test(request, workspace, editor, test_module, enable_prefab_system=False)
+        self._run_test(request, workspace, editor, test_module)
 
     def test_Joints_HingeNoLimitsConstrained(self, request, workspace, editor, launcher_platform):
         from .tests.joints import Joints_HingeNoLimitsConstrained as test_module


### PR DESCRIPTION
Signed-off-by: chiyenteng <82238204+chiyenteng@users.noreply.github.com>