### PR TITLE
{lyn10803} remove invalid characters from the mesh group name

### DIFF
--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupBehavior.cpp
@@ -309,7 +309,13 @@ namespace AZ::SceneAPI::Behaviors
                 AZStd::string meshGroupName = "default_";
                 meshGroupName += scene.GetName();
                 meshGroupName += meshNodePath;
-                AZ::StringFunc::Replace(meshGroupName, ".", "_");
+
+                // clean up the mesh group name
+                AZStd::replace_if(
+                    meshGroupName.begin(),
+                    meshGroupName.end(),
+                    [](char c) { return (!AZStd::is_alnum(c) && c != '_'); },
+                    '_');
 
                 auto meshGroup = AZStd::make_shared<AZ::SceneAPI::SceneData::MeshGroup>();
                 meshGroup->SetName(meshGroupName);


### PR DESCRIPTION
remove invalid characters from the mesh group name to fix up nodes that use non-alpha-numeric characters

so node names like "foo:bar_baz" will become "foo_bar_baz"

Signed-off-by: Allen Jackson <23512001+jackalbe@users.noreply.github.com>