### PR TITLE
Material Component P1 null renderer tests

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -462,7 +462,10 @@ class AtomComponentProperties:
         Material component properties. Requires one of Actor OR Mesh component.
           - 'requires' a list of component names as strings required by this component.
             Only one of these is required at a time for this component.\n
-          - 'Material Asset': the material Asset.id of the material.
+          - 'Material Asset': the default material Asset.id. Overrides all Model and LOD materials.
+          - 'Enable LOD Materials' toggles the use of LOD Materials.
+          - 'Lod Materials' container property for specified LOD materials. (list of EditorMaterialComponentSlot)
+          - 'Model Materials' container property of materials included with model. (EditorMaterialComponentSlot)
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.
         """
@@ -470,6 +473,9 @@ class AtomComponentProperties:
             'name': 'Material',
             'requires': [AtomComponentProperties.actor(), AtomComponentProperties.mesh()],
             'Material Asset': 'Default Material|Material Asset',
+            'Enable LOD Materials': 'Enable LOD Materials',
+            'LOD Materials': 'LOD Materials',
+            'Model Materials': 'Model Materials',
         }
         return properties[property]
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/atom_utils/atom_constants.py
@@ -464,7 +464,7 @@ class AtomComponentProperties:
             Only one of these is required at a time for this component.\n
           - 'Material Asset': the default material Asset.id. Overrides all Model and LOD materials.
           - 'Enable LOD Materials' toggles the use of LOD Materials.
-          - 'Lod Materials' container property for specified LOD materials. (list of EditorMaterialComponentSlot)
+          - 'LOD Materials' container property for specified LOD materials. (list of EditorMaterialComponentSlot)
           - 'Model Materials' container property of materials included with model. (EditorMaterialComponentSlot)
         :param property: From the last element of the property tree path. Default 'name' for component name string.
         :return: Full property path OR component name if no property specified.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -14,7 +14,7 @@ class Tests:
         "P0: REDO Entity creation failed")
     material_creation = (
         "Material Entity successfully created",
-        "Material Entity failed to be created")
+        "P0: Material Entity failed to be created")
     material_component = (
         "Entity has a Material component",
         "P0: Entity failed to find Material component")

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -8,52 +8,88 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 class Tests:
     creation_undo = (
         "UNDO Entity creation success",
-        "UNDO Entity creation failed")
+        "P0: UNDO Entity creation failed")
     creation_redo = (
         "REDO Entity creation success",
-        "REDO Entity creation failed")
+        "P0: REDO Entity creation failed")
     material_creation = (
         "Material Entity successfully created",
         "Material Entity failed to be created")
     material_component = (
         "Entity has a Material component",
-        "Entity failed to find Material component")
+        "P0: Entity failed to find Material component")
     material_disabled = (
         "Material component disabled",
-        "Material component was not disabled.")
+        "P0: Material component was not disabled.")
     actor_component = (
         "Entity has an Actor component",
-        "Entity did not have an Actor component")
+        "P0: Entity did not have an Actor component")
     actor_undo = (
         "Entity Actor component gone",
-        "Entity Actor component add failed to undo")
+        "P0: Entity Actor component add failed to undo")
     mesh_component = (
         "Entity has a Mesh component",
-        "Entity did not have a Mesh component")
+        "P0: Entity did not have a Mesh component")
     material_enabled = (
         "Material component enabled",
-        "Material component was not enabled.")
+        "P0: Material component was not enabled.")
     enter_game_mode = (
         "Entered game mode",
-        "Failed to enter game mode")
+        "P0: Failed to enter game mode")
     exit_game_mode = (
         "Exited game mode",
-        "Couldn't exit game mode")
+        "P0: Couldn't exit game mode")
     is_visible = (
         "Entity is visible",
-        "Entity was not visible")
+        "P0: Entity was not visible")
     is_hidden = (
         "Entity is hidden",
-        "Entity was not hidden")
+        "P0: Entity was not hidden")
     entity_deleted = (
         "Entity deleted",
-        "Entity was not deleted")
+        "P0: Entity was not deleted")
     deletion_undo = (
         "UNDO deletion success",
-        "UNDO deletion failed")
+        "P0: UNDO deletion failed")
     deletion_redo = (
         "REDO deletion success",
-        "REDO deletion failed")
+        "P0: REDO deletion failed")
+    mesh_asset = (
+        "Mesh Asset set",
+        "P1: Mesh Asset not set")
+    default_material = (
+        "Default Material set to metal_gold.azmaterial",
+        "P1: Default Material was not set as expected")
+    model_material_count = (
+        "Model Material count is 5 as expected",
+        "P1: Model Material count did not reach 5 within timeout")
+    model_material_label = (
+        "Model Material zero index is labeled lambert0",
+        "P1: Model Material index zero does not have the expected label")
+    model_material_asset_path = (
+        "Asset path of the Material Model index zero is as expected",
+        "P1: Material Model index zero Asset path is not as expected")
+    enable_lod_materials = (
+        "Enable LOD Materials property set to True",
+        "P1: Enable LOD Materials property was not set correctly ")
+    lod_material_count = (
+        "LOD Material count is 5 as expected",
+        "P1: LOD Material count did not reach 5 within timeout")
+    lod_material_label = (
+        "LOD Material zero index is labeled lambert0",
+        "P1: LOD Material index zero does not have the expected label")
+    lod_material_asset_path = (
+        "Asset path of LOD Material index zero first item is as expected",
+        "P1: Asset path of LOD Material index zero first item is not as expected")
+    lod_material_set = (
+        "LOD material zero is set to metal_gold.azmaterial id",
+        "P1: LOD material zero was not property set as expected")
+    controler_materials_is_empty_container = (
+        "Controller|Materials is a container property and is empty",
+        "P1: Controller|Materials is not a container or is not empty as expected")
+    clear_default_material = (
+        "Default Material cleared with MaterialComponentRequestBus",
+        "P1: Default Material FAILED to clear with MaterialComponentRequestBus. does not contain empty AssetId.")
 
 
 def AtomEditorComponents_Material_AddedToEntity():
@@ -77,23 +113,37 @@ def AtomEditorComponents_Material_AddedToEntity():
     5) Verify Material component not enabled.
     6) Add Actor component since it is required by the Material component.
     7) Verify Material component is enabled.
-    8) UNDO add Actor component
+    8) Remove Actor component
     9) Verify Material component not enabled.
     10) Add Mesh component since it is required by the Material component.
     11) Verify Material component is enabled.
-    12) Enter/Exit game mode.
-    13) Test IsHidden.
-    14) Test IsVisible.
-    15) Delete Material entity.
-    16) UNDO deletion.
-    17) REDO deletion.
-    18) Look for errors.
+    12) Set a model asset to Mesh component
+    13) Wait for Model Materials to indicate count 5 terminate early if container fails to reflect correct count
+    14) Get the slot zero material from the container property Model Materials (materials defined in the fbx)
+    15) Enable the use of LOD materials
+    16) Wait for LOD Materials to indicate count 5 terminate early if container fails to reflect correct count
+    17) Get the slot zero list from LOD Material
+    18) Override the slot zero LOD Material asset using EditorMaterialComponentSlot method SetAssetId
+    19) Clear the LOD Material override and confirm the active asset is the default value
+    20) Set the Default Material asset to an override using set component property by path
+    21) Clear the assignment of a default material using MaterialComponentRequestBus and confirm null asset
+    22) Set the Default Material asset using MaterialComponentRequestBus
+    23) Enter/Exit game mode.
+    24) Test IsHidden.
+    25) Test IsVisible.
+    26) Delete Material entity.
+    27) UNDO deletion.
+    28) REDO deletion.
+    29) Look for errors or asserts.
 
     :return: None
     """
 
     import azlmbr.legacy.general as general
+    import azlmbr.bus as bus
+    import azlmbr.render as render
 
+    from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorEntity
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
     from Atom.atom_utils.atom_constants import AtomComponentProperties
@@ -143,14 +193,14 @@ def AtomEditorComponents_Material_AddedToEntity():
         Report.result(Tests.material_disabled, not material_component.is_enabled())
 
         # 6. Add Actor component since it is required by the Material component.
-        material_entity.add_component(AtomComponentProperties.actor())
+        actor_component = material_entity.add_component(AtomComponentProperties.actor())
         Report.result(Tests.actor_component, material_entity.has_component(AtomComponentProperties.actor()))
 
         # 7. Verify Material component is enabled.
         Report.result(Tests.material_enabled, material_component.is_enabled())
 
-        # 8. UNDO component addition.
-        general.undo()
+        # 8. Remove actor component.
+        actor_component.remove()
         general.idle_wait_frames(1)
         Report.result(Tests.actor_undo, not material_entity.has_component(AtomComponentProperties.actor()))
 
@@ -158,41 +208,140 @@ def AtomEditorComponents_Material_AddedToEntity():
         Report.result(Tests.material_disabled, not material_component.is_enabled())
 
         # 10. Add Mesh component since it is required by the Material component.
-        material_entity.add_component(AtomComponentProperties.mesh())
+        mesh_component = material_entity.add_component(AtomComponentProperties.mesh())
         Report.result(Tests.mesh_component, material_entity.has_component(AtomComponentProperties.mesh()))
 
         # 11. Verify Material component is enabled.
         Report.result(Tests.material_enabled, material_component.is_enabled())
 
-        # 12. Enter/Exit game mode.
+        # 12. Set a model asset to Mesh component
+        # Set a simple model to ensure that the more complex model will load cleanly
+        model_path = os.path.join('Objects', 'cube.azmodel')
+        model = Asset.find_asset_by_path(model_path)
+        mesh_component.set_component_property_value(AtomComponentProperties.mesh('Mesh Asset'), model.id)
+        general.idle_wait_frames(1)
+        # Update mesh asset to a model with 5 LOD materials
+        model_path = os.path.join('Objects', 'sphere_5lods_fbx_psphere_base_1.azmodel')
+        model = Asset.find_asset_by_path(model_path)
+        mesh_component.set_component_property_value(AtomComponentProperties.mesh('Mesh Asset'), model.id)
+        general.idle_wait_frames(1)
+        Report.result(
+            Tests.mesh_asset,
+            mesh_component.get_component_property_value(AtomComponentProperties.mesh('Mesh Asset')) == model.id)
+
+        # 13. Wait for Model Materials to indicate count 5 terminate early if container fails to reflect correct count
+        Report.critical_result(Tests.model_material_count, TestHelper.wait_for_condition(
+            lambda: (material_component.get_container_count(
+                AtomComponentProperties.material('Model Materials')) == 5), timeout_in_seconds=5))
+
+        # 14. Get the slot zero material from the container property Model Materials (materials defined in the fbx)
+        item = material_component.get_container_item(AtomComponentProperties.material('Model Materials'), key=0)
+        # item is an EditorMaterialComponentSlot which defines a number of method interfaces found in
+        # .\o3de\Gems\AtomLyIntegration\CommonFeatures\Code\Source\Material\EditorMaterialComponentSlot.cpp
+        label = item.GetLabel()
+        Report.result(Tests.model_material_label, label == 'lambert0')
+        # Asset path for lambert0 is 'objects/sphere_5lods_lambert0_11781189446760285338.azmaterial'; numbers may vary
+        default_asset = Asset(item.GetDefaultAssetId())
+        default_asset_path = default_asset.get_path()
+        Report.result(Tests.model_material_asset_path, default_asset_path.startswith('objects/sphere_5lods_lambert0_'))
+
+        # 15. Enable the use of LOD materials
+        material_component.set_component_property_value(AtomComponentProperties.material('Enable LOD Materials'), True)
+        general.idle_wait_frames(1)
+        Report.result(
+            Tests.enable_lod_materials,
+            material_component.get_component_property_value(
+                AtomComponentProperties.material('Enable LOD Materials')) is True)
+
+        # 16. Wait for LOD Materials to indicate count 5 terminate early if container fails to reflect correct count
+        Report.critical_result(Tests.lod_material_count, TestHelper.wait_for_condition(
+            lambda: (material_component.get_container_count(
+                AtomComponentProperties.material('LOD Materials')) == 5), timeout_in_seconds=5))
+
+        # 17. Get the slot zero list from LOD Material
+        item = material_component.get_container_item(
+            AtomComponentProperties.material('LOD Materials'), key=0)  # list of EditorMaterialComponentSlot
+        active_asset = Asset(item[0].GetActiveAssetId())
+        active_asset_path = active_asset.get_path()
+        Report.result(
+            Tests.lod_material_asset_path,
+            active_asset_path.startswith('objects/sphere_5lods_lambert0_'))
+
+        # Setup a material for overrides in further testing
+        material_path = os.path.join('Materials', 'Presets', 'PBR', 'metal_gold.azmaterial')
+        metal_gold = Asset.find_asset_by_path(material_path)
+
+        # 18. Override the slot zero LOD Material asset using EditorMaterialComponentSlot method SetAssetId
+        item[0].SetAssetId(metal_gold.id)
+        # check override with EditorMaterialComponentSlot method GetActiveAssetId
+        Report.result(Tests.lod_material_set, item[0].GetActiveAssetId() == metal_gold.id)
+        # FindMaterialAsignementId expects slot index and slot label (index for default material is -1, slot 0 is 0)
+        assignment_id = render.MaterialComponentRequestBus(
+            bus.Event, "FindMaterialAssignmentId", material_entity.id, 0, 'lambert0')
+        # check override with ebus call
+        Report.result(Tests.lod_material_set,
+                      render.MaterialComponentRequestBus(
+                          bus.Event, "GetMaterialOverride", material_entity.id, assignment_id) == metal_gold.id)
+
+        # 19. Clear the LOD Material override and confirm the active asset is the default value
+        item[0].Clear()
+        general.idle_wait_frames(1)
+        active_asset = Asset(item[0].GetActiveAssetId())
+        active_asset_path = active_asset.get_path()
+        Report.result(
+            Tests.lod_material_asset_path,
+            active_asset_path.startswith('objects/sphere_5lods_lambert0_'))
+
+        # 20. Set the Default Material asset to an override using set component property by path
+        material_component.set_component_property_value(
+            AtomComponentProperties.material('Material Asset'), metal_gold.id)
+        Report.result(
+            Tests.default_material,
+            material_component.get_component_property_value(
+                AtomComponentProperties.material('Material Asset')) == metal_gold.id)
+
+        # 21. Clear the assignment of a default material using MaterialComponentRequestBus and confirm null asset
+        render.MaterialComponentRequestBus(bus.Event, "ClearDefaultMaterialOverride", material_entity.id)
+        default_material_asset_id = render.MaterialComponentRequestBus(
+            bus.Event, "GetDefaultMaterialOverride", material_entity.id)
+        Report.result(Tests.clear_default_material, default_material_asset_id == azlmbr.asset.AssetId())
+
+        # 22. Set the Default Material asset using MaterialComponentRequestBus
+        render.MaterialComponentRequestBus(
+            bus.Event, "SetDefaultMaterialOverride", material_entity.id, metal_gold.id)
+        default_material_asset_id = render.MaterialComponentRequestBus(
+            bus.Event, "GetDefaultMaterialOverride", material_entity.id)
+        Report.result(Tests.default_material, default_material_asset_id == metal_gold.id)
+
+        # 23. Enter/Exit game mode.
         TestHelper.enter_game_mode(Tests.enter_game_mode)
         general.idle_wait_frames(1)
         TestHelper.exit_game_mode(Tests.exit_game_mode)
 
-        # 13. Test IsHidden.
+        # 24. Test IsHidden.
         material_entity.set_visibility_state(False)
         Report.result(Tests.is_hidden, material_entity.is_hidden() is True)
 
-        # 14. Test IsVisible.
+        # 25. Test IsVisible.
         material_entity.set_visibility_state(True)
         general.idle_wait_frames(1)
         Report.result(Tests.is_visible, material_entity.is_visible() is True)
 
-        # 15. Delete Material entity.
+        # 26. Delete Material entity.
         material_entity.delete()
         Report.result(Tests.entity_deleted, not material_entity.exists())
 
-        # 16. UNDO deletion.
+        # 27. UNDO deletion.
         general.undo()
         general.idle_wait_frames(1)
         Report.result(Tests.deletion_undo, material_entity.exists())
 
-        # 17. REDO deletion.
+        # 28. REDO deletion.
         general.redo()
         general.idle_wait_frames(1)
         Report.result(Tests.deletion_redo, not material_entity.exists())
 
-        # 18. Look for errors or asserts.
+        # 29. Look for errors or asserts.
         TestHelper.wait_for_condition(lambda: error_tracer.has_errors or error_tracer.has_asserts, 1.0)
         for error_info in error_tracer.errors:
             Report.info(f"Error: {error_info.filename} {error_info.function} | {error_info.message}")


### PR DESCRIPTION
Adds several P1 tests for Material component working with LOD's and overriding materials. Uses both container item EditorMaterialsComponentSlot accessor methods and ebus calls to azlmbr.render.MaterialComponentRequestBus.

Report:
[SUCCESS] Success: Material Entity successfully created
[SUCCESS] Success: Entity has a Material component
[SUCCESS] Success: UNDO Entity creation success
[SUCCESS] Success: REDO Entity creation success
[SUCCESS] Success: Material component disabled
[SUCCESS] Success: Entity has an Actor component
[SUCCESS] Success: Material component enabled
[SUCCESS] Success: Entity Actor component gone
[SUCCESS] Success: Material component disabled
[SUCCESS] Success: Entity has a Mesh component
[SUCCESS] Success: Material component enabled
[SUCCESS] Success: Mesh Asset set
[SUCCESS] Success: Model Material count is 5 as expected
[SUCCESS] Success: Model Material zero index is labeled lambert0
[SUCCESS] Success: Asset path of the Material Model index zero is as expected
[SUCCESS] Success: Enable LOD Materials property set to True
[SUCCESS] Success: LOD Material count is 5 as expected
[SUCCESS] Success: Asset path of LOD Material index zero first item is as expected
[SUCCESS] Success: LOD material zero is set to metal_gold.azmaterial id
[SUCCESS] Success: LOD material zero is set to metal_gold.azmaterial id
[SUCCESS] Success: Asset path of LOD Material index zero first item is as expected
[SUCCESS] Success: Default Material set to metal_gold.azmaterial
[SUCCESS] Success: Default Material cleared with MaterialComponentRequestBus
[SUCCESS] Success: Default Material set to metal_gold.azmaterial
[SUCCESS] Success: Entered game mode
[SUCCESS] Success: Exited game mode
[SUCCESS] Success: Entity is hidden
[SUCCESS] Success: Entity is visible
[SUCCESS] Success: Entity deleted
[SUCCESS] Success: UNDO deletion success
[SUCCESS] Success: REDO deletion success
Test result:  SUCCESS

.\python\python.cmd -m pytest --build-directory atom_dev/bin/profile  .\AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py
============================= test session starts 
platform win32 -- Python 3.7.12, pytest-5.3.2, py-1.11.0, pluggy-0.13.1
rootdir: D:\workspace\o3de, inifile: pytest.ini
plugins: mock-2.0.0, timeout-1.3.4, ly-test-tools-1.0.0
collected 29 items

AutomatedTesting\Gem\PythonTests\Atom\TestSuite_Main.py ..............................[100%]

=================================================== warnings summary
tools\lytesttools\ly_test_tools\o3de\editor_test.py:333
  d:\workspace\o3de\tools\lytesttools\ly_test_tools\o3de\editor_test.py:333: PytestCollectionWarning: cannot collect test class 'TestData' because it has a __init__ constructor (from: AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py::TestAutomation)
    class TestData:

AutomatedTesting/Gem/PythonTests/Atom/TestSuite_Main.py::TestMaterialEditorBasicTests::test_MaterialEditorBasicTests[windows-MaterialEditor-windows_generic-AutomatedTesting]
  d:\workspace\o3de\tools\lytesttools\ly_test_tools\_internal\pytest_plugin\test_tools_fixtures.py:298: DeprecationWarning: This method is deprecated and will be removed on 3/31/22. Please use another helper method instead.
    return ly_test_tools.launchers.launcher_helper.create_generic_launcher(workspace, launcher_platform, exe_file_name)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================= 30 passed, 2 warnings in 131.88s (0:02:11)