### PR TITLE
Motion Matching: Trajectory prediction based on joystick input using exponential curve

### DIFF
--- a/Gems/MotionMatching/Code/Source/MotionMatchingInstance.cpp
+++ b/Gems/MotionMatching/Code/Source/MotionMatchingInstance.cpp
@@ -289,7 +289,7 @@ namespace EMotionFX::MotionMatching
         m_trajectoryHistory.Update(timePassedInSeconds);
 
         // Update the trajectory query control points.
-        m_trajectoryQuery.Update(m_actorInstance,
+        m_trajectoryQuery.Update(*m_actorInstance,
             m_cachedTrajectoryFeature,
             m_trajectoryHistory,
             mode,

--- a/Gems/MotionMatching/Code/Source/TrajectoryQuery.cpp
+++ b/Gems/MotionMatching/Code/Source/TrajectoryQuery.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <TrajectoryQuery.h>
 #include <EMotionFX/Source/ActorInstance.h>
+#include <TrajectoryQuery.h>
 #include <FeatureTrajectory.h>
 
 namespace EMotionFX::MotionMatching
@@ -21,39 +21,98 @@ namespace EMotionFX::MotionMatching
         return displacement;
     }
 
+    void TrajectoryQuery::PredictFutureTrajectory(const ActorInstance* actorInstance,
+        const FeatureTrajectory* trajectoryFeature,
+        const AZ::Vector3& targetPos,
+        [[maybe_unused]] const AZ::Vector3& targetFacingDir)
+    {
+        const AZ::Vector3 actorInstanceWorldPosition = actorInstance->GetWorldSpaceTransform().m_position;
+        const AZ::Quaternion actorInstanceWorldRotation = actorInstance->GetWorldSpaceTransform().m_rotation;
+        const AZ::Vector3 actorInstanceToTarget = (targetPos - actorInstanceWorldPosition);
+
+        const size_t numFutureSamples = trajectoryFeature->GetNumFutureSamples();
+        const float numSections = aznumeric_cast<float>(numFutureSamples-1);
+
+        float linearDisplacementPerSample = 0.0f;
+        AZ::Quaternion targetFacingDirQuat = actorInstanceWorldRotation;
+        if (!actorInstanceToTarget.IsClose(AZ::Vector3::CreateZero(), m_deadZone))
+        {
+            // Calculate the desired linear velocity from the current position to the target position based on the trajectory future time range.
+            AZ_Assert(trajectoryFeature->GetFutureTimeRange() > AZ::Constants::FloatEpsilon, "Trajectory feature future time range is too small.");
+            const float velocity = actorInstanceToTarget.GetLength() / trajectoryFeature->GetFutureTimeRange();
+
+            // Use the direction from the current actor instance position to the target as the target facing direction
+            // and convert the direction vector to a quaternion.
+            targetFacingDirQuat = AZ::Quaternion::CreateShortestArc(trajectoryFeature->GetFacingAxisDir(), actorInstanceToTarget);
+        }
+
+        // Set the first control point to the current position and facing direction.
+        m_futureControlPoints[0].m_position = actorInstanceWorldPosition;
+        m_futureControlPoints[0].m_facingDirection = actorInstanceWorldRotation.TransformVector(trajectoryFeature->GetFacingAxisDir());
+
+        for (size_t i = 1; i < numFutureSamples; ++i)
+        {
+            const float t = aznumeric_cast<float>(i) / numSections;
+
+            // Position
+            {
+                const AZ::Vector3 prevFacingDir = m_futureControlPoints[i - 1].m_facingDirection;
+
+                // Interpolate between the linear direction to target and the facing direction from the previous sample.
+                // This will make sure the facing direction close to the current time matches the current facing direction and
+                // the facing direction in the most far future matches the desired target facing direction.
+                const float weight = 1.0f - powf(1.0f - t, m_positionBias);
+                const AZ::Vector3 interpolatedPosDelta = prevFacingDir.Lerp(actorInstanceToTarget.GetNormalized(), weight);
+
+                // Scale it by the desired velocity.
+                const AZ::Vector3 scaledPosDelta = interpolatedPosDelta * linearDisplacementPerSample;
+
+                m_futureControlPoints[i].m_position = m_futureControlPoints[i - 1].m_position + scaledPosDelta;
+            }
+
+            // Facing direction
+            {
+                // Interpolate facing direction from current character facing direction (first sample) to the target facing direction (most far future sample).
+                const float weight = 1.0f - powf(1.0f - t, m_rotationBias);
+                const AZ::Quaternion interpolatedRotation = actorInstanceWorldRotation.Slerp(targetFacingDirQuat, weight);
+
+                // Convert the interpolated rotation result back to a facing direction vector.
+                const AZ::Vector3 interpolatedFacingDir = interpolatedRotation.TransformVector(trajectoryFeature->GetFacingAxisDir());
+
+                m_futureControlPoints[i].m_facingDirection = interpolatedFacingDir.GetNormalizedSafe();
+            }
+        }
+    }
+
     void TrajectoryQuery::Update(const ActorInstance* actorInstance,
         const FeatureTrajectory* trajectoryFeature,
         const TrajectoryHistory& trajectoryHistory,
         EMode mode,
-        [[maybe_unused]] AZ::Vector3 targetPos,
-        [[maybe_unused]] AZ::Vector3 targetFacingDir,
+        const AZ::Vector3& targetPos,
+        const AZ::Vector3& targetFacingDir,
         float timeDelta,
         float pathRadius,
         float pathSpeed)
     {
+        // Build the past trajectory control points.
+        const size_t numPastSamples = trajectoryFeature->GetNumPastSamples();
+        m_pastControlPoints.resize(numPastSamples);
+        const float pastTimeRange = trajectoryFeature->GetPastTimeRange();
+
+        for (size_t i = 0; i < numPastSamples; ++i)
+        {
+            const float sampleTimeNormalized = i / static_cast<float>(numPastSamples - 1);
+            const TrajectoryHistory::Sample sample = trajectoryHistory.Evaluate(sampleTimeNormalized * pastTimeRange);
+            m_pastControlPoints[i] = { sample.m_position, sample.m_facingDirection };
+        }
+
         // Build the future trajectory control points.
         const size_t numFutureSamples = trajectoryFeature->GetNumFutureSamples();
         m_futureControlPoints.resize(numFutureSamples);
 
         if (mode == MODE_TARGETDRIVEN)
         {
-            const AZ::Vector3 curPos = actorInstance->GetWorldSpaceTransform().m_position;
-            if (curPos.IsClose(targetPos, 0.1f))
-            {
-                for (size_t i = 0; i < numFutureSamples; ++i)
-                {
-                    m_futureControlPoints[i].m_position = curPos;
-                }
-            }
-            else
-            {
-                // NOTE: Improve it by using a curve to the target.
-                for (size_t i = 0; i < numFutureSamples; ++i)
-                {
-                    const float sampleTime = static_cast<float>(i) / (numFutureSamples - 1);
-                    m_futureControlPoints[i].m_position = curPos.Lerp(targetPos, sampleTime);
-                }
-            }
+            PredictFutureTrajectory(actorInstance, trajectoryFeature, targetPos, targetFacingDir);
         }
         else
         {
@@ -72,18 +131,6 @@ namespace EMotionFX::MotionMatching
                 const AZ::Vector3 dir = deltaSample - curSample;
                 m_futureControlPoints[i].m_facingDirection = dir.GetNormalizedSafe();
             }
-        }
-
-        // Build the past trajectory control points.
-        const size_t numPastSamples = trajectoryFeature->GetNumPastSamples();
-        m_pastControlPoints.resize(numPastSamples);
-        const float pastTimeRange = trajectoryFeature->GetPastTimeRange();
-
-        for (size_t i = 0; i < numPastSamples; ++i)
-        {
-            const float sampleTimeNormalized = i / static_cast<float>(numPastSamples - 1);
-            const TrajectoryHistory::Sample sample = trajectoryHistory.Evaluate(sampleTimeNormalized * pastTimeRange);
-            m_pastControlPoints[i] = { sample.m_position, sample.m_facingDirection };
         }
     }
 

--- a/Gems/MotionMatching/Code/Source/TrajectoryQuery.h
+++ b/Gems/MotionMatching/Code/Source/TrajectoryQuery.h
@@ -43,8 +43,8 @@ namespace EMotionFX::MotionMatching
             const FeatureTrajectory* trajectoryFeature,
             const TrajectoryHistory& trajectoryHistory,
             EMode mode,
-            AZ::Vector3 targetPos,
-            AZ::Vector3 targetFacingDir,
+            const AZ::Vector3& targetPos,
+            const AZ::Vector3& targetFacingDir,
             float timeDelta,
             float pathRadius,
             float pathSpeed);
@@ -59,8 +59,17 @@ namespace EMotionFX::MotionMatching
             const AZStd::vector<ControlPoint>& controlPoints,
             const AZ::Color& color);
 
+        void PredictFutureTrajectory(const ActorInstance* actorInstance,
+            const FeatureTrajectory* trajectoryFeature,
+            const AZ::Vector3& targetPos,
+            const AZ::Vector3& targetFacingDir);
+
         AZStd::vector<ControlPoint> m_pastControlPoints;
         AZStd::vector<ControlPoint> m_futureControlPoints;
+
+        float m_positionBias = 2.0f; //< Indicates how fast the curve will bend towards the target.
+        float m_rotationBias = 3.0f; //< Indicates how fast the facing direction matches the target facing direction.
+        float m_deadZone = 0.2f; //< Similarly to a joystick deadzone, this represents the area around the character that does not respond to movement.
 
         float m_automaticModePhase = 0.0f; //< Current phase for the automatic demo mode. Not needed by the target-driven mode.
     };

--- a/Gems/MotionMatching/Code/Source/TrajectoryQuery.h
+++ b/Gems/MotionMatching/Code/Source/TrajectoryQuery.h
@@ -39,7 +39,7 @@ namespace EMotionFX::MotionMatching
             MODE_AUTOMATIC = 1
         };
 
-        void Update(const ActorInstance* actorInstance,
+        void Update(const ActorInstance& actorInstance,
             const FeatureTrajectory* trajectoryFeature,
             const TrajectoryHistory& trajectoryHistory,
             EMode mode,
@@ -59,7 +59,7 @@ namespace EMotionFX::MotionMatching
             const AZStd::vector<ControlPoint>& controlPoints,
             const AZ::Color& color);
 
-        void PredictFutureTrajectory(const ActorInstance* actorInstance,
+        void PredictFutureTrajectory(const ActorInstance& actorInstance,
             const FeatureTrajectory* trajectoryFeature,
             const AZ::Vector3& targetPos,
             const AZ::Vector3& targetFacingDir);

--- a/Gems/MotionMatching/README.md
+++ b/Gems/MotionMatching/README.md
@@ -101,6 +101,12 @@ The trajectory history stores world space position and facing direction data of 
 
 ![Trajectory Feature](https://user-images.githubusercontent.com/43751992/151819315-beb8d9a1-69ca-49cd-bec0-ba2bae2dc469.png)
 
+## Trajectory prediction
+
+The user controls the character by its future trajectory. The future trajectory contains the path the character is expected to move along, if it should accelerate, move faster, or come to a stop, and if it should be walking forward doing a turn, or strafe sideways. Based on a joystick position, we need to predict the future trajectory and build the path and the facing direction vectors across the control points. The trajectory feature defines the time window of the prediction and the number of samples to be generated. We generate an exponential curve that starts in the direction of the character and then bends towards the given target.
+
+https://user-images.githubusercontent.com/43751992/156741698-d2306bac-cdf5-4a25-96bd-0fc4422b598b.mp4
+
 ## Motion Matching data
 
 Data based on a given skeleton but independent of the instance like the motion capture database, the feature schema or feature matrix is stored here. It is just a wrapper to group the sharable data.


### PR DESCRIPTION
* Building the future trajectory based on an exponential curve and the joystick input.
* The curve starts in the direction of the character and then bends towards the target.
* Facing direction gets interpolated from the current character facing direction to the relative joystick target position.
* In case the joystick is within a given deadzone (joystick centered) the facing direction can still be controlled so that the character can turn in-place.
* Added section about trajectory prediction to the ReadMe.md

https://user-images.githubusercontent.com/43751992/156764525-ec9a96ac-81d9-46ed-969c-deaf7ee7d3f5.mp4


