### PR TITLE
Initial implementation of DocumentAdapter

### DIFF
--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.cpp
@@ -596,7 +596,7 @@ namespace AZ::Dom
             else
             {
                 lhs.GetError().reserve(lhs.GetError().length() + rhs.GetError().length() + 1);
-                lhs.GetError().append("\n");
+                lhs.GetError().append(1, '\n');
                 lhs.GetError().append(rhs.GetError());
             }
         }

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.cpp
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.cpp
@@ -585,7 +585,7 @@ namespace AZ::Dom
         return AZ::Success();
     }
 
-    void CombinePatchOutcomes(PatchOutcome& lhs, const PatchOutcome& rhs)
+    void CombinePatchOutcomes(PatchOutcome& lhs, PatchOutcome&& rhs)
     {
         if (!rhs.IsSuccess())
         {
@@ -595,12 +595,9 @@ namespace AZ::Dom
             }
             else
             {
-                AZStd::string newError;
-                newError.reserve(lhs.GetError().length() + rhs.GetError().length() + 1);
-                newError.append(lhs.TakeError());
-                newError.append("\n");
-                newError.append(rhs.GetError());
-                lhs = AZ::Failure<AZStd::string>(AZStd::move(newError));
+                lhs.GetError().reserve(lhs.GetError().length() + rhs.GetError().length() + 1);
+                lhs.GetError().append("\n");
+                lhs.GetError().append(rhs.GetError());
             }
         }
     }

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
@@ -112,7 +112,7 @@ namespace AZ::Dom
     struct PatchApplicationState
     {
         //! The outcome of the last operation, may be overridden to produce a different failure outcome.
-        PatchOutcome m_outcome;
+        PatchOutcome m_outcome = AZ::Success();
         //! The patch being applied.
         const Patch* m_patch = nullptr;
         //! The last operation attempted.

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
@@ -14,13 +14,14 @@
 
 namespace AZ::Dom
 {
+    using PatchOutcome = AZ::Outcome<void, AZStd::string>;
+    void CombinePatchOutcomes(PatchOutcome& lhs, const PatchOutcome& rhs);
+
     //! A patch operation that represents an atomic operation for mutating or validating a Value.
     //! PatchOperations can be created with helper methods in Patch. /see Patch
     class PatchOperation final
     {
     public:
-        using PatchOutcome = AZ::Outcome<void, AZStd::string>;
-
         //! The operation to perform.
         enum class Type
         {
@@ -111,7 +112,7 @@ namespace AZ::Dom
     struct PatchApplicationState
     {
         //! The outcome of the last operation, may be overridden to produce a different failure outcome.
-        PatchOperation::PatchOutcome m_outcome;
+        PatchOutcome m_outcome;
         //! The patch being applied.
         const Patch* m_patch = nullptr;
         //! The last operation attempted.
@@ -175,7 +176,7 @@ namespace AZ::Dom
         size_t size() const;
 
         AZ::Outcome<Value, AZStd::string> Apply(Value rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
-        AZ::Outcome<void, AZStd::string> ApplyInPlace(Value& rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
+        PatchOutcome ApplyInPlace(Value& rootElement, StrategyFunctor strategy = PatchApplicationStrategy::HaltOnFailure) const;
 
         Value GetDomRepresentation() const;
         static AZ::Outcome<Patch, AZStd::string> CreateFromDomRepresentation(Value domValue);

--- a/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
+++ b/Code/Framework/AzCore/AzCore/DOM/DomPatch.h
@@ -15,7 +15,7 @@
 namespace AZ::Dom
 {
     using PatchOutcome = AZ::Outcome<void, AZStd::string>;
-    void CombinePatchOutcomes(PatchOutcome& lhs, const PatchOutcome& rhs);
+    void CombinePatchOutcomes(PatchOutcome& lhs, PatchOutcome&& rhs);
 
     //! A patch operation that represents an atomic operation for mutating or validating a Value.
     //! PatchOperations can be created with helper methods in Patch. /see Patch

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
@@ -11,11 +11,6 @@
 
 namespace AZ::DocumentPropertyEditor
 {
-    AdapterBuilder::AdapterBuilder(RoutingAdapter* routingAdapter)
-        : m_routingAdapter(routingAdapter)
-    {
-    }
-
     void AdapterBuilder::Value(Dom::Value value)
     {
         CurrentNode().SetNodeValue(value);

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzFramework/DocumentPropertyEditor/DocumentSchema.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    AdapterBuilder::AdapterBuilder(RoutingAdapter* routingAdapter)
+        : m_routingAdapter(routingAdapter)
+    {
+    }
+
+    void AdapterBuilder::Value(Dom::Value value)
+    {
+        CurrentNode().SetNodeValue(value);
+    }
+
+    void AdapterBuilder::Attribute(Name attribute, Dom::Value value)
+    {
+        CurrentNode()[attribute] = AZStd::move(value);
+    }
+
+    bool AdapterBuilder::IsError() const
+    {
+        return !m_error.empty();
+    }
+
+    const AZStd::string& AdapterBuilder::GetError() const
+    {
+        return m_error;
+    }
+
+    Dom::Value&& AdapterBuilder::FinishAndTakeResult()
+    {
+        AZ_Assert(m_entries.empty(), "AdapterBuilder::FinishAndTakeResult called before the builder finished");
+        return AZStd::move(m_value);
+    }
+
+    void AdapterBuilder::Error(AZStd::string_view message)
+    {
+        m_error.append(message);
+        m_error.append("\n");
+    }
+
+    Dom::Value& AdapterBuilder::CurrentNode()
+    {
+        AZ_Assert(!m_entries.empty(), "AdapterBuilder::CurrentNode called without a node on the entry stack");
+        return m_entries.top();
+    }
+
+    void AdapterBuilder::BeginNode(Name name)
+    {
+        if (!m_entries.empty())
+        {
+            m_currentPath.Push(CurrentNode().ArraySize());
+        }
+        else
+        {
+            m_currentPath.Push(0);
+        }
+        m_entries.push(Dom::Value::CreateNode(name));
+    }
+
+    void AdapterBuilder::EndNode([[maybe_unused]] AZ::Name expectedName)
+    {
+        AZ_Assert(!m_entries.empty(), "AdapterBuilder::EndNode called with an empty entry stack");
+        AZ_Assert(
+            expectedName.IsEmpty() || CurrentNode().GetNodeName() == expectedName,
+            "AdapterBuilder::EndNode called for %s when %s was expected", CurrentNode().GetNodeName().GetCStr(), expectedName.GetCStr());
+        m_currentPath.Pop();
+        Dom::Value value = AZStd::move(m_entries.top());
+        m_entries.pop();
+        if (!m_entries.empty())
+        {
+            CurrentNode().ArrayPushBack(AZStd::move(value));
+        }
+        else
+        {
+            m_value = AZStd::move(value);
+        }
+    }
+
+    void AdapterBuilder::BeginAdapter()
+    {
+        BeginNode<Nodes::Adapter>();
+    }
+
+    void AdapterBuilder::EndAdapter()
+    {
+        EndNode<Nodes::Adapter>();
+    }
+
+    void AdapterBuilder::BeginRow()
+    {
+        BeginNode<Nodes::Row>();
+    }
+
+    void AdapterBuilder::EndRow()
+    {
+        EndNode<Nodes::Row>();
+    }
+
+    void AdapterBuilder::BeginLabel()
+    {
+        BeginNode<Nodes::Label>();
+    }
+
+    void AdapterBuilder::EndLabel()
+    {
+        EndNode<Nodes::Label>();
+    }
+
+    void AdapterBuilder::BeginPropertyEditor(AZStd::string_view type, Dom::Value value)
+    {
+        BeginNode<Nodes::PropertyEditor>();
+        if (!type.empty())
+        {
+            Attribute(Nodes::PropertyEditor::Type, type);
+        }
+        if (!value.IsNull())
+        {
+            Value(AZStd::move(value));
+        }
+    }
+
+    void AdapterBuilder::EndPropertyEditor()
+    {
+        EndNode<Nodes::PropertyEditor>();
+    }
+
+    void AdapterBuilder::Label(AZStd::string_view text, bool copy)
+    {
+        BeginLabel();
+        Value(Dom::Value(text, copy));
+        EndLabel();
+    }
+} // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.cpp
@@ -13,7 +13,7 @@ namespace AZ::DocumentPropertyEditor
 {
     void AdapterBuilder::Value(Dom::Value value)
     {
-        CurrentNode().SetNodeValue(value);
+        CurrentNode().SetNodeValue(AZStd::move(value));
     }
 
     void AdapterBuilder::Attribute(Name attribute, Dom::Value value)
@@ -40,7 +40,7 @@ namespace AZ::DocumentPropertyEditor
     void AdapterBuilder::Error(AZStd::string_view message)
     {
         m_error.append(message);
-        m_error.append("\n");
+        m_error.append(1, '\n');
     }
 
     Dom::Value& AdapterBuilder::CurrentNode()

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
@@ -20,11 +20,7 @@ namespace AZ::DocumentPropertyEditor
     class AdapterBuilder
     {
     public:
-        //! Creates an AdapterBuilder.
-        //! A routing adapter may optionally be specified to enable routing via calls to
-        //! NestedAdapter.
-        //! Constructing an AdapterBuilder immediately opens an Adapter tag.
-        AdapterBuilder(RoutingAdapter* routingAdapter = nullptr);
+        AdapterBuilder() = default;
 
         //! Begins a new Node, pushing its value to the entry stack.
         //! Nodes may have child nodes, values, and attributes, as dictated by their node definiton.
@@ -107,7 +103,6 @@ namespace AZ::DocumentPropertyEditor
         void Error(AZStd::string_view message);
         Dom::Value& CurrentNode();
 
-        RoutingAdapter* m_routingAdapter = nullptr;
         Dom::Value m_value;
         Dom::Path m_currentPath;
         AZStd::stack<Dom::Value> m_entries;

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/AdapterBuilder.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/std/containers/stack.h>
+#include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
+#include <AzFramework/DocumentPropertyEditor/DocumentSchema.h>
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    //! Helper class that builds a DOM suitable for usage in a DocumentAdapter.
+    //! Uses a visitor pattern to establish node elements.
+    class AdapterBuilder
+    {
+    public:
+        //! Creates an AdapterBuilder.
+        //! A routing adapter may optionally be specified to enable routing via calls to
+        //! NestedAdapter.
+        //! Constructing an AdapterBuilder immediately opens an Adapter tag.
+        AdapterBuilder(RoutingAdapter* routingAdapter = nullptr);
+
+        //! Begins a new Node, pushing its value to the entry stack.
+        //! Nodes may have child nodes, values, and attributes, as dictated by their node definiton.
+        //! Calls to Attribute and Value will apply to the last BeginNode call.
+        //! Each call to BeginNode must have a corresponding EndNode invocation.
+        void BeginNode(AZ::Name name);
+        //! Ends the current node, popping its value from the entry stack.
+        //! Once the last BeginNode call has had a corresponding EndNode invocation, this builder is in a finished state.
+        //! The result may then be retrieved.
+        void EndNode(AZ::Name expectedName);
+
+        //! Convenience method, calls BeginNode<Nodes::Adapter>()
+        void BeginAdapter();
+        //! Convenience method, calls EndNode<Nodes::Adapter>()
+        void EndAdapter();
+        //! Convenience method, calls BeginNode<Nodes::Row>()
+        void BeginRow();
+        //! Convenience method, calls EndNode<Nodes::Row>()
+        void EndRow();
+        //! Convenience method, calls BeginNode<Nodes::Label>()
+        void BeginLabel();
+        //! Convenience method, calls EndNode<Nodes::Label>()
+        void EndLabel();
+        //! Convenience method, calls BeginNode<Nodes::PropertyEditor>()
+        //! If type and value are specified, the Nodes::PropertyEditor::Type attribute and the
+        //! property editor value shall be set.
+        void BeginPropertyEditor(AZStd::string_view type = "", Dom::Value value = {});
+        //! Convenience method, calls EndNode<Nodes::PropertyEditor>()
+        void EndPropertyEditor();
+
+        //! Inserts a Label node with the specified text.
+        void Label(AZStd::string_view text, bool copy = true);
+
+        //! Sets the value of the last node. Used for setting the current value of a property editor.
+        void Value(Dom::Value value);
+        //! Sets an attribute of the last node. Rows, labels, and property editors all support different attributes.
+        //! \see DocumentPropertyEditor::Nodes
+        void Attribute(Name attribute, Dom::Value value);
+
+        //! Returns true if an error has been encountered during the build process, 
+        bool IsError() const;
+        //! Returns the error information, if any, encountered during the build process.
+        const AZStd::string& GetError() const;
+        //! Ends the build operation and retrieves the builder result.
+        //! Operations are no longer valid on this builder once this is called.
+        Dom::Value&& FinishAndTakeResult();
+
+        template <class NodeDefinition>
+        void BeginNode()
+        {
+            BeginNode(GetNodeName<NodeDefinition>());
+        }
+
+        template <class NodeDefinition>
+        void EndNode()
+        {
+            EndNode(GetNodeName<NodeDefinition>());
+        }
+
+        template <class AttributeType>
+        void Attribute(const AttributeDefinition<AttributeType>& definition, Dom::Value value)
+        {
+            Attribute(definition.GetName(), Dom::Value(AZStd::move(value)));
+        }
+
+        template <class AttributeType>
+        void Attribute(const AttributeDefinition<AttributeType>& definition, AttributeType value)
+        {
+            Attribute(definition.GetName(), definition.ValueToDom(AZStd::move(value)));
+        }
+
+        template <>
+        void Attribute<AZStd::string_view>(const AttributeDefinition<AZStd::string_view>& definition, AZStd::string_view value)
+        {
+            Attribute(definition.GetName(), Dom::Value(value, true));
+        }
+
+
+    private:
+        void Error(AZStd::string_view message);
+        Dom::Value& CurrentNode();
+
+        RoutingAdapter* m_routingAdapter = nullptr;
+        Dom::Value m_value;
+        Dom::Path m_currentPath;
+        AZStd::stack<Dom::Value> m_entries;
+        AZStd::string m_error;
+    };
+} // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/BasicAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/BasicAdapter.cpp
@@ -14,7 +14,7 @@ namespace AZ::DocumentPropertyEditor
     void BasicAdapter::SetContents(Dom::Value contents)
     {
         m_value = contents;
-        ResetDocument();
+        NotifyResetDocument();
     }
 
     Dom::Value BasicAdapter::GetContents() const

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/BasicAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/BasicAdapter.cpp
@@ -1,0 +1,31 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/DocumentPropertyEditor/BasicAdapter.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    void BasicAdapter::SetContents(Dom::Value contents)
+    {
+        m_value = contents;
+        ResetDocument();
+    }
+
+    Dom::Value BasicAdapter::GetContents() const
+    {
+        return m_value;
+    }
+
+    Dom::PatchOutcome BasicAdapter::RequestContentChange(const Dom::Patch& patch)
+    {
+        Dom::PatchOutcome result = patch.ApplyInPlace(m_value);
+        NotifyContentsChanged(patch);
+        return result;
+    }
+} // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/BasicAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/BasicAdapter.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    //! BasicAdapter is a DocumentAdapter that simply provides a fixed DOM provided
+    //! by a call to SetContents. The consumer is responsible for listening to change
+    //! and reset events and handling them accordingly to provide interactivity.
+    class BasicAdapter : public DocumentAdapter
+    {
+    public:
+        //! Resets the contents of this adapter with a new DOM.
+        void SetContents(Dom::Value contents);
+        Dom::Value GetContents() const override;
+        Dom::PatchOutcome RequestContentChange(const Dom::Patch& patch) override;
+
+    private:
+        Dom::Value m_value;
+    };
+} // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/DocumentPropertyEditor/DocumentAdapter.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    void DocumentAdapter::ConnectResetHandler(ResetEvent::Handler& handler)
+    {
+        handler.Connect(m_resetEvent);
+    }
+
+    void DocumentAdapter::ConnectChangedHandler(ChangedEvent::Handler& handler)
+    {
+        handler.Connect(m_changedEvent);
+    }
+
+    void DocumentAdapter::ResetDocument()
+    {
+        m_resetEvent.Signal();
+    }
+
+    void DocumentAdapter::NotifyContentsChanged(const AZ::Dom::Patch& patch)
+    {
+        m_changedEvent.Signal(patch);
+    }
+} // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.cpp
@@ -20,7 +20,7 @@ namespace AZ::DocumentPropertyEditor
         handler.Connect(m_changedEvent);
     }
 
-    void DocumentAdapter::ResetDocument()
+    void DocumentAdapter::NotifyResetDocument()
     {
         m_resetEvent.Signal();
     }

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -35,7 +35,7 @@ namespace AZ::DocumentPropertyEditor
     //! - Label elements displayed as textual labels within a Row. Labels may have attributes, but no children.
     //! - PropertyEditor elements that display a property editor of an arbitrary type, specified by the mandatory
     //!   "type" attribute. The Document Property View will scan for a registered property editor of this type, and provide
-    //!   this node to the property editor for rendering. The contents of a PropertyEditor are dicated by its type.
+    //!   this node to the property editor for rendering. The contents of a PropertyEditor are dictated by its type.
     class DocumentAdapter
     {
     public:
@@ -63,7 +63,7 @@ namespace AZ::DocumentPropertyEditor
     protected:
         //! Subclasses may call this to trigger a ResetEvent and let the view know that GetContents should be requeried.
         //! Where possible, prefer to use NotifyContentsChanged instead.
-        void ResetDocument();
+        void NotifyResetDocument();
         //! Subclasses may call this to trigger a ChangedEvent to notify the view that this adapter's contents have changed.
         //! This patch should apply cleanly on the last result GetContents would have returned after any preceding changed
         //! or reset events.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentAdapter.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/DOM/DomPatch.h>
+#include <AzCore/DOM/DomValue.h>
+#include <AzCore/EBus/Event.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    // Forward declarations
+    class DocumentAdapter;
+    class RoutingAdapter;
+
+    using DocumentAdapterPtr = AZStd::shared_ptr<DocumentAdapter>;
+    using ConstDocumentAdapterPtr = AZStd::shared_ptr<const DocumentAdapter>;
+
+    //! A DocumentAdapter provides an interface for transforming data from an arbitrary
+    //! source into a DOM hierarchy that can be viewed and edited by a DocumentPropertyView.
+    //!
+    //! A DocumentAdapter shall provide hierarchical contents in the form of a DOM structure in a
+    //! node-based hierarchy comprised of:
+    //! - A root Adapter element that contains any number of child rows. A mininmal correct adapter may be represented
+    //!   as an empty Adapter element.
+    //! - Row elements, that may contain any number of property editors or rows within. Nested rows will be displayed
+    //!   as children within the hierarchy, while all other nodes will be turned into widget representations
+    //!   and laid out horizontally within the row.
+    //! - Label elements displayed as textual labels within a Row. Labels may have attributes, but no children.
+    //! - PropertyEditor elements that display a property editor of an arbitrary type, specified by the mandatory
+    //!   "type" attribute. The Document Property View will scan for a registered property editor of this type, and provide
+    //!   this node to the property editor for rendering. The contents of a PropertyEditor are dicated by its type.
+    class DocumentAdapter
+    {
+    public:
+        using ResetEvent = Event<>;
+        using ChangedEvent = Event<const Dom::Patch&>;
+
+        virtual ~DocumentAdapter() = default;
+
+        //! Retrieves the contents of this adapter. This must be an Adapter DOM node.
+        //! \see AdapterBuilder for building out this DOM structure.
+        virtual Dom::Value GetContents() const = 0;
+        //! Called when the view would like to change the current contents - for example, by changing the value of
+        //! a property within a Property Editor. If this patch is accepted and triggers a mutation to the contents of this
+        //! adapter, NotifyContentsChanged should be called to trigger a change event with the accepted patches.
+        virtual Dom::PatchOutcome RequestContentChange(const Dom::Patch& patch) = 0;
+
+        //! Connects a listener for the reset event, fired when the contents of this adapter have completely changed.
+        //! Any views listening to this adapter will need to call GetContents to retrieve the new contents of the adapter.
+        void ConnectResetHandler(ResetEvent::Handler& handler);
+        //! Connects a listener for the changed event, fired when the contents of the adapter have changed.
+        //! The provided patch contains all the changes provided (i.e. it shall apply cleanly on top of the last
+        //! GetContents() result).
+        void ConnectChangedHandler(ChangedEvent::Handler& handler);
+
+    protected:
+        //! Subclasses may call this to trigger a ResetEvent and let the view know that GetContents should be requeried.
+        //! Where possible, prefer to use NotifyContentsChanged instead.
+        void ResetDocument();
+        //! Subclasses may call this to trigger a ChangedEvent to notify the view that this adapter's contents have changed.
+        //! This patch should apply cleanly on the last result GetContents would have returned after any preceding changed
+        //! or reset events.
+        void NotifyContentsChanged(const Dom::Patch& patch);
+
+    private:
+        ResetEvent m_resetEvent;
+        ChangedEvent m_changedEvent;
+    };
+} // namespace AZ::DocumentPropertyEditor

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/DOM/DomValue.h>
+#include <AzCore/std/string/fixed_string.h>
+#include <AzCore/Name/Name.h>
+
+namespace AZ::DocumentPropertyEditor
+{
+    //! Defines a schema definition for a DocumentAdapter node.
+    //! Nodes have a name and metadata for validating their contents.
+    //! To register a Node you may inheirt from NodeDefinition and define traits:
+    //! struct MyNode : NodeDefinition
+    //! {
+    //!     static constexpr AZStd::string_view Name = "MyNode";
+    //!     static bool CanAddToParentNode(const Dom::Value& parentNode);
+    //! };
+    struct NodeDefinition
+    {
+        //! Defines the Name of the node definition.
+        //! This field must be defined for all NodeDefinitions.
+        static constexpr AZStd::string_view Name = "<undefined node name>";
+
+        //! If defined, specifies if this node may be added to a given parent (a DOM node).
+        //! By default all parent nodes are accepted.
+        static bool CanAddToParentNode([[maybe_unused]] const Dom::Value& parentNode)
+        {
+            return true;
+        }
+
+        //! If defined, specifies if this node may receive a child (a DOM Value that may be of an arbitrary type).
+        //! By default all values are accepted.
+        static bool CanBeParentToValue([[maybe_unused]] const Dom::Value& value)
+        {
+            return true;
+        }
+    };
+
+    //! Retrieves a node's name from a node definition.
+    //! \see NodeDefinition
+    template <typename TNodeDefinition>
+    Name GetNodeName()
+    {
+        return AZ::Name(TNodeDefinition::Name);
+    }
+
+    //! Defines an attribute applicable to a Node.
+    //! Attributes may be defined inline inside of a NodeDefinition.
+    //! AttributeDefinitions may be used to marshal types to and from a DOM representation.
+    //! This representation is not guaranteed to be serializable - for functions and complex types
+    //! they may be stored as non-serializeable opaque types in the DOM.
+    template<typename AttributeType>
+    class AttributeDefinition
+    {
+    public:
+        constexpr AttributeDefinition(AZStd::string_view name)
+            : m_name(name)
+        {
+        }
+
+        //! Retrieves the name of this attribute, as used as a key in the DOM.
+        Name GetName() const
+        {
+            return AZ::Name(m_name);
+        }
+
+        //! Converts a value of this attribute's type to a DOM value.
+        Dom::Value ValueToDom(const AttributeType& attribute) const
+        {
+            return Dom::Value(attribute);
+        }
+
+        //! Converts a DOM value to an instance of AttributeType.
+        AttributeType&& DomToValue(const Dom::Value& value)
+        {
+            AZ_Assert(false, "DomToValue is not yet implemented");
+            return {};
+        }
+
+    private:
+        AZStd::fixed_string<128> m_name;
+    };
+}

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/DocumentSchema.h
@@ -16,7 +16,7 @@ namespace AZ::DocumentPropertyEditor
 {
     //! Defines a schema definition for a DocumentAdapter node.
     //! Nodes have a name and metadata for validating their contents.
-    //! To register a Node you may inheirt from NodeDefinition and define traits:
+    //! To register a Node you may inherit from NodeDefinition and define traits:
     //! struct MyNode : NodeDefinition
     //! {
     //!     static constexpr AZStd::string_view Name = "MyNode";
@@ -45,10 +45,10 @@ namespace AZ::DocumentPropertyEditor
 
     //! Retrieves a node's name from a node definition.
     //! \see NodeDefinition
-    template <typename TNodeDefinition>
+    template <typename NodeDefinition>
     Name GetNodeName()
     {
-        return AZ::Name(TNodeDefinition::Name);
+        return AZ::Name(NodeDefinition::Name);
     }
 
     //! Defines an attribute applicable to a Node.

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
+
+namespace AZ::DocumentPropertyEditor::Nodes
+{
+    bool Adapter::CanAddToParentNode([[maybe_unused]] const Dom::Value& parentNode)
+    {
+        // Adapters are root nodes, they can't be parented to anything
+        return false;
+    }
+
+    bool Adapter::CanBeParentToValue(const Dom::Value& value)
+    {
+        // Adapters can only be parents to rows
+        return value.IsNode() && value.GetNodeName() == GetNodeName<Row>();
+    }
+
+    bool Row::CanAddToParentNode(const Dom::Value& parentNode)
+    {
+        // Rows may only be children of other rows or the Adapter element
+        const AZ::Name nodeName = parentNode.GetNodeName();
+        return nodeName == GetNodeName<Row>() || nodeName == GetNodeName<Adapter>();
+    }
+
+    bool Row::CanBeParentToValue(const Dom::Value& value)
+    {
+        // Rows may only contain nodes, not arbitrary values
+        return value.IsNode();
+    }
+} // namespace AZ::DocumentPropertyEditor::Nodes

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzFramework/DocumentPropertyEditor/DocumentSchema.h>
+
+namespace AZ::DocumentPropertyEditor::Nodes
+{
+    //! Adapter: The top-level tag for a DocumentAdapter that may contain any number of Rows.
+    struct Adapter : NodeDefinition
+    {
+        static constexpr AZStd::string_view Name = "Adapter";
+        static bool CanAddToParentNode(const Dom::Value& parentNode);
+        static bool CanBeParentToValue(const Dom::Value& value);
+    };
+
+    //! Row: An adapter entry that may contain any number of child nodes or other Rows
+    struct Row : NodeDefinition
+    {
+        static constexpr AZStd::string_view Name = "Row";
+        static bool CanAddToParentNode(const Dom::Value& parentNode);
+        static bool CanBeParentToValue(const Dom::Value& value);
+    };
+
+    //! Label: A textual label that shall render its contents as part of a Row.
+    struct Label : NodeDefinition
+    {
+        static constexpr AZStd::string_view Name = "Label";
+    };
+
+    //! PropertyEditor: A property editor, of a type dictated by its "type" field,
+    //! that can edit an associated value.
+    struct PropertyEditor : NodeDefinition
+    {
+        static constexpr AZStd::string_view Name = "PropertyEditor";
+        static constexpr auto Type = AttributeDefinition<AZStd::string_view>("type");
+    };
+} // namespace AZ::DocumentPropertyEditor::Nodes

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -135,8 +135,6 @@ set(FILES
     Components/AzFrameworkConfigurationSystemComponent.cpp
     Components/NonUniformScaleComponent.h
     Components/NonUniformScaleComponent.cpp
-    DocumentPropertyEditor/DocumentAdapter.cpp
-    DocumentPropertyEditor/DocumentAdapter.h
     DocumentPropertyEditor/AdapterBuilder.cpp
     DocumentPropertyEditor/AdapterBuilder.h
     DocumentPropertyEditor/BasicAdapter.cpp

--- a/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
+++ b/Code/Framework/AzFramework/AzFramework/azframework_files.cmake
@@ -135,6 +135,17 @@ set(FILES
     Components/AzFrameworkConfigurationSystemComponent.cpp
     Components/NonUniformScaleComponent.h
     Components/NonUniformScaleComponent.cpp
+    DocumentPropertyEditor/DocumentAdapter.cpp
+    DocumentPropertyEditor/DocumentAdapter.h
+    DocumentPropertyEditor/AdapterBuilder.cpp
+    DocumentPropertyEditor/AdapterBuilder.h
+    DocumentPropertyEditor/BasicAdapter.cpp
+    DocumentPropertyEditor/BasicAdapter.h
+    DocumentPropertyEditor/DocumentAdapter.cpp
+    DocumentPropertyEditor/DocumentAdapter.h
+    DocumentPropertyEditor/DocumentSchema.h
+    DocumentPropertyEditor/PropertyEditorNodes.cpp
+    DocumentPropertyEditor/PropertyEditorNodes.h
     FileFunc/FileFunc.h
     FileFunc/FileFunc.cpp
     Font/FontInterface.h

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/AdapterBuilderTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/AdapterBuilderTests.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.h>
+#include <AzFramework/DocumentPropertyEditor/AdapterBuilder.h>
+#include <AzFramework/DocumentPropertyEditor/PropertyEditorNodes.h>
+#include <AzCore/DOM/DomUtils.h>
+#include <AzCore/std/any.h>
+
+namespace AZ::DocumentPropertyEditor::Tests
+{
+    using AdapterBuilderTests = DocumentPropertyEditorTestFixture;
+
+    TEST_F(AdapterBuilderTests, VisitSimpleStructure)
+    {
+        AdapterBuilder builder;
+        builder.BeginAdapter();
+        builder.BeginRow();
+        builder.Label("label");
+        builder.BeginPropertyEditor("TextEditor", Dom::Value("lorem ipsum", true));
+        builder.Attribute(AZ::Name("attr"), Dom::Value(2));
+        builder.EndPropertyEditor();
+        builder.EndRow();
+        builder.EndAdapter();
+
+        Dom::Value result = builder.FinishAndTakeResult();
+
+        /**
+        Expect the following structure:
+        <Adapter>
+            <Row>
+                <Label>label</Label>
+                <PropertyEditor type="TextEditor" attr=2>value</TextEditor>
+            </Row>
+        </Adapter>
+        */
+        Dom::Value expectedValue = Dom::Value::CreateNode("Adapter");
+        Dom::Value row = Dom::Value::CreateNode("Row");
+        Dom::Value label = Dom::Value::CreateNode("Label");
+        label.SetNodeValue(Dom::Value("label", true));
+        row.ArrayPushBack(label);
+        Dom::Value editor = Dom::Value::CreateNode("PropertyEditor");
+        editor["type"] = Dom::Value("TextEditor", true);
+        editor["attr"] = 2;
+        editor.SetNodeValue(Dom::Value("lorem ipsum", true));
+        row.ArrayPushBack(editor);
+        expectedValue.ArrayPushBack(row);
+
+        EXPECT_TRUE(Dom::Utils::DeepCompareIsEqual(expectedValue, result));
+    }
+
+    TEST_F(AdapterBuilderTests, VisitNestedRows)
+    {
+        AdapterBuilder builder;
+        builder.BeginAdapter();
+        Dom::Value expectedValue = Dom::Value::CreateNode("Adapter");
+        for (int i = 0; i < 2; ++i)
+        {
+            builder.BeginRow();
+            Dom::Value ri = Dom::Value::CreateNode("Row");
+            for (int j = 0; j < 2; ++j)
+            {
+                builder.BeginRow();
+                Dom::Value rj = Dom::Value::CreateNode("Row");
+                for (int k = 0; k < 3; ++k)
+                {
+                    builder.BeginRow();
+                    Dom::Value rk = Dom::Value::CreateNode("Row");
+                    rj.ArrayPushBack(rk);
+                    builder.EndRow();
+                }
+                ri.ArrayPushBack(rj);
+                builder.EndRow();
+            }
+            expectedValue.ArrayPushBack(ri);
+            builder.EndRow();
+        }
+        builder.EndAdapter();
+
+        /**
+        Expect the following structure:
+        <Adapter>
+            <Row>
+                <Row>
+                    <Row />
+                    <Row />
+                    <Row />
+                </Row>
+                <Row>
+                    <Row />
+                    <Row />
+                    <Row />
+                </Row>
+            </Row>
+            <Row>
+                <Row>
+                    <Row />
+                    <Row />
+                    <Row />
+                </Row>
+                <Row>
+                    <Row />
+                    <Row />
+                    <Row />
+                </Row>
+            </Row>
+        </Adapter>
+        */
+        Dom::Value result = builder.FinishAndTakeResult();
+        EXPECT_TRUE(Dom::Utils::DeepCompareIsEqual(expectedValue, result));
+    }
+}

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/AdapterBuilderTests.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/AdapterBuilderTests.cpp
@@ -28,7 +28,7 @@ namespace AZ::DocumentPropertyEditor::Tests
         builder.EndRow();
         builder.EndAdapter();
 
-        Dom::Value result = builder.FinishAndTakeResult();
+        Dom::Value domFromBuilder = builder.FinishAndTakeResult();
 
         /**
         Expect the following structure:
@@ -39,45 +39,45 @@ namespace AZ::DocumentPropertyEditor::Tests
             </Row>
         </Adapter>
         */
-        Dom::Value expectedValue = Dom::Value::CreateNode("Adapter");
-        Dom::Value row = Dom::Value::CreateNode("Row");
-        Dom::Value label = Dom::Value::CreateNode("Label");
+        Dom::Value expectedDom = Dom::Value::CreateNode(Nodes::Adapter::Name);
+        Dom::Value row = Dom::Value::CreateNode(Nodes::Row::Name);
+        Dom::Value label = Dom::Value::CreateNode(Nodes::Label::Name);
         label.SetNodeValue(Dom::Value("label", true));
         row.ArrayPushBack(label);
-        Dom::Value editor = Dom::Value::CreateNode("PropertyEditor");
-        editor["type"] = Dom::Value("TextEditor", true);
+        Dom::Value editor = Dom::Value::CreateNode(Nodes::PropertyEditor::Name);
+        editor[Nodes::PropertyEditor::Type.GetName()] = Dom::Value("TextEditor", true);
         editor["attr"] = 2;
         editor.SetNodeValue(Dom::Value("lorem ipsum", true));
         row.ArrayPushBack(editor);
-        expectedValue.ArrayPushBack(row);
+        expectedDom.ArrayPushBack(row);
 
-        EXPECT_TRUE(Dom::Utils::DeepCompareIsEqual(expectedValue, result));
+        EXPECT_TRUE(Dom::Utils::DeepCompareIsEqual(expectedDom, domFromBuilder));
     }
 
     TEST_F(AdapterBuilderTests, VisitNestedRows)
     {
         AdapterBuilder builder;
         builder.BeginAdapter();
-        Dom::Value expectedValue = Dom::Value::CreateNode("Adapter");
+        Dom::Value expectedDom = Dom::Value::CreateNode(Nodes::Adapter::Name);
         for (int i = 0; i < 2; ++i)
         {
             builder.BeginRow();
-            Dom::Value ri = Dom::Value::CreateNode("Row");
+            Dom::Value ri = Dom::Value::CreateNode(Nodes::Row::Name);
             for (int j = 0; j < 2; ++j)
             {
                 builder.BeginRow();
-                Dom::Value rj = Dom::Value::CreateNode("Row");
+                Dom::Value rj = Dom::Value::CreateNode(Nodes::Row::Name);
                 for (int k = 0; k < 3; ++k)
                 {
                     builder.BeginRow();
-                    Dom::Value rk = Dom::Value::CreateNode("Row");
+                    Dom::Value rk = Dom::Value::CreateNode(Nodes::Row::Name);
                     rj.ArrayPushBack(rk);
                     builder.EndRow();
                 }
                 ri.ArrayPushBack(rj);
                 builder.EndRow();
             }
-            expectedValue.ArrayPushBack(ri);
+            expectedDom.ArrayPushBack(ri);
             builder.EndRow();
         }
         builder.EndAdapter();
@@ -111,7 +111,7 @@ namespace AZ::DocumentPropertyEditor::Tests
             </Row>
         </Adapter>
         */
-        Dom::Value result = builder.FinishAndTakeResult();
-        EXPECT_TRUE(Dom::Utils::DeepCompareIsEqual(expectedValue, result));
+        Dom::Value domFromBuilder = builder.FinishAndTakeResult();
+        EXPECT_TRUE(Dom::Utils::DeepCompareIsEqual(expectedDom, domFromBuilder));
     }
 }

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.cpp
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.h>
+#include <AzCore/Name/NameDictionary.h>
+
+namespace AZ::DocumentPropertyEditor::Tests
+{
+    void DocumentPropertyEditorTestFixture::SetUp()
+    {
+        UnitTest::AllocatorsFixture::SetUp();
+        NameDictionary::Create();
+        AZ::AllocatorInstance<Dom::ValueAllocator>::Create();
+        m_adapter = AZStd::make_unique<BasicAdapter>();
+    }
+
+    void DocumentPropertyEditorTestFixture::TearDown()
+    {
+        m_adapter.reset();
+        AZ::AllocatorInstance<Dom::ValueAllocator>::Destroy();
+        NameDictionary::Destroy();
+        UnitTest::AllocatorsFixture::TearDown();
+    }
+}

--- a/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.h
+++ b/Code/Framework/AzFramework/Tests/DocumentPropertyEditor/DocumentPropertyEditorFixture.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/UnitTest/TestTypes.h>
+#include <AzFramework/DocumentPropertyEditor/BasicAdapter.h>
+
+namespace AZ::DocumentPropertyEditor::Tests
+{
+    class DocumentPropertyEditorTestFixture
+        : public UnitTest::AllocatorsFixture
+    {
+    public:
+        void SetUp() override;
+        void TearDown() override;
+
+        AZStd::unique_ptr<BasicAdapter> m_adapter;
+    };
+}

--- a/Code/Framework/AzFramework/Tests/framework_shared_tests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/framework_shared_tests_files.cmake
@@ -7,6 +7,8 @@
 #
 
 set(FILES
+    DocumentPropertyEditor/DocumentPropertyEditorFixture.h
+    DocumentPropertyEditor/DocumentPropertyEditorFixture.cpp
     Mocks/MockSpawnableEntitiesInterface.h
     Mocks/MockWindowRequests.h
     Utils/Utils.h

--- a/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
+++ b/Code/Framework/AzFramework/Tests/frameworktests_files.cmake
@@ -33,4 +33,5 @@ set(FILES
     Scene.cpp
     CameraState.cpp
     InputTests.cpp
+    DocumentPropertyEditor/AdapterBuilderTests.cpp
 )


### PR DESCRIPTION
This implements the DocumentAdapter API (see the [Document Property Editor RFC](https://github.com/o3de/sig-content/blob/main/rfcs/rfc-11-document-property-editor.md) for reference) and comes with associated tooling:
- AdapterBuilder is an optional helper class that helps construct a DOM suitable for the DPE intended to be used by adapters. It allows constructing a DOM using a visitor pattern intended to be suitable for adapting data from other sources - in the near term, CVARs followed by the Reflection 2.0 visitor interface.
- DocumentSchema and the associated PropertyEditorNodes are a lightweight abstraction for defining the node schema - this is a work in progress that will need some runtime reflection for doing node name -> definition lookup for validation, but is intended to allow for added programmer convenience (autocomplete for nodes) and safety (runtime schema validation, which isn't wired up yet).
- BasicAdapter, a pass-through adapter suitable for test usage (and cases where you might use something like a QStandardItemModel)
- A simple fixture for DPE tests

This resides in AzFramework as it is purely a backend DOM model and not the UI that displays it, allowing document adapters to be defined closer to their sources of truth, as desired, and leaving the door open for a runtime interface that consumes a DocumentAdapter.

Signed-off-by: Nicholas Van Sickle <nvsickle@amazon.com>