### PR TITLE
Fixing the failing test_Material_DefaultLibraryUpdatedAcrossLevels tests in Physics TestSuite_Periodic 

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/TestSuite_Periodic.py
@@ -527,7 +527,7 @@ class TestAutomation(TestAutomationBase):
                           search_subdirs=True)
         def levels_before(self, request, workspace, editor, launcher_platform):
             from .tests.material import Material_DefaultLibraryUpdatedAcrossLevels_before as test_module_0
-            self._run_test(request, workspace, editor, test_module_0, enable_prefab_system=False)
+            self._run_test(request, workspace, editor, test_module_0)
 
         # File override replaces the previous physxconfiguration file with another where the only difference is the default material library
         @fm.file_override("physxsystemconfiguration.setreg",
@@ -536,7 +536,7 @@ class TestAutomation(TestAutomationBase):
                           search_subdirs=True)
         def levels_after(self, request, workspace, editor, launcher_platform):
             from .tests.material import Material_DefaultLibraryUpdatedAcrossLevels_after as test_module_1
-            self._run_test(request, workspace, editor, test_module_1, enable_prefab_system=False)
+            self._run_test(request, workspace, editor, test_module_1)
 
         levels_before(self, request, workspace, editor, launcher_platform)
         levels_after(self, request, workspace, editor, launcher_platform)

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/material/Material_DefaultLibraryUpdatedAcrossLevels_after.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/material/Material_DefaultLibraryUpdatedAcrossLevels_after.py
@@ -105,6 +105,7 @@ def Material_DefaultLibraryUpdatedAcrossLevels_after():
     import azlmbr.legacy.general as general
     import azlmbr.bus
     import azlmbr.math as math
+    import ly_test_tools._internal.managers.abstract_resource_locator as arl
 
     # Constants
     FLOAT_THRESHOLD = 0.0001
@@ -205,7 +206,7 @@ def Material_DefaultLibraryUpdatedAcrossLevels_after():
         try:
             with open(
                 os.path.join(
-                    os.getcwd(), "AutomatedTesting", "Levels", "Physics", "Material_DefaultLibraryUpdatedAcrossLevels", "_last_run_before_change_data.txt"
+                    arl._find_engine_root(os.getcwd()), "AutomatedTesting", "Levels", "Physics", "Material_DefaultLibraryUpdatedAcrossLevels", "_last_run_before_change_data.txt"
                 )) as data_file:
                 lines = data_file.readlines()
                 for i, line in enumerate(lines):

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/material/Material_DefaultLibraryUpdatedAcrossLevels_before.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/material/Material_DefaultLibraryUpdatedAcrossLevels_before.py
@@ -98,6 +98,7 @@ def Material_DefaultLibraryUpdatedAcrossLevels_before():
     import azlmbr.legacy.general as general
     import azlmbr.bus
     import azlmbr.math as math
+    import ly_test_tools._internal.managers.abstract_resource_locator as arl
 
     # Constants
     TIMEOUT = 2.0
@@ -169,7 +170,7 @@ def Material_DefaultLibraryUpdatedAcrossLevels_before():
         try:
             with open(
                 os.path.join(
-                    os.getcwd(), "AutomatedTesting", "Levels", "Physics", "Material_DefaultLibraryUpdatedAcrossLevels", "_last_run_before_change_data.txt"
+                    arl._find_engine_root(os.getcwd()), "AutomatedTesting", "Levels", "Physics", "Material_DefaultLibraryUpdatedAcrossLevels", "_last_run_before_change_data.txt"
                 ),"w") as data_file:
                 for data_point in data:
                     data_file.write(str(data_point))

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/0/0.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/0/0.prefab
@@ -1,0 +1,414 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "0",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[272131015882]": {
+            "Id": "Entity_[272131015882]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[4712694840150876798]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4712694840150876798
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[282420030039]": {
+            "Id": "Entity_[282420030039]",
+            "Name": "sphere",
+            "Components": {
+                "Component_[10993315499752397]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 10993315499752397,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 11666786328012046566
+                        },
+                        {
+                            "ComponentId": 4540728435480896449,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 4871894532499667184,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 7385062050909259476,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[11346323631807681262]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11346323631807681262
+                },
+                "Component_[1153076453892596685]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1153076453892596685
+                },
+                "Component_[11661243386226779330]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11661243386226779330
+                },
+                "Component_[11666786328012046566]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11666786328012046566,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            34.0
+                        ]
+                    }
+                },
+                "Component_[11807150630527866772]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 11807150630527866772
+                },
+                "Component_[12776370151403695976]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 12776370151403695976
+                },
+                "Component_[13338286725710048127]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 13338286725710048127
+                },
+                "Component_[13909061641056605790]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13909061641056605790
+                },
+                "Component_[3794026202591989554]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3794026202591989554
+                },
+                "Component_[4540728435480896449]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 4540728435480896449,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{A9E990B3-4EA5-4108-8569-B4CC54D37527}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[4871894532499667184]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 4871894532499667184,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[7385062050909259476]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 7385062050909259476,
+                    "GameView": true
+                }
+            }
+        },
+        "Entity_[285015917770]": {
+            "Id": "Entity_[285015917770]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[12368241148684771968]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12368241148684771968
+                },
+                "Component_[14478545718944713607]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14478545718944713607
+                },
+                "Component_[15040144110435456820]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15040144110435456820
+                },
+                "Component_[15842267116631028419]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 15842267116631028419,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                0.05000000074505806
+                            ]
+                        }
+                    }
+                },
+                "Component_[16443795256702860286]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16443795256702860286
+                },
+                "Component_[17330090464471840363]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17330090464471840363
+                },
+                "Component_[17677871050724466222]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17677871050724466222
+                },
+                "Component_[18281896566349969781]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18281896566349969781,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[4311545963646456975]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4311545963646456975,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18281896566349969781
+                        },
+                        {
+                            "ComponentId": 15842267116631028419,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5741926347424366246]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5741926347424366246
+                },
+                "Component_[7071637913266534486]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7071637913266534486
+                }
+            }
+        },
+        "Entity_[856246568138]": {
+            "Id": "Entity_[856246568138]",
+            "Name": "trigger",
+            "Components": {
+                "Component_[13626650174290508267]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13626650174290508267,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6641730631353192465
+                        },
+                        {
+                            "ComponentId": 19128539585771127,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5978412002759572004,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[16014778893970138866]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16014778893970138866
+                },
+                "Component_[17048341836974969891]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17048341836974969891
+                },
+                "Component_[17532876198879399583]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17532876198879399583
+                },
+                "Component_[17846398774750863991]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17846398774750863991
+                },
+                "Component_[19128539585771127]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 19128539585771127,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                2.0,
+                                2.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[2623239905992330416]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2623239905992330416
+                },
+                "Component_[5038359400525372476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5038359400525372476
+                },
+                "Component_[5978412002759572004]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 5978412002759572004,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                2.0,
+                                2.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[6641730631353192465]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6641730631353192465,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            34.70000076293945
+                        ]
+                    }
+                },
+                "Component_[6873431808813245234]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6873431808813245234
+                },
+                "Component_[9461177873056538692]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9461177873056538692
+                }
+            }
+        }
+    }
+}

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/1/1.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/1/1.prefab
@@ -1,0 +1,418 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "1",
+        "Components": {
+            "Component_[10182366347512475253]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 10182366347512475253
+            },
+            "Component_[12917798267488243668]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12917798267488243668
+            },
+            "Component_[3261249813163778338]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3261249813163778338
+            },
+            "Component_[3837204912784440039]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 3837204912784440039
+            },
+            "Component_[4272963378099646759]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 4272963378099646759,
+                "Parent Entity": ""
+            },
+            "Component_[4848458548047175816]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 4848458548047175816
+            },
+            "Component_[5787060997243919943]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 5787060997243919943
+            },
+            "Component_[7804170251266531779]": {
+                "$type": "EditorLockComponent",
+                "Id": 7804170251266531779
+            },
+            "Component_[7874177159288365422]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 7874177159288365422
+            },
+            "Component_[8018146290632383969]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 8018146290632383969
+            },
+            "Component_[8452360690590857075]": {
+                "$type": "SelectionComponent",
+                "Id": 8452360690590857075
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[261705524673]": {
+            "Id": "Entity_[261705524673]",
+            "Name": "sphere",
+            "Components": {
+                "Component_[11646493884547176136]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11646493884547176136
+                },
+                "Component_[11906722936407481270]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 11906722936407481270,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {
+                                    "MaterialId": "{A9E990B3-4EA5-4108-8569-B4CC54D37527}"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[13737032633113379089]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 13737032633113379089,
+                    "Configuration": {
+                        "entityId": "",
+                        "Initial linear velocity": [
+                            0.0,
+                            0.0,
+                            -10.0
+                        ],
+                        "Gravity Enabled": false,
+                        "Compute Mass": false,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 10.0
+                        }
+                    }
+                },
+                "Component_[14780167336961960724]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14780167336961960724
+                },
+                "Component_[16693144650759658888]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 16693144650759658888
+                },
+                "Component_[17948413883941236289]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17948413883941236289,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 4457629284796421044
+                        },
+                        {
+                            "ComponentId": 11906722936407481270,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 13737032633113379089,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 8661895046904719390,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[2838007474093539174]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2838007474093539174
+                },
+                "Component_[3533807943454727054]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3533807943454727054
+                },
+                "Component_[4457629284796421044]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4457629284796421044,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            34.0
+                        ]
+                    }
+                },
+                "Component_[4592977644338473914]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4592977644338473914
+                },
+                "Component_[7015480219054359195]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7015480219054359195
+                },
+                "Component_[7518132197169021484]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7518132197169021484
+                },
+                "Component_[8661895046904719390]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 8661895046904719390,
+                    "GameView": true
+                }
+            }
+        },
+        "Entity_[272131015882]": {
+            "Id": "Entity_[272131015882]",
+            "Name": "DefaultLevelSetup",
+            "Components": {
+                "Component_[10017568850356726118]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 10017568850356726118
+                },
+                "Component_[13730791873699866292]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13730791873699866292
+                },
+                "Component_[14036484285432839222]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14036484285432839222,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 9432950532896492451
+                        },
+                        {
+                            "ComponentId": 16094906495473882735,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[17819059404707659501]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17819059404707659501
+                },
+                "Component_[2317367007807622931]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2317367007807622931
+                },
+                "Component_[2676812743453687109]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2676812743453687109
+                },
+                "Component_[3047355939801335922]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3047355939801335922
+                },
+                "Component_[3687396159953003426]": {
+                    "$type": "SelectionComponent",
+                    "Id": 3687396159953003426
+                },
+                "Component_[4712694840150876798]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4712694840150876798
+                },
+                "Component_[9432950532896492451]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 9432950532896492451,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            512.0,
+                            512.0,
+                            100.0
+                        ]
+                    }
+                }
+            }
+        },
+        "Entity_[285015917770]": {
+            "Id": "Entity_[285015917770]",
+            "Name": "terrain",
+            "Components": {
+                "Component_[12368241148684771968]": {
+                    "$type": "SelectionComponent",
+                    "Id": 12368241148684771968
+                },
+                "Component_[14478545718944713607]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14478545718944713607
+                },
+                "Component_[15040144110435456820]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 15040144110435456820
+                },
+                "Component_[16443795256702860286]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 16443795256702860286
+                },
+                "Component_[17330090464471840363]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17330090464471840363
+                },
+                "Component_[17677871050724466222]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17677871050724466222
+                },
+                "Component_[18005002941285960013]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 18005002941285960013,
+                    "ColliderConfiguration": {
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                10.0,
+                                10.0,
+                                0.05000000074505806
+                            ]
+                        }
+                    }
+                },
+                "Component_[18281896566349969781]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18281896566349969781,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            32.0
+                        ]
+                    }
+                },
+                "Component_[4311545963646456975]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4311545963646456975,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 18281896566349969781
+                        },
+                        {
+                            "ComponentId": 18005002941285960013,
+                            "SortIndex": 1
+                        }
+                    ]
+                },
+                "Component_[5741926347424366246]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5741926347424366246
+                },
+                "Component_[7071637913266534486]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 7071637913266534486
+                }
+            }
+        },
+        "Entity_[856246568138]": {
+            "Id": "Entity_[856246568138]",
+            "Name": "trigger",
+            "Components": {
+                "Component_[13626650174290508267]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13626650174290508267,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 6641730631353192465
+                        },
+                        {
+                            "ComponentId": 19128539585771127,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 5978412002759572004,
+                            "SortIndex": 2
+                        }
+                    ]
+                },
+                "Component_[16014778893970138866]": {
+                    "$type": "SelectionComponent",
+                    "Id": 16014778893970138866
+                },
+                "Component_[17048341836974969891]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 17048341836974969891
+                },
+                "Component_[17532876198879399583]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17532876198879399583
+                },
+                "Component_[17846398774750863991]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17846398774750863991
+                },
+                "Component_[19128539585771127]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 19128539585771127,
+                    "ColliderConfiguration": {
+                        "Trigger": true,
+                        "InSceneQueries": false,
+                        "MaterialSelection": {
+                            "MaterialIds": [
+                                {}
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                2.0,
+                                2.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[2623239905992330416]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 2623239905992330416
+                },
+                "Component_[5038359400525372476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5038359400525372476
+                },
+                "Component_[5978412002759572004]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 5978412002759572004,
+                    "GameView": true,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                2.0,
+                                2.0,
+                                0.25
+                            ]
+                        }
+                    }
+                },
+                "Component_[6641730631353192465]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6641730631353192465,
+                    "Parent Entity": "ContainerEntity",
+                    "Transform Data": {
+                        "Translate": [
+                            503.0,
+                            529.0,
+                            34.70000076293945
+                        ]
+                    }
+                },
+                "Component_[6873431808813245234]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6873431808813245234
+                },
+                "Component_[9461177873056538692]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9461177873056538692
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
`os.getcwd()` was returning the _build\*\bin\profile_ directory causing the tests to blow up.

Sanitized CWD call to insure that it's returning the O3DE root directory by passing `os.getcwd()` through the LyTestTools Abstract Resource Locator's `_find_engine_root()` helper.

Addtionally, these tests have been updated to include the Slice → Prefab conversion.

Note: These tests will fail if we ever moved AutomatedTesting outside of the O3DE repo into its own project repository. If this every happens, there needs to be a strike team effort to rewrite a massive swath of tests to support the `AbstractResourceLocator` object so the `project()` method can be used to return the project path no matter where it's located. This effort was not used since it would require a larger rewrite of these tests.

Testing Performed:
Ran tests locally through pycharm and CLI and they are now passing.

Signed-off-by: Fuzzy Carter <jscar@amazon.com>

