### PR TITLE
Skip invalid or broken periodic tests that fail in nightly builds

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/scripting/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/TestSuite_Periodic.py
@@ -37,7 +37,7 @@ class TestAutomation(TestAutomationBase):
         from . import Pane_HappyPath_ResizesProperly as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptCanvas_TwoComponents_InteractSuccessfully(self, request, workspace, editor, launcher_platform, level):
         def teardown():
@@ -47,7 +47,7 @@ class TestAutomation(TestAutomationBase):
         from . import ScriptCanvas_TwoComponents_InteractSuccessfully as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptCanvas_ChangingAssets_ComponentStable(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -61,12 +61,12 @@ class TestAutomation(TestAutomationBase):
         from . import Graph_HappyPath_ZoomInZoomOut as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails on nightly build builds, it needs to be fixed.")
     def test_NodePalette_HappyPath_CanSelectNode(self, request, workspace, editor, launcher_platform):
         from . import NodePalette_HappyPath_CanSelectNode as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptCanvasComponent_OnEntityActivatedDeactivated_PrintMessage(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -80,7 +80,7 @@ class TestAutomation(TestAutomationBase):
         from . import NodePalette_HappyPath_ClearSelection as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptCanvas_TwoEntities_UseSimultaneously(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -114,7 +114,7 @@ class TestAutomation(TestAutomationBase):
         from . import Debugger_HappyPath_TargetMultipleGraphs as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails on nightly build builds, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_Debugger_HappyPath_TargetMultipleEntities(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -124,7 +124,7 @@ class TestAutomation(TestAutomationBase):
         from . import Debugger_HappyPath_TargetMultipleEntities as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     def test_EditMenu_Default_UndoRedo(self, request, workspace, editor, launcher_platform, project):
         from . import EditMenu_Default_UndoRedo as test_module
         self._run_test(request, workspace, editor, test_module)
@@ -146,7 +146,7 @@ class TestAutomation(TestAutomationBase):
         from . import Pane_Default_RetainOnSCRestart as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptEvents_HappyPath_SendReceiveAcrossMultiple(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -156,7 +156,7 @@ class TestAutomation(TestAutomationBase):
         from . import ScriptEvents_HappyPath_SendReceiveAcrossMultiple as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptEvents_Default_SendReceiveSuccessfully(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -166,7 +166,7 @@ class TestAutomation(TestAutomationBase):
         from . import ScriptEvents_Default_SendReceiveSuccessfully as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     @pytest.mark.parametrize("level", ["tmp_level"])
     def test_ScriptEvents_ReturnSetType_Successfully(self, request, workspace, editor, launcher_platform, project, level):
         def teardown():
@@ -176,7 +176,7 @@ class TestAutomation(TestAutomationBase):
         from . import ScriptEvents_ReturnSetType_Successfully as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails on nightly build builds, it needs to be fixed.")
     def test_NodeCategory_ExpandOnClick(self, request, workspace, editor, launcher_platform):
         from . import NodeCategory_ExpandOnClick as test_module
         self._run_test(request, workspace, editor, test_module)
@@ -185,17 +185,17 @@ class TestAutomation(TestAutomationBase):
         from . import NodePalette_SearchText_Deletion as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     def test_VariableManager_UnpinVariableType_Works(self, request, workspace, editor, launcher_platform):
         from . import VariableManager_UnpinVariableType_Works as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails on nightly build builds, it needs to be fixed.")
     def test_Node_HappyPath_DuplicateNode(self, request, workspace, editor, launcher_platform):
         from . import Node_HappyPath_DuplicateNode as test_module
         self._run_test(request, workspace, editor, test_module)
 
-    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails on nightly build builds, it needs to be fixed.")
     def test_ScriptEvent_AddRemoveParameter_ActionsSuccessful(self, request, workspace, editor, launcher_platform):
         def teardown():
             file_system.delete(
@@ -218,7 +218,7 @@ class TestScriptCanvasTests(object):
     The following tests use hydra_test_utils.py to launch the editor and validate the results.
     """
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     def test_FileMenu_Default_NewAndOpen(self, request, editor, launcher_platform):
         expected_lines = [
             "File->New action working as expected: True",
@@ -234,7 +234,7 @@ class TestScriptCanvasTests(object):
             timeout=60,
         )
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     def test_NewScriptEventButton_HappyPath_ContainsSCCategory(self, request, editor, launcher_platform):
         expected_lines = [
             "New Script event action found: True",
@@ -268,7 +268,7 @@ class TestScriptCanvasTests(object):
             timeout=60,
         )
 
-    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails on nightly build builds, it needs to be fixed.")
     def test_VariableManager_Default_CreateDeleteVars(self, request, editor, launcher_platform):
         var_types = ["Boolean", "Color", "EntityID", "Number", "String", "Transform", "Vector2", "Vector3", "Vector4"]
         expected_lines = [f"Success: {var_type} variable is created" for var_type in var_types]
@@ -318,7 +318,7 @@ class TestScriptCanvasTests(object):
             timeout=60,
         )
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     def test_ScriptEvent_AddRemoveMethod_UpdatesInSC(self, request, workspace, editor, launcher_platform):
         def teardown():
             file_system.delete(
@@ -346,7 +346,7 @@ class TestScriptCanvasTests(object):
             timeout=60,
         )
 
-    @pytest.mark.xfail(reason="Test fails to find expected lines, it needs to be fixed.")
+    @pytest.mark.skip(reason="Test fails to find expected lines, it needs to be fixed.")
     def test_ScriptEvents_AllParamDatatypes_CreationSuccess(self, request, workspace, editor, launcher_platform):
         def teardown():
             file_system.delete(

--- a/AutomatedTesting/Gem/PythonTests/scripting/TestSuite_Periodic.py
+++ b/AutomatedTesting/Gem/PythonTests/scripting/TestSuite_Periodic.py
@@ -195,6 +195,7 @@ class TestAutomation(TestAutomationBase):
         from . import Node_HappyPath_DuplicateNode as test_module
         self._run_test(request, workspace, editor, test_module)
 
+    @pytest.mark.xfail(reason="Test fails on nightly build builds, it needs to be fixed.")
     def test_ScriptEvent_AddRemoveParameter_ActionsSuccessful(self, request, workspace, editor, launcher_platform):
         def teardown():
             file_system.delete(


### PR DESCRIPTION
These tests need to be removed or refreshed to have deterministic behaviors. They will be skipped from the periodic test suite until they are investigated.

Signed-off-by: lsemp3d <58790905+lsemp3d@users.noreply.github.com>