### PR TITLE
Change pass build order so the input connections from pass request ar…

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/Pass.cpp
@@ -1224,11 +1224,11 @@ namespace AZ
             // Bindings, inputs and attachments
             CreateBindingsFromTemplate();
             RegisterPipelineGlobalConnections();
-            SetupInputsFromRequest();
             SetupPassDependencies();
             CreateAttachmentsFromTemplate();
             CreateAttachmentsFromRequest();
             SetupInputsFromTemplate();
+            SetupInputsFromRequest();
 
             // Custom pass behavior
             BuildInternal();


### PR DESCRIPTION
…e created after pass template just list other elements of pass.

The input connect from pass request can override input connect from pass template

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>

Tested with ASV tests and in Editor.