### PR TITLE
[MacOS] Update MacOS version check to use numbers instead of defines that may not exist

### DIFF
--- a/Code/Editor/LogFile_mac.mm
+++ b/Code/Editor/LogFile_mac.mm
@@ -26,7 +26,7 @@ QString graphicsCardName()
     // Create an iterator
     io_iterator_t iterator;
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_12_0
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 // Needs to be 120000 instead of __MAC_12_0 because that will not be defined in earlier versions on the SDK.
     if (IOServiceGetMatchingServices(kIOMainPortDefault,matchDict,
                                      &iterator) == kIOReturnSuccess)
 #else

--- a/Gems/Microphone/Code/Source/Platform/Mac/MicrophoneSystemComponent_Mac.mm
+++ b/Gems/Microphone/Code/Source/Platform/Mac/MicrophoneSystemComponent_Mac.mm
@@ -84,7 +84,7 @@ public:
         AudioObjectPropertyAddress theAddress = {
             kAudioHardwarePropertyDefaultInputDevice,
             kAudioObjectPropertyScopeGlobal,
-#if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_12_0
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 // Needs to be 120000 instead of __MAC_12_0 because that will not be defined in earlier versions on the SDK.
             kAudioObjectPropertyElementMain
 #else
             kAudioObjectPropertyElementMaster


### PR DESCRIPTION
If the version of MacOS is earlier than 12, then __MAC_12_0 will not be defined.
Ref: https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html

Signed-off-by: amzn-sj <srikkant@amazon.com>