### PR TITLE
Fixed checking of atomic variable within the APConnectionTest

### DIFF
--- a/Code/Framework/AzFramework/Tests/AssetProcessorConnection.cpp
+++ b/Code/Framework/AzFramework/Tests/AssetProcessorConnection.cpp
@@ -61,8 +61,13 @@ protected:
 
     bool WaitForConnectionStateToBeEqual(AzFramework::AssetSystem::AssetProcessorConnection& connectionObject, AzFramework::SocketConnection::EConnectionState desired)
     {
+        // The connection state must be copied to a local variable as once the condition
+        // matches in the loop condition it could later not match in the return statement
+        // as the state is being updated on another thread
+        AzFramework::SocketConnection::EConnectionState connectionState;
         auto started = AZStd::chrono::system_clock::now();
-        while (connectionObject.GetConnectionState() != desired )
+        for (connectionState = connectionObject.GetConnectionState(); connectionState != desired;
+            connectionState = connectionObject.GetConnectionState())
         {
             auto seconds_passed = AZStd::chrono::seconds(AZStd::chrono::system_clock::now() - started).count();
             if (seconds_passed > secondsMaxConnectionAttempt)
@@ -71,14 +76,19 @@ protected:
             }
             AZStd::this_thread::yield();
         }
-        return connectionObject.GetConnectionState() == desired;
+        return connectionState == desired;
     }
 
 
     bool WaitForConnectionStateToNotBeEqual(AzFramework::AssetSystem::AssetProcessorConnection& connectionObject, AzFramework::SocketConnection::EConnectionState notDesired)
     {
+        // The connection state must be copied to a local variable as once the condition
+        // matches in the loop condition it could later not match in the return statement
+        // as the state is being updated on another thread
+        AzFramework::SocketConnection::EConnectionState connectionState;
         auto started  = AZStd::chrono::system_clock::now();
-        while (connectionObject.GetConnectionState() == notDesired)
+        for (connectionState = connectionObject.GetConnectionState(); connectionState == notDesired;
+            connectionState = connectionObject.GetConnectionState())
         {
             auto seconds_passed = AZStd::chrono::seconds(AZStd::chrono::system_clock::now() - started).count();
             if (seconds_passed > secondsMaxConnectionAttempt)
@@ -87,7 +97,7 @@ protected:
             }
             AZStd::this_thread::yield();
         }
-        return connectionObject.GetConnectionState() != notDesired;
+        return connectionState != notDesired;
     }
 
 };


### PR DESCRIPTION
The [WaitForConnectionStateToNotBeEqual](https://github.com/o3de/o3de/blob/5a4a96348f54caa25afa11e9ed29b86dd8e89094/Code/Framework/AzFramework/Tests/AssetProcessorConnection.cpp#L81-L90) function and the [WaitForConnectionStateToBeEqual](https://github.com/o3de/o3de/blob/5a4a96348f54caa25afa11e9ed29b86dd8e89094/Code/Framework/AzFramework/Tests/AssetProcessorConnection.cpp#L65-L74) function were querying the value of connection state atomic variable at two points within that function, which leads to a race condition where the AP connection thread can update the value the connection state before it is read in the return statement.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>