### PR TITLE
Add support for rendering textures with ImGui.

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/ImGui/ImGui.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/ImGui/ImGui.azsl
@@ -25,7 +25,7 @@ struct VertexOutput
     uint TextureIndex : INSTANCE_DATA;
 };
 
-ShaderResourceGroup ObjectSrg : SRG_PerObject
+ShaderResourceGroup PassSrg : SRG_PerPass
 {
     Texture2D<float4> m_textures[16];
     
@@ -45,10 +45,10 @@ ShaderResourceGroup ObjectSrg : SRG_PerObject
 VertexOutput MainVS(in VertexInput input)
 {
     VertexOutput output;
-    output.Position = mul(float4(input.Position, 0.0f, 1.0f), ObjectSrg::m_projectionMatrix);
+    output.Position = mul(float4(input.Position, 0.0f, 1.0f), PassSrg::m_projectionMatrix);
     output.Color = float4(input.Color.rgb, input.Color.a);
     output.UV = input.UV;
-    output.TextureId = input.TextureIndex;
+    output.TextureIndex = input.TextureIndex;
     return output;
 }
 
@@ -60,7 +60,7 @@ struct PixelOutput
 PixelOutput MainPS(in VertexOutput input)
 {
     PixelOutput output;
-    float4 color = ObjectSrg::m_textures[input.TextureIndex].Sample(ObjectSrg::LinearSampler, input.UV) * input.Color;
+    float4 color = PassSrg::m_textures[input.TextureIndex].Sample(PassSrg::LinearSampler, input.UV) * input.Color;
     output.m_color = float4(color.rgb * color.a, color.a);
     return output;
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/ImGui/ImGui.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/ImGui/ImGui.azsl
@@ -14,6 +14,7 @@ struct VertexInput
     float2 Position : POSITION;
     float2 UV : UV;
     float4 Color : COLOR;
+    uint TextureIndex : INSTANCE_DATA;
 };
 
 struct VertexOutput
@@ -21,11 +22,12 @@ struct VertexOutput
     float4 Position : SV_Position;
     float4 Color : COLOR;
     float2 UV : UV;
+    uint TextureIndex : INSTANCE_DATA;
 };
 
 ShaderResourceGroup ObjectSrg : SRG_PerObject
 {
-    Texture2D<float4> FontImage;
+    Texture2D<float4> m_textures[16];
     
     Sampler LinearSampler
     {
@@ -46,6 +48,7 @@ VertexOutput MainVS(in VertexInput input)
     output.Position = mul(float4(input.Position, 0.0f, 1.0f), ObjectSrg::m_projectionMatrix);
     output.Color = float4(input.Color.rgb, input.Color.a);
     output.UV = input.UV;
+    output.TextureId = input.TextureIndex;
     return output;
 }
 
@@ -57,7 +60,7 @@ struct PixelOutput
 PixelOutput MainPS(in VertexOutput input)
 {
     PixelOutput output;
-    float4 color = ObjectSrg::FontImage.Sample(ObjectSrg::LinearSampler, input.UV) * input.Color;
+    float4 color = ObjectSrg::m_textures[input.TextureIndex].Sample(ObjectSrg::LinearSampler, input.UV) * input.Color;
     output.m_color = float4(color.rgb * color.a, color.a);
     return output;
 }

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -510,6 +510,8 @@ namespace AZ
                     ->Channel("POSITION", RHI::Format::R32G32_FLOAT)
                     ->Channel("UV", RHI::Format::R32G32_FLOAT)
                     ->Channel("COLOR", RHI::Format::R8G8B8A8_UNORM);
+                layoutBuilder.AddBuffer(RHI::StreamStepFunction::PerInstance)
+                    ->Channel("INSTANCE_DATA", RHI::Format::R8_UINT);
                 m_pipelineState->InputStreamLayout() = layoutBuilder.End();
 
             }
@@ -560,8 +562,21 @@ namespace AZ
                 io.Fonts->AddFontDefault();
                 io.Fonts->Build();
             }
-            m_resourceGroup->SetImage(m_fontImageIndex, m_fontAtlas);
+
+            const uint32_t fontTextureIndex = 0;
+            m_resourceGroup->SetImage(m_texturesIndex, m_fontAtlas, fontTextureIndex);
             io.Fonts->TexID = reinterpret_cast<ImTextureID>(m_fontAtlas.get());
+
+            // ImGuiPass will support binding 16 textures at most per frame. 
+            const uint8_t instanceData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            RPI::CommonBufferDescriptor desc;
+            desc.m_poolType = RPI::CommonBufferPoolType::StaticInputAssembly;
+            desc.m_bufferName = "InstanceBuffer";
+            desc.m_elementSize = 1;
+            desc.m_byteCount = 16;
+            desc.m_bufferData = instanceData;
+            m_instanceBuffer = RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(desc);
+            m_instanceBufferView = RHI::StreamBufferView(*m_instanceBuffer->GetRHIBuffer(), 0, 16, 1);
         }
 
         void ImGuiPass::InitializeInternal()
@@ -587,12 +602,11 @@ namespace AZ
 
         void ImGuiPass::CompileResources([[maybe_unused]] const RHI::FrameGraphCompileContext& context)
         {
-            m_resourceGroup->Compile();
-
             // Create all the DrawIndexeds so they can be submitted in parallel on BuildCommandListInternal()
             uint32_t vertexOffset = 0;
             uint32_t indexOffset = 0;
 
+            m_userTextures.clear();
             for (ImDrawData& drawData : m_drawData)
             {
                 for (int32_t cmdListIdx = 0; cmdListIdx < drawData.CmdListsCount; cmdListIdx++)
@@ -608,10 +622,21 @@ namespace AZ
                         //otherwise it is possible to have a frame where scissor bounds can be bigger than window's bounds if we resize the window
                         scissorMaxX = AZStd::min(scissorMaxX, m_viewportWidth);
                         scissorMaxY = AZStd::min(scissorMaxY, m_viewportHeight);
-                        
+
+                        // check if texture id needs to be bound to the srg
+                        uint32_t index = 0;
+                        if (drawCmd.TextureId != ImGui::GetIO().Fonts->TexID)
+                        {
+                            Data::Instance<RPI::StreamingImage> img = reinterpret_cast<RPI::StreamingImage*>(drawCmd.TextureId);
+                            // Texture index 0 is reserved for the font atlas, so we start from 1 to 15 for user textures.
+                            index = aznumeric_cast<uint32_t>(m_userTextures.size() + 1);
+                            m_userTextures[img.get()] = index;
+                        }
+
                         m_draws.push_back(
                             {
-                                RHI::DrawIndexed(1, 0, vertexOffset, drawCmd.ElemCount, indexOffset),
+                                // Instance offset is used to index to the correct texture in the shader
+                                RHI::DrawIndexed(1, index, vertexOffset, drawCmd.ElemCount, indexOffset),
                                 RHI::Scissor(
                                     static_cast<int32_t>(drawCmd.ClipRect.x),
                                     static_cast<int32_t>(drawCmd.ClipRect.y),
@@ -631,6 +656,12 @@ namespace AZ
             auto imguiContextScope = ImguiContextScope(m_imguiContext);
             ImGui::GetIO().MouseWheel = m_lastFrameMouseWheel;
             m_lastFrameMouseWheel = 0.0;
+
+            for (auto& [streamingImage, index] : m_userTextures)
+            {
+                m_resourceGroup->SetImage(m_texturesIndex, streamingImage, index);
+            }
+            m_resourceGroup->Compile();
         }
 
         void ImGuiPass::BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context)
@@ -653,7 +684,7 @@ namespace AZ
                 drawItem.m_indexBufferView = &m_indexBufferView;
                 drawItem.m_shaderResourceGroupCount = 1;
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = 1;
+                drawItem.m_streamBufferViewCount = 2;
                 drawItem.m_streamBufferViews = m_vertexBufferView.data();
                 drawItem.m_scissorsCount = 1;
                 drawItem.m_scissors = &m_draws.at(i).m_scissor;
@@ -725,6 +756,7 @@ namespace AZ
             static_assert(indexSize == 2, "Expected index size from ImGui to be 2 to match RHI::IndexFormat::Uint16");
             m_indexBufferView = indexBuffer->GetIndexBufferView(RHI::IndexFormat::Uint16);
             m_vertexBufferView[0] = vertexBuffer->GetStreamBufferView(vertexSize);
+            m_vertexBufferView[1] = m_instanceBufferView;
 
             RHI::ValidateStreamBufferViews(m_pipelineState->ConstDescriptor().m_inputStreamLayout, m_vertexBufferView);
 

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.cpp
@@ -634,6 +634,10 @@ namespace AZ
                                 index = aznumeric_cast<uint32_t>(m_userTextures.size() + 1);
                                 m_userTextures[img.get()] = index;
                             }
+                            else
+                            {
+                                AZ_Warning("ImGuiPass", false, "The maximum number of textures ImGui can render per frame is %d", MaxUserTextures);
+                            }
                         }
 
                         m_draws.push_back(

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -95,6 +95,8 @@ namespace AZ
             void BuildCommandListInternal(const RHI::FrameGraphExecuteContext& context) override;
 
         private:
+            static const int MaxUserTextures = 15;
+
             //! Class which connects to the tick handler using the tick order required at the start of an ImGui frame.
             class TickHandlerFrameStart : protected TickBus::Handler
             {
@@ -149,7 +151,7 @@ namespace AZ
             RHI::Viewport m_viewportState;
 
             RHI::IndexBufferView m_indexBufferView;
-            AZStd::array<RHI::StreamBufferView, 2> m_vertexBufferView; // For vertex buffer and instance data since most RHI apis expect an array.
+            AZStd::array<RHI::StreamBufferView, 2> m_vertexBufferView; // For vertex buffer and instance data
             AZStd::vector<DrawInfo> m_draws;
             Data::Instance<RPI::StreamingImage> m_fontAtlas;
 
@@ -163,8 +165,8 @@ namespace AZ
             uint32_t m_viewportWidth = 0;
             uint32_t m_viewportHeight = 0;
 
-            AZStd::unordered_map<RPI::StreamingImage*, uint32_t> m_userTextures;
-            AZ::Data::Instance<AZ::RPI::Buffer> m_instanceBuffer;
+            AZStd::unordered_map<Data::Instance<RPI::StreamingImage>, uint32_t> m_userTextures;
+            Data::Instance<RPI::Buffer> m_instanceBuffer;
             RHI::StreamBufferView m_instanceBufferView;
         };
     }   // namespace RPI

--- a/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
+++ b/Gems/Atom/Feature/Common/Code/Source/ImGui/ImGuiPass.h
@@ -13,6 +13,7 @@
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
 
 #include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/StreamBufferView.h>
 
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
@@ -143,12 +144,12 @@ namespace AZ
             Data::Instance<RPI::Shader> m_shader;
 
             Data::Instance<RPI::ShaderResourceGroup> m_resourceGroup;
-            RHI::ShaderInputNameIndex m_fontImageIndex = "FontImage";
+            RHI::ShaderInputNameIndex m_texturesIndex = "m_textures";
             RHI::ShaderInputNameIndex m_projectionMatrixIndex = "m_projectionMatrix";
             RHI::Viewport m_viewportState;
 
             RHI::IndexBufferView m_indexBufferView;
-            AZStd::array<RHI::StreamBufferView, 1> m_vertexBufferView; // Only 1 vertex stream view needed, but most RHI apis expect an array.
+            AZStd::array<RHI::StreamBufferView, 2> m_vertexBufferView; // For vertex buffer and instance data since most RHI apis expect an array.
             AZStd::vector<DrawInfo> m_draws;
             Data::Instance<RPI::StreamingImage> m_fontAtlas;
 
@@ -162,6 +163,9 @@ namespace AZ
             uint32_t m_viewportWidth = 0;
             uint32_t m_viewportHeight = 0;
 
+            AZStd::unordered_map<RPI::StreamingImage*, uint32_t> m_userTextures;
+            AZ::Data::Instance<AZ::RPI::Buffer> m_instanceBuffer;
+            RHI::StreamBufferView m_instanceBufferView;
         };
     }   // namespace RPI
 }   // namespace AZ


### PR DESCRIPTION
Notes:
* Allow for 16 textures to be rendered per frame by ImGui (1 texture slot for font, then 15 user textures)

ASV Test:
```
RHI API: dx12
Test Script Count: 22
Screenshot Count: 210
Manually Validated Screenshots: 0/209
Screenshot automatic checks failed: 1
	scripts/shadowtest.bv.luac D:/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_filter_method.png 'Level H' 0.059251
```