### PR TITLE
Move AZ Event serialize context reflection into shared component

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/ReflectComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/ReflectComponent.cpp
@@ -9,6 +9,7 @@
 #include <AssetBuilderSDK/AssetBuilderSDK.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/ranges/elements_view.h>
 #include <Editor/Include/ScriptCanvas/Components/EditorGraph.h>
 #include <Editor/ReflectComponent.h>
 #include <Editor/View/Dialogs/SettingsDialog.h>
@@ -176,9 +177,103 @@ namespace ScriptCanvasEditor
 
     void ReflectComponent::Activate()
     {
+        ReflectEventTypes();
     }
 
     void ReflectComponent::Deactivate()
     {
+    }
+
+    void ReflectComponent::ReflectEventTypes()
+    {
+        AZ::BehaviorContext* behaviorContext{};
+        AZ::ComponentApplicationBus::BroadcastResult(behaviorContext, &AZ::ComponentApplicationBus::Events::GetBehaviorContext);
+        AZ_Assert(behaviorContext, "BehaviorContext is required to lookup methods returning AZ::Event");
+
+        AZ::SerializeContext* serializeContext{};
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+        AZ_Assert(serializeContext, "SerializeContext is required to register AZ::Event type");
+
+        auto ReflectEventTypeOnDemand = [](AZ::SerializeContext* context, const AZ::BehaviorMethod& behaviorMethod) -> void
+        {
+            if (AZ::MethodReturnsAzEventByReferenceOrPointer(behaviorMethod))
+            {
+                const AZ::BehaviorParameter* resultParameter = behaviorMethod.GetResult();
+                AZ::SerializeContext::ClassData classData;
+                classData.m_name = resultParameter->m_name;
+                classData.m_typeId = resultParameter->m_typeId;
+                classData.m_azRtti = resultParameter->m_azRtti;
+
+                auto EventPlaceholderAnyCreator = [](AZ::SerializeContext*) -> AZStd::any
+                {
+                    return AZStd::make_any<AZStd::monostate>();
+                };
+
+                context->RegisterType(resultParameter->m_typeId, AZStd::move(classData), EventPlaceholderAnyCreator);
+            }
+        };
+
+        // Behavior Context Global Methods
+        for (auto behaviorMethod : AZStd::ranges::views::values(behaviorContext->m_methods))
+        {
+            if (behaviorMethod != nullptr)
+            {
+                ReflectEventTypeOnDemand(serializeContext, *behaviorMethod);
+            }
+        }
+
+        // Behavior Context Global Properties
+        for (auto behaviorProperty : AZStd::ranges::views::values(behaviorContext->m_properties))
+        {
+            // Only the getter can reflect a method that returns an AZ::Event& or AZ::Event*
+            if (behaviorProperty != nullptr && behaviorProperty->m_getter != nullptr)
+            {
+                ReflectEventTypeOnDemand(serializeContext, *behaviorProperty->m_getter);
+            }
+        }
+
+        // Behavior Context Class Methods
+        // Behavior Context Getter Property Methods
+        for (auto behaviorClass : AZStd::ranges::views::values(behaviorContext->m_classes))
+        {
+            if (behaviorClass != nullptr)
+            {
+                for (auto behaviorClassMethod : AZStd::ranges::views::values(behaviorClass->m_methods))
+                {
+                    if (behaviorClassMethod != nullptr)
+                    {
+                        ReflectEventTypeOnDemand(serializeContext, *behaviorClassMethod);
+                    }
+                }
+
+                // Behavior Context Global Properties
+                for (auto behaviorClassProperty : AZStd::ranges::views::values(behaviorClass->m_properties))
+                {
+                    // Only the getter can reflect a method that returns an AZ::Event& or AZ::Event*
+                    if (behaviorClassProperty != nullptr && behaviorClassProperty->m_getter != nullptr)
+                    {
+                        ReflectEventTypeOnDemand(serializeContext, *behaviorClassProperty->m_getter);
+                    }
+                }
+            }
+        }
+
+        // Behavior Context EBus event sender
+        for (auto behaviorEbus : AZStd::ranges::views::values(behaviorContext->m_ebuses))
+        {
+            if (behaviorEbus != nullptr)
+            {
+                for (auto behaviorEventSender : AZStd::ranges::views::values(behaviorEbus->m_events))
+                {
+                    // An event sender has the same signature for all of its functions and it's guaranteed
+                    // that it will have a valid m_broadcast.
+                    // So use that to reflect the any EBus event that returns an AZ Event pointer or reference
+                    if (behaviorEventSender.m_broadcast != nullptr)
+                    {
+                        ReflectEventTypeOnDemand(serializeContext, *behaviorEventSender.m_broadcast);
+                    }
+                }
+            }
+        }
     }
 }

--- a/Gems/ScriptCanvas/Code/Editor/ReflectComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/ReflectComponent.h
@@ -33,5 +33,7 @@ namespace ScriptCanvasEditor
         void Activate();
         void Deactivate();
         ////
+
+        void ReflectEventTypes();
     };
 }

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
@@ -43,8 +43,6 @@ namespace ScriptCanvasEditor
         , private AzToolsFramework::AssetSystemBus::Handler
     {
     public:
-        
-
         AZ_COMPONENT(SystemComponent, "{1DE7A120-4371-4009-82B5-8140CB1D7B31}");
 
         SystemComponent();

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -136,20 +136,12 @@ namespace
             return;
         }
 
-        // If the reflected method returns an AZ::Event, reflect it to the SerializeContext
-        if (AZ::MethodReturnsAzEventByReferenceOrPointer(method))
-        {
-            const AZ::BehaviorParameter* resultParameter = method.GetResult();
-            ScriptCanvas::ReflectEventTypeOnDemand(resultParameter->m_typeId, resultParameter->m_name, resultParameter->m_azRtti);
-        }
-
         nodePaletteModel.RegisterClassNode(categoryPath, behaviorClass ? behaviorClass->m_name : "", name, &method, &behaviorContext, propertyStatus, isOverloaded);
     }
 
     void RegisterGlobalMethod(ScriptCanvasEditor::NodePaletteModel& nodePaletteModel, const AZ::BehaviorContext& behaviorContext,
         const AZ::BehaviorMethod& behaviorMethod)
     {
-
         AZ_PROFILE_SCOPE(NodePaletteModel, "RegisterGlobalMethod");
 
         const auto isExposableOutcome = ScriptCanvas::IsExposable(behaviorMethod);
@@ -165,13 +157,6 @@ namespace
             return; // skip this method
         }
 
-        // If the reflected method returns an AZ::Event, reflect it to the SerializeContext
-        if (AZ::MethodReturnsAzEventByReferenceOrPointer(behaviorMethod))
-        {
-            const AZ::BehaviorParameter* resultParameter = behaviorMethod.GetResult();
-            ScriptCanvas::ReflectEventTypeOnDemand(resultParameter->m_typeId, resultParameter->m_name, resultParameter->m_azRtti);
-
-        }
         nodePaletteModel.RegisterMethodNode(behaviorContext, behaviorMethod);
     }
 
@@ -683,7 +668,7 @@ namespace
                 }
 
                 const bool isOverload{ false }; // overloaded events are not trivially supported
-                nodePaletteModel.RegisterEBusSenderNodeModelInformation(categoryPath, behaviorEbus.m_name, event.first, ScriptCanvas::EBusBusId(behaviorEbus.m_name.c_str()), ScriptCanvas::EBusEventId(event.first.c_str()), event.second, ScriptCanvas::PropertyStatus::None, isOverload);
+                nodePaletteModel.RegisterEBusSenderNodeModelInformation(categoryPath, behaviorEbus.m_name, event.first, ScriptCanvas::EBusBusId(behaviorEbus.m_name.c_str()), ScriptCanvas::EBusEventId(event.first.c_str()), ScriptCanvas::PropertyStatus::None, isOverload);
             }
         }
     }
@@ -1159,7 +1144,6 @@ namespace ScriptCanvasEditor
         , AZStd::string_view eventName
         , const ScriptCanvas::EBusBusId& busId
         , const ScriptCanvas::EBusEventId& eventId
-        , const AZ::BehaviorEBusEventSender& sender
         , ScriptCanvas::PropertyStatus propertyStatus
         , bool isOverload)
     {
@@ -1193,17 +1177,6 @@ namespace ScriptCanvasEditor
             senderInformation->m_displayName = details.m_name.empty() ? eventName : details.m_name.c_str();
             senderInformation->m_toolTip = details.m_tooltip.empty() ? "" : details.m_tooltip;
 
-            auto safeRegister = [](AZ::BehaviorMethod* method)
-            {
-                if (method && AZ::MethodReturnsAzEventByReferenceOrPointer(*method))
-                {
-                    const AZ::BehaviorParameter* resultParameter = method->GetResult();
-                    ScriptCanvas::ReflectEventTypeOnDemand(resultParameter->m_typeId, resultParameter->m_name, resultParameter->m_azRtti);
-                }
-            };
-
-            safeRegister(sender.m_event);
-            safeRegister(sender.m_broadcast);
             m_registeredNodes.emplace(AZStd::make_pair(nodeIdentifier, senderInformation));
         }
     }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -84,7 +84,7 @@ namespace ScriptCanvasEditor
 
 
         void RegisterEBusHandlerNodeModelInformation(AZStd::string_view categoryPath, AZStd::string_view busName, AZStd::string_view eventName, const ScriptCanvas::EBusBusId& busId, const AZ::BehaviorEBusHandler::BusForwarderEvent& forwardEvent);
-        void RegisterEBusSenderNodeModelInformation(AZStd::string_view categoryPath, AZStd::string_view busName, AZStd::string_view eventName, const ScriptCanvas::EBusBusId& busId, const ScriptCanvas::EBusEventId& eventId, const AZ::BehaviorEBusEventSender& eventSender, ScriptCanvas::PropertyStatus propertyStatus, bool isOverload);
+        void RegisterEBusSenderNodeModelInformation(AZStd::string_view categoryPath, AZStd::string_view busName, AZStd::string_view eventName, const ScriptCanvas::EBusBusId& busId, const ScriptCanvas::EBusEventId& eventId, ScriptCanvas::PropertyStatus propertyStatus, bool isOverload);
 
         // Asset Based Registrations
         AZStd::vector<ScriptCanvas::NodeTypeIdentifier> RegisterScriptEvent(ScriptEvents::ScriptEventsAsset* scriptEventAsset);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -173,23 +173,6 @@ namespace ScriptCanvas
         runtimeVersion = RuntimeVersion::Current;
         fileVersion = FileVersion::Current;
     }
-
-    void ReflectEventTypeOnDemand(const AZ::TypeId& typeId, AZStd::string_view name, AZ::IRttiHelper* rttiHelper)
-    {
-        AZ::SerializeContext* serializeContext{};
-        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
-        AZ::SerializeContext::ClassData classData;
-        classData.m_name = name.data();
-        classData.m_typeId = typeId;
-        classData.m_azRtti = rttiHelper;
-
-        auto EventPlaceholderAnyCreator = [](AZ::SerializeContext*) -> AZStd::any
-        {
-            return AZStd::make_any<AZStd::monostate>();
-        };
-
-        serializeContext->RegisterType(typeId, AZStd::move(classData), EventPlaceholderAnyCreator);
-    }
 }
 
 namespace ScriptCanvasEditor

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.h
@@ -302,8 +302,6 @@ namespace ScriptCanvas
         bool m_wasAdded = false;
         AZ::Entity* m_buildEntity = nullptr;
     };
-
-    void ReflectEventTypeOnDemand(const AZ::TypeId& typeId, AZStd::string_view name, AZ::IRttiHelper* rttiHelper = nullptr);
 }
 
 namespace ScriptCanvas


### PR DESCRIPTION
## Details
Previously we reflect AZ Event into serialize context on the fly through NodePalette, which causes AP and Editor out of sync of required AZ Event information
As @lumberyard-employee-dm pointed out, move Event serialize context reflection into a shared component, so both AP and Editor can have synced serialize context as required.

## Testing
There is no runtime impact, the fix is for Editor and AP warning and error messages.
 Manually tested scriptcanvas graph with AZ Event node, no more error message like following:
 [Error] (Serialize) - Element with class ID 'XXXXXXX' is not registered with the serializer!

Signed-off-by: onecent1101 <liug@amazon.com>