### PR TITLE
Prevents changing the parent of an entity in a prefab

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -956,12 +956,9 @@ namespace AzToolsFramework
             }
 
             // Don't allow entities to be parented outside their container.
-            if (m_focusModeInterface)
+            if (m_focusModeInterface && !m_focusModeInterface->IsInFocusSubTree(actualValue))
             {
-                if (!m_focusModeInterface->IsInFocusSubTree(actualValue))
-                {
-                    return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab."));
-                }
+                return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab."));
             }
 
             return AZ::Success();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -956,10 +956,12 @@ namespace AzToolsFramework
             }
 
             // Don't allow entities to be parented outside their container.
-            AzToolsFramework::EntityIdList entities = m_focusModeInterface->GetFocusedEntities(GetEntityContextId());
-            if (std::find(entities.begin(), entities.end(), actualValue) == entities.end())
+            if (m_focusModeInterface)
             {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a different container!"));
+                if (!m_focusModeInterface->IsInFocusSubTree(actualValue))
+                {
+                    return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a different container!"));
+                }
             }
 
             return AZ::Success();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -194,6 +194,7 @@ namespace AzToolsFramework
             , m_suppressTransformChangedEvent(false)
             , m_interpolatePosition(AZ::InterpolationMode::NoInterpolation)
             , m_interpolateRotation(AZ::InterpolationMode::NoInterpolation)
+            , m_focusModeInterface(AZ::Interface<AzToolsFramework::FocusModeInterface>::Get())
         {
         }
 
@@ -952,6 +953,13 @@ namespace AzToolsFramework
                 !containerEntityInterface->IsContainerOpen(actualValue))
             {
                 return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a closed container!"));
+            }
+
+            // Don't allow entities to be parented outside their container.
+            AzToolsFramework::EntityIdList entities = m_focusModeInterface->GetFocusedEntities(GetEntityContextId());
+            if (std::find(entities.begin(), entities.end(), actualValue) == entities.end())
+            {
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a different container!"));
             }
 
             return AZ::Success();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -922,7 +922,7 @@ namespace AzToolsFramework
             if (azrtti_typeid<AZ::EntityId>() != valueType)
             {
                 AZ_Assert(false, "Unexpected value type");
-                return AZ::Failure(AZStd::string("Trying to set an entity ID to something that isn't an entity ID!"));
+                return AZ::Failure(AZStd::string("Trying to set an entity ID to something that isn't an entity ID."));
             }
 
             AZ::EntityId actualValue = static_cast<AZ::EntityId>(*((AZ::EntityId*)newValue));
@@ -930,14 +930,14 @@ namespace AzToolsFramework
             // Prevent setting the parent to the entity itself.
             if (actualValue == GetEntityId())
             {
-                return AZ::Failure(AZStd::string("You cannot set an entity's parent to itself!"));
+                return AZ::Failure(AZStd::string("You cannot set an entity's parent to itself."));
             }
 
             // Don't allow the change if it will result in a cycle hierarchy
             auto potentialParentTransformComponent = GetTransformComponent(actualValue);
             if (potentialParentTransformComponent && potentialParentTransformComponent->IsEntityInHierarchy(GetEntityId()))
             {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of one of its own children!"));
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of one of its own children."));
             }
 
             // Don't allow read-only entities to be re-parented at all.
@@ -945,14 +945,14 @@ namespace AzToolsFramework
             if (auto readOnlyEntityPublicInterface = AZ::Interface<ReadOnlyEntityPublicInterface>::Get();
                 readOnlyEntityPublicInterface->IsReadOnly(GetEntityId()) || readOnlyEntityPublicInterface->IsReadOnly(actualValue))
             {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a read-only entity!"));
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a read-only entity."));
             }
 
             // Don't allow entities to be parented under closed containers.
             if (auto containerEntityInterface = AZ::Interface<ContainerEntityInterface>::Get();
                 !containerEntityInterface->IsContainerOpen(actualValue))
             {
-                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a closed container!"));
+                return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a closed container."));
             }
 
             // Don't allow entities to be parented outside their container.
@@ -960,7 +960,7 @@ namespace AzToolsFramework
             {
                 if (!m_focusModeInterface->IsInFocusSubTree(actualValue))
                 {
-                    return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab!"));
+                    return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab."));
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -960,7 +960,7 @@ namespace AzToolsFramework
             {
                 if (!m_focusModeInterface->IsInFocusSubTree(actualValue))
                 {
-                    return AZ::Failure(AZStd::string("You cannot set an entity to be a child of a different container!"));
+                    return AZ::Failure(AZStd::string("You can only set a parent as one of the entities belonging to the focused prefab!"));
                 }
             }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.h
@@ -20,6 +20,7 @@
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <AzToolsFramework/Commands/SelectionCommand.h>
 #include <AzToolsFramework/ToolsComponents/EditorNonUniformScaleComponent.h>
+#include <AzToolsFramework/FocusMode/FocusModeInterface.h>
 
 #include "EditorComponentBase.h"
 #include "TransformComponentBus.h"
@@ -244,6 +245,8 @@ namespace AzToolsFramework
 
             // Used to check whether entity was just created vs manually reactivated. Set true after OnEntityActivated is called the first time.
             bool m_initialized = false;
+
+            FocusModeInterface* m_focusModeInterface = nullptr;
 
             // Deprecated
             AZ::InterpolationMode m_interpolatePosition;


### PR DESCRIPTION
Fixes #7670

Signed-off-by: John Jones-Steele <82226755+jjjoness@users.noreply.github.com>

At present it is illegal to move a child entity of a prefab into another container. Until that is fixed, this code prevents it happening.