### PR TITLE
LuaIDE supports DPI scaling

### DIFF
--- a/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
+++ b/Code/Tools/LuaIDE/Source/Editor/LuaEditor.cpp
@@ -8,12 +8,15 @@
 
 #include <Source/LuaIDEApplication.h>
 
+#include <AzQtComponents/Utilities/HandleDpiAwareness.h>
+
 #include <QtCore/QCoreApplication>
 
 #if defined(EXTERNAL_CRASH_REPORTING)
 #include <ToolsCrashHandler.h>
 #endif
 
+#include <QApplication>
 #include <QDir>
 #include <QFileInfo>
 
@@ -37,6 +40,12 @@ int main(int argc, char* argv[])
 
         AZStd::unique_ptr<AZ::IO::LocalFileIO> fileIO = AZStd::unique_ptr<AZ::IO::LocalFileIO>(aznew AZ::IO::LocalFileIO());
         AZ::IO::FileIOBase::SetInstance(fileIO.get());
+
+        QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+        QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+        QCoreApplication::setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+        QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+        AzQtComponents::Utilities::HandleDpiAwareness(AzQtComponents::Utilities::PerScreenDpiAware);
 
         LUAEditor::Application app(argc, argv);
 


### PR DESCRIPTION
The LuaIDE window and controls were not scaling on Windows for display scaling above 100%. For example if you have a 4K monitor you can configure Windows to scale your display to 200% to have larger text and controls. The other o3de editors scale as expected. 

Signed-off-by: billowsofcode <billowsofcode@gmail.com>