### PR TITLE
Atom Tools: Extend RegExpFilter to support any regular expression

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
@@ -228,7 +228,7 @@ namespace AzToolsFramework
             return selection;
         }
 
-        AssetSelectionModel AssetSelectionModel::SourceAssetTypeSelection(const QString& pattern, bool multiselect)
+        AssetSelectionModel AssetSelectionModel::SourceAssetTypeSelection(const QRegExp& pattern, bool multiselect)
         {
             AssetSelectionModel selection;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
@@ -64,7 +64,7 @@ namespace AzToolsFramework
             static AssetSelectionModel AssetTypeSelection(const char* assetTypeName, bool multiselect = false);
             static AssetSelectionModel AssetTypesSelection(const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect = false);
             static AssetSelectionModel AssetGroupSelection(const char* group, bool multiselect = false);
-            static AssetSelectionModel SourceAssetTypeSelection(const QString& pattern, bool multiselect = false);
+            static AssetSelectionModel SourceAssetTypeSelection(const QRegExp& pattern, bool multiselect = false);
             static AssetSelectionModel EverythingSelection(bool multiselect = false);
 
         private:

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -260,11 +260,10 @@ namespace AzToolsFramework
         // RegExpFilter
         //////////////////////////////////////////////////////////////////////////
         RegExpFilter::RegExpFilter()
-            : m_filterPattern("")
         {
         }
 
-        void RegExpFilter::SetFilterPattern(const QString& filterPattern)
+        void RegExpFilter::SetFilterPattern(const QRegExp& filterPattern)
         {
             m_filterPattern = filterPattern;
             Q_EMIT updatedSignal();
@@ -272,22 +271,13 @@ namespace AzToolsFramework
 
         QString RegExpFilter::GetNameInternal() const
         {
-            return m_filterPattern;
+            return m_filterPattern.pattern();
         }
 
         bool RegExpFilter::MatchInternal(const AssetBrowserEntry* entry) const
         {
-            // no filter pattern matches any asset
-            if (m_filterPattern.isEmpty())
-            {
-                return true;
-            }
-
-            // entry's name matches regular expression pattern
-            QRegExp regExp(m_filterPattern);
-            regExp.setPatternSyntax(QRegExp::Wildcard);
-
-            return regExp.exactMatch(entry->GetDisplayName());
+            // entry's name matches regular expression pattern if specified
+            return m_filterPattern.isEmpty() || m_filterPattern.exactMatch(entry->GetDisplayName());
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
@@ -128,14 +128,14 @@ namespace AzToolsFramework
             RegExpFilter();
             ~RegExpFilter() override = default;
 
-            void SetFilterPattern(const QString& filterPattern);
+            void SetFilterPattern(const QRegExp& filterPattern);
 
         protected:
             QString GetNameInternal() const override;
             bool MatchInternal(const AssetBrowserEntry* entry) const override;
 
         private:
-            QString m_filterPattern;
+            QRegExp m_filterPattern;
         };
 
         //////////////////////////////////////////////////////////////////////////

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -76,7 +76,7 @@ namespace ScriptCanvasEditor
         m_model->SetFilter(selection.GetDisplayFilter());
     }
 
-    void SourceHandlePropertyAssetCtrl::SetSourceAssetFilterPattern(const QString& filterPattern)
+    void SourceHandlePropertyAssetCtrl::SetSourceAssetFilterPattern(const QRegExp& filterPattern)
     {
         m_sourceAssetFilterPattern = filterPattern;
     }
@@ -128,7 +128,7 @@ namespace ScriptCanvasEditor
             AZStd::string filterPattern;
             if (attrValue->Read<AZStd::string>(filterPattern))
             {
-                GUI->SetSourceAssetFilterPattern(filterPattern.c_str());
+                GUI->SetSourceAssetFilterPattern(QRegExp(filterPattern.c_str(), Qt::CaseInsensitive, QRegExp::Wildcard));
             }
         }
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
@@ -31,7 +31,7 @@ namespace ScriptCanvasEditor
         void ClearAssetInternal() override;
         void ConfigureAutocompleter() override;
 
-        void SetSourceAssetFilterPattern(const QString& filterPattern);
+        void SetSourceAssetFilterPattern(const QRegExp& filterPattern);
 
         AZ::IO::Path GetSelectedSourcePath() const;
         void SetSelectedSourcePath(const AZ::IO::Path& sourcePath);
@@ -43,7 +43,7 @@ namespace ScriptCanvasEditor
         //! A regular expression pattern for filtering by source assets
         //! If this is set, the PropertyAssetCtrl will be dealing with source assets
         //! instead of a specific asset type
-        QString m_sourceAssetFilterPattern;
+        QRegExp m_sourceAssetFilterPattern;
 
         AZ::IO::Path m_selectedSourcePath;
     };


### PR DESCRIPTION
RegExpFilter was previously only being used by the script canvas component to enable selection of source assets. Material editor and other atom tools need to be able to use the asset picker to select multiple source file types. It was not possible to specify multiple file filters or extensions using a wild card regular expression. The filter was updated to pass in a QRegExp object that can be configured to support different types of expressions and existing code was updated to use wildcards explicitly.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>